### PR TITLE
nixos-install: fix mount: command not found on foreign-distro hosts

### DIFF
--- a/pkgs/by-name/ni/nixos-install/nixos-install.sh
+++ b/pkgs/by-name/ni/nixos-install/nixos-install.sh
@@ -306,7 +306,18 @@ if [[ -z $noBootLoader ]]; then
     echo "installing the boot loader..."
     # Grub needs an mtab.
     ln -sfn /proc/mounts "$mountPoint"/etc/mtab
-    export mountPoint
+    # Resolve mount/umount from nixos-install's own PATH before entering the chroot.
+    # nixos-enter runs bash --login which sources the target's /etc/profile, resetting
+    # PATH to NixOS profile paths. On a running NixOS system, mount lives at
+    # /run/wrappers/bin/mount (a suid wrapper created by wrappers.service at first
+    # boot). That service has not run during installation, so the chroot cannot find
+    # mount, and the heredoc exits immediately with "mount: command not found".
+    # Exporting the resolved absolute store paths sidesteps the issue: they survive
+    # the --login PATH reset and are accessible inside the chroot because nixos-enter
+    # bind-mounts the Nix store.
+    mountBin="$(command -v mount)"
+    umountBin="$(command -v umount)"
+    export mountPoint mountBin umountBin
     NIXOS_INSTALL_BOOTLOADER=1 nixos-enter --root "$mountPoint" -c "$(cat <<'EOF'
       set -e
       # Clear the cache for executable locations. They were invalidated by the chroot.
@@ -316,11 +327,10 @@ if [[ -z $noBootLoader ]]; then
       # the root with `nixos-enter`.
       # Without this the bootloader installation may fail due to options that
       # contain paths referenced during evaluation, like initrd.secrets.
-      # when not root, re-execute the script in an unshared namespace
-      mount --rbind --mkdir / "$mountPoint"
-      mount --make-rslave "$mountPoint"
+      "$mountBin" --rbind --mkdir / "$mountPoint"
+      "$mountBin" --make-rslave "$mountPoint"
       /run/current-system/bin/switch-to-configuration boot
-      umount -R "$mountPoint" && (rmdir "$mountPoint" 2>/dev/null || true)
+      "$umountBin" -R "$mountPoint" && (rmdir "$mountPoint" 2>/dev/null || true)
 EOF
 )"
 fi


### PR DESCRIPTION
## Problem

When `nixos-install` is run from a non-NixOS host (Fedora, Ubuntu, Arch — any
distro with upstream or Determinate Nix installed), it exits non-zero with:

```
bash: line 10: mount: command not found
```

The script aborts, but the installation has often already succeeded. Users
who see this abandon the install or re-run it unnecessarily.

## Root cause

`nixos-install` adds `util-linux` to its own PATH (line 7 of the generated
script). The bootloader-installation step then spawns
`nixos-enter --root "$mountPoint"`, which invokes `bash --login`. The `--login`
flag sources the target system's `/etc/profile`, resetting PATH to the NixOS
profile paths — which include `/run/wrappers/bin` first.

On NixOS, `/run/wrappers/bin/mount` is a suid wrapper created by `wrappers.service`
at first boot. That service has not run during installation, so the path does not
exist inside the chroot. The `mount --rbind` call in the heredoc fails
immediately, `set -e` exits the heredoc, and `nixos-enter` propagates the
non-zero exit to `nixos-install`.

This does not reproduce on NixOS live ISOs because `wrappers.service` has already
run on the live system, so `/run/wrappers/bin/mount` exists in the host's
`/run`, which `nixos-enter` bind-mounts into the chroot.

## Fix

Resolve `mount` and `umount` to absolute paths from `nixos-install`'s own PATH
before entering the chroot. Export them as environment variables. The heredoc is
already single-quoted (`<<'EOF'`), so `$mountBin` and `$umountBin` are literal
text inside it; the inner `bash` inherits the env and expands them. Absolute Nix
store paths survive the `--login` PATH reset and are accessible inside the chroot
because `nixos-enter` bind-mounts the Nix store.

No behaviour change on native NixOS installs: `command -v mount` resolves to the
suid wrapper (which exists on a live system), and the heredoc behaves identically.

## Testing

Reproduced and fixed on Fedora 44 with Determinate Nix 2.x, installing NixOS
25.05 onto a LUKS2+btrfs target with pre-partitioned subvolumes at `/mnt`.
Without the fix: `nixos-install` exits 1 with the mount error printed.
With the fix: installation completes and the system boots normally.