### PR TITLE
shortwave: fix missing glib-networking buildInput

### DIFF
--- a/pkgs/by-name/sh/shortwave/package.nix
+++ b/pkgs/by-name/sh/shortwave/package.nix
@@ -9,6 +9,7 @@
   gettext,
   gitMinimal,
   glib,
+  glib-networking,
   gst_all_1,
   gtk4,
   libadwaita,
@@ -63,6 +64,7 @@ stdenv.mkDerivation rec {
     dbus
     gdk-pixbuf
     glib
+    glib-networking
     gtk4
     libadwaita
     libglycin-gtk4


### PR DESCRIPTION
I really like Shortwave, but one bug has been driving me up the wall.

Several HTTPS radio stations just won't play. Logging:

- "Internal data stream error. (reason error (-5))"
- "Stream doesn't contain enough data."

This exists as an issue at upstream & I've even commented on it, with no avail. [gitlab.gnome.org:World/Shortwave#652](https://gitlab.gnome.org/World/Shortwave/-/work_items/652)

After quite a bit of digging, I found that TLS Support was unavailable for Shortwave. Libsoup needs glib-networking to do HTTPS, but it's a runtime plugin (loaded through GIO_EXTRA_MODULES, not linked at build time) so it never ends up in the closure unless you list it explicitly.

Adding `glib-networking` to buildInputs fixed every broken station for me.

<details>
<summary>Noteable stations to that would error out before this patch:</summary>

- "[DnB&EDM](https://www.radio-browser.info/history/e2f8a671-835a-4223-ad0f-33ac7aa9ed05)" (with URL: `https://edmdnb.com:448/radio/8000/radio.mp3`)
- "[Classic Vinyl HD](https://www.radio-browser.info/history/d1a54d2e-623e-4970-ab11-35f7b56c5ec3)" (with URL: `https://icecast.walmradio.com:8443/classic`)
- "[Adroit Jazz Underground](https://www.radio-browser.info/history/ea8059be-d119-4de3-b27b-0d9bd6aedb17)" (with URL: `https://icecast.walmradio.com:8443/jazz`)

</details>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
