### PR TITLE
lomiri.mediascanner2: 0.200 -> 0.201, init lomiri-qt6 variant

### DIFF
--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -53,6 +53,7 @@ let
       lomiri-indicator-network = callPackage ./services/lomiri-indicator-network { };
       lomiri-thumbnailer = callPackage ./services/lomiri-thumbnailer { };
       lomiri-url-dispatcher = callPackage ./services/lomiri-url-dispatcher { };
+      mediascanner2 = callPackage ./services/mediascanner2 { };
     }
     // lib.optionalAttrs useQt6 {
       #### Core Apps
@@ -98,7 +99,6 @@ let
       lomiri-indicator-datetime = ayatana-indicator-datetime.override { enableLomiriFeatures = true; };
       lomiri-polkit-agent = callPackage ./services/lomiri-polkit-agent { };
       lomiri-telephony-service = callPackage ./services/lomiri-telephony-service { };
-      mediascanner2 = callPackage ./services/mediascanner2 { };
     };
 in
 lib.makeScope qtPackages.newScope packages

--- a/pkgs/desktops/lomiri/services/mediascanner2/default.nix
+++ b/pkgs/desktops/lomiri/services/mediascanner2/default.nix
@@ -27,15 +27,18 @@
   wrapQtAppsHook,
 }:
 
+let
+  withQt6 = lib.versions.major qtbase.version == "6";
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "mediascanner2";
-  version = "0.200";
+  version = "0.201";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/mediascanner2";
     tag = finalAttrs.version;
-    hash = "sha256-tTEbH5gXK+0y3r1LCxsZ6vr1FVyXWZaNAXaR6jcIP0Y=";
+    hash = "sha256-Z57ptFR+/W80sPquM5hgaqnCjd9pWYheq2VnkR+fGSY=";
   };
 
   outputs = [
@@ -46,12 +49,6 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     substituteInPlace src/qml/MediaScanner.*/CMakeLists.txt \
       --replace-fail "\''${CMAKE_INSTALL_LIBDIR}/qt\''${QT_VERSION_MAJOR}/qml" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}"
-  ''
-  # https://gitlab.com/ubports/development/core/mediascanner2/-/commit/4268b8c0a7e99c1d12f43599b1ae76b5b27572ec
-  # Remove when version > 0.200
-  + ''
-    substituteInPlace src/extractor/CMakeLists.txt src/qml/MediaScanner.0.1/CMakeLists.txt \
-      --replace-fail 'msg(' 'message('
   '';
 
   strictDeps = true;
@@ -86,10 +83,12 @@ stdenv.mkDerivation (finalAttrs: {
     gst-plugins-good
   ]);
 
+  nativeCheckInputs = [ dbus ];
+
   checkInputs = [ gtest ];
 
   cmakeFlags = [
-    (lib.cmakeBool "ENABLE_QT6" (lib.strings.versionAtLeast qtbase.version "6"))
+    (lib.cmakeBool "ENABLE_QT6" withQt6)
     (lib.cmakeBool "ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
   ];
 
@@ -97,6 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   preCheck = ''
     export QT_PLUGIN_PATH=${lib.getBin qtbase}/${qtbase.qtPluginPrefix}
+    export QML2_IMPORT_PATH=${lib.getBin qtdeclarative}/${qtbase.qtQmlPrefix}
     export XDG_DATA_DIRS=${shared-mime-info}/share:$XDG_DATA_DIRS
   '';
 
@@ -109,10 +109,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests = {
+      pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    }
+    // lib.optionalAttrs (!withQt6) {
       # music app needs mediascanner to work properly, so it can find files
       music-app = nixosTests.lomiri-music-app;
-
-      pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
     };
     updateScript = gitUpdater { };
   };


### PR DESCRIPTION
https://gitlab.com/ubports/development/core/mediascanner2/-/blob/0.201/ChangeLog?ref_type=tags

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
