### PR TITLE
lib.cli: performance refactors

### DIFF
--- a/lib/cli.nix
+++ b/lib/cli.nix
@@ -140,7 +140,7 @@ rec {
 
           mkBool ? k: v: optional v (mkOptionName k),
 
-          mkList ? k: v: concatMap (mkOption k) v,
+          mkList ? k: concatMap (mkOption k),
 
           mkOption ?
             k: v:

--- a/lib/cli.nix
+++ b/lib/cli.nix
@@ -155,7 +155,6 @@ rec {
 
           optionValueSeparator ? null,
         }:
-        options:
         let
           render =
             k: v:
@@ -165,9 +164,8 @@ rec {
               mkList k v
             else
               mkOption k v;
-
         in
-        concatLists (mapAttrsToList render options)
+        options: concatLists (mapAttrsToList render options)
       );
 
   /**

--- a/lib/cli.nix
+++ b/lib/cli.nix
@@ -421,7 +421,7 @@
     - `lib.cli.toCommandLineShellGNU`
   */
   toCommandLine =
-    optionFormat: attrs:
+    optionFormat:
     let
       handlePair =
         k: v:
@@ -458,5 +458,5 @@
               arg
             ];
     in
-    builtins.concatLists (lib.mapAttrsToList handlePair attrs);
+    attrs: builtins.concatLists (lib.mapAttrsToList handlePair attrs);
 }

--- a/lib/cli.nix
+++ b/lib/cli.nix
@@ -1,6 +1,21 @@
 { lib }:
 
-{
+let
+  inherit (lib)
+    concatLists
+    concatMap
+    escapeShellArgs
+    isBool
+    isList
+    mapAttrsToList
+    oldestSupportedReleaseIsAtLeast
+    optional
+    stringLength
+    warnIf
+    ;
+  inherit (lib.generators) mkValueStringDefault;
+in
+rec {
   /**
     Automatically convert an attribute set to command-line options.
 
@@ -40,9 +55,9 @@
     :::
   */
   toGNUCommandLineShell =
-    lib.warnIf (lib.oldestSupportedReleaseIsAtLeast 2511)
+    warnIf (oldestSupportedReleaseIsAtLeast 2511)
       "lib.cli.toGNUCommandLineShell is deprecated, please use lib.cli.toCommandLineShell or lib.cli.toCommandLineShellGNU instead."
-      (options: attrs: lib.escapeShellArgs (lib.cli.toGNUCommandLine options attrs));
+      (options: attrs: escapeShellArgs (toGNUCommandLine options attrs));
 
   /**
     Automatically convert an attribute set to a list of command-line options.
@@ -116,15 +131,15 @@
     :::
   */
   toGNUCommandLine =
-    lib.warnIf (lib.oldestSupportedReleaseIsAtLeast 2511)
+    warnIf (oldestSupportedReleaseIsAtLeast 2511)
       "lib.cli.toGNUCommandLine is deprecated, please use lib.cli.toCommandLine or lib.cli.toCommandLineShellGNU instead."
       (
         {
-          mkOptionName ? k: if builtins.stringLength k == 1 then "-${k}" else "--${k}",
+          mkOptionName ? k: if stringLength k == 1 then "-${k}" else "--${k}",
 
-          mkBool ? k: v: lib.optional v (mkOptionName k),
+          mkBool ? k: v: optional v (mkOptionName k),
 
-          mkList ? k: v: lib.concatMap (mkOption k) v,
+          mkList ? k: v: concatMap (mkOption k) v,
 
           mkOption ?
             k: v:
@@ -133,10 +148,10 @@
             else if optionValueSeparator == null then
               [
                 (mkOptionName k)
-                (lib.generators.mkValueStringDefault { } v)
+                (mkValueStringDefault { } v)
               ]
             else
-              [ "${mkOptionName k}${optionValueSeparator}${lib.generators.mkValueStringDefault { } v}" ],
+              [ "${mkOptionName k}${optionValueSeparator}${mkValueStringDefault { } v}" ],
 
           optionValueSeparator ? null,
         }:
@@ -144,15 +159,15 @@
         let
           render =
             k: v:
-            if builtins.isBool v then
+            if isBool v then
               mkBool k v
-            else if builtins.isList v then
+            else if isList v then
               mkList k v
             else
               mkOption k v;
 
         in
-        builtins.concatLists (lib.mapAttrsToList render options)
+        concatLists (mapAttrsToList render options)
       );
 
   /**
@@ -163,8 +178,7 @@
     For further reference see:
     [`lib.cli.toCommandLineGNU`](#function-library-lib.cli.toCommandLineGNU)
   */
-  toCommandLineShellGNU =
-    options: attrs: lib.escapeShellArgs (lib.cli.toCommandLineGNU options attrs);
+  toCommandLineShellGNU = options: attrs: escapeShellArgs (toCommandLineGNU options attrs);
 
   /**
     Converts an attribute set into a list of GNU-style command-line arguments.
@@ -227,9 +241,9 @@
   */
   toCommandLineGNU =
     {
-      isLong ? optionName: builtins.stringLength optionName > 1,
+      isLong ? optionName: stringLength optionName > 1,
       explicitBool ? false,
-      formatArg ? lib.generators.mkValueStringDefault { },
+      formatArg ? mkValueStringDefault { },
     }:
     let
       optionFormat = optionName: {
@@ -238,7 +252,7 @@
         inherit explicitBool formatArg;
       };
     in
-    lib.cli.toCommandLine optionFormat;
+    toCommandLine optionFormat;
 
   /**
     Converts the given attributes into a single shell-escaped command-line
@@ -248,8 +262,7 @@
     For further reference see:
     [`lib.cli.toCommandLine`](#function-library-lib.cli.toCommandLine)
   */
-  toCommandLineShell =
-    optionFormat: attrs: lib.escapeShellArgs (lib.cli.toCommandLine optionFormat attrs);
+  toCommandLineShell = optionFormat: attrs: escapeShellArgs (toCommandLine optionFormat attrs);
 
   /**
     Converts an attribute set into a list of command-line arguments.
@@ -426,9 +439,9 @@
       handlePair =
         k: v:
         if k == "" then
-          lib.throw "lib.cli.toCommandLine only accepts non-empty option names."
-        else if builtins.isList v then
-          builtins.concatMap (handleOption k) v
+          throw "lib.cli.toCommandLine only accepts non-empty option names."
+        else if isList v then
+          concatMap (handleOption k) v
         else
           handleOption k v;
 
@@ -439,7 +452,7 @@
           option,
           sep,
           explicitBool,
-          formatArg ? lib.generators.mkValueStringDefault { },
+          formatArg ? mkValueStringDefault { },
         }:
         k: v:
         if v == null || (!explicitBool && v == false) then
@@ -458,5 +471,5 @@
               arg
             ];
     in
-    attrs: builtins.concatLists (lib.mapAttrsToList handlePair attrs);
+    attrs: concatLists (mapAttrsToList handlePair attrs);
 }

--- a/lib/cli.nix
+++ b/lib/cli.nix
@@ -14,6 +14,7 @@ let
     warnIf
     ;
   inherit (lib.generators) mkValueStringDefault;
+  mkValueString = mkValueStringDefault { };
 in
 rec {
   /**
@@ -148,10 +149,10 @@ rec {
             else if optionValueSeparator == null then
               [
                 (mkOptionName k)
-                (mkValueStringDefault { } v)
+                (mkValueString v)
               ]
             else
-              [ "${mkOptionName k}${optionValueSeparator}${mkValueStringDefault { } v}" ],
+              [ "${mkOptionName k}${optionValueSeparator}${mkValueString v}" ],
 
           optionValueSeparator ? null,
         }:
@@ -241,7 +242,7 @@ rec {
     {
       isLong ? optionName: stringLength optionName > 1,
       explicitBool ? false,
-      formatArg ? mkValueStringDefault { },
+      formatArg ? mkValueString,
     }:
     let
       optionFormat = optionName: {
@@ -450,7 +451,7 @@ rec {
           option,
           sep,
           explicitBool,
-          formatArg ? mkValueStringDefault { },
+          formatArg ? mkValueString,
         }:
         k: v:
         if v == null || (!explicitBool && v == false) then


### PR DESCRIPTION
Before I recommended someone use this in a project of mine, I wanted to give the file a once-over.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
