### PR TITLE
nixos/apparmor: fix lsm loading order

### DIFF
--- a/nixos/modules/security/default.nix
+++ b/nixos/modules/security/default.nix
@@ -1,4 +1,8 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  ...
+}:
 let
   cfg = config.security;
 in
@@ -16,10 +20,16 @@ in
   config = lib.mkMerge [
     {
       # We set the default LSM's here due to them not being present if set when enabling AppArmor.
-      security.lsm = [
-        "landlock"
-        "yama"
-        "bpf"
+      security.lsm = lib.mkMerge [
+        [
+          "landlock"
+          "yama"
+        ]
+        # Load BPF last unconditionally. See: https://github.com/NixOS/nixpkgs/pull/533428.
+        # Apparmor (and potentially other modules) will load incorrectly if they are not before BPF.
+        # It is believed that there was a regression between kernel 6.12 and 6.18 which caused the
+        # passthrough stub or LSM stacking of the BPF module to interact with other modules incorrectly.
+        (lib.mkAfter [ "bpf" ])
       ];
     }
     (lib.mkIf (lib.lists.length cfg.lsm > 0) {

--- a/nixos/modules/virtualisation/incus.nix
+++ b/nixos/modules/virtualisation/incus.nix
@@ -363,20 +363,26 @@ in
           include ${cfg.lxcPackage}/etc/apparmor.d/lxc-containers
         '';
         "incusd".profile = ''
-          # This profile allows everything and only exists to give the
-          # application a name instead of having the label "unconfined"
+          # incusd is deliberatly left unconfined, with NO named profile attached to the binary.
+          # Incus checks its own confinement at startup by reading /proc/self/attr/current
+          # (https://github.com/lxc/incus/blob/92b0cbbc5728ed45578fdeeec634606af8826404/internal/server/sys/apparmor.go).
+          # Anything other than "unconfined" makes Incus believe that the host process is
+          # itself confined, which sends every container down the "reuse my own profile" branch in
+          # https://github.com/lxc/incus/blob/92b0cbbc5728ed45578fdeeec634606af8826404/internal/server/instance/drivers/driver_lxc.go
+          # instead of generating a "proper" per-container profile. Furthermore,
+          # that branch only strips " (enforce)" suffix before handing the string to lxc.apparmor.profile
+          # (https://github.com/lxc/incus/blob/92b0cbbc5728ed45578fdeeec634606af8826404/internal/server/instance/drivers/driver_lxc.go#L96),
+          # so the named profile with flags=(unconfined) produces a literal string
+          # "incusd (unconfined)", which the kernel rejects at change_profile() time
+          # with "label not found", failing every `incus start` when AppArmor is enabled.
+          # This was not caught before as AppArmor was stifled by bpf.
+
+          # We keep this policy to pull in the per-container /
+          # per-archive profiles incusd generates at runtime so
+          # apparmor_parser loads them.
 
           abi <abi/4.0>,
           include <tunables/global>
-
-          profile incusd ${lib.getExe' config.virtualisation.incus.package "incusd"} flags=(unconfined) {
-            userns,
-
-            include "/var/lib/incus/security/apparmor/cache"
-
-            # Site-specific additions and overrides. See local/README for details.
-            include if exists <local/incusd>
-          }
 
           include "/var/lib/incus/security/apparmor/profiles"
         '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

As noted in #483085, enabling audit and apparmor at the same time caused some issues.

I originally thought this was a systemd ordering issue, but it turned out to be about LSM module ordering instead. From what I can tell, if AppArmor isn't loaded before the BPF LSM module, things break badly. This came up while working on nix-mineral.

After some investigation I came across https://gitlab.com/apparmor/apparmor/-/work_items/199, which pointed to LSM ordering being the actual cause rather than systemd ordering.

I then did some further research and found that BPF handles things in an unusual way, based on these references.
- https://patchwork.kernel.org/project/linux-security-module/patch/20210722004758.12371-23-casey@schaufler-ca.com/
- https://lkml.kernel.org/lkml/d753115f-6cbd-0886-473c-b10485cb7c52@schaufler-ca.com/

This PR also clears up the errors that would get spammed repeatedly when apparmor and audit were both enabled ("audit: error in audit_log_subj_ctx"). My guess is that apparmor loading after BPF caused certain messages (and ACKS that the audit subsystem requires) to not get forwarded correctly because of LSM stacking behaviors.

Worth noting that this isn't unique to nixpkgs. Manjaro users hit the same problem after moving to kernel 6.18, as described in this [thread](https://forum.manjaro.org/t/kernel-6-18-audit-framework/185988/11). That lines up with what we're seeing here. It looks like this only started showing up from 6.18 onward, which is probably why it's becoming more visible in NixOS now that 6.18 is the default kernel for 26.05.

The fact that audit behaves this way, and that apparmor seems fine when audit is disabled is beyond me at the moment.

A few open questions for discussion.

- How should we integrate testing for this? Not sure if it belongs in the apparmor testing module or the audit one. Either way it should be fairly simple to add.
- Given that this may really be a BPF issue to begin with, an alternative approach could be to load BPF last instead, something like: 

```nix
security.lsm = lib.mkMerge [ 
    ["landlock" "yama"] 
    (lib.mkAfter ["bpf"]) 
];
```

This would also leave room for other security modules that might run into similar issues, such as SELinux down the line, to be loaded before BPF as well.

Made with love and without AI.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
