### PR TITLE
maintainers: remove afldcr

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -772,12 +772,6 @@
     githubId = 168;
     name = "Alexander Flatter";
   };
-  afldcr = {
-    email = "alex@fldcr.com";
-    github = "afldcr";
-    githubId = 335271;
-    name = "James Alexander Feldman-Crough";
-  };
   afontain = {
     email = "afontain@posteo.net";
     github = "necessarily-equal";

--- a/pkgs/by-name/po/polybar/package.nix
+++ b/pkgs/by-name/po/polybar/package.nix
@@ -132,7 +132,6 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      afldcr
       moni
     ];
     mainProgram = "polybar";


### PR DESCRIPTION
## Reasons

- Last commented in [March 2018](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Aafldcr)
- Hasn't created any PRs / Issues since [December 2017](https://github.com/NixOS/nixpkgs/issues?q=author%3Aafldcr)
- About 26 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Aafldcr%20-commenter%3Aafldcr%20-author%3Aafldcr%20-reviewed-by%3Aafldcr) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.