### PR TITLE
bookworm: unstable-2022-01-09 -> unstable-2026-05-28

### DIFF
--- a/pkgs/by-name/bo/bookworm/package.nix
+++ b/pkgs/by-name/bo/bookworm/package.nix
@@ -24,19 +24,19 @@
   unar,
   unzip,
   vala,
-  # webkitgtk_4_0,
+  webkitgtk_4_1,
   wrapGAppsHook3,
 }:
 
 stdenv.mkDerivation {
   pname = "bookworm";
-  version = "unstable-2022-01-09";
+  version = "unstable-2026-05-28";
 
   src = fetchFromGitHub {
     owner = "babluboy";
     repo = "bookworm";
-    rev = "f3df858ce748a6bbc43f03a6e261ff76a6d7d303";
-    hash = "sha256-mLyJfblF5WnWBV3rX1ZRupccou4t5mBpo3W7+ECNMVI=";
+    rev = "fa06f1b80bb2372c1f20b0cfb21dc88eed410e29";
+    hash = "sha256-xml6jOE0tJBz1CwE+0ecSbiGAajh398bw+leFapctiE=";
   };
 
   nativeBuildInputs = [
@@ -60,12 +60,18 @@ stdenv.mkDerivation {
     poppler
     python3
     sqlite
-    # webkitgtk_4_0
+    webkitgtk_4_1
   ];
 
   postPatch = ''
     chmod +x meson/post_install.py
     patchShebangs meson/post_install.py
+    substituteInPlace meson.build \
+      --replace-fail "webkit2gtk-4.0" "webkit2gtk-4.1"
+    substituteInPlace src/window.vala \
+      --replace-fail "Soup.URI.decode" "Uri.unescape_string"
+    substituteInPlace src/utils.vala \
+      --replace-fail "Soup.URI.decode" "Uri.unescape_string"
   '';
 
   # These programs are expected in PATH from the source code and scripts
@@ -92,8 +98,6 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    # webkitgtk_4_0 was removed
-    broken = true;
     description = "Simple, focused eBook reader";
     mainProgram = "com.github.babluboy.bookworm";
     longDescription = ''


### PR DESCRIPTION
update version and un-break by using webkitgtk_4_1

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
