### PR TITLE
archon-lite: init at 9.3.85

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26086,6 +26086,12 @@
     githubId = 13762043;
     matrix = "@sophie:nue.soopy.moe";
   };
+  sophiebsw = {
+    name = "Sophia";
+    email = "nixpkgs@drifter.dev";
+    github = "sophiebsw";
+    githubId = 4594464;
+  };
   sophronesis = {
     email = "oleksandr.buzynnyi@gmail.com";
     github = "sophronesis";

--- a/pkgs/by-name/ar/archon-lite/package.nix
+++ b/pkgs/by-name/ar/archon-lite/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+  nix-update-script,
+}:
+let
+  pname = "archon-lite";
+  version = "9.3.85";
+  src = fetchurl {
+    url = "https://github.com/RPGLogs/Uploaders-archon-lite/releases/download/v${version}/archon-lite-v${version}.AppImage";
+    hash = "sha256-ooNvgbtV6HKgzRLgHZul92NLnEB8oX6fHL6iwfHajVA=";
+  };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Application for uploading MMORPG combat logs";
+    homepage = "https://www.archon.gg/download";
+    downloadPage = "https://github.com/RPGLogs/Uploaders-archon-lite/releases/tag/v${version}";
+    license = lib.licenses.unfree; # no license listed
+    mainProgram = "archon-lite";
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      hekazu
+      sophiebsw
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
This is my first contribution, apologies if I did anything wrong. Please read https://github.com/NixOS/nixpkgs/pull/529294 for context. The following is copied from that PR:

> Introduce the MMORPG combat log uploader tool archon-lite that replaces (at least) the FF Logs Uploader client after June 29th 2026 per a warning now present in the application. The preceding upload client is currently part of nixpkgs. FYI @keysmashes as the current maintainer of the FF Logs Uploader.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
