### PR TITLE
 python3Packages.pytest-memray: init at 1.8.0 ;  python314Packages.pyturbojpeg: enable tests 

### DIFF
--- a/pkgs/development/python-modules/pytest-memray/default.nix
+++ b/pkgs/development/python-modules/pytest-memray/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  anyio,
+  buildPythonPackage,
+  fetchFromGitHub,
+  flaky,
+  hatchling,
+  hatch-vcs,
+  memray,
+  pytest,
+  pytest-xdist,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pytest-memray";
+  version = "1.8.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "bloomberg";
+    repo = "pytest-memray";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-73Lyy14t2Hcqo0aTlWbGMzaxJ73bKjzc4BFE/jPG99I=";
+  };
+
+  build-system = [
+    hatchling
+    hatch-vcs
+  ];
+
+  dependencies = [ memray ];
+
+  buildInputs = [ pytest ];
+
+  nativeCheckInputs = [
+    anyio
+    flaky
+    pytest-xdist
+    pytestCheckHook
+  ];
+
+  enabledTestPaths = [
+    # don't run the demo tests
+    "tests"
+  ];
+
+  pythonImportsCheck = [ "pytest_memray" ];
+
+  meta = {
+    description = "Pytest plugin for easy integration of memray memory profiler";
+    homepage = "https://github.com/bloomberg/pytest-memray";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+  };
+})

--- a/pkgs/development/python-modules/pyturbojpeg/default.nix
+++ b/pkgs/development/python-modules/pyturbojpeg/default.nix
@@ -6,7 +6,8 @@
   libjpeg_turbo,
   setuptools,
   numpy,
-  python,
+  pytest-memray,
+  pytestCheckHook,
   replaceVars,
 }:
 
@@ -32,14 +33,15 @@ buildPythonPackage rec {
 
   dependencies = [ numpy ];
 
-  # upstream has no tests, but we want to test whether the library is found
-  checkPhase = ''
-    runHook preCheck
+  nativeCheckInputs = [
+    pytest-memray
+    pytestCheckHook
+  ];
 
-    ${python.interpreter} -c 'from turbojpeg import TurboJPEG; TurboJPEG()'
-
-    runHook postCheck
-  '';
+  disabledTests = [
+    # our patch breaks the test
+    "test_library_loading_error_message"
+  ];
 
   pythonImportsCheck = [ "turbojpeg" ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15846,6 +15846,8 @@ self: super: with self; {
 
   pytest-md-report = callPackage ../development/python-modules/pytest-md-report { };
 
+  pytest-memray = callPackage ../development/python-modules/pytest-memray { };
+
   pytest-metadata = callPackage ../development/python-modules/pytest-metadata { };
 
   pytest-mock = callPackage ../development/python-modules/pytest-mock { };


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
