### PR TITLE
libressl: 4.3.1 → 4.3.2

### DIFF
--- a/pkgs/by-name/li/libressl/default.nix
+++ b/pkgs/by-name/li/libressl/default.nix
@@ -151,23 +151,10 @@ in
     ];
   };
 
-  # 4.3 was released April 2026 and will become unsupported one year after the
-  # release of OpenBSD 7.9.
+  # 4.3 was released April 2026 and will become unsupported on May 19, 2027,
+  # one year after the release of OpenBSD 7.9.
   libressl_4_3 = generic {
-    version = "4.3.1";
-    hash = "sha256-wttCrOFOfVQZgm+rNadC7G5NEnJaBRpR0M6jwQug+lA=";
-    patches = [
-      # Fix for https://github.com/libressl/portable/issues/1278, where LibreSSL
-      # 4.3 started requiring executable stack because some objects were missing
-      # a .note.GNU-stack section; will probably be included in the next release.
-      (fetchpatch {
-        url = "https://raw.githubusercontent.com/libressl/portable/4dae91d056c6c75ba5cf2bc5e6148b8e02239119/patches/gnu-stack.patch";
-        hash = "sha256-Q1oWL4N8w5Zmjfq5QkTJR53NgZ4GqChSDaBicli5G2I=";
-        # This patch is written to be applied with -p0, with no leading path
-        # component, but Nix applies with -p1 by default, so we add it to not
-        # break compatibility with how other patches must be applied.
-        decode = "sed 's|^--- |--- a/|; s|^+++ |+++ b/|'";
-      })
-    ];
+    version = "4.3.2";
+    hash = "sha256-7fAa7iTGXWnmqe/LnUS82mgv+dTzu72V55Th36kIR7U=";
   };
 }


### PR DESCRIPTION
[Release notes](https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-4.3.2-relnotes.txt)

(Reviewers, if you are approving this PR, could you please also check [this bugfix for `pkgsStatic.libressl`](https://github.com/NixOS/nixpkgs/pull/535370)?)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy]. (No AI was involved in the construction of this pull request.)

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

I also built a new new version of my webserver against this new version of LibreSSL, and it still works. In particular W^X still works.

This targets staging because 4.3 has not yet landed in master.