### PR TITLE
python3Packages.zigpy: disable flaky race-driven mock test

### DIFF
--- a/pkgs/development/python-modules/zigpy/default.nix
+++ b/pkgs/development/python-modules/zigpy/default.nix
@@ -66,6 +66,8 @@ buildPythonPackage (finalAttrs: {
   disabledTests = [
     # assert quirked.quirk_metadata.quirk_location.endswith("zigpy/tests/test_quirks_v2.py]-line:104") is False
     "test_quirks_v2"
+    # (Race condition) AssertionError: assert 4 == 3
+    "test_periodic_scan_priority"
   ];
 
   disabledTestPaths = [


### PR DESCRIPTION
Test dies on lightly-loaded machines:
```sh
       >             # Now we can cancel the periodic scan
       >             topology.stop_periodic_scans()
       >             await asyncio.sleep(0)
       >
       >         # Our two manual scans succeeded and the periodic one was attempted
       > >       assert len(mock_scan.mock_calls) == 3
       > E       AssertionError: assert 4 == 3
       > E        +  where 4 = len([call(None), call(None), call(None), call(None)])
       > E        +    where [call(None), call(None), call(None), call(None)] = <AsyncMock name='_scan' id='140736975094848'>.mock_calls
       >
       > tests/test_topology.py:419: AssertionError
```

Disabled test.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
