### PR TITLE
neovim-unwrapped, tree-sitter: add optional wasmtime support

### DIFF
--- a/pkgs/by-name/ne/neovim-unwrapped/package.nix
+++ b/pkgs/by-name/ne/neovim-unwrapped/package.nix
@@ -11,6 +11,7 @@
   unibilium,
   utf8proc,
   tree-sitter,
+  wasmtime_36,
   fetchurl,
   buildPackages,
   treesitter-parsers ? import ./treesitter-parsers.nix { inherit fetchurl; },
@@ -20,6 +21,7 @@
   versionCheckHook,
   nix-update-script,
   writableTmpDirAsHomeHook,
+  wasmSupport ? false,
 
   # now defaults to false because some tests can be flaky (clipboard etc), see
   # also: https://github.com/neovim/neovim/issues/16233
@@ -30,6 +32,9 @@
 
 let
   lua = if lib.meta.availableOn stdenv.hostPlatform luajit then luajit else lua5_1;
+  treeSitterForNeovim = tree-sitter.override {
+    inherit wasmSupport;
+  };
 in
 
 stdenv.mkDerivation (
@@ -161,9 +166,12 @@ stdenv.mkDerivation (
       # and it's definition at: pkgs/development/lua-modules/overrides.nix
       lua.pkgs.libluv
       neovimLuaEnv
-      tree-sitter
+      treeSitterForNeovim
       unibilium
       utf8proc
+    ]
+    ++ lib.optionals wasmSupport [
+      wasmtime_36
     ]
     ++ lib.optionals (stdenv.hostPlatform.libc != "glibc") [
       # Provide libintl for non-glibc platforms
@@ -202,13 +210,20 @@ stdenv.mkDerivation (
         pyEnv # for src/clint.py
       ];
 
-    # nvim --version output retains compilation flags and references to build tools
-    postPatch = lib.optionalString (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
-      sed -i runtime/CMakeLists.txt \
-        -e "s|\".*/bin/nvim|\${stdenv.hostPlatform.emulator buildPackages} &|g"
-      sed -i src/nvim/po/CMakeLists.txt \
-        -e "s|\$<TARGET_FILE:nvim|\${stdenv.hostPlatform.emulator buildPackages} &|g"
-    '';
+    postPatch =
+      lib.optionalString wasmSupport ''
+        substituteInPlace src/nvim/CMakeLists.txt \
+          --replace-fail \
+            'find_package(Wasmtime 36.0.6 EXACT REQUIRED)' \
+            'find_package(Wasmtime REQUIRED)'
+      ''
+      # nvim --version output retains compilation flags and references to build tools
+      + lib.optionalString (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+        sed -i runtime/CMakeLists.txt \
+          -e "s|\".*/bin/nvim|\${stdenv.hostPlatform.emulator buildPackages} &|g"
+        sed -i src/nvim/po/CMakeLists.txt \
+          -e "s|\$<TARGET_FILE:nvim|\${stdenv.hostPlatform.emulator buildPackages} &|g"
+      '';
     # check that the above patching actually works
     disallowedRequisites = [
       stdenv.cc
@@ -228,6 +243,12 @@ stdenv.mkDerivation (
       (lib.cmakeBool "USE_BUNDLED" false)
       (lib.cmakeBool "ENABLE_TRANSLATIONS" true)
       (lib.cmakeBool "USE_BUNDLED_BUSTED" false)
+    ]
+    ++ lib.optionals wasmSupport [
+      # FindWasmtime has no pkg-config fallback.
+      (lib.cmakeBool "ENABLE_WASMTIME" true)
+      (lib.cmakeFeature "WASMTIME_INCLUDE_DIR" "${lib.getDev wasmtime_36}/include")
+      (lib.cmakeFeature "WASMTIME_LIBRARY" "${lib.getLib wasmtime_36}/lib/libwasmtime${stdenv.hostPlatform.extensions.sharedLibrary}")
     ]
     ++ (
       if lua.pkgs.isLuaJIT then

--- a/pkgs/by-name/tr/tree-sitter/package.nix
+++ b/pkgs/by-name/tr/tree-sitter/package.nix
@@ -18,8 +18,11 @@
   substitute,
   installShellFiles,
   buildPackages,
+  cmake,
+  wasmtime_36,
   enableShared ? !stdenv.hostPlatform.isStatic,
   enableStatic ? stdenv.hostPlatform.isStatic,
+  wasmSupport ? false,
   webUISupport ? false,
 }:
 
@@ -124,8 +127,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-9FeWnWWPUWmMF15Psmul8GxGv2JceHWc2WZPmOr81gw=";
 
+  cargoBuildFeatures = lib.optionals wasmSupport [ "wasm" ];
+
   buildInputs = [
     installShellFiles
+  ]
+  ++ lib.optionals wasmSupport [
+    wasmtime_36
   ]
   ++ lib.optionals webUISupport [
     openssl
@@ -133,6 +141,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeBuildInputs = [
     rustPlatform.bindgenHook
     which
+  ]
+  ++ lib.optionals wasmSupport [
+    cmake
   ]
   ++ lib.optionals webUISupport [
     emscripten
@@ -164,6 +175,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
       sed -i '/^install:/,/^[^[:space:]]/ { /$(SOEXT/d; }' ./Makefile
     '';
 
+  # The Makefile install can't enable the wasm feature.
+  cmakeFlags = lib.optionals wasmSupport [
+    (lib.cmakeBool "TREE_SITTER_FEATURE_WASM" true)
+    (lib.cmakeFeature "WASMTIME_INCLUDE_DIR" "${lib.getDev wasmtime_36}/include")
+    (lib.cmakeFeature "WASMTIME_LIBRARY" "${lib.getLib wasmtime_36}/lib/libwasmtime${stdenv.hostPlatform.extensions.sharedLibrary}")
+    (lib.cmakeFeature "CMAKE_INSTALL_INCLUDEDIR" "include")
+    (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "lib")
+  ];
+
   # Compile web assembly with emscripten. The --debug flag prevents us from
   # minifying the JavaScript; passing it allows us to side-step more Node
   # JS dependencies for installation.
@@ -175,6 +195,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   postInstall = ''
     PREFIX=$out make install
+  ''
+  + lib.optionalString wasmSupport ''
+    cmake --install $cmakeBuildDir
+  ''
+  + ''
     ${lib.optionalString (!enableShared) "rm -f $out/lib/*.so{,.*}"}
     ${lib.optionalString (!enableStatic) "rm -f $out/lib/*.a"}
 
@@ -195,6 +220,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   # test result: FAILED. 120 passed; 13 failed; 0 ignored; 0 measured; 0 filtered out
   doCheck = false;
+
+  # CMake builds libtree-sitter with wasm support; cargo still builds the CLI.
+  ${if wasmSupport then "configurePhase" else null} = ''
+    cmakeConfigurePhase
+    cd ..
+  '';
+
+  ${if wasmSupport then "postBuild" else null} = ''
+    cmake --build $cmakeBuildDir
+  '';
 
   passthru = {
     inherit

--- a/pkgs/by-name/wa/wasmtime/package.nix
+++ b/pkgs/by-name/wa/wasmtime/package.nix
@@ -10,23 +10,40 @@
   nix-update-script,
   enableShared ? !stdenv.hostPlatform.isStatic,
   enableStatic ? stdenv.hostPlatform.isStatic,
+  majorVersion ? "45",
 }:
+let
+  sources = {
+    "36" = {
+      version = "36.0.11";
+      hash = "sha256-rrSI2dSOA8/1CL7JhW0eQ7LaeS5EqTVnyn2HTI+/x20=";
+      cargoHash = "sha256-S67/fv7179uDy4PpwycyXSWAknIC/7ZzvzWPOd6MD+8=";
+    };
+    "45" = {
+
+      version = "45.0.2";
+      hash = "sha256-LEQitwz+UDSX4mrjEecmoO/ZPgRnYTZ3DsD1pu8Jybs=";
+      cargoHash = "sha256-uTgEW2w0RSMetd2W1ucGiVMEEvz2A7CQ79SEsE8/+BM=";
+    };
+  };
+  source = sources.${majorVersion};
+in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "wasmtime";
-  version = "45.0.2";
+  version = source.version;
 
   src = fetchFromGitHub {
     owner = "bytecodealliance";
     repo = "wasmtime";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-LEQitwz+UDSX4mrjEecmoO/ZPgRnYTZ3DsD1pu8Jybs=";
+    hash = source.hash;
     fetchSubmodules = true;
   };
 
   # Disable cargo-auditable until https://github.com/rust-secure-code/cargo-auditable/issues/124 is solved.
   auditable = false;
 
-  cargoHash = "sha256-uTgEW2w0RSMetd2W1ucGiVMEEvz2A7CQ79SEsE8/+BM=";
+  cargoHash = source.cargoHash;
   cargoBuildFlags = [
     "--package"
     "wasmtime-cli"

--- a/pkgs/by-name/wa/wasmtime_36/package.nix
+++ b/pkgs/by-name/wa/wasmtime_36/package.nix
@@ -1,0 +1,18 @@
+{
+  nix-update-script,
+  wasmtime,
+}:
+
+# NOTE: LTS Version EOL August 20 2027
+(wasmtime.override { majorVersion = "36"; }).overrideAttrs (old: {
+  __structuredAttrs = true;
+
+  passthru = old.passthru // {
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--version-regex"
+        "^v(36\\.\\d+\\.\\d+)$"
+      ];
+    };
+  };
+})


### PR DESCRIPTION
Adds opt-in WebAssembly parser support for Neovim/tree-sitter without changing default builds.

- adds `wasmtime_36`, pinned to the supported Wasmtime 36.x C API
- adds `tree-sitter.override { wasmSupport = true; }`
- adds `neovim-unwrapped.override { wasmSupport = true; }`
- keeps default `wasmtime`, `tree-sitter`, and `neovim-unwrapped` derivations unchanged

Neovim upstream defaults `ENABLE_WASMTIME` to `OFF`, so nixpkgs keeps the same default. Users can opt in when they need `vim.treesitter.language.add(... .wasm)` support.

The tree-sitter CMake path is only used for `wasmSupport = true` because the Makefile install cannot enable `TREE_SITTER_FEATURE_WASM`.

Supersedes https://github.com/NixOS/nixpkgs/pull/394870

Reminded about implementing wasm support when neovim-nightly-overlay was broken due to upstream wasm related changes. Keeping wasm stuff opt-in so we can just get support added without forcing rebuilds for everyone else not using it. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
