### PR TITLE
tack: init at 1.0.0; init module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -328,6 +328,7 @@
   ./programs/sysdig.nix
   ./programs/system-config-printer.nix
   ./programs/systemtap.nix
+  ./programs/tack.nix
   ./programs/tcpdump.nix
   ./programs/television.nix
   ./programs/throne.nix

--- a/nixos/modules/programs/tack.nix
+++ b/nixos/modules/programs/tack.nix
@@ -1,0 +1,26 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.tack;
+in
+{
+  options.programs.tack = {
+    enable = lib.mkEnableOption "tack, flake-like toml nix pins";
+
+    package = lib.mkPackageOption pkgs "tack" { };
+
+    nixConfTokens = lib.mkEnableOption "tack reading access tokens from nix.conf (significantly improves comparison speed)";
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    environment.sessionVariables = lib.mkIf cfg.nixConfTokens {
+      TACK_NIX_CONF_TOKENS = "1";
+    };
+  };
+}

--- a/pkgs/by-name/ta/tack/package.nix
+++ b/pkgs/by-name/ta/tack/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tack";
+  version = "1.0.0";
+  src = fetchFromGitHub {
+    owner = "manic-systems";
+    repo = "tack";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KhJb0NWLhj8AkD8uWEbXt179YlFLemk0OgOltw4jEk8=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  cargoHash = "sha256-3vDMM5uTsmRso6McH/b3+RpjeKjhgQm9V1piBrnSRjk=";
+
+  prePatch = ''
+    rm .cargo/config.toml
+  '';
+
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://github.com/manic-systems/tack";
+    description = "flake-like toml nix pins, lazily fetched and transformed";
+    mainProgram = "tack";
+    license = [ lib.licenses.eupl12 ];
+    maintainers = with lib.maintainers; [
+      amaanq
+      atagen
+      faukah
+      max
+      NotAShelf
+    ];
+  };
+})


### PR DESCRIPTION
cc @amaanq @faukah @max-privatevoid @NotAShelf 

add [tack](https://github.com/manic-systems/tack) package + module.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
