### PR TITLE
smartgit: 24.1.5 -> 26.1.038

### DIFF
--- a/pkgs/by-name/sm/smartgit/package.nix
+++ b/pkgs/by-name/sm/smartgit/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  git,
   stdenv,
   fetchurl,
   makeDesktopItem,
@@ -16,13 +17,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "smartgit";
-  version = "24.1.5";
+  version = "26.1.038";
 
   src = fetchurl {
-    url = "https://www.syntevo.com/downloads/smartgit/smartgit-linux-${
+    url = "https://download.smartgit.dev/smartgit/smartgit-${
       builtins.replaceStrings [ "." ] [ "_" ] finalAttrs.version
-    }.tar.gz";
-    hash = "sha256-YqueTbwA9KcXEJG5TeWkPzzNyAnnJQ1+VQYsqZKS2/I=";
+    }-no-git-linux-amd64.tar.gz";
+    hash = "sha256-XyMdojfyaTS3S3felGRvOOazx1mym/wE3j4GyCU9crc=";
   };
 
   nativeBuildInputs = [ wrapGAppsHook3 ];
@@ -37,6 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     gappsWrapperArgs+=( \
       --prefix PATH : ${
         lib.makeBinPath [
+          git
           jre
           which
         ]
@@ -103,11 +105,11 @@ stdenv.mkDerivation (finalAttrs: {
       SmartGit is a multi-platform Git GUI client, free to use for active Open Source developers and users from academic institutions.
       Command line Git is required.
     '';
-    homepage = "https://www.syntevo.com/smartgit/";
-    changelog = "https://www.syntevo.com/smartgit/changelog-${lib.versions.majorMinor finalAttrs.version}.txt";
+    homepage = "https://www.smartgit.dev/";
+    changelog = "https://www.smartgit.dev/changelogs/changelog-${lib.versions.majorMinor finalAttrs.version}.txt";
     license = lib.licenses.unfree;
     mainProgram = "smartgit";
-    platforms = lib.platforms.linux;
+    platforms = [ "x86_64-linux" ];
     maintainers = with lib.maintainers; [
       jraygauthier
       tmssngr


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelogs:
https://www.smartgit.dev/changelogs/changelog-24.1.txt
https://www.smartgit.dev/changelogs/changelog-25.1.txt
https://www.smartgit.dev/changelogs/changelog-26.1.txt

Version 24.1.5 has expired for non-commercial use and doesn't launch anymore, so I updated it to the current version on their new site.

It also seems they don't support aarch64-linux anymore so I changed the platform to just x86_64-linux.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
