### PR TITLE
python3Packages.grpc-google-iam-v1: 3.31.3 -> 0.14.4

### DIFF
--- a/pkgs/development/python-modules/grpc-google-iam-v1/default.nix
+++ b/pkgs/development/python-modules/grpc-google-iam-v1/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  gitUpdater,
   googleapis-common-protos,
   grpcio,
   pytestCheckHook,
@@ -10,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "grpc-google-iam-v1";
-  version = "3.31.3";
+  version = "0.14.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "googleapis";
     repo = "google-cloud-python";
-    tag = "google-cloud-build-v${version}";
-    hash = "sha256-qQ+8X6I8lt4OTgbvODsbdab2dYUk0wxWsbaVT2T651U=";
+    tag = "grpc-google-iam-v1-v${version}";
+    hash = "sha256-i2t8qtF2czaP9vgGOUN9AjQ3XhLkk8g05FtXUdk/Vng=";
   };
 
   sourceRoot = "${src.name}/packages/grpc-google-iam-v1";
@@ -41,6 +42,11 @@ buildPythonPackage rec {
   pytestFlags = [
     "-Wignore::DeprecationWarning"
   ];
+
+  passthru = {
+    skipBulkUpdate = true; # chooses tag for a different project
+    updateScript = gitUpdater { rev-prefix = "grpc-google-iam-v1-v"; };
+  };
 
   meta = {
     description = "GRPC library for the google-iam-v1 service";


### PR DESCRIPTION
Diff: https://github.com/googleapis/google-cloud-python/compare/grpc-google-iam-v1-v3.31.3...grpc-google-iam-v1-v0.14.4

Changelog: https://github.com/googleapis/google-cloud-python/blob/grpc-google-iam-v1-v0.14.4/packages/grpc-google-iam-v1/CHANGELOG.md

relevant for https://github.com/NixOS/nixpkgs/pull/532778
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
