### PR TITLE
maintainers: remove chaduffy

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4737,12 +4737,6 @@
     githubId = 32384814;
     name = "Nikita Mitasov";
   };
-  chaduffy = {
-    email = "charles@dyfis.net";
-    github = "charles-dyfis-net";
-    githubId = 22370;
-    name = "Charles Duffy";
-  };
   changlinli = {
     email = "mail@changlinli.com";
     github = "changlinli";

--- a/pkgs/by-name/be/bees/package.nix
+++ b/pkgs/by-name/be/bees/package.nix
@@ -79,6 +79,6 @@ stdenv.mkDerivation (finalAttrs: {
     longDescription = "Best-Effort Extent-Same: bees finds not just identical files, but also identical extents within files that differ";
     license = lib.licenses.gpl3;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ chaduffy ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/de/desync/package.nix
+++ b/pkgs/by-name/de/desync/package.nix
@@ -62,9 +62,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/folbricht/desync";
     changelog = "https://github.com/folbricht/desync/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [
-      chaduffy
-      matshch
-    ];
+    maintainers = with lib.maintainers; [ matshch ];
   };
 })

--- a/pkgs/by-name/fr/freeplane/package.nix
+++ b/pkgs/by-name/fr/freeplane/package.nix
@@ -102,7 +102,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://freeplane.org/";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ chaduffy ];
+    maintainers = [ ];
     mainProgram = "freeplane";
   };
 })

--- a/pkgs/by-name/ov/ovh-ttyrec/package.nix
+++ b/pkgs/by-name/ov/ovh-ttyrec/package.nix
@@ -29,9 +29,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Terminal interaction recorder and player";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [
-      chaduffy
-      zimbatm
-    ];
+    maintainers = with lib.maintainers; [ zimbatm ];
   };
 })


### PR DESCRIPTION
## Reasons
* Last commented/approved in [December 2025](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Acharles-dyfis-net)
* Hasn't created any PRs / Issues since [October 2025](https://github.com/NixOS/nixpkgs/issues?q=author%3Acharles-dyfis-net)
* About 40 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Acharles-dyfis-net%20-commenter%3Acharles-dyfis-net%20-author%3Acharles-dyfis-net%20-reviewed-by%3Acharles-dyfis-net) PRs / Issues, 9 of which are since December 2025

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. @charles-dyfis-net, you have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages
Those packages only have them as their maintainer and would need at least one new maintainer.

* [ ] bees
* [x] desync — I am ready to take over the ownership #533421
* [ ] freeplane