### PR TITLE
{lomiri,lomiri-qt6}.qqc2-suru-style: 0.20230630 -> 0.20260619

### DIFF
--- a/pkgs/desktops/lomiri/qml/qqc2-suru-style/default.nix
+++ b/pkgs/desktops/lomiri/qml/qqc2-suru-style/default.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  fetchpatch,
   gitUpdater,
   cmake,
   qmake,
@@ -18,28 +17,18 @@
 }:
 
 let
-  withQt6 = lib.strings.versionAtLeast qtbase.version "6";
+  withQt6 = lib.versions.major qtbase.version == "6";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "qqc2-suru-style";
-  version = "0.20230630";
+  version = "0.20260619";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/qqc2-suru-style";
     tag = finalAttrs.version;
-    hash = "sha256-kAgHsNWwUWxHg26bTMmlq8m9DR4+ob4pl/oUX7516hM=";
+    hash = "sha256-yGm3rBKS1DKrpIVerfZVn5j0keGlQXr7nn6lSmI8xEw=";
   };
-
-  patches = [
-    # https://gitlab.com/ubports/development/core/qqc2-suru-style/-/merge_requests/69
-    # Remove when version > 0.20230630
-    (fetchpatch {
-      name = "0001-qqc2-suru-style-Qt6-port.patch";
-      url = "https://gitlab.com/ubports/development/core/qqc2-suru-style/-/commit/30b662113900ce2a4e27a0647e439ffdba5fd609.patch";
-      hash = "sha256-RCXEhDUgMqi+oeY313hXOVTr3rGiyF/Mqe/Uf4+YaBU=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace qqc2-suru/suru.pri \


### PR DESCRIPTION
https://gitlab.com/ubports/development/core/qqc2-suru-style/-/blob/0.20260619/ChangeLog

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
