### PR TITLE
cvise: fix tarball hash

### DIFF
--- a/pkgs/development/tools/misc/cvise/default.nix
+++ b/pkgs/development/tools/misc/cvise/default.nix
@@ -21,7 +21,7 @@ python3Packages.buildPythonApplication rec {
     owner = "marxin";
     repo = "cvise";
     tag = "v${version}";
-    hash = "sha256-UaWOHjgTiSVvpKKw6VFAeRAYkYp4y0Dnamzr7yhH0vQ=";
+    hash = "sha256-ObnhFe7hAKUoUxNJ+9jo0Q4AE6jQqDgI1Ta/jsumqpI=";
   };
 
   patches = [


### PR DESCRIPTION
Without the change the re-fetch of original source fails as:

```
$ nix build --no-link -f. cvise.src --rebuild
error: hash mismatch in fixed-output derivation '/nix/store/rd0vycm33x3hfwsa6iljj1229f9035am-source.drv':
         specified: sha256-UaWOHjgTiSVvpKKw6VFAeRAYkYp4y0Dnamzr7yhH0vQ=
            got:    sha256-ObnhFe7hAKUoUxNJ+9jo0Q4AE6jQqDgI1Ta/jsumqpI=
```

This happens because the `github` tarball generation is dependent on abbreviated hash length of `cvise` source:

```
$ diffoscope before/ after/
--- before/
+++ after/
│   --- before/CMakeLists.txt
├── +++ after/CMakeLists.txt
│ @@ -84,15 +84,15 @@
│
│  # Determine the short git hash for the source tree.
│  #
│  ## METHOD 1: The source tree is the result of `git archive'.
│  # `git archive' inserts the abbreviated hash of the archive's commit into this
│  # file.  (See the `.gitattributes' file.)
│  #
│ -set(GIT_HASH "2d0889e7")
│ +set(GIT_HASH "2d0889e73")
```

Intially noticed the hash instability when enabled `config.fetchedSourceNameDefault` locally. Ideally the upstream tarball should be fixed by https://github.com/marxin/cvise/pull/506. Meanwhile let's update the hash.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
