### PR TITLE
python3Packages.fasthtml: 0.12.48 -> 0.13.3

### DIFF
--- a/pkgs/development/python-modules/fasthtml/default.nix
+++ b/pkgs/development/python-modules/fasthtml/default.nix
@@ -31,14 +31,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "fasthtml";
-  version = "0.12.48";
+  version = "0.13.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "AnswerDotAI";
     repo = "fasthtml";
     tag = finalAttrs.version;
-    hash = "sha256-lMAuIw4sMkS3XSG/0Bs0iQPSjMusbmjUKv0w4cINwas=";
+    hash = "sha256-PS5HGegC6pG/bJAGrKDsRYguBnNS9EDrZIjWvjErO4M=";
   };
 
   build-system = [


### PR DESCRIPTION
.starlette upgrade in 83ece5c3a1e broke compatibility:
https://hydra.nixos.org/build/331250021/nixlog/6/tail

Upstream fixes that v0.13.0 and updating past 0.13.3 would need resolving
 - fastcore>=1.12.41 not satisfied by version 1.12.39
 (which isn't great approach for stable 26.05 which motivates this commit)
 https://github.com/AnswerDotAI/fasthtml/releases

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux atop staging-next-26.05
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
