### PR TITLE
python3Packages.inject: 5.3.0-unstable-2026-01-05 -> 5.4.0

### DIFF
--- a/pkgs/development/python-modules/inject/default.nix
+++ b/pkgs/development/python-modules/inject/default.nix
@@ -9,19 +9,15 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "inject";
-  version = "5.3.0-unstable-2026-01-05";
+  version = "5.4.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ivankorobkov";
     repo = "python-inject";
-    rev = "2ca60abc5370cd91d87e5a21ac373d0ca710f76d";
-    hash = "sha256-FumossBUGwp1XxWthx3gpIietvZsmPpkd52y9jjVKjQ=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ITnqTGCOPLzATisAcPi52cpxsm9/Adj/Xb53jd18IWo=";
   };
-
-  env.SETUPTOOLS_SCM_PRETEND_VERSION =
-    assert lib.hasInfix "unstable" finalAttrs.version;
-    builtins.head (lib.splitString "-" finalAttrs.version);
 
   build-system = [
     hatchling
@@ -37,7 +33,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Python dependency injection framework";
     homepage = "https://github.com/ivankorobkov/python-inject";
-    changelog = "https://github.com/ivankorobkov/python-inject/blob/${finalAttrs.src.rev}/CHANGES.md";
+    changelog = "https://github.com/ivankorobkov/python-inject/blob/${finalAttrs.src.tag}/CHANGES.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ PerchunPak ];
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: https://github.com/ivankorobkov/python-inject/blob/v5.4.0/CHANGES.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
  I did not use AI

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
