### PR TITLE
terminal-notifier: refactor

### DIFF
--- a/pkgs/by-name/te/terminal-notifier/package.nix
+++ b/pkgs/by-name/te/terminal-notifier/package.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-Hd9cI3R2nQK2deBb5CBYz4DTHAEcO4vzqtA5qZwa1Ao=";
   };
 
+  strictDeps = true;
+
   nativeBuildInputs = [
     ibtool
     makeBinaryWrapper

--- a/pkgs/by-name/te/terminal-notifier/package.nix
+++ b/pkgs/by-name/te/terminal-notifier/package.nix
@@ -1,5 +1,4 @@
 {
-  apple-sdk,
   fetchFromGitHub,
   ibtool,
   lib,
@@ -30,10 +29,6 @@ stdenv.mkDerivation (finalAttrs: {
     xcbuildHook
     # TODO: Clean up on `staging`
     llvmPackages.lld
-  ];
-
-  buildInputs = [
-    apple-sdk
   ];
 
   xcbuildFlags = [

--- a/pkgs/by-name/te/terminal-notifier/package.nix
+++ b/pkgs/by-name/te/terminal-notifier/package.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-Hd9cI3R2nQK2deBb5CBYz4DTHAEcO4vzqtA5qZwa1Ao=";
   };
 
+  __structuredAttrs = true;
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/te/terminal-notifier/package.nix
+++ b/pkgs/by-name/te/terminal-notifier/package.nix
@@ -34,8 +34,6 @@ stdenv.mkDerivation (finalAttrs: {
   xcbuildFlags = [
     "-target"
     "terminal-notifier"
-    "-configuration"
-    "Release"
   ];
 
   # TODO: Clean up on `staging`

--- a/pkgs/by-name/te/terminal-notifier/package.nix
+++ b/pkgs/by-name/te/terminal-notifier/package.nix
@@ -47,8 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     makeWrapper \
       $out/Applications/terminal-notifier.app/Contents/MacOS/terminal-notifier \
-      $out/bin/terminal-notifier \
-      --chdir $out/Applications/terminal-notifier.app
+      $out/bin/terminal-notifier
 
     runHook postInstall
   '';

--- a/pkgs/by-name/te/terminal-notifier/package.nix
+++ b/pkgs/by-name/te/terminal-notifier/package.nix
@@ -49,8 +49,9 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/{Applications,bin}
+    mkdir -p $out/Applications
     cp -r Products/Release/terminal-notifier.app $out/Applications/
+
     makeWrapper \
       $out/Applications/terminal-notifier.app/Contents/MacOS/terminal-notifier \
       $out/bin/terminal-notifier \


### PR DESCRIPTION
 A series of packaging cleanups for terminal-notifier. The version is unchanged (2.0.0), and the build output is identical apart from the wrapper fix.

This pull request summary was written with the assistance of Claude Code (Claude Opus 4.8).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
