### PR TITLE
lib.checkedDerivation: init

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -373,8 +373,102 @@ rec {
       mapAttrs mkAttrOverridable pkgs;
 
   /**
+    Instantiate a derivation and check a given condition when evaluating. This
+    is not intended to be called by individual derivations, and is instead
+    called by functions like `stdenv.mkDerivation`.
+
+    Unlike `lib.extendDerivation`, this calls `builtins.derivationStrict`
+    directly, which is more performant than extending immediately after calling
+    `builtins.derivation`. For this reason, it's recommended to use this
+    function for new instantiations.
+
+    # Inputs
+
+    `condition`
+
+    : 1\. Function argument
+
+    `passthru`
+
+    : 2\. Function argument
+
+    `drvAttrs`
+
+    : 3\. Function argument
+
+    # Type
+
+    ```
+    checkedDerivation :: Bool -> Any -> AttrSet -> Derivation
+    ```
+  */
+  checkedDerivation =
+    let
+      defaultOutputs = [ "out" ];
+    in
+    condition: passthru:
+    drvAttrs@{
+      outputs ? defaultOutputs,
+      ...
+    }:
+    let
+      strict = derivationStrict drvAttrs;
+      commonAttrs =
+        drvAttrs
+        // (
+          if !drvAttrs ? outputs || outputs == defaultOutputs then
+            {
+              out = mkOutput "out";
+            }
+          else
+            listToAttrs (
+              map (name: {
+                inherit name;
+                value = mkOutput name;
+              }) outputs
+            )
+        )
+        // passthru
+        // {
+          type = "derivation";
+          inherit drvAttrs;
+          outputName = head outputs;
+          all = map mkOutput outputs;
+          drvPath =
+            assert condition;
+            strict.drvPath;
+          outPath =
+            assert condition;
+            strict.${head outputs};
+        };
+
+      mkOutput =
+        outputName:
+        commonAttrs
+        // {
+          inherit outputName;
+          outputSpecified = true;
+          outPath =
+            assert condition;
+            strict.${outputName};
+          # TODO: give the derivation control over the outputs.
+          #       `overrideAttrs` may not be the only attribute that needs
+          #       updating when switching outputs.
+          # TODO: also add overrideAttrs when overrideAttrs is not custom, e.g. when not splicing.
+          ${if passthru ? overrideAttrs then "overrideAttrs" else null} =
+            f: (passthru.overrideAttrs f).${outputName};
+        };
+    in
+    commonAttrs;
+
+  /**
     Add attributes to each output of a derivation without changing
     the derivation itself and check a given condition when evaluating.
+
+    This function should only be used when extending a previously-instantiated
+    derivation. To instantiate a new derivation with a condition, use
+    `lib.checkedDerivation`. In the future, this function may be deprecated in
+    favor of using `meta.problems`.
 
     # Inputs
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -409,6 +409,7 @@ let
         makeOverridable
         callPackageWith
         callPackagesWith
+        checkedDerivation
         extendDerivation
         hydraJob
         makeScope

--- a/pkgs/os-specific/linux/minimal-bootstrap/utils.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/utils.nix
@@ -31,31 +31,30 @@ rec {
       passthru = attrs.passthru or { };
       validity = assertValidity { inherit meta attrs; };
       meta = commonMeta { inherit validity attrs; };
-      baseDrv = derivation (
-        {
-          inherit (buildPlatform) system;
-          # redefining from meta to avoid forcing the thunk until it's used
-          name = attrs.name or "${attrs.pname}-${attrs.version}";
-        }
-        // maybeContentAddressed
-        // (removeAttrs attrs removedAttributeNames)
-      );
+      baseDrvAttrs = {
+        inherit (buildPlatform) system;
+        # redefining from meta to avoid forcing the thunk until it's used
+        name = attrs.name or "${attrs.pname}-${attrs.version}";
+      }
+      // maybeContentAddressed
+      // (removeAttrs attrs removedAttributeNames);
       passthru' =
         if passthru ? tests then
           passthru
           // {
-            tests = lib.mapAttrs (_: f: f baseDrv) passthru.tests;
+            tests = lib.mapAttrs (_: f: f final) passthru.tests;
           }
         else
           passthru;
+      final = lib.checkedDerivation validity.handled (
+        {
+          inherit meta;
+          passthru = passthru';
+        }
+        // passthru'
+      ) baseDrvAttrs;
     in
-    lib.extendDerivation validity.handled (
-      {
-        inherit meta;
-        passthru = passthru';
-      }
-      // passthru'
-    ) baseDrv;
+    final;
 
   writeTextFile =
     let

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -12,13 +12,13 @@ let
   inherit (lib)
     all
     attrNames
+    checkedDerivation
     concatLists
     concatMap
     concatMapStrings
     concatMapStringsSep
     concatStringsSep
     elem
-    extendDerivation
     filter
     filterAttrs
     foldl'
@@ -1012,7 +1012,7 @@ let
         ) env';
     in
 
-    extendDerivation validity.handled (
+    checkedDerivation validity.handled (
       {
         # A derivation that always builds successfully and whose runtime
         # dependencies are the original derivations build time dependencies
@@ -1068,7 +1068,7 @@ let
         # should be made available to Nix expressions using the
         # derivation (e.g., in assertions).
         passthru
-    ) (derivation (derivationArg // checkedEnv));
+    ) (derivationArg // checkedEnv);
 
 in
 {


### PR DESCRIPTION
Fixes #522442.

Stats diff for `pkgs.hello`:
```json
{
  "attrset": {
    "lookups": "-8.43%",
    "merges": "-20.84%",
    "mergeCopies": "-1.51%"
  },
  "list": {
    "concats": "-28.8%"
  },
  "parser": {
    "expressions": "-0%"
  },
  "memoryBytes": {
    "envs": "-3.87%",
    "list": "-13.1%",
    "sets": "-2.83%",
    "symbols": "+0%",
    "values": "-2.44%",
    "total": "-2.88%"
  },
  "speed": {
    "primops": "-8.03%",
    "functionCalls": "-3.76%",
    "thunksMade": "-6.58%",
    "thunksAvoided": "-6.11%"
  }
}
```
For `pkgs.firefox`:
```json
{
  "attrset": {
    "lookups": "-7.91%",
    "merges": "-17.77%",
    "mergeCopies": "-3.02%"
  },
  "list": {
    "concats": "-10.24%"
  },
  "parser": {
    "expressions": "-0%"
  },
  "memoryBytes": {
    "envs": "-3.11%",
    "list": "-12.33%",
    "sets": "-3.95%",
    "symbols": "+0%",
    "values": "-3.05%",
    "total": "-3.76%"
  },
  "speed": {
    "primops": "-9.48%",
    "functionCalls": "-3.09%",
    "thunksMade": "-5.68%",
    "thunksAvoided": "-5.01%"
  }
}
```
And for a minimal NixOS config:
```sh
NIX_SHOW_STATS=1 \
      nix eval --impure --expr '
      let nixos = import ./nixos/lib/eval-config.nix {
        modules = [ ./nixos/modules/profiles/minimal.nix
          { fileSystems."/" = { device = "/dev/sda1"; fsType = "ext4"; };
            boot.loader.grub.devices = ["/dev/sda"]; } ];
      }; in nixos.config.system.build.toplevel
    '
```

```json
{
  "attrset": {
    "lookups": "-1.32%",
    "merges": "-5.94%",
    "mergeCopies": "-3.15%"
  },
  "list": {
    "concats": "-3.97%"
  },
  "parser": {
    "expressions": "-0%"
  },
  "memoryBytes": {
    "envs": "-0.6%",
    "list": "-3%",
    "sets": "-2.69%",
    "symbols": "+0%",
    "values": "-1.07%",
    "total": "-1.75%"
  },
  "speed": {
    "primops": "-1.68%",
    "functionCalls": "-0.51%",
    "thunksMade": "-1.38%",
    "thunksAvoided": "-1.23%"
  }
}
```

Running hyperfine on `pkgs.firefox` with an alpha value of 0.01:
```sh
# before
Benchmark 1: nix-instantiate --eval -E '(import ./. {}).firefox.outPath'
  Time (mean ± σ):      1.234 s ±  0.011 s    [User: 1.006 s, System: 0.216 s]
  Range (min … max):    1.220 s …  1.263 s    25 runs

# after
Benchmark 2: nix-instantiate --eval -E '(import ./. {}).firefox.outPath'
  Time (mean ± σ):      1.205 s ±  0.010 s    [User: 0.987 s, System: 0.205 s]
  Range (min … max):    1.183 s …  1.220 s    25 runs
```
Plugging this into 2PropTTest in a TI84 and testing whether the execution time has decreased, we get a P-value of 3.13 * 10^-13, or 0.000000000000313. Since that's less than the established alpha value, we reject the null and accept the alternative.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
