### PR TITLE
python3Packages.openai-agents: 0.6.9 → 0.17.6

### DIFF
--- a/pkgs/development/python-modules/openai-agents/default.nix
+++ b/pkgs/development/python-modules/openai-agents/default.nix
@@ -3,7 +3,7 @@
   buildPythonPackage,
   fetchPypi,
   hatchling,
-  griffe,
+  griffelib,
   mcp,
   openai,
   pydantic,
@@ -14,13 +14,13 @@
 
 buildPythonPackage rec {
   pname = "openai-agents";
-  version = "0.6.9";
+  version = "0.17.6";
   pyproject = true;
 
   src = fetchPypi {
     inherit version;
     pname = "openai_agents";
-    hash = "sha256-5VYjgntKGxHWbsAIS9K56ixtYPIz4EVHgDr0M5Z+L9s=";
+    hash = "sha256-/tlPjPDrTFfGOomtSxB5MtdfKgttnolciPo8IX5jyCI=";
   };
 
   build-system = [
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   ];
 
   dependencies = [
-    griffe
+    griffelib
     mcp
     openai
     pydantic

--- a/pkgs/development/python-modules/openai-agents/default.nix
+++ b/pkgs/development/python-modules/openai-agents/default.nix
@@ -12,13 +12,13 @@
   typing-extensions,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "openai-agents";
   version = "0.17.6";
   pyproject = true;
 
   src = fetchPypi {
-    inherit version;
+    inherit (finalAttrs) version;
     pname = "openai_agents";
     hash = "sha256-/tlPjPDrTFfGOomtSxB5MtdfKgttnolciPo8IX5jyCI=";
   };
@@ -42,10 +42,10 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    changelog = "https://github.com/openai/openai-agents-python/releases/tag/${version}";
+    changelog = "https://github.com/openai/openai-agents-python/releases/tag/v${finalAttrs.version}";
     homepage = "https://github.com/openai/openai-agents-python";
     description = "Lightweight, powerful framework for multi-agent workflows";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.bryanhonof ];
   };
-}
+})


### PR DESCRIPTION
https://github.com/openai/openai-agents-python/compare/v0.6.9...v0.17.6

Depends on #520204.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
