### PR TITLE
shellbar: init at 1.9.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23324,6 +23324,12 @@
     githubId = 220211;
     name = "Renato Garcia";
   };
+  rendergraf = {
+    name = "Xavier Araque";
+    email = "xavieraraque@gmail.com";
+    github = "rendergraf";
+    githubId = 5533099;
+  };
   renesat = {
     name = "Ivan Smolyakov";
     email = "smol.ivan97@gmail.com";

--- a/pkgs/by-name/sh/shellbar/package.nix
+++ b/pkgs/by-name/sh/shellbar/package.nix
@@ -1,0 +1,64 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, ninja
+, pkg-config
+, zig
+, gtk4
+, libadwaita
+, cairo
+, pango
+, gdk-pixbuf
+, graphene
+, harfbuzz
+, vulkan-headers
+, vulkan-loader
+, glib
+, wrapGAppsHook4
+}:
+
+stdenv.mkDerivation rec {
+  pname = "shellbar";
+  version = "1.9.0";
+
+  src = fetchFromGitHub {
+    owner = "rendergraf";
+    repo = "shellbar";
+    rev = "v${version}";
+    hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    zig
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    gtk4
+    libadwaita
+    cairo
+    pango
+    gdk-pixbuf
+    graphene
+    harfbuzz
+    vulkan-headers
+    vulkan-loader
+    glib
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+  ];
+
+  meta = with lib; {
+    description = "A Ghostty-like terminal emulator with a configurable command toolbar";
+    homepage = "https://github.com/rendergraf/shellbar";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    mainProgram = "shellbar";
+  };
+}

--- a/pkgs/by-name/sh/shellbar/package.nix
+++ b/pkgs/by-name/sh/shellbar/package.nix
@@ -1,6 +1,13 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchzip
+, fetchurl
+, fetchgit
+, linkFarm
+, runCommand
+, runCommandLocal
+, zstd
 , cmake
 , ninja
 , pkg-config
@@ -15,18 +22,48 @@
 , vulkan-headers
 , vulkan-loader
 , glib
+, expat
+, libxdmcp
+, libsysprof-capture
+, pcre2
 , wrapGAppsHook4
 }:
 
-stdenv.mkDerivation rec {
+let
+  ghosttySrc = fetchFromGitHub {
+    owner = "ghostty-org";
+    repo = "ghostty";
+    rev = "b0f8276658fbcc75318d2125d40146074a3fc505";
+    hash = lib.fakeHash;
+  };
+
+  zigDepsRaw = import "${ghosttySrc}/build.zig.zon.nix" {
+    inherit lib linkFarm fetchzip fetchurl fetchgit zstd;
+    inherit runCommandLocal;
+    zig_0_15 = zig;
+  };
+
+  zigDeps = runCommand "zig-global-cache" { } ''
+    mkdir -p "$out/p"
+    for dep in "${zigDepsRaw}/"*; do
+      if [ -e "$dep" ]; then
+        ln -s "$(readlink -f "$dep")" "$out/p/$(basename "$dep")"
+      fi
+    done
+  '';
+in
+stdenv.mkDerivation (finalAttrs: {
   pname = "shellbar";
   version = "1.9.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "rendergraf";
     repo = "shellbar";
-    rev = "v${version}";
-    hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2gVUEVS2Kw3HokJwifztcDE7Nhp8E4+exAK9p7X+1FQ=";
   };
 
   nativeBuildInputs = [
@@ -48,17 +85,32 @@ stdenv.mkDerivation rec {
     vulkan-headers
     vulkan-loader
     glib
+    expat
+    libxdmcp
+    libsysprof-capture
+    pcre2
   ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'set(ZIG_NEED_DOWNLOAD TRUE)' 'set(ZIG_NEED_DOWNLOAD TRUE CACHE BOOL "Whether to download Zig")'
+  '';
 
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE=Release"
+    "-DFETCHCONTENT_SOURCE_DIR_GHOSTTY=${ghosttySrc}"
+    "-DZIG_EXECUTABLE=${zig}/bin/zig"
+    "-DZIG_NEED_DOWNLOAD=FALSE"
   ];
+
+  ZIG_GLOBAL_CACHE_DIR = "${zigDeps}";
 
   meta = with lib; {
     description = "A Ghostty-like terminal emulator with a configurable command toolbar";
     homepage = "https://github.com/rendergraf/shellbar";
     license = licenses.mit;
-    platforms = platforms.linux;
     mainProgram = "shellbar";
+    maintainers = with maintainers; [ rendergraf ];
+    platforms = platforms.linux;
   };
-}
+})


### PR DESCRIPTION
## Description
Add ShellBar — a Ghostty-like terminal emulator with a configurable command toolbar for Linux.

**Upstream:** https://github.com/rendergraf/shellbar
**License:** MIT
**Homepage:** https://rendergraf.github.io/shellbar/

Built on libghostty-vt (Ghostty's VT engine) with GTK4 + libadwaita.

## Checklist
- [x] Tested using sandboxing
- [x] Built on x86_64-linux
- [x] Executable runs