### PR TITLE
lomiri.lomiri-system-settings: 1.3.2 -> 1.4.0

### DIFF
--- a/nixos/tests/lomiri-system-settings.nix
+++ b/nixos/tests/lomiri-system-settings.nix
@@ -29,6 +29,7 @@
         ubuntu-classic
       ];
 
+      services.printing.enable = true;
       services.upower.enable = true;
     };
 
@@ -37,7 +38,7 @@
   testScript =
     let
       settingsPages = [
-        # Base pages
+        # Network
         {
           name = "wifi";
           type = "internal";
@@ -55,6 +56,8 @@
           element = "Add|Manual|Configuration";
           skipOCR = true;
         }
+
+        # Personal
         {
           name = "appearance";
           type = "internal";
@@ -85,6 +88,13 @@
           type = "internal";
           element = "Edge drag";
         }
+
+        # System
+        {
+          name = "printing";
+          type = "internal";
+          element = "no printers configured";
+        }
         {
           name = "mouse";
           type = "internal";
@@ -95,13 +105,10 @@
           type = "internal";
           element = "Time zone|Set the time and date";
         }
-
-        # External plugins
         {
           name = "security-privacy";
-          type = "external";
+          type = "internal";
           element = "Locking|unlocking|permissions";
-          elementLocalised = "Sperren|Entsperren|Berechtigungen";
         }
       ];
     in

--- a/pkgs/desktops/lomiri/applications/lomiri-system-settings/2000-Support-wrapping-for-Nixpkgs.patch
+++ b/pkgs/desktops/lomiri/applications/lomiri-system-settings/2000-Support-wrapping-for-Nixpkgs.patch
@@ -1,15 +1,3 @@
-From 8e21cf46551091c884014985d3e0dd9704d6dc04 Mon Sep 17 00:00:00 2001
-From: OPNA2608 <opna2608@protonmail.com>
-Date: Wed, 14 Feb 2024 16:00:24 +0100
-Subject: [PATCH] Support wrapping for Nixpkgs
-
----
- src/CMakeLists.txt   | 24 +++++++++++++++++++-----
- src/main.cpp         |  8 +++++---
- src/plugin.cpp       | 19 +++++++++++++++++--
- tests/CMakeLists.txt | 18 ++++++++++++++----
- 4 files changed, 55 insertions(+), 14 deletions(-)
-
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
 index cd3131d0..fcd78bdf 100644
 --- a/src/CMakeLists.txt
@@ -48,7 +36,7 @@ index cd3131d0..fcd78bdf 100644
  add_subdirectory(SystemSettings)
  
 diff --git a/src/main.cpp b/src/main.cpp
-index 64441da3..cfcabe42 100644
+index d0897fa9..d244fead 100644
 --- a/src/main.cpp
 +++ b/src/main.cpp
 @@ -42,6 +42,8 @@ int main(int argc, char **argv)
@@ -60,7 +48,7 @@ index 64441da3..cfcabe42 100644
      // Ensure printing environment is correct.
      qputenv("QT_PRINTER_MODULE", "cupsprintersupport");
  
-@@ -78,12 +80,12 @@ int main(int argc, char **argv)
+@@ -79,12 +81,12 @@ int main(int argc, char **argv)
      qmlRegisterType<LomiriSystemSettings::PluginManager>("SystemSettings", 1, 0, "PluginManager");
      view.engine()->rootContext()->setContextProperty("Utilities", &utils);
      view.setResizeMode(QQuickView::SizeRootObjectToView);
@@ -76,6 +64,28 @@ index 64441da3..cfcabe42 100644
      view.rootContext()->setContextProperty("pluginOptions", pluginOptions);
      view.rootContext()->setContextProperty("view", &view);
      view.setSource(QUrl("qrc:/qml/MainWindow.qml"));
+diff --git a/src/plugin-manager.cpp b/src/plugin-manager.cpp
+index 0f5133ce..e2f0bf84 100644
+--- a/src/plugin-manager.cpp
++++ b/src/plugin-manager.cpp
+@@ -87,8 +87,16 @@ void PluginManagerPrivate::reload()
+      * does not seem to work with a dir and file pattern, which means it will
+      * look for all .settings files, not just those in well-known locations. */
+     QStandardPaths::StandardLocation loc = QStandardPaths::GenericDataLocation;
++    QStringList searchPathBases;
++    QString nixDefinedPrefix = qgetenv("NIX_LSS_PREFIX");
++    if (!nixDefinedPrefix.isEmpty()) {
++        searchPathBases.append(nixDefinedPrefix + "/share");
++    } else {
++        searchPathBases = QStandardPaths::standardLocations(loc);
++    }
++
+     QFileInfoList searchPaths;
+-    Q_FOREACH(const QString &path, QStandardPaths::standardLocations(loc)) {
++    Q_FOREACH(const QString &path, searchPathBases) {
+         QDir dir(QStringLiteral("%1/%2").arg(path, baseDir), "*.settings");
+         searchPaths.append(dir.entryInfoList());
+     }
 diff --git a/src/plugin.cpp b/src/plugin.cpp
 index 133821af..6a1a152c 100644
 --- a/src/plugin.cpp
@@ -155,6 +165,3 @@ index c10b2e2d..a998b641 100644
  add_definitions(-DSYSTEM_IMAGE_DBUS_TEMPLATE="${CMAKE_SOURCE_DIR}/tests/autopilot/lomiri_system_settings/tests/systemimage.py")
  
  add_library(test-plugin SHARED test-plugin.cpp test-plugin.h)
--- 
-2.42.0
-

--- a/pkgs/desktops/lomiri/applications/lomiri-system-settings/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-system-settings/default.nix
@@ -27,6 +27,7 @@
   lomiri-indicator-network,
   lomiri-schemas,
   lomiri-settings-components,
+  lomiri-ui-extras,
   lomiri-ui-toolkit,
   maliit-keyboard,
   mesa,
@@ -48,13 +49,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-system-settings-unwrapped";
-  version = "1.3.2";
+  version = "1.4.0";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lomiri-system-settings";
     tag = finalAttrs.version;
-    hash = "sha256-bVBxJgOy1eXqwzcgBRUTlFoJxxw9I1Qc+Wn92U0QzA4=";
+    hash = "sha256-tFdAWPoMJlkKXaWg4H/pv2VJGCutprcjL4CyBSRPXeI=";
   };
 
   outputs = [
@@ -86,14 +87,12 @@ stdenv.mkDerivation (finalAttrs: {
     # Don't use absolute paths in desktop file
     substituteInPlace lomiri-system-settings.desktop.in.in \
       --replace-fail 'Icon=@SETTINGS_SHARE_DIR@/system-settings.svg' 'Icon=lomiri-system-settings' \
-      --replace-fail 'X-Lomiri-Splash-Image=@SETTINGS_SHARE_DIR@/system-settings-app-splash.svg' 'X-Lomiri-Splash-Image=lomiri-app-launch/splash/lomiri-system-settings.svg' \
-      --replace-fail 'X-Screenshot=@SETTINGS_SHARE_DIR@/screenshot.png' 'X-Screenshot=lomiri-app-launch/screenshot/lomiri-system-settings.png'
-
-    # https://gitlab.com/ubports/development/core/lomiri-system-settings/-/merge_requests/525
-    substituteInPlace \
-      plugins/notifications/click_applications_model.h \
-      plugins/notifications/general_notification_settings.h \
-      --replace-fail '<QGSettings/QGSettings>' '<QGSettings>'
+      --replace-fail 'X-Lomiri-Splash-Image=@SETTINGS_SHARE_DIR@/system-settings-app-splash.svg' 'X-Lomiri-Splash-Image=lomiri-app-launch/splash/lomiri-system-settings.svg'
+  ''
+  # TODO Submit upstream
+  + ''
+    substituteInPlace plugins/printing/CMakeLists.txt \
+      --replace-fail 'GLIB_LD_FLAGS' 'GLIB_LDFLAGS'
   '';
 
   strictDeps = true;
@@ -134,6 +133,7 @@ stdenv.mkDerivation (finalAttrs: {
     lomiri-indicator-network
     lomiri-schemas
     lomiri-settings-components
+    lomiri-ui-extras
     lomiri-ui-toolkit
     maliit-keyboard
     qmenumodel
@@ -188,11 +188,10 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall = ''
     glib-compile-schemas $out/share/glib-2.0/schemas
 
-    mkdir -p $out/share/{icons/hicolor/scalable/apps,lomiri-app-launch/{splash,screenshot}}
+    mkdir -p $out/share/{icons/hicolor/scalable/apps,lomiri-app-launch/splash}
 
     ln -s $out/share/lomiri-system-settings/system-settings.svg $out/share/icons/hicolor/scalable/apps/lomiri-system-settings.svg
     ln -s $out/share/lomiri-system-settings/system-settings-app-splash.svg $out/share/lomiri-app-launch/splash/lomiri-system-settings.svg
-    ln -s $out/share/lomiri-system-settings/screenshot.png $out/share/lomiri-app-launch/screenshot/lomiri-system-settings.png
   '';
 
   passthru = {

--- a/pkgs/desktops/lomiri/applications/lomiri-system-settings/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-system-settings/default.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitLab,
+  fetchpatch,
   gitUpdater,
   testers,
   accountsservice,
@@ -27,6 +28,7 @@
   lomiri-indicator-network,
   lomiri-schemas,
   lomiri-settings-components,
+  lomiri-ui-extras,
   lomiri-ui-toolkit,
   maliit-keyboard,
   mesa,
@@ -48,13 +50,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-system-settings-unwrapped";
-  version = "1.3.2";
+  version = "1.4.0";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lomiri-system-settings";
     tag = finalAttrs.version;
-    hash = "sha256-bVBxJgOy1eXqwzcgBRUTlFoJxxw9I1Qc+Wn92U0QzA4=";
+    hash = "sha256-tFdAWPoMJlkKXaWg4H/pv2VJGCutprcjL4CyBSRPXeI=";
   };
 
   outputs = [
@@ -63,37 +65,47 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   patches = [
+    # Remove when version > 1.4.0
+    (fetchpatch {
+      name = "0001-lomiri-system-settings-Avoid-UB-when-VARIANT_ID-is-not-set.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-system-settings/-/commit/78b462aed589213e7a26064ec1bd27d201bb8f04.patch";
+      hash = "sha256-Xb6x/AlL+m8qD29bHeiU20Je2GeHzybcUprPLQuh8fk=";
+    })
+
     ./2000-Support-wrapping-for-Nixpkgs.patch
   ];
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \
-      --replace-fail "\''${CMAKE_INSTALL_LIBDIR}/qt5/qml" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}" \
-
-    # Port from lomiri-keyboard to maliit-keyboard
+      --replace-fail "\''${CMAKE_INSTALL_LIBDIR}/qt5/qml" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}"
+  ''
+  # Port from lomiri-keyboard to maliit-keyboard
+  + ''
     substituteInPlace plugins/language/{PageComponent,SpellChecking,ThemeValues}.qml plugins/language/onscreenkeyboard-plugin.cpp plugins/sound/PageComponent.qml \
       --replace-fail 'com.lomiri.keyboard.maliit' 'org.maliit.keyboard.maliit'
-
-    # Gets list of available localisations from current system, but later drops any language that doesn't cover LSS
-    # So just give it its own prefix
+  ''
+  # Gets list of available localisations from current system, but later drops any language that doesn't cover LSS
+  # So just give it its own prefix
+  + ''
     substituteInPlace plugins/language/language-plugin.cpp \
       --replace-fail '/usr/share/locale' '${placeholder "out"}/share/locale'
-
-    # Decide which entries should be visible based on the current system
+  ''
+  # Decide which entries should be visible based on the current system
+  + ''
     substituteInPlace plugins/*/*.settings \
       --replace-warn '/etc' '/run/current-system/sw/etc'
-
-    # Don't use absolute paths in desktop file
+  ''
+  # Don't use absolute paths in desktop file
+  + ''
     substituteInPlace lomiri-system-settings.desktop.in.in \
       --replace-fail 'Icon=@SETTINGS_SHARE_DIR@/system-settings.svg' 'Icon=lomiri-system-settings' \
-      --replace-fail 'X-Lomiri-Splash-Image=@SETTINGS_SHARE_DIR@/system-settings-app-splash.svg' 'X-Lomiri-Splash-Image=lomiri-app-launch/splash/lomiri-system-settings.svg' \
-      --replace-fail 'X-Screenshot=@SETTINGS_SHARE_DIR@/screenshot.png' 'X-Screenshot=lomiri-app-launch/screenshot/lomiri-system-settings.png'
-
-    # https://gitlab.com/ubports/development/core/lomiri-system-settings/-/merge_requests/525
-    substituteInPlace \
-      plugins/notifications/click_applications_model.h \
-      plugins/notifications/general_notification_settings.h \
-      --replace-fail '<QGSettings/QGSettings>' '<QGSettings>'
+      --replace-fail 'X-Lomiri-Splash-Image=@SETTINGS_SHARE_DIR@/system-settings-app-splash.svg' 'X-Lomiri-Splash-Image=lomiri-app-launch/splash/lomiri-system-settings.svg'
+  ''
+  # https://gitlab.com/ubports/development/core/lomiri-system-settings/-/merge_requests/547
+  # Remove when version > 1.4.0
+  + ''
+    substituteInPlace plugins/printing/CMakeLists.txt \
+      --replace-fail 'GLIB_LD_FLAGS' 'GLIB_LDFLAGS'
   '';
 
   strictDeps = true;
@@ -134,6 +146,7 @@ stdenv.mkDerivation (finalAttrs: {
     lomiri-indicator-network
     lomiri-schemas
     lomiri-settings-components
+    lomiri-ui-extras
     lomiri-ui-toolkit
     maliit-keyboard
     qmenumodel
@@ -188,11 +201,10 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall = ''
     glib-compile-schemas $out/share/glib-2.0/schemas
 
-    mkdir -p $out/share/{icons/hicolor/scalable/apps,lomiri-app-launch/{splash,screenshot}}
+    mkdir -p $out/share/{icons/hicolor/scalable/apps,lomiri-app-launch/splash}
 
     ln -s $out/share/lomiri-system-settings/system-settings.svg $out/share/icons/hicolor/scalable/apps/lomiri-system-settings.svg
     ln -s $out/share/lomiri-system-settings/system-settings-app-splash.svg $out/share/lomiri-app-launch/splash/lomiri-system-settings.svg
-    ln -s $out/share/lomiri-system-settings/screenshot.png $out/share/lomiri-app-launch/screenshot/lomiri-system-settings.png
   '';
 
   passthru = {

--- a/pkgs/desktops/lomiri/applications/lomiri-system-settings/wrapper.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-system-settings/wrapper.nix
@@ -62,7 +62,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     )
   '';
 
-  passthru.tests.standalone = nixosTests.lomiri-system-settings;
+  passthru.tests = {
+    inherit (lomiri-system-settings-unwrapped.passthru.tests) pkg-config;
+    standalone = nixosTests.lomiri-system-settings;
+  };
 
   meta = lomiri-system-settings-unwrapped.meta // {
     description = "System Settings application for Lomiri (wrapped)";


### PR DESCRIPTION
https://gitlab.com/ubports/development/core/lomiri-system-settings/-/blob/1.4.0/ChangeLog

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
