### PR TITLE
maintainers: remove vbmithr

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29020,12 +29020,6 @@
     githubId = 2612464;
     name = "Vincent Laporte";
   };
-  vbmithr = {
-    email = "vb@luminar.eu.org";
-    github = "vbmithr";
-    githubId = 797581;
-    name = "Vincent Bernardoff";
-  };
   vbrandl = {
     name = "Valentin Brandl";
     email = "mail+nixpkgs@vbrandl.net";

--- a/pkgs/development/ocaml-modules/pcre/default.nix
+++ b/pkgs/development/ocaml-modules/pcre/default.nix
@@ -23,8 +23,6 @@ buildDunePackage (finalAttrs: {
     homepage = "https://mmottl.github.io/pcre-ocaml";
     description = "Efficient C-library for pattern matching with Perl-style regular expressions in OCaml";
     license = lib.licenses.lgpl21Plus;
-    maintainers = with lib.maintainers; [
-      vbmithr
-    ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/development/ocaml-modules/react/default.nix
+++ b/pkgs/development/ocaml-modules/react/default.nix
@@ -34,7 +34,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.bsd3;
     inherit (ocaml.meta) platforms;
     maintainers = with lib.maintainers; [
-      vbmithr
       gal_bolle
     ];
   };

--- a/pkgs/development/tools/ocaml/findlib/default.nix
+++ b/pkgs/development/tools/ocaml/findlib/default.nix
@@ -90,9 +90,7 @@ stdenv.mkDerivation rec {
     description = "O'Caml library manager";
     homepage = "http://projects.camlcity.org/projects/findlib.html";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [
-      vbmithr
-    ];
+    maintainers = [ ];
     mainProgram = "ocamlfind";
     platforms = ocaml.meta.platforms or [ ];
   };


### PR DESCRIPTION
## Reasons

- Last commented in [November 2014](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Avbmithr)
- Hasn't created any PRs / Issues since [November 2014](https://github.com/NixOS/nixpkgs/issues?q=author%3Avbmithr)
- About 15 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Avbmithr%20-commenter%3Avbmithr%20-author%3Avbmithr%20-reviewed-by%3Avbmithr) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] ocamlPackages.pcre2
- [ ] ocamlPackages.findlib