### PR TITLE
sfcgal,python3Packages.pysfcgal: 2.2.0 → 2.3.0

### DIFF
--- a/pkgs/by-name/sf/sfcgal/package.nix
+++ b/pkgs/by-name/sf/sfcgal/package.nix
@@ -5,36 +5,37 @@
   cmake,
   cgal,
   boost,
+  eigen,
   mpfr,
+  nlohmann_json,
   gmp,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sfcgal";
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchFromGitLab {
     owner = "sfcgal";
     repo = "SFCGAL";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-9caucSIEAjzc4cWShuwbBC+BLs5a3e3y58aT4aLzN5E=";
+    hash = "sha256-VwbcAdSORUUbkYoH5H1wkKMOqBlUMltMVYEoNtPH0p4=";
   };
-
-  # boost 1.89 removed the boost_system stub library
-  postPatch = ''
-    substituteInPlace CMakeLists.txt --replace-fail \
-      'set( SFCGAL_Boost_COMPONENTS thread system serialization )' \
-      'set( SFCGAL_Boost_COMPONENTS thread serialization )'
-  '';
 
   buildInputs = [
     cgal
     boost
+    eigen
     mpfr
+    nlohmann_json
     gmp
   ];
 
   nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "SFCGAL_WITH_EIGEN" true)
+  ];
 
   meta = {
     description = "C++ wrapper library around CGAL with the aim of supporting ISO 191007:2013 and OGC Simple Features for 3D operations";

--- a/pkgs/development/python-modules/pysfcgal/default.nix
+++ b/pkgs/development/python-modules/pysfcgal/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitLab,
+  fetchpatch,
   pytestCheckHook,
 
   cffi,
@@ -13,15 +14,28 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pysfcgal";
-  version = "2.2.0";
+  version = "2.3.0";
   pyproject = true;
 
   src = fetchFromGitLab {
     owner = "sfcgal";
     repo = "pysfcgal";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-/G6yC7u2CYM7D9xO2IOB8+AjWc4ErzTIdvHmwGRxXBc=";
+    hash = "sha256-43+AFnXL5fTmLJBlkJrBC87xY5WRYwwwNJgRGfQqB3Y=";
   };
+
+  patches = [
+    # Fix test_boundary, https://gitlab.com/sfcgal/pysfcgal/-/merge_requests/246
+    (fetchpatch {
+      url = "https://gitlab.com/sfcgal/pysfcgal/-/commit/ac0f26a6860e329519ab3a1035fc5c9bc65020e4.patch";
+      hash = "sha256-vehPPX4brPWOgQg5bCk9kcMj85z70/IpC8ynGdg9Lr8=";
+    })
+    # Fix test_create_from_base_class, https://gitlab.com/sfcgal/pysfcgal/-/merge_requests/249
+    (fetchpatch {
+      url = "https://gitlab.com/sfcgal/pysfcgal/-/commit/faae666b60e1cb03f3533d89d9c30cc8cf92b14a.patch";
+      hash = "sha256-tPxVRXAouUbgwLTfZlBp0IaLdJDbzHb+Bu5bS4sJz7I=";
+    })
+  ];
 
   buildInputs = [
     sfcgal


### PR DESCRIPTION
- https://gitlab.com/sfcgal/SFCGAL/-/releases/v2.3.0
- https://github.com/SFCGAL/PySFCGAL/blob/v2.3.0/CHANGELOG.md

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
