### PR TITLE
emacsPackages.ghostel: fix Darwin build

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/ghostel/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/ghostel/package.nix
@@ -48,8 +48,17 @@ let
     zigBuildFlags = finalAttrs.zigCheckFlags;
 
     postConfigure = ''
-      cp -rLT ${finalAttrs.deps} "$ZIG_GLOBAL_CACHE_DIR/p"
-      chmod -R u+w "$ZIG_GLOBAL_CACHE_DIR/p"
+        cp -rLT ${finalAttrs.deps} "$ZIG_GLOBAL_CACHE_DIR/p"
+        chmod -R u+w "$ZIG_GLOBAL_CACHE_DIR/p"
+
+        # Ghostel only consumes Ghostty's libghostty-vt module.  Ghostty's build
+        # still eagerly initializes disabled benchmark artifacts, which probes the
+        # native Darwin SDK and fails in the Nix sandbox with DarwinSdkNotFound.
+        substituteInPlace "$ZIG_GLOBAL_CACHE_DIR"/p/ghostty-*/build.zig \
+          --replace-fail '    const bench = try buildpkg.GhosttyBench.init(b, &deps);' '    if (config.emit_bench) {
+          const bench = try buildpkg.GhosttyBench.init(b, &deps);' \
+          --replace-fail '    if (config.emit_bench) bench.install();' '        bench.install();
+      }'
     '';
   });
 


### PR DESCRIPTION
## Summary

Fix `emacsPackages.ghostel.passthru.module` on Darwin by avoiding eager initialization of Ghostty benchmark artifacts when Ghostel only consumes Ghostty's `libghostty-vt` module.

Ghostty's dependency build currently initializes `GhosttyBench` even when `config.emit_bench` is false. On Darwin this goes through `SharedDeps.add`, calls `std.zig.LibCInstallation.findNative`, and fails in the Nix sandbox with `DarwinSdkNotFound`.

Ghostel builds only the native Emacs module against `ghostty-vt`; benchmark artifacts are not emitted. This patch narrows the vendored Ghostty build initialization so `GhosttyBench` is constructed only when `emit_bench` is enabled.

Fixes #515993.

## Testing

On `aarch64-darwin`:

- Before patch: `nix build --no-link .#emacsPackages.ghostel.passthru.module` failed with `DarwinSdkNotFound` from `GhosttyBench.init -> SharedDeps.add`.
- After patch: `nix build --no-link .#emacsPackages.ghostel.passthru.module`
- After patch: `nix build --no-link .#emacsPackages.ghostel`
