### PR TITLE
python3Packages.supervision: init at 0.29.0.post0

### DIFF
--- a/pkgs/development/python-modules/supervision/default.nix
+++ b/pkgs/development/python-modules/supervision/default.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  defusedxml,
+  matplotlib,
+  numpy,
+  opencv-python,
+  pillow,
+  pydeprecate,
+  pyyaml,
+  requests,
+  scipy,
+  tqdm,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "supervision";
+  version = "0.29.0.post0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "roboflow";
+    repo = "supervision";
+    tag = finalAttrs.version;
+    hash = "sha256-Pug95Srb8dv+3QctaZzF5Gz88eaOmlw4OkZWI7QFsXI=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    defusedxml
+    matplotlib
+    numpy
+    opencv-python
+    pillow
+    pydeprecate
+    pyyaml
+    requests
+    scipy
+    tqdm
+  ];
+
+  # Tests require network access and GPU/model resources.
+  doCheck = false;
+
+  pythonImportsCheck = [ "supervision" ];
+
+  meta = {
+    description = "Set of easy-to-use utils that will come in handy in any Computer Vision project";
+    homepage = "https://github.com/roboflow/supervision";
+    changelog = "https://github.com/roboflow/supervision/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mahyarmirrashed ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19252,6 +19252,8 @@ self: super: with self; {
 
   supervise-api = callPackage ../development/python-modules/supervise-api { };
 
+  supervision = callPackage ../development/python-modules/supervision { };
+
   supervisor = callPackage ../development/python-modules/supervisor { };
 
   sure = callPackage ../development/python-modules/sure { };


### PR DESCRIPTION
Adds https://github.com/roboflow/supervision.

A set of easy-to-use utilities for any computer vision project.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
