### PR TITLE
authentik: 2025.12.5 -> 2025.12.6

### DIFF
--- a/pkgs/by-name/au/authentik/package.nix
+++ b/pkgs/by-name/au/authentik/package.nix
@@ -20,13 +20,13 @@
 let
   nodejs = nodejs_24;
 
-  version = "2025.12.5";
+  version = "2025.12.6";
 
   src = fetchFromGitHub {
     owner = "goauthentik";
     repo = "authentik";
     tag = "version/${version}";
-    hash = "sha256-LPGAhbtmuztDQ4CVhUXb+vBU5HjvNZ7JicI5r3lr1QQ=";
+    hash = "sha256-uIg47z4LaCawF/5ir4mKE6DpDnEpQ8DuObCNaq6TcYk=";
   };
 
   meta = {
@@ -137,8 +137,8 @@ let
 
     outputHash =
       {
-        "aarch64-linux" = "sha256-smm9x29z7gOI7Wq0NvP45KHtBbT6p1lH6IjEf9LRuGs=";
-        "x86_64-linux" = "sha256-K86wnn50svP+QG3i0mggH8RQgfoIqEmyQTouz35xzw8=";
+        "aarch64-linux" = "sha256-EbLneRDCyLLLBOZ2DUDpf2TbZoTL8QMXP4WlAZEzS90=";
+        "x86_64-linux" = "sha256-yDjwN/+lX2i9WYDXq4yWwf9o8nA4342iHDDQH4Jt7eQ=";
       }
       .${stdenvNoCC.hostPlatform.system} or (throw "authentik-website-deps: unsupported host platform");
 


### PR DESCRIPTION
Diff: https://github.com/goauthentik/authentik/compare/version/2025.12.5...version/2025.12.6

Changelog: https://github.com/goauthentik/authentik/releases/tag/version%2F2025.12.6

fixes https://github.com/NixOS/nixpkgs/issues/527437
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
