### PR TITLE
hypr-relay: init at 0.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12459,6 +12459,12 @@
     githubId = 1982341;
     name = "Jack Cummings";
   };
+  jcvega = {
+    email = "jcvega0b1@gmail.com";
+    github = "Vega-0b1";
+    githubId = 24194859;
+    name = "jcvega";
+  };
   jdagilliland = {
     email = "jdagilliland@gmail.com";
     github = "jdagilliland";

--- a/pkgs/by-name/hy/hypr-relay/package.nix
+++ b/pkgs/by-name/hy/hypr-relay/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage {
+  __structuredAttrs = true;
+
+  pname = "hypr-relay";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "Vega-0b1";
+    repo = "hypr-relay";
+    rev = "v0.3.0";
+    hash = "sha256-IYiUwekQS6cSZ/S/jy6IOmPQOhMRlJpPF5aDS7autXg=";
+  };
+
+  cargoHash = "sha256-IsTS6OZmGCWFIwl70HOa1f+dEiqriWbAKmvHJ4fSRYg=";
+
+  meta = {
+    description = "Lightweight daemon for Hyprland that bridges system events to desktop notifications";
+    homepage = "https://github.com/Vega-0b1/hypr-relay";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jcvega ];
+    mainProgram = "hypr-relay";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--

^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adding hypr-relay, a small daemon I wrote for Hyprland that sends desktop notifications for workspace switches, Bluetooth connections, volume changes, and brightness adjustments via D-Bus.

https://github.com/Vega-0b1/hypr-relay

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

AI tools were used to assist in writing the Nix derivation and PR description. The upstream package was written by the maintainer.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
