### PR TITLE
nbfc-linux: 0.3.19 -> 0.5.2

### DIFF
--- a/pkgs/by-name/nb/nbfc-linux/package.nix
+++ b/pkgs/by-name/nb/nbfc-linux/package.nix
@@ -3,29 +3,46 @@
   stdenv,
   fetchFromGitHub,
   autoreconfHook,
+  pkg-config,
+  lua5_4,
   curl,
+  libxml2,
+  openssl,
+  nix-update-script,
+  versionCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nbfc-linux";
-  version = "0.3.19";
+  version = "0.5.2";
 
   src = fetchFromGitHub {
     owner = "nbfc-linux";
     repo = "nbfc-linux";
     tag = finalAttrs.version;
-    hash = "sha256-ARUhm1K3A0bzVRen6VO3KvomkPl1S7vx2+tmg2ZtL8s=";
+    hash = "sha256-468/dFRjEgyJ0AW98wKq04WKZ4sZyzswBASSF6hyjVY=";
   };
 
-  nativeBuildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
 
-  buildInputs = [ curl ];
+  buildInputs = [
+    lua5_4
+    curl
+    libxml2
+    openssl
+  ];
 
   configureFlags = [
-    "--prefix=${placeholder "out"}"
-    "--sysconfdir=${placeholder "out"}/etc"
     "--bindir=${placeholder "out"}/bin"
   ];
+
+  passthru.updateScript = nix-update-script { };
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "C port of Stefan Hirschmann's NoteBook FanControl";
@@ -33,8 +50,11 @@ stdenv.mkDerivation (finalAttrs: {
       nbfc-linux provides fan control service for notebooks
     '';
     homepage = "https://github.com/nbfc-linux/nbfc-linux";
-    license = lib.licenses.gpl3;
-    maintainers = [ lib.maintainers.Celibistrial ];
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      Celibistrial
+      bohanubis
+    ];
     mainProgram = "nbfc";
     platforms = lib.platforms.linux;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
https://github.com/nbfc-linux/nbfc-linux/releases/tag/0.5.2
I guess this is the release notes
yay an update after more than one year
mentining the original maintainer: @Celibistrial 
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
