### PR TITLE
buildLinux: Forward buildDTBs and target arguments

### DIFF
--- a/pkgs/os-specific/linux/kernel/build.nix
+++ b/pkgs/os-specific/linux/kernel/build.nix
@@ -152,8 +152,6 @@ lib.makeOverridable (
     isModular = config.isYes "MODULES";
     withRust = config.isYes "RUST";
 
-    inherit buildDTBs target;
-
     # Dependencies that are required to build kernel modules
     moduleBuildDependencies = [
       pahole

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -79,6 +79,9 @@ lib.makeOverridable (
     extraMeta ? { },
     extraPassthru ? { },
 
+    target ? null,
+    buildDTBs ? null,
+
     isLTS ? false,
     isZen ? false,
 
@@ -284,26 +287,34 @@ lib.makeOverridable (
       };
     }; # end of configfile derivation
 
-    kernel = (callPackage ./build.nix { inherit lib stdenv buildPackages; }) {
-      inherit
-        pname
-        version
-        src
-        kernelPatches
-        randstructSeed
-        extraMakeFlags
-        extraMeta
-        configfile
-        modDirVersion
-        ;
-      pos = builtins.unsafeGetAttrPos "version" args;
+    kernel = (callPackage ./build.nix { inherit lib stdenv buildPackages; }) (
+      {
+        inherit
+          pname
+          version
+          src
+          kernelPatches
+          randstructSeed
+          extraMakeFlags
+          extraMeta
+          configfile
+          modDirVersion
+          ;
+        pos = builtins.unsafeGetAttrPos "version" args;
 
-      config = {
-        CONFIG_MODULES = "y";
-        CONFIG_FW_LOADER = "y";
-        CONFIG_RUST = if withRust then "y" else "n";
-      };
-    };
+        config = {
+          CONFIG_MODULES = "y";
+          CONFIG_FW_LOADER = "y";
+          CONFIG_RUST = if withRust then "y" else "n";
+        };
+      }
+      // lib.optionalAttrs (target != null) {
+        inherit target;
+      }
+      // lib.optionalAttrs (buildDTBs != null) {
+        inherit buildDTBs;
+      }
+    );
 
   in
   kernel.overrideAttrs (


### PR DESCRIPTION
Fixes #533937


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
