### PR TITLE
nixos/albyhub: add service module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1129,6 +1129,7 @@
   ./services/networking/3proxy.nix
   ./services/networking/acme-dns.nix
   ./services/networking/adguardhome.nix
+  ./services/networking/albyhub.nix
   ./services/networking/alice-lg.nix
   ./services/networking/amuled.nix
   ./services/networking/anubis.nix

--- a/nixos/modules/services/networking/albyhub.md
+++ b/nixos/modules/services/networking/albyhub.md
@@ -1,0 +1,119 @@
+# Alby Hub {#module-services-albyhub}
+
+[Alby Hub](https://albyhub.com/) is a self-custodial Lightning wallet server with
+a web interface and Nostr Wallet Connect support. It can manage its own embedded
+LDK node or connect to an external Lightning backend such as LND or phoenixd.
+
+## Basic Usage {#module-services-albyhub-basic-usage}
+
+A minimal configuration starts the Hub on the module's default local port:
+
+```nix
+{
+  services.albyhub.enable = true;
+}
+```
+
+By default, the module creates a dedicated `albyhub` system user and group,
+stores state under `/var/lib/albyhub`, writes Hub's runtime `.env` file in that
+directory, and runs the service with systemd hardening enabled.
+
+These defaults are intended to be safe starting points for a local service that
+is either accessed directly on the machine or placed behind a reverse proxy.
+After the first start, Hub can still be configured through its web interface
+unless you deliberately force a backend configuration.
+
+## Common Settings {#module-services-albyhub-common-settings}
+
+Most installations only need to set the public URL and, when using an external
+Lightning node, the backend connection details.
+
+```nix
+{
+  services.albyhub = {
+    enable = true;
+    autoLinkAlbyAccount = true;
+    baseUrl = "https://hub.example.local";
+    mempoolApi = "https://mempool.example.local/api";
+  };
+}
+```
+
+Set {option}`services.albyhub.baseUrl` when Hub is reachable through a real
+hostname. This is required for custom Alby OAuth clients because the callback URL
+is derived from it. Set {option}`services.albyhub.frontendUrl` separately only
+when browser redirects should use a different public URL than the backend.
+
+Set {option}`services.albyhub.network`, {option}`services.albyhub.mempoolApi`,
+or {option}`services.albyhub.boltzApi` for signet, regtest, custom chain data
+providers, or non-default swap infrastructure.
+
+The module defaults {option}`services.albyhub.autoLinkAlbyAccount` to `false` so
+starting a NixOS service does not implicitly associate the instance with the
+currently authenticated Alby account. Enable it only when you want that linking
+to happen automatically.
+
+## Lightning Backends {#module-services-albyhub-lightning-backends}
+
+Alby Hub supports backend settings through environment variables. The module
+exposes common service-level settings as Nix options and leaves
+backend-specific variables to {option}`services.albyhub.extraConfig`.
+
+Use `extraConfig` for non-secret `KEY=value` lines that Hub understands but the
+module does not model directly:
+
+```nix
+{
+  services.albyhub.extraConfig = ''
+    LN_BACKEND_TYPE=LND
+    LND_ADDRESS=127.0.0.1:10009
+    LND_CERT_FILE=/var/lib/albyhub/lnd-tls.cert
+    LND_MACAROON_FILE=/var/lib/albyhub/lnd-admin.macaroon
+  '';
+}
+```
+
+For LND, use a client-reachable address such as `127.0.0.1:10009`. The `albyhub`
+service user must be able to read the certificate and macaroon files. Copy both
+files to a path readable by Hub, such as its {option}`services.albyhub.dataDir`,
+and point `LND_CERT_FILE` and `LND_MACAROON_FILE` at those copies. Advanced
+setups can orchestrate these files declaratively with a secrets manager such as
+[sops-nix](https://github.com/Mic92/sops-nix).
+
+For phoenixd, the non-secret endpoint can be declared in `extraConfig`, but the
+API password should be supplied with your normal NixOS secret-management
+workflow rather than written directly into a Nix string:
+
+```nix
+{
+  services.albyhub.extraConfig = ''
+    LN_BACKEND_TYPE=PHOENIX
+    PHOENIXD_ADDRESS=http://127.0.0.1:9740
+  '';
+}
+```
+
+See the [upstream user guide](https://guides.getalby.com/user-guide/alby-hub)
+and the Hub README for the complete backend variable list.
+
+## Secrets {#module-services-albyhub-secrets}
+
+Do not put secrets in {option}`services.albyhub.extraConfig`, because Nix strings
+can be stored in the Nix store. This includes OAuth client secrets, JWT secrets,
+auto-unlock passwords, phoenixd API passwords, and copied admin macaroons.
+
+The module provides file-based options for some secrets:
+
+```nix
+{
+  services.albyhub = {
+    autoUnlockPasswordFile = "/run/secrets/albyhub-unlock-password";
+    jwtSecretFile = "/run/secrets/albyhub-jwt-secret";
+    albyOAuth.clientSecretFile = "/run/secrets/albyhub-oauth-secret";
+  };
+}
+```
+
+Use {option}`services.albyhub.autoUnlockPasswordFile` only for unattended
+restarts where you accept the trade-off: Hub can unlock itself on boot, but the
+unlock secret is now available to the service at runtime.

--- a/nixos/modules/services/networking/albyhub.nix
+++ b/nixos/modules/services/networking/albyhub.nix
@@ -1,0 +1,283 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+let
+  cfg = config.services.albyhub;
+
+  albyhubSystemdSandbox = {
+    PrivateTmp = true;
+    ProtectSystem = "strict";
+    ProtectHome = true;
+    NoNewPrivileges = true;
+    PrivateDevices = true;
+    ProtectKernelTunables = true;
+    ProtectKernelModules = true;
+    ProtectKernelLogs = true;
+    RestrictAddressFamilies = "AF_UNIX AF_INET AF_INET6";
+    RestrictNamespaces = true;
+    LockPersonality = true;
+    RestrictSUIDSGID = true;
+    RestrictRealtime = true;
+    CapabilityBoundingSet = "";
+    SystemCallArchitectures = "native";
+  };
+
+  rootScript = name: text: "+${pkgs.writeShellScript name text}";
+
+  envFileContent = ''
+    WORK_DIR=${cfg.dataDir}
+    DATABASE_URI=${cfg.dataDir}/nwc.db
+    PORT=${toString cfg.port}
+    LOG_LEVEL=${toString cfg.logLevel}
+    AUTO_LINK_ALBY_ACCOUNT=${boolToString cfg.autoLinkAlbyAccount}
+    ${optionalString (cfg.logToFile != null) "LOG_TO_FILE=${boolToString cfg.logToFile}"}
+    ${optionalString (cfg.logDBQueries != null) "LOG_DB_QUERIES=${boolToString cfg.logDBQueries}"}
+    ${optionalString (cfg.network != null) "NETWORK=${cfg.network}"}
+    ${optionalString (cfg.mempoolApi != null) "MEMPOOL_API=${cfg.mempoolApi}"}
+    ${optionalString (cfg.albyOAuth.clientId != null) "ALBY_OAUTH_CLIENT_ID=${cfg.albyOAuth.clientId}"}
+    ${optionalString (cfg.baseUrl != null) "BASE_URL=${cfg.baseUrl}"}
+    ${optionalString (cfg.frontendUrl != null) "FRONTEND_URL=${cfg.frontendUrl}"}
+    ${optionalString (cfg.logEvents != null) "LOG_EVENTS=${boolToString cfg.logEvents}"}
+    ${optionalString (cfg.relay != null) "RELAY=${cfg.relay}"}
+    ${optionalString (cfg.boltzApi != null) "BOLTZ_API=${cfg.boltzApi}"}
+    ${optionalString (cfg.extraConfig != null) cfg.extraConfig}
+  '';
+
+  envFile = "${cfg.dataDir}/.env";
+
+in
+{
+  options.services.albyhub = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Alby Hub, a service to control lightning wallets over nostr.
+        See the user guide at https://guides.getalby.com/user-guide/alby-hub.
+      '';
+    };
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.albyhub;
+      defaultText = literalExpression "pkgs.albyhub";
+      description = "The Alby Hub package to use.";
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = "albyhub";
+      description = "User account under which Alby Hub runs.";
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = cfg.user;
+      defaultText = literalExpression "config.services.albyhub.user";
+      description = "Group account under which Alby Hub runs.";
+    };
+
+    dataDir = mkOption {
+      type = types.path;
+      default = "/var/lib/albyhub";
+      description = "Directory where Alby Hub stores its state.";
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 8082;
+      description = "Port on which Alby Hub listens.";
+    };
+
+    relay = mkOption {
+      type = with types; nullOr (listOf str);
+      example = [
+        "wss://relay.damus.io"
+        "wss://offchain.pub"
+        "wss://relay.primal.net"
+      ];
+      default = null;
+      apply = value: if builtins.isList value then concatStringsSep "," value else value;
+      description = "The nostr relays to use. Find more relays: https://nostrwat.ch/";
+    };
+
+    logLevel = mkOption {
+      type = types.int;
+      default = 4;
+      description = "Log level for the application. Higher is more verbose.";
+    };
+
+    logToFile = mkOption {
+      type = with types; nullOr bool;
+      default = null;
+      description = "Log to file.";
+    };
+
+    logDBQueries = mkOption {
+      type = with types; nullOr bool;
+      default = null;
+      description = "Log database queries.";
+    };
+
+    network = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      description = "The network to use (e.g. mainnet, testnet, regtest).";
+      example = "signet";
+    };
+
+    mempoolApi = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      description = "Mempool API endpoint.";
+      example = "https://mempool.space/api";
+    };
+
+    baseUrl = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      description = ''
+        Public base URL of your Alby Hub backend (used as `BASE_URL`).
+        This must be reachable by the browser and is required when using a custom Alby OAuth client,
+        because the OAuth callback is ''${baseUrl}/api/alby/callback.
+      '';
+      example = "http://localhost:8082";
+    };
+
+    frontendUrl = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      description = ''
+        Public URL of the Hub frontend UI used for browser redirects (for example after OAuth or logout).
+        If unset, redirects fall back to `baseUrl`.
+      '';
+    };
+
+    logEvents = mkOption {
+      type = with types; nullOr bool;
+      default = null;
+      description = "Log events.";
+    };
+
+    autoLinkAlbyAccount = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Auto link Alby account.";
+    };
+
+    boltzApi = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      example = "wss://api.boltz.exchange/";
+      description = "Boltz API endpoint.";
+    };
+
+    extraConfig = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      description = "Extra configuration options appended to the environment file.";
+    };
+
+    autoUnlockPasswordFile = mkOption {
+      type = with types; nullOr path;
+      default = null;
+      description = ''
+        Path to a file containing the password to auto-unlock Alby Hub on startup.
+        Password will still be required to access the interface.
+        Setting this option is insecure. The password file will be world-readable
+        in the Nix store.
+      '';
+    };
+
+    jwtSecretFile = mkOption {
+      type = with types; nullOr path;
+      default = null;
+      description = ''
+        Path to a file containing the JWT secret.
+        Setting this option is insecure. The secret file will be world-readable
+        in the Nix store.
+      '';
+    };
+
+    albyOAuth = {
+      clientId = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        description = "Alby OAuth Client ID.";
+      };
+      clientSecretFile = mkOption {
+        type = with types; nullOr path;
+        default = null;
+        description = "Path to a file containing the Alby OAuth client secret.";
+      };
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+
+    users.users.${cfg.user} = {
+      isSystemUser = true;
+      group = cfg.group;
+    };
+    users.groups.${cfg.group} = { };
+
+    systemd.tmpfiles.rules = [
+      "d '${cfg.dataDir}' 0770 ${cfg.user} ${cfg.group} - -"
+    ];
+
+    systemd.services.albyhub = {
+      description = mkDefault "Alby Hub";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig = albyhubSystemdSandbox // {
+        # Build `${envFile}` at service start so dynamic values and secrets are resolved at runtime,
+        # rather than being baked into the Nix-evaluated config. This hook also handles privileged
+        # setup (for example copying LND macaroon and fixing ownership/permissions) before dropping to `${cfg.user}`.
+        ExecStartPre =
+          let
+            catSecret = secret: optionalString (secret != null) "cat ${secret}";
+            appendToFile =
+              key: secret:
+              optionalString (secret != null) ''
+                echo -n '${key}=' >> ${envFile}
+                ${catSecret secret} >> ${envFile}
+                echo >> ${envFile}
+              '';
+          in
+          [
+            (rootScript "albyhub-setup" ''
+              cat > ${envFile} <<EOF
+              ${envFileContent}
+              EOF
+              ${appendToFile "AUTO_UNLOCK_PASSWORD" cfg.autoUnlockPasswordFile}
+              ${optionalString (cfg.jwtSecretFile != null) (appendToFile "JWT_SECRET" cfg.jwtSecretFile)}
+              ${optionalString (cfg.albyOAuth.clientSecretFile != null) (
+                appendToFile "ALBY_OAUTH_CLIENT_SECRET" cfg.albyOAuth.clientSecretFile
+              )}
+
+              chown -R ${cfg.user}:${cfg.group} ${cfg.dataDir}
+              chmod 600 ${envFile}
+            '')
+          ];
+
+        User = cfg.user;
+        Group = cfg.group;
+        ExecStart = lib.getExe cfg.package;
+        EnvironmentFile = "-${envFile}";
+        WorkingDirectory = cfg.dataDir;
+        Restart = "on-failure";
+        RestartSec = "10s";
+        ReadWritePaths = [ cfg.dataDir ];
+      };
+
+    };
+
+  };
+}


### PR DESCRIPTION
This is a simplified version of the abandoned `albyhub` service module that was [drafted for nix-bitcoin](https://github.com/fort-nix/nix-bitcoin/pull/794). I'm using this module on my own system, so I can confirm that it works. This is my first PR adding a service module.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
