### PR TITLE
xviewer: Support avif, heif, jxl, webp

### DIFF
--- a/pkgs/by-name/xv/xviewer/package.nix
+++ b/pkgs/by-name/xv/xviewer/package.nix
@@ -26,6 +26,11 @@
   yelp-tools,
   xapp,
   xapp-symbolic-icons,
+  gnome,
+  libavif,
+  libheif,
+  libjxl,
+  webp-pixbuf-loader,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -74,6 +79,21 @@ stdenv.mkDerivation (finalAttrs: {
     libxml2
     xapp
   ];
+
+  postInstall = ''
+    # In postInstall to run before gappsWrapperArgsHook.
+    export GDK_PIXBUF_MODULE_FILE="${
+      gnome._gdkPixbufCacheBuilder_DO_NOT_USE {
+        extraLoaders = [
+          libavif
+          libheif.lib
+          libjxl
+          librsvg
+          webp-pixbuf-loader
+        ];
+      }
+    }"
+  '';
 
   preFixup = ''
     gappsWrapperArgs+=(

--- a/pkgs/by-name/xv/xviewer/package.nix
+++ b/pkgs/by-name/xv/xviewer/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  fetchpatch,
   docbook_xsl,
   exempi,
   gdk-pixbuf,
@@ -38,6 +39,14 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-ayd91gVLuSUVlCxaPSBbx7hg4tthVTaBEnl5V9YYbQw=";
   };
 
+  patches = [
+    # build: Add support for GIRepository-2.0.
+    (fetchpatch {
+      url = "https://github.com/linuxmint/xviewer/commit/74d7d4ba2584c658ae6fb87208543671664943cc.patch";
+      hash = "sha256-lL4MTvC2RvdVZ4O5RaYyK+1sHnLGPYzGNbZ99aN22U8=";
+    })
+  ];
+
   nativeBuildInputs = [
     docbook_xsl
     gobject-introspection
@@ -65,18 +74,6 @@ stdenv.mkDerivation (finalAttrs: {
     libxml2
     xapp
   ];
-
-  postPatch = ''
-    # Switch to girepository-2.0
-    substituteInPlace src/main.c \
-      --replace-fail "#include <girepository.h>" "#include <girepository/girepository.h>" \
-      --replace-fail "g_irepository_get_option_group" "gi_repository_get_option_group"
-
-    substituteInPlace src/xviewer-plugin-engine.c \
-      --replace-fail "#include <girepository.h>" "#include <girepository/girepository.h>" \
-      --replace-fail "g_irepository_get_default" "gi_repository_dup_default" \
-      --replace-fail "g_irepository_require" "gi_repository_require"
-  '';
 
   preFixup = ''
     gappsWrapperArgs+=(


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
