### PR TITLE
sone: 0.19.0 -> 0.20.0

### DIFF
--- a/pkgs/by-name/so/sone/package.nix
+++ b/pkgs/by-name/so/sone/package.nix
@@ -26,22 +26,22 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sone";
-  version = "0.19.0";
+  version = "0.20.0";
 
   src = fetchFromGitHub {
     owner = "lullabyX";
     repo = "sone";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-DDUMbKhcVzUGiButQivMQdY8+j6LXBVICMMRI55yTnM=";
+    hash = "sha256-dVAVMcEr9cUPJetcVj9y9Lkj6LevJH0M7WYui43IjnY=";
   };
 
-  cargoHash = "sha256-OJLC0daanMoIhsRGOxUgmFdG0vzeMbLCDesgrVxCwOA=";
+  cargoHash = "sha256-gsg/aKy+RpJFF6Q2P5O7btoeY4Q/A9D/w3s1nLvnp1Q=";
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     inherit pnpm;
     fetcherVersion = 4;
-    hash = "sha256-mstEHVONYW4NOYUxG+6pwMdobwuY0ZBMHC49skh/pEQ=";
+    hash = "sha256-vOfDSTu7AnZINejVwnIXdZJYlmHSljJpddRRQqlI7ko=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--version bump to 0.20.0
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->👤 Profiles

    View your profile page — avatar, bio, social links, and your public playlists.
    Edit your profile in-app: write a bio, add social/brand links, and upload & crop an avatar (or remove it).
    Public playlists appear as a horizontal scrolling row with a "View all" page.
    Your avatar now shows in the account menu — click your name to jump to your profile.

⚙️ Redesigned Settings

    Settings is now a single centered window with a grouped sidebar instead of scattered modals.
    Organized into tabs: Playback, Themes, Discord, Network, MCP, Scrobbling, General, and Utilities.
    Themes, scrobbling, and gapless controls all moved into Settings; the old standalone dialogs are gone.
    Title-bar / window decoration options are now a clear radio list.
    Reveal the log folder directly from Utilities for easier troubleshooting.

🎨 Themes

    Three new presets — Noir, Meadow, and Blossom.
    A custom in-app color picker with a live "app in miniature" preview, so you can see changes before applying.
    Preset tiles redesigned as surface swatches with accent and background dots.

🔊 Streaming Quality

    Set a maximum streaming quality ceiling in Playback settings — SONE never requests above it.
    Album quality badges now correctly read Hi-Res Lossless from the stream.

🖼️ Cover Art & Page Design

    Full-width cover-art banners with a theme-aware blur sit behind album, playlist, mix, and artist headers.
    Animated Album Cover — album covers gently animate in the drawer, fullscreen view, and on the album page.
    Album, playlist, artist, and mix headers redesigned — artist image, quality tag, creator line, total duration, and clearly labelled action buttons.
    Full-bleed artist hero with fan count and progressive image loading.
    An animated "Living Heart" banner on the Loved Tracks header.
    Matching skeleton loaders across all redesigned pages for smoother loads.

🔌 MCP, Network & Discord

    MCP tab shows full connection details with a portable config you can copy; your token is masked in the URL.
    Network tab adds an endpoint builder with a live connection status banner.
    Discord tab adds tags and a live presence preview.

🐛 Fixes

    Logging out now fully tears down your session — audio, scrobbling, Discord, and MCP — and clears all cross-account state. Logging back in restores Discord/MCP and refreshes your region.
    Playing a recommended track from a playlist now queues those recommendations as their own source, not the playlist's own tracks.
    The shuffle button on album/playlist/mix pages no longer flips your global shuffle mode.
    Repeat-all now preserves play history on source-backed playlists.
    Playback position stays correct on pause/resume, track load, and miniplayer sync.
    The favorite button is hidden on playlists you created, which now show your profile name as the creator.
    API error details are surfaced in readable toasts instead of raw response bodies.
    Sensitive data is redacted from session-refresh logs.
    Disabled the WebKitGTK DMA-BUF renderer on NVIDIA (X11 and Wayland) to fix rendering glitches.

📦 Packaging

    New Snap package (core24) with working rendering, GPU acceleration, MPRIS, and screen-inhibit support.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
