### PR TITLE
flameshot: 13.3.0 -> 14.0.0

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -58,6 +58,8 @@
 
 - `rebuilderd` has been updated to 0.27.0 introducing breaking changes. See upstream changelog for details: [0.26.0](https://github.com/kpcyrd/rebuilderd/releases/tag/v0.26.0), [0.27.0](https://github.com/kpcyrd/rebuilderd/releases/tag/v0.27.0)
 
+- Starting with v14, `flameshot` will primarily utilise xdg-desktop-portal calls for screenshotting. This will directly affect users on X11 window managers due to the lack of a compatible portal with Screenshot feature. See [upstream changelog](https://github.com/flameshot-org/flameshot/releases/tag/v14.0.0) or [NixOS Flameshot](https://wiki.nixos.org/wiki/Flameshot) wiki page for workarounds.
+
 ## Other Notable Changes {#sec-nixpkgs-release-26.11-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/pkgs/by-name/fl/flameshot/load-missing-deps.patch
+++ b/pkgs/by-name/fl/flameshot/load-missing-deps.patch
@@ -1,46 +1,46 @@
---- a/CMakeLists.txt	2025-08-21 13:12:55
-+++ b/CMakeLists.txt	2025-08-21 13:16:26
-@@ -24,28 +24,8 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -35,27 +35,7 @@
  #Needed due to linker error with QtColorWidget
  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
-+find_package(QtColorWidgets REQUIRED)
  
+-
 -# Dependency can be fetched via flatpak builder
 -if(EXISTS "${CMAKE_SOURCE_DIR}/external/Qt-Color-Widgets/CMakeLists.txt")
--    add_subdirectory("${CMAKE_SOURCE_DIR}/external/Qt-Color-Widgets" EXCLUDE_FROM_ALL)
+-  add_subdirectory("${CMAKE_SOURCE_DIR}/external/Qt-Color-Widgets" EXCLUDE_FROM_ALL)
 -else()
--    FetchContent_Declare(
--        qtColorWidgets
--        GIT_REPOSITORY https://gitlab.com/mattbas/Qt-Color-Widgets.git
--        GIT_TAG 352bc8f99bf2174d5724ee70623427aa31ddc26a
--    )
+-  FetchContent_Declare(
+-    qtColorWidgets
+-    GIT_REPOSITORY https://gitlab.com/mattbas/Qt-Color-Widgets.git
+-    GIT_TAG 5d52e907e50dc88cf969b41cea44665ff6c475b1
+-  )
 -  #Workaround for duplicate GUID in windows WIX installer
--  if (WIN32)
--      FetchContent_GetProperties(qtColorWidgets)
--      if(NOT qtcolorwidgets_POPULATED)
--          FetchContent_Populate(qtColorWidgets)
--          add_subdirectory(${qtcolorwidgets_SOURCE_DIR} ${qtcolorwidgets_BINARY_DIR} EXCLUDE_FROM_ALL)
--      endif()
+-  if(WIN32)
+-    FetchContent_GetProperties(qtColorWidgets)
+-    if(NOT qtcolorwidgets_POPULATED)
+-      FetchContent_Populate(qtColorWidgets)
+-      add_subdirectory(${qtcolorwidgets_SOURCE_DIR} ${qtcolorwidgets_BINARY_DIR} EXCLUDE_FROM_ALL)
+-    endif()
 -  else()
--      FetchContent_MakeAvailable(qtColorWidgets)
+-    FetchContent_MakeAvailable(qtColorWidgets)
 -  endif()
 -endif()
--
++find_package(QtColorWidgets REQUIRED)
+ 
  # This can be read from ${PROJECT_NAME} after project() is called
- if (APPLE)
-   set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum OS X deployment version")
-@@ -133,12 +113,7 @@
+ if(APPLE)
+@@ -124,12 +104,7 @@
+ # ToDo: Check if this is used anywhere
  option(BUILD_STATIC_LIBS ON)
-
- if (APPLE)
+ 
+ if(WIN32 OR APPLE)
 -  FetchContent_Declare(
--      qHotKey
--      GIT_REPOSITORY https://github.com/flameshot-org/QHotkey
--      GIT_TAG master
+-    qHotKey
+-    GIT_REPOSITORY https://github.com/flameshot-org/QHotkey
+-    GIT_TAG master
 -  )
 -  FetchContent_MakeAvailable(QHotKey)
 +  find_package(QHotKey REQUIRED)
  endif()
-
+ 
  add_subdirectory(src)

--- a/pkgs/by-name/fl/flameshot/package.nix
+++ b/pkgs/by-name/fl/flameshot/package.nix
@@ -19,13 +19,13 @@ assert stdenv.hostPlatform.isDarwin -> (!enableWlrSupport);
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "flameshot";
-  version = "13.3.0";
+  version = "14.0.0";
 
   src = fetchFromGitHub {
     owner = "flameshot-org";
     repo = "flameshot";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-RyoLniRmJRinLUwgmaA4RprYAVHnoPxCP9LyhHfUPe0=";
+    hash = "sha256-GnJ3nOJyyqQbCTMrTYhnQfEOXqCy0x3IapX/PsaZ3VI=";
   };
 
   cmakeFlags = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updates Flameshot to the next major release version, 14.0.0.
Release notes: https://github.com/flameshot-org/flameshot/releases/tag/v14.0.0
Diff: https://github.com/flameshot-org/flameshot/compare/v13.3.0...v14.0

For clarity and to avoid previous situation repeating, I would like to explicitly mention significant changes in the software's functionality here (this information will also be added to the Flameshot NixOS wiki page):
- **Flameshot uses XDG desktop portal calls for screenshotting by default**. Users on either X11 or Wayland Desktop environments will not notice this change as those provide sane portal configurations. Window manager users, on the other hand, will need to include a portal that provides an "Access" interface (`xdg-desktop-portal-gtk` as the generic choice) as well as one with a "Screenshot" interface. 
For Wayland WMs, that is often `xdg-desktop-portal-wlr`, while X11 users have no such options. Instead, they will need to use the *Legacy X11 Screenshot Fallback* option in the Flameshot GUI config. Those with the Home Manager module for Flameshot can instead set `useX11LegacyScreenshot = true`   

- **On multi-monitor setups, screenshotting will trigger a monitor selection prompt**. This is contrast with the pre-v14 behaviour, where capturing was rendered across all screens. Users on X11 may disable this behaviour by setting *Capture active monitor (skip monitor selection)* in Flameshot GUI config. Those with the Home Manager module for Flameshot can instead set `captureActiveMonitor=true`. 
Wayland users are unable to disable this due to its security design, lack of cross-platform solutions, and sheer variability in setups as per upstream. Instead, they can change their bind to `flameshot screen -e`. This will capture the currently active display (wherever the cursor is) and open the GUI editor. Note that is apparently doesn't always currently function as intended.

- **X11 Window manager users may experience incorrect capture renders**. That is, instead of opening as an overlay, it might open as a separate window instead. I don't know why or that happens, but that is the reality currently. 

These are the main changes that I believe are worth mentioning (and am aware of).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
