### PR TITLE
[Backport release-25.11] ci/treefmt: use wrapper from `pkgs.treefmt`

### DIFF
--- a/ci/default.nix
+++ b/ci/default.nix
@@ -26,11 +26,7 @@ let
 
   fmt =
     let
-      treefmtNixSrc = fetchTarball {
-        inherit (pinned.treefmt-nix) url;
-        sha256 = pinned.treefmt-nix.hash;
-      };
-      treefmtEval = (import treefmtNixSrc).evalModule pkgs ./treefmt.nix;
+      treefmt = pkgs.treefmt.withConfig ./treefmt.nix;
       fs = pkgs.lib.fileset;
       nixFilesSrc = fs.toSource {
         root = ../.;
@@ -38,9 +34,8 @@ let
       };
     in
     {
-      shell = treefmtEval.config.build.devShell;
-      pkg = treefmtEval.config.build.wrapper;
-      check = treefmtEval.config.build.check nixFilesSrc;
+      pkg = treefmt;
+      check = treefmt.check nixFilesSrc;
     };
 
 in

--- a/ci/pinned.json
+++ b/ci/pinned.json
@@ -12,19 +12,6 @@
       "revision": "8c91a71d13451abc40eb9dae8910f972f979852f",
       "url": "https://github.com/NixOS/nixpkgs/archive/8c91a71d13451abc40eb9dae8910f972f979852f.tar.gz",
       "hash": "sha256-fnzKKPvS+oieI/pTzotA5tkoM47EB1NpaBcgk4R97hE="
-    },
-    "treefmt-nix": {
-      "type": "Git",
-      "repository": {
-        "type": "GitHub",
-        "owner": "numtide",
-        "repo": "treefmt-nix"
-      },
-      "branch": "main",
-      "submodules": false,
-      "revision": "db947814a175b7ca6ded66e21383d938df01c227",
-      "url": "https://github.com/numtide/treefmt-nix/archive/db947814a175b7ca6ded66e21383d938df01c227.tar.gz",
-      "hash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM="
     }
   },
   "version": 8

--- a/ci/treefmt.nix
+++ b/ci/treefmt.nix
@@ -1,122 +1,171 @@
-{ pkgs, ... }: {
-  # Important: The auto-rebase script uses `git filter-branch --tree-filter`,
-  # which creates trees within the Git repository under `.git-rewrite/t`,
-  # notably without having a `.git` themselves.
-  # So if this projectRootFile were the default `.git/config`,
-  # having the auto-rebase script use treefmt on such a tree would make it
-  # format all files in the _parent_ Git tree as well.
-  projectRootFile = ".git-blame-ignore-revs";
-
-  # Be a bit more verbose by default, so we can see progress happening
-  settings.verbose = 1;
-
-  # By default it's info, which is too noisy since we have many unmatched files
-  settings.on-unmatched = "debug";
-
-  programs.actionlint.enable = true;
-
-  programs.biome = {
-    enable = true;
-    # Disable settings validation because its inputs are liable to hash mismatch
-    validate.enable = false;
-    settings.formatter = {
-      useEditorconfig = true;
-    };
-    settings.javascript.formatter = {
-      quoteStyle = "single";
-      semicolons = "asNeeded";
-    };
-    settings.json.formatter.enabled = false;
-  };
-  settings.formatter.biome.excludes = [
-    "*.min.js"
-    "pkgs/*"
-  ];
-
-  programs.keep-sorted.enable = true;
-
-  # This uses nixfmt underneath, the default formatter for Nix code.
-  # See https://github.com/NixOS/nixfmt
-  programs.nixfmt = {
-    enable = true;
-    package = pkgs.nixfmt;
-  };
-
-  programs.yamlfmt = {
-    enable = true;
-    settings.formatter = {
-      retain_line_breaks = true;
-    };
-  };
-  settings.formatter.yamlfmt.excludes = [
-    # Aligns comments with whitespace
-    "pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml"
-    # TODO: Fix formatting for auto-generated file
-    "pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml"
-  ];
-
-  programs.nixf-diagnose = {
-    enable = true;
-    ignore = [
-      # Rule names can currently be looked up here:
-      # https://github.com/nix-community/nixd/blob/main/libnixf/src/Basic/diagnostic.py
-      # TODO: Remove the following and fix things.
-      "sema-unused-def-lambda-noarg-formal"
-      "sema-unused-def-lambda-witharg-arg"
-      "sema-unused-def-lambda-witharg-formal"
-      "sema-unused-def-let"
-      # Keep this rule, because we have `lib.or`.
-      "or-identifier"
-      # TODO: remove after outstanding prelude diagnostics issues are fixed:
-      # https://github.com/nix-community/nixd/issues/761
-      # https://github.com/nix-community/nixd/issues/762
-      "sema-primop-removed-prefix"
-      "sema-primop-overridden"
-      "sema-constant-overridden"
-      "sema-primop-unknown"
-    ];
-  };
-  settings.formatter.nixf-diagnose = {
-    # Ensure nixfmt cleans up after nixf-diagnose.
-    priority = -1;
+{
+  lib,
+  pkgs,
+  ...
+}:
+{
+  settings = {
+    # numtide/treefmt-nix defaults
     excludes = [
-      # Auto-generated; violates sema-extra-with
-      # Can only sensibly be removed when --auto-fix supports multiple fixes at once:
-      # https://github.com/inclyc/nixf-diagnose/issues/13
-      "pkgs/servers/home-assistant/component-packages.nix"
-      # https://github.com/nix-community/nixd/issues/708
-      "nixos/maintainers/scripts/azure-new/examples/basic/system.nix"
+      "*.lock"
+      "*.patch"
+      "*.diff"
+      "package-lock.json"
+      "go.mod"
+      "go.sum"
+      ".gitattributes"
+      ".gitignore"
+      ".gitmodules"
+      "COPYING"
+      "LICENSE"
     ];
-  };
 
-  settings.formatter.editorconfig-checker = {
-    command = "${pkgs.lib.getExe pkgs.editorconfig-checker}";
-    options = [
-      "-disable-indent-size"
-      # TODO: Remove this once this upstream issue is fixed:
-      #   https://github.com/editorconfig-checker/editorconfig-checker/issues/505
-      "-disable-charset"
-    ];
-    includes = [ "*" ];
-    priority = 1;
-  };
+    # Be a bit more verbose by default, so we can see progress happening
+    verbose = 1;
 
-  # TODO: Upstream this into treefmt-nix eventually:
-  #   https://github.com/numtide/treefmt-nix/issues/387
-  settings.formatter.markdown-code-runner = {
-    command = pkgs.lib.getExe pkgs.markdown-code-runner;
-    options =
-      let
-        config = pkgs.writers.writeTOML "markdown-code-runner-config" {
-          presets.nixfmt = {
-            language = "nix";
-            command = [ (pkgs.lib.getExe pkgs.nixfmt) ];
-          };
-        };
-      in
-      [ "--config=${config}" ];
-    includes = [ "*.md" ];
-  };
+    # By default it's info, which is too noisy since we have many unmatched files
+    on-unmatched = "debug";
 
-  programs.zizmor.enable = true;
+    formatter = {
+
+      actionlint = {
+        command = lib.getExe pkgs.actionlint;
+        includes = [
+          ".github/workflows/*.yml"
+          ".github/workflows/*.yaml"
+        ];
+      };
+
+      biome = {
+        command = lib.getExe pkgs.biome;
+        excludes = [
+          "*.min.js"
+          "pkgs/*"
+        ];
+        includes = [
+          "*.js"
+          "*.ts"
+          "*.mjs"
+          "*.mts"
+          "*.cjs"
+          "*.cts"
+          "*.jsx"
+          "*.tsx"
+          "*.d.ts"
+          "*.d.cts"
+          "*.d.mts"
+          "*.css"
+        ];
+        options = [
+          "check"
+          "--write"
+          "--no-errors-on-unmatched"
+          "--use-editorconfig=true"
+          "--javascript-formatter-quote-style=single"
+          "--semicolons=as-needed"
+        ];
+      };
+
+      keep-sorted = {
+        command = lib.getExe pkgs.keep-sorted;
+        includes = [ "*" ];
+      };
+
+      # This uses nixfmt underneath, the default formatter for Nix code.
+      # See https://github.com/NixOS/nixfmt
+      nixfmt = {
+        command = lib.getExe pkgs.nixfmt;
+        includes = [ "*.nix" ];
+      };
+
+      yamlfmt = {
+        command = lib.getExe pkgs.yamlfmt;
+        excludes = [
+          # Aligns comments with whitespace
+          "pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml"
+          # TODO: Fix formatting for auto-generated file
+          "pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml"
+        ];
+        includes = [
+          "*.yaml"
+          "*.yml"
+        ];
+        options = [
+          "-formatter"
+          "retain_line_breaks=true"
+        ];
+      };
+
+      nixf-diagnose = {
+        command = lib.getExe pkgs.nixf-diagnose;
+        excludes = [
+          # Auto-generated; violates sema-extra-with
+          # Can only sensibly be removed when --auto-fix supports multiple fixes at once:
+          # https://github.com/inclyc/nixf-diagnose/issues/13
+          "pkgs/servers/home-assistant/component-packages.nix"
+          # https://github.com/nix-community/nixd/issues/708
+          "nixos/maintainers/scripts/azure-new/examples/basic/system.nix"
+        ];
+        includes = [ "*.nix" ];
+        options = [
+          "--auto-fix"
+          # Rule names can currently be looked up here:
+          # https://github.com/nix-community/nixd/blob/main/libnixf/src/Basic/diagnostic.py
+          # TODO: Remove the following and fix things.
+          "--ignore=sema-unused-def-lambda-noarg-formal"
+          "--ignore=sema-unused-def-lambda-witharg-arg"
+          "--ignore=sema-unused-def-lambda-witharg-formal"
+          "--ignore=sema-unused-def-let"
+          # Keep this rule, because we have `lib.or`.
+          "--ignore=or-identifier"
+          # TODO: remove after outstanding prelude diagnostics issues are fixed:
+          # https://github.com/nix-community/nixd/issues/761
+          # https://github.com/nix-community/nixd/issues/762
+          "--ignore=sema-primop-removed-prefix"
+          "--ignore=sema-primop-overridden"
+          "--ignore=sema-constant-overridden"
+          "--ignore=sema-primop-unknown"
+        ];
+        # Ensure nixfmt cleans up after nixf-diagnose.
+        priority = -1;
+      };
+
+      editorconfig-checker = {
+        command = lib.getExe pkgs.editorconfig-checker;
+        options = [
+          "-disable-indent-size"
+          # TODO: Remove this once this upstream issue is fixed:
+          #   https://github.com/editorconfig-checker/editorconfig-checker/issues/505
+          "-disable-charset"
+        ];
+        includes = [ "*" ];
+        priority = 1;
+      };
+
+      markdown-code-runner = {
+        command = lib.getExe pkgs.markdown-code-runner;
+        options =
+          let
+            config = pkgs.writers.writeTOML "markdown-code-runner-config" {
+              presets.nixfmt = {
+                language = "nix";
+                command = [ (lib.getExe pkgs.nixfmt) ];
+              };
+            };
+          in
+          [ "--config=${config}" ];
+        includes = [ "*.md" ];
+      };
+
+      zizmor = {
+        command = lib.getExe pkgs.zizmor;
+        includes = [
+          ".github/workflows/*.yml"
+          ".github/workflows/*.yaml"
+          ".github/actions/**/*.yml"
+          ".github/actions/**/*.yaml"
+        ];
+      };
+    };
+  };
 }

--- a/ci/treefmt.nix
+++ b/ci/treefmt.nix
@@ -27,7 +27,7 @@
     on-unmatched = "debug";
 
     formatter = {
-
+      # keep-sorted start block=yes newline_separated=yes
       actionlint = {
         command = lib.getExe pkgs.actionlint;
         includes = [
@@ -66,34 +66,36 @@
         ];
       };
 
+      editorconfig-checker = {
+        command = lib.getExe pkgs.editorconfig-checker;
+        options = [
+          "-disable-indent-size"
+          # TODO: Remove this once this upstream issue is fixed:
+          #   https://github.com/editorconfig-checker/editorconfig-checker/issues/505
+          "-disable-charset"
+        ];
+        includes = [ "*" ];
+        priority = 1;
+      };
+
       keep-sorted = {
         command = lib.getExe pkgs.keep-sorted;
         includes = [ "*" ];
       };
 
-      # This uses nixfmt underneath, the default formatter for Nix code.
-      # See https://github.com/NixOS/nixfmt
-      nixfmt = {
-        command = lib.getExe pkgs.nixfmt;
-        includes = [ "*.nix" ];
-      };
-
-      yamlfmt = {
-        command = lib.getExe pkgs.yamlfmt;
-        excludes = [
-          # Aligns comments with whitespace
-          "pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml"
-          # TODO: Fix formatting for auto-generated file
-          "pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml"
-        ];
-        includes = [
-          "*.yaml"
-          "*.yml"
-        ];
-        options = [
-          "-formatter"
-          "retain_line_breaks=true"
-        ];
+      markdown-code-runner = {
+        command = lib.getExe pkgs.markdown-code-runner;
+        options =
+          let
+            config = pkgs.writers.writeTOML "markdown-code-runner-config" {
+              presets.nixfmt = {
+                language = "nix";
+                command = [ (lib.getExe pkgs.nixfmt) ];
+              };
+            };
+          in
+          [ "--config=${config}" ];
+        includes = [ "*.md" ];
       };
 
       nixf-diagnose = {
@@ -130,31 +132,29 @@
         priority = -1;
       };
 
-      editorconfig-checker = {
-        command = lib.getExe pkgs.editorconfig-checker;
-        options = [
-          "-disable-indent-size"
-          # TODO: Remove this once this upstream issue is fixed:
-          #   https://github.com/editorconfig-checker/editorconfig-checker/issues/505
-          "-disable-charset"
-        ];
-        includes = [ "*" ];
-        priority = 1;
+      # This uses nixfmt underneath, the default formatter for Nix code.
+      # See https://github.com/NixOS/nixfmt
+      nixfmt = {
+        command = lib.getExe pkgs.nixfmt;
+        includes = [ "*.nix" ];
       };
 
-      markdown-code-runner = {
-        command = lib.getExe pkgs.markdown-code-runner;
-        options =
-          let
-            config = pkgs.writers.writeTOML "markdown-code-runner-config" {
-              presets.nixfmt = {
-                language = "nix";
-                command = [ (lib.getExe pkgs.nixfmt) ];
-              };
-            };
-          in
-          [ "--config=${config}" ];
-        includes = [ "*.md" ];
+      yamlfmt = {
+        command = lib.getExe pkgs.yamlfmt;
+        excludes = [
+          # Aligns comments with whitespace
+          "pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml"
+          # TODO: Fix formatting for auto-generated file
+          "pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml"
+        ];
+        includes = [
+          "*.yaml"
+          "*.yml"
+        ];
+        options = [
+          "-formatter"
+          "retain_line_breaks=true"
+        ];
       };
 
       zizmor = {
@@ -166,6 +166,7 @@
           ".github/actions/**/*.yaml"
         ];
       };
+      # keep-sorted end
     };
   };
 }

--- a/shell.nix
+++ b/shell.nix
@@ -34,7 +34,7 @@ curPkgs
   packages = with pkgs; [
     # Helper to review Nixpkgs PRs
     # See CONTRIBUTING.md
-    nixpkgs-review
+    nixpkgs-reviewFull
     # Command-line utility for working with GitHub
     # Used by nixpkgs-review to fetch eval results
     gh

--- a/shell.nix
+++ b/shell.nix
@@ -28,15 +28,14 @@ let
 in
 curPkgs
 // pkgs.mkShellNoCC {
-  inputsFrom = [
-    fmt.shell
-  ];
-  packages = with pkgs; [
+  packages = [
     # Helper to review Nixpkgs PRs
     # See CONTRIBUTING.md
-    nixpkgs-reviewFull
+    pkgs.nixpkgs-reviewFull
     # Command-line utility for working with GitHub
     # Used by nixpkgs-review to fetch eval results
-    gh
+    pkgs.gh
+    # treefmt wrapper
+    fmt.pkg
   ];
 }


### PR DESCRIPTION
Manual backport of #465059 and #530947
