### PR TITLE
linuxPackages.bcachefs: fix vmlinux path

### DIFF
--- a/pkgs/by-name/bc/bcachefs-tools/kernel-module.nix
+++ b/pkgs/by-name/bc/bcachefs-tools/kernel-module.nix
@@ -11,8 +11,14 @@ stdenv.mkDerivation {
   version = "${kernel.version}-${bcachefs-tools.version}";
 
   __structuredAttrs = true;
+  strictDeps = true;
 
   src = bcachefs-tools.dkms;
+
+  postPatch = ''
+    substituteInPlace src/fs/bcachefs/Makefile \
+      --replace-fail '$(objtree)/vmlinux' '${kernel.dev}/vmlinux'
+  '';
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 


### PR DESCRIPTION
From PR https://github.com/koverstreet/bcachefs-tools/pull/620

Also enable strictDeps.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.