### PR TITLE
freeswitch: 1.10.12 -> 1.11.1

### DIFF
--- a/pkgs/by-name/fr/freeswitch/package.nix
+++ b/pkgs/by-name/fr/freeswitch/package.nix
@@ -12,7 +12,7 @@
   sqlite,
   libjpeg,
   speex,
-  pcre,
+  pcre2,
   libuuid,
   ldns,
   libedit,
@@ -109,12 +109,12 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "freeswitch";
-  version = "1.10.12";
+  version = "1.11.1";
   src = fetchFromGitHub {
     owner = "signalwire";
     repo = "freeswitch";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-uOO+TpKjJkdjEp4nHzxcHtZOXqXzpkIF3dno1AX17d8=";
+    hash = "sha256-uXn5MLEsGPfRzTQJ/v3Tq1yXVIWZQwNQIyvZulMxSqU=";
   };
 
   postPatch = ''
@@ -146,7 +146,7 @@ stdenv.mkDerivation (finalAttrs: {
     readline
     libjpeg
     sqlite
-    pcre
+    pcre2
     speex
     ldns
     libedit


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Release notes: https://github.com/signalwire/freeswitch/releases

Relates to: https://github.com/NixOS/nixpkgs/issues/356387
Migration from pcre to pcre2 happened in version [1.11.0](https://github.com/signalwire/freeswitch/releases/tag/v1.11.0)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
