### PR TITLE
battleships: init at 2.15

### DIFF
--- a/pkgs/by-name/ba/battleships/package.nix
+++ b/pkgs/by-name/ba/battleships/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  ncurses,
+  asciidoctor,
+  installShellFiles,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "battleships";
+  version = "2.15";
+
+  src = fetchFromGitLab {
+    owner = "esr";
+    repo = "bs";
+    tag = finalAttrs.version;
+    hash = "sha256-7HOqgiZ/KeY+ZKZVaM6Dl52S32NiVvWwwxByVQcJ49g=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    asciidoctor
+    installShellFiles
+  ];
+
+  buildInputs = [
+    ncurses
+  ];
+
+  buildFlags = [
+    "bs"
+    "bs.6"
+  ];
+
+  # Upstream bs.c has two declaration mismatches that newer GCC treats
+  # as errors
+  postPatch = ''
+    substituteInPlace bs.c  \
+      --replace-fail "static bool checkplace(int b, ship_t *ss, int vis);"  \
+                     "static bool checkplace(int b, const ship_t *ss, int vis);"  \
+      --replace-fail "static void do_options(int c, const char *op[]) {"  \
+                     "static void do_options(int c, char *op[]) {"
+
+    substituteInPlace bs.desktop  \
+      --replace-fail "Exec=bs" "Exec=battleships"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 bs $out/bin/battleships
+    cp bs.6 battleships.6
+    installManPage battleships.6
+    install -Dm644 bs.desktop $out/share/applications/battleships.desktop
+    install -Dm644 battleship.png  \
+      $out/share/icons/hicolor/32x32/apps/battleship.png
+    install -Dm644 bs.adoc $out/share/appdata/battleships.adoc
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "The classic game of Battleships against the computer";
+    homepage = "https://gitlab.com/esr/bs";
+    changelog = "https://gitlab.com/esr/bs/-/tags/${finalAttrs.version}";
+    mainProgram = "battleships";
+    license = lib.licenses.bsd2;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ castorNova2 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds [bs](https://gitlab.com/esr/bs) which is a TUI game of Battleships against the computer. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
