### PR TITLE
teams-for-linux: 2.11.1 -> 2.12.0

### DIFF
--- a/pkgs/by-name/te/teams-for-linux/package.nix
+++ b/pkgs/by-name/te/teams-for-linux/package.nix
@@ -6,6 +6,7 @@
   alsa-utils,
   copyDesktopItems,
   electron_41,
+  libicns,
   makeDesktopItem,
   makeWrapper,
   nix-update-script,
@@ -18,22 +19,23 @@ let
 in
 buildNpmPackage rec {
   pname = "teams-for-linux";
-  version = "2.11.1";
+  version = "2.12.0";
 
   src = fetchFromGitHub {
     owner = "IsmaelMartinez";
     repo = "teams-for-linux";
     tag = "v${version}";
-    hash = "sha256-XEu0x9g2mEsmY+vZtazTOzW6KNMRbrxlPck/kPNehmo=";
+    hash = "sha256-n9Ibno6NqiZ9W5KpPPZKD5/MTO8CKYdf/fXDf0cGsi4=";
   };
 
-  npmDepsHash = "sha256-urLRj7668NX7CaDWAVxAoOg+c1TmMyvf23Je+RmFwHE=";
+  npmDepsHash = "sha256-euf/6RtAO84ZtbdhglBd6gRCcg2m6a+fhthNvFzMlho=";
 
   nativeBuildInputs = [
     makeWrapper
     versionCheckHook
   ]
-  ++ lib.optionals (stdenv.hostPlatform.isLinux) [ copyDesktopItems ];
+  ++ lib.optionals (stdenv.hostPlatform.isLinux) [ copyDesktopItems ]
+  ++ lib.optionals (stdenv.hostPlatform.isDarwin) [ libicns ];
 
   doInstallCheck = stdenv.hostPlatform.isLinux;
 
@@ -48,13 +50,29 @@ buildNpmPackage rec {
     cp -r ${electron.dist}/. "$electron_dist"
     chmod -R u+w "$electron_dist"
 
-    npm exec electron-builder -- \
-        --dir \
-        -c.npmRebuild=true \
-        -c.asarUnpack="**/*.node" \
-        -c.electronDist="$electron_dist" \
-        -c.electronVersion=${electron.version} \
-        -c.mac.identity=null
+    electron_builder_args=(
+      --dir
+      -c.npmRebuild=true
+      -c.asarUnpack="**/*.node"
+      -c.electronDist="$electron_dist"
+      -c.electronVersion=${electron.version}
+      -c.mac.identity=null
+    )
+
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    png2icns build/icon.icns \
+      build/icons/16x16.png \
+      build/icons/32x32.png \
+      build/icons/128x128.png \
+      build/icons/256x256.png \
+      build/icons/512x512.png \
+      build/icons/1024x1024.png
+    electron_builder_args+=(-c.mac.icon=build/icon.icns)
+  ''
+  + ''
+
+    npm exec electron-builder -- "''${electron_builder_args[@]}"
 
     runHook postBuild
   '';


### PR DESCRIPTION
Update teams-for-linux and generate the macOS .icns locally during Darwin builds.

electron-builder 26.15.3 tries to download its icon conversion toolset when only PNG icons are available. Using libicns keeps the build offline and points electron-builder at a prebuilt icon instead.

Closes https://github.com/NixOS/nixpkgs/pull/533503
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
