### PR TITLE
python3Packages.geojson: 3.2.0 → 3.3.0

### DIFF
--- a/pkgs/development/python-modules/geojson/default.nix
+++ b/pkgs/development/python-modules/geojson/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  fetchpatch,
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
@@ -9,23 +8,15 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "geojson";
-  version = "3.2.0";
+  version = "3.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jazzband";
     repo = "geojson";
     tag = finalAttrs.version;
-    hash = "sha256-0p8FW9alcWCSdi66wanS/F9IgO714WIRQIXvg3f9op8=";
+    hash = "sha256-Gz+hiv0CxitE+upLsiln+H8TtWezpUDaPH80UM7VHTA=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "allow-install-python314";
-      url = "https://github.com/jazzband/geojson/commit/2584c0de5651bd694499449f9da5321b15597270.patch";
-      hash = "sha256-64LPEwC1qc83wF48878fH31CVFn2txTmSxxr0cnQbRg=";
-    })
-  ];
 
   build-system = [ setuptools ];
 


### PR DESCRIPTION
https://github.com/jazzband/geojson/blob/3.3.0/CHANGELOG.rst

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
