### PR TITLE
snyk: 1.1301.2 -> 1.1305.1, adopt package

### DIFF
--- a/pkgs/by-name/sn/snyk/package.nix
+++ b/pkgs/by-name/sn/snyk/package.nix
@@ -43,7 +43,7 @@ buildNpmPackage {
     homepage = "https://snyk.io";
     changelog = "https://github.com/snyk/cli/releases/tag/v${version}";
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ iamanaws ];
     mainProgram = "snyk";
   };
 }

--- a/pkgs/by-name/sn/snyk/package.nix
+++ b/pkgs/by-name/sn/snyk/package.nix
@@ -2,29 +2,37 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
+  nodejs_24,
+  npm-lockfile-fix,
   testers,
   snyk,
 }:
 
-let
-  version = "1.1301.2";
-in
-buildNpmPackage {
+buildNpmPackage (finalAttrs: {
   pname = "snyk";
-  inherit version;
+  version = "1.1305.1";
 
   src = fetchFromGitHub {
     owner = "snyk";
     repo = "cli";
-    tag = "v${version}";
-    hash = "sha256-dyP9KywtwXYHkKDrCeNwJbZbhhIQdwYzk2GAY2+CEWM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-xOB2ZY4R5BE9a9bZ4+16h4K2O5OmGz6W0YwbPU/ZBWY=";
+
+    # TODO: Remove once https://github.com/snyk/cli/pull/6924 is released.
+    postFetch = ''
+      ${lib.getExe npm-lockfile-fix} $out/package-lock.json
+    '';
   };
 
-  npmDepsHash = "sha256-HBMOqFi3lvvVdPA+sx54Vj3cUQCV802SiWWR3+cq9Qo=";
+  npmDepsFetcherVersion = 3;
+
+  npmDepsHash = "sha256-pSnkANyHygjUqexCkxh/zsrB1143onYexeOUFQHN6sU=";
+
+  nodejs = nodejs_24;
 
   postPatch = ''
     substituteInPlace package.json \
-      --replace-fail '"version": "1.0.0-monorepo"' '"version": "${version}"'
+      --replace-fail '"version": "1.0.0-monorepo"' '"version": "${finalAttrs.version}"'
   '';
 
   postInstall = ''
@@ -41,9 +49,9 @@ buildNpmPackage {
   meta = {
     description = "Scans and monitors projects for security vulnerabilities";
     homepage = "https://snyk.io";
-    changelog = "https://github.com/snyk/cli/releases/tag/v${version}";
+    changelog = "https://github.com/snyk/cli/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ iamanaws ];
     mainProgram = "snyk";
   };
-}
+})


### PR DESCRIPTION
Latest release notes https://github.com/snyk/cli/releases/tag/v1.1305.1
Comparison https://github.com/snyk/cli/compare/v1.1301.2...v1.1305.1

Using `npm-lockfile-fix` to fix lockfile metadata. Made PR to fix upstream https://github.com/snyk/cli/pull/6924

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
