### PR TITLE
maintainers: update luna-the-tuna email and username

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16375,6 +16375,12 @@
     githubId = 80571430;
     name = "Luminar Leaf";
   };
+  luna-the-tuna = {
+    email = "contact@luna.fish";
+    github = "luna-the-tuna";
+    githubId = 112084382;
+    name = "Luna Heyman";
+  };
   luna_1024 = {
     email = "contact@luna.computer";
     github = "luna-1024";
@@ -28251,12 +28257,6 @@
     github = "tonybutt";
     githubId = 38566841;
     name = "Anthony Butt";
-  };
-  toodeluna = {
-    email = "luna@toodeluna.net";
-    github = "toodeluna";
-    githubId = 112084382;
-    name = "Luna Heyman";
   };
   toonn = {
     email = "nixpkgs@toonn.io";

--- a/pkgs/by-name/cr/crosspatch/package.nix
+++ b/pkgs/by-name/cr/crosspatch/package.nix
@@ -67,6 +67,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/NickPlayzGITHUB/CrossPatch";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ toodeluna ];
+    maintainers = with lib.maintainers; [ luna-the-tuna ];
   };
 }

--- a/pkgs/by-name/dt/dtsfmt/package.nix
+++ b/pkgs/by-name/dt/dtsfmt/package.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     description = "Auto formatter for device tree files";
     homepage = "https://github.com/mskelton/dtsfmt";
     license = lib.licenses.isc;
-    maintainers = with lib.maintainers; [ toodeluna ];
+    maintainers = with lib.maintainers; [ luna-the-tuna ];
     mainProgram = "dtsfmt";
   };
 })


### PR DESCRIPTION
I changed my GitHub username and email address, so I updated my entry in the maintainer-list file and the two packages I'm a maintainer of to match.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
