### PR TITLE
oscar: fix icon, clean up installPhase

### DIFF
--- a/pkgs/by-name/os/oscar/package.nix
+++ b/pkgs/by-name/os/oscar/package.nix
@@ -35,19 +35,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   installPhase = ''
     runHook preInstall
-    install -d $out/bin
-    install -d $out/share/OSCAR/Help
-    install -d $out/share/OSCAR/Html
-    install -d $out/share/OSCAR/Translations
-    install -d $out/share/icons/OSCAR
-    install -d $out/share/applications
-    install -T oscar/OSCAR $out/bin/OSCAR
+    install -D oscar/OSCAR -t $out/bin
     # help browser was removed 'temporarily' in https://gitlab.com/pholy/OSCAR-code/-/commit/57c3e4c33ccdd2d0eddedbc24c0e4f2969da3841
-    # install oscar/Help/* $out/share/OSCAR/Help
-    install oscar/Html/* $out/share/OSCAR/Html
-    install oscar/Translations/* $out/share/OSCAR/Translations
-    install -T Building/Linux/OSCAR.png $out/share/icons/OSCAR/OSCAR.png
-    install -T Building/Linux/OSCAR.desktop $out/share/applications/OSCAR.desktop
+    # install -D oscar/Help/* -t $out/share/OSCAR/Help
+    install -D oscar/Html/* -t $out/share/OSCAR/Html
+    install -D oscar/Translations/* -t $out/share/OSCAR/Translations
+    install -D Building/Linux/OSCAR.png -t $out/share/icons/hicolor/48x48/apps
+    install -D Building/Linux/OSCAR.svg -t $out/share/icons/hicolor/scalable/apps
+    install -D Building/Linux/OSCAR.desktop -t $out/share/applications
     runHook postInstall
   '';
 


### PR DESCRIPTION
Fixes #515313 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
