### PR TITLE
salmon: 1.11.4 -> 1.12.1

### DIFF
--- a/pkgs/by-name/sa/salmon/package.nix
+++ b/pkgs/by-name/sa/salmon/package.nix
@@ -26,15 +26,15 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "salmon";
-  version = "1.11.4";
+  version = "1.12.1";
 
   # SALMON_PUFFERFISH_GIT_TAG defined in cmake/SalmonDependencies.cmake
   pufferFishSrc = fetchFromGitHub {
     owner = "COMBINE-lab";
     repo = "pufferfish";
     fetchSubmodules = true;
-    rev = "ace68c1c022816ba8c50a1a07c5d08f2abd597d6";
-    hash = "sha256-Zwl45sUYSmHOqsYLZPscigjgd1V3Waza0jRvhvNh7jU=";
+    rev = "1c788594cef77f0558b183281f32152e0ed22ba9";
+    hash = "sha256-N9KYmFsl90eY8R1wH1Jbi3nnNld6YVGeQjqoxYxPqtE=";
   };
 
   # SALMON_FQFEEDER_GIT_TAG defined in cmake/SalmonDependencies.cmake
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "COMBINE-lab";
     repo = "salmon";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-BjWXNQtycSwCTe40kujN/YzCNhGjkz2ULGOYtI01yos=";
+    hash = "sha256-ggFPp6sHPcR4Wq/B0AaMVf0LZVIz+QcvKMNrTfnAY4w=";
   };
 
   patches = [ ./fix_pufferfish.patch ];
@@ -92,6 +92,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     "-DSALMON_PUFFERFISH_SOURCE_DIR=${finalAttrs.pufferFishSrc}"
     "-DSALMON_FQFEEDER_SOURCE_DIR=${finalAttrs.FQFeederSrc}"
+    "-DSALMON_FETCH_MISSING_DEPS=OFF"
   ];
 
   # These are needed to please htslib
@@ -120,6 +121,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/COMBINE-lab/salmon/releases/tag/" + "v${finalAttrs.version}";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.all;
-    maintainers = [ lib.maintainers.kupac ];
+    maintainers = [ ];
   };
 })


### PR DESCRIPTION
- Last release of the C++ -based salmon.
- Updated pufferfish
- Prevented downloading missing deps (fails faster)

The author released the 2.0.0 series, which is an LLM-assisted rust rewrite. Due to the overly active release frequency, I don't intend to maintain this package any longer (excelpt maybe security fixes for the C++-branch, if any)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
