### PR TITLE
oggvideotools: unbreak on Darwin, add patches

### DIFF
--- a/pkgs/by-name/di/diffoscope/package.nix
+++ b/pkgs/by-name/di/diffoscope/package.nix
@@ -232,6 +232,7 @@ python.pkgs.buildPythonApplication rec {
         mono
         ocaml
         odt2txt
+        oggvideotools
         openssh
         pdftk
         perl
@@ -255,8 +256,6 @@ python.pkgs.buildPythonApplication rec {
         r2pipe
         # docx2txt, nixpkgs packages another project named the same, which does not work
       ])
-      # oggvideotools is broken on Darwin, please put it back when it will be fixed?
-      ++ lib.optionals stdenv.hostPlatform.isLinux [ oggvideotools ]
       # Causes an eval failure
       # See https://github.com/NixOS/nixpkgs/issues/463873
       ++ lib.optionals (!stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isAarch64) [

--- a/pkgs/by-name/og/oggvideotools/package.nix
+++ b/pkgs/by-name/og/oggvideotools/package.nix
@@ -3,6 +3,8 @@
   stdenv,
   fetchurl,
   fetchpatch,
+  fetchDebianPatch,
+  libresample,
   cmake,
   pkg-config,
   boost,
@@ -22,29 +24,71 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches = [
-    # Fix pending upstream inclusion for missing includes:
-    #  https://sourceforge.net/p/oggvideotools/bugs/12/
-    (fetchpatch {
-      name = "gcc-10.patch";
-      url = "https://sourceforge.net/p/oggvideotools/bugs/12/attachment/fix-compile.patch";
-      hash = "sha256-mJttoC3jCLM3vmPhlyqh+W0ryp2RjJGIBXd6sJfLJA4=";
+    # Avoid crashing in oggjoin on bogus input
+    (fetchDebianPatch {
+      inherit (finalAttrs) pname version;
+      debianRevision = "7";
+      patch = "mayhem-crash-oggjoin.patch";
+      hash = "sha256-0D22P+Qdf9Sfp6vptSnL4E33NVUL/XL72gNE36BF6QI=";
     })
-
-    # Fix pending upstream inclusion for build failure on gcc-12:
-    #  https://sourceforge.net/p/oggvideotools/bugs/13/
+    # Fix typos in manpages
+    (fetchDebianPatch {
+      inherit (finalAttrs) pname version;
+      debianRevision = "7";
+      patch = "manual-typos.patch";
+      hash = "sha256-yGzHGEADlSRnWZIN8x6xfg9ChAn8WKFQgZAJmbKtKq8=";
+    })
+    # Avoid crash on unknown command-line arguments
+    (fetchDebianPatch {
+      inherit (finalAttrs) pname version;
+      debianRevision = "7";
+      patch = "oggThumb-zero-getopt-long.patch";
+      hash = "sha256-LBgmpyyxmeAFE3zpeHRryuxboMBdBztUEGxbs0Ay+HU=";
+    })
+    # Prevent uninitialized read
+    (fetchDebianPatch {
+      inherit (finalAttrs) pname version;
+      debianRevision = "7";
+      patch = "init-for-valgrind.patch";
+      hash = "sha256-7BtdAGHHW860hFZYlRWDVfEw6CDkb18HfFROZHl+guY=";
+    })
+    # Fix compilation due to missing include
+    (fetchDebianPatch {
+      inherit (finalAttrs) pname version;
+      debianRevision = "7";
+      patch = "import-cstring.patch";
+      hash = "sha256-KMs4nyILveKY+ZmcSONmtS5+sAPPB+ypNUi9yzxBsXQ=";
+    })
+    # Fix out-of-bounds read
     (fetchpatch {
-      name = "gcc-12.patch";
-      url = "https://sourceforge.net/p/oggvideotools/bugs/13/attachment/fix-gcc-12.patch";
-      hash = "sha256-zuDXe86djWkR8SgYZHkuAJJ7Lf2VYsVRBrlEaODtMKE=";
-      # svn patch, rely on prefix added by fetchpatch:
-      extraPrefix = "";
+      url = "https://salsa.debian.org/multimedia-team/oggvideotools/-/raw/ed006e5d78f9509508dbc72277de8ab3c06d2362/debian/patches/1010-kate-header-buffer-read-past-end.patch";
+      hash = "sha256-CEkNG9tHZIggCvKRPj2pKI855pVWQUdudLfpda/ZVME=";
+    })
+    # Fix null pointer crash (CVE-2020-21723)
+    (fetchpatch {
+      url = "https://salsa.debian.org/multimedia-team/oggvideotools/-/raw/122047a7cf644e282906370f277ae83b4672e5e4/debian/patches/1020-CVE-2020-21723-null-pointer-crash.patch";
+      hash = "sha256-dUkMfEaB5Hn9I5+QbE/002X6ij+xIzzqjc8QTom1ITk=";
+    })
+    # Unbundle libresample
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/oggvideotools/raw/23f918f39278d87adb5a5ab2e57d5cc1816e1e8a/f/0005-unbundle-libresample.patch";
+      hash = "sha256-JSuH8ScYBi6zAgEhrFdPOGCSXzDk+lEnSHX9wuctAsg=";
+    })
+    # Fix buffer overflow (CVE-2020-21724)
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/oggvideotools/raw/2dd078ea81773a34cc0c4817ebbf3c4038b8098c/f/stream-serializer.diff";
+      hash = "sha256-3HkAuCBaNjKoTN8Q3oW89e3zXo13Ev5g7VJ/RPO3zRA=";
     })
   ];
 
   postPatch = ''
     # Don't disable optimisations
-    substituteInPlace CMakeLists.txt --replace " -O0 " ""
-  '';
+    substituteInPlace CMakeLists.txt --replace-fail " -O0 " ""
+  ''
+  # Fix "src/effect/pictureBlend.cpp:28:11: error: no matching conversion for functional-style cast from 'const char[39]' to 'OggException'"
+  + (lib.optionalString stdenv.hostPlatform.isDarwin ''
+    sed -i '1i #include <string>' src/effect/pictureBlend.cpp
+  '');
 
   nativeBuildInputs = [
     cmake
@@ -55,6 +99,7 @@ stdenv.mkDerivation (finalAttrs: {
     boost
     gd
     libogg
+    libresample
     libtheora
     libvorbis
   ];
@@ -69,9 +114,5 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://sourceforge.net/projects/oggvideotools/";
     license = lib.licenses.gpl2Only;
     maintainers = [ ];
-    # Compilation error on Darwin:
-    # error: invalid argument '--std=c++0x' not allowed with 'C'
-    # make[2]: *** [src/libresample/CMakeFiles/resample.dir/build.make:76: src/libresample/CMakeFiles/resample.dir/filterkit.c.o] Error 1
-    broken = stdenv.hostPlatform.isDarwin;
   };
 })


### PR DESCRIPTION
Fixes: CVE-2020-21723, CVE-2020-21724

Closes: #357139
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
