### PR TITLE
python3Packages.python-subunit: rename from subunit

### DIFF
--- a/pkgs/development/python-modules/os-client-config/default.nix
+++ b/pkgs/development/python-modules/os-client-config/default.nix
@@ -10,7 +10,7 @@
   python-glanceclient,
   setuptools,
   stestr,
-  subunit,
+  python-subunit,
   testscenarios,
   testtools,
 }:
@@ -40,7 +40,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     fixtures
     jsonschema
-    subunit
+    python-subunit
     oslotest
     stestr
     testscenarios

--- a/pkgs/development/python-modules/oslotest/default.nix
+++ b/pkgs/development/python-modules/oslotest/default.nix
@@ -5,7 +5,7 @@
   fixtures,
   pbr,
   six,
-  subunit,
+  python-subunit,
   callPackage,
 }:
 
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     fixtures
     six
-    subunit
+    python-subunit
   ];
 
   # check in passthru.tests.pytest to escape infinite recursion with other oslo components

--- a/pkgs/development/python-modules/python-octaviaclient/tests.nix
+++ b/pkgs/development/python-modules/python-octaviaclient/tests.nix
@@ -7,7 +7,7 @@
   doc8,
   docutils,
   pygments,
-  subunit,
+  python-subunit,
   oslotest,
   stestr,
   testscenarios,
@@ -29,7 +29,7 @@ buildPythonPackage {
     doc8
     docutils
     pygments
-    subunit
+    python-subunit
     oslotest
     stestr
     testscenarios

--- a/pkgs/development/python-modules/python-subunit/default.nix
+++ b/pkgs/development/python-modules/python-subunit/default.nix
@@ -18,8 +18,8 @@
 }:
 
 buildPythonPackage {
+  pname = "python-subunit";
   inherit (subunit)
-    pname
     version
     src
     meta

--- a/pkgs/development/python-modules/stestr/default.nix
+++ b/pkgs/development/python-modules/stestr/default.nix
@@ -5,7 +5,7 @@
   cliff,
   fixtures,
   flit-core,
-  subunit,
+  python-subunit,
   testtools,
   tomlkit,
   voluptuous,
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   dependencies = [
     cliff
     fixtures
-    subunit
+    python-subunit
     testtools
     tomlkit
     voluptuous

--- a/pkgs/development/python-modules/tempest/default.nix
+++ b/pkgs/development/python-modules/tempest/default.nix
@@ -24,7 +24,7 @@
   setuptools,
   stestr,
   stevedore,
-  subunit,
+  python-subunit,
   testscenarios,
   testtools,
   urllib3,
@@ -67,7 +67,7 @@ buildPythonPackage rec {
     pyyaml
     stestr
     stevedore
-    subunit
+    python-subunit
     testscenarios
     testtools
     urllib3

--- a/pkgs/development/python-modules/testrepository/default.nix
+++ b/pkgs/development/python-modules/testrepository/default.nix
@@ -5,7 +5,7 @@
   testtools,
   testresources,
   pbr,
-  subunit,
+  python-subunit,
   fixtures,
   python,
 }:
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   buildInputs = [ pbr ];
   propagatedBuildInputs = [
     fixtures
-    subunit
+    python-subunit
     testtools
   ];
 

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -600,6 +600,7 @@ mapAliases {
   sqlalchemy_migrate = throw "'sqlalchemy_migrate' has been renamed to/replaced by 'sqlalchemy-migrate'"; # Converted to throw 2025-10-29
   steamship = throw "'steamship' has been removed because it is broken and unmaintained upstream"; # Added 2026-05-06
   subunit2sql = throw "subunit2sql has been removed because it has been marked as broken since at least November 2024."; # Added 2025-10-04
+  subunit = python-subunit; # added 2026-06-21
   supafunc = throw "'supafunc' has been replaced by 'supabase-functions'"; # Added 2026-03-08
   supervise_api = throw "'supervise_api' has been renamed to/replaced by 'supervise-api'"; # Converted to throw 2025-10-29
   swh-perfecthash = throw "'swh-perfecthash' has been renamed to/replaced by 'swh-shard'"; # added 2025-11-13

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16343,6 +16343,10 @@ self: super: with self; {
 
   python-string-utils = callPackage ../development/python-modules/python-string-utils { };
 
+  python-subunit = callPackage ../development/python-modules/python-subunit {
+    inherit (pkgs) subunit cppunit check;
+  };
+
   python-swiftclient = callPackage ../development/python-modules/python-swiftclient { };
 
   python-tado = callPackage ../development/python-modules/python-tado { };
@@ -19203,10 +19207,6 @@ self: super: with self; {
   subprocess-tee = callPackage ../development/python-modules/subprocess-tee { };
 
   subprocess4 = callPackage ../development/python-modules/subprocess4 { };
-
-  subunit = callPackage ../development/python-modules/subunit {
-    inherit (pkgs) subunit cppunit check;
-  };
 
   subzerod = callPackage ../development/python-modules/subzerod { };
 


### PR DESCRIPTION
The project name (e.g. on PyPI) is python-subunit.

relevant for https://github.com/NixOS/nixpkgs/pull/532778
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
