### PR TITLE
elmPackages.elm-wrap: init at 1.0.1

### DIFF
--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -69,6 +69,8 @@ lib.makeScope pkgs.newScope (
       elm-xref = callPackage ./packages/elm-xref { };
 
       lamdera = callPackage ./packages/lamdera { };
+
+      elm-wrap = callPackage ./packages/elm-wrap { };
     }
     // lib.optionalAttrs config.allowAliases {
       create-elm-app = throw "'elmPackages.create-elm-app' has not had a release since December 2020, so it was removed."; # Added 2025-11-15

--- a/pkgs/development/compilers/elm/packages/elm-wrap/default.nix
+++ b/pkgs/development/compilers/elm/packages/elm-wrap/default.nix
@@ -1,0 +1,50 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  hostname,
+  rsync,
+  zip,
+  curl,
+  python3,
+  lib,
+}:
+stdenv.mkDerivation rec {
+  name = "elm-wrap";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "dsimunic";
+    repo = "elm-wrap";
+    tag = "v${version}";
+    hash = "sha256-n7wX2jP4sX2LYiiFKOIyrEw5B4eJB9Bp2JD4qpp9Kmw=";
+  };
+
+  nativeBuildInputs = [
+    hostname
+    rsync
+    zip
+  ];
+
+  buildInputs = [
+    curl
+  ];
+
+  nativeCheckInputs = [
+    python3
+  ];
+
+  doCheck = true;
+  checkPhase = "make test";
+
+  buildFlags = [ "RELEASE_VERSION=1" ];
+  installFlags = [ "PREFIX=$(out)" ];
+
+  meta = {
+    changelog = "https://github.com/dsimunic/elm-wrap/blob/${version}/CHANGELOG.md";
+    description = "This utility is a comprehensive package management solution for Elm programming language packages and code. It wraps Elm compiler and intercepts its package management commands like install to augment them with support for custom package registries and policies.";
+    homepage = "https://elm-wrap.dev/";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ turbomack ];
+    mainProgram = "wrap";
+  };
+}


### PR DESCRIPTION
Add elmPackages.elm-wrap

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
