### PR TITLE
murale: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28818,6 +28818,12 @@
     github = "username-generic";
     githubId = 202454830;
   };
+  Username404-59 = {
+    name = "Charlie Quinet";
+    email = "charlie.quinet@gmail.com";
+    github = "Username404-59";
+    githubId = 53659497;
+  };
   usertam = {
     name = "Samuel Tam";
     email = "code@usertam.dev";

--- a/pkgs/by-name/mu/murale/package.nix
+++ b/pkgs/by-name/mu/murale/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  mpv,
+  wayland,
+  libxkbcommon,
+  libglvnd,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "murale";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "brenton-keller";
+    repo = "murale";
+    rev = "8461aace00fbda96fbf3e988b314e9dbef1e1a4d"; # There are no tags yet as of writing
+    hash = "sha256-UUHIboFU4aES1zQ2RwuG4dIFSiVpyhy3+WVgbbCEteo=";
+  };
+
+  cargoHash = "sha256-+jlkV+umcbHpPYbwdx0qrzuMkxA7RkSQ2BoYy0xEkck=";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    mpv
+    wayland
+    libxkbcommon
+    libglvnd
+  ];
+
+  meta = {
+    description = "Lean, memory-safe video wallpaper player for Wayland compositors ";
+    homepage = "https://github.com/brenton-keller/murale";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "murale";
+    maintainers = with lib.maintainers; [ Username404-59 ];
+  };
+}


### PR DESCRIPTION
Hello! This is a package for [murale](https://github.com/brenton-keller/murale), a memory-safe video wallpaper player (unlike mpvpaper which [continuously leaks memory](https://github.com/GhostNaN/mpvpaper/issues/101)).
**I started using NixOS 3 days ago this is my first package so tell me if something's wrong.**

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
