### PR TITLE
nixos/tmpfiles: fix layer inversion in activatable-script

### DIFF
--- a/nixos/modules/services/system/nix-daemon.nix
+++ b/nixos/modules/services/system/nix-daemon.nix
@@ -301,7 +301,9 @@ in
     (lib.mkIf cfg.enable {
       systemd.tmpfiles.rules = [
         "d  /nix/var                           0755 root root - -"
-        "L+ /nix/var/nix/gcroots/booted-system 0755 root root - /run/booted-system"
+        # Prevent the current configuration from being garbage-collected.
+        "L+ /nix/var/nix/gcroots/booted-system  - - - - /run/booted-system"
+        "L+ /nix/var/nix/gcroots/current-system - - - - /run/current-system"
         # Boot-time cleanup
         "R! /nix/var/nix/gcroots/tmp           -    -    -    - -"
         "R! /nix/var/nix/temproots             -    -    -    - -"

--- a/nixos/modules/system/activation/activation-script.nix
+++ b/nixos/modules/system/activation/activation-script.nix
@@ -277,11 +277,6 @@ in
     systemd.tmpfiles.rules = [
       "D /var/empty 0555 root root -"
       "h /var/empty - - - - +i"
-    ]
-    ++ lib.optionals config.nix.enable [
-      # Prevent the current configuration from being garbage-collected.
-      "d /nix/var/nix/gcroots -"
-      "L+ /nix/var/nix/gcroots/current-system - - - - /run/current-system"
     ];
 
     system.activationScripts.usrbinenv =


### PR DESCRIPTION
Same as #507873

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
