### PR TITLE
maintainers: remove hypersw

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11245,12 +11245,6 @@
     github = "hxtmdev";
     githubId = 7771007;
   };
-  hypersw = {
-    email = "baltic@hypersw.net";
-    github = "hypersw";
-    githubId = 2332070;
-    name = "Serge Baltic";
-  };
   hythera = {
     name = "Hythera";
     github = "Hythera";

--- a/pkgs/by-name/fa/far2l/package.nix
+++ b/pkgs/by-name/fa/far2l/package.nix
@@ -130,10 +130,7 @@ stdenv.mkDerivation rec {
     description = "Linux port of FAR Manager v2, a program for managing files and archives in Windows operating systems";
     homepage = "https://github.com/elfmz/far2l";
     license = lib.licenses.gpl2Only;
-    maintainers = with lib.maintainers; [
-      hypersw
-      smakarov
-    ];
+    maintainers = with lib.maintainers; [ smakarov ];
     platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION
## Reasons

- Last commented in [March 2024](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Ahypersw)
- Hasn't created any PRs / Issues since [February 2021](https://github.com/NixOS/nixpkgs/issues?q=author%3Ahypersw)
- About 20 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Ahypersw%20-commenter%3Ahypersw%20-author%3Ahypersw%20-reviewed-by%3Ahypersw) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.