### PR TITLE
python3Packages.stanza: 1.12.2 -> 1.13.0

### DIFF
--- a/pkgs/development/python-modules/stanza/default.nix
+++ b/pkgs/development/python-modules/stanza/default.nix
@@ -6,6 +6,7 @@
   setuptools,
   # dependencies
   emoji,
+  huggingface-hub,
   networkx,
   numpy,
   peft,
@@ -20,20 +21,21 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "stanza";
-  version = "1.12.2";
+  version = "1.13.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "stanfordnlp";
     repo = "stanza";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-hUI8sZDwBK8ZRS9asyDiTqpoIGnGbHeH/Q9i/gasut0=";
+    hash = "sha256-+quLNaxaGCUpsg3PH11nEMeKjIoHsKaBqK4FdIHlaMM=";
   };
 
   build-system = [ setuptools ];
 
   dependencies = [
     emoji
+    huggingface-hub
     networkx
     numpy
     peft


### PR DESCRIPTION
Changelog: https://github.com/stanfordnlp/stanza/releases/tag/v1.13.0

This release uses huggingface-hub to download models instead of downloading them over HTTP with the requests library, hence the new dependency (note: huggingface-hub is already a transitive dependency of this package via peft).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Tested by translating with argostranslate. I've verified that the new huggingface-hub works (and now bugs me about setting HF_TOKEN... but oh well).

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test