### PR TITLE
gallery-dl: update homepage and changelog url

### DIFF
--- a/pkgs/by-name/ga/gallery-dl/package.nix
+++ b/pkgs/by-name/ga/gallery-dl/package.nix
@@ -47,9 +47,9 @@ python3Packages.buildPythonApplication (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    changelog = "https://github.com/mikf/gallery-dl/blob/v${finalAttrs.version}/CHANGELOG.md";
+    changelog = "https://codeberg.org/mikf/gallery-dl/src/tag/v${finalAttrs.version}/CHANGELOG.md";
     description = "Command-line program to download image-galleries and -collections from several image hosting sites";
-    homepage = "https://github.com/mikf/gallery-dl";
+    homepage = "https://codeberg.org/mikf/gallery-dl";
     license = lib.licenses.gpl2Only;
     mainProgram = "gallery-dl";
     maintainers = with lib.maintainers; [


### PR DESCRIPTION
gallery-dl has been moved to Codeberg.

Changelog link has been update to follow Codeberg's schema: `codeberg.org/mikf/gallery-dl/src/tag/v{finalAttrs.version}/<any-file-in-repo>`

- [Announcement] Moving to Codeberg: https://github.com/mikf/gallery-dl/issues/9374

