### PR TITLE
libtommath: expose mp_set_double on darwin

### DIFF
--- a/pkgs/by-name/li/libtommath/force_mp_set_double.patch
+++ b/pkgs/by-name/li/libtommath/force_mp_set_double.patch
@@ -1,0 +1,14 @@
+diff --git a/bn_mp_set_double.c b/bn_mp_set_double.c
+index a42fc70..4a13539 100644
+--- a/bn_mp_set_double.c
++++ b/bn_mp_set_double.c
+@@ -3,7 +3,8 @@
+ /* LibTomMath, multiple-precision integer library -- Tom St Denis */
+ /* SPDX-License-Identifier: Unlicense */
+ 
+-#if defined(__STDC_IEC_559__) || defined(__GCC_IEC_559)
++#if defined(__STDC_IEC_559__) || defined(__GCC_IEC_559) || \
++     (defined(__APPLE__) && defined(__aarch64__))
+ mp_err mp_set_double(mp_int *a, double b)
+ {
+    uint64_t frac;

--- a/pkgs/by-name/li/libtommath/package.nix
+++ b/pkgs/by-name/li/libtommath/package.nix
@@ -14,6 +14,10 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-KWJy2TQ1mRMI63NgdgDANLVYgHoH6CnnURQuZcz6nQg=";
   };
 
+  patches = [
+    ./force_mp_set_double.patch
+  ];
+
   postPatch = ''
     substituteInPlace makefile.shared \
       --replace-fail glibtool libtool \


### PR DESCRIPTION
I'm trying to fix the ladybird browser build on Darwin, and the last remaining issue prior to making a PR for that is fixing an issue it has with `libtommath`. When compiling ladybird, it fails to build since it cannot find the symbol `mp_set_double`, which is declared in `mp_set_double.c`. The declaration is macro-define guarded behind `__STDC_IEC_559__` or `__GCC_IEC_559` (only on the published source; the GitHub source provides a macro `HAS_MP_SET_DOUBLE`), neither of which are defined by Clang on Darwin despite (AFAIU) clang on Darwin using IEEE 754 floats. The version of `libtommath` from `vcpkg` that Ladybird uses patches the macro define to allow it to work in that case, and so manually applying a patch to remove the macro guard on Darwin allows it to compile the symbol and produces a functioning ladybird binary when ladybird is built with this patched libtommath (plus a few unrelated patches I will PR soon).

It is also possible to achieve the same by defining `__STDC_IEC_559__`, but that feels worse IMO. Additionally, it is possible that we should just keep this isolated to the Ladybird derivation like we do with the patch for skia, in which case I can close this and leave this for the ladybird darwin fix PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
