### PR TITLE
maintainers: remove henrikolsson

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10809,12 +10809,6 @@
     githubId = 328259;
     name = "Henning Kiel";
   };
-  henrikolsson = {
-    email = "henrik@fixme.se";
-    github = "henrikolsson";
-    githubId = 982322;
-    name = "Henrik Olsson";
-  };
   henrikvtcodes = {
     github = "henrikvtcodes";
     githubId = 22358337;

--- a/pkgs/by-name/rn/rnnoise-plugin/package.nix
+++ b/pkgs/by-name/rn/rnnoise-plugin/package.nix
@@ -66,7 +66,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [
       panaeon
-      henrikolsson
       sciencentistguy
     ];
   };


### PR DESCRIPTION
## Reasons

- Last commented in [October 2020](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Ahenrikolsson)
- Hasn't created any PRs / Issues since [October 2020](https://github.com/NixOS/nixpkgs/issues?q=author%3Ahenrikolsson)
- About 2 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Ahenrikolsson%20-commenter%3Ahenrikolsson%20-author%3Ahenrikolsson%20-reviewed-by%3Ahenrikolsson) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.
