### PR TITLE
{lomiri,lomiri-qt6}.lomiri-wallpapers: 20.04.0 -> 20.04.1

### DIFF
--- a/pkgs/desktops/lomiri/data/lomiri-wallpapers/default.nix
+++ b/pkgs/desktops/lomiri/data/lomiri-wallpapers/default.nix
@@ -7,13 +7,13 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "lomiri-wallpapers";
-  version = "20.04.0";
+  version = "20.04.1";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lomiri-wallpapers";
     rev = finalAttrs.version;
-    hash = "sha256-n8+vY+MPVqW6s5kSo4aEtGZv1AsjB3nNEywbmcNWfhI=";
+    hash = "sha256-NttA+je2jbE0q0EXZ5PSxrpB0ijRbqpSq0N0GCWEzJk=";
   };
 
   dontConfigure = true;
@@ -23,15 +23,16 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook preInstall
 
     mkdir -p $out/share
-
-    # release-specific wallpapers
+  ''
+  # release-specific wallpapers
+  + ''
     cp -r ${lib.versions.majorMinor finalAttrs.version} $out/share/wallpapers
-    rm $out/share/wallpapers/.placeholder
-
-    # eternal hardwired fallback/default
-    install -Dm644 {.,$out/share/wallpapers}/warty-final-ubuntu.png
-    ln -s warty-final-ubuntu.png $out/share/wallpapers/lomiri-default-background.png
-
+  ''
+  # default
+  + ''
+    install -Dm644 {.,$out/share/wallpapers}/lomiri-default-background.png
+  ''
+  + ''
     runHook postInstall
   '';
 


### PR DESCRIPTION
https://gitlab.com/ubports/development/core/lomiri-wallpapers/-/blob/20.04.1/ChangeLog

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
