### PR TITLE
drm_info: 2.8.0 -> 2.10.0

### DIFF
--- a/pkgs/by-name/dr/drm_info/package.nix
+++ b/pkgs/by-name/dr/drm_info/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitLab,
   libdrm,
+  libdisplay-info,
   json_c,
   pciutils,
   meson,
@@ -14,17 +15,22 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "drm_info";
-  version = "2.8.0";
+  version = "2.10.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "emersion";
     repo = "drm_info";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-LtZ7JJmVNWMjJL2F6k+tcBpJ2v2fd+HNWyHAOvIi7Ko=";
+    hash = "sha256-QKF0frDPelwHOzf3r0tzSo7i1WfGhcFGJfxf2bj1+OE=";
   };
 
   strictDeps = true;
+
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace-fail "'<2.4.134'" "'<2.4.133'"
+  '';
 
   depsBuildBuild = [
     pkg-config
@@ -39,6 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     libdrm
+    libdisplay-info
     json_c
     pciutils
   ];


### PR DESCRIPTION
update to 2.10.0
patch to allow libdrm 2.4.133

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
