### PR TITLE
mariadb: mark insecure

### DIFF
--- a/nixos/release-small.nix
+++ b/nixos/release-small.nix
@@ -97,7 +97,6 @@ rec {
       imagemagick
       jdk
       linux
-      mariadb
       nginx
       nodejs
       openssh

--- a/pkgs/kde/gear/akonadi/default.nix
+++ b/pkgs/kde/gear/akonadi/default.nix
@@ -18,6 +18,14 @@ assert lib.assertOneOf "backend" backend [
   "sqlite"
 ];
 
+let
+  mariadb' = mariadb.overrideAttrs (old: {
+    meta = old.meta // {
+      # Akonadi runs MariaDB under the same user only allowing them socket access
+      knownVulnerabilities = [ ];
+    };
+  });
+in
 mkKdeDerivation {
   pname = "akonadi";
 
@@ -30,7 +38,7 @@ mkKdeDerivation {
     "-DDATABASE_BACKEND=${lib.toUpper backend}"
   ]
   ++ lib.optionals (backend == "mysql") [
-    "-DMYSQLD_SCRIPTS_PATH=${lib.getBin mariadb}/bin"
+    "-DMYSQLD_SCRIPTS_PATH=${lib.getBin mariadb'}/bin"
   ]
   ++ lib.optionals (backend == "postgres") [
     "-DPOSTGRES_PATH=${lib.getBin libpq}/bin"
@@ -46,7 +54,7 @@ mkKdeDerivation {
     accounts-qt
     xz
   ]
-  ++ lib.optionals (backend == "mysql") [ mariadb ]
+  ++ lib.optionals (backend == "mysql") [ mariadb' ]
   ++ lib.optionals (backend == "postgres") [ libpq ]
   ++ lib.optionals (backend == "sqlite") [ sqlite ];
 
@@ -56,7 +64,7 @@ mkKdeDerivation {
     mkdir -p $out/nix-support
   ''
   + lib.optionalString (backend == "mysql") ''
-    echo "${mariadb}" > $out/nix-support/depends
+    echo "${mariadb'}" > $out/nix-support/depends
   ''
   + lib.optionalString (backend == "postgres") ''
     echo "${libpq}" > $out/nix-support/depends

--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -227,6 +227,20 @@ let
             thoughtpolice
           ];
           platforms = lib.platforms.all;
+          knownVulnerabilities = [
+            "CVE-2026-3494"
+            "CVE-2026-34303"
+            "CVE-2026-35549"
+            "CVE-2026-44168"
+            "CVE-2026-44169"
+            "CVE-2026-44170"
+            "CVE-2026-44171"
+            "CVE-2026-44172"
+            "CVE-2026-44173"
+            "CVE-2026-48163"
+            "CVE-2026-48165"
+            "CVE-2026-49261"
+          ];
         };
       };
 

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -125,7 +125,6 @@ let
             jobs.ghc.x86_64-darwin
             jobs.git.x86_64-darwin
             jobs.go.x86_64-darwin
-            jobs.mariadb.x86_64-darwin
             jobs.nix.x86_64-darwin
             jobs.nixpkgs-review.x86_64-darwin
             jobs.nix-info.x86_64-darwin
@@ -167,7 +166,6 @@ let
             jobs.ghc.aarch64-darwin
             jobs.git.aarch64-darwin
             jobs.go.aarch64-darwin
-            jobs.mariadb.aarch64-darwin
             jobs.nix.aarch64-darwin
             jobs.nixpkgs-review.aarch64-darwin
             jobs.nix-info.aarch64-darwin
@@ -263,7 +261,6 @@ let
         jobs.nix-info.x86_64-darwin
         jobs.nix-info-tested.x86_64-darwin
         jobs.git.x86_64-darwin
-        jobs.mariadb.x86_64-darwin
         jobs.vim.x86_64-darwin
         jobs.inkscape.x86_64-darwin
         jobs.qt5.qtmultimedia.x86_64-darwin
@@ -289,7 +286,6 @@ let
         jobs.nix-info.aarch64-darwin
         jobs.nix-info-tested.aarch64-darwin
         jobs.git.aarch64-darwin
-        jobs.mariadb.aarch64-darwin
         jobs.vim.aarch64-darwin
         jobs.inkscape.aarch64-darwin
         jobs.qt5.qtmultimedia.aarch64-darwin


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
