### PR TITLE
maintainers: remove deepfire

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6544,12 +6544,6 @@
     githubId = 48378098;
     name = "Danila Danko";
   };
-  deepfire = {
-    email = "_deepfire@feelingofgreen.ru";
-    github = "deepfire";
-    githubId = 452652;
-    name = "Kosyrev Serge";
-  };
   DeeUnderscore = {
     email = "d.anzorge@gmail.com";
     github = "DeeUnderscore";

--- a/pkgs/by-name/au/aurulent-sans/package.nix
+++ b/pkgs/by-name/au/aurulent-sans/package.nix
@@ -27,7 +27,7 @@ stdenvNoCC.mkDerivation rec {
     description = "Aurulent Sans";
     longDescription = "Aurulent Sans is a humanist sans serif intended to be used as an interface font.";
     homepage = "http://delubrum.org/";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ pancaek ];
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/au/aurulent-sans/package.nix
+++ b/pkgs/by-name/au/aurulent-sans/package.nix
@@ -27,7 +27,7 @@ stdenvNoCC.mkDerivation rec {
     description = "Aurulent Sans";
     longDescription = "Aurulent Sans is a humanist sans serif intended to be used as an interface font.";
     homepage = "http://delubrum.org/";
-    maintainers = with lib.maintainers; [ deepfire ];
+    maintainers = [ ];
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/ch/chntpw/package.nix
+++ b/pkgs/by-name/ch/chntpw/package.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "http://pogostick.net/~pnh/ntpasswd/";
     description = "Utility to reset the password of any user that has a valid local account on a Windows system";
-    maintainers = with lib.maintainers; [ deepfire ];
+    maintainers = [ ];
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/op/openwsman/package.nix
+++ b/pkgs/by-name/op/openwsman/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     downloadPage = "https://github.com/Openwsman/openwsman/releases";
     homepage = "https://openwsman.github.io";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ deepfire ];
+    maintainers = [ ];
     platforms = lib.platforms.linux; # PAM is not available on Darwin
   };
 })

--- a/pkgs/by-name/sa/sayonara/package.nix
+++ b/pkgs/by-name/sa/sayonara/package.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Sayonara music player";
     homepage = "https://sayonara-player.com/";
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ deepfire ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/sb/sblim-sfcc/package.nix
+++ b/pkgs/by-name/sb/sblim-sfcc/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
     description = "Small Footprint CIM Client Library";
     homepage = "https://sourceforge.net/projects/sblim/";
     license = lib.licenses.cpl10;
-    maintainers = with lib.maintainers; [ deepfire ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/xf/xfs-undelete/package.nix
+++ b/pkgs/by-name/xf/xfs-undelete/package.nix
@@ -54,6 +54,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/ianka/xfs_undelete";
     license = lib.licenses.gpl3;
     platforms = lib.platforms.linux;
-    maintainers = [ lib.maintainers.deepfire ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/tools/irony-server/default.nix
+++ b/pkgs/development/tools/irony-server/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
     description = "Server part of irony";
     mainProgram = "irony-server";
     homepage = "https://melpa.org/#/irony";
-    maintainers = [ lib.maintainers.deepfire ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
     license = lib.licenses.free;
   };


### PR DESCRIPTION
## Reasons

- Last commented in [November 2024](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Adeepfire)
- Hasn't created any PRs / Issues since [November 2024](https://github.com/NixOS/nixpkgs/issues?q=author%3Adeepfire)
- About 41 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Adeepfire%20-commenter%3Adeepfire%20-author%3Adeepfire%20-reviewed-by%3Adeepfire) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] aurulent-sans
- [ ] chntpw
- [ ] irony-server
- [ ] openwsman
- [ ] sayonara
- [ ] sblim-sfcc
- [ ] xfs-undelete