### PR TITLE
sonobuoy: 0.57.3 -> 0.57.4

### DIFF
--- a/pkgs/by-name/so/sonobuoy/package.nix
+++ b/pkgs/by-name/so/sonobuoy/package.nix
@@ -9,11 +9,11 @@
 # SHA of ${finalAttrs.version} for the tool's help output. Unfortunately this is needed in build flags.
 # The update script can update this automatically, the comment is used to find the line.
 let
-  rev = "a988242e8bbded3ef4602eda48addcfac24a1a91"; # update-commit-sha
+  rev = "09b10f4ef2c32b3ee04ec59821ccae492e1e140d"; # update-commit-sha
 in
 buildGoModule (finalAttrs: {
   pname = "sonobuoy";
-  version = "0.57.3"; # Do not forget to update `rev` above
+  version = "0.57.4"; # Do not forget to update `rev` above
 
   ldflags =
     let
@@ -30,10 +30,10 @@ buildGoModule (finalAttrs: {
     owner = "vmware-tanzu";
     repo = "sonobuoy";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-YFItnwU08g4pVo4OOHscRmPRVXyr+R9YWYTxhSzd7iI=";
+    hash = "sha256-LFYn7Ym1RS8/Uysm6I2HbVD48fu542TsHdqybzvLgrw=";
   };
 
-  vendorHash = "sha256-QjVnC6CZXuw6qLNyX9ut2g1Ws1cYO1JuT043aqqeF0Q=";
+  vendorHash = "sha256-0PELYc2CK8FCDUvQomY6AkYd7VmhmTai64ITbpudMc4=";
 
   subPackages = [ "." ];
 

--- a/pkgs/by-name/so/sonobuoy/update.sh
+++ b/pkgs/by-name/so/sonobuoy/update.sh
@@ -47,4 +47,4 @@ echo "updating commit hash of ${owner}/${repo} @ ${tag} to ${sha}" >&2
 
 cd "$(dirname "$(readlink -f "$0")")"
 
-sed -i "s|\".*\"; # update-commit-sha|${sha}; # update-commit-sha|" default.nix
+sed -i "s|\".*\"; # update-commit-sha|${sha}; # update-commit-sha|" package.nix


### PR DESCRIPTION
update to 0.57.4 and fix update script

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
