### PR TITLE
nvidia-x11: strip debug info from the kernel modules at install

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/kernel-modules.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/kernel-modules.nix
@@ -47,6 +47,7 @@ stdenv.mkDerivation {
     ];
 
   buildTargets = [ "modules" ];
+  installFlags = [ "INSTALL_MOD_STRIP=1" ];
   installTargets = [ "modules_install" ];
   enableParallelBuilding = true;
 


### PR DESCRIPTION
The modules record absolute `${kernel.dev}` paths in DWARF that the fixup `strip` can't reach as it's already compressed, so `allowedReferences = [ ]` only passes when compression hides the hash. When setting `MODULE_COMPRESS_ZSTD`, the hash is not hidden, causing this module to fail to build.

This commit strips the module before compression.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
