### PR TITLE
diffoscope: 319 -> 321, fix condition for aapt/apktool inclusion

### DIFF
--- a/pkgs/by-name/di/diffoscope/package.nix
+++ b/pkgs/by-name/di/diffoscope/package.nix
@@ -7,6 +7,7 @@
   apksigcopier,
   apksigner,
   apktool,
+  asar,
   binutils-unwrapped-all-targets,
   bzip2,
   cbfstool,
@@ -23,10 +24,10 @@
   enableBloat ? true,
   enjarify,
   fetchurl,
+  ffmpeg,
   file,
   findutils,
   fontforge-fonttools,
-  ffmpeg,
   fpc,
   gettext,
   ghc,
@@ -54,6 +55,7 @@
   oggvideotools,
   openssh,
   openssl,
+  p7zip,
   pdftk,
   perl,
   pgpdump,
@@ -75,7 +77,6 @@
   xz,
   zip,
   zstd,
-  binwalk,
   # updater only
   writeScript,
 }:
@@ -149,18 +150,14 @@ python.pkgs.buildPythonApplication rec {
   # Still missing these tools:
   # Android-specific tools:
   # dexdump
-  # Darwin-specific tools:
+  # Darwin-specific tools (llvm-lipo and llvm-otool don't suffice):
   # lipo
   # otool
   # Other tools:
-  # docx2txt <- makes tests broken:
-  # > FAILED tests/comparators/test_docx.py::test_diff - IndexError: list index out of range
-  # > FAILED tests/comparators/test_docx.py::test_compare_non_existing - AssertionError
+  # docx2txt (needs Debian's package called this, not the python package)
   # radare2
-  # > FAILED tests/comparators/test_elf_decompiler.py::test_ghidra_diff - IndexError: list index out of range
-  # > FAILED tests/comparators/test_elf_decompiler.py::test_radare2_diff - AssertionError
-  # > FAILED tests/comparators/test_macho_decompiler.py::test_ghidra_diff - assert 0 == 1
-  # > FAILED tests/comparators/test_macho_decompiler.py::test_radare2_diff - AssertionError
+  # > FAILED tests/comparators/test_elf_decompiler.py::test_radare2_diff - KeyError: 'offset'
+  # > FAILED tests/comparators/test_macho_decompiler.py::test_radare2_diff - KeyError: 'offset'
   #
   # We filter automatically all packages for the host platform (some dependencies are not supported on Darwin, aarch64, etc.).
   # Packages which are marked broken for a platform are not automatically filtered to avoid accidentally removing them without noticing it.
@@ -201,13 +198,13 @@ python.pkgs.buildPythonApplication rec {
     ]
     ++ (with python.pkgs; [
       argcomplete
-      python-debian
       defusedxml
       jsbeautifier
       jsondiff
       libarchive-c
       progressbar
       pypdf
+      python-debian
       python-magic
       pyxattr
       rpm
@@ -218,6 +215,7 @@ python.pkgs.buildPythonApplication rec {
         abootimg
         apksigcopier
         apksigner
+        asar
         cbfstool
         colord
         enjarify
@@ -238,6 +236,7 @@ python.pkgs.buildPythonApplication rec {
         odt2txt
         oggvideotools
         openssh
+        p7zip
         pdftk
         perl
         poppler-utils
@@ -249,7 +248,6 @@ python.pkgs.buildPythonApplication rec {
         ubootTools
         wabt
         xmlbeans
-        binwalk
       ]
       ++ (with python.pkgs; [
         androguard

--- a/pkgs/by-name/di/diffoscope/package.nix
+++ b/pkgs/by-name/di/diffoscope/package.nix
@@ -108,12 +108,12 @@ in
 # Note: when upgrading this package, please run the list-missing-tools.sh script as described below!
 python.pkgs.buildPythonApplication rec {
   pname = "diffoscope";
-  version = "319";
+  version = "321";
   pyproject = true;
 
   src = fetchurl {
     url = "https://diffoscope.org/archive/diffoscope-${version}.tar.bz2";
-    hash = "sha256-oIEC3ssdp0p2cE0VunTv6oo5CFuMQyftr4e5kqWmfP4=";
+    hash = "sha256-M/rsyUGlJDpU3o1RMfaN9fNMpOn9Xpz2ydflPUXVhD4=";
   };
 
   outputs = [
@@ -121,7 +121,11 @@ python.pkgs.buildPythonApplication rec {
     "man"
   ];
 
-  patches = [ ./ignore_links.patch ];
+  patches = [
+    ./ignore_links.patch
+    # Remove flags output from an OCaml test's diff, as it's Debian-specific
+    ./remove-flags-from-ocaml-diff.patch
+  ];
 
   postPatch = ''
     # When generating manpage, use the installed version

--- a/pkgs/by-name/di/diffoscope/package.nix
+++ b/pkgs/by-name/di/diffoscope/package.nix
@@ -258,11 +258,10 @@ python.pkgs.buildPythonApplication rec {
         h5py
         pdfminer-six
         r2pipe
-        # docx2txt, nixpkgs packages another project named the same, which does not work
       ])
       # Causes an eval failure
       # See https://github.com/NixOS/nixpkgs/issues/463873
-      ++ lib.optionals (!stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isAarch64) [
+      ++ lib.optionals (!stdenv.hostPlatform.isLinux || !stdenv.hostPlatform.isAarch64) [
         aapt
         apktool
       ]

--- a/pkgs/by-name/di/diffoscope/remove-flags-from-ocaml-diff.patch
+++ b/pkgs/by-name/di/diffoscope/remove-flags-from-ocaml-diff.patch
@@ -1,0 +1,27 @@
+From 18cf9ab675691c7173a9b7fafd6d521c3ea75862 Mon Sep 17 00:00:00 2001
+From: Michael Daniels <mdaniels5757@gmail.com>
+Date: Sat, 20 Jun 2026 11:42:29 -0400
+Subject: [PATCH] tests/data/ocaml_expected_diff: remove flags from diff
+
+This output comes from a Debian-specific OCaml patch, see
+https://salsa.debian.org/ocaml-team/ocaml/-/blob/archive/debian/5.4.1-1/debian/patches/Print-.cmi-flags-in-objinfo.patch
+---
+ tests/data/ocaml_expected_diff | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/tests/data/ocaml_expected_diff b/tests/data/ocaml_expected_diff
+index 79631882..a48de841 100644
+--- a/tests/data/ocaml_expected_diff
++++ b/tests/data/ocaml_expected_diff
+@@ -1,7 +1,6 @@
+-@@ -1,6 +1,6 @@
++@@ -1,5 +1,5 @@
+ -Unit name: Test1
+ +Unit name: Test2
+- Flags: [ Alerts _ ]
+  Interfaces imported:
+ -	351c2dc2fb4a56dac258b47c26262db6	Test1
+ +	ac02205dc900024a67ede9f394c59d72	Test2
+-- 
+2.54.0
+


### PR DESCRIPTION
- **diffoscope: 319 -> 321**
  Release note for 320: https://diffoscope.org/news/diffoscope-320-released/
  Release note for 321: https://diffoscope.org/news/diffoscope-321-released/
- **diffoscope: fix condition for aapt/apktool inclusion**
  The dependency works on x86_64-linux.
- **diffoscope: sort dependencies, update comments**
  Remove binwalk: it needs binwalk v2 (a python library), not v3 (Rust).
  python3Packages.binwalk3 doesn't help either.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
