### PR TITLE
qelectrotech: fix build and resource paths

### DIFF
--- a/pkgs/by-name/qe/qelectrotech/package.nix
+++ b/pkgs/by-name/qe/qelectrotech/package.nix
@@ -63,6 +63,15 @@ stdenv.mkDerivation rec {
     pugixml
   ];
 
+  qtWrapperArgs = [
+    "--add-flags"
+    "--common-elements-dir=${placeholder "out"}/share/qelectrotech/elements"
+    "--add-flags"
+    "--common-tbt-dir=${placeholder "out"}/share/qelectrotech/titleblocks"
+    "--add-flags"
+    "--lang-dir=${placeholder "out"}/share/qelectrotech/lang"
+  ];
+
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/by-name/qe/qelectrotech/package.nix
+++ b/pkgs/by-name/qe/qelectrotech/package.nix
@@ -30,6 +30,9 @@ stdenv.mkDerivation rec {
   patches = [
     # stripped down version of https://codeberg.org/gentoo/gentoo/src/branch/master/sci-electronics/qelectrotech/files/qelectrotech-0.90_pre20250820-cmake.patch
     ./system-pugixml.patch
+    # Manual 0.100-compatible backport of the Qt-only color widget fallback from
+    # https://github.com/qelectrotech/qelectrotech-source-mirror/pull/533.
+    ./qt-color-widgets.patch
   ];
 
   # fix wrong cmake conditional
@@ -65,16 +68,16 @@ stdenv.mkDerivation rec {
 
     install -Dm555 qelectrotech $out/bin/qelectrotech
 
-    install -Dm444 -t $out/share/applications misc/qelectrotech.desktop
+    install -Dm444 -t $out/share/applications ../misc/org.qelectrotech.qelectrotech.desktop
 
     mkdir -p $out/share/qelectrotech
-    cp -r elements $out/share/qelectrotech
-    cp -r titleblocks $out/share/qelectrotech
-    cp -r lang $out/share/qelectrotech
-    cp -r examples $out/share/qelectrotech
+    cp -r ../elements $out/share/qelectrotech
+    cp -r ../titleblocks $out/share/qelectrotech
+    cp -r ../lang $out/share/qelectrotech
+    cp -r ../examples $out/share/qelectrotech
 
     mkdir -p $out/share/icons/hicolor
-    cp -r ico $out/share/icons/hicolor
+    cp -r ../ico $out/share/icons/hicolor
 
     runHook postInstall
   '';

--- a/pkgs/by-name/qe/qelectrotech/qt-color-widgets.patch
+++ b/pkgs/by-name/qe/qelectrotech/qt-color-widgets.patch
@@ -1,0 +1,168 @@
+diff --git a/cmake/qet_compilation_vars.cmake b/cmake/qet_compilation_vars.cmake
+index 84d7dce..c8a7d53 100644
+--- a/cmake/qet_compilation_vars.cmake
++++ b/cmake/qet_compilation_vars.cmake
+@@ -710,6 +710,15 @@ set(QET_SRC_FILES
+   ${QET_DIR}/sources/xml/terminalstripitemxml.h
+   )
+
++if(NOT BUILD_WITH_KF5)
++  list(APPEND QET_SRC_FILES
++    ${QET_DIR}/sources/ui/kcolorbutton.cpp
++    ${QET_DIR}/sources/ui/kcolorbutton.h
++    ${QET_DIR}/sources/ui/kcolorcombo.cpp
++    ${QET_DIR}/sources/ui/kcolorcombo.h
++  )
++endif()
++
+ set(TS_FILES
+   ${QET_DIR}/lang/qet_ar.ts
+   ${QET_DIR}/lang/qet_ca.ts
+diff --git a/sources/ui/kcolorbutton.cpp b/sources/ui/kcolorbutton.cpp
+new file mode 100644
+index 0000000..c778100
+--- /dev/null
++++ b/sources/ui/kcolorbutton.cpp
+@@ -0,0 +1,45 @@
++#include "kcolorbutton.h"
++
++#include <QColorDialog>
++#include <QPalette>
++
++KColorButton::KColorButton(QWidget *parent) :
++	QPushButton{parent},
++	m_color{Qt::black}
++{
++	connect(this, &QPushButton::clicked, this, &KColorButton::chooseColor);
++	updateButton();
++}
++
++QColor KColorButton::color() const
++{
++	return m_color;
++}
++
++void KColorButton::setColor(const QColor &color)
++{
++	m_color = color;
++	updateButton();
++}
++
++void KColorButton::chooseColor()
++{
++	const auto selected = QColorDialog::getColor(m_color, this);
++	if (!selected.isValid() || selected == m_color) {
++		return;
++	}
++
++	m_color = selected;
++	updateButton();
++	emit changed(m_color);
++}
++
++void KColorButton::updateButton()
++{
++	setText(m_color.isValid() ? m_color.name() : QString{});
++	auto pal = palette();
++	pal.setColor(QPalette::Button, m_color.isValid() ? m_color : QPalette{}.color(QPalette::Button));
++	setAutoFillBackground(true);
++	setPalette(pal);
++	update();
++}
+diff --git a/sources/ui/kcolorbutton.h b/sources/ui/kcolorbutton.h
+new file mode 100644
+index 0000000..a30c077
+--- /dev/null
++++ b/sources/ui/kcolorbutton.h
+@@ -0,0 +1,31 @@
++#ifndef QET_KCOLORBUTTON_H
++#define QET_KCOLORBUTTON_H
++
++#include <QColor>
++#include <QPushButton>
++
++class KColorButton : public QPushButton
++{
++	Q_OBJECT
++
++	public:
++		explicit KColorButton(QWidget *parent = nullptr);
++
++		QColor color() const;
++
++	public slots:
++		void setColor(const QColor &color);
++
++	signals:
++		void changed(const QColor &color);
++
++	private slots:
++		void chooseColor();
++
++	private:
++		void updateButton();
++
++		QColor m_color;
++};
++
++#endif // QET_KCOLORBUTTON_H
+diff --git a/sources/ui/kcolorcombo.cpp b/sources/ui/kcolorcombo.cpp
+new file mode 100644
+index 0000000..c0ac10d
+--- /dev/null
++++ b/sources/ui/kcolorcombo.cpp
+@@ -0,0 +1,27 @@
++#include "kcolorcombo.h"
++
++#include <QVariant>
++
++KColorCombo::KColorCombo(QWidget *parent) :
++	QComboBox{parent}
++{
++	connect(this, QOverload<int>::of(&QComboBox::activated), this, [this](int index) {
++		emit activated(itemData(index).value<QColor>());
++	});
++}
++
++void KColorCombo::setColors(const QList<QColor> &colors)
++{
++	clear();
++	for (const auto &color : colors) {
++		addItem(color.name(), color);
++	}
++}
++
++QColor KColorCombo::color(int index) const
++{
++	if (index < 0 || index >= count()) {
++		return {};
++	}
++	return itemData(index).value<QColor>();
++}
+diff --git a/sources/ui/kcolorcombo.h b/sources/ui/kcolorcombo.h
+new file mode 100644
+index 0000000..ca8f1c9
+--- /dev/null
++++ b/sources/ui/kcolorcombo.h
+@@ -0,0 +1,21 @@
++#ifndef QET_KCOLORCOMBO_H
++#define QET_KCOLORCOMBO_H
++
++#include <QColor>
++#include <QComboBox>
++
++class KColorCombo : public QComboBox
++{
++	Q_OBJECT
++
++	public:
++		explicit KColorCombo(QWidget *parent = nullptr);
++
++		void setColors(const QList<QColor> &colors);
++		QColor color(int index) const;
++
++	signals:
++		void activated(const QColor &color);
++};
++
++#endif // QET_KCOLORCOMBO_H


### PR DESCRIPTION
Fixes the `qelectrotech` build without reintroducing KF5 by adding Qt-only replacements for the remaining `KColorButton` and `KColorCombo` uses.

Also adjusts the manual `installPhase` to install files from the source tree when CMake builds out-of-source, and passes qelectrotech's resource path options through the Qt wrapper so translations, elements, and titleblocks load from `$out/share/qelectrotech/...` instead of upstream's `/usr/local/share/qelectrotech/...` default.

Closes #532690
Closes #534359

Assisted-by: pi coding agent / Mika (OpenAI GPT-5.5)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
