### PR TITLE
oxibooru: init at 0.8.1; nixos/oxibooru: init at 0.8.1

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -931,6 +931,18 @@
   "module-services-szurubooru-extra-config": [
     "index.html#module-services-szurubooru-extra-config"
   ],
+  "module-services-oxibooru": [
+    "index.html#module-services-oxibooru"
+  ],
+  "module-services-oxibooru-basic-usage": [
+    "index.html#module-services-oxibooru-basic-usage"
+  ],
+  "module-services-oxibooru-reverse-proxy-configuration": [
+    "index.html#module-services-oxibooru-reverse-proxy-configuration"
+  ],
+  "module-services-oxibooru-extra-config": [
+    "index.html#module-services-oxibooru-extra-config"
+  ],
   "module-services-suwayomi-server": [
     "index.html#module-services-suwayomi-server"
   ],

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -80,6 +80,8 @@
 
 - [Kener](https://kener.ing), a modern, open-source status page application built with Node.js. Available as [services.kener](#opt-services.kener.enable).
 
+- [Oxibooru](https://github.com/liamw1/oxibooru), an image board engine based on Szurubooru, with a compatible API. Available as [services.oxibooru](#opt-services.oxibooru.enable).
+
 - [FlapAlerted](https://github.com/Kioubit/FlapAlerted), detects BGP flapping events and provides statistics based on BGP update messages. Available as [services.flap-alerted](#opt-services.flap-alerted.enable).
 
 - [gocron](https://github.com/flohoss/gocron), a task scheduler with web interface. Available as [services.gocron](#opt-services.gocron.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1798,6 +1798,7 @@
   ./services/web-apps/openvscode-server.nix
   ./services/web-apps/openwebrx.nix
   ./services/web-apps/outline.nix
+  ./services/web-apps/oxibooru.nix
   ./services/web-apps/pairdrop.nix
   ./services/web-apps/papra.nix
   ./services/web-apps/part-db.nix

--- a/nixos/modules/services/web-apps/oxibooru.md
+++ b/nixos/modules/services/web-apps/oxibooru.md
@@ -1,0 +1,68 @@
+# Oxibooru {#module-services-oxibooru}
+
+An image board engine based on Szurubooru.
+
+## Configuration {#module-services-oxibooru-basic-usage}
+
+By default the module will execute Oxibooru server only, the web client only contains static files that can be reached via a reverse proxy.
+
+Here is a basic configuration:
+
+```nix
+{
+  services.oxibooru = {
+    enable = true;
+
+    server = {
+      port = 8080;
+
+      settings = {
+        domain = "https://oxibooru.domain.tld";
+        secretFile = /path/to/secret/file;
+      };
+    };
+
+    database = {
+      passwordFile = /path/to/secret/file;
+    };
+  };
+}
+```
+
+## Reverse proxy configuration {#module-services-oxibooru-reverse-proxy-configuration}
+
+The preferred method to run this service is behind a reverse proxy not to expose an open port.
+You can use for this the options in {option}`services.oxibooru.virtualHost`. For example, to use nginx:
+
+```nix
+{
+  services.szurubooru = {
+    enable = true;
+
+    virtualHost = {
+      domain = "oxibooru.domain.tld";
+      nginx.enable = true;
+    };
+
+    server = {
+      port = 8080;
+      # ...
+    };
+  };
+
+  services.nginx.virtualHosts."oxibooru.domain.tld" = {
+    locations = {
+      "/api/".proxyPass = "http://localhost:8080/";
+      "/data/".root = config.services.oxibooru.dataDir;
+      "/" = {
+        root = config.services.oxibooru.client.package;
+        tryFiles = "$uri /index.htm";
+      };
+    };
+  };
+}
+```
+
+## Extra configuration {#module-services-oxibooru-extra-config}
+
+You can find all of the options in the default config file available [here](https://github.com/rr-/szurubooru/blob/master/server/config.yaml.dist).

--- a/nixos/modules/services/web-apps/oxibooru.nix
+++ b/nixos/modules/services/web-apps/oxibooru.nix
@@ -1,0 +1,419 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.services.oxibooru;
+  inherit (lib)
+    mkOption
+    mkEnableOption
+    mkIf
+    mkPackageOption
+    types
+    ;
+
+  format = pkgs.formats.toml { };
+in
+
+{
+  options = {
+    services.oxibooru = {
+      enable = mkEnableOption "Oxibooru, an image board engine based on Szurubooru";
+
+      user = mkOption {
+        type = types.str;
+        default = "oxibooru";
+        description = ''
+          User account under which Oxibooru runs.
+        '';
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "oxibooru";
+        description = ''
+          Group under which Oxibooru runs.
+        '';
+      };
+
+      dataDir = mkOption {
+        type = types.path;
+        default = "/var/lib/oxibooru";
+        example = "/var/lib/booru";
+        description = ''
+          The path to the data directory in which Oxibooru will store its data.
+        '';
+      };
+
+      openFirewall = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = ''
+          Whether to open the firewall for the port in {option}`services.oxibooru.server.port`.
+        '';
+      };
+
+      server = {
+        package = mkPackageOption pkgs [
+          "oxibooru"
+          "server"
+        ] { };
+
+        port = mkOption {
+          type = types.port;
+          default = 8080;
+          example = 9000;
+          description = ''
+            Port to expose HTTP service.
+          '';
+        };
+
+        baseUrl = lib.mkOption {
+          type = types.str;
+          default = "/";
+          example = "/booru";
+          description = "URL base to run oxibooru under";
+        };
+
+        settings = mkOption {
+          type = types.submodule {
+            freeformType = format.type;
+            options = {
+              domain = mkOption {
+                type = types.str;
+                example = "http://example.com";
+                description = "Full URL to the homepage of this Oxibooru site (with no trailing slash).";
+              };
+
+              # NOTE: this is not a real upstream option
+              secretFile = mkOption {
+                type = types.path;
+                example = "/run/secrets/oxibooru-server-secret";
+                description = ''
+                  File containing a secret used to salt the users' password hashes and generate filenames for static content.
+                '';
+              };
+
+              webhooks = mkOption {
+                type = types.listOf types.str;
+                default = [ ];
+                example = [ "https://example.org/callback/oxibooru" ];
+                description = "Webhooks to call when events occur.";
+              };
+
+              delete_source_files = mkOption {
+                type = types.enum [
+                  "yes"
+                  "no"
+                ];
+                default = "no";
+                example = "yes";
+                description = "Whether to delete thumbnails and source files on post delete.";
+              };
+
+              append_tag_implications_on_post_edit = mkOption {
+                type = types.bool;
+                default = false;
+                example = true;
+                description = "Adds tag implications to post tags on edit.";
+              };
+
+              post_similarity_threshold = mkOption {
+                type = types.float;
+                default = 0.55;
+                example = 0.8;
+                description = "Threshold used for reverse search (must be a number between 0 and 1).";
+              };
+
+              smtp = {
+                host = mkOption {
+                  type = types.nullOr types.str;
+                  default = null;
+                  example = "localhost";
+                  description = "Host of the SMTP server used to send reset password.";
+                };
+
+                port = mkOption {
+                  type = types.nullOr types.port;
+                  default = null;
+                  example = 25;
+                  description = "Port of the SMTP server.";
+                };
+
+                username = mkOption {
+                  type = types.nullOr types.str;
+                  default = null;
+                  example = "bot";
+                  description = "User to connect to the SMTP server.";
+                };
+
+                # NOTE: this is not a real upstream option
+                passwordFile = mkOption {
+                  type = types.nullOr types.path;
+                  default = null;
+                  example = "/run/secrets/oxibooru-smtp-pass";
+                  description = "File containing the password associated to the given user for the SMTP server.";
+                };
+
+                from = mkOption {
+                  type = types.nullOr types.str;
+                  default = null;
+                  example = "App <noreply@example.org>";
+                  description = "Content of the From header.";
+                };
+              };
+
+              data_url = mkOption {
+                type = types.str;
+                default = "data";
+                example = "content";
+                description = "Data endpoint that will be appended to the base URL.";
+              };
+
+              data_dir = mkOption {
+                type = types.path;
+                default = "${cfg.dataDir}/data";
+                defaultText = lib.literalExpression ''"''${services.oxibooru.dataDir}/data"'';
+                example = "/srv/oxibooru/data";
+                description = "Path to the static files.";
+              };
+
+              log_filter = mkOption {
+                type = types.str;
+                default = "oxibooru_server=info,tower_http=debug,axum=trace";
+                example = "oxibooru_server=trace,tower_http=info,axum=debug";
+                description = "Directive for controlling log verbosity for different parts of the server.";
+              };
+
+              auto_explain = mkOption {
+                type = types.bool;
+                default = false;
+                example = true;
+                description = "Whether to show SQL in server logs.";
+              };
+
+              public_info = {
+                name = mkOption {
+                  type = types.str;
+                  default = "oxibooru";
+                  example = "booru";
+                  description = "Name shown in the website title and on the front page.";
+                };
+
+                default_user_rank = mkOption {
+                  type = types.str;
+                  default = "regular";
+                  example = "anonymous";
+                  description = "Default rank given for new users.";
+                };
+              };
+            };
+          };
+          description = ''
+            Configuration to write to {file}`config.toml`.
+            See <https://github.com/liamw1/oxibooru/blob/master/server/config.toml.dist> for more information.
+          '';
+        };
+      };
+
+      client = {
+        package = mkPackageOption pkgs [
+          "oxibooru"
+          "client"
+        ] { };
+      };
+
+      database = {
+        host = mkOption {
+          type = types.str;
+          default = "localhost";
+          example = "192.168.1.2";
+          description = "Host on which the PostgreSQL database runs.";
+        };
+
+        port = mkOption {
+          type = types.port;
+          default = 5432;
+          description = "The port under which PostgreSQL listens to.";
+        };
+
+        name = mkOption {
+          type = types.str;
+          default = cfg.database.user;
+          defaultText = lib.literalExpression "oxibooru.database.name";
+          example = "oxi";
+          description = "Name of the PostgreSQL database.";
+        };
+
+        user = mkOption {
+          type = types.str;
+          default = "oxibooru";
+          example = "oxi";
+          description = "PostgreSQL user.";
+        };
+
+        passwordFile = mkOption {
+          type = types.path;
+          example = "/run/secrets/oxibooru-db-password";
+          description = "A file containing the password for the PostgreSQL user.";
+        };
+      };
+
+      extraEnv = lib.mkOption {
+        type = types.attrs;
+        default = { };
+        example = {
+          BUILD_INFO = "latest";
+        };
+        description = ''
+          Extra environment variables to be passed to the Oxibooru service.
+          Refer to <https://github.com/liamw1/oxibooru/blob/master/example.env> for details on supported variables.
+        '';
+      };
+
+      virtualHost = {
+        nginx.enable = mkEnableOption "a virtualhost to serve oxibooru through nginx";
+
+        domain = mkOption {
+          type = types.str;
+          description = ''
+            Domain to use for the virtual host.
+
+            This can be used to change nginx options like
+            ```nix
+            services.nginx.virtualHosts."$\{config.services.oxibooru.virtualHost.domain}".listen = [ ... ]
+            ```
+            or
+            ```nix
+            services.nginx.virtualHosts."example.com".listen = [ ... ]
+            ```
+          '';
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.server.port ];
+
+    users.groups = mkIf (cfg.group == "oxibooru") {
+      oxibooru = { };
+    };
+
+    users.users = mkIf (cfg.user == "oxibooru") {
+      oxibooru = {
+        group = cfg.group;
+        description = "Oxibooru daemon user";
+        isSystemUser = true;
+      };
+    };
+
+    systemd.services.oxibooru =
+      let
+        envFile = pkgs.writeText ".env" ''
+          POSTGRES_HOST=${cfg.database.host}
+          POSTGRES_USER=${cfg.database.user}
+          POSTGRES_PASSWORD=$OXIBOORU_DATABASE_PASSWORD
+          POSTGRES_DB=${cfg.database.name}
+          POSTGRES_PORT=${toString cfg.database.port}
+
+          SERVER_PORT=${toString cfg.server.port}
+          BASE_URL=${cfg.server.baseUrl}
+
+          MOUNT_DATA=${cfg.server.settings.data_dir}
+          MOUNT_SQL=${cfg.dataDir}/sql
+        '';
+        configFile = format.generate "config.toml" (
+          lib.pipe cfg.server.settings [
+            (
+              settings:
+              lib.recursiveUpdate settings {
+                secretFile = null;
+                password_secret = "$OXIBOORU_SECRET";
+                content_secret = "$OXIBOORU_SECRET";
+
+                smtp =
+                  if settings.smtp.host == null then
+                    null
+                  else
+                    {
+                      password = if settings.smtp.passwordFile != null then "$OXIBOORU_SMTP_PASS" else null;
+                      passwordFile = null;
+                    };
+              }
+            )
+            (lib.filterAttrsRecursive (_: x: x != null))
+          ]
+        );
+      in
+      {
+        description = "Server of Oxibooru, an image board engine based on Szurubooru";
+
+        wantedBy = [
+          "multi-user.target"
+          "oxibooru-client.service"
+        ];
+        before = [ "oxibooru-client.service" ];
+        after = [
+          "network.target"
+          "network-online.target"
+        ];
+        wants = [ "network-online.target" ];
+
+        script = ''
+          export OXIBOORU_SECRET="$(<$CREDENTIALS_DIRECTORY/secret)"
+          export OXIBOORU_DATABASE_PASSWORD="$(<$CREDENTIALS_DIRECTORY/database)"
+          ${lib.optionalString (cfg.server.settings.smtp.passwordFile != null) ''
+            export OXIBOORU_SMTP_PASS=$(<$CREDENTIALS_DIRECTORY/smtp)
+          ''}
+          install -m0640 ${cfg.server.package.src}/config.toml.dist ${cfg.dataDir}/config.toml.dist
+          touch ${cfg.dataDir}/config.toml
+          chmod 0640 ${cfg.dataDir}/config.toml
+          ${lib.getExe pkgs.envsubst} -i ${configFile} -o ${cfg.dataDir}/config.toml
+          ${lib.getExe pkgs.envsubst} -i ${envFile} -o ${cfg.dataDir}/.env
+          exec ${lib.getExe cfg.server.package} --config-path=${cfg.dataDir}/config.toml --env-path=${cfg.dataDir}/.env --ffmpeg-path=${lib.getExe pkgs.ffmpeg-headless}
+        '';
+
+        serviceConfig = {
+          LoadCredential = [
+            "secret:${cfg.server.settings.secretFile}"
+            "database:${cfg.database.passwordFile}"
+          ]
+          ++ lib.optionals (cfg.server.settings.smtp.passwordFile != null) [
+            "smtp:${cfg.server.settings.smtp.passwordFile}"
+          ];
+
+          User = cfg.user;
+          Group = cfg.group;
+
+          Type = "simple";
+          Restart = "on-failure";
+
+          StateDirectory = mkIf (cfg.dataDir == "/var/lib/oxibooru") "oxibooru";
+          WorkingDirectory = cfg.dataDir;
+        };
+      };
+
+    services.nginx = mkIf cfg.virtualHost.nginx.enable {
+      enable = true;
+      virtualHosts."${cfg.virtualHost.domain}" = {
+        locations."/" = {
+          root = cfg.client.package;
+          tryFiles = "$uri /index.htm";
+        };
+        locations."/api/".proxyPass = "http://localhost:${toString cfg.server.port}/";
+        locations."/data/".root = cfg.dataDir;
+      };
+    };
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [ ratcornu ];
+    doc = ./oxibooru.md;
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1341,6 +1341,7 @@ in
   overlayfs = runTest ./overlayfs.nix;
   owi = runTest ./owi.nix;
   owncast = runTest ./owncast.nix;
+  oxibooru = handleTest ./oxibooru.nix { };
   oxidized = handleTest ./oxidized.nix { };
   oxwm = runTestOn [ "x86_64-linux" "aarch64-linux" ] ./oxwm.nix;
   pacemaker = runTest ./pacemaker.nix;

--- a/nixos/tests/oxibooru.nix
+++ b/nixos/tests/oxibooru.nix
@@ -1,0 +1,51 @@
+import ./make-test-python.nix (
+  { lib, pkgs, ... }:
+  {
+    name = "oxibooru";
+    meta.maintainers = with lib.maintainers; [ ratcornu ];
+
+    nodes.machine =
+      let
+        dbpass = "changeme";
+      in
+
+      { config, ... }:
+      {
+        services.postgresql = {
+          enable = true;
+          initialScript = pkgs.writeText "init.sql" ''
+            CREATE USER ${config.services.oxibooru.database.user} WITH PASSWORD '${dbpass}';
+            CREATE DATABASE ${config.services.oxibooru.database.name} WITH OWNER ${config.services.oxibooru.database.user};
+          '';
+        };
+
+        services.oxibooru = {
+          enable = true;
+
+          dataDir = "/var/lib/oxibooru";
+
+          server = {
+            port = 7777;
+            settings = {
+              domain = "http://127.0.0.1";
+              secretFile = pkgs.writeText "secret" "secret";
+            };
+          };
+
+          database = {
+            host = "localhost";
+            port = 5432;
+            name = "oxibooru";
+            user = "oxibooru";
+            passwordFile = pkgs.writeText "pass" "${dbpass}";
+          };
+        };
+      };
+
+    testScript = ''
+      machine.wait_for_unit("oxibooru.service")
+      machine.wait_for_open_port(7777)
+      machine.succeed('curl -H "Content-Type: application/json" -H "Accept: application/json" --fail http://127.0.0.1:7777/info')
+    '';
+  }
+)

--- a/pkgs/servers/web-apps/oxibooru/client.nix
+++ b/pkgs/servers/web-apps/oxibooru/client.nix
@@ -1,0 +1,36 @@
+{
+  src,
+  version,
+  lib,
+  buildNpmPackage,
+}:
+
+buildNpmPackage {
+  pname = "oxibooru-client";
+  inherit version;
+
+  src = "${src}/client";
+
+  npmDepsHash = "sha256-Cn45jyRkQPkqc9XgqvTvXT2yOjG8uEag1KGwXJ/7GnQ=";
+  makeCacheWritable = true;
+
+  npmBuildFlags = [
+    "--gzip"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    mv ./public/* $out
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Client of Oxibooru, an image board engine based on Szurubooru";
+    homepage = "https://github.com/liamw1/oxibooru";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ ratcornu ];
+  };
+}

--- a/pkgs/servers/web-apps/oxibooru/default.nix
+++ b/pkgs/servers/web-apps/oxibooru/default.nix
@@ -14,7 +14,8 @@ let
   };
 in
 
-lib.recurseIntoAttrs {
+lib.recurseIntoAttrs rec {
   client = callPackage ./client.nix { inherit src version; };
   server = callPackage ./server.nix { inherit src version; };
+  inherit (server) tests;
 }

--- a/pkgs/servers/web-apps/oxibooru/default.nix
+++ b/pkgs/servers/web-apps/oxibooru/default.nix
@@ -1,0 +1,20 @@
+{
+  callPackage,
+  fetchFromGitHub,
+  lib,
+}:
+
+let
+  version = "0.8.1";
+  src = fetchFromGitHub {
+    owner = "liamw1";
+    repo = "oxibooru";
+    tag = version;
+    hash = "sha256-rKgSCXpVanIrihAYT3R6Gt7ajK9DTq8qfLnBqvnCgHo=";
+  };
+in
+
+lib.recurseIntoAttrs {
+  client = callPackage ./client.nix { inherit src version; };
+  server = callPackage ./server.nix { inherit src version; };
+}

--- a/pkgs/servers/web-apps/oxibooru/server.nix
+++ b/pkgs/servers/web-apps/oxibooru/server.nix
@@ -5,6 +5,7 @@
   rustPlatform,
   perl,
   tomlq,
+  nixosTests,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -22,6 +23,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   # Test relies on .env
   doCheck = false;
+
+  passthru.tests.oxibooru = nixosTests.oxibooru;
 
   meta = {
     description = "Server of Oxibooru, an image board engine based on Szurubooru";

--- a/pkgs/servers/web-apps/oxibooru/server.nix
+++ b/pkgs/servers/web-apps/oxibooru/server.nix
@@ -1,0 +1,33 @@
+{
+  src,
+  version,
+  lib,
+  rustPlatform,
+  perl,
+  tomlq,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "oxibooru-server";
+  inherit version;
+
+  src = "${src}/server";
+
+  cargoHash = "sha256-BGUPR4imND0/glU7Zm2dFoyCY3JNoH69ytk63SNn1MM=";
+
+  nativeBuildInputs = [
+    perl
+    tomlq
+  ];
+
+  # Test relies on .env
+  doCheck = false;
+
+  meta = {
+    description = "Server of Oxibooru, an image board engine based on Szurubooru";
+    homepage = "https://github.com/rr-/szurubooru";
+    license = lib.licenses.gpl3;
+    mainProgram = "oxibooru_server";
+    maintainers = with lib.maintainers; [ ratcornu ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6368,6 +6368,8 @@ with pkgs;
     openssl_4_0
     ;
 
+  oxibooru = callPackage ../servers/web-apps/oxibooru { };
+
   # pcre32 seems unused
   pcre-cpp = pcre.override { variant = "cpp"; };
 


### PR DESCRIPTION
[Oxibooru](https://github.com/liamw1/oxibooru) is an image board engine based on Szurubooru (it is a fork of it). The server is entirely rewritten in Rust, with a fully compatible API. I expect it to be easier to maintain on a long term as Szurubooru did not update any dependency for years.

I added a package, some needed python dependencies, a nixos module calling the package, a small documentation of the module and a test.

It might interest szurubooru users as the repo of oxibooru has a script to import data from an existing szurubooru server.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
