### PR TITLE
niri: add libXcursor and libXi to buildInputs

### DIFF
--- a/pkgs/by-name/ni/niri/package.nix
+++ b/pkgs/by-name/ni/niri/package.nix
@@ -9,6 +9,8 @@
   libinput,
   libxkbcommon,
   libgbm,
+  libxcursor,
+  libxi,
   versionCheckHook,
   nix-update-script,
   pango,
@@ -63,6 +65,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     libinput
     libxkbcommon
     libgbm
+    libxcursor
+    libxi
     pango
     seatd
     wayland # For libwayland-client


### PR DESCRIPTION
niri: add libXcursor and libXi to buildInputs

After upgrading to version `26.04`, `niri` panics on startup due to a missing runtime dependency libXcursor and libXi.

This PR fixes the crash by adding `libXcursor` and `libXi` to `buildInputs`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test