### PR TITLE
nixos/akkoma: fix media_proxy base_url assertion and make it more informative

### DIFF
--- a/nixos/modules/services/web-apps/akkoma.nix
+++ b/nixos/modules/services/web-apps/akkoma.nix
@@ -1173,7 +1173,7 @@ in
           cfg.config.":pleroma".":media_proxy".enabled
           -> cfg.config.":pleroma".":media_proxy".base_url != null;
         message = ''
-          `services.akkoma.config.":pleroma".":media_proxy".base_url` must be set when the media proxy is enabled.
+          `services.akkoma.config.":pleroma".":media_proxy".base_url` must be set to a URL with a different host component (domain name) than the web endpoint when the media proxy is enabled.
         '';
       }
     ];

--- a/nixos/modules/services/web-apps/akkoma.nix
+++ b/nixos/modules/services/web-apps/akkoma.nix
@@ -1167,17 +1167,16 @@ in
   };
 
   config = mkIf cfg.enable {
-    assertions =
-      optionals
-        (
+    assertions = [
+      {
+        assertion =
           cfg.config.":pleroma".":media_proxy".enabled
-          && cfg.config.":pleroma".":media_proxy".base_url == null
-        )
-        [
-          ''
-            `services.akkoma.config.":pleroma".":media_proxy".base_url` must be set when the media proxy is enabled.
-          ''
-        ];
+          -> cfg.config.":pleroma".":media_proxy".base_url != null;
+        message = ''
+          `services.akkoma.config.":pleroma".":media_proxy".base_url` must be set when the media proxy is enabled.
+        '';
+      }
+    ];
     warnings =
       optionals (with config.security; cfg.installWrapper && (!sudo.enable) && (!sudo-rs.enable))
         [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
