### PR TITLE
bindfs: 1.18.1 -> 1.18.4

### DIFF
--- a/pkgs/by-name/bi/bindfs/package.nix
+++ b/pkgs/by-name/bi/bindfs/package.nix
@@ -10,25 +10,13 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "1.18.1";
+  version = "1.18.4";
   pname = "bindfs";
 
   src = fetchurl {
     url = "https://bindfs.org/downloads/bindfs-${finalAttrs.version}.tar.gz";
-    hash = "sha256-KnBk2ZOl8lXFLXI4XvFONJwTG8RBlXZuIXNCjgbSef0=";
+    hash = "sha256-MmbQqreHqTKLuw7VYaNx4Z8f8HcnPmaEypKpD+2y/iQ=";
   };
-
-  patches = [
-    # This commit fixes macfuse support but breaks fuse support
-    # The condition to include `uint32_t position` in bindfs_setxattr and bindfs_getxattr
-    # is wrong, leading to -Wincompatible-function-pointer-types
-    # https://github.com/mpartel/bindfs/issues/169
-    (fetchpatch {
-      url = "https://github.com/mpartel/bindfs/commit/3293dc98e37eed0fb0cbfcbd40434d3c37c69480.patch";
-      hash = "sha256-dtjvSJTS81R+sksl7n1QiyssseMQXPlm+LJYZ8/CESQ=";
-      revert = true;
-    })
-  ];
 
   nativeBuildInputs = [
     autoreconfHook
@@ -48,7 +36,9 @@ stdenv.mkDerivation (finalAttrs: {
     description = "FUSE filesystem for mounting a directory to another location";
     homepage = "https://bindfs.org";
     license = lib.licenses.gpl2Only;
+    mainProgram = "bindfs";
     maintainers = with lib.maintainers; [
+      fidgetingbits
       lovesegfault
     ];
     platforms = lib.platforms.unix;


### PR DESCRIPTION
Added `mainProgram` and bumped to 1.18.4. I removed the patches section since the revert doesn't work on 1.18.4 and since fuse dependencies were recently changed, maybe it will work without. I don't have darwin to test, but we'll see.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
