### PR TITLE
surge: fix build with glibc 2.41

### DIFF
--- a/pkgs/by-name/su/surge/package.nix
+++ b/pkgs/by-name/su/surge/package.nix
@@ -73,6 +73,14 @@ stdenv.mkDerivation (finalAttrs: {
   # Fix build with gcc 15
   env.NIX_CFLAGS_COMPILE = "-Wno-deprecated";
 
+  # The generated ScalablePiggy.S has no .note.GNU-stack section, so the linker
+  # marks the LV2/VST3 plugin .so as requiring an executable stack. Since glibc
+  # 2.41 dlopen() refuses to load such objects ("cannot enable executable stack
+  # as shared object requires"). This breaks the post-build step that dlopens
+  # the freshly built LV2 plugin to generate its .ttl manifest. Force a
+  # non-executable stack at link time.
+  env.NIX_LDFLAGS = "-z noexecstack";
+
   postPatch = ''
     substituteInPlace src/common/SurgeStorage.cpp \
       --replace "/usr/share/Surge" "$out/share/surge"


### PR DESCRIPTION
The generated ScalablePiggy.S has no .note.GNU-stack section, so the linker marks the LV2/VST3 plugin .so as requiring an executable stack. Since glibc 2.41, dlopen() refuses to load such objects, which breaks the post-build LV2 step that dlopen()s the freshly built plugin to generate its .ttl manifest:

    OSError: .../Surge.lv2/Surge.so: cannot enable executable stack as
    shared object requires: Invalid argument

Force a non-executable stack at link time with -z noexecstack.

Fixes #533882


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
