### PR TITLE
python3Packages.triton: 3.7.0 -> 3.7.1; python3Packages.torch: 2.12.0 -> 2.13.0

### DIFF
--- a/pkgs/by-name/tr/triton-llvm/package.nix
+++ b/pkgs/by-name/tr/triton-llvm/package.nix
@@ -68,7 +68,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "triton-llvm";
-  version = "23.0.0-unstable-2026-01-29"; # See https://github.com/llvm/llvm-project/blob/main/cmake/Modules/LLVMVersion.cmake
+  version = "23.0.0-unstable-2026-06-16"; # See https://github.com/llvm/llvm-project/blob/main/cmake/Modules/LLVMVersion.cmake
 
   __structuredAttrs = true;
 
@@ -82,12 +82,12 @@ stdenv.mkDerivation (finalAttrs: {
     "man"
   ];
 
-  # See https://github.com/triton-lang/triton/blob/main/cmake/llvm-hash.txt
+  # See https://github.com/triton-lang/triton/blob/v3.7.1/cmake/llvm-hash.txt
   src = fetchFromGitHub {
     owner = "llvm";
     repo = "llvm-project";
-    rev = "ac5dc54d509169d387fcfd495d71853d81c46484";
-    hash = "sha256-tA1KcZqyPsgfxQs9tbNhX11oFcNGJefxWmfCpYqdI9M=";
+    rev = "1f126a6dea50d185c0781743a667390037ae88bd";
+    hash = "sha256-U14/YrUkTsjtEWoaegASN0oyQ08E11sTRs6DuNeqxnE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/torch/source/default.nix
+++ b/pkgs/development/python-modules/torch/source/default.nix
@@ -3,6 +3,7 @@
   lib,
   fetchFromGitHub,
   fetchFromGitLab,
+  fetchpatch,
   git-unroll,
   buildPythonPackage,
   python,
@@ -65,10 +66,8 @@
   typing-extensions,
 
   binutils,
-  expecttest,
   hypothesis,
   psutil,
-  types-dataclasses,
   # ROCm build and `torch.compile` requires `triton`
   tritonSupport ? (!stdenv.hostPlatform.isDarwin),
   triton,
@@ -290,7 +289,7 @@ in
 buildPythonPackage.override { inherit stdenv; } (finalAttrs: {
   pname = "torch";
   # Don't forget to update torch-bin to the same version.
-  version = "2.12.0";
+  version = "2.13.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -318,7 +317,20 @@ buildPythonPackage.override { inherit stdenv; } (finalAttrs: {
   ]
   ++ lib.optionals cudaSupport [
     ./fix-cmake-cuda-toolkit.patch
+
+    # Let CMake find CUPTI through the variables we export in `preConfigure`, so that the
+    # `CUDA::cupti` target kineto requires gets defined
+    ./forward-cupti-env-vars.patch
+
     ./nvtx3-hpp-path-fix.patch
+
+    # Don't emit both `sm_103` and `sm_103f` gencode flags, which nvcc rejects:
+    # https://github.com/pytorch/pytorch/pull/187006
+    (fetchpatch {
+      name = "avoid-duplicate-sm_103-codegen.patch";
+      url = "https://github.com/pytorch/pytorch/commit/94079bfd49e1d8a458a8d7714a8bf7379bba947a.patch";
+      hash = "sha256-PFj8RihqeKTAogoCt59ikTbQ8wwpPJvUXGFlpBs8gE0=";
+    })
   ]
   ++ lib.optionals (lib.getName blas.provider == "mkl") [
     # The CMake install tries to add some hardcoded rpaths, incompatible
@@ -334,9 +346,7 @@ buildPythonPackage.override { inherit stdenv; } (finalAttrs: {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail "setuptools>=70.1.0,<82" "setuptools"
-    substituteInPlace setup.py \
-      --replace-fail "setuptools<82" setuptools
+      --replace-fail "setuptools>=77.0.0,<82" "setuptools"
   ''
   # Provide path to openssl binary for inductor code cache hash
   # InductorError: FileNotFoundError: [Errno 2] No such file or directory: 'openssl'
@@ -412,8 +422,8 @@ buildPythonPackage.override { inherit stdenv; } (finalAttrs: {
   preConfigure =
     lib.optionalString cudaSupport ''
       export TORCH_CUDA_ARCH_LIST="${gpuTargetString}"
-      export CUPTI_INCLUDE_DIR=${lib.getDev cudaPackages.cuda_cupti}/include
-      export CUPTI_LIBRARY_DIR=${lib.getLib cudaPackages.cuda_cupti}/lib
+      export CUDAToolkit_CUPTI_INCLUDE_DIR=${lib.getInclude cudaPackages.cuda_cupti}/include
+      export CUDA_cupti_LIBRARY=${lib.getLib cudaPackages.cuda_cupti}/lib/libcupti.so
     ''
     + lib.optionalString (cudaSupport && cudaPackages ? cudnn) ''
       export CUDNN_INCLUDE_DIR=${lib.getLib cudnn}/include

--- a/pkgs/development/python-modules/torch/source/forward-cupti-env-vars.patch
+++ b/pkgs/development/python-modules/torch/source/forward-cupti-env-vars.patch
@@ -1,0 +1,12 @@
+diff --git a/cmake/EnvVarForwarding.cmake b/cmake/EnvVarForwarding.cmake
+--- a/cmake/EnvVarForwarding.cmake
++++ b/cmake/EnvVarForwarding.cmake
+@@ -18,6 +18,8 @@
+   CUDA_HOST_COMPILER
+   CUDA_NVCC_EXECUTABLE
+   CUDA_SEPARABLE_COMPILATION
++  CUDA_cupti_LIBRARY
++  CUDAToolkit_CUPTI_INCLUDE_DIR
+   CUDNN_LIBRARY
+   CUDNN_INCLUDE_DIR
+   CUDNN_ROOT

--- a/pkgs/development/python-modules/torch/source/src.nix
+++ b/pkgs/development/python-modules/torch/source/src.nix
@@ -4,13 +4,19 @@
   fetchFromGitHub,
   runCommand,
 }:
-assert version == "2.12.0";
+assert version == "2.13.0";
 rec {
   src_aiter = fetchFromGitHub {
     owner = "ROCm";
     repo = "aiter";
     rev = "9a469a608b2c10b7157df573a38d31e5bf4038b4";
     hash = "sha256-kaX3uAkgE99puYu+ODdKjvsN+LLl1Jt95vtd5Xh0Mg8=";
+  };
+  src_aiter_flash-attention = fetchFromGitHub {
+    owner = "ROCm";
+    repo = "aiter";
+    rev = "b4b75165fbd2456dfd0f074c5b2ef91bc87d97e5";
+    hash = "sha256-Q3nTakD9XbeHe5myYUrv51Iwh6Ifg46hKfn0CK9izhc=";
   };
   src_asmjit = fetchFromGitHub {
     owner = "asmjit";
@@ -54,6 +60,12 @@ rec {
     rev = "fcc9372c009c8e0a23fece77b582da83b04a654f";
     hash = "sha256-Xwj48Ftwqlea5ZIP7q7cRh2U2tlHTd1cdW4TYf5J0Dg=";
   };
+  src_composable_kernel_aiter_flash-attention = fetchFromGitHub {
+    owner = "ROCm";
+    repo = "composable_kernel";
+    rev = "eb033ef2089e00f821930c04ef7c589da073f1c8";
+    hash = "sha256-43he+hJYdu++a8zIg2A4eycMeU/KyzoiWFxeti96eEA=";
+  };
   src_composable_kernel_fbgemm_MSLK = fetchFromGitHub {
     owner = "ROCm";
     repo = "composable_kernel";
@@ -63,14 +75,14 @@ rec {
   src_composable_kernel_flash-attention = fetchFromGitHub {
     owner = "ROCm";
     repo = "composable_kernel";
-    rev = "13f6d635653bd5ffbfcac8577f1ef09590c23d78";
-    hash = "sha256-nS1Apx4kLTIz7U2/X1BVQHiBwa5j59VboaibOhH9ADM=";
+    rev = "791afc64655301487cac6e5361c677a0a4b82059";
+    hash = "sha256-at/UrMSQP+6f9AeTmw2/UmBbNog8OQNQFZvbGkmGAtQ=";
   };
   src_cpp-httplib = fetchFromGitHub {
     owner = "yhirose";
     repo = "cpp-httplib";
-    rev = "4d7c9a788de136071ccf0dd4e96239151e2adadb";
-    hash = "sha256-VXEhoxoQjGEuA2g/y6fDTA4LrPd4SggrS3aOjznDSvc=";
+    rev = "811dd0b6f2382f50f801f3cfdb5ba349d08bb575";
+    hash = "sha256-+tJPA2yUT4irfEBRv2LHxc70xYY6+gWJWtSRtMGF3sw=";
   };
   src_cpr = fetchFromGitHub {
     owner = "libcpr";
@@ -81,8 +93,8 @@ rec {
   src_cpuinfo = fetchFromGitHub {
     owner = "pytorch";
     repo = "cpuinfo";
-    rev = "f858c30bcb16f8effd5ff46996f0514539e17abc";
-    hash = "sha256-9eXqsdgGl4oZEC8uJgiyqrvD3HVyUuNcSkJ8VTmZBj8=";
+    rev = "bc3c01e230c6974283e4b89421cfb0e232435589";
+    hash = "sha256-nm1ifv/ASJwCWoz+9HeuCi+bcCNTh/swvkxJolItgyU=";
   };
   src_cpuinfo_fbgemm = fetchFromGitHub {
     owner = "pytorch";
@@ -93,8 +105,8 @@ rec {
   src_cudnn-frontend = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "cudnn-frontend";
-    rev = "a91f0e04dcea10515f0f776fc5a89535e316a9c8";
-    hash = "sha256-OOKdkjsVnWgrtcI7IMPSRi2YxtqF2YNV4Fd2rD9I1K8=";
+    rev = "c4a97621eca52fa0c3a1862a411a16be580b25c6";
+    hash = "sha256-I6el8e6Jo1l/S5eqxWiH2KksNxw4hJ+av5qj/yqJjI8=";
   };
   src_cutlass = fetchFromGitHub {
     owner = "NVIDIA";
@@ -102,23 +114,17 @@ rec {
     rev = "da5e086dab31d63815acafdac9a9c5893b1c69e2";
     hash = "sha256-0q9Ad0Z6E/rO2PdM4uQc8H0E0qs9uKc3reHepiHhjEc=";
   };
-  src_cutlass_fbgemm = fetchFromGitHub {
+  src_cutlass_fbgemm_MSLK = fetchFromGitHub {
     owner = "jwfromm";
     repo = "cutlass";
-    rev = "a54461186bc30c39bf89bc433f89198892ad9e5f";
-    hash = "sha256-me+IKK79OJz4tCioc1GxJxp620KFL4yYk5r85XHj3zQ=";
+    rev = "571edeb2d0ac872a8392fc49285b156b07884b4e";
+    hash = "sha256-EnEtWPJqJBLGOk93HdUL45NFqIVG5qetJX6vnc7K6pE=";
   };
   src_cutlass_flash-attention = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "cutlass";
     rev = "7127592069c2fe01b041e174ba4345ef9b279671";
     hash = "sha256-/fEfuriQbrjjLP+yRjeo88SgW3IurdlU+6rR9+w5woQ=";
-  };
-  src_cutlass_MSLK = fetchFromGitHub {
-    owner = "jwfromm";
-    repo = "cutlass";
-    rev = "571edeb2d0ac872a8392fc49285b156b07884b4e";
-    hash = "sha256-EnEtWPJqJBLGOk93HdUL45NFqIVG5qetJX6vnc7K6pE=";
   };
   src_DCGM = fetchFromGitHub {
     owner = "NVIDIA";
@@ -135,8 +141,8 @@ rec {
   src_fbgemm = fetchFromGitHub {
     owner = "pytorch";
     repo = "fbgemm";
-    rev = "c246916f9e3804eacc3c95058e51cce02ae00fff";
-    hash = "sha256-jNc9Z3fe4pUTP5FY3sV1WINoEEd8te6tTyjNsFWZFxY=";
+    rev = "d08742c6602efedc6a3c9fca124b96ad555316e4";
+    hash = "sha256-lPZFwSjr1yd3lXhyYA6UrYr+kVHo0IA5QJvQpPtNiU8=";
   };
   src_fbjni = fetchFromGitHub {
     owner = "facebookincubator";
@@ -147,8 +153,8 @@ rec {
   src_flash-attention = fetchFromGitHub {
     owner = "Dao-AILab";
     repo = "flash-attention";
-    rev = "fec3a6a18460c1b40f097208d4c16fe8964a679d";
-    hash = "sha256-7yEFNM2lslkBA/9slblAbiK1PHKqKmo1MCFJYz2BOLk=";
+    rev = "6c4f74fb338e0c3cdb07ac6f5eab5f54fc367c15";
+    hash = "sha256-k6158mEJocKIRS4MQIM+Ih4VMHnXCKJGcykZFi91J2w=";
   };
   src_flatbuffers = fetchFromGitHub {
     owner = "google";
@@ -213,8 +219,8 @@ rec {
   src_gloo = fetchFromGitHub {
     owner = "pytorch";
     repo = "gloo";
-    rev = "3135b0b41b67dde590eef0938a0bf3d6238df5f7";
-    hash = "sha256-lCKZyH8p54UaSDGRTxM6ZMorc+japeJulv7FQn0GnHc=";
+    rev = "bcd1672ee07538123ea8f4fac76832efc58fb8ef";
+    hash = "sha256-taZFCV6+4hXL63P+coJHEuOuyoGfDEr2BrSGOMdFprk=";
   };
   src_googletest = fetchFromGitHub {
     owner = "google";
@@ -249,7 +255,7 @@ rec {
   src_ideep = fetchFromGitHub {
     owner = "intel";
     repo = "ideep";
-    rev = "e539e0f9774e2018f0d56fe865da66581f692e3d";
+    rev = "e087b6e4b32a7ba684db82231d1558123968ac1d";
     hash = "sha256-AVSsugGYiQ4QOWMVaHj1hzlPTZmg65yrGMmrWytvUuM=";
   };
   src_ittapi = fetchFromGitHub {
@@ -270,17 +276,11 @@ rec {
     rev = "4f8fba14066156b73f1189a2b8bd568bde5284c5";
     hash = "sha256-DTsZrdB9GcaNkx7ZKxcgCA3A9ShM5icSF0xyGguJNbk=";
   };
-  src_json_fbgemm = fetchFromGitHub {
-    owner = "nlohmann";
-    repo = "json";
-    rev = "9cca280a4d0ccf0c08f47a99aa71d1b0e52f8d03";
-    hash = "sha256-7F0Jon+1oWL7uqet5i1IgHX0fUw/+z0QwEcA3zs5xHg=";
-  };
   src_kineto = fetchFromGitHub {
     owner = "pytorch";
     repo = "kineto";
-    rev = "b2103f78d13fde4937af010c0ef8e24313568bc5";
-    hash = "sha256-Ix5zulGaUPbLeVrrTm/EzcVWT4TkDYcBsQADAl4N7TA=";
+    rev = "094d3c1d072362d0a919a77299459eee94f97931";
+    hash = "sha256-KFP2wrFj3Tgv1U5b4YJr2mWq+xo1mZzVUejFxGhv9z4=";
   };
   src_kleidiai = fetchFromGitHub {
     owner = "ARM-software";
@@ -303,14 +303,14 @@ rec {
   src_mimalloc = fetchFromGitHub {
     owner = "microsoft";
     repo = "mimalloc";
-    rev = "048d969a1c5ee2fb89c226298f41ea38445546ef";
-    hash = "sha256-ZxIkzMIqwYZpiqbPAHDrO26xaiaF77Dlosbw43VkOpc=";
+    rev = "02a2f5df9d7d46d30263b83832eebeeab62dc5fe";
+    hash = "sha256-7wJ6IE6WXuIFmuuM1W5TawC4LYjhc18aYlaujnOXyx4=";
   };
   src_mkl-dnn = fetchFromGitHub {
     owner = "intel";
     repo = "mkl-dnn";
-    rev = "03c022d3ffdcee958cfacbe720048e725fdf644c";
-    hash = "sha256-xJTllrKs6mPNM85ZqyHTHWKpVOtOghmg4ZRFAvQZ4WU=";
+    rev = "80afa71049cd69a3df32adcccb623b12cd7baa22";
+    hash = "sha256-t5+DF4/qgEYQpTY8Qox0BTfpykfs5kFqYy6HrEJaVu0=";
   };
   src_MSLK = fetchFromGitHub {
     owner = "meta-pytorch";
@@ -373,16 +373,16 @@ rec {
     hash = "sha256-lV+VZi2b4SQlRYrhKx9Dxc6HlDEFz3newvcBjTekupo=";
   };
   src_pthreadpool = fetchFromGitHub {
-    owner = "Maratyszcza";
+    owner = "google";
     repo = "pthreadpool";
-    rev = "4fe0e1e183925bf8cfa6aae24237e724a96479b8";
-    hash = "sha256-R4YmNzWEELSkAws/ejmNVxqXDTJwcqjLU/o/HvgRn2E=";
+    rev = "a56dcd79c699366e7ac6466792c3025883ff7704";
+    hash = "sha256-WfyuPfII4eSmLskZV0TAcu4K6OyW38TjkDHm+VUx5eY=";
   };
   src_pybind11 = fetchFromGitHub {
     owner = "pybind";
     repo = "pybind11";
-    rev = "f5fbe867d2d26e4a0a9177a51f6e568868ad3dc8";
-    hash = "sha256-ZiwNGsE1FOkhnWv/1ib1akhQ4FZvrXRCDnnBZoPp6r4=";
+    rev = "d03662f0984f652b60e7ddce53d3868002275197";
+    hash = "sha256-QZKnIOopEDsiRFkc1qQ+DaDHoTNuEEgQVeiAL0sQqak=";
   };
   src_pybind11_onnx = fetchFromGitHub {
     owner = "pybind";
@@ -399,8 +399,8 @@ rec {
   src_pytorch = fetchFromGitHub {
     owner = "pytorch";
     repo = "pytorch";
-    rev = "v2.12.0";
-    hash = "sha256-IyQs9CQbbpZYpd+8YhIj/ULjsIWu6gjkGrGSeMWqKvw=";
+    rev = "v2.13.0";
+    hash = "sha256-ho3L7gDflBkJ+i47rpTc7/AaHWgXe1U00wFaRLLH8W8=";
   };
   src_sleef = fetchFromGitHub {
     owner = "shibatch";
@@ -431,6 +431,11 @@ rec {
     chmod u+w $out/3rdparty/composable_kernel
     cp -r ${src_composable_kernel_aiter_recursive}/* $out/3rdparty/composable_kernel
   '';
+  src_aiter_flash-attention_recursive = runCommand "aiter_flash-attention" { } ''
+    cp -r ${src_aiter_flash-attention} $out
+    chmod u+w $out/3rdparty/composable_kernel
+    cp -r ${src_composable_kernel_aiter_flash-attention_recursive}/* $out/3rdparty/composable_kernel
+  '';
   src_asmjit_recursive = src_asmjit;
   src_benchmark_recursive = src_benchmark;
   src_benchmark_protobuf_recursive = src_benchmark_protobuf;
@@ -438,6 +443,7 @@ rec {
   src_clang-cindex-python3_recursive = src_clang-cindex-python3;
   src_composable_kernel_recursive = src_composable_kernel;
   src_composable_kernel_aiter_recursive = src_composable_kernel_aiter;
+  src_composable_kernel_aiter_flash-attention_recursive = src_composable_kernel_aiter_flash-attention;
   src_composable_kernel_fbgemm_MSLK_recursive = src_composable_kernel_fbgemm_MSLK;
   src_composable_kernel_flash-attention_recursive = src_composable_kernel_flash-attention;
   src_cpp-httplib_recursive = src_cpp-httplib;
@@ -446,9 +452,8 @@ rec {
   src_cpuinfo_fbgemm_recursive = src_cpuinfo_fbgemm;
   src_cudnn-frontend_recursive = src_cudnn-frontend;
   src_cutlass_recursive = src_cutlass;
-  src_cutlass_fbgemm_recursive = src_cutlass_fbgemm;
+  src_cutlass_fbgemm_MSLK_recursive = src_cutlass_fbgemm_MSLK;
   src_cutlass_flash-attention_recursive = src_cutlass_flash-attention;
-  src_cutlass_MSLK_recursive = src_cutlass_MSLK;
   src_DCGM_recursive = src_DCGM;
   src_dynolog_recursive = runCommand "dynolog" { } ''
     cp -r ${src_dynolog} $out
@@ -480,13 +485,13 @@ rec {
     chmod u+w $out/external/cpuinfo
     cp -r ${src_cpuinfo_fbgemm_recursive}/* $out/external/cpuinfo
     chmod u+w $out/external/cutlass
-    cp -r ${src_cutlass_fbgemm_recursive}/* $out/external/cutlass
+    cp -r ${src_cutlass_fbgemm_MSLK_recursive}/* $out/external/cutlass
     chmod u+w $out/external/googletest
     cp -r ${src_googletest_recursive}/* $out/external/googletest
     chmod u+w $out/external/hipify_torch
     cp -r ${src_hipify_torch_recursive}/* $out/external/hipify_torch
     chmod u+w $out/external/json
-    cp -r ${src_json_fbgemm_recursive}/* $out/external/json
+    cp -r ${src_json_recursive}/* $out/external/json
   '';
   src_fbjni_recursive = src_fbjni;
   src_flash-attention_recursive = runCommand "flash-attention" { } ''
@@ -495,6 +500,8 @@ rec {
     cp -r ${src_composable_kernel_flash-attention_recursive}/* $out/csrc/composable_kernel
     chmod u+w $out/csrc/cutlass
     cp -r ${src_cutlass_flash-attention_recursive}/* $out/csrc/cutlass
+    chmod u+w $out/third_party/aiter
+    cp -r ${src_aiter_flash-attention_recursive}/* $out/third_party/aiter
   '';
   src_flatbuffers_recursive = src_flatbuffers;
   src_fmt_recursive = src_fmt;
@@ -524,7 +531,6 @@ rec {
   src_ittapi_recursive = src_ittapi;
   src_json_recursive = src_json;
   src_json_dynolog_recursive = src_json_dynolog;
-  src_json_fbgemm_recursive = src_json_fbgemm;
   src_kineto_recursive = runCommand "kineto" { } ''
     cp -r ${src_kineto} $out
     chmod u+w $out/libkineto/third_party/dynolog
@@ -533,6 +539,8 @@ rec {
     cp -r ${src_fmt_kineto_recursive}/* $out/libkineto/third_party/fmt
     chmod u+w $out/libkineto/third_party/googletest
     cp -r ${src_googletest_recursive}/* $out/libkineto/third_party/googletest
+    chmod u+w $out/libkineto/third_party/json
+    cp -r ${src_json_recursive}/* $out/libkineto/third_party/json
   '';
   src_kleidiai_recursive = src_kleidiai;
   src_libnop_recursive = src_libnop;
@@ -544,7 +552,7 @@ rec {
     chmod u+w $out/external/composable_kernel
     cp -r ${src_composable_kernel_fbgemm_MSLK_recursive}/* $out/external/composable_kernel
     chmod u+w $out/external/cutlass
-    cp -r ${src_cutlass_MSLK_recursive}/* $out/external/cutlass
+    cp -r ${src_cutlass_fbgemm_MSLK_recursive}/* $out/external/cutlass
     chmod u+w $out/external/googletest
     cp -r ${src_googletest_recursive}/* $out/external/googletest
     chmod u+w $out/external/hipify_torch

--- a/pkgs/development/python-modules/torch/tests/mk-torch-compile-check.nix
+++ b/pkgs/development/python-modules/torch/tests/mk-torch-compile-check.nix
@@ -24,6 +24,14 @@ cudaPackages.writeGpuTestPython
       "PATH"
       ":"
       "${lib.getBin stdenv.cc}/bin"
+    ]
+    # Inductor compiles its generated C++ with `-g1`, which makes clang spawn `dsymutil`.
+    # The bintools wrapper does not re-export it, so take it from the unwrapped cctools.
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      "--suffix"
+      "PATH"
+      ":"
+      "${lib.getBin stdenv.cc.bintools.bintools}/bin"
     ];
   }
   ''

--- a/pkgs/development/python-modules/torchcodec/default.nix
+++ b/pkgs/development/python-modules/torchcodec/default.nix
@@ -3,17 +3,24 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  symlinkJoin,
 
   # nativeBuildInputs
   pkg-config,
 
   # buildInputs
-  # FIXME: unpin when upstream supports ffmpeg 9
-  ffmpeg_8,
+  ffmpeg,
+  libavif,
+  libheif,
+  libjpeg,
+  libpng,
+  libwebp,
 
   # build-system
   cmake,
-  setuptools,
+  ninja,
+  pybind11,
+  scikit-build-core,
   torch,
 
   # tests
@@ -26,10 +33,23 @@
 
 let
   inherit (torch) cudaCapabilities cudaPackages;
+
+  # Unlike the other image codecs, upstream's CMake has no `find_package` path for libavif: it
+  # unconditionally FetchContent-downloads a prebuilt tarball from S3.
+  # Point FetchContent at our own libavif instead, which it expects to find as `include/` and
+  # `lib/libavif.so.16` under a single root.
+  # https://github.com/meta-pytorch/torchcodec/blob/v0.16.0/src/torchcodec/_core/fetch_avif_from_s3.cmake
+  libavif-root = symlinkJoin {
+    name = "libavif-root";
+    paths = [
+      (lib.getDev libavif)
+      (lib.getLib libavif)
+    ];
+  };
 in
 buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
   pname = "torchcodec";
-  version = "0.14.0";
+  version = "0.16.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -37,7 +57,7 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
     owner = "meta-pytorch";
     repo = "torchcodec";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-eGof2Rk/dGYPlKVRSuJ+ZeeMh2u4K6/qXmROo187HTA=";
+    hash = "sha256-eXe86DQqXWePWn9UcMVLdJTaO0YQZIQaQ4o1ao/5dH8=";
   };
 
   postPatch = ''
@@ -46,17 +66,17 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
       test/test_encoders.py \
       --replace-fail \
         '"ffprobe"' \
-        '"${lib.getExe' ffmpeg_8 "ffprobe"}"'
+        '"${lib.getExe' ffmpeg "ffprobe"}"'
 
     substituteInPlace test/test_encoders.py \
       --replace-fail \
         '"ffmpeg"' \
-        '"${lib.getExe ffmpeg_8}"'
+        '"${lib.getExe ffmpeg}"'
 
     substituteInPlace test/test_transform_ops.py \
       --replace-fail \
         'ffmpeg_cli = "ffmpeg"' \
-        'ffmpeg_cli = "${lib.getExe ffmpeg_8}"'
+        'ffmpeg_cli = "${lib.getExe ffmpeg}"'
   '';
 
   nativeBuildInputs = [
@@ -70,7 +90,12 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
   ];
 
   buildInputs = [
-    ffmpeg_8
+    ffmpeg
+    libavif
+    libheif
+    libjpeg
+    libpng
+    libwebp
   ]
   ++ lib.optionals cudaSupport (
     with cudaPackages;
@@ -81,12 +106,15 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
       libcusolver # cusolverDn.h
       libcusparse # cusparse.h
       libnpp # nppicc
+      libnvjpeg # nvjpeg.h
     ]
   );
 
   build-system = [
     cmake
-    setuptools
+    ninja
+    pybind11
+    scikit-build-core
     torch
   ];
   dontUseCmakeConfigure = true;
@@ -101,6 +129,10 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
     I_CONFIRM_THIS_IS_NOT_A_LICENSE_VIOLATION = true;
 
     ENABLE_CUDA = cudaSupport;
+
+    CMAKE_ARGS = toString [
+      (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_AVIF_S3" libavif-root.outPath)
+    ];
   }
   // lib.optionalAttrs cudaSupport {
     TORCH_CUDA_ARCH_LIST = "${lib.concatStringsSep ";" cudaCapabilities}";
@@ -109,7 +141,7 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
     ROCM_PATH = torch.rocmtoolkit_joined;
     ROCM_SOURCE_DIR = torch.rocmtoolkit_joined;
     PYTORCH_ROCM_ARCH = torch.gpuTargetString;
-    CMAKE_CXX_FLAGS = "-I${torch.rocmtoolkit_joined}/include";
+    CMAKE_CXX_FLAGS = "-I${lib.getInclude torch.rocmtoolkit_joined}/include";
   };
 
   pythonImportsCheck = [ "torchcodec" ];
@@ -117,6 +149,11 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
   nativeCheckInputs = [
     pytestCheckHook
     torchvision
+  ];
+
+  disabledTestPaths = [
+    # Shells out to `pip install` to set up a plugin package
+    "test/plugin/test_plugins.py"
   ];
 
   disabledTests =

--- a/pkgs/development/python-modules/torchvision/default.nix
+++ b/pkgs/development/python-modules/torchvision/default.nix
@@ -28,7 +28,7 @@ let
 in
 buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
   pname = "torchvision";
-  version = "0.27.0";
+  version = "0.28.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -36,7 +36,7 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
     owner = "pytorch";
     repo = "vision";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-HOTD45xY7Gye1GI1+AsF3KmMUTAp1QlzHOUeBHvzv0A=";
+    hash = "sha256-rku0QAW7RTkCjD4RorY7DeYfr6PDvqdm+6Yw9wBjGHU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/triton/default.nix
+++ b/pkgs/development/python-modules/triton/default.nix
@@ -47,7 +47,7 @@ let
 in
 buildPythonPackage.override { stdenv = effectiveStdenv; } (finalAttrs: {
   pname = "triton";
-  version = "3.7.0";
+  version = "3.7.1";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -56,7 +56,7 @@ buildPythonPackage.override { stdenv = effectiveStdenv; } (finalAttrs: {
     owner = "triton-lang";
     repo = "triton";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-FxbBY1lPq7765MqAPR7UljzPsmjOhKKbYExlKgeudew=";
+    hash = "sha256-2+NAHZZjFQxj+9UGiNpk4TVAKW6nydw1L1FTTJpNya4=";
   };
 
   patches = [


### PR DESCRIPTION
## Things done

- **triton-llvm: 23.0.0-unstable-2026-01-29 -> 23.0.0-unstable-2026-06-16**
- **python3Packages.triton: 3.7.0 -> 3.7.1** ([Changelog](https://github.com/triton-lang/triton/releases/tag/v3.7.1), [Diff](https://github.com/triton-lang/triton/compare/v3.7.0...v3.7.1))
- **python3Packages.torch: 2.12.0 -> 2.13.0** ([Changelog](https://github.com/pytorch/pytorch/releases/tag/v2.13.0), [Diff](https://github.com/pytorch/pytorch/compare/v2.12.0...v2.13.0))
- **python3Packages.torchcodec: 0.14.0 -> 0.16.0** ([Changelog](https://github.com/meta-pytorch/torchcodec/releases/tag/v0.16.0), [Diff](https://github.com/meta-pytorch/torchcodec/compare/v0.14.0...v0.16.0))
- **python3Packages.torchvision: 0.27.0 -> 0.28.0** ([Changelog](https://github.com/pytorch/vision/releases/tag/v0.28.0), [Diff](https://github.com/pytorch/vision/compare/v0.27.0...v0.28.0))

cc @teh @thoughtpolice @tscholak @junjihashimoto @ericsagnes
cc @NixOS/cuda-maintainers

Previous update: #519925, #519914 (bin)

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
