### PR TITLE
lua-language-server: 3.18.1 -> 3.18.2

### DIFF
--- a/pkgs/by-name/lu/lua-language-server/package.nix
+++ b/pkgs/by-name/lu/lua-language-server/package.nix
@@ -137,6 +137,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       gepbird
+      yvnth
     ];
     mainProgram = "lua-language-server";
     platforms = lib.platforms.linux ++ lib.platforms.darwin;

--- a/pkgs/by-name/lu/lua-language-server/package.nix
+++ b/pkgs/by-name/lu/lua-language-server/package.nix
@@ -19,13 +19,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lua-language-server";
-  version = "3.18.1";
+  version = "3.18.2";
 
   src = fetchFromGitHub {
     owner = "luals";
     repo = "lua-language-server";
     tag = finalAttrs.version;
-    hash = "sha256-fD7qFY2xL86x/Ac03HkusvNh9Tn4LiqkJGGXNO0bPO8=";
+    hash = "sha256-c8YxTNmvloN9oabdbl5ZKgXqhxeZ9eVBt3B0Q9wA/GQ=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
Bump lua-language-server from 3.18.1 to 3.18.2. Also add myself as maintainer.

Changelog: https://github.com/LuaLS/lua-language-server/releases/tag/3.18.2

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [[NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests)] in [[nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)].
  - [ ] [[Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)] at `passthru.tests`.
  - [ ] Tests in [[lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests)] or [[pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [[nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- [x] Fits [[CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)], [[pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md)], [[maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md)] and other READMEs.
- [x] Follows the [[automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy)].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test