### PR TITLE
python3Packages.sse-starlette: add missing dependency, fix cross

### DIFF
--- a/pkgs/development/python-modules/sse-starlette/default.nix
+++ b/pkgs/development/python-modules/sse-starlette/default.nix
@@ -38,6 +38,7 @@ buildPythonPackage rec {
 
   dependencies = [
     anyio
+    starlette
   ];
 
   optional-dependencies = {
@@ -46,7 +47,6 @@ buildPythonPackage rec {
       aiosqlite
       fastapi
       sqlalchemy
-      starlette
       uvicorn
     ]
     ++ sqlalchemy.optional-dependencies.asyncio;


### PR DESCRIPTION
fixes `nix-build -A pkgsCross.aarch64-multiplatform.python3Packages.sse-starlette`, which would previously fail:

> Checking runtime dependencies for sse_starlette-3.2.0-py3-none-any.whl
>   - starlette not installed

In fact, non-cross builds would fail at runtime:

```
$ nix-build --expr 'with import ./. {}; python3.withPackages (ps: [ ps.sse-starlette])'
/nix/store/6v6l4jwpgy2zgd1cwnrgcm2mxlaxiyka-python3-3.13.13-env
$ ./result/bin/python
>>> import sse_starlette
Traceback (most recent call last):
  File "<python-input-0>", line 1, in <module>
    import sse_starlette
  File "/nix/store/6v6l4jwpgy2zgd1cwnrgcm2mxlaxiyka-python3-3.13.13-env/lib/python3.13/site-packages/sse_starlette/__init__.py", line 2, in <module>
    from sse_starlette.sse import EventSourceResponse
  File "/nix/store/6v6l4jwpgy2zgd1cwnrgcm2mxlaxiyka-python3-3.13.13-env/lib/python3.13/site-packages/sse_starlette/sse.py", line 21, in <module>
    from starlette.background import BackgroundTask
ModuleNotFoundError: No module named 'starlette'
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
