### PR TITLE
yt-dlp: fix riscv64-linux build

### DIFF
--- a/pkgs/by-name/yt/yt-dlp/package.nix
+++ b/pkgs/by-name/yt/yt-dlp/package.nix
@@ -2,11 +2,12 @@
   lib,
   stdenvNoCC,
   python3Packages,
+  buildPackages,
   atomicparsley,
   deno,
   # Override jsRuntime with `nodejs`, `bun`, `quickjs`, or `quickjs-ng` if you want to use another default JS runtime.
   # You still need to enable them in your yt-dlp config with `--js-runtimes [runtime]`.
-  jsRuntime ? deno,
+  jsRuntime ? if stdenvNoCC.hostPlatform.isRiscV64 then nodejs else deno,
   fetchFromGitHub,
   ffmpeg-headless,
   installShellFiles,
@@ -18,6 +19,7 @@
   rtmpSupport ? true,
   withAlias ? false, # Provides bin/youtube-dl for backcompat
   withSecretStorage ? !stdenvNoCC.hostPlatform.isDarwin,
+  buildManpage ? buildPackages.pandoc.compiler.bootstrapAvailable,
   nix-update-script,
   # required for tests
   yt-dlp,
@@ -57,16 +59,16 @@ python3Packages.buildPythonApplication rec {
   __structuredAttrs = true;
   outputs = [
     "out"
-    "man"
     "doc"
-  ];
+  ]
+  ++ lib.optionals buildManpage [ "man" ];
 
   build-system = with python3Packages; [ hatchling ];
 
   nativeBuildInputs = [
     installShellFiles
-    pandoc
-  ];
+  ]
+  ++ lib.optionals buildManpage [ pandoc ];
 
   # expose optional-dependencies, but provide all features
   dependencies =
@@ -98,16 +100,18 @@ python3Packages.buildPythonApplication rec {
     python devscripts/make_lazy_extractors.py
   '';
 
-  postBuild = ''
-    python devscripts/prepare_manpage.py yt-dlp.1.temp.md
-    pandoc -s -f markdown-smart -t man yt-dlp.1.temp.md -o yt-dlp.1
-    rm yt-dlp.1.temp.md
-
-    mkdir -p completions/{bash,fish,zsh}
-    python devscripts/bash-completion.py completions/bash/yt-dlp
-    python devscripts/zsh-completion.py completions/zsh/_yt-dlp
-    python devscripts/fish-completion.py completions/fish/yt-dlp.fish
-  '';
+  postBuild =
+    lib.optionalString buildManpage ''
+      python devscripts/prepare_manpage.py yt-dlp.1.temp.md
+      pandoc -s -f markdown-smart -t man yt-dlp.1.temp.md -o yt-dlp.1
+      rm yt-dlp.1.temp.md
+    ''
+    + ''
+      mkdir -p completions/{bash,fish,zsh}
+      python devscripts/bash-completion.py completions/bash/yt-dlp
+      python devscripts/zsh-completion.py completions/zsh/_yt-dlp
+      python devscripts/fish-completion.py completions/fish/yt-dlp.fish
+    '';
 
   # Ensure these utilities are available in $PATH:
   # - ffmpeg: post-processing & transcoding support
@@ -136,19 +140,21 @@ python3Packages.buildPythonApplication rec {
     fi
   '';
 
-  postInstall = ''
-    installManPage yt-dlp.1
+  postInstall =
+    lib.optionalString buildManpage ''
+      installManPage yt-dlp.1
+    ''
+    + ''
+      installShellCompletion \
+        --bash completions/bash/yt-dlp \
+        --fish completions/fish/yt-dlp.fish \
+        --zsh completions/zsh/_yt-dlp
 
-    installShellCompletion \
-      --bash completions/bash/yt-dlp \
-      --fish completions/fish/yt-dlp.fish \
-      --zsh completions/zsh/_yt-dlp
-
-    install -Dm644 Changelog.md README.md -t "$doc/share/doc/yt_dlp"
-  ''
-  + lib.optionalString withAlias ''
-    ln -s "$out/bin/yt-dlp" "$out/bin/youtube-dl"
-  '';
+      install -Dm644 Changelog.md README.md -t "$doc/share/doc/yt_dlp"
+    ''
+    + lib.optionalString withAlias ''
+      ln -s "$out/bin/yt-dlp" "$out/bin/youtube-dl"
+    '';
 
   passthru = {
     updateScript = nix-update-script { };

--- a/pkgs/by-name/yt/yt-dlp/package.nix
+++ b/pkgs/by-name/yt/yt-dlp/package.nix
@@ -2,11 +2,12 @@
   lib,
   stdenvNoCC,
   python3Packages,
+  buildPackages,
   atomicparsley,
   deno,
   # Override jsRuntime with `nodejs`, `bun`, `quickjs`, or `quickjs-ng` if you want to use another default JS runtime.
   # You still need to enable them in your yt-dlp config with `--js-runtimes [runtime]`.
-  jsRuntime ? deno,
+  jsRuntime ? if stdenvNoCC.hostPlatform.isRiscV64 then nodejs else deno,
   fetchFromGitHub,
   ffmpeg-headless,
   installShellFiles,
@@ -18,6 +19,7 @@
   rtmpSupport ? true,
   withAlias ? false, # Provides bin/youtube-dl for backcompat
   withSecretStorage ? !stdenvNoCC.hostPlatform.isDarwin,
+  buildManpage ? buildPackages.pandoc.compiler.bootstrapAvailable,
   nix-update-script,
   # required for tests
   yt-dlp,
@@ -57,16 +59,16 @@ python3Packages.buildPythonApplication rec {
   __structuredAttrs = true;
   outputs = [
     "out"
-    "man"
     "doc"
-  ];
+  ]
+  ++ lib.optionals buildManpage [ "man" ];
 
   build-system = with python3Packages; [ hatchling ];
 
   nativeBuildInputs = [
     installShellFiles
-    pandoc
-  ];
+  ]
+  ++ lib.optionals buildManpage [ pandoc ];
 
   # expose optional-dependencies, but provide all features
   dependencies =
@@ -97,16 +99,18 @@ python3Packages.buildPythonApplication rec {
     python devscripts/make_lazy_extractors.py
   '';
 
-  postBuild = ''
-    python devscripts/prepare_manpage.py yt-dlp.1.temp.md
-    pandoc -s -f markdown-smart -t man yt-dlp.1.temp.md -o yt-dlp.1
-    rm yt-dlp.1.temp.md
-
-    mkdir -p completions/{bash,fish,zsh}
-    python devscripts/bash-completion.py completions/bash/yt-dlp
-    python devscripts/zsh-completion.py completions/zsh/_yt-dlp
-    python devscripts/fish-completion.py completions/fish/yt-dlp.fish
-  '';
+  postBuild =
+    lib.optionalString buildManpage ''
+      python devscripts/prepare_manpage.py yt-dlp.1.temp.md
+      pandoc -s -f markdown-smart -t man yt-dlp.1.temp.md -o yt-dlp.1
+      rm yt-dlp.1.temp.md
+    ''
+    + ''
+      mkdir -p completions/{bash,fish,zsh}
+      python devscripts/bash-completion.py completions/bash/yt-dlp
+      python devscripts/zsh-completion.py completions/zsh/_yt-dlp
+      python devscripts/fish-completion.py completions/fish/yt-dlp.fish
+    '';
 
   # Ensure these utilities are available in $PATH:
   # - ffmpeg: post-processing & transcoding support
@@ -135,19 +139,21 @@ python3Packages.buildPythonApplication rec {
     fi
   '';
 
-  postInstall = ''
-    installManPage yt-dlp.1
+  postInstall =
+    lib.optionalString buildManpage ''
+      installManPage yt-dlp.1
+    ''
+    + ''
+      installShellCompletion \
+        --bash completions/bash/yt-dlp \
+        --fish completions/fish/yt-dlp.fish \
+        --zsh completions/zsh/_yt-dlp
 
-    installShellCompletion \
-      --bash completions/bash/yt-dlp \
-      --fish completions/fish/yt-dlp.fish \
-      --zsh completions/zsh/_yt-dlp
-
-    install -Dm644 Changelog.md README.md -t "$doc/share/doc/yt_dlp"
-  ''
-  + lib.optionalString withAlias ''
-    ln -s "$out/bin/yt-dlp" "$out/bin/youtube-dl"
-  '';
+      install -Dm644 Changelog.md README.md -t "$doc/share/doc/yt_dlp"
+    ''
+    + lib.optionalString withAlias ''
+      ln -s "$out/bin/yt-dlp" "$out/bin/youtube-dl"
+    '';
 
   passthru = {
     updateScript = nix-update-script { };

--- a/pkgs/development/python-modules/curl-cffi/default.nix
+++ b/pkgs/development/python-modules/curl-cffi/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
@@ -92,6 +93,9 @@ buildPythonPackage rec {
     "tests/unittest/test_websockets.py::test_on_data_callback"
     "tests/unittest/test_websockets.py::test_hello_twice_async"
   ];
+
+  # scipy tests segfault on riscv64 so skip its tests on riscv64.
+  doCheck = !stdenv.hostPlatform.isRiscV64;
 
   disabledTests = [
     # FIXME ImpersonateError: Impersonating chrome136 is not supported

--- a/pkgs/development/python-modules/curl-cffi/default.nix
+++ b/pkgs/development/python-modules/curl-cffi/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
@@ -94,6 +95,9 @@ buildPythonPackage rec {
     "tests/unittest/test_websockets.py::test_on_data_callback"
     "tests/unittest/test_websockets.py::test_hello_twice_async"
   ];
+
+  # scipy tests segfault on riscv64 so skip its tests on riscv64.
+  doCheck = !stdenv.hostPlatform.isRiscV64;
 
   disabledTests = [
     # FIXME ImpersonateError: Impersonating chrome136 is not supported


### PR DESCRIPTION
fix yt-dlp issue : 

```
       … while calling the 'derivationStrict' builtin
         at «nix-internal»/derivation-internal.nix:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|
       … while evaluating derivation 'shell'
         whose name attribute is located at /nix/store/9figz32vbiblaw5x3li1hc8q9qwlwf27-source/pkgs/stdenv/generic/make-derivation.nix:647:11
       … while evaluating attribute 'buildInputs' of derivation 'shell'
         at /nix/store/9figz32vbiblaw5x3li1hc8q9qwlwf27-source/pkgs/stdenv/generic/make-derivation.nix:718:11:
          717|           depsHostHost = hostHostOutputs;
          718|           buildInputs = hostTargetOutputs;
             |           ^
          719|           depsTargetTarget = targetTargetOutputs;
       (stack trace truncated; use '--show-trace' to show the full, detailed trace)
       error: cannot bootstrap GHC on this platform ('riscv64-linux' with libc 'defaultLibc')
```

fix curl-cffi issue : 

```
scipy> ........................................................................ [ 85%]
scipy> .........Fatal Python error: Segmentation fault
scipy> 
```

Segfault confirmed x4 times

Build OK :

```
yt-dlp --version
2026.06.09
```

This PR also unlock mpv build :

```
mpv --version
mpv v0.41.0 Copyright © 2000-2025 mpv/MPlayer/mplayer2 projects
 built on Jan  1 1980 00:00:00
libplacebo version: v7.360.1
FFmpeg version: 8.1
FFmpeg library versions:
   libavcodec      62.28.100
   libavdevice     62.3.100
   libavfilter     11.14.100
   libavformat     62.12.100
   libavutil       60.26.100
   libswresample   6.3.100
   libswscale      9.5.100
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] riscv64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
