### PR TITLE
zix: 0.6.2 -> 0.8.2, adopt, modernize

### DIFF
--- a/pkgs/by-name/zi/zix/package.nix
+++ b/pkgs/by-name/zi/zix/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "zix";
-  version = "0.6.2";
+  version = "0.8.2";
 
   src = fetchFromGitLab {
     owner = "drobilla";
     repo = "zix";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-1fdW014QKvTYHaEmDsivUVPzF/vZgnW3Srk6edp6G1o=";
+    hash = "sha256-EfljHq73FA5llX2nnr6pn75nB/FbKnWvr3/Phl5716M=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/zi/zix/package.nix
+++ b/pkgs/by-name/zi/zix/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitLab {
     owner = "drobilla";
     repo = "zix";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-EfljHq73FA5llX2nnr6pn75nB/FbKnWvr3/Phl5716M=";
   };
 

--- a/pkgs/by-name/zi/zix/package.nix
+++ b/pkgs/by-name/zi/zix/package.nix
@@ -37,6 +37,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://gitlab.com/drobilla/zix/-/blob/${finalAttrs.src.rev}/NEWS";
     license = lib.licenses.isc;
     platforms = lib.platforms.unix;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ qweered ];
   };
 })


### PR DESCRIPTION
Closes #491374

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
