### PR TITLE
llvmPackages: add `shouldCheck` escape hatch to mkPackage

### DIFF
--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -21,6 +21,7 @@
   officialRelease ? null,
   monorepoSrc ? null,
   version ? null,
+  shouldCheck ? true,
   patchesFn ? lib.id,
   cmake,
   cmakeMinimal,

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -5,6 +5,7 @@
   pkgsBuildBuild,
   src ? null,
   monorepoSrc ? null,
+  shouldCheck,
   runCommand,
   cmake,
   darwin,
@@ -571,7 +572,8 @@ stdenv.mkDerivation (
       )
       && (!stdenv.hostPlatform.isMusl)
       && !(stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isBigEndian)
-      && (stdenv.hostPlatform == stdenv.buildPlatform);
+      && (stdenv.hostPlatform == stdenv.buildPlatform)
+      && shouldCheck;
 
     checkTarget = "check-all";
 

--- a/pkgs/development/compilers/llvm/common/mlir/default.nix
+++ b/pkgs/development/compilers/llvm/common/mlir/default.nix
@@ -5,6 +5,7 @@
   release_version,
   buildLlvmPackages,
   monorepoSrc,
+  shouldCheck,
   runCommand,
   cmake,
   ninja,
@@ -23,7 +24,8 @@ stdenv.mkDerivation (finalAttrs: {
     (
       !stdenv.hostPlatform.isx86_32 # TODO: why
     )
-    && (!stdenv.hostPlatform.isMusl);
+    && (!stdenv.hostPlatform.isMusl)
+    && shouldCheck;
 
   # Blank llvm dir just so relative path works
   src = runCommand "${finalAttrs.pname}-src-${version}" { inherit (monorepoSrc) passthru; } ''

--- a/pkgs/development/compilers/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/default.nix
@@ -42,6 +42,7 @@ let
       gitRelease ? null,
       monorepoSrc ? null,
       version ? null,
+      shouldCheck ? true,
     }@args:
     let
       inherit
@@ -65,6 +66,7 @@ let
               gitRelease
               monorepoSrc
               version
+              shouldCheck
               patchesFn
               bootBintools
               bootBintoolsNoLibc


### PR DESCRIPTION
This introduces a way to skip tests in LLVM, which is a prerequisite for work on getting support for the latest version of OpenBSD (there is a dependency on their compiler patches, which unfortunately introduce changes to LLVM codegen without updating the tests).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
