### PR TITLE
libjxl, jpegli: Fix file conflicts when installed together (proper split outputs)

### DIFF
--- a/pkgs/by-name/jp/jpegli/package.nix
+++ b/pkgs/by-name/jp/jpegli/package.nix
@@ -31,7 +31,10 @@ stdenv.mkDerivation {
 
   outputs = [
     "out"
+    "bin"
+    "dev"
     "man"
+    "benchmark"
   ];
 
   strictDeps = true;
@@ -69,6 +72,12 @@ stdenv.mkDerivation {
     (lib.cmakeBool "JPEGXL_ENABLE_AVX512_ZEN4" true)
     (lib.cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.5")
   ];
+
+  # Move `benchmark_xl` into a separate output to avoid a file collision
+  # with the `benchmark_xl` binary provided by `libjxl`.
+  postInstall = ''
+    moveToOutput "bin/benchmark_xl" "$benchmark"
+  '';
 
   doCheck = true;
 

--- a/pkgs/by-name/li/libjxl/package.nix
+++ b/pkgs/by-name/li/libjxl/package.nix
@@ -35,7 +35,9 @@ stdenv.mkDerivation rec {
 
   outputs = [
     "out"
+    "bin"
     "dev"
+    "benchmark"
   ];
 
   src = fetchFromGitHub {
@@ -150,18 +152,22 @@ stdenv.mkDerivation rec {
       --replace 'sh$' 'sh( -e$|$)'
   '';
 
-  postInstall =
-    lib.optionalString enablePlugins ''
-      GDK_PIXBUF_MODULEDIR="$out/${gdk-pixbuf.moduleDir}" \
-      GDK_PIXBUF_MODULE_FILE="$out/${loadersPath}" \
-        gdk-pixbuf-query-loaders --update-cache
-    ''
-    # Cross-compiled gdk-pixbuf doesn't support thumbnailers
-    + lib.optionalString (enablePlugins && stdenv.hostPlatform == stdenv.buildPlatform) ''
-      mkdir -p "$out/bin"
-      makeWrapper ${gdk-pixbuf}/bin/gdk-pixbuf-thumbnailer "$out/libexec/gdk-pixbuf-thumbnailer-jxl" \
-        --set GDK_PIXBUF_MODULE_FILE "$out/${loadersPath}"
-    '';
+  # Move `benchmark_xl` into a separate output to avoid a file collision
+  # with the `benchmark_xl` binary provided by `jpegli`.
+  postInstall = ''
+    moveToOutput "bin/benchmark_xl" "$benchmark"
+  ''
+  + lib.optionalString enablePlugins ''
+    GDK_PIXBUF_MODULEDIR="$out/${gdk-pixbuf.moduleDir}" \
+    GDK_PIXBUF_MODULE_FILE="$out/${loadersPath}" \
+      gdk-pixbuf-query-loaders --update-cache
+  ''
+  # Cross-compiled gdk-pixbuf doesn't support thumbnailers
+  + lib.optionalString (enablePlugins && stdenv.hostPlatform == stdenv.buildPlatform) ''
+    mkdir -p "$out/bin"
+    makeWrapper ${gdk-pixbuf}/bin/gdk-pixbuf-thumbnailer "$out/libexec/gdk-pixbuf-thumbnailer-jxl" \
+      --set GDK_PIXBUF_MODULE_FILE "$out/${loadersPath}"
+  '';
 
   env = lib.optionalAttrs stdenv.hostPlatform.isAarch32 {
     CXXFLAGS = "-mfp16-format=ieee";


### PR DESCRIPTION
Fixes #3459.

Done by moving the benchmarks and library files to separate outputs so one can reference only `.bin` in `systemPackages`, avoiding the overlapping names:

    bin/benchmark_xl
    lib/libjxl_cms.so
    lib/libjxl_threads.so
    lib/libjxl_extras_codec.a

For jpegli, a `dev` output also needed to be added to remove a cyclic reference (from `out` to `bin`):
With a `bin` output newly present, the nixpkgs `multiple-outputs` hook emits `nix-support/propagated-build-inputs` (which lists the `bin` output) as development metadata. Without a `dev` output this lands in `out`, creating an `out -> bin -> out` reference cycle (`bin` links the runtime libs in `out`).
Example of what was in `bin`'s `nix-support/propagated-build-inputs`:

    /nix/store/99f61f783cd29k1gmr7hrxjnb4v584jn-jpegli-0-unstable-2026-04-30-bin /nix/store/320lmb4fnd2x5alv9hlpdlgz73aj8f26-jpegli-0-unstable-2026-04-30

Creating `dev` moves `nix-support` there, breaking the cycle and matching the `libjxl` output layout.

Assisted-By: Claude Opus 4.8 in Zoo Code


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
