### PR TITLE
gpu-screen-recorder: 5.13.8 -> 5.13.9

### DIFF
--- a/pkgs/by-name/gp/gpu-screen-recorder/package.nix
+++ b/pkgs/by-name/gp/gpu-screen-recorder/package.nix
@@ -14,7 +14,6 @@
   wayland,
   wayland-scanner,
   vulkan-headers,
-  vulkan-loader,
   pipewire,
   libdrm,
   libva,
@@ -29,12 +28,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gpu-screen-recorder";
-  version = "5.13.8";
+  version = "5.13.9";
 
   src = fetchgit {
     url = "https://repo.dec05eba.com/gpu-screen-recorder";
     tag = finalAttrs.version;
-    hash = "sha256-0uYj9NA6KqORr7ag8OOMphWWyHU27ptuOs5q0lGLGLc=";
+    hash = "sha256-rGjS21eY2XfcdRwmKE2hJO1+FIXAmmBJ4y2oKgSwoRM=";
   };
 
   nativeBuildInputs = [
@@ -53,7 +52,6 @@ stdenv.mkDerivation (finalAttrs: {
     wayland
     wayland-scanner
     vulkan-headers
-    vulkan-loader
     libdrm
     libva
     libxdamage


### PR DESCRIPTION
gpu-screen-recorder: 5.13.8 -> 5.13.9
Changelog: https://git.dec05eba.com/gpu-screen-recorder/log/
  - Wayland socket: bypass flatpak sandbox
  - Only install nvidia profile when the driver is loaded
  - Fix `-c whip` not working for live streams
  - meson: Remove vulkan dependency (only headers are used)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
