### PR TITLE
maintainers: remove f4814n

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8648,12 +8648,6 @@
     github = "f2k1de";
     githubId = 11199213;
   };
-  f4814n = {
-    email = "me@f4814n.de";
-    github = "f4814";
-    githubId = 11909469;
-    name = "Fabian Geiselhart";
-  };
   f4z3r = {
     email = "f4z3r-github@pm.me";
     name = "Jakob Beckmann";

--- a/nixos/modules/services/games/quake3-server.nix
+++ b/nixos/modules/services/games/quake3-server.nix
@@ -127,6 +127,4 @@ in
         };
       };
     };
-
-  meta.maintainers = with lib.maintainers; [ f4814n ];
 }

--- a/pkgs/by-name/ra/razergenie/package.nix
+++ b/pkgs/by-name/ra/razergenie/package.nix
@@ -74,9 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Qt application for configuring your Razer devices under GNU/Linux";
     mainProgram = "razergenie";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [
-      f4814n
-    ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/rc/rcon/package.nix
+++ b/pkgs/by-name/rc/rcon/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     homepage = "https://github.com/n0la/rcon";
     description = "Source RCON client for command line";
-    maintainers = with lib.maintainers; [ f4814n ];
+    maintainers = [ ];
     platforms = with lib.platforms; linux ++ darwin;
     license = lib.licenses.bsd2;
     mainProgram = "rcon";


### PR DESCRIPTION
## Reasons

- Last commented in [April 2021](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Af4814)
- Hasn't created any PRs / Issues since [April 2021](https://github.com/NixOS/nixpkgs/issues?q=author%3Af4814)
- About 4 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Af4814%20-commenter%3Af4814%20-author%3Af4814%20-reviewed-by%3Af4814) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] razergenie
- [ ] rcon