### PR TITLE
[Backport release-25.11] maintainers/scripts/update.nix: allow `true` for boolean args along w/ `"true"`

### DIFF
--- a/maintainers/scripts/update.nix
+++ b/maintainers/scripts/update.nix
@@ -13,9 +13,9 @@
   path ? null,
   max-workers ? null,
   include-overlays ? false,
-  keep-going ? null,
-  commit ? null,
-  skip-prompt ? null,
+  keep-going ? false,
+  commit ? false,
+  skip-prompt ? false,
   order ? null,
 }:
 
@@ -206,18 +206,18 @@ let
 
     to increase the number of jobs in parallel, or
 
-        --argstr keep-going true
+        --arg keep-going true
 
     to continue running when a single update fails.
 
     You can also make the updater automatically commit on your behalf from updateScripts
     that support it by adding
 
-        --argstr commit true
+        --arg commit true
 
-    to skip prompt:
+    To skip the prompt, you can add
 
-        --argstr skip-prompt true
+        --arg skip-prompt true
 
     By default, the updater will update the packages in arbitrary order. Alternately, you can force a specific order based on the packages’ dependency relations:
 
@@ -250,11 +250,15 @@ let
   # JSON file with data for update.py.
   packagesJson = pkgs.writeText "packages.json" (builtins.toJSON (map packageData packages));
 
+  # Allow boolean arguments to be provided with either --arg or --argstr.
+  # The ability to use the string "true" will be deprecated.
+  isTrue = arg: arg == true || arg == "true";
+
   optionalArgs =
     lib.optional (max-workers != null) "--max-workers=${max-workers}"
-    ++ lib.optional (keep-going == "true") "--keep-going"
-    ++ lib.optional (commit == "true") "--commit"
-    ++ lib.optional (skip-prompt == "true") "--skip-prompt"
+    ++ lib.optional (isTrue keep-going) "--keep-going"
+    ++ lib.optional (isTrue commit) "--commit"
+    ++ lib.optional (isTrue skip-prompt) "--skip-prompt"
     ++ lib.optional (order != null) "--order=${order}";
 
   args = [ packagesJson ] ++ optionalArgs;

--- a/pkgs/README.md
+++ b/pkgs/README.md
@@ -1023,7 +1023,7 @@ Furthermore each update script will be passed the following environment variable
 > An update script will be usually run from the root of the Nixpkgs repository, but you should not rely on that.
 > Also note that `update.nix` executes update scripts in parallel by default, so you should avoid running `git commit` or any other commands that cannot handle that.
 
-While update scripts should not create commits themselves, `update.nix` supports automatically creating commits when running it with `--argstr commit true`.
+While update scripts should not create commits themselves, `update.nix` supports automatically creating commits when running it with `--arg commit true`.
 If you need to customize commit message, you can have the update script implement the `commit` feature.
 
 ### Supported features
@@ -1050,7 +1050,7 @@ If you need to customize commit message, you can have the update script implemen
   ```
   :::
 
-  When `update.nix` is run with `--argstr commit true`, it will create a separate commit for each of the objects.
+  When `update.nix` is run with `--arg commit true`, it will create a separate commit for each of the objects.
   An empty list can be returned when the script did not update any files; for example, when the package is already at the latest version.
 
   The commit object contains the following values:

--- a/pkgs/by-name/bu/buck2/package.nix
+++ b/pkgs/by-name/bu/buck2/package.nix
@@ -34,7 +34,7 @@
 # from the root of the nixpkgs git repository, run:
 #
 #    nix-shell maintainers/scripts/update.nix \
-#      --argstr commit true \
+#      --arg commit true \
 #      --argstr package buck2
 
 let

--- a/pkgs/by-name/cl/claude-code/package.nix
+++ b/pkgs/by-name/cl/claude-code/package.nix
@@ -1,6 +1,6 @@
 # NOTE: Use the following command to update the package
 # ```sh
-# nix-shell maintainers/scripts/update.nix --argstr commit true --arg predicate '(path: pkg: builtins.elem path [["claude-code"] ["vscode-extensions" "anthropic" "claude-code"]])'
+# nix-shell maintainers/scripts/update.nix --arg commit true --arg predicate '(path: pkg: builtins.elem path [["claude-code"] ["vscode-extensions" "anthropic" "claude-code"]])'
 # ```
 {
   lib,

--- a/pkgs/by-name/li/lightning-terminal/package.nix
+++ b/pkgs/by-name/li/lightning-terminal/package.nix
@@ -123,7 +123,7 @@ buildGoModule rec {
         fi
       '';
 
-  # Usage: nix-shell maintainers/scripts/update.nix --argstr package lightning-terminal --argstr commit true
+  # Usage: nix-shell maintainers/scripts/update.nix --argstr package lightning-terminal --arg commit true
   passthru.updateScript = _experimental-update-script-combinators.sequence [
     (gitUpdater {
       rev-prefix = "v";

--- a/pkgs/by-name/uh/uhd/package.nix
+++ b/pkgs/by-name/uh/uhd/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "uhd";
   # NOTE: Use the following command to update the package, and the uhdImageSrc attribute:
   #
-  #     nix-shell maintainers/scripts/update.nix --argstr package uhd --argstr commit true
+  #     nix-shell maintainers/scripts/update.nix --argstr package uhd --arg commit true
   #
   version = "4.9.0.0";
 

--- a/pkgs/data/fonts/nerd-fonts/update.py
+++ b/pkgs/data/fonts/nerd-fonts/update.py
@@ -12,7 +12,7 @@ if not all(
     raise Exception(
         "Please don't run this script manually, only with:\n"
         "nix-shell maintainers/scripts/update.nix --argstr path nerd-fonts "
-        "--argstr commit true"
+        "--arg commit true"
     )
 
 RELEASE_INFO_URL = "https://api.github.com/repos/ryanoasis/nerd-fonts/releases/latest"

--- a/pkgs/development/mobile/androidenv/README.md
+++ b/pkgs/development/mobile/androidenv/README.md
@@ -1,6 +1,6 @@
 # How to update
 
-`nix-shell maintainers/scripts/update.nix  --argstr package androidenv.test-suite --argstr commit true`
+`nix-shell maintainers/scripts/update.nix  --argstr package androidenv.test-suite --arg commit true`
 
 # How to run tests
 

--- a/pkgs/development/tools/infisical/default.nix
+++ b/pkgs/development/tools/infisical/default.nix
@@ -13,7 +13,7 @@
 # from the root of the nixpkgs git repository, run:
 #
 #    nix-shell maintainers/scripts/update.nix \
-#      --argstr commit true \
+#      --arg commit true \
 #      --argstr package infisical
 
 let

--- a/pkgs/tools/games/minecraft/optifine/default.nix
+++ b/pkgs/tools/games/minecraft/optifine/default.nix
@@ -8,7 +8,7 @@
 
 # The `versions.json` can be automatically updated and committed with a commit summary.
 # To do so, change directory to nixpkgs root, and do:
-# $ nix-shell ./maintainers/scripts/update.nix --argstr package optifinePackages.optifine-latest --argstr commit true
+# $ nix-shell ./maintainers/scripts/update.nix --argstr package optifinePackages.optifine-latest --arg commit true
 
 lib.recurseIntoAttrs (
   lib.mapAttrs (name: value: callPackage ./generic.nix value) (lib.importJSON ./versions.json)


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
