### PR TITLE
maintaines: remove trepetti

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28350,12 +28350,6 @@
     githubId = 207457;
     name = "Matthieu Chevrier";
   };
-  trepetti = {
-    email = "trepetti@cs.columbia.edu";
-    github = "trepetti";
-    githubId = 25440339;
-    name = "Tom Repetti";
-  };
   trespaul = {
     email = "paul@trespaul.com";
     github = "trespaul";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -736,7 +736,6 @@ with lib.maintainers;
       dduan
       samasaur
       stephank
-      trepetti
     ];
     scope = "Maintain Swift compiler suite for NixOS.";
     shortName = "Swift";

--- a/pkgs/by-name/fu/fujprog/package.nix
+++ b/pkgs/by-name/fu/fujprog/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "fujprog";
     homepage = "https://github.com/kost/fujprog";
     license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ trepetti ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
     changelog = "https://github.com/kost/fujprog/releases/tag/v${finalAttrs.version}";
   };

--- a/pkgs/by-name/le/lemon-graph/package.nix
+++ b/pkgs/by-name/le/lemon-graph/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://lemon.cs.elte.hu/trac/lemon";
     description = "Efficient library for combinatorial optimization tasks on graphs and networks";
     license = lib.licenses.boost;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ hzeller ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/le/lemon-graph/package.nix
+++ b/pkgs/by-name/le/lemon-graph/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://lemon.cs.elte.hu/trac/lemon";
     description = "Efficient library for combinatorial optimization tasks on graphs and networks";
     license = lib.licenses.boost;
-    maintainers = with lib.maintainers; [ trepetti ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/ma/marker/package.nix
+++ b/pkgs/by-name/ma/marker/package.nix
@@ -55,7 +55,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://fabiocolacio.github.io/Marker/";
     description = "Markdown editor for the Linux desktop made with GTK3";
     maintainers = with lib.maintainers; [
-      trepetti
       aleksana
     ];
     license = lib.licenses.gpl3Plus;

--- a/pkgs/by-name/no/noaa-apt/package.nix
+++ b/pkgs/by-name/no/noaa-apt/package.nix
@@ -60,7 +60,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://noaa-apt.mbernardi.com.ar/";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
-      trepetti
       tmarkus
     ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/op/openroad/package.nix
+++ b/pkgs/by-name/op/openroad/package.nix
@@ -183,7 +183,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.bsd3;
     mainProgram = "openroad";
     maintainers = with lib.maintainers; [
-      trepetti
       hzeller
     ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;

--- a/pkgs/by-name/sv/svlint/package.nix
+++ b/pkgs/by-name/sv/svlint/package.nix
@@ -26,6 +26,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/dalance/svlint";
     changelog = "https://github.com/dalance/svlint/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ trepetti ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/sv/svls/package.nix
+++ b/pkgs/by-name/sv/svls/package.nix
@@ -22,6 +22,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mainProgram = "svls";
     homepage = "https://github.com/dalance/svls";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ trepetti ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/development/python-modules/pyverilog/default.nix
+++ b/pkgs/development/python-modules/pyverilog/default.nix
@@ -46,6 +46,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/PyHDI/Pyverilog";
     description = "Python-based Hardware Design Processing Toolkit for Verilog HDL";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ trepetti ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/rfcat/default.nix
+++ b/pkgs/development/python-modules/rfcat/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     description = "Swiss Army knife of sub-GHz ISM band radio";
     homepage = "https://github.com/atlas0fd00m/rfcat";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ trepetti ];
+    maintainers = [ ];
     changelog = "https://github.com/atlas0fd00m/rfcat/releases/tag/v${version}";
   };
 }

--- a/pkgs/development/python-modules/svglib/default.nix
+++ b/pkgs/development/python-modules/svglib/default.nix
@@ -46,6 +46,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/deeplook/svglib";
     changelog = "https://github.com/deeplook/svglib/blob/v${version}/CHANGELOG.rst";
     license = lib.licenses.lgpl3Only;
-    maintainers = with lib.maintainers; [ trepetti ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
## Reasons

- Last commented in [November 2023](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Atrepetti)
- Hasn't created any PRs / Issues since [December 2022](https://github.com/NixOS/nixpkgs/issues?q=author%3Atrepetti)
- About 145 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Atrepetti%20-commenter%3Atrepetti%20-author%3Atrepetti%20-reviewed-by%3Atrepetti) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] fujprog
- [ ] lemon-graph
- [ ] svlint
- [ ] svls
- [ ] python3Packages.pyverilog
- [ ] python3Packages.rfcat
- [ ] python3Packages.svglib