### PR TITLE
[release-26.05] filebrowser: 2.63.14 -> 2.63.15

### DIFF
--- a/pkgs/by-name/fi/filebrowser/package.nix
+++ b/pkgs/by-name/fi/filebrowser/package.nix
@@ -12,13 +12,13 @@
 }:
 
 let
-  version = "2.63.14";
+  version = "2.63.15";
 
   src = fetchFromGitHub {
     owner = "filebrowser";
     repo = "filebrowser";
     rev = "v${version}";
-    hash = "sha256-9CXHoQWr1RpTwFR8JRR72oQZxHrndTrnxYa6/0Z3Mk0=";
+    hash = "sha256-O2USjwP1g+yDZpz0628YTRN2BUUnmjFvS+0qc6JU294=";
   };
 
   frontend = buildNpmPackage rec {
@@ -59,7 +59,7 @@ buildGoModule {
   pname = "filebrowser";
   inherit version src;
 
-  vendorHash = "sha256-ofeQkbvBfCpu2g1CLAwUZAZISyAOz+0smEZRx/koj/8=";
+  vendorHash = "sha256-WXbXD75acK4woS7UC0G73pY48aGmp1l0spDc3sGYXMg=";
 
   excludedPackages = [ "tools" ];
 


### PR DESCRIPTION
Backport of #533743 to `release-26.05`.

The automatic backport failed to cherry-pick cleanly: master's `filebrowser` was refactored to build its frontend with `pnpmBuildHook` (`stdenvNoCC` + `nodejs-slim`, `tag =`), but `pnpmBuildHook` was added to `pkgs/by-name/` only after `release-26.05` was branched, so it does not exist on this branch. I resolved the conflict manually as a **minimal** backport: the branch's existing `buildNpmPackage` + `pnpmConfigHook` frontend builder (and `rev =`) is kept, and only `version`, the `src` hash, and `vendorHash` are updated. The frontend `pnpmDeps` hash is unchanged between 2.63.14 and 2.63.15.

### Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] `nix-build -A filebrowser` succeeds; `./result/bin/filebrowser version` reports `v2.63.15`.
- [ ] Tested via `nixosTests.filebrowser` (passthru test).
