### PR TITLE
nixos/systemd: add many Varlink APIs since v260

### DIFF
--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -4231,8 +4231,10 @@ let
           "systemd-networkd-wait-online@.service"
           "systemd-networkd.service"
           "systemd-networkd.socket"
-          "systemd-networkd-persistent-storage.service"
+          "systemd-networkd-resolve-hook.socket"
           "systemd-networkd-varlink-metrics.socket"
+          "systemd-networkd-varlink.socket"
+          "systemd-networkd-persistent-storage.service"
         ];
 
         systemd.sockets.systemd-networkd-varlink-metrics.wantedBy = [ "sockets.target" ];
@@ -4314,6 +4316,9 @@ let
         systemd.additionalUpstreamUnits = [
           "systemd-networkd-wait-online.service"
           "systemd-networkd.service"
+          "systemd-networkd-resolve-hook.socket"
+          "systemd-networkd-varlink-metrics.socket"
+          "systemd-networkd-varlink.socket"
           "systemd-networkd.socket"
           "systemd-network-generator.service"
           "network-online.target"

--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -185,7 +185,11 @@ in
       # added with order 501 to allow modules to go before with mkBefore
       system.nssDatabases.hosts = (mkOrder 501 [ "resolve [!UNAVAIL=return]" ]);
 
-      systemd.additionalUpstreamSystemUnits = [ "systemd-resolved.service" ];
+      systemd.additionalUpstreamSystemUnits = [
+        "systemd-resolved.service"
+        "systemd-resolved-monitor.socket"
+        "systemd-resolved-varlink.socket"
+      ];
 
       systemd.services.systemd-resolved = {
         wantedBy = [ "sysinit.target" ];
@@ -248,7 +252,12 @@ in
         tmpfiles.settings.systemd-resolved-stub."/etc/resolv.conf".L.argument =
           "/run/systemd/resolve/stub-resolv.conf";
 
-        additionalUpstreamUnits = [ "systemd-resolved.service" ];
+        additionalUpstreamUnits = [
+          "systemd-resolved.service"
+          "systemd-resolved-monitor.socket"
+          "systemd-resolved-varlink.socket"
+        ];
+
         users.systemd-resolve = { };
         groups.systemd-resolve = { };
         storePaths = [ "${config.boot.initrd.systemd.package}/lib/systemd/systemd-resolved" ];

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -180,6 +180,7 @@ let
   ]
   ++ optionals cfg.package.withImportd [
     "systemd-importd.service"
+    "systemd-importd.socket"
   ]
   ++ optionals cfg.package.withMachined [
     "machine.slice"

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -209,6 +209,11 @@ let
     "dbus-org.freedesktop.portable1.service"
     "systemd-portabled.service"
   ]
+  ++ optionals cfg.package.withRepart [
+    # Varlink APIs
+    "systemd-repart@.service"
+    "systemd-repart.socket"
+  ]
   ++ [
     "systemd-exit.service"
     "systemd-update-done.service"

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -65,6 +65,7 @@ let
     # Udev.
     "systemd-udevd-control.socket"
     "systemd-udevd-kernel.socket"
+    "systemd-udevd-varlink.socket"
     "systemd-udevd.service"
   ]
   ++ (optional (!config.boot.isContainer) "systemd-udev-trigger.service")

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -157,6 +157,8 @@ let
     "systemd-ask-password-wall.service"
 
     # Varlink APIs
+    "systemd-ask-password@.service"
+    "systemd-ask-password.socket"
   ]
   ++ lib.optionals cfg.package.withBootloader [
     "systemd-bootctl@.service"

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -186,6 +186,7 @@ let
     "machine.slice"
     "machines.target"
     "systemd-machined.service"
+    "systemd-machined.socket"
   ]
   ++ optionals cfg.package.withNspawn [
     "systemd-nspawn@.service"

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -195,6 +195,9 @@ let
     # Misc.
     "systemd-sysctl.service"
     "systemd-machine-id-commit.service"
+
+    "systemd-mute-console@.service"
+    "systemd-mute-console.socket"
   ]
   ++ optionals cfg.package.withTimedated [
     "dbus-org.freedesktop.timedate1.service"

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -233,6 +233,8 @@ let
     "factory-reset.target"
     "systemd-factory-reset-request.service"
     "systemd-factory-reset-reboot.service"
+    "systemd-factory-reset@.service"
+    "systemd-factory-reset.socket"
   ]
   ++ cfg.additionalUpstreamSystemUnits;
 

--- a/nixos/modules/system/boot/systemd/repart.nix
+++ b/nixos/modules/system/boot/systemd/repart.nix
@@ -157,6 +157,12 @@ in
     boot.initrd.systemd = lib.mkIf initrdCfg.enable {
       additionalUpstreamUnits = [
         "systemd-repart.service"
+        # Varlink APIs
+        # NOTE: compared to stage 2 where the IPC is enabled in the global location, initrd
+        # might be optimized to keep away the repart binary.
+        # As a result, we enable repart IPC in the initrd only if repart is enabled in the initrd.
+        "systemd-repart.socket"
+        "systemd-repart@.service"
       ];
 
       storePaths = [

--- a/nixos/modules/system/boot/systemd/tpm2.nix
+++ b/nixos/modules/system/boot/systemd/tpm2.nix
@@ -43,6 +43,8 @@
           "tpm2.target"
           "systemd-tpm2-setup-early.service"
           "systemd-tpm2-setup.service"
+          "systemd-pcrextend.socket"
+          "systemd-pcrextend@.service"
         ];
       }
     )
@@ -69,6 +71,8 @@
         boot.initrd.systemd.additionalUpstreamUnits = [
           "tpm2.target"
           "systemd-tpm2-setup-early.service"
+          "systemd-pcrextend.socket"
+          "systemd-pcrextend@.service"
         ];
 
         boot.initrd.availableKernelModules = [
@@ -81,6 +85,7 @@
           pkgs.tpm2-tss
           "${cfg.package}/lib/systemd/systemd-tpm2-setup"
           "${cfg.package}/lib/systemd/system-generators/systemd-tpm2-generator"
+          "${cfg.package}/lib/systemd/systemd-pcrextend"
         ];
       }
     )
@@ -89,7 +94,9 @@
         cfg = config.boot.initrd.systemd;
       in
       lib.mkIf (cfg.enable && cfg.tpm2.enable && cfg.tpm2.pcrphases.enable) {
-        boot.initrd.systemd.additionalUpstreamUnits = [ "systemd-pcrphase-initrd.service" ];
+        boot.initrd.systemd.additionalUpstreamUnits = [
+          "systemd-pcrphase-initrd.service"
+        ];
         boot.initrd.systemd.services.systemd-pcrphase-initrd.wantedBy = [ "initrd.target" ];
         boot.initrd.systemd.storePaths = [ "${cfg.package}/lib/systemd/systemd-pcrextend" ];
       }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1676,6 +1676,7 @@ in
   systemd-user-settings = runTest ./systemd-user-settings.nix;
   systemd-user-tmpfiles-rules = runTest ./systemd-user-tmpfiles-rules.nix;
   systemd-userdbd = runTest ./systemd-userdbd.nix;
+  systemd-varlink = runTest ./systemd-varlink.nix;
   systemtap = handleTest ./systemtap.nix { };
   szurubooru = handleTest ./szurubooru.nix { };
   taler = handleTest ./taler { };

--- a/nixos/tests/systemd-varlink.nix
+++ b/nixos/tests/systemd-varlink.nix
@@ -1,0 +1,46 @@
+{ lib, ... }:
+{
+  name = "systemd-varlink";
+  meta.maintainers = [ lib.maintainers.raitobezarius ];
+  nodes.machine =
+    { config, pkgs, ... }:
+    {
+      networking.useNetworkd = true;
+      services.resolved.enable = true;
+      systemd.network.enable = true;
+    };
+  testScript = ''
+    def list_interfaces(intf_path: str) -> list[str]:
+      return machine.succeed(f"varlinkctl list-interfaces {intf_path}").split('\n')
+
+    expected_reg_sd_interfaces = [
+      ("BootControl", "bootctl"),
+      ("Credentials", "creds"),
+      ("Hostname", "hostnamed"),
+      ("JournalAccess", "journald"),
+      ("Import", "importd"),
+      ("Machine", "machined"),
+      ("Resolve", "resolved-varlink"),
+      ("Resolve.Monitor", "resolved-monitor"),
+      ("Udev", "udevd-varlink"),
+      ("MuteConsole", "mute-console"),
+      ("FactoryReset", "factory-reset"),
+      ("AskPassword", "ask-password"),
+      ("Network", "networkd-varlink"),
+      ("Repart", "repart"),
+    ]
+    expected_priv_sd_interfaces = [
+      ("Login", None), # systemd-logind-varlink.socket exist but is not necessary.
+    ]
+    expected_interfaces = [
+      (f"io.systemd.{intf}", f"systemd-{socket_name}", f"/run/varlink/registry/io.systemd.{intf}") for intf, socket_name in expected_reg_sd_interfaces
+    ] + [
+      (f"io.systemd.{intf}", f"systemd-{socket_name}" if socket_name is not None else None, f"/run/systemd/io.systemd.{intf}") for intf, socket_name in expected_priv_sd_interfaces
+    ]
+
+    for intf, socket_name, intf_path in expected_interfaces:
+      if socket_name is not None:
+        machine.wait_for_unit(f"{socket_name}.socket")
+      assert intf in list_interfaces(intf_path), f"Interface '{intf}' not found in the Varlink registry"
+  '';
+}

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -703,6 +703,7 @@ stdenv.mkDerivation (finalAttrs: {
       withMachined
       withNetworkd
       withNspawn
+      withRepart
       withPortabled
       withSysupdate
       withTimedated


### PR DESCRIPTION
This adds the Varlink APIs for:

- repart
- importd
- machined
- mute-console
- factory-reset
- networkd
- logind
- udevd
- resolved
- pcrextend
- ask-password

Already present:

- pcrlock (under the right conditions — measured boot)
- journald
- hostnamed
- creds
- bootctl
- logind (under /run/systemd)
- oomd (under /run/systemd)
- PID1 (under /run/systemd)

Some are skipped (nsresourced, mountfsd, userdbd) as NixOS does not support these subsystems.
Additionally, a NixOS test for Varlink is added to test them, not all of them (e.g. metrics, monitoring, resolvhook are left aside as an exercise for the reader).

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
