### PR TITLE
lomiri.lomiri-push-qml: 0.4.0 -> 0.4.1, init qt6 variant

### DIFF
--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -37,6 +37,7 @@ let
         withDocumentation = !useQt6;
       };
       lomiri-notifications = callPackage ./qml/lomiri-notifications { };
+      lomiri-push-qml = callPackage ./qml/lomiri-push-qml { };
       lomiri-ui-extras = callPackage ./qml/lomiri-ui-extras { };
       lomiri-ui-toolkit = callPackage ./qml/lomiri-ui-toolkit { };
       qqc2-suru-style = callPackage ./qml/qqc2-suru-style { };
@@ -90,7 +91,6 @@ let
       u1db-qt = callPackage ./development/u1db-qt { };
 
       #### QML / QML-related
-      lomiri-push-qml = callPackage ./qml/lomiri-push-qml { };
       lomiri-settings-components = callPackage ./qml/lomiri-settings-components { };
 
       #### Services

--- a/pkgs/desktops/lomiri/qml/lomiri-push-qml/default.nix
+++ b/pkgs/desktops/lomiri/qml/lomiri-push-qml/default.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-push-qml";
-  version = "0.4.0";
+  version = "0.4.1";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lomiri-push-qml";
     tag = finalAttrs.version;
-    hash = "sha256-QpkW/fbl0Px5HsKfz/gv+D1S+iSpMZM8TiZCuAq1myk=";
+    hash = "sha256-+D8F0H3S+lfU53CJarE7Wrsc66JvJywzih0IgGD8cJo=";
   };
 
   postPatch = ''

--- a/pkgs/desktops/lomiri/qml/lomiri-push-qml/default.nix
+++ b/pkgs/desktops/lomiri/qml/lomiri-push-qml/default.nix
@@ -11,6 +11,9 @@
   qtdeclarative,
 }:
 
+let
+  withQt6 = lib.versions.major qtbase.version == "6";
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-push-qml";
   version = "0.4.1";
@@ -22,11 +25,20 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-+D8F0H3S+lfU53CJarE7Wrsc66JvJywzih0IgGD8cJo=";
   };
 
-  postPatch = ''
-    # Queries QMake for QML install location, returns QtBase build path
-    substituteInPlace src/*/PushNotifications/CMakeLists.txt \
-      --replace-fail 'qmake -query QT_INSTALL_QML' 'echo ''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}'
-  '';
+  postPatch =
+    if (!withQt6) then
+      ''
+        # Queries QMake for QML install location, returns QtBase build path
+        substituteInPlace src/*/PushNotifications/CMakeLists.txt \
+          --replace-fail 'qmake -query QT_INSTALL_QML' 'echo ''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}'
+      ''
+    else
+      ''
+        substituteInPlace src/Lomiri/PushNotifications/CMakeLists.txt \
+          --replace-fail \
+            'set(QT_INSTALL_QML "''${CMAKE_INSTALL_LIBDIR}/qt6/qml/")' \
+            'set(QT_INSTALL_QML "''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}")'
+      '';
 
   strictDeps = true;
 
@@ -46,8 +58,8 @@ stdenv.mkDerivation (finalAttrs: {
   dontWrapQtApps = true;
 
   cmakeFlags = [
-    (lib.cmakeBool "ENABLE_QT6" (lib.strings.versionAtLeast qtbase.version "6"))
-    (lib.cmakeBool "ENABLE_UBUNTU_COMPAT" (!lib.strings.versionAtLeast qtbase.version "6"))
+    (lib.cmakeBool "ENABLE_QT6" withQt6)
+    (lib.cmakeBool "ENABLE_UBUNTU_COMPAT" (!withQt6))
   ];
 
   preBuild = ''


### PR DESCRIPTION
https://gitlab.com/ubports/development/core/lomiri-push-qml/-/blob/0.4.1/ChangeLog

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
