### PR TITLE
python3Packages.xpybutil: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/xpybutil/default.nix
+++ b/pkgs/development/python-modules/xpybutil/default.nix
@@ -7,17 +7,19 @@
   pillow,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "xpybutil";
   version = "0.0.6";
   pyproject = true;
+
+  __structuredAttrs = true;
 
   # Pypi only offers a wheel
   src = fetchFromGitHub {
     owner = "BurntSushi";
     repo = "xpybutil";
-    rev = version;
-    sha256 = "17gbqq955fcl29aayn8l0x14azc60cxgkvdxblz9q8x3l50w0xpg";
+    tag = finalAttrs.version;
+    hash = "sha256-73bAQaGjI5w+Xb3t+ToDhn1FQgcUWa9UEpS5UhLG650=";
   };
 
   build-system = [ setuptools ];
@@ -41,4 +43,4 @@ buildPythonPackage rec {
     license = lib.licenses.wtfpl;
     maintainers = with lib.maintainers; [ artturin ];
   };
-}
+})

--- a/pkgs/development/python-modules/xpybutil/default.nix
+++ b/pkgs/development/python-modules/xpybutil/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
   xcffib,
   pillow,
 }:
@@ -9,7 +10,7 @@
 buildPythonPackage rec {
   pname = "xpybutil";
   version = "0.0.6";
-  format = "setuptools";
+  pyproject = true;
 
   # Pypi only offers a wheel
   src = fetchFromGitHub {
@@ -19,8 +20,10 @@ buildPythonPackage rec {
     sha256 = "17gbqq955fcl29aayn8l0x14azc60cxgkvdxblz9q8x3l50w0xpg";
   };
 
+  build-system = [ setuptools ];
+
   # pillow is a dependency in image.py which is not listed in setup.py
-  propagatedBuildInputs = [
+  dependencies = [
     pillow
     xcffib
   ];


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
