### PR TITLE
nixos/acme: also allow _PATH-suffixed credential files

### DIFF
--- a/nixos/modules/security/acme/default.nix
+++ b/nixos/modules/security/acme/default.nix
@@ -2,13 +2,11 @@
   config,
   lib,
   pkgs,
-  options,
   ...
 }:
 let
 
   cfg = config.security.acme;
-  opt = options.security.acme;
   user = if cfg.useRoot then "root" else "acme";
 
   # Used to calculate timer accuracy for coalescing

--- a/nixos/modules/security/acme/default.nix
+++ b/nixos/modules/security/acme/default.nix
@@ -826,8 +826,8 @@ let
           type = lib.types.attrsOf (lib.types.path);
           inherit (defaultAndText "credentialFiles" { }) default defaultText;
           description = ''
-            Environment variables suffixed by "_FILE" to set for the cert's service
-            for your selected dnsProvider.
+            Environment variables suffixed by "_FILE" or "_PATH" to set for the
+            cert's service for your selected dnsProvider.
             To find out what values you need to set, consult the documentation at
             <https://go-acme.github.io/lego/dns/> for the corresponding dnsProvider.
             This allows to securely pass credential files to lego by leveraging systemd
@@ -1186,10 +1186,13 @@ in
               }
             )
             {
-              assertion = lib.all (lib.hasSuffix "_FILE") (lib.attrNames data.credentialFiles);
+              assertion = lib.all (n: lib.hasSuffix "_FILE" n || lib.hasSuffix "_PATH" n) (
+                lib.attrNames data.credentialFiles
+              );
+
               message = ''
                 Option `security.acme.certs.${cert}.credentialFiles` can only be
-                used for variables suffixed by "_FILE".
+                used for variables suffixed by "_FILE" or "_PATH".
               '';
             }
 


### PR DESCRIPTION
The acmedns backend consumes a ACME_DNS_STORAGE_PATH environment variable.

Upstream does treat this file as mutable (if you create or delete accounts through the CLI, it would update it. We don't do this in our module).

But the possibility for edits is probably why they didn't go with `ACME_DNS_CONFIG` env var for the contents (as they'd be read-only), or a `ACME_DNS_CONFIG_FILE`. (And the fact that a
`ACME_DNS_STORAGE_PATH_FILE` env var with questionable usability exists is due to this logic being generic for most env vars).

So instead of fighting upstream over this, let's simply make our module assertion also accept `_PATH` suffixes for `credentialFiles`.

Fixes #344684.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
