### PR TITLE
arduino-cli: add cobra as maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5481,6 +5481,13 @@
     githubId = 180339;
     name = "Andrew Cobb";
   };
+  cobrasoftware = {
+    name = "Cobra";
+    email = "nix.sector025@passinbox.com";
+    github = "CobraSoftware";
+    githubId = 169102765;
+
+  };
   coca = {
     github = "Coca162";
     githubId = 62479942;

--- a/pkgs/by-name/ar/arduino-cli/package.nix
+++ b/pkgs/by-name/ar/arduino-cli/package.nix
@@ -92,6 +92,7 @@ let
       maintainers = with lib.maintainers; [
         ryantm
         sfrijters
+        cobrasoftware
       ];
     };
 


### PR DESCRIPTION

I am updating the Arduino CLI package and adding myself as a maintainer, as the package was severely out of date and I have the time and passion to keep it up‑to‑date.

A changelog can be found here: <https://github.com/arduino/arduino-cli/releases/tag/v1.5.1>

While this is my first pull request on the Nixpkgs repository, I have contributed to other open‑source projects before. Additionally, I did my best to read all documentation and follow the contributing guide. Additionally, I tested it as much as I could with the hardware I have. If I missed something, please let me know. No AI agents were used in the making of this PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
