### PR TITLE
eiskaltdcpp: 2.4.2 -> 2.4.2-unstable-2024-11-25

### DIFF
--- a/pkgs/by-name/ei/eiskaltdcpp/package.nix
+++ b/pkgs/by-name/ei/eiskaltdcpp/package.nix
@@ -2,14 +2,14 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch2,
   cmake,
   pkg-config,
   bzip2,
   libx11,
   libsForQt5,
   libiconv,
-  pcre-cpp,
+  pcre2,
+  libidn2,
   libidn,
   lua5,
   miniupnpc,
@@ -18,22 +18,20 @@
   perl,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "eiskaltdcpp";
-  version = "2.4.2";
+  version = "2.4.2-unstable-2024-11-25";
 
   src = fetchFromGitHub {
     owner = "eiskaltdcpp";
     repo = "eiskaltdcpp";
-    rev = "v${version}";
-    sha256 = "sha256-JmAopXFS6MkxW0wDQ1bC/ibRmWgOpzU0971hcqAehLU=";
+    rev = "697db4b03e3d9ffa48b3d4c74fd043dee7663266";
+    hash = "sha256-6ExzvfBzV/iVMjdObW76usexm9MW5xwyvTisAFPLQ6Y=";
   };
 
   patches = [
-    (fetchpatch2 {
-      url = "https://github.com/eiskaltdcpp/eiskaltdcpp/commit/5ab5e1137a46864b6ecd1ca302756da8b833f754.patch?full_index=1";
-      hash = "sha256-GIdcIHKXNSbHxbiMGRPgfq2w/zNSfR/FhyyXayFWfg8=";
-    })
+    # Upstream PR: https://github.com/eiskaltdcpp/eiskaltdcpp/pull/550
+    ./patches/cmake-raise-minimum-version-to-3.10.0.patch
   ];
 
   nativeBuildInputs = [
@@ -48,7 +46,8 @@ stdenv.mkDerivation rec {
     libsForQt5.qtscript
     bzip2
     libx11
-    pcre-cpp
+    pcre2
+    libidn2
     libidn
     lua5
     miniupnpc
@@ -62,17 +61,6 @@ stdenv.mkDerivation rec {
     ))
   ]
   ++ lib.optional stdenv.hostPlatform.isDarwin libiconv;
-
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace-fail "cmake_minimum_required (VERSION 2.6.3)" "cmake_minimum_required (VERSION 3.10)"
-    substituteInPlace {dcpp,dht,extra,json}/CMakeLists.txt \
-      --replace-fail "cmake_minimum_required (VERSION 2.6)" "cmake_minimum_required (VERSION 3.10)"
-    substituteInPlace eiskaltdcpp-{cli,daemon}/CMakeLists.txt \
-      --replace-fail "cmake_minimum_required(VERSION 2.6)" "cmake_minimum_required (VERSION 3.10)"
-    substituteInPlace eiskaltdcpp-qt/CMakeLists.txt \
-      --replace-fail "cmake_minimum_required (VERSION 2.8.11)" "cmake_minimum_required (VERSION 3.10)"
-  '';
 
   cmakeFlags = [
     (lib.cmakeBool "DBUS_NOTIFY" true)

--- a/pkgs/by-name/ei/eiskaltdcpp/patches/cmake-raise-minimum-version-to-3.10.0.patch
+++ b/pkgs/by-name/ei/eiskaltdcpp/patches/cmake-raise-minimum-version-to-3.10.0.patch
@@ -1,0 +1,149 @@
+From 0a1b682aaa9c4a566ebb75e8c734597eba9a6acd Mon Sep 17 00:00:00 2001
+From: fliiiix <hi@l33t.name>
+Date: Sun, 26 Jul 2026 14:51:14 +0200
+Subject: [PATCH] cmake: raise minimum version to 3.10.0 to support cmake 4
+
+---
+ CMakeLists.txt                    | 2 +-
+ dcpp/CMakeLists.txt               | 2 +-
+ dht/CMakeLists.txt                | 2 +-
+ eiskaltdcpp-cli/CMakeLists.txt    | 2 +-
+ eiskaltdcpp-daemon/CMakeLists.txt | 2 +-
+ eiskaltdcpp-gtk/CMakeLists.txt    | 2 +-
+ eiskaltdcpp-qt/CMakeLists.txt     | 2 +-
+ extra/CMakeLists.txt              | 2 +-
+ haiku/CMakeLists.txt              | 2 +-
+ json/CMakeLists.txt               | 2 +-
+ windows/install-deps.cmake        | 2 +-
+ 11 files changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ae08c726..bd85ec4a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ project (eiskaltdcpp)
+-cmake_minimum_required (VERSION 3.2.0)
++cmake_minimum_required (VERSION 3.10.0)
+ 
+ set (PROJECT_NAME "EiskaltDC++")
+ set (APP_VERSION "2.4.2+devel") # Main program version (displayed in UI)
+diff --git a/dcpp/CMakeLists.txt b/dcpp/CMakeLists.txt
+index 01ed3914..d96c90f4 100644
+--- a/dcpp/CMakeLists.txt
++++ b/dcpp/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ project (dcpp)
+ 
+-cmake_minimum_required (VERSION 3.2.0)
++cmake_minimum_required (VERSION 3.10.0)
+ 
+ aux_source_directory(${PROJECT_SOURCE_DIR} dcpp_srcs)
+ file (GLOB dcpp_hdrs ${PROJECT_SOURCE_DIR}/*.h)
+diff --git a/dht/CMakeLists.txt b/dht/CMakeLists.txt
+index 9cf03102..6c1f4768 100644
+--- a/dht/CMakeLists.txt
++++ b/dht/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ project (dht)
+ 
+-cmake_minimum_required (VERSION 3.2.0)
++cmake_minimum_required (VERSION 3.10.0)
+ 
+ aux_source_directory(${PROJECT_SOURCE_DIR} dht_srcs)
+ 
+diff --git a/eiskaltdcpp-cli/CMakeLists.txt b/eiskaltdcpp-cli/CMakeLists.txt
+index cceac2b5..e47dafe8 100644
+--- a/eiskaltdcpp-cli/CMakeLists.txt
++++ b/eiskaltdcpp-cli/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ project(eiskaltdcpp-cli)
+ 
+-cmake_minimum_required(VERSION 3.2.0)
++cmake_minimum_required(VERSION 3.10.0)
+ 
+ if (USE_CLI_XMLRPC)
+     install (FILES cli-xmlrpc.pl DESTINATION ${BINDIR} RENAME ${PROJECT_NAME}-xmlrpc
+diff --git a/eiskaltdcpp-daemon/CMakeLists.txt b/eiskaltdcpp-daemon/CMakeLists.txt
+index 0f825adc..e77cdb4d 100644
+--- a/eiskaltdcpp-daemon/CMakeLists.txt
++++ b/eiskaltdcpp-daemon/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ project(eiskaltdcpp-daemon)
+ 
+-cmake_minimum_required(VERSION 3.2.0)
++cmake_minimum_required(VERSION 3.10.0)
+ # ######### General setup ##########
+ include_directories(${PROJECT_SOURCE_DIR}
+                     ${PROJECT_SOURCE_DIR}/..
+diff --git a/eiskaltdcpp-gtk/CMakeLists.txt b/eiskaltdcpp-gtk/CMakeLists.txt
+index 57b2662f..b4c55e03 100644
+--- a/eiskaltdcpp-gtk/CMakeLists.txt
++++ b/eiskaltdcpp-gtk/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ project (eiskaltdcpp-gtk)
+ 
+-cmake_minimum_required (VERSION 3.2.0)
++cmake_minimum_required (VERSION 3.10.0)
+ 
+ set (GTK2_DIR "${PROJECT_SOURCE_DIR}/cmake/")
+ 
+diff --git a/eiskaltdcpp-qt/CMakeLists.txt b/eiskaltdcpp-qt/CMakeLists.txt
+index e5750a80..4df35699 100644
+--- a/eiskaltdcpp-qt/CMakeLists.txt
++++ b/eiskaltdcpp-qt/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ project (eiskaltdcpp-qt)
+ 
+-cmake_minimum_required (VERSION 3.2.0)
++cmake_minimum_required (VERSION 3.10.0)
+ 
+ include_directories(${PROJECT_BINARY_DIR})
+ 
+diff --git a/extra/CMakeLists.txt b/extra/CMakeLists.txt
+index 9c679d8a..efa7e947 100644
+--- a/extra/CMakeLists.txt
++++ b/extra/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ project (extra)
+-cmake_minimum_required (VERSION 3.2.0)
++cmake_minimum_required (VERSION 3.10.0)
+ include_directories (${PROJECT_SOURCE_DIR}
+                      ${GETTEXT_INCLUDE_DIR}
+                      ${MINIUPNP_INCLUDE_DIR}
+diff --git a/haiku/CMakeLists.txt b/haiku/CMakeLists.txt
+index 5300e3cc..2132fcc1 100644
+--- a/haiku/CMakeLists.txt
++++ b/haiku/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ project(haiku)
+ 
+-cmake_minimum_required (VERSION 3.2.0)
++cmake_minimum_required (VERSION 3.10.0)
+ 
+ if (HAIKU_PKG)
+     install (CODE "
+diff --git a/json/CMakeLists.txt b/json/CMakeLists.txt
+index 2c89ec89..075a276f 100644
+--- a/json/CMakeLists.txt
++++ b/json/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ project (jsonrpcpp)
+-cmake_minimum_required (VERSION 3.2.0)
++cmake_minimum_required (VERSION 3.10.0)
+ 
+ # ######### General setup ##########
+ 
+diff --git a/windows/install-deps.cmake b/windows/install-deps.cmake
+index 6847bdad..fa07e3af 100644
+--- a/windows/install-deps.cmake
++++ b/windows/install-deps.cmake
+@@ -1,4 +1,4 @@
+-cmake_minimum_required (VERSION 3.2.0)
++cmake_minimum_required (VERSION 3.10.0)
+ 
+ if (CMAKE_PREFIX_PATH MATCHES "mxe" AND NOT BUILD_STATIC)
+     set (LIBS_TARGET install-dependencies)
+-- 
+2.54.0
+


### PR DESCRIPTION
## Things done

This helps to remove the pcre -> pcre-cpp dependency (for https://github.com/NixOS/nixpkgs/issues/356387). And it does not seem that they will release any time soon.
https://github.com/eiskaltdcpp/eiskaltdcpp/issues/547

It builds and i could start the binary.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
