### PR TITLE
[25.11] sqlpage: 0.39.0 -> 0.44.1

### DIFF
--- a/pkgs/by-name/sq/sqlpage/package.nix
+++ b/pkgs/by-name/sq/sqlpage/package.nix
@@ -42,13 +42,13 @@ in
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sqlpage";
-  version = "0.39.1";
+  version = "0.40.0";
 
   src = fetchFromGitHub {
     owner = "lovasoa";
     repo = "SQLpage";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Hj3tMi+3tZ4r/Jpf0PZiWykJsAPItkR/BPwFHYoEOi8=";
+    hash = "sha256-CmsAImnySdXlPQGWNMkPYhVj0HsvCzFB2LXeqFnjWG4=";
   };
 
   postPatch = ''
@@ -76,7 +76,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace-fail "copy_url_to_opened_file(&client, sprite_url, &mut sprite_content).await;" "sprite_content = std::fs::read(sprite_url).unwrap();"
   '';
 
-  cargoHash = "sha256-yTavtt5D0vfcMSvQnBQrIfSfssJ0Ld3O3q4lLSgrgIk=";
+  cargoHash = "sha256-CTJYFzSOLYFq7I9lJhD3JcO2PuqQjqtXnBCEk2VfLfI=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/by-name/sq/sqlpage/package.nix
+++ b/pkgs/by-name/sq/sqlpage/package.nix
@@ -10,31 +10,31 @@
 }:
 
 let
-  apexcharts = fetchurl {
-    url = "https://cdn.jsdelivr.net/npm/apexcharts@5.3.0/dist/apexcharts.min.js";
-    hash = "sha256-OtfH8igG4/XVMWV1155dCl8kGhruowISVUm7ZZF0VwU=";
+  apexcharts = {
+    url = "https://cdn.jsdelivr.net/npm/apexcharts@5.3.6/dist/apexcharts.min.js";
+    hash = "sha256-qNJtESJROYHRKwS/u3zdu4Fev69db17hKHZvrqGiqRs=";
   };
-  tablerCss = fetchurl {
+  tablerCss = {
     url = "https://cdn.jsdelivr.net/npm/@tabler/core@1.4.0/dist/css/tabler.min.css";
     hash = "sha256-fvdQvRBUamldCxJ2etgEi9jz7F3n2u+xBn+dDao9HJo=";
   };
-  tomSelectCss = fetchurl {
+  tomSelectCss = {
     url = "https://cdn.jsdelivr.net/npm/tom-select@2.4.3/dist/css/tom-select.bootstrap5.css";
     hash = "sha256-vW5UjM/Ka9/jIY8I5s5KcudaTRWh/cCGE1ZUsrJvlI0=";
   };
-  tablerVendorsCss = fetchurl {
+  tablerVendorsCss = {
     url = "https://cdn.jsdelivr.net/npm/@tabler/core@1.4.0/dist/css/tabler-vendors.min.css";
     hash = "sha256-/VPz9GtiH1Es1KGLY706UIayEEgG93B6aIBa3WzwKYc=";
   };
-  tablerJs = fetchurl {
+  tablerJs = {
     url = "https://cdn.jsdelivr.net/npm/@tabler/core@1.4.0/dist/js/tabler.min.js";
     hash = "sha256-tgx2Fg6XYkV027jPEKvmrummSTtgCW/fwV3R3SvZnrk=";
   };
-  tablerIcons = fetchurl {
+  tablerIcons = {
     url = "https://cdn.jsdelivr.net/npm/@tabler/icons-sprite@3.34.0/dist/tabler-sprite.svg";
     hash = "sha256-pCPkhrx0GnPg5/EthJ7pLdMxb7wbYMJ0R7WchDcffpg=";
   };
-  tomselect = fetchurl {
+  tomselect = {
     url = "https://cdn.jsdelivr.net/npm/tom-select@2.4.1/dist/js/tom-select.popular.min.js";
     hash = "sha256-Cb1Xmb9qQO8I1mMVkz4t2bT8l7HX+1JeKncGBSytSHQ=";
   };
@@ -42,41 +42,41 @@ in
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sqlpage";
-  version = "0.40.0";
+  version = "0.41.0";
 
   src = fetchFromGitHub {
     owner = "lovasoa";
     repo = "SQLpage";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-CmsAImnySdXlPQGWNMkPYhVj0HsvCzFB2LXeqFnjWG4=";
+    hash = "sha256-rUij1nhXcLEwdUUVpKoUbgNqV47TvmMCEds4ihP9QL4=";
   };
 
   postPatch = ''
     substituteInPlace sqlpage/apexcharts.js \
-      --replace-fail '/* !include https://cdn.jsdelivr.net/npm/apexcharts@5.3.0/dist/apexcharts.min.js */' \
-      "$(cat ${apexcharts})"
+      --replace-fail '/* !include ${apexcharts.url} */' \
+      "$(cat ${fetchurl apexcharts})"
     substituteInPlace sqlpage/sqlpage.css \
-      --replace-fail '/* !include https://cdn.jsdelivr.net/npm/@tabler/core@1.4.0/dist/css/tabler.min.css */' \
-      "$(cat ${tablerCss})" \
-      --replace-fail '/* !include https://cdn.jsdelivr.net/npm/@tabler/core@1.4.0/dist/css/tabler-vendors.min.css */' \
-      "$(cat ${tablerVendorsCss})" \
-      --replace-fail '/* !include https://cdn.jsdelivr.net/npm/tom-select@2.4.3/dist/css/tom-select.bootstrap5.css */' \
-      "$(cat ${tomSelectCss})"
+      --replace-fail '/* !include ${tablerCss.url} */' \
+      "$(cat ${fetchurl tablerCss})" \
+      --replace-fail '/* !include ${tablerVendorsCss.url} */' \
+      "$(cat ${fetchurl tablerVendorsCss})" \
+      --replace-fail '/* !include ${tomSelectCss.url} */' \
+      "$(cat ${fetchurl tomSelectCss})"
     substituteInPlace sqlpage/sqlpage.js \
-      --replace-fail '/* !include https://cdn.jsdelivr.net/npm/@tabler/core@1.4.0/dist/js/tabler.min.js */' \
-      "$(cat ${tablerJs})"
+      --replace-fail '/* !include ${tablerJs.url} */' \
+      "$(cat ${fetchurl tablerJs})"
     substituteInPlace sqlpage/tabler-icons.svg \
-      --replace-fail '/* !include https://cdn.jsdelivr.net/npm/@tabler/icons-sprite@3.34.0/dist/tabler-sprite.svg */' \
-      "$(cat ${tablerIcons})"
+      --replace-fail '/* !include ${tablerIcons.url} */' \
+      "$(cat ${fetchurl tablerIcons})"
     substituteInPlace sqlpage/tomselect.js \
-      --replace-fail '/* !include https://cdn.jsdelivr.net/npm/tom-select@2.4.1/dist/js/tom-select.popular.min.js */' \
-      "$(cat ${tomselect})"
+      --replace-fail '/* !include ${tomselect.url} */' \
+      "$(cat ${fetchurl tomselect})"
     substituteInPlace build.rs \
-      --replace-fail "https://cdn.jsdelivr.net/npm/@tabler/icons-sprite@3.35.0/dist/tabler-sprite.svg" "${tablerIcons}" \
+      --replace-fail "https://cdn.jsdelivr.net/npm/@tabler/icons-sprite@3.35.0/dist/tabler-sprite.svg" "${fetchurl tablerIcons}" \
       --replace-fail "copy_url_to_opened_file(&client, sprite_url, &mut sprite_content).await;" "sprite_content = std::fs::read(sprite_url).unwrap();"
   '';
 
-  cargoHash = "sha256-CTJYFzSOLYFq7I9lJhD3JcO2PuqQjqtXnBCEk2VfLfI=";
+  cargoHash = "sha256-jyhvhViPz/tj76mvmaIih4LaCH+ODFa8gs0/MTYbuQg=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/by-name/sq/sqlpage/package.nix
+++ b/pkgs/by-name/sq/sqlpage/package.nix
@@ -42,13 +42,13 @@ in
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sqlpage";
-  version = "0.39.0";
+  version = "0.39.1";
 
   src = fetchFromGitHub {
     owner = "lovasoa";
     repo = "SQLpage";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-M9WtpDc067G/EfRTJBoDxBrdXRMqOwVTdGgyXSdHlhE=";
+    hash = "sha256-Hj3tMi+3tZ4r/Jpf0PZiWykJsAPItkR/BPwFHYoEOi8=";
   };
 
   postPatch = ''
@@ -71,9 +71,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
     substituteInPlace sqlpage/tomselect.js \
       --replace-fail '/* !include https://cdn.jsdelivr.net/npm/tom-select@2.4.1/dist/js/tom-select.popular.min.js */' \
       "$(cat ${tomselect})"
+    substituteInPlace build.rs \
+      --replace-fail "https://cdn.jsdelivr.net/npm/@tabler/icons-sprite@3.35.0/dist/tabler-sprite.svg" "${tablerIcons}" \
+      --replace-fail "copy_url_to_opened_file(&client, sprite_url, &mut sprite_content).await;" "sprite_content = std::fs::read(sprite_url).unwrap();"
   '';
 
-  cargoHash = "sha256-lUQ1j2f/LXpqpb6VK4Bq2NI0L9KoyEdlPkENMOKkt0w=";
+  cargoHash = "sha256-yTavtt5D0vfcMSvQnBQrIfSfssJ0Ld3O3q4lLSgrgIk=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/by-name/sq/sqlpage/package.nix
+++ b/pkgs/by-name/sq/sqlpage/package.nix
@@ -43,13 +43,13 @@ in
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sqlpage";
-  version = "0.44.0";
+  version = "0.44.1";
 
   src = fetchFromGitHub {
     owner = "sqlpage";
     repo = "SQLpage";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-qhfJHzPUBQZ6GKGet/6IZfU5zjKXqDxftJX3ylVwOQE=";
+    hash = "sha256-QpengTtKBLJga/LXcN3oPuXDru1zr9Ti/Qpb0tfiEYc=";
   };
 
   postPatch = ''
@@ -77,7 +77,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace-fail "copy_url_to_opened_file(&client, sprite_url, &mut sprite_content).await;" "sprite_content = std::fs::read(sprite_url).unwrap();"
   '';
 
-  cargoHash = "sha256-VNKRXzy9TQdNlk/kEfFKBEWALP/r+hBcd32n6bwK/J0=";
+  cargoHash = "sha256-w4GfkC+sAJRQgo9GEYm4buv+Q8id84wgRSV1WczZUBI=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/by-name/sq/sqlpage/package.nix
+++ b/pkgs/by-name/sq/sqlpage/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  rustPlatform,
+  rustPackages_1_95,
   fetchFromGitHub,
   pkg-config,
   sqlite,
@@ -11,15 +11,15 @@
 
 let
   apexcharts = {
-    url = "https://cdn.jsdelivr.net/npm/apexcharts@5.3.6/dist/apexcharts.min.js";
-    hash = "sha256-qNJtESJROYHRKwS/u3zdu4Fev69db17hKHZvrqGiqRs=";
+    url = "https://cdn.jsdelivr.net/npm/apexcharts@5.13.0/dist/apexcharts.min.js";
+    hash = "sha256-DgRUn+X1cxT0z5O+QcrX48NuVrY1KhoCmHPvVZAvS8k=";
   };
   tablerCss = {
     url = "https://cdn.jsdelivr.net/npm/@tabler/core@1.4.0/dist/css/tabler.min.css";
     hash = "sha256-fvdQvRBUamldCxJ2etgEi9jz7F3n2u+xBn+dDao9HJo=";
   };
   tomSelectCss = {
-    url = "https://cdn.jsdelivr.net/npm/tom-select@2.4.3/dist/css/tom-select.bootstrap5.css";
+    url = "https://cdn.jsdelivr.net/npm/tom-select@2.6.1/dist/css/tom-select.bootstrap5.css";
     hash = "sha256-vW5UjM/Ka9/jIY8I5s5KcudaTRWh/cCGE1ZUsrJvlI0=";
   };
   tablerVendorsCss = {
@@ -31,24 +31,25 @@ let
     hash = "sha256-tgx2Fg6XYkV027jPEKvmrummSTtgCW/fwV3R3SvZnrk=";
   };
   tablerIcons = {
-    url = "https://cdn.jsdelivr.net/npm/@tabler/icons-sprite@3.34.0/dist/tabler-sprite.svg";
-    hash = "sha256-pCPkhrx0GnPg5/EthJ7pLdMxb7wbYMJ0R7WchDcffpg=";
+    url = "https://cdn.jsdelivr.net/npm/@tabler/icons-sprite@3.44.0/dist/tabler-sprite.svg";
+    hash = "sha256-aHeH8IGC75mepyW2gj/aYrW7LCEtjobwxvGnVp5j3Uc=";
   };
   tomselect = {
-    url = "https://cdn.jsdelivr.net/npm/tom-select@2.4.1/dist/js/tom-select.popular.min.js";
-    hash = "sha256-Cb1Xmb9qQO8I1mMVkz4t2bT8l7HX+1JeKncGBSytSHQ=";
+    url = "https://cdn.jsdelivr.net/npm/tom-select@2.6.1/dist/js/tom-select.popular.min.js";
+    hash = "sha256-KmjMBvL4Ni3AYc9OCi9xSEuamESyLEBL4B2gzFrWPGE=";
   };
+  rustPlatform = rustPackages_1_95.rustPlatform;
 in
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sqlpage";
-  version = "0.41.0";
+  version = "0.44.0";
 
   src = fetchFromGitHub {
     owner = "lovasoa";
     repo = "SQLpage";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-rUij1nhXcLEwdUUVpKoUbgNqV47TvmMCEds4ihP9QL4=";
+    hash = "sha256-qhfJHzPUBQZ6GKGet/6IZfU5zjKXqDxftJX3ylVwOQE=";
   };
 
   postPatch = ''
@@ -72,11 +73,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace-fail '/* !include ${tomselect.url} */' \
       "$(cat ${fetchurl tomselect})"
     substituteInPlace build.rs \
-      --replace-fail "https://cdn.jsdelivr.net/npm/@tabler/icons-sprite@3.35.0/dist/tabler-sprite.svg" "${fetchurl tablerIcons}" \
+      --replace-fail "${tablerIcons.url}" "${fetchurl tablerIcons}" \
       --replace-fail "copy_url_to_opened_file(&client, sprite_url, &mut sprite_content).await;" "sprite_content = std::fs::read(sprite_url).unwrap();"
   '';
 
-  cargoHash = "sha256-jyhvhViPz/tj76mvmaIih4LaCH+ODFa8gs0/MTYbuQg=";
+  cargoHash = "sha256-VNKRXzy9TQdNlk/kEfFKBEWALP/r+hBcd32n6bwK/J0=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/by-name/sq/sqlpage/package.nix
+++ b/pkgs/by-name/sq/sqlpage/package.nix
@@ -96,7 +96,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/sqlpage/SQLpage";
     changelog = "https://github.com/sqlpage/SQLpage/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ dit7ya ];
+    maintainers = with lib.maintainers; [ hythera ];
     mainProgram = "sqlpage";
   };
 })

--- a/pkgs/by-name/sq/sqlpage/package.nix
+++ b/pkgs/by-name/sq/sqlpage/package.nix
@@ -46,7 +46,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.44.0";
 
   src = fetchFromGitHub {
-    owner = "lovasoa";
+    owner = "sqlpage";
     repo = "SQLpage";
     tag = "v${finalAttrs.version}";
     hash = "sha256-qhfJHzPUBQZ6GKGet/6IZfU5zjKXqDxftJX3ylVwOQE=";
@@ -93,8 +93,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "SQL-only webapp builder, empowering data analysts to build websites and applications quickly";
-    homepage = "https://github.com/lovasoa/SQLpage";
-    changelog = "https://github.com/lovasoa/SQLpage/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    homepage = "https://github.com/sqlpage/SQLpage";
+    changelog = "https://github.com/sqlpage/SQLpage/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ dit7ya ];
     mainProgram = "sqlpage";

--- a/pkgs/development/compilers/rust/1_95.nix
+++ b/pkgs/development/compilers/rust/1_95.nix
@@ -1,0 +1,104 @@
+# New rust versions should first go to staging.
+# Things to check after updating:
+# 1. Rustc should produce rust binaries on x86_64-linux, aarch64-linux and x86_64-darwin:
+#    i.e. nix-shell -p fd or @GrahamcOfBorg build fd on github
+#    This testing can be also done by other volunteers as part of the pull
+#    request review, in case platforms cannot be covered.
+# 2. The LLVM version used for building should match with rust upstream.
+#    Check the version number in the src/llvm-project git submodule in:
+#    https://github.com/rust-lang/rust/blob/<version-tag>/.gitmodules
+
+# Note: The way this is structured is:
+# 1. Import default.nix, and apply arguments as needed for the file-defined function
+# 2. Implicitly, all arguments to this file are applied to the function that is imported.
+#    if you want to add an argument to default.nix's top-level function, but not the function
+#    it instantiates, add it to the `removeAttrs` call below.
+{
+  stdenv,
+  lib,
+  newScope,
+  callPackage,
+  pkgsBuildTarget,
+  pkgsBuildBuild,
+  pkgsBuildHost,
+  pkgsHostTarget,
+  pkgsTargetTarget,
+  makeRustPlatform,
+  wrapRustcWith,
+  llvmPackages,
+  llvm,
+  cargo-auditable,
+  wrapCCWith,
+  overrideCC,
+  fetchpatch,
+}@args:
+let
+  llvmSharedFor =
+    pkgSet:
+    pkgSet.llvmPackages.libllvm.override (
+      {
+        enableSharedLibraries = true;
+      }
+      // lib.optionalAttrs (stdenv.targetPlatform.useLLVM or false) {
+        # Force LLVM to compile using clang + LLVM libs when targeting pkgsLLVM
+        stdenv = pkgSet.stdenv.override {
+          allowedRequisites = null;
+          cc = pkgSet.pkgsBuildHost.llvmPackages.clangUseLLVM;
+        };
+      }
+    );
+in
+import ./default.nix
+  {
+    rustcVersion = "1.95.0";
+    rustcSha256 = "sha256-6puCqD5GlnU3w1ac6db6FoEcBDqW5lE3bDSecCQcpRU=";
+
+    llvmSharedForBuild = llvmSharedFor pkgsBuildBuild;
+    llvmSharedForHost = llvmSharedFor pkgsBuildHost;
+    llvmSharedForTarget = llvmSharedFor pkgsBuildTarget;
+
+    inherit llvmPackages;
+
+    # For use at runtime
+    llvmShared = llvmSharedFor pkgsHostTarget;
+
+    # Note: the version MUST be the same version that we are building. Upstream
+    # ensures that each released compiler can compile itself:
+    # https://github.com/NixOS/nixpkgs/pull/351028#issuecomment-2438244363
+    bootstrapVersion = "1.95.0";
+
+    # fetch hashes by running `print-hashes.sh ${bootstrapVersion}`
+    bootstrapHashes = {
+      i686-unknown-linux-gnu = "3ef2320bdfa9b69b19c6ca42f950b6bfb9d2af3b925b0c43a6bfecc4d355a66e";
+      x86_64-unknown-linux-gnu = "a47ac940abd12399d59ad15c877e7113fa35f2b9ec7e6a8a045d4fd8b9741dea";
+      x86_64-unknown-linux-musl = "059086762ac6f4ebe15b5b10e629e4e33e96b372765e65741251f75c4fdfb4e0";
+      arm-unknown-linux-gnueabihf = "7d742098e8bb0d10415775634eed83240ae88c1bae6bc73b470ccf0be4629b4c";
+      armv7-unknown-linux-gnueabihf = "23a201e72c082c285e957a32b40e1c30805b15d344b84b984be3659e9aefadf6";
+      aarch64-unknown-linux-gnu = "3b9385d3144ac57616befa0ccbac524f857ba1b4ab074226e73a24d43568a98e";
+      aarch64-unknown-linux-musl = "ad35bcc6928ccb4fd8a12fe19ce88c8fb6e6e3690578a0cb4e0839008017484f";
+      x86_64-apple-darwin = "3f3d9f29f8eb7aa821bd8531cb9b1c3c74c3976aa558dfabfcc15c2febb3cfb8";
+      aarch64-apple-darwin = "ec23ad2e0e15a7397d2c3c232356149cc871b7df7f47e25c2acb1070157f5398";
+      powerpc64-unknown-linux-gnu = "6d89e3739cfb7b3a05880734513361d5860492385217dcd166d033f3e974e823";
+      powerpc64le-unknown-linux-gnu = "29e3430f38406c926ee24ff911357dba0c46ff1d3ea59e91625b03677bd51b30";
+      powerpc64le-unknown-linux-musl = "b8856b651d64f4f4a2e2ee009366d99ea6135bdf88d15cf2134fc9e166745030";
+      riscv64gc-unknown-linux-gnu = "8b527cb1a09f53f83aa3420b4e763c9ea64a54d89e6d7242da35c8aeaa325593";
+      s390x-unknown-linux-gnu = "e9598bdd3bc1438d965208ef5186f0dd671826cddd4bcbb20e22a3cec14c111d";
+      loongarch64-unknown-linux-gnu = "18038ce7a910930c6742cc76e06fdd4b21b879466a3e67d63a0b6cae955bb4dc";
+      loongarch64-unknown-linux-musl = "eef910858c7e833b13c9cb32e79e59d89434999bc2a7d0b6447ab4046eb40461";
+      x86_64-unknown-freebsd = "0ffb7aa1999ea12363bbfaea500e152565bb4918ad5a73e9713be40510d75e49";
+    };
+
+    selectRustPackage = pkgs: pkgs.rust_1_95;
+  }
+
+  (
+    removeAttrs args [
+      "llvmPackages"
+      "llvm"
+      "wrapCCWith"
+      "overrideCC"
+      "pkgsHostTarget"
+      "fetchpatch"
+      "cargo-auditable"
+    ]
+  )

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5233,6 +5233,7 @@ with pkgs;
 
   rust_1_91 = callPackage ../development/compilers/rust/1_91.nix { };
   rust_1_94 = callPackage ../development/compilers/rust/1_94.nix { };
+  rust_1_95 = callPackage ../development/compilers/rust/1_95.nix { };
   rust = rust_1_91;
 
   mrustc = callPackage ../development/compilers/mrustc { };
@@ -5241,6 +5242,7 @@ with pkgs;
 
   rustPackages_1_91 = rust_1_91.packages.stable;
   rustPackages_1_94 = rust_1_94.packages.stable;
+  rustPackages_1_95 = rust_1_95.packages.stable;
   rustPackages = rustPackages_1_91;
 
   inherit (rustPackages)


### PR DESCRIPTION
Backports #462428
Backports #477319
Backoprts #529563 (modified)
Backports #515947 (partially)
Backports #533808

Sqlpage now requires rust `1.95+` which wasn't available on `25.11` before.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
