### PR TITLE
maintainers: remove midchildan

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18026,14 +18026,6 @@
     githubId = 837312;
     name = "Michael Mercier";
   };
-  midchildan = {
-    email = "git@midchildan.org";
-    matrix = "@midchildan:matrix.org";
-    github = "midchildan";
-    githubId = 7343721;
-    name = "midchildan";
-    keys = [ { fingerprint = "FEF0 AE2D 5449 3482 5F06  40AA 186A 1EDA C5C6 3F83"; } ];
-  };
   midischwarz12 = {
     email = "midischwarz@proton.me";
     github = "midischwarz12";

--- a/nixos/modules/services/video/epgstation/default.nix
+++ b/nixos/modules/services/video/epgstation/default.nix
@@ -104,8 +104,6 @@ let
     ) instruction;
 in
 {
-  meta.maintainers = with lib.maintainers; [ midchildan ];
-
   imports = [
     (deprecateTopLevelOption [ "port" ])
     (deprecateTopLevelOption [ "socketioPort" ])

--- a/nixos/tests/noto-fonts.nix
+++ b/nixos/tests/noto-fonts.nix
@@ -3,7 +3,6 @@
   name = "noto-fonts";
   meta.maintainers = with lib.maintainers; [
     nickcao
-    midchildan
   ];
 
   nodes.machine =

--- a/nixos/tests/trafficserver.nix
+++ b/nixos/tests/trafficserver.nix
@@ -22,9 +22,6 @@
 { pkgs, ... }:
 {
   name = "trafficserver";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ midchildan ];
-  };
 
   nodes = {
     ats =

--- a/pkgs/by-name/ar/arc_unpacker/package.nix
+++ b/pkgs/by-name/ar/arc_unpacker/package.nix
@@ -108,7 +108,7 @@ stdenv.mkDerivation {
     description = "Tool to extract files from visual novel archives";
     homepage = "https://github.com/vn-tools/arc_unpacker";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ midchildan ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
     mainProgram = "arc_unpacker";
   };

--- a/pkgs/by-name/ar/aribb25/package.nix
+++ b/pkgs/by-name/ar/aribb25/package.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation {
     description = "Sample implementation of the ARIB STD-B25 standard";
     homepage = "https://code.videolan.org/videolan/aribb25";
     license = lib.licenses.isc;
-    maintainers = with lib.maintainers; [ midchildan ];
+    maintainers = [ ];
     mainProgram = "b25";
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/cj/cjose/package.nix
+++ b/pkgs/by-name/cj/cjose/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/zmartzone/cjose/blob/${finalAttrs.version}/CHANGELOG.md";
     description = "C library for Javascript Object Signing and Encryption. This is a maintained fork of the original project";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ midchildan ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/ep/epgstation/package.nix
+++ b/pkgs/by-name/ep/epgstation/package.nix
@@ -130,7 +130,7 @@ buildNpmPackage rec {
     description = "DVR software compatible with Mirakurun";
     homepage = "https://github.com/l3tnun/EPGStation";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ midchildan ];
+    maintainers = [ ];
     mainProgram = "epgstation";
   };
 }

--- a/pkgs/by-name/in/intel-media-sdk/package.nix
+++ b/pkgs/by-name/in/intel-media-sdk/package.nix
@@ -67,7 +67,6 @@ stdenv.mkDerivation rec {
     mainProgram = "mfx-tracer-config";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      midchildan
       pjungkamp
     ];
     knownVulnerabilities = [

--- a/pkgs/by-name/ma/macfuse-stubs/package.nix
+++ b/pkgs/by-name/ma/macfuse-stubs/package.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
       project website</link>.
     '';
     platforms = lib.platforms.darwin;
-    maintainers = with lib.maintainers; [ midchildan ];
+    maintainers = [ ];
 
     # macFUSE as a whole includes code with restrictions on commercial
     # redistribution. However, the build artifacts that we actually touch for

--- a/pkgs/by-name/ma/mackerel-agent/package.nix
+++ b/pkgs/by-name/ma/mackerel-agent/package.nix
@@ -44,6 +44,6 @@ buildGoModule (finalAttrs: {
     mainProgram = "mackerel-agent";
     homepage = "https://github.com/mackerelio/mackerel-agent";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ midchildan ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/mi/mirakurun/package.nix
+++ b/pkgs/by-name/mi/mirakurun/package.nix
@@ -75,6 +75,6 @@ buildNpmPackage rec {
     description = "Resource manager for TV tuners";
     homepage = "https://github.com/Chinachu/Mirakurun";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ midchildan ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ny/nyancat/package.nix
+++ b/pkgs/by-name/ny/nyancat/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Nyancat in your terminal, rendered through ANSI escape sequences";
     homepage = "https://nyancat.dakko.us";
     license = lib.licenses.ncsa;
-    maintainers = with lib.maintainers; [ midchildan ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
     mainProgram = "nyancat";
   };

--- a/pkgs/by-name/on/onscripter/package.nix
+++ b/pkgs/by-name/on/onscripter/package.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Japanese visual novel scripting engine";
     license = lib.licenses.gpl2Plus;
     mainProgram = "onscripter";
-    maintainers = with lib.maintainers; [ midchildan ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/po/powerline-symbols/package.nix
+++ b/pkgs/by-name/po/powerline-symbols/package.nix
@@ -12,7 +12,7 @@ runCommand "powerline-symbols-${version}"
     meta = {
       inherit (powerline.meta) license;
       priority = (powerline.meta.priority or lib.meta.defaultPriority) + 1;
-      maintainers = with lib.maintainers; [ midchildan ];
+      maintainers = [ ];
     };
   }
   ''

--- a/pkgs/by-name/sd/sd-local/package.nix
+++ b/pkgs/by-name/sd/sd-local/package.nix
@@ -24,6 +24,6 @@ buildGoModule (finalAttrs: {
     mainProgram = "sd-local";
     homepage = "https://github.com/screwdriver-cd/sd-local";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ midchildan ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/ti/tilix/package.nix
+++ b/pkgs/by-name/ti/tilix/package.nix
@@ -72,7 +72,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://gnunn1.github.io/tilix-web";
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [
-      midchildan
       jtbx
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/tr/trafficserver/package.nix
+++ b/pkgs/by-name/tr/trafficserver/package.nix
@@ -195,7 +195,7 @@ stdenv.mkDerivation (finalAttrs: {
       large intranets by maximizing existing and available bandwidth.
     '';
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ midchildan ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/tools/inputmethods/skk/skk-dicts/default.nix
+++ b/pkgs/tools/inputmethods/skk/skk-dicts/default.nix
@@ -82,7 +82,6 @@ let
           homepage = "https://github.com/skk-dev/dict";
           maintainers = with lib.maintainers; [
             yuriaisaka
-            midchildan
           ];
           platforms = lib.platforms.all;
         };


### PR DESCRIPTION
## Reasons

- Last commented in [November 2025](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Amidchildan)
- Hasn't created any PRs / Issues since [November 2025](https://github.com/NixOS/nixpkgs/issues?q=author%3Amidchildan)
- About 19 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Amidchildan%20-commenter%3Amidchildan%20-author%3Amidchildan%20-reviewed-by%3Amidchildan%20created%3A%3E2025-11-01) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] arc_unpacker
- [ ] aribb25
- [ ] cjose
- [ ] epgstation
- [ ] macfuse-stubs
- [ ] mackerel-agent
- [ ] mirakurun
- [ ] nyancat
- [ ] onscripter
- [ ] powerline-symbols
- [ ] sd-local
- [ ] trafficserver