### PR TITLE
python3Packages.lerobot: unbreak tests on darwin

### DIFF
--- a/pkgs/development/python-modules/lerobot/default.nix
+++ b/pkgs/development/python-modules/lerobot/default.nix
@@ -34,6 +34,7 @@
   wandb,
 
   # tests
+  llvmPackages,
   pytestCheckHook,
   writableTmpDirAsHomeHook,
   pytest-timeout,
@@ -57,6 +58,11 @@ buildPythonPackage (finalAttrs: {
     setuptools
   ];
   dontUseCmakeConfigure = true;
+
+  checkInputs = lib.optionals stdenv.cc.isClang [
+    # test_async_iterator_* hangs after failing to find OMP headers
+    llvmPackages.openmp
+  ];
 
   pythonRelaxDeps = [
     "av"

--- a/pkgs/development/python-modules/lerobot/default.nix
+++ b/pkgs/development/python-modules/lerobot/default.nix
@@ -198,6 +198,8 @@ buildPythonPackage (finalAttrs: {
     "tests/policies/rtc/test_modeling_rtc.py"
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   meta = {
     description = "Making AI for Robotics more accessible with end-to-end learning";
     homepage = "https://github.com/huggingface/lerobot";

--- a/pkgs/development/python-modules/lerobot/default.nix
+++ b/pkgs/development/python-modules/lerobot/default.nix
@@ -178,6 +178,9 @@ buildPythonPackage (finalAttrs: {
 
     # TypeError: 'NoneType' object is not subscriptable
     "test_pi0_rtc_inference_with_prev_chunk"
+
+    # Flakes under load with AssertionError: assert 'second' == 'last'
+    "test_get_last_item_multiple_items_with_torch_queue"
   ]
   ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
     # RuntimeError: Failed to initialize cpuinfo!

--- a/pkgs/development/python-modules/lerobot/default.nix
+++ b/pkgs/development/python-modules/lerobot/default.nix
@@ -187,6 +187,12 @@ buildPythonPackage (finalAttrs: {
     "test_complementary_data_float_dtype_conversion"
     "test_float_dtype_conversion"
     "test_float_dtype_with_mixed_tensors"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # gRPC fails to connect on loopback in sandbox despite __darwinAllowLocalNetworking
+    "test_end_to_end_interactions_flow"
+    "test_end_to_end_parameters_flow"
+    "test_end_to_end_transitions_flow"
   ];
 
   disabledTestPaths = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
