### PR TITLE
nixosTests: remove deprecated config attribute access

### DIFF
--- a/nixos/tests/alps.nix
+++ b/nixos/tests/alps.nix
@@ -61,7 +61,7 @@ in
           certs.ca.cert
         ];
         networking.extraHosts = ''
-          ${nodes.server.config.networking.primaryIPAddress} ${domain}
+          ${nodes.server.networking.primaryIPAddress} ${domain}
         '';
         services.alps = {
           enable = true;
@@ -83,7 +83,7 @@ in
 
             baseurl = "http://localhost:${toString config.services.alps.port}"
             username = "alice"
-            password = "${nodes.server.config.users.users.alice.password}"
+            password = "${nodes.server.users.users.alice.password}"
             cookiejar = CookieJar()
             cookieprocessor = HTTPCookieProcessor(cookiejar)
             opener = build_opener(cookieprocessor)
@@ -125,7 +125,7 @@ in
 
       client.start()
       client.wait_for_unit("alps.service")
-      client.wait_for_open_port(${toString nodes.client.config.services.alps.port})
+      client.wait_for_open_port(${toString nodes.client.services.alps.port})
       client.succeed("test-alps-login")
     '';
 }

--- a/nixos/tests/cage.nix
+++ b/nixos/tests/cage.nix
@@ -29,7 +29,7 @@
   testScript =
     { nodes, ... }:
     let
-      user = nodes.machine.config.users.users.alice;
+      user = nodes.machine.users.users.alice;
     in
     ''
       with subtest("Wait for cage to boot up"):

--- a/nixos/tests/cagebreak.nix
+++ b/nixos/tests/cagebreak.nix
@@ -47,7 +47,7 @@ in
   testScript =
     { nodes, ... }:
     let
-      user = nodes.machine.config.users.users.alice;
+      user = nodes.machine.users.users.alice;
       XDG_RUNTIME_DIR = "/run/user/${toString user.uid}";
     in
     ''

--- a/nixos/tests/containers-ip.nix
+++ b/nixos/tests/containers-ip.nix
@@ -47,9 +47,9 @@ in
           # need to distinguish because show-ip won't work for ipv6
           if container == "webserver4":
               ip = machine.succeed(f"nixos-container show-ip {container}").rstrip()
-              assert ip == "${nodes.machine.config.containers.webserver4.localAddress}"
+              assert ip == "${nodes.machine.containers.webserver4.localAddress}"
               return ip
-          return "${nodes.machine.config.containers.webserver6.localAddress}"
+          return "${nodes.machine.containers.webserver6.localAddress}"
 
 
       for container in "webserver4", "webserver6":

--- a/nixos/tests/docker-rootless.nix
+++ b/nixos/tests/docker-rootless.nix
@@ -22,7 +22,7 @@
   testScript =
     { nodes, ... }:
     let
-      user = nodes.machine.config.users.users.alice;
+      user = nodes.machine.users.users.alice;
       sudo = lib.concatStringsSep " " [
         "XDG_RUNTIME_DIR=/run/user/${toString user.uid}"
         "DOCKER_HOST=unix:///run/user/${toString user.uid}/docker.sock"

--- a/nixos/tests/enlightenment.nix
+++ b/nixos/tests/enlightenment.nix
@@ -33,7 +33,7 @@
   testScript =
     { nodes, ... }:
     let
-      user = nodes.machine.config.users.users.alice;
+      user = nodes.machine.users.users.alice;
     in
     ''
       with subtest("Ensure x starts"):

--- a/nixos/tests/iscsi-multipath-root.nix
+++ b/nixos/tests/iscsi-multipath-root.nix
@@ -126,7 +126,7 @@ in
         ];
 
         environment.etc."initiator-root-disk-closure".source =
-          nodes.initiatorRootDisk.config.system.build.toplevel;
+          nodes.initiatorRootDisk.system.build.toplevel;
 
         nix.settings = {
           substituters = lib.mkForce [ ];

--- a/nixos/tests/iscsi-root.nix
+++ b/nixos/tests/iscsi-root.nix
@@ -169,7 +169,7 @@ in
       initiatorAuto.succeed("mkfs.xfs /dev/sda")
       initiatorAuto.succeed("mkdir /mnt && mount /dev/sda /mnt")
       initiatorAuto.succeed(
-          "nixos-install --no-bootloader --no-root-passwd --system ${nodes.initiatorRootDisk.config.system.build.toplevel}"
+          "nixos-install --no-bootloader --no-root-passwd --system ${nodes.initiatorRootDisk.system.build.toplevel}"
       )
       initiatorAuto.succeed("umount /mnt && rmdir /mnt")
       initiatorAuto.shutdown()

--- a/nixos/tests/kerberos/heimdal.nix
+++ b/nixos/tests/kerberos/heimdal.nix
@@ -169,7 +169,7 @@ import ../make-test-python.nix (
         with subtest("Server: initialize host principal with keytab"):
           server.send_chars("sudo ktutil get -p alice/admin host/server.foo.bar\n")
           server.wait_until_tty_matches("1", "password for alice:")
-          server.send_chars("${nodes.server.config.users.users.alice.password}\n")
+          server.send_chars("${nodes.server.users.users.alice.password}\n")
           server.wait_until_tty_matches("1", "alice/admin@FOO.BAR's Password:")
           server.send_chars(f'{alice_krb_admin_pw}\n')
           server.wait_for_file("/etc/krb5.keytab")
@@ -194,7 +194,7 @@ import ../make-test-python.nix (
 
           client.send_chars("sudo ktutil get -p alice/admin host/client.foo.bar\n")
           client.wait_until_tty_matches("1", "password for alice:")
-          client.send_chars("${nodes.client.config.users.users.alice.password}\n")
+          client.send_chars("${nodes.client.users.users.alice.password}\n")
           client.wait_until_tty_matches("1", "alice/admin@FOO.BAR's Password:")
           client.send_chars(f"{alice_krb_admin_pw}\n")
           client.wait_for_file("/etc/krb5.keytab")

--- a/nixos/tests/knot.nix
+++ b/nixos/tests/knot.nix
@@ -209,11 +209,11 @@ in
   testScript =
     { nodes, ... }:
     let
-      primary4 = (lib.head nodes.primary.config.networking.interfaces.eth1.ipv4.addresses).address;
-      primary6 = (lib.head nodes.primary.config.networking.interfaces.eth1.ipv6.addresses).address;
+      primary4 = (lib.head nodes.primary.networking.interfaces.eth1.ipv4.addresses).address;
+      primary6 = (lib.head nodes.primary.networking.interfaces.eth1.ipv6.addresses).address;
 
-      secondary4 = (lib.head nodes.secondary.config.networking.interfaces.eth1.ipv4.addresses).address;
-      secondary6 = (lib.head nodes.secondary.config.networking.interfaces.eth1.ipv6.addresses).address;
+      secondary4 = (lib.head nodes.secondary.networking.interfaces.eth1.ipv4.addresses).address;
+      secondary6 = (lib.head nodes.secondary.networking.interfaces.eth1.ipv6.addresses).address;
     in
     ''
       import re

--- a/nixos/tests/libuiohook.nix
+++ b/nixos/tests/libuiohook.nix
@@ -8,7 +8,7 @@
   nodes.client =
     { nodes, ... }:
     let
-      user = nodes.client.config.users.users.alice;
+      user = nodes.client.users.users.alice;
     in
     {
       imports = [
@@ -24,7 +24,7 @@
   testScript =
     { nodes, ... }:
     let
-      user = nodes.client.config.users.users.alice;
+      user = nodes.client.users.users.alice;
     in
     ''
       client.wait_for_x()

--- a/nixos/tests/lightdm.nix
+++ b/nixos/tests/lightdm.nix
@@ -20,7 +20,7 @@
   testScript =
     { nodes, ... }:
     let
-      user = nodes.machine.config.users.users.alice;
+      user = nodes.machine.users.users.alice;
     in
     ''
       start_all()

--- a/nixos/tests/nsd.nix
+++ b/nixos/tests/nsd.nix
@@ -21,7 +21,7 @@ in
       {
         imports = [ common ];
         networking.nameservers = lib.mkForce [
-          (lib.head nodes.server.config.networking.interfaces.eth1.ipv4.addresses).address
+          (lib.head nodes.server.networking.interfaces.eth1.ipv4.addresses).address
         ];
         networking.interfaces.eth1.ipv4.addresses = [
           {
@@ -36,7 +36,7 @@ in
       {
         imports = [ common ];
         networking.nameservers = lib.mkForce [
-          (lib.head nodes.server.config.networking.interfaces.eth1.ipv6.addresses).address
+          (lib.head nodes.server.networking.interfaces.eth1.ipv6.addresses).address
         ];
         networking.interfaces.eth1.ipv4.addresses = [
           {

--- a/nixos/tests/parsedmarc/default.nix
+++ b/nixos/tests/parsedmarc/default.nix
@@ -93,8 +93,8 @@ in
     testScript =
       { nodes, ... }:
       let
-        esPort = toString nodes.parsedmarc.config.services.elasticsearch.port;
-        valueObject = lib.optionalString (lib.versionAtLeast nodes.parsedmarc.config.services.elasticsearch.package.version "7") ".value";
+        esPort = toString nodes.parsedmarc.services.elasticsearch.port;
+        valueObject = lib.optionalString (lib.versionAtLeast nodes.parsedmarc.services.elasticsearch.package.version "7") ".value";
       in
       ''
         parsedmarc.start()
@@ -143,7 +143,7 @@ in
 
             networking.extraHosts = ''
               127.0.0.1 ${parsedmarcDomain}
-              ${nodes.mail.config.networking.primaryIPAddress} ${mailDomain}
+              ${nodes.mail.networking.primaryIPAddress} ${mailDomain}
             '';
 
             services.parsedmarc = {
@@ -170,7 +170,7 @@ in
 
             networking.extraHosts = ''
               127.0.0.1 ${mailDomain}
-              ${nodes.parsedmarc.config.networking.primaryIPAddress} ${parsedmarcDomain}
+              ${nodes.parsedmarc.networking.primaryIPAddress} ${parsedmarcDomain}
             '';
 
             services.dovecot2 = {
@@ -204,8 +204,8 @@ in
       testScript =
         { nodes, ... }:
         let
-          esPort = toString nodes.parsedmarc.config.services.elasticsearch.port;
-          valueObject = lib.optionalString (lib.versionAtLeast nodes.parsedmarc.config.services.elasticsearch.package.version "7") ".value";
+          esPort = toString nodes.parsedmarc.services.elasticsearch.port;
+          valueObject = lib.optionalString (lib.versionAtLeast nodes.parsedmarc.services.elasticsearch.package.version "7") ".value";
         in
         ''
           mail.start()

--- a/nixos/tests/pass-secret-service.nix
+++ b/nixos/tests/pass-secret-service.nix
@@ -39,7 +39,7 @@
   testScript =
     { nodes, ... }:
     let
-      user = nodes.machine.config.users.users.alice;
+      user = nodes.machine.users.users.alice;
       gpg-uid = "alice@example.net";
       gpg-pw = "foobar9000";
       ready-file = "/tmp/secrets-dbus-init.done";

--- a/nixos/tests/proxy.nix
+++ b/nixos/tests/proxy.nix
@@ -41,8 +41,8 @@ in
 
               <Proxy balancer://cluster>
                 Require all granted
-                BalancerMember http://${nodes.backend1.config.networking.hostName} retry=0
-                BalancerMember http://${nodes.backend2.config.networking.hostName} retry=0
+                BalancerMember http://${nodes.backend1.networking.hostName} retry=0
+                BalancerMember http://${nodes.backend2.networking.hostName} retry=0
               </Proxy>
 
               ProxyStatus       full

--- a/nixos/tests/service-runner.nix
+++ b/nixos/tests/service-runner.nix
@@ -29,7 +29,7 @@
           machine.succeed(
               """
               mkdir -p /run/nginx /var/log/nginx /var/cache/nginx
-              ${nodes.machine.config.systemd.services.nginx.runner} >&2 &
+              ${nodes.machine.systemd.services.nginx.runner} >&2 &
               echo $!>my-nginx.pid
               """
           )

--- a/nixos/tests/signal-desktop.nix
+++ b/nixos/tests/signal-desktop.nix
@@ -42,7 +42,7 @@ in
   testScript =
     { nodes, ... }:
     let
-      user = nodes.machine.config.users.users.alice;
+      user = nodes.machine.users.users.alice;
     in
     ''
       start_all()

--- a/nixos/tests/sway.nix
+++ b/nixos/tests/sway.nix
@@ -194,7 +194,7 @@
       swaymsg("exec swaylock")
       machine.wait_until_succeeds("pgrep -xf swaylock")
       machine.sleep(3)
-      machine.send_chars("${nodes.machine.config.users.users.alice.password}")
+      machine.send_chars("${nodes.machine.users.users.alice.password}")
       machine.send_key("ret")
       machine.wait_until_fails("pgrep -xf swaylock")
 

--- a/nixos/tests/thanos.nix
+++ b/nixos/tests/thanos.nix
@@ -322,7 +322,7 @@ in
       # and check if the blocks have the correct labels:
       store.succeed(
           "thanos tools bucket ls "
-          + "--objstore.config-file=${nodes.store.config.services.thanos.store.objstore.config-file} "
+          + "--objstore.config-file=${nodes.store.services.thanos.store.objstore.config-file} "
           + "--output=json | "
           + "jq .thanos.labels.some_label | "
           + "grep 'required by thanos'"

--- a/nixos/tests/txredisapi.nix
+++ b/nixos/tests/txredisapi.nix
@@ -25,7 +25,7 @@
   testScript =
     { nodes, ... }:
     let
-      inherit (nodes.machine.config.services) redis;
+      inherit (nodes.machine.services) redis;
     in
     ''
       start_all()

--- a/nixos/tests/xrdp-with-audio-pulseaudio.nix
+++ b/nixos/tests/xrdp-with-audio-pulseaudio.nix
@@ -73,7 +73,7 @@
   testScript =
     { nodes, ... }:
     let
-      user = nodes.client.config.users.users.alice;
+      user = nodes.client.users.users.alice;
     in
     ''
       start_all()


### PR DESCRIPTION
```
sed -i 's/\(nodes\.[^.]*\)\.config/\1/g' nixos/tests/**.nix
```

should have matched the trailing dot after `config`, too. :melting_face: 


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
