### PR TITLE
zk: update homepage link

### DIFF
--- a/pkgs/by-name/zk/zk/package.nix
+++ b/pkgs/by-name/zk/zk/package.nix
@@ -37,7 +37,7 @@ buildGoModule (finalAttrs: {
     maintainers = with lib.maintainers; [ pinpox ];
     license = lib.licenses.gpl3;
     description = "Zettelkasten plain text note-taking assistant";
-    homepage = "https://github.com/mickael-menu/zk";
+    homepage = "https://github.com/zk-org/zk";
     mainProgram = "zk";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Update the homepage link to [zk](https://github.com/zk-org/zk). You can see in https://github.com/NixOS/nixpkgs/commit/3dfc7246ccda0290c905d1a9f9d98b1364791651 that the owner for the github repo was updated correctly, but not in the metadata.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
