### PR TITLE
convertx: 0.17.0 -> 0.18.0

### DIFF
--- a/pkgs/by-name/co/convertx/package.nix
+++ b/pkgs/by-name/co/convertx/package.nix
@@ -1,5 +1,5 @@
 {
-  stdenv,
+  stdenvNoCC,
   lib,
   fetchFromGitHub,
 
@@ -43,11 +43,12 @@ let
     hash = pin.srcHash;
   };
 
-  node_modules = stdenv.mkDerivation (finalAttrs: {
+  node_modules = stdenvNoCC.mkDerivation (finalAttrs: {
     pname = "${pname}-node_modules";
     inherit version src;
 
     dontConfigure = true;
+    dontFixup = true;
 
     nativeBuildInputs = [
       bun
@@ -70,11 +71,11 @@ let
       cp package.json $out/lib
     '';
 
-    outputHash = pin."${stdenv.system}";
+    outputHash = pin."${stdenvNoCC.system}";
     outputHashMode = "recursive";
   });
 in
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   inherit pname version src;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/co/convertx/pin.json
+++ b/pkgs/by-name/co/convertx/pin.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.17.0",
-  "srcHash": "sha256-1W7M9BfAh89ntmJW7tNwydwPCkVy5CoddWb2aPPUFds=",
-  "x86_64-linux": "sha256-7B4ZGGew6isFnz7EoaLyJgO6a66V9ZTKsKxXwVSsnfs=",
-  "aarch64-linux": "sha256-IoQP9UBd64qecOwmI8oQREgiYCL2pXGjfVx1Ylvd/WA="
+  "version": "0.18.0",
+  "srcHash": "sha256-S8oUU21VOy+4MiWvnEBOSUBuMysYq9H4tQIcEOvLjKw=",
+  "x86_64-linux": "sha256-rAZROhjbvGg/7aRPlh6yGmPDmbEsYjDHJEVaWXejxts=",
+  "aarch64-linux": "sha256-yJbwexqwe95XIZ51gbjwpg6cRm5ssJl1qrIS+Vrd+vo="
 }


### PR DESCRIPTION
https://github.com/C4illin/ConvertX/releases/tag/v0.18.0

No changes to runtime dependencies in this release.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
