### PR TITLE
jetbrains-jdk: 25.0.2b432.48 -> 25.0.3b508.4  

### DIFF
--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   callPackage,
   fetchurl,
   jetbrains,
@@ -8,6 +9,7 @@
   wayland-scanner,
   wayland-protocols,
   libxkbcommon,
+  speechd-minimal,
 }:
 
 let
@@ -26,8 +28,8 @@ let
   # cd jetbrainsruntime
   # git tag --points-at [revision]
   # Look for the line that starts with jbr-
-  javaVersion = "25.0.2";
-  build = "432.48";
+  javaVersion = "25.0.3";
+  build = "508.4";
 in
 callPackage ./common.nix
   {
@@ -36,12 +38,21 @@ callPackage ./common.nix
   {
     inherit javaVersion build;
     # run `git log -1 --pretty=%ct` in jdk repo for new value on update
-    sourceDateEpoch = 1777242155;
-    srcHash = "sha256-BKyvBUKtg+JbZNuH/RZY87eJng6Eyd6L3cOwcOgOx/Y=";
+    sourceDateEpoch = 1780959777;
+    srcHash = "sha256-N+7D++Cxu0RGWChEWW8gtNz7E2I8qM2AFbXv4luAXto=";
     homePath = "${jetbrains.jdk}/lib/openjdk";
     jcefPackage = jetbrains.jcef;
     extraBuildPhase = ''
       cp -r ${gtk-protocols.out} gtk-shell.xml
+
+      # JBR hardcodes the speech-dispatcher header location to
+      # /usr/include/speech-dispatcher in its mkimages scripts.
+      substituteInPlace \
+        jb/project/tools/linux/scripts/mkimages_x64.sh \
+        jb/project/tools/linux/scripts/mkimages_aarch64.sh \
+        --replace-fail \
+          "--with-speechd-include=/usr/include/speech-dispatcher" \
+          "--with-speechd-include=${lib.getDev speechd-minimal}/include/speech-dispatcher"
     '';
     vendorVersionString = "nix/JBR-${javaVersion}-b${build}${if withJcef then "-jcef" else ""}";
     extraConfigureFlags = [

--- a/pkgs/development/compilers/jetbrains-jdk/jcef.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/jcef.nix
@@ -53,15 +53,15 @@ let
   inherit (arches) depsArch projectArch targetArch;
 
   # `cef_binary_${CEF_VERSION}_linux64_minimal`, where CEF_VERSION is from $src/CMakeLists.txt
-  cef-name = "cef_binary_137.0.17+gf354b0e+chromium-137.0.7151.104_${platform}_minimal";
+  cef-name = "cef_binary_144.0.15+g72717cf+chromium-144.0.7559.172_${platform}_minimal";
 
   cef-bin = cef-binary.override {
-    version = "137.0.17"; # follow upstream. https://github.com/Almamu/linux-wallpaperengine/blob/b39f12757908eda9f4c1039613b914606568bb84/CMakeLists.txt#L47
-    gitRevision = "f354b0e";
-    chromiumVersion = "137.0.7151.104";
+    version = "144.0.15";
+    gitRevision = "72717cf";
+    chromiumVersion = "144.0.7559.172";
     srcHashes = {
-      aarch64-linux = "sha256-C9P4+TpzjyMD5z2qLbzubbrIr66usFjRx7QqiAxI2D8=";
-      x86_64-linux = "sha256-iDC3a/YN0NqjX/b2waKvUAZCaR0lkLmUPqBJphE037Q=";
+      aarch64-linux = "sha256-2w2TDj7LGjYeUjpVvojAsHb8HlqG82AwH8Arg0NxREg=";
+      x86_64-linux = "sha256-JDlZmIEg9ajjuFOL8qAr6HDVbeu3/Cg21Z57fHryfdc=";
     };
   };
 
@@ -92,11 +92,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "jcef-jetbrains";
-  rev = "97d05cdf1720586ebfff5d4bc6e15a6a533eb21e";
+  rev = "fa677024a129747bd8cb05447af8918c494e4af7";
   # This is the commit number
   # Currently from the branch: https://github.com/JetBrains/jcef/tree/261
   # Run `git rev-list --count HEAD`
-  version = "1156";
+  version = "1207";
 
   nativeBuildInputs = [
     cmake
@@ -126,7 +126,7 @@ stdenv.mkDerivation rec {
     owner = "jetbrains";
     repo = "jcef";
     inherit rev;
-    hash = "sha256-31WV6vYp0zIf6EkccQTeiggCRtQnDOg8/4J2q6axiGs=";
+    hash = "sha256-eYn1T4cRrHeVDSye6FKBv8X3zZPDGFurk6HJG+jPypY=";
   };
 
   # Find the hash in tools/buildtools/linux64/clang-format.sha1


### PR DESCRIPTION
change log: https://github.com/JetBrains/JetBrainsRuntime/compare/jbr-release-25.0.2b432.48...jbr-release-25.0.3b508.4

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
