### PR TITLE
fire-alpaca: init at 2.16.0

### DIFF
--- a/pkgs/by-name/fi/fire-alpaca/package.nix
+++ b/pkgs/by-name/fi/fire-alpaca/package.nix
@@ -1,0 +1,103 @@
+{
+  appimageTools,
+  fetchurl,
+  lib,
+  stdenvNoCC,
+  unzip,
+}:
+
+let
+  baseUrl = "https://web.archive.org/web/20260622062138/https://firealpaca.com/download/";
+
+  pname = "fire-alpaca";
+  version = "2.16.0";
+  __structuredAttrs = true;
+  strictDeps = true;
+  passthru.updateScript = ./update.sh;
+  meta = {
+    description = "Digital painting software";
+    longDescription = ''
+      FireAlpaca is a freeware paint tool that has been used
+      worldwide, supports 10 languages.
+    '';
+    homepage = "https://firealpaca.com";
+    license = lib.licenses.unfree;
+    mainProgram = "fire-alpaca";
+    maintainers = with lib.maintainers; [ yiyu ];
+    platforms = [
+      "aarch64-darwin"
+      "x86_64-linux"
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+in
+if stdenvNoCC.hostPlatform.system == "aarch64-darwin" then
+  stdenvNoCC.mkDerivation {
+    inherit
+      pname
+      version
+      __structuredAttrs
+      strictDeps
+      passthru
+      meta
+      ;
+
+    src = fetchurl {
+      url = "${baseUrl}mac";
+      hash = "sha256-hium+wJESzkgV0X2gf5fyNImI8ss9W8MWGi1Pk2mIY8=";
+    };
+
+    nativeBuildInputs = [ unzip ];
+
+    unpackPhase = ''
+      runHook preUnpack
+
+      unzip "$src"
+
+      runHook postUnpack
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir --parents "$out"/Applications
+      cp --recursive FireAlpaca.app "$_"
+
+      runHook postInstall
+    '';
+  }
+else if stdenvNoCC.hostPlatform.system == "x86_64-linux" then
+  (appimageTools.wrapType2 rec {
+    inherit
+      pname
+      version
+      passthru
+      meta
+      ;
+
+    src = fetchurl {
+      url = "${baseUrl}linux";
+      hash = "sha256-kPW1pPPr1HIAZNrJJhieiaT2g6aMMbvbHhFTuzxviX8=";
+    };
+
+    extraInstallCommands =
+      let
+        appimageContents = appimageTools.extract {
+          inherit pname version src;
+        };
+      in
+      ''
+        install -Dm444 ${appimageContents}/FireAlpaca.desktop \
+          --target-directory="$out"/share/applications
+
+        substituteInPlace "$out"/share/applications/FireAlpaca.desktop \
+          --replace-fail Exec=FireAlpaca Exec=${meta.mainProgram}
+
+        cp --recursive ${appimageContents}/usr/share/icons $out/share
+      '';
+  }).overrideAttrs
+    (oldAttrs: {
+      inherit __structuredAttrs strictDeps;
+    })
+else
+  { }

--- a/pkgs/by-name/fi/fire-alpaca/update.sh
+++ b/pkgs/by-name/fi/fire-alpaca/update.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash -p curl nix gnused
+set -euo pipefail
+
+nix_file=$(nix-instantiate --eval -A fire-alpaca.meta.position 2>/dev/null |
+  sed -re 's/^"(.*):[0-9]+"$/\1/')
+
+version=$(
+  curl -sfL "https://firealpaca.com/download/" |
+    grep -oP 'FireAlpaca\s+\K\d+\.\d+\.\d+(?=\s+Download)' |
+    head -1
+)
+
+base_url=https://firealpaca.com/download
+archive_url=https://web.archive.org/save
+timestamp=
+
+for platform in x86_64-linux aarch64-darwin; do
+  case "$platform" in
+  x86_64-linux) suffix=linux ;;
+  aarch64-darwin) suffix=mac ;;
+  esac
+
+  live_url="$base_url"/"$suffix"
+
+  archived_url=$(
+    curl -sI -L -o /dev/null -w '%{url_effective}' --max-time 120 \
+      "$archive_url"/"$live_url" 2>/dev/null || true
+  )
+
+  if [[ "$archived_url" == "$archive_url"* ]] || [[ -z "$archived_url" ]]; then
+    printf 'web.archive.org/save failed for %s, using live URL\n' "$live_url" >&2
+    archived_url="$live_url"
+  else
+    [[ -z "$timestamp" ]] && timestamp=$(sed -n 's|.*web/\([0-9]*\)/.*|\1|p' <<<"$archived_url")
+  fi
+
+  hash=$(nix-prefetch-url "$archived_url" 2>/dev/null || true)
+  if [[ -z "$hash" ]]; then
+    printf 'nix-prefetch-url failed for %s, trying live URL\n' "$archived_url" >&2
+    hash=$(nix-prefetch-url "$live_url" 2>/dev/null || true)
+    archived_url=$live_url
+  fi
+  sri=$(nix --extra-experimental-features nix-command hash to-sri --type sha256 "$hash")
+  [[ -z "$timestamp" ]] && timestamp=$(date -u +%Y%m%d%H%M%S)
+
+  sed -i '/url =.*'"$suffix"'"/{n;s|hash = "[^"]*"|hash = "'"$sri"'"|;}' "$nix_file"
+done
+
+sed -i \
+  -e "s/version = \"[0-9.]*\";/version = \"$version\";/" \
+  -e "s|https://web.archive.org/web/[0-9]*/https://firealpaca.com/download/|https://web.archive.org/web/$timestamp/https://firealpaca.com/download/|" \
+  "$nix_file"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
