### PR TITLE
ocamlPackages.findlib: drop compiler references from built closures

### DIFF
--- a/pkgs/build-support/ocaml/dune.nix
+++ b/pkgs/build-support/ocaml/dune.nix
@@ -42,7 +42,11 @@ lib.extendMkDerivation {
       {
         name = "ocaml${ocaml.version}-${pname}-${version}";
 
+        __structuredAttrs = true;
+
         strictDeps = true;
+
+        env.DUNE_CACHE = "disabled";
 
         inherit enableParallelBuilding;
         dontAddStaticConfigureFlags = true;

--- a/pkgs/development/tools/ocaml/findlib/default.nix
+++ b/pkgs/development/tools/ocaml/findlib/default.nix
@@ -5,6 +5,7 @@
   ncurses,
   ocaml,
   writeText,
+  removeReferencesTo,
 }:
 
 stdenv.mkDerivation rec {
@@ -73,6 +74,10 @@ stdenv.mkDerivation rec {
         exit 1
       fi
     }
+    stripOCamlReferences () {
+      if [[ -n "''${dontStripOCamlReferences-}" || ! -d "$prefix" ]]; then return; fi
+      find "$prefix" -type f -name '*.cmt*' -exec ${removeReferencesTo}/bin/remove-references-to -t ${ocaml} {} +
+    }
 
     # run for every buildInput
     addEnvHooks "$targetOffset" addOCamlPath
@@ -80,6 +85,8 @@ stdenv.mkDerivation rec {
     preInstallHooks+=(createOcamlDestDir)
     # run even in nix-shell, and even without buildInputs
     addEnvHooks "$hostOffset" exportOcamlDestDir
+    # nuke compiler paths from bin-annot files
+    fixupOutputHooks+=(stripOCamlReferences)
     # runs after all calls to addOCamlPath
     if [[ -z "''${dontDetectOcamlConflicts-}" ]]; then
       postHooks+=("detectOcamlConflicts")


### PR DESCRIPTION
close https://github.com/NixOS/nixpkgs/issues/484653

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
