### PR TITLE
Katifetch init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -30234,6 +30234,12 @@
     githubId = 16359093;
     name = "Xinyang Li";
   };
+  ximimoments = {
+    name = "Valentino Martinez Ferreira";
+    github = "ximimoments";
+    githubId = 161499192;
+    email = "ximimoments3232@hotmail.com";
+  };
   xiorcale = {
     email = "quentin.vaucher@pm.me";
     github = "xiorcale";

--- a/pkgs/by-name/ka/katifetch/package.nix
+++ b/pkgs/by-name/ka/katifetch/package.nix
@@ -1,0 +1,43 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeWrapper
+, bash
+}:
+
+stdenv.mkDerivation rec {
+  pname = "katifetch";
+  version = "13.1";
+
+  src = fetchFromGitHub {
+    owner = "ximimoments";
+    repo = "katifetch";
+    rev = "main";
+    sha256 = "sha256-Vboo0sGqywGNFxr4n++LOPX2gtXiXE/16oA0UFMRF0c=";
+  };
+
+  # Use makeWrapper to create a reliable entry point
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/katifetch
+    
+    # Copy all files to the share directory
+    cp -r . $out/share/katifetch/
+    
+    # Ensure the main script is executable
+    chmod +x $out/share/katifetch/katifetch.sh
+    
+    # Create the binary using makeWrapper
+    makeWrapper ${bash}/bin/bash $out/bin/katifetch \
+      --run "cd $out/share/katifetch && ./katifetch.sh"
+  '';
+
+  meta = with lib; {
+    description = "A custom fetch script";
+    homepage = "https://github.com/ximimoments/katifetch";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ ximimoments ];
+  };
+}


### PR DESCRIPTION
katifetch: init at 13.1

## Things done

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
  - [x] Tested basic functionality of all binary files, usually in ./result/bin/.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Katifetch is a lightweight, bash-based system fetch script that displays hardware and software information.
Homepage: https://github.com/ximimoments/katifetch