### PR TITLE
home-assistant: 2026.6.3 -> 2026.6.4

### DIFF
--- a/pkgs/development/python-modules/aioamazondevices/default.nix
+++ b/pkgs/development/python-modules/aioamazondevices/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "aioamazondevices";
-  version = "14.0.4";
+  version = "14.1.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "chemelli74";
     repo = "aioamazondevices";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-C0cwPtAiA63DXqs8x0zlJ+y1BXgVe87Q56WKER/cmnk=";
+    hash = "sha256-MUPj3smDMOCV+g1cC6YKWSGYvB1UD8OKzlil61H4rZg=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/aiocomelit/default.nix
+++ b/pkgs/development/python-modules/aiocomelit/default.nix
@@ -1,40 +1,42 @@
 {
   lib,
   aiohttp,
+  aioresponses,
+  anyio,
   buildPythonPackage,
-  colorlog,
   fetchFromGitHub,
   orjson,
   pint,
-  pytest-cov-stub,
   pytestCheckHook,
   setuptools,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "aiocomelit";
-  version = "2.0.4";
+  version = "2.0.7";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "chemelli74";
     repo = "aiocomelit";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-E5hI3PGNmJxly5RvOsV4DsGxOLsdfYppcMSTcoX0ohQ=";
+    hash = "sha256-T48aRtuF9eNrW5L97CGkjc2PCdRzbuGCvhdWCuqe7yk=";
   };
 
   build-system = [ setuptools ];
 
   dependencies = [
     aiohttp
-    colorlog
     orjson
     pint
   ];
 
   nativeCheckInputs = [
-    pytest-cov-stub
+    aioresponses
+    anyio
     pytestCheckHook
+    writableTmpDirAsHomeHook
   ];
 
   pythonImportsCheck = [ "aiocomelit" ];

--- a/pkgs/development/python-modules/aioimmich/default.nix
+++ b/pkgs/development/python-modules/aioimmich/default.nix
@@ -1,7 +1,7 @@
 {
   aiofiles,
   aiohttp,
-  aioresponses,
+  aiointercept,
   buildPythonPackage,
   fetchFromGitHub,
   lib,
@@ -14,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "aioimmich";
-  version = "0.14.1";
+  version = "0.15.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mib1185";
     repo = "aioimmich";
     tag = "v${version}";
-    hash = "sha256-wKB2WtC5zMEnT2wF9Ed0yW2w9c1p642SXJmy5jJrQQc=";
+    hash = "sha256-lsxN4gl1t7za/0ac6fXZysEeXSQtNAvQCMN/eqRvWoQ=";
   };
 
   postPatch = ''
@@ -40,7 +40,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "aioimmich" ];
 
   nativeCheckInputs = [
-    aioresponses
+    aiointercept
     pytest-asyncio
     pytestCheckHook
     syrupy

--- a/pkgs/development/python-modules/alphaessopenapi/default.nix
+++ b/pkgs/development/python-modules/alphaessopenapi/default.nix
@@ -8,14 +8,14 @@
 }:
 buildPythonPackage rec {
   pname = "alphaess";
-  version = "0.0.17";
+  version = "0.0.19";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "CharlesGillanders";
     repo = "alphaess-openAPI";
     tag = version;
-    sha256 = "sha256-ECOL1fCJDL9OEDKElw9yAzF5SF3RB/6TrgK26ddtSzw=";
+    sha256 = "sha256-wdwA1MIQrkZCT4zIf8WXyq0+F+peC/auVtjDJ8ZZyxE=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/dsmr-parser/default.nix
+++ b/pkgs/development/python-modules/dsmr-parser/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "dsmr-parser";
-  version = "1.8.0";
+  version = "1.9.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ndokter";
     repo = "dsmr_parser";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-h7huLTdyDon2l2dUXwqilrM0tr6Tkk6918KLK/c2S9s=";
+    hash = "sha256-KoSRfkTKdAusDi1twiU4Xs0p4nijDslkDPJMTfUvWsE=";
   };
 
   pythonRelaxDeps = [ "dlms_cosem" ];

--- a/pkgs/development/python-modules/midea-local/default.nix
+++ b/pkgs/development/python-modules/midea-local/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "midea-local";
-  version = "6.6.0";
+  version = "6.8.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "midea-lan";
     repo = "midea-local";
     tag = "v${version}";
-    hash = "sha256-c66SvwyJZpTVA4bOgiOtrO3wHfK0rMpU2Uolu0Zpa6w=";
+    hash = "sha256-tJxSAjugFWvlpmLE7A7+wqsxM8RlgPQGE0fH7cdwxxI=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/opower/default.nix
+++ b/pkgs/development/python-modules/opower/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "opower";
-  version = "0.18.4";
+  version = "0.18.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tronikos";
     repo = "opower";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-AAKaRnjj6M4mmFkYRInmxlIwEGA7lA2foiT8FwDOB98=";
+    hash = "sha256-s6nacD6k9OgByt2ZdBrZsHtAhdUto7gngqqQWI3henY=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/pyituran/default.nix
+++ b/pkgs/development/python-modules/pyituran/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "pyituran";
-  version = "0.1.5";
+  version = "0.1.6";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "shmuelzon";
     repo = "pyituran";
     tag = version;
-    hash = "sha256-Nil9bxXzDvwMIVTxeaVUOtJwx92zagA6OzQV3LMR8d8=";
+    hash = "sha256-+3trWl9eijrtGfgBn5m4KfIVhS8u/o8n90bs3a3K9mo=";
   };
 
   postPatch = ''

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2026.6.3";
+  version = "2026.6.4";
   components = {
     "3_day_blinds" =
       ps: with ps; [

--- a/pkgs/servers/home-assistant/custom-components/alphaess/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/alphaess/package.nix
@@ -7,13 +7,13 @@
 buildHomeAssistantComponent rec {
   owner = "CharlesGillanders";
   domain = "alphaess";
-  version = "0.8.4";
+  version = "0.8.5";
 
   src = fetchFromGitHub {
     owner = "CharlesGillanders";
     repo = "homeassistant-alphaESS";
     tag = "v${version}";
-    hash = "sha256-p5F1qBeTQ/LshyvApo0xWN/WmFLFf7J9tL7XiIr+/fU=";
+    hash = "sha256-7IswE+Eqdo+hXic4MQ+vx6lBAudoQPW80eT6AEPFDjQ=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-components/blueprints-updater/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/blueprints-updater/package.nix
@@ -13,13 +13,13 @@
 buildHomeAssistantComponent rec {
   owner = "luuquangvu";
   domain = "blueprints_updater";
-  version = "2.7.4";
+  version = "2.8.1";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = "blueprints-updater";
     tag = version;
-    hash = "sha256-8vq/tU9a0faioSmy9CdJerIx1ry67B+gqdlnSNiEFGU=";
+    hash = "sha256-aqufiwH9yJmyr5Bd3Etwf5aK9dAfa7srXpBcmXDFAoY=";
   };
 
   patches = [

--- a/pkgs/servers/home-assistant/custom-components/dreo/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/dreo/package.nix
@@ -12,13 +12,13 @@
 buildHomeAssistantComponent rec {
   owner = "JeffSteinbok";
   domain = "dreo";
-  version = "1.9.14";
+  version = "1.9.16";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = "hass-dreo";
     tag = "v${version}";
-    hash = "sha256-zLt/nFb0mhiz6sI4ZoSekMWsJfQejcV8p1xd7vWoWPk=";
+    hash = "sha256-qhO0qTB5aieO1C1RrZfW9eHVDqy6QzFneqVOnMjCLag=";
   };
 
   dependencies = [ websockets ];

--- a/pkgs/servers/home-assistant/custom-components/ecoflow_ble/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/ecoflow_ble/package.nix
@@ -18,13 +18,13 @@
 buildHomeAssistantComponent rec {
   owner = "rabits";
   domain = "ef_ble";
-  version = "0.9.3";
+  version = "0.9.4";
 
   src = fetchFromGitHub {
     owner = "rabits";
     repo = "ha-ef-ble";
     tag = "v${version}";
-    hash = "sha256-MSfXSvnaVFot4JkLSZrbL3DB3MV7DvgRT8MCxv6qHlQ=";
+    hash = "sha256-OGU5PkW+H+tIPRwMWFEAMUZbJsm880HurLAdjIV0zG4=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-components/frigidaire/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/frigidaire/package.nix
@@ -7,13 +7,13 @@
 buildHomeAssistantComponent rec {
   owner = "bm1549";
   domain = "frigidaire";
-  version = "0.1.20";
+  version = "0.1.21";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = "home-assistant-frigidaire";
     tag = version;
-    hash = "sha256-XUtffkwy1HGVt41rrPl5Yk2DkYQie2FcYMoxSnzlArY=";
+    hash = "sha256-Pa1pVxP1gB/1XNqFy3U5t2xeHk+BUe6TQKtU00xcbx4=";
   };
 
   dependencies = [ frigidaire ];

--- a/pkgs/servers/home-assistant/custom-components/meshcore/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/meshcore/package.nix
@@ -14,13 +14,13 @@
 buildHomeAssistantComponent (finalAttrs: {
   owner = "meshcore-dev";
   domain = "meshcore";
-  version = "2.7.0";
+  version = "2.8.0";
 
   src = fetchFromGitHub {
     owner = "meshcore-dev";
     repo = "meshcore-ha";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-DykWjoMVVKzDa05UtytrkwUej80zteZThi8E3e7M+ZU=";
+    hash = "sha256-K1DYBcuAilcKBzQVSUQvoA9OoxUbtfISYNY8IwgUdZk=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-components/midea_ac_lan/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/midea_ac_lan/package.nix
@@ -8,13 +8,13 @@
 buildHomeAssistantComponent rec {
   owner = "wuwentao";
   domain = "midea_ac_lan";
-  version = "0.6.11";
+  version = "0.6.12";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = domain;
     tag = "v${version}";
-    hash = "sha256-s5Rk3xBVWBicKVCbPDTuwyMRaLqIG8ttGthtQtastBs=";
+    hash = "sha256-3+DCG08VZL1w4sn9igZE/ysbrPRpOn7/fPV6nZWwntY=";
   };
 
   dependencies = [ midea-local ];

--- a/pkgs/servers/home-assistant/custom-components/powercalc/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/powercalc/package.nix
@@ -2,7 +2,6 @@
   lib,
   buildHomeAssistantComponent,
   fetchFromGitHub,
-  fetchpatch,
 
   # dependencies
   numpy,
@@ -18,22 +17,14 @@
 buildHomeAssistantComponent rec {
   owner = "bramstroker";
   domain = "powercalc";
-  version = "1.20.14";
+  version = "1.21.0";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = "homeassistant-powercalc";
     tag = "v${version}";
-    hash = "sha256-Tm9h6ZHByuiM9XZz3D1TZR3ISbb16l0K1Vy8sJxI4+s=";
+    hash = "sha256-XVLemGYPuArcwek6zEZW/MS79sUWL2qbeUSTNarsZ8I=";
   };
-
-  patches = [
-    # Fix compatibility with Home-Assistant 2026.5.0
-    (fetchpatch {
-      url = "https://github.com/bramstroker/homeassistant-powercalc/commit/3d5e162954c21adfd9251c4d8e21872e66680454.patch";
-      hash = "sha256-7InjKxT8gPiR2IvLbA4oZpkgPRJbQY39SF4YNPilp4k=";
-    })
-  ];
 
   dependencies = [ numpy ];
 

--- a/pkgs/servers/home-assistant/custom-components/solax_modbus/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/solax_modbus/package.nix
@@ -8,13 +8,13 @@
 buildHomeAssistantComponent rec {
   owner = "wills106";
   domain = "solax_modbus";
-  version = "2026.06.5";
+  version = "2026.06.6";
 
   src = fetchFromGitHub {
     owner = "wills106";
     repo = "homeassistant-solax-modbus";
     tag = version;
-    hash = "sha256-FNb/3SwpJb5fPJ/qegLy6XMxHs3YQjHAjkgmL+14qMI=";
+    hash = "sha256-25JXvgcxx2DX7/obQhdlpCtMKxrZnEmpqChn/gaiRhk=";
   };
 
   dependencies = [ pymodbus ];

--- a/pkgs/servers/home-assistant/custom-components/tibber_local/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/tibber_local/package.nix
@@ -8,13 +8,13 @@
 buildHomeAssistantComponent rec {
   owner = "marq24";
   domain = "tibber_local";
-  version = "2026.5.1";
+  version = "2026.6.1";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = "ha-tibber-pulse-local";
     tag = version;
-    hash = "sha256-PjFPk/hwgpyCtjy/kRrLpDDpcGq+JwcsSA3P9NG+W/w=";
+    hash = "sha256-HalEHJg3+6D+3TXVsfdlxL3HvSqXUcaSrW1owtRPff8=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-components/tuya_local/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/tuya_local/package.nix
@@ -11,13 +11,13 @@
 buildHomeAssistantComponent rec {
   owner = "make-all";
   domain = "tuya_local";
-  version = "2026.6.1";
+  version = "2026.6.2";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = "tuya-local";
     tag = version;
-    hash = "sha256-guZEslmDKsQr/wcjLqpHNLZo1qrKqmz4i8dTlGsiL2k=";
+    hash = "sha256-4897QCslPQ/5Rt1U6EcapUav7XMa65i+5aXbMyv9mxE=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-components/waste_collection_schedule/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/waste_collection_schedule/package.nix
@@ -20,13 +20,13 @@
 buildHomeAssistantComponent rec {
   owner = "mampfes";
   domain = "waste_collection_schedule";
-  version = "2.27.0";
+  version = "2.28.0";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = "hacs_waste_collection_schedule";
     tag = "v${version}";
-    hash = "sha256-jjLebP2rkxI59JN4peTAGDBQe8/Si6xihQW8aqE1neo=";
+    hash = "sha256-fE2/nMUsAtqZMRsZyxNFvQzv1QtMxmWP52vvjqWmfJw=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/auto-entities/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/auto-entities/package.nix
@@ -6,16 +6,16 @@
 
 buildNpmPackage rec {
   pname = "auto-entities";
-  version = "2.4.1";
+  version = "2.5.0";
 
   src = fetchFromGitHub {
     owner = "Lint-Free-Technology";
     repo = "lovelace-auto-entities";
     tag = "v${version}";
-    hash = "sha256-m8rR4IqB4k3ZJAJVR6A1lzCTutDdbuWBEIBd+6xIh6Y=";
+    hash = "sha256-qKhxVLD4NbkCzpUNX5UkjEjLOMQ7ZvHHLVLTrcunTPQ=";
   };
 
-  npmDepsHash = "sha256-jQfEUWlxavD4+RsfA1vQlwtkP0uAzNVs8aC93ccQcEk=";
+  npmDepsHash = "sha256-Z+9Lp1AzrY2I+unpBxdbr9rkfcIe/dDblB3MDSd2D8w=";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/weather-radar-card/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/weather-radar-card/package.nix
@@ -7,13 +7,13 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "weather-radar-card";
-  version = "3.6.5";
+  version = "3.7.0";
 
   src = fetchFromGitHub {
     owner = "jpettitt";
     repo = "weather-radar-card";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-D+aWTcUOVkt99mdl3q1VahJKXDBIbh6RX3psYsjnTLo=";
+    hash = "sha256-ZEd27lt5S7pnGGzTnxLV6voEpzXjvRjubjmusLuISZg=";
   };
 
   npmDepsFetcherVersion = 2;

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -265,7 +265,7 @@ let
   extraBuildInputs = extraPackages python3Packages;
 
   # Don't forget to run update-component-packages.py after updating
-  hassVersion = "2026.6.3";
+  hassVersion = "2026.6.4";
 
 in
 python3Packages.buildPythonApplication rec {
@@ -286,13 +286,13 @@ python3Packages.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     tag = version;
-    hash = "sha256-I9vmwlCoxEK3o04e1x5LissX3u0fgxVOu6Uzq88e9kI=";
+    hash = "sha256-NeqJT2CW8A0VfUJ2yrR+KGmmQMK8q0Wdag43rUBBoWU=";
   };
 
   # Secondary source is pypi sdist for translations
   sdist = fetchPypi {
     inherit pname version;
-    hash = "sha256-23tqASXXrhYh1x7Qy+ZR4T7z+XKkhW0Qn6YGM2iNJOk=";
+    hash = "sha256-7Y26vN0oskJBgijtm9RZcvHw/xBEH3IsI8hezgsOVr0=";
   };
 
   build-system = with python3Packages; [

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -8,7 +8,7 @@ buildPythonPackage (finalAttrs: {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20260527.6";
+  version = "20260527.7";
   format = "wheel";
 
   src = fetchPypi {
@@ -17,7 +17,7 @@ buildPythonPackage (finalAttrs: {
     pname = "home_assistant_frontend";
     dist = "py3";
     python = "py3";
-    hash = "sha256-tvJXB+lFrlDA3eUnE5NPQwXbWn8XGggPJ9I1f9U1ddk=";
+    hash = "sha256-zYm8K3HJnAkT41S6TmGvj8V8zpt7tb4pRtWCiB9PEXw=";
   };
 
   # there is nothing to strip in this package

--- a/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
+++ b/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "pytest-homeassistant-custom-component";
-  version = "0.13.339";
+  version = "0.13.340";
   pyproject = true;
 
   disabled = pythonOlder "3.13";

--- a/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
+++ b/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     owner = "MatthewFlamm";
     repo = "pytest-homeassistant-custom-component";
     tag = version;
-    hash = "sha256-4BmtdmQyeYaOPPMDnnBNCvB0EgWcw9umC5hV4rFRTLA=";
+    hash = "sha256-08hshNdSbOJSu/uJVBeZSxksYaCSZo7KjwwyaooqNGo=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/servers/home-assistant/stubs.nix
+++ b/pkgs/servers/home-assistant/stubs.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "homeassistant-stubs";
-  version = "2026.6.3";
+  version = "2026.6.4";
   pyproject = true;
 
   disabled = python.version != home-assistant.python3Packages.python.version;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "KapJI";
     repo = "homeassistant-stubs";
     tag = version;
-    hash = "sha256-YJT0/2NJiuh7Do3gik2Rr2a1A2rMJYVEjrV6xrxF9Ww=";
+    hash = "sha256-nfBY+nXBv0ZrXXr0Be/0xttYMncx7NmMPbAbx6D00SU=";
   };
 
   build-system = [

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -139,6 +139,11 @@ let
       # https://github.com/home-assistant/core/pull/172909
       "test_upload_image_device_not_in_range"
     ];
+    teslemetry = [
+      # [2026.6.4] http://github.com/home-assistant/core/commit/a33a92982af19e682a0d0fa7bec0cb16929c00d1
+      "test_sensors"
+      "test_sensors_streaming"
+    ];
     yardian = [
       # [2026.6.1] failing snapshot
       "test_all_entities"


### PR DESCRIPTION
Diff: https://github.com/home-assistant/core/compare/2026.6.3...2026.6.4

Changelog: https://github.com/home-assistant/core/releases/tag/2026.6.4

closes https://github.com/NixOS/nixpkgs/pull/533370
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
