### PR TITLE
intel_fw: init at 0.1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14041,6 +14041,12 @@
     email = "nixos@karpfen.dev";
     matrix = "@karpfen:matrix.org";
   };
+  karui = {
+    name = "Karui Hoshimiya";
+    email = "git@second2050.me";
+    github = "second2050";
+    githubId = 37344371;
+  };
   kashw2 = {
     email = "supra4keanu@hotmail.com";
     github = "kashw2";

--- a/pkgs/by-name/in/intel_fw/package.nix
+++ b/pkgs/by-name/in/intel_fw/package.nix
@@ -1,0 +1,34 @@
+{
+  fetchFromGitHub,
+  lib,
+  rustPlatform,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "intel_fw";
+  version = "0.1.2";
+  src = fetchFromGitHub {
+    owner = "platform-system-interface";
+    repo = "intel_fw";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-eOJDbRwq4ilbRSmfKfZ95qyUvnPYZrwt+BhGCzij2R8=";
+  };
+  __structuredAttrs = true;
+
+  cargoHash = "sha256-PLqvgG8qasbuE15EuiDlFaaU6Jm0UnODspCW1OZrE/I=";
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Modern Intel Firmware Tool and Library";
+    homepage = "https://platform-system-interface.github.io/intel_fw/";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [
+      karui
+    ];
+    platforms = lib.platforms.all;
+    mainProgram = "intel_fw";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
