### PR TITLE
maintainers: add fengmk2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8907,6 +8907,12 @@
       { fingerprint = "7E08 6842 0934 AA1D 6821  1F2A 671E 39E6 744C 807D"; }
     ];
   };
+  fengmk2 = {
+    email = "fengmk2@gmail.com";
+    github = "fengmk2";
+    githubId = 156269;
+    name = "MK";
+  };
   fernsehmuell = {
     email = "fernsehmuel@googlemail.com";
     matrix = "@fernsehmuell:matrix.org";


### PR DESCRIPTION
Adds myself to the maintainer list so I can maintain `vite-plus` (#533925), which (correctly) can't be merged without a maintainer.

## Things done
- [x] Added the entry to `maintainers/maintainer-list.nix`, sorted alphabetically; `nix-instantiate --eval` resolves `lib.maintainers.fengmk2`.



---

Assisted-by: Claude Code (Claude Opus 4.8)
