### PR TITLE
ta-lib: 0.4.0 -> 0.6.4

### DIFF
--- a/pkgs/by-name/ta/ta-lib/package.nix
+++ b/pkgs/by-name/ta/ta-lib/package.nix
@@ -3,31 +3,23 @@
   stdenv,
   fetchFromGitHub,
   autoreconfHook,
-  pkg-config,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ta-lib";
-  version = "0.4.0";
+  version = "0.6.4";
   src = fetchFromGitHub {
-    owner = "rafa-dot-el";
-    repo = "talib";
-    rev = finalAttrs.version;
-    sha256 = "sha256-bIzN8f9ZiOLaVzGAXcZUHUh/v9z1U+zY+MnyjJr1lSw=";
+    owner = "TA-Lib";
+    repo = "ta-lib";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-aTRiScPNWsGDwJvumZXlMilvSDYZVDWgpeZ2F/S5WgQ=";
   };
-
-  nativeBuildInputs = [
-    pkg-config
-    autoreconfHook
-  ];
-  hardeningDisable = [ "format" ];
-
+  nativeBuildInputs = [ autoreconfHook ];
   meta = {
     description = "Add technical analysis to your own financial market trading applications";
     mainProgram = "ta-lib-config";
     homepage = "https://ta-lib.org/";
     license = lib.licenses.bsd3;
-
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ rafael ];
   };


### PR DESCRIPTION
This lib remains version `0.4.0` since 2007: https://web.archive.org/web/20230602201010/https://ta-lib.org/hdr_dw.html
until `2024-12` they released `0.6.1`: https://github.com/TA-Lib/ta-lib/releases/tag/v0.6.1

The original src is a GitHub repo that created by the maintainer who initialized this pkg in #206363
it contains files from the uncompressed release tarball on https://sourceforge.net/projects/ta-lib/files/ta-lib/0.4.0/ta-lib-0.4.0-src.tar.gz/download
which differs from source in SVN repo on sourceforge: https://sourceforge.net/p/ta-lib/code/HEAD/tree/tags/release-0-4-0/ta-lib/c/
and later its official GitHub repo: https://github.com/TA-Lib/ta-lib/tree/v0.4.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
