### PR TITLE
firefox: fix-build on musl

### DIFF
--- a/pkgs/build-support/build-mozilla-mach/default.nix
+++ b/pkgs/build-support/build-mozilla-mach/default.nix
@@ -340,6 +340,15 @@ buildStdenv.mkDerivation {
       # https://bugzilla.mozilla.org/show_bug.cgi?id=1985509
       ./140-bindgen-string-view.patch
     ]
+    ++ lib.optionals (stdenv.hostPlatform.isMusl) [
+      ./firefox-146-musl-linux-sys-prctl-conflict.patch
+      ./firefox-148-mach-clobber.patch
+      ./firefox-148-webrtc-missing-includes.patch
+      ./firefox-152-missing-cstdint-include.patch
+      ./mallinfo.patch
+      ./rust-lto-thin.patch
+      ./single-threaded-header.patch
+    ]
     ++ extraPatches;
 
   postPatch = ''

--- a/pkgs/build-support/build-mozilla-mach/firefox-146-musl-linux-sys-prctl-conflict.patch
+++ b/pkgs/build-support/build-mozilla-mach/firefox-146-musl-linux-sys-prctl-conflict.patch
@@ -1,0 +1,14 @@
+Including linux/prrctl.h and sys/prctl.h with musl results in the redifinition
+of `struct prctl_mm_map`.
+--- a/third_party/libwebrtc/rtc_base/platform_thread_types.cc
++++ b/third_party/libwebrtc/rtc_base/platform_thread_types.cc
+@@ -12,7 +12,9 @@
+ 
+ // IWYU pragma: begin_keep
+ #if defined(WEBRTC_LINUX)
++#if defined(__GLIBC__)
+ #include <linux/prctl.h>
++#endif
+ #include <sys/prctl.h>
+ #include <sys/syscall.h>
+ 

--- a/pkgs/build-support/build-mozilla-mach/firefox-148-mach-clobber.patch
+++ b/pkgs/build-support/build-mozilla-mach/firefox-148-mach-clobber.patch
@@ -1,0 +1,11 @@
+--- a/python/mozbuild/mozbuild/action/dump_env.py
++++ b/python/mozbuild/mozbuild/action/dump_env.py
+@@ -8,7 +8,7 @@
+ import os
+ import sys
+ 
+-sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
++sys.path.append(os.path.join(os.path.dirname(__file__), "../../../../testing/mozbase/mozshellutil"))
+ 
+ from mozshellutil import quote
+ 

--- a/pkgs/build-support/build-mozilla-mach/firefox-148-webrtc-missing-includes.patch
+++ b/pkgs/build-support/build-mozilla-mach/firefox-148-webrtc-missing-includes.patch
@@ -1,0 +1,10 @@
+--- a/dom/media/webrtc/libwebrtc_overrides/call/call_basic_stats.h
++++ b/dom/media/webrtc/libwebrtc_overrides/call/call_basic_stats.h
+@@ -7,6 +7,7 @@
+ #ifndef DOM_MEDIA_WEBRTC_LIBWEBRTCOVERRIDES_CALL_CALL_BASIC_STATS_H_
+ #define DOM_MEDIA_WEBRTC_LIBWEBRTCOVERRIDES_CALL_CALL_BASIC_STATS_H_
+ 
++#include <cstdint>
+ #include <optional>
+ #include <string>
+ 

--- a/pkgs/build-support/build-mozilla-mach/firefox-152-missing-cstdint-include.patch
+++ b/pkgs/build-support/build-mozilla-mach/firefox-152-missing-cstdint-include.patch
@@ -1,0 +1,10 @@
+--- a/dom/media/webaudio/blink/DenormalDisabler.h
++++ b/dom/media/webaudio/blink/DenormalDisabler.h
+@@ -29,6 +29,7 @@
+ 
+ #include <cmath>
+ #include <cstring>
++#include <cstdint>
+ 
+ namespace WebCore {
+ 

--- a/pkgs/build-support/build-mozilla-mach/mallinfo.patch
+++ b/pkgs/build-support/build-mozilla-mach/mallinfo.patch
@@ -1,0 +1,34 @@
+--- a/xpcom/base/nsMemoryReporterManager.cpp	2019-03-19 17:12:20.844810044 +0100
++++ b/xpcom/base/nsMemoryReporterManager.cpp	2019-03-19 17:13:32.505133615 +0100
+@@ -123,6 +123,7 @@
+   return GetProcSelfSmapsPrivate(aN);
+ }
+ 
++#ifdef __GLIBC__
+ #  ifdef HAVE_MALLINFO
+ #    define HAVE_SYSTEM_HEAP_REPORTER 1
+ static MOZ_MUST_USE nsresult SystemHeapSize(int64_t* aSizeOut) {
+@@ -142,6 +143,7 @@
+   return NS_OK;
+ }
+ #  endif
++#endif // __GLIBC__
+ 
+ #elif defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__) || \
+     defined(__OpenBSD__) || defined(__FreeBSD_kernel__)
+@@ -642,6 +644,7 @@
+   return NS_OK;
+ }
+ 
++#ifdef __GLIBC__
+ #  define HAVE_SYSTEM_HEAP_REPORTER 1
+ // Windows can have multiple separate heaps. During testing there were multiple
+ // heaps present but the non-default ones had sizes no more than a few 10s of
+@@ -698,6 +701,7 @@
+   *aSizeOut = heapsSize;
+   return NS_OK;
+ }
++#endif // __GLIBC__
+ 
+ struct SegmentKind {
+   DWORD mState;

--- a/pkgs/build-support/build-mozilla-mach/rust-lto-thin.patch
+++ b/pkgs/build-support/build-mozilla-mach/rust-lto-thin.patch
@@ -1,0 +1,12 @@
+set rust crate lto to thin to not use fatlto for gkrust which fails sometimes
+--- a/config/makefiles/rust.mk
++++ b/config/makefiles/rust.mk
+@@ -92,7 +92,7 @@
+ # Never enable when coverage is enabled to work around https://github.com/rust-lang/rust/issues/90045.
+ ifndef MOZ_CODE_COVERAGE
+ ifeq (,$(findstring gkrust_gtest,$(RUST_LIBRARY_FILE)))
+-cargo_rustc_flags += -Clto$(if $(filter full,$(MOZ_LTO_RUST_CROSS)),=fat)
++cargo_rustc_flags += -Clto=thin
+ endif
+ # We need -Cembed-bitcode=yes for all crates when using -Clto.
+ RUSTFLAGS += -Cembed-bitcode=yes

--- a/pkgs/build-support/build-mozilla-mach/single-threaded-header.patch
+++ b/pkgs/build-support/build-mozilla-mach/single-threaded-header.patch
@@ -1,0 +1,12 @@
+diff --git a/config/system-headers.mozbuild b/config/system-headers.mozbuild
+index 361455ba5c..81f60c5973 100644
+--- a/config/system-headers.mozbuild
++++ b/config/system-headers.mozbuild
+@@ -857,7 +857,6 @@ system_headers = [
+     "sys/shm.h",
+     "sys/siginfo.h",
+     "sys/signal.h",
+-    "sys/single_threaded.h",
+     "sys/socket.h",
+     "sys/sockio.h",
+     "sys/sparc/frame.h",


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR fixes the firefox build on musl (exciting I know), by adding 7 patches. 6 from [Void repos](https://github.com/void-linux/void-packages/tree/master/srcpkgs/firefox/patches), and 1 from me, so massive thanks to them :)

Not going to set as draft as this is mergeable in its current state, but maybe people will have different ideas on where to put the patches or how to apply them or whatnot. Since they're from void they SHOULD work on both glibc and musl but I haven't tested a glibc build, hence the condition.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
