### PR TITLE
lomiri.lomiri: 0.5.0 -> 0.6.1

### DIFF
--- a/pkgs/desktops/lomiri/applications/lomiri/2014_lomiri-greeter-wrapper-on-wayland.patch
+++ b/pkgs/desktops/lomiri/applications/lomiri/2014_lomiri-greeter-wrapper-on-wayland.patch
@@ -1,0 +1,130 @@
+Description: For Lomiri Greeter on Desktop we ship our very own lomiri-greeter-wrapper script.
+Author: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+Forwarded: not yet, for now Debian-specific
+
+--- a/data/lomiri-greeter-wrapper
++++ b/data/lomiri-greeter-wrapper
+@@ -14,6 +14,13 @@
+ # the session died.  We could try to do this in-process, but we want to do this
+ # cleanup even if the greeter aborts.
+ 
++# Ensure the shell always gets unthrottled touch events, so that applications
++# who want full speed low-latency input can get it (LP: #1497105) and so that
++# apps can use QML touch compression safely (the QML touch compression
++# algorithm does not support nesting well - LP: #1486341, LP: #1556763 - so
++# must be fed by the raw input event stream from Unity8).
++export QML_NO_TOUCH_COMPRESSION=1
++
+ trap cleanup TERM EXIT
+ 
+ cleanup()
+@@ -31,77 +38,57 @@
+     dbus-update-activation-environment --systemd "$1=$2"
+ }
+ 
+-SUB_SOCKET=$XDG_RUNTIME_DIR/mir_socket
+-rm -f $SUB_SOCKET # clear socket in case we were hard shut down
+-
+ echo "DBUS_SESSION_BUS_ADDRESS=${DBUS_SESSION_BUS_ADDRESS}" >"$XDG_RUNTIME_DIR/dbus-session"
+ 
+-# If touch session script (which sets up grid units and mir variables) is available, use it
+-TOUCH_WRAPPER=
+-if which lomiri-touch-session >/dev/null; then
+-    TOUCH_WRAPPER=lomiri-touch-session
++if [ -x "$(command -v device-info)" ]; then
++    set_greeter_var GRID_UNIT_PX $(device-info get GridUnit)
++    set_greeter_var QTWEBKIT_DPR $(device-info get WebkitDpr)
++    set_greeter_var NATIVE_ORIENTATION $(device-info get PrimaryOrientation)
++    set_greeter_var QT_WAYLAND_FORCE_DPI $((12 * ${GRID_UNIT_PX}))
+ fi
+ 
+-# Advertise as a lomiri session, so that indicator-network will start.
+-set_greeter_var XDG_SESSION_DESKTOP lomiri
+-set_greeter_var DESKTOP_SESSION $XDG_SESSION_DESKTOP
++# Hack for virtual machines that fails to probe modeset
++if ([ -x "$(command -v hostnamectl)" ] && [ "$(hostnamectl status | grep 'Chassis: vm')" ]) \
++   || grep -wq hypervisor /proc/cpuinfo; then
++    set_greeter_var MIR_MESA_KMS_DISABLE_MODESET_PROBE 1
++fi
+ 
+-set_greeter_var QT_IM_MODULE Maliit
+-set_greeter_var QT_QPA_PLATFORM ubuntumirclient
++set_greeter_var QT_IM_MODULE maliit
++set_greeter_var QT_QPA_PLATFORM wayland
++set_greeter_var MALIIT_FORCE_DBUS_CONNECTION 1
++set_greeter_var UITK_ICON_THEME suru
++set_greeter_var QT_WAYLAND_DISABLE_WINDOWDECORATION 1
++set_greeter_var QT_ACCESSIBILITY 1
++set_greeter_var QT_AUTO_SCREEN_SCALE_FACTOR 0
++set_greeter_var GTK_CSD 0
+ 
+ # We disable ofono using pulse.  It causes problems with racing with the user's
+ # pulse.  We need to come up with a better long-term fix for this, because we
+ # eventually need the greeter to play ringtones for users that aren't logged in.
+ set_greeter_var PA_DISABLED 1
+ 
+-# Define language here for phone if available.  When phone user switches their
+-# language, they expect that to affect the greeter too.  But the user doesn't
+-# have permission to switch system language, only their own.  So we notice if
+-# the phablet user exists and use their language if so.  TODO: talk to design
+-# about whether we should switch language on fly as users are selected (this
+-# is very hard to do technically).
+-#
+-# Do this after lomiri-greeter-starting, in case a customization upstart job
+-# changes language.
+-if [ "$(id -u phablet 2>/dev/null)" = "32011" ]; then
+-    USER_LANG=$(gdbus call --system --dest org.freedesktop.Accounts --object-path /org/freedesktop/Accounts/User32011 --method org.freedesktop.DBus.Properties.Get org.freedesktop.Accounts.User Language | cut -d\' -f2)
+-    if [ -n "$USER_LANG" ]; then
+-        set_greeter_var LANGUAGE "$USER_LANG"
+-    fi
+-    USER_LOCALE=$(gdbus call --system --dest org.freedesktop.Accounts --object-path /org/freedesktop/Accounts/User32011 --method org.freedesktop.DBus.Properties.Get org.freedesktop.Accounts.User FormatsLocale | cut -d\' -f2)
+-    if [ -n "$USER_LOCALE" ]; then
+-        set_greeter_var LANG "$USER_LOCALE"
+-        set_greeter_var LC_ALL "$USER_LOCALE"
+-    fi
+-fi
++# Claim the user wldisplay
++set_greeter_var WAYLAND_DISPLAY=wayland-0
+ 
+ # And finally actually start the greeter
+-if [ -n "$(command -v device-info)" ]; then
+-    GRID_UNIT_PX="$(device-info get GridUnit)"
+-fi
++exec ${LOMIRI_BINARY:-lomiri} --mode=greeter "$@" &
++CMD_PID=$!
+ 
+-export GRID_UNIT_PX="${GRID_UNIT_PX:-18}"
+-export MIR_SERVER_ENABLE_MIRCLIENT=1
++sleep 1
+ 
+-rm "$XDG_RUNTIME_DIR/mir_socket"
+-exec env MIR_SERVER_FILE=$SUB_SOCKET $TOUCH_WRAPPER $@ &
+-CMD_PID=$!
++# Advertise as a lomiri session, so that lomiri-indicator-network will start
++# and also all other indicators will recognize being run in Lomiri
++set_greeter_var XDG_CURRENT_DESKTOP Lomiri
++set_greeter_var DESKTOP_SESSION lomiri
+ 
+-count=0
+-limit=60
+-while [ true ]; do
+-    count=$((count + 1))
+-    [ $count -gt $limit ] && break
+-    [ -e "$XDG_RUNTIME_DIR/mir_socket" ] && break
+-    sleep 1s
+-done
++systemctl --user start lomiri-indicators.target
+ 
+-systemctl --user restart maliit-server.service &
+-systemctl --user restart lomiri-indicators.target &
++sleep 2
++
++systemctl --user start lomiri-keyboard.service
+ 
+ wait $CMD_PID
+ CMD_PID=
+ 
+-systemctl --user stop maliit-server.service
++systemctl --user stop lomiri-keyboard.service
+ systemctl --user stop lomiri-indicators.target
+-

--- a/pkgs/desktops/lomiri/applications/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri/default.nix
@@ -57,17 +57,18 @@
   qtsvg,
   wrapGAppsHook3,
   wrapQtAppsHook,
+  xwayland,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri";
-  version = "0.5.0";
+  version = "0.6.0";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lomiri";
     tag = finalAttrs.version;
-    hash = "sha256-blXEfDauwtDH+0OdUx0vAR+8lnAGrREssqjsBNmvomk=";
+    hash = "sha256-ON5vKDzVogAVfQ7fbFAFDy4s/rWgljiKJ9AgBtu+vr0=";
   };
 
   patches = [
@@ -86,11 +87,8 @@ stdenv.mkDerivation (finalAttrs: {
     })
 
     # Make greeter behave nicer & more Wayland-native
-    (fetchpatch {
-      name = "2014-lomiri-greeter-wrapper-on-wayland.patch";
-      url = "https://salsa.debian.org/ubports-team/lomiri/-/raw/e655e14c7d420021193e37debd3e7da620b45429/debian/patches/2014_lomiri-greeter-wrapper-on-wayland.patch";
-      hash = "sha256-aEId3UDqH1iUi9gV5IpW/5S5rke93UyZVr0jWlNYnOU=";
-    })
+    # https://salsa.debian.org/ubports-team/lomiri/-/raw/e655e14c7d420021193e37debd3e7da620b45429/debian/patches/2014_lomiri-greeter-wrapper-on-wayland.patch, adjusted for 0.6.0
+    ./2014_lomiri-greeter-wrapper-on-wayland.patch
     (fetchpatch {
       name = "2015-lomiri-greeter-use-wayland.patch";
       url = "https://salsa.debian.org/ubports-team/lomiri/-/raw/2f5acfa085c901359bf6f6cccbce36d7e2981555/debian/patches/2015_lomiri-greeter-use-wayland.patch";
@@ -102,21 +100,6 @@ stdenv.mkDerivation (finalAttrs: {
       name = "1005-lomiri-cursor-always-follow-cursor-position-from-mir.patch";
       url = "https://salsa.debian.org/ubports-team/lomiri/-/raw/f3ba943006f5469a8a7aa24f232d6383afb3bc74/debian/patches/1005_cursor-always-follow-cursor-position-from-mir.patch";
       hash = "sha256-FYWRHt3//gm3jT9dr35tH4PlZssMMA/zBhjkszgqTYo=";
-    })
-
-    # Undo start-here integration & uglier colours for launcher
-    (fetchpatch {
-      name = "0001-lomiri-LauncherPanel-Use-Lomiri-upstream-home-logo-and-home-background-color.patch";
-      url = "https://gitlab.com/ubports/development/core/lomiri/-/commit/defaabfaf4818ee6b618c97b34acf5e0ed2ebb2e.patch";
-      hash = "sha256-9YRWMV+1UT+EQd9Uq1+6enNzz+HDlSt3LTPM1BKJxiE=";
-    })
-
-    # Compatibility with newer lomiri-api
-    # Remove when version > 0.5.0
-    (fetchpatch {
-      name = "0002-lomiri-Adjust-to-newer-lomiri-api.patch";
-      url = "https://gitlab.com/ubports/development/core/lomiri/-/commit/26cbfa458766df406ed7d2c351ec84522371b083.patch";
-      hash = "sha256-1mPDtitMpktuvLs3Zn+6pCaMGTwGvIglGBdrm4Y8QwA=";
     })
 
     ./9901-lomiri-Disable-Wizard.patch
@@ -156,6 +139,8 @@ stdenv.mkDerivation (finalAttrs: {
   + lib.optionalString finalAttrs.finalPackage.doCheck ''
     patchShebangs tests/whitespace/check_whitespace.py
   '';
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     cmake
@@ -201,6 +186,7 @@ stdenv.mkDerivation (finalAttrs: {
     qtdeclarative
     qtmir
     qtsvg
+    xwayland
 
     # QML import path
     biometryd
@@ -212,7 +198,10 @@ stdenv.mkDerivation (finalAttrs: {
     qtmultimedia
   ];
 
-  nativeCheckInputs = [ (python3.withPackages (ps: with ps; [ python-dbusmock ])) ];
+  nativeCheckInputs = [
+    libqtdbustest
+    (python3.withPackages (ps: with ps; [ python-dbusmock ]))
+  ];
 
   checkInputs = [
     libqtdbustest
@@ -226,8 +215,11 @@ stdenv.mkDerivation (finalAttrs: {
   dontWrapQtApps = true;
 
   cmakeFlags = [
-    (lib.cmakeBool "NO_TESTS" (!finalAttrs.finalPackage.doCheck))
-    (lib.cmakeBool "WITH_MIR2" true)
+    (lib.strings.cmakeBool "NO_TESTS" (!finalAttrs.finalPackage.doCheck))
+    (lib.strings.cmakeBool "WITH_MIR2" true)
+    # These get embedded into systemd service files
+    (lib.strings.cmakeFeature "DUAE_BIN" (lib.getExe' dbus "dbus-update-activation-environment"))
+    (lib.strings.cmakeFeature "XWAYLAND_BIN" (lib.getExe xwayland))
   ];
 
   postInstall = ''

--- a/pkgs/desktops/lomiri/applications/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri/default.nix
@@ -40,6 +40,7 @@
   lomiri-schemas,
   lomiri-telephony-service,
   lomiri-thumbnailer,
+  lomiri-ui-extras,
   lomiri-ui-toolkit,
   maliit-keyboard,
   mir_2_15,
@@ -57,17 +58,18 @@
   qtsvg,
   wrapGAppsHook3,
   wrapQtAppsHook,
+  xwayland,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri";
-  version = "0.5.0";
+  version = "0.6.1";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lomiri";
     tag = finalAttrs.version;
-    hash = "sha256-blXEfDauwtDH+0OdUx0vAR+8lnAGrREssqjsBNmvomk=";
+    hash = "sha256-BzkQNvQLDzeai8b3qZytmq6F/PwiRJ/F0XCB+NiKpm0=";
   };
 
   patches = [
@@ -86,11 +88,8 @@ stdenv.mkDerivation (finalAttrs: {
     })
 
     # Make greeter behave nicer & more Wayland-native
-    (fetchpatch {
-      name = "2014-lomiri-greeter-wrapper-on-wayland.patch";
-      url = "https://salsa.debian.org/ubports-team/lomiri/-/raw/e655e14c7d420021193e37debd3e7da620b45429/debian/patches/2014_lomiri-greeter-wrapper-on-wayland.patch";
-      hash = "sha256-aEId3UDqH1iUi9gV5IpW/5S5rke93UyZVr0jWlNYnOU=";
-    })
+    # https://salsa.debian.org/ubports-team/lomiri/-/raw/e655e14c7d420021193e37debd3e7da620b45429/debian/patches/2014_lomiri-greeter-wrapper-on-wayland.patch, adjusted for 0.6.0
+    ./2014_lomiri-greeter-wrapper-on-wayland.patch
     (fetchpatch {
       name = "2015-lomiri-greeter-use-wayland.patch";
       url = "https://salsa.debian.org/ubports-team/lomiri/-/raw/2f5acfa085c901359bf6f6cccbce36d7e2981555/debian/patches/2015_lomiri-greeter-use-wayland.patch";
@@ -102,21 +101,6 @@ stdenv.mkDerivation (finalAttrs: {
       name = "1005-lomiri-cursor-always-follow-cursor-position-from-mir.patch";
       url = "https://salsa.debian.org/ubports-team/lomiri/-/raw/f3ba943006f5469a8a7aa24f232d6383afb3bc74/debian/patches/1005_cursor-always-follow-cursor-position-from-mir.patch";
       hash = "sha256-FYWRHt3//gm3jT9dr35tH4PlZssMMA/zBhjkszgqTYo=";
-    })
-
-    # Undo start-here integration & uglier colours for launcher
-    (fetchpatch {
-      name = "0001-lomiri-LauncherPanel-Use-Lomiri-upstream-home-logo-and-home-background-color.patch";
-      url = "https://gitlab.com/ubports/development/core/lomiri/-/commit/defaabfaf4818ee6b618c97b34acf5e0ed2ebb2e.patch";
-      hash = "sha256-9YRWMV+1UT+EQd9Uq1+6enNzz+HDlSt3LTPM1BKJxiE=";
-    })
-
-    # Compatibility with newer lomiri-api
-    # Remove when version > 0.5.0
-    (fetchpatch {
-      name = "0002-lomiri-Adjust-to-newer-lomiri-api.patch";
-      url = "https://gitlab.com/ubports/development/core/lomiri/-/commit/26cbfa458766df406ed7d2c351ec84522371b083.patch";
-      hash = "sha256-1mPDtitMpktuvLs3Zn+6pCaMGTwGvIglGBdrm4Y8QwA=";
     })
 
     ./9901-lomiri-Disable-Wizard.patch
@@ -156,6 +140,8 @@ stdenv.mkDerivation (finalAttrs: {
   + lib.optionalString finalAttrs.finalPackage.doCheck ''
     patchShebangs tests/whitespace/check_whitespace.py
   '';
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     cmake
@@ -201,6 +187,7 @@ stdenv.mkDerivation (finalAttrs: {
     qtdeclarative
     qtmir
     qtsvg
+    xwayland
 
     # QML import path
     biometryd
@@ -209,10 +196,14 @@ stdenv.mkDerivation (finalAttrs: {
     lomiri-settings-components
     lomiri-telephony-service
     lomiri-thumbnailer
+    lomiri-ui-extras
     qtmultimedia
   ];
 
-  nativeCheckInputs = [ (python3.withPackages (ps: with ps; [ python-dbusmock ])) ];
+  nativeCheckInputs = [
+    libqtdbustest
+    (python3.withPackages (ps: with ps; [ python-dbusmock ]))
+  ];
 
   checkInputs = [
     libqtdbustest
@@ -226,8 +217,11 @@ stdenv.mkDerivation (finalAttrs: {
   dontWrapQtApps = true;
 
   cmakeFlags = [
-    (lib.cmakeBool "NO_TESTS" (!finalAttrs.finalPackage.doCheck))
-    (lib.cmakeBool "WITH_MIR2" true)
+    (lib.strings.cmakeBool "NO_TESTS" (!finalAttrs.finalPackage.doCheck))
+    (lib.strings.cmakeBool "WITH_MIR2" true)
+    # These get embedded into systemd service files
+    (lib.strings.cmakeFeature "DUAE_BIN" (lib.getExe' dbus "dbus-update-activation-environment"))
+    (lib.strings.cmakeFeature "XWAYLAND_BIN" (lib.getExe xwayland))
   ];
 
   postInstall = ''


### PR DESCRIPTION
https://gitlab.com/ubports/development/core/lomiri/-/blob/0.6.1/ChangeLog

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
