### PR TITLE
nixos-test-driver: reintroduce `--test-script` flag

### DIFF
--- a/nixos/lib/test-driver/src/test_driver/__init__.py
+++ b/nixos/lib/test-driver/src/test_driver/__init__.py
@@ -89,6 +89,11 @@ def main() -> None:
         required=True,
     )
     arg_parser.add_argument(
+        "--test-script",
+        help="path to a test script to run, taking precedence over the one defined in the config file",
+        type=Path,
+    )
+    arg_parser.add_argument(
         "--keep-vm-state",
         help=argparse.SUPPRESS,
         dest="keep_machine_state",
@@ -162,8 +167,12 @@ def main() -> None:
     if args.debug_hook_attach is not None:
         debugger = Debug(logger, args.debug_hook_attach)
 
+    config = load_driver_configuration(args.config)
+    if args.test_script is not None:
+        config.test_script = args.test_script
+
     with Driver(
-        config=load_driver_configuration(args.config),
+        config=config,
         out_dir=output_directory,
         logger=logger,
         keep_machine_state=args.keep_machine_state,


### PR DESCRIPTION
Restore the ability to pass a test script on the command line through:
```
--test-script [PATH]
```
which was possible prior to its removal in: f1bcb61731224bd8440510fc620d3c51f3e51c85

I have found the flag to be quite practical for NixOS test iteration and propose
hereby to reintroduce it again.

While it is still possible without this flag to pass an external test
script, it now needs to be done through the indirection of a `--config`
configuration file - which now has to have configuration which points towards
the test script, which adds enough friction as to not make it ergonomic anymore.

The `--test-script` flag overwrites the configuration from the test config.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
