### PR TITLE
postgresqlPackages.timescaledb_toolkit: 1.21.0 -> 1.23.0

### DIFF
--- a/pkgs/development/tools/rust/cargo-pgrx/pinned.nix
+++ b/pkgs/development/tools/rust/cargo-pgrx/pinned.nix
@@ -1,11 +1,5 @@
 # nixpkgs-update: no auto update
 {
-  cargo-pgrx_0_12_6 = {
-    version = "0.12.6";
-    hash = "sha256-7aQkrApALZe6EoQGVShGBj0UIATnfOy2DytFj9IWdEA=";
-    cargoHash = "sha256-pnMxWWfvr1/AEp8DvG4awig8zjdHizJHoZ5RJA8CL08=";
-  };
-
   cargo-pgrx_0_16_0 = {
     version = "0.16.0";
     hash = "sha256-emNR7fXNVD9sY/Mdno7mwpH6l/7AD28cBUsFRn9je50=";

--- a/pkgs/servers/sql/postgresql/ext/timescaledb_toolkit.nix
+++ b/pkgs/servers/sql/postgresql/ext/timescaledb_toolkit.nix
@@ -1,6 +1,6 @@
 {
   buildPgrxExtension,
-  cargo-pgrx_0_12_6,
+  cargo-pgrx_0_18_0,
   fetchFromGitHub,
   lib,
   nix-update-script,
@@ -9,19 +9,19 @@
 
 buildPgrxExtension (finalAttrs: {
   inherit postgresql;
-  cargo-pgrx = cargo-pgrx_0_12_6;
+  cargo-pgrx = cargo-pgrx_0_18_0;
 
   pname = "timescaledb_toolkit";
-  version = "1.21.0";
+  version = "1.23.0";
 
   src = fetchFromGitHub {
     owner = "timescale";
     repo = "timescaledb-toolkit";
     tag = finalAttrs.version;
-    hash = "sha256-gGGSNvvJprqLkVwPr7cfmGY1qEUTXMdqdvwPYIzXaTA=";
+    hash = "sha256-we2w2rYGRC9Did9oocgCWbIUxb8a/g0BlCHXQUe1f8I=";
   };
 
-  cargoHash = "sha256-kyUpfNEXJ732VO6JDxU+dIoL57uWzG4Ff03/GnvsxLE=";
+  cargoHash = "sha256-R6daWAQssopVps+IqF94dGBcZMC/u1J4eEg6WouAwOo=";
   buildAndTestSubdir = "extension";
 
   postInstall = ''
@@ -46,8 +46,8 @@ buildPgrxExtension (finalAttrs: {
       lib.versionOlder postgresql.version "15"
       ||
         # Check after next package update.
-        lib.warnIf (finalAttrs.version != "1.21.0")
-          "Is postgresql18Packages.timescaledb_toolkit still broken?"
-          (lib.versionAtLeast postgresql.version "18");
+        lib.warnIf (finalAttrs.version != "1.23.0")
+          "Is postgresql19Packages.timescaledb_toolkit still broken?"
+          (lib.versionAtLeast postgresql.version "19");
   };
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4197,7 +4197,6 @@ with pkgs;
   defaultCrateOverrides = callPackage ../build-support/rust/default-crate-overrides.nix { };
 
   inherit (callPackages ../development/tools/rust/cargo-pgrx { })
-    cargo-pgrx_0_12_6
     cargo-pgrx_0_16_0
     cargo-pgrx_0_16_1
     cargo-pgrx_0_17_0


### PR DESCRIPTION
Updates the timescaledb_toolkit postgres extension from 1.21.0 to 1.23.0.

Changelog: [https://github.com/timescale/timescaledb-toolkit/blob/main/Changelog.md](https://github.com/timescale/timescaledb-toolkit/blob/main/Changelog.md)


## Things done

- Updated timescaledb_toolkit to 1.23.0.
- Removed the broken marker when using postgres 18, as that is now working.
- Tested and verified that it works with postgres 15, 16, 17 and 18 on x86_64-linux.

I noticed that this was the only package using cargo-pgrx_0_12_6 and the new version uses 0_18_0. Should cargo-pgrx_0_12_6 be removed?

Both the old and new version of the package are broken on darwin. This change does not fix it.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].


