### PR TITLE
cwm: 7.4 -> 7.9, add iamanaws as maintainer

### DIFF
--- a/pkgs/by-name/cw/cwm/package.nix
+++ b/pkgs/by-name/cw/cwm/package.nix
@@ -13,16 +13,17 @@
 stdenv.mkDerivation (finalAttrs: {
 
   pname = "cwm";
-  version = "7.4";
+  version = "7.9";
 
   src = fetchFromGitHub {
     owner = "leahneukirchen";
     repo = "cwm";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-L3u4mH2UH2pTHhSPVr5dUi94b9DheslkIWL6EgQ05yA=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-YC+x4YSPAgZ47PFMbzICv9ixfDxA1PG3ncLiMahSoUc=";
   };
 
   strictDeps = true;
+  __structuredAttrs = true;
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/cw/cwm/package.nix
+++ b/pkgs/by-name/cw/cwm/package.nix
@@ -40,7 +40,10 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Lightweight and efficient window manager for X11";
     homepage = "https://github.com/leahneukirchen/cwm";
-    maintainers = with lib.maintainers; [ _0x4A6F ];
+    maintainers = with lib.maintainers; [
+      _0x4A6F
+      iamanaws
+    ];
     license = lib.licenses.isc;
     platforms = lib.platforms.linux;
     mainProgram = "cwm";


### PR DESCRIPTION
Supersedes https://github.com/NixOS/nixpkgs/pull/522110

Update version and add myself as maintainer
https://github.com/leahneukirchen/cwm/compare/v7.4...v7.9

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
