### PR TITLE
lomiri.hfd-service: 0.2.3 -> 0.2.4

### DIFF
--- a/pkgs/desktops/lomiri/services/hfd-service/default.nix
+++ b/pkgs/desktops/lomiri/services/hfd-service/default.nix
@@ -17,28 +17,28 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hfd-service";
-  version = "0.2.3";
+  version = "0.2.4";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/hfd-service";
     rev = finalAttrs.version;
-    hash = "sha256-PvZPdisqpKl9OSuQXIJW1y6EJ5moesJiEAQjpQjzyWQ=";
+    hash = "sha256-gk0LHRmHqcG42H3Syje7XfZLiQ6hwzb22XcFa0xf7pc=";
   };
 
   postPatch = ''
     substituteInPlace qt/feedback-plugin/CMakeLists.txt \
-      --replace "\''${CMAKE_INSTALL_LIBDIR}/qt5/plugins" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtPluginPrefix}"
+      --replace-fail "\''${CMAKE_INSTALL_LIBDIR}/qt5/plugins" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtPluginPrefix}"
 
     # Queries pkg-config via pkg_get_variable, can't override prefix
     substituteInPlace init/CMakeLists.txt \
-      --replace 'pkg_get_variable(SYSTEMD_SYSTEM_DIR systemd systemdsystemunitdir)' 'set(SYSTEMD_SYSTEM_DIR ''${CMAKE_INSTALL_PREFIX}/lib/systemd/system)'
+      --replace-fail 'pkg_get_variable(SYSTEMD_SYSTEM_DIR systemd systemdsystemunitdir)' 'set(SYSTEMD_SYSTEM_DIR ''${CMAKE_INSTALL_PREFIX}/lib/systemd/system)'
     substituteInPlace CMakeLists.txt \
-      --replace 'pkg_get_variable(AS_INTERFACES_DIR accountsservice interfacesdir)' 'set(AS_INTERFACES_DIR "''${CMAKE_INSTALL_FULL_DATADIR}/accountsservice/interfaces")' \
-      --replace '../../dbus-1/interfaces' "\''${CMAKE_INSTALL_PREFIX}/\''${DBUS_INTERFACES_DIR}" \
-      --replace 'DESTINATION ''${DBUS_INTERFACES_DIR}' 'DESTINATION ''${CMAKE_INSTALL_PREFIX}/''${DBUS_INTERFACES_DIR}'
+      --replace-fail 'pkg_get_variable(AS_INTERFACES_DIR accountsservice interfacesdir)' 'set(AS_INTERFACES_DIR "''${CMAKE_INSTALL_FULL_DATADIR}/accountsservice/interfaces")' \
+      --replace-fail '../../dbus-1/interfaces' "\''${CMAKE_INSTALL_PREFIX}/\''${DBUS_INTERFACES_DIR}" \
+      --replace-fail 'DESTINATION ''${DBUS_INTERFACES_DIR}' 'DESTINATION ''${CMAKE_INSTALL_PREFIX}/''${DBUS_INTERFACES_DIR}'
     substituteInPlace src/CMakeLists.txt \
-      --replace "\''${DBUS_INTERFACES_DIR}/org.freedesktop.Accounts.xml" '${accountsservice}/share/dbus-1/interfaces/org.freedesktop.Accounts.xml'
+      --replace-fail "\''${DBUS_INTERFACES_DIR}/org.freedesktop.Accounts.xml" '${accountsservice}/share/dbus-1/interfaces/org.freedesktop.Accounts.xml'
   '';
 
   strictDeps = true;


### PR DESCRIPTION
https://gitlab.com/ubports/development/core/hfd-service/-/blob/0.2.4/ChangeLog

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
