### PR TITLE
sabiql: init at 1.13.0

### DIFF
--- a/pkgs/by-name/sa/sabiql/package.nix
+++ b/pkgs/by-name/sa/sabiql/package.nix
@@ -1,0 +1,60 @@
+{
+  fetchFromGitHub,
+  lib,
+  stdenv,
+  rustPlatform,
+  rustc,
+  graphviz,
+  postgresql,
+  xdg-utils,
+  makeBinaryWrapper,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "sabiql";
+  version = "1.13.0";
+
+  src = fetchFromGitHub {
+    owner = "riii111";
+    repo = "sabiql";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-HDaiCLu1L2aQ+9swQWWPzb9MWqI44ECf71KyhI43emk=";
+  };
+
+  cargoHash = "sha256-5o68x2pOe4ArDzPJmGI9ooqRgs8rEReSFnpT8TKItl4=";
+
+  # Upstream use latest rust version need to patch use nixpkgs version
+  postPatch = ''
+    sed -i 's/rust-version\s*=\s*".*"/rust-version = "${rustc.version}"/' Cargo.toml
+  '';
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+  ];
+
+  postInstall =
+    let
+      runtimePathDeps = [
+        graphviz
+        postgresql
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isLinux [ xdg-utils ];
+    in
+    ''
+      wrapProgram $out/bin/sabiql \
+        --prefix PATH : ${lib.makeBinPath runtimePathDeps}
+    '';
+
+  passthru.updateScript = nix-update-script { };
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Fast PostgreSQL TUI written in Rust. driver-less, vim-first, with ER diagrams. No database drivers, no setup, just psql";
+    mainProgram = "sabiql";
+    homepage = "https://github.com/riii111/sabiql";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ theeasternfurry ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
