### PR TITLE
NixOS/plasma6: Modularize various services, avoid "with" & mixed use of "lib." / "inherits"

### DIFF
--- a/nixos/modules/services/desktop-managers/plasma6.nix
+++ b/nixos/modules/services/desktop-managers/plasma6.nix
@@ -103,11 +103,26 @@ in
       };
     };
 
-    environment.plasma6.excludePackages = mkOption {
-      description = "List of default packages to exclude from the configuration";
-      type = types.listOf types.package;
-      default = [ ];
-      example = literalExpression "[ pkgs.kdePackages.elisa ]";
+    environment.plasma6 = {
+      excludePackages = mkOption {
+        description = "List of default packages to exclude from the configuration";
+        type = types.listOf types.package;
+        default = [ ];
+        example = literalExpression "[ pkgs.kdePackages.elisa ]";
+      };
+      # FIXME: warn the user effectively about the potential danger of this option
+      excludeRequiredPackages = mkOption {
+        description = ''
+          WARNING: although some packages here can be safely removed, many will make the desktop fundamentally unuseable if removed
+          and or quitely and subtley break many different features. ensure you understand what you are excluding.
+          removal of many of these packages after having previously included them may make for invalid user config and or state which could both quitely break features or outright break the desktop.
+
+          List of required packages to exclude from the configuration.
+        '';
+        type = types.listOf types.package;
+        default = [ ];
+        example = literalExpression "[ pkgs.kdePackages.kde-inotify-survey ]";
+      };
     };
   };
 
@@ -244,7 +259,7 @@ in
               kdePackages.discover
             ];
         in
-        requiredPackages
+        utils.removePackagesByName requiredPackages config.environment.plasma6.excludeRequiredPackages
         ++ utils.removePackagesByName optionalPackages config.environment.plasma6.excludePackages
         ++ optionals config.services.desktopManager.plasma6.enableQt5Integration [
           kdePackages.breeze.qt5

--- a/nixos/modules/services/desktop-managers/plasma6.nix
+++ b/nixos/modules/services/desktop-managers/plasma6.nix
@@ -14,6 +14,7 @@ let
     literalExpression
     mkDefault
     mkIf
+    mkMerge
     mkOption
     mkPackageOption
     mkRenamedOptionModule
@@ -34,6 +35,60 @@ in
         type = types.bool;
         default = false;
         description = "Enable the Plasma 6 (KDE 6) desktop environment.";
+      };
+
+      themes = {
+        breeze.enable = mkOption {
+          type = types.bool;
+          default = true;
+          description = "Enable Breeze theming (window decorations, plasma style, icons, sounds etc).";
+        };
+        gtk = {
+          enable = mkOption {
+            type = types.bool;
+            default = true;
+            description = "Enable KDE to manage GTK themes and settings through dconf.";
+          };
+          setBreeze = mkOption {
+            type = types.bool;
+            default = true;
+            description = "Include and set the GTK theme to the breeze theme defaults.";
+          };
+        };
+      };
+
+      services = {
+        drkonqi.enable = mkOption {
+          type = types.bool;
+          default = true;
+          description = "Enable the kde crash handling, including notificatons and GUI.";
+        };
+        plasma-browser-integration.enable = mkOption {
+          type = types.bool;
+          default = true;
+          description = "Include and prompt installation of the plasma browser integration extension, applets and services.";
+        };
+        kwallet = {
+          enable = mkOption {
+            type = types.bool;
+            default = true;
+            description = "Enable the KDE secrets management services and GUI manager.";
+          };
+          unlock-with-luks = mkOption {
+            type = types.bool;
+            default = false;
+            description = "Enable KWallet to be automatically unlocked when luks is used and unlocked.";
+          };
+        };
+        rebuild-cache-service = mkOption {
+          type = types.bool;
+          default = true;
+          description = ''
+            rebuilds the ksycoca6 cache on system activation and graphical target start.
+            This is a workaround to be a incompatibility with NixOS and how ksycoca6 chooses to invalidate cache.
+            You can follow the issue here, https://github.com/NixOS/nixpkgs/issues/292632.
+          '';
+        };
       };
 
       enableQt5Integration = mkOption {
@@ -71,357 +126,427 @@ in
     )
   ];
 
-  config = mkIf cfg.enable {
-    qt.enable = true;
-    programs.xwayland.enable = true;
-    environment.systemPackages =
-      let
-        requiredPackages =
-          (builtins.attrValues {
-            inherit (kdePackages)
-              qtwayland # Hack? To make everything run on Wayland
-              qtsvg # Needed to render SVG icons
+  config = mkMerge [
+    (mkIf cfg.enable {
+      qt.enable = true;
+      programs.xwayland.enable = true;
+      environment.systemPackages =
+        let
+          requiredPackages =
+            (builtins.attrValues {
+              inherit (kdePackages)
+                qtwayland # Hack? To make everything run on Wayland
+                qtsvg # Needed to render SVG icons
 
-              # Frameworks with globally loadable bits
-              frameworkintegration # provides Qt plugin
-              kauth # provides helper service
-              kcoreaddons # provides extra mime type info
-              kded # provides helper service
-              kfilemetadata # provides Qt plugins
-              kguiaddons # provides geo URL handlers
-              kiconthemes # provides Qt plugins
-              kimageformats # provides Qt plugins
-              qtimageformats # provides optional image formats such as .webp and .avif
-              kio # provides helper service + a bunch of other stuff
-              kio-admin # managing files as admin
-              kio-extras # stuff for MTP, AFC, etc
-              kio-fuse # fuse interface for KIO
-              knighttime # night mode switching daemon
-              kpackage # provides kpackagetool tool
-              kservice # provides kbuildsycoca6 tool
-              kunifiedpush # provides a background service and a KCM
-              kwallet # provides helper service
-              kwallet-pam # provides helper service
-              kwalletmanager # provides KCMs and stuff
-              plasma-activities # provides plasma-activities-cli tool
-              solid # provides solid-hardware6 tool
-              phonon-vlc # provides Phonon plugin
+                # Frameworks with globally loadable bits
+                frameworkintegration # provides Qt plugin
+                kauth # provides helper service
+                kcoreaddons # provides extra mime type info
+                kded # provides helper service
+                kfilemetadata # provides Qt plugins
+                kguiaddons # provides geo URL handlers
+                kiconthemes # provides Qt plugins
+                kimageformats # provides Qt plugins
+                qtimageformats # provides optional image formats such as .webp and .avif
+                kio # provides helper service + a bunch of other stuff
+                kio-admin # managing files as admin
+                kio-extras # stuff for MTP, AFC, etc
+                kio-fuse # fuse interface for KIO
+                knighttime # night mode switching daemon
+                kpackage # provides kpackagetool tool
+                kservice # provides kbuildsycoca6 tool
+                kunifiedpush # provides a background service and a KCM
+                plasma-activities # provides plasma-activities-cli tool
+                solid # provides solid-hardware6 tool
+                phonon-vlc # provides Phonon plugin
 
-              # Core Plasma parts
-              kwin
-              kscreen
-              libkscreen
-              kscreenlocker
-              kactivitymanagerd
-              kde-cli-tools
-              kglobalacceld # keyboard shortcut daemon
-              kwrited # wall message proxy, not to be confused with kwrite
-              baloo # system indexer
-              milou # search engine atop baloo
-              kdegraphics-thumbnailers # pdf etc thumbnailer
-              polkit-kde-agent-1 # polkit auth ui
-              plasma-desktop
-              plasma-workspace
-              drkonqi # crash handler
-              kde-inotify-survey # warns the user on low inotifywatch limits
+                # Core Plasma parts
+                kwin
+                kscreen
+                libkscreen
+                kscreenlocker
+                kactivitymanagerd
+                kde-cli-tools
+                kglobalacceld # keyboard shortcut daemon
+                kwrited # wall message proxy, not to be confused with kwrite
+                baloo # system indexer
+                milou # search engine atop baloo
+                kdegraphics-thumbnailers # pdf etc thumbnailer
+                polkit-kde-agent-1 # polkit auth ui
+                plasma-desktop
+                plasma-workspace
+                kde-inotify-survey # warns the user on low inotifywatch limits
 
-              # Application integration
-              libplasma # provides Kirigami platform theme
-              plasma-integration # provides Qt platform theme
-              kde-gtk-config # syncs KDE settings to GTK
+                # Application integration
+                libplasma # provides Kirigami platform theme
+                plasma-integration # provides Qt platform theme
+                kde-gtk-config # syncs KDE settings to GTK
 
-              # Artwork + themes
-              breeze
-              breeze-icons
-              breeze-gtk
-              ocean-sound-theme
-              qqc2-breeze-style
-              qqc2-desktop-style
+                # Artwork + themes
+                breeze-gtk
 
-              # misc Plasma extras
-              kdeplasma-addons
+                # misc Plasma extras
+                kdeplasma-addons
 
-              # Plasma utilities
-              kmenuedit
-              kinfocenter
-              plasma-systemmonitor
-              ksystemstats
-              libksysguard
-              systemsettings
-              kcmutils
-              ;
-          })
-          ++ [
-            pkgs.hicolor-icon-theme # fallback icons
-            pkgs.xdg-user-dirs # recommended upstream
-          ];
-        optionalPackages =
-          (builtins.attrValues {
-            inherit (kdePackages)
-              aurorae
-              plasma-browser-integration
-              plasma-workspace-wallpapers
-              konsole
-              kwin-x11
-              ark
-              elisa
-              gwenview
-              okular
-              kate
-              ktexteditor # provides elevated actions for kate
-              khelpcenter
-              dolphin
-              baloo-widgets # baloo information in Dolphin
-              dolphin-plugins
-              spectacle
-              ffmpegthumbs
-              krdp
-              kconfig # required for xdg-terminal from xdg-utils
-              qtbase # for qtpaths which is required for xdg-mime from xdg-utils
-              # touch keyboard
-              plasma-keyboard
-              qtvirtualkeyboard # used by plasma-keyboard KCM
+                # Plasma utilities
+                kmenuedit
+                kinfocenter
+                plasma-systemmonitor
+                ksystemstats
+                libksysguard
+                systemsettings
+                kcmutils
+                ;
+            })
+            ++ [
+              pkgs.hicolor-icon-theme # fallback icons
+              pkgs.xdg-user-dirs # recommended upstream
+            ];
+          optionalPackages =
+            (builtins.attrValues {
+              inherit (kdePackages)
+                aurorae
+                plasma-workspace-wallpapers
+                konsole
+                kwin-x11
+                ark
+                elisa
+                gwenview
+                okular
+                kate
+                ktexteditor # provides elevated actions for kate
+                khelpcenter
+                dolphin
+                baloo-widgets # baloo information in Dolphin
+                dolphin-plugins
+                spectacle
+                ffmpegthumbs
+                krdp
+                kconfig # required for xdg-terminal from xdg-utils
+                qtbase # for qtpaths which is required for xdg-mime from xdg-utils
+                # touch keyboard
+                plasma-keyboard
+                qtvirtualkeyboard # used by plasma-keyboard KCM
 
-              # experimental(?) Union theme
-              union
-              ;
-          })
-          ++ [ (getBin kdePackages.qttools) ] # Expose qdbus in PATH
-          ++ optional config.networking.networkmanager.enable kdePackages.qrca
-          ++ optionals config.hardware.sensor.iio.enable [
-            # This is required for autorotation in Plasma 6
-            kdePackages.qtsensors
-          ]
-          ++ optionals (config.services.flatpak.enable || config.services.fwupd.enable) [
-            # Since PackageKit Nix support is not there yet,
-            # only install discover if flatpak or fwupd is enabled.
-            kdePackages.discover
-          ];
-      in
-      requiredPackages
-      ++ utils.removePackagesByName optionalPackages config.environment.plasma6.excludePackages
-      ++ optionals config.services.desktopManager.plasma6.enableQt5Integration [
-        kdePackages.breeze.qt5
-        kdePackages.plasma-integration.qt5
-        kdePackages.kwayland-integration
-        (
-          # Only symlink the KIO plugins, so we don't accidentally pull any services
-          # like KCMs or kcookiejar
-          let
-            kioPluginPath = "${pkgs.libsForQt5.qtbase.qtPluginPrefix}/kf5/kio";
-            inherit (pkgs.libsForQt5.__internalKF5) kio;
-          in
-          pkgs.runCommand "kio5-plugins-only" { } ''
-            mkdir -p $out/${kioPluginPath}
-            ln -s ${kio}/${kioPluginPath}/* $out/${kioPluginPath}
-          ''
-        )
-        kdePackages.kio-extras-kf5
-      ]
-      # Optional and hardware support features
-      ++ optionals config.hardware.bluetooth.enable [
-        kdePackages.bluedevil
-        kdePackages.bluez-qt
-        pkgs.openobex
-        pkgs.obexftp
-      ]
-      ++ optional config.networking.networkmanager.enable kdePackages.plasma-nm
-      ++ optional config.services.pulseaudio.enable kdePackages.plasma-pa
-      ++ optional config.services.pipewire.pulse.enable kdePackages.plasma-pa
-      ++ optional config.powerManagement.enable kdePackages.powerdevil
-      ++ optional config.services.printing.enable kdePackages.print-manager
-      ++ optional config.hardware.sane.enable kdePackages.skanpage
-      ++ optional config.services.colord.enable kdePackages.colord-kde
-      ++ optional config.services.hardware.bolt.enable kdePackages.plasma-thunderbolt
-      ++ optional config.services.samba.enable kdePackages.kdenetwork-filesharing
-      ++ optional config.services.xserver.wacom.enable kdePackages.wacomtablet
-      ++ optional config.services.flatpak.enable kdePackages.flatpak-kcm;
+                # experimental(?) Union theme
+                union
+                ;
+            })
+            ++ [ (getBin kdePackages.qttools) ] # Expose qdbus in PATH
+            ++ optional config.networking.networkmanager.enable kdePackages.qrca
+            ++ optionals config.hardware.sensor.iio.enable [
+              # This is required for autorotation in Plasma 6
+              kdePackages.qtsensors
+            ]
+            ++ optionals (config.services.flatpak.enable || config.services.fwupd.enable) [
+              # Since PackageKit Nix support is not there yet,
+              # only install discover if flatpak or fwupd is enabled.
+              kdePackages.discover
+            ];
+        in
+        requiredPackages
+        ++ utils.removePackagesByName optionalPackages config.environment.plasma6.excludePackages
+        ++ optionals config.services.desktopManager.plasma6.enableQt5Integration [
+          kdePackages.breeze.qt5
+          kdePackages.plasma-integration.qt5
+          kdePackages.kwayland-integration
+          (
+            # Only symlink the KIO plugins, so we don't accidentally pull any services
+            # like KCMs or kcookiejar
+            let
+              kioPluginPath = "${pkgs.libsForQt5.qtbase.qtPluginPrefix}/kf5/kio";
+              inherit (pkgs.libsForQt5.__internalKF5) kio;
+            in
+            pkgs.runCommand "kio5-plugins-only" { } ''
+              mkdir -p $out/${kioPluginPath}
+              ln -s ${kio}/${kioPluginPath}/* $out/${kioPluginPath}
+            ''
+          )
+          kdePackages.kio-extras-kf5
+        ]
+        # Optional and hardware support features
+        ++ optionals config.hardware.bluetooth.enable [
+          kdePackages.bluedevil
+          kdePackages.bluez-qt
+          pkgs.openobex
+          pkgs.obexftp
+        ]
+        ++ optional config.networking.networkmanager.enable kdePackages.plasma-nm
+        ++ optional config.services.pulseaudio.enable kdePackages.plasma-pa
+        ++ optional config.services.pipewire.pulse.enable kdePackages.plasma-pa
+        ++ optional config.powerManagement.enable kdePackages.powerdevil
+        ++ optional config.services.printing.enable kdePackages.print-manager
+        ++ optional config.hardware.sane.enable kdePackages.skanpage
+        ++ optional config.services.colord.enable kdePackages.colord-kde
+        ++ optional config.services.hardware.bolt.enable kdePackages.plasma-thunderbolt
+        ++ optional config.services.samba.enable kdePackages.kdenetwork-filesharing
+        ++ optional config.services.xserver.wacom.enable kdePackages.wacomtablet
+        ++ optional config.services.flatpak.enable kdePackages.flatpak-kcm;
 
-    environment.pathsToLink = [
       # FIXME: modules should link subdirs of `/share` rather than relying on this
-      "/share"
-      "/libexec" # for drkonqi
-    ];
+      environment.pathsToLink = [ "/share" ];
 
-    environment.etc."X11/xkb".source = config.services.xserver.xkb.dir;
+      environment.etc."X11/xkb".source = config.services.xserver.xkb.dir;
 
-    # Add ~/.config/kdedefaults to XDG_CONFIG_DIRS for shells, since Plasma sets that.
-    # FIXME: maybe we should append to XDG_CONFIG_DIRS in /etc/set-environment instead?
-    environment.sessionVariables.XDG_CONFIG_DIRS = [ "$HOME/.config/kdedefaults" ];
+      # Add ~/.config/kdedefaults to XDG_CONFIG_DIRS for shells, since Plasma sets that.
+      # FIXME: maybe we should append to XDG_CONFIG_DIRS in /etc/set-environment instead?
+      environment.sessionVariables.XDG_CONFIG_DIRS = [ "$HOME/.config/kdedefaults" ];
 
-    # Needed for things that depend on other store.kde.org packages to install correctly,
-    # notably Plasma look-and-feel packages (a.k.a. Global Themes)
-    #
-    # FIXME: this is annoyingly impure and should really be fixed at source level somehow,
-    # but kpackage is a library so we can't just wrap the one thing invoking it and be done.
-    # This also means things won't work for people not on Plasma, but at least this way it
-    # works for SOME people.
-    environment.sessionVariables.KPACKAGE_DEP_RESOLVERS_PATH = "${kdePackages.frameworkintegration.out}/libexec/kf6/kpackagehandlers";
+      # Needed for things that depend on other store.kde.org packages to install correctly,
+      # notably Plasma look-and-feel packages (a.k.a. Global Themes)
+      #
+      # FIXME: this is annoyingly impure and should really be fixed at source level somehow,
+      # but kpackage is a library so we can't just wrap the one thing invoking it and be done.
+      # This also means things won't work for people not on Plasma, but at least this way it
+      # works for SOME people.
+      environment.sessionVariables.KPACKAGE_DEP_RESOLVERS_PATH = "${kdePackages.frameworkintegration.out}/libexec/kf6/kpackagehandlers";
 
-    # Enable GTK applications to load SVG icons
-    programs.gdk-pixbuf.modulePackages = [ pkgs.librsvg ];
-
-    fonts.packages = [
-      cfg.notoPackage
-      pkgs.hack-font
-    ];
-    fonts.fontconfig.defaultFonts = {
-      monospace = [
-        "Hack"
-        "Noto Sans Mono"
+      fonts.packages = [
+        cfg.notoPackage
+        pkgs.hack-font
       ];
-      sansSerif = [ "Noto Sans" ];
-      serif = [ "Noto Serif" ];
-    };
-
-    programs.gnupg.agent.pinentryPackage = mkDefault pkgs.pinentry-qt;
-    programs.kde-pim.enable = mkDefault true;
-    programs.ssh.askPassword = mkDefault "${kdePackages.ksshaskpass.out}/bin/ksshaskpass";
-
-    # Enable helpful DBus services.
-    services.accounts-daemon.enable = true;
-    # when changing an account picture the accounts-daemon reads a temporary file containing the image which systemsettings5 may place under /tmp
-    systemd.services.accounts-daemon.serviceConfig.PrivateTmp = false;
-
-    services.power-profiles-daemon.enable = mkDefault true;
-    services.system-config-printer.enable = mkIf config.services.printing.enable (mkDefault true);
-    programs.fuse.enable = true;
-    services.udisks2.enable = true;
-    services.upower.enable = config.powerManagement.enable;
-    services.libinput.enable = mkDefault true;
-    services.geoclue2.enable = mkDefault true;
-    services.fwupd.enable = mkDefault true;
-
-    # Extra UDEV rules used by Solid
-    services.udev.packages = [
-      # libmtp has "bin", "dev", "out" outputs. UDEV rules file is in "out".
-      pkgs.libmtp.out
-      pkgs.media-player-info
-    ];
-
-    # Set up Dr. Konqi as crash handler
-    systemd.packages = [ kdePackages.drkonqi ];
-    systemd.services."drkonqi-coredump-processor@".wantedBy = [ "systemd-coredump@.service" ];
-
-    xdg.icons.enable = true;
-    xdg.icons.fallbackCursorThemes = mkDefault [ "breeze_cursors" ];
-
-    xdg.portal.enable = true;
-    xdg.portal.extraPortals = [
-      kdePackages.kwallet
-      kdePackages.xdg-desktop-portal-kde
-      pkgs.xdg-desktop-portal-gtk
-    ];
-    xdg.portal.configPackages = mkDefault [ kdePackages.plasma-workspace ];
-    services.pipewire.enable = mkDefault true;
-
-    # Enable screen reader by default
-    services.orca.enable = mkDefault true;
-
-    services.displayManager = {
-      sessionPackages = [ kdePackages.plasma-workspace.sessions ];
-      defaultSession = mkDefault "plasma";
-    };
-    services.displayManager.sddm = {
-      package = kdePackages.sddm;
-      theme = mkDefault "breeze";
-      wayland = mkDefault {
-        enable = true;
-        compositor = "kwin";
+      fonts.fontconfig.defaultFonts = {
+        monospace = [
+          "Hack"
+          "Noto Sans Mono"
+        ];
+        sansSerif = [ "Noto Sans" ];
+        serif = [ "Noto Serif" ];
       };
-      extraPackages = builtins.attrValues {
+
+      programs.gnupg.agent.pinentryPackage = mkDefault pkgs.pinentry-qt;
+      programs.kde-pim.enable = mkDefault true;
+      programs.ssh.askPassword = mkDefault "${kdePackages.ksshaskpass.out}/bin/ksshaskpass";
+
+      # Enable helpful DBus services.
+      services.accounts-daemon.enable = true;
+      # when changing an account picture the accounts-daemon reads a temporary file containing the image which systemsettings5 may place under /tmp
+      systemd.services.accounts-daemon.serviceConfig.PrivateTmp = false;
+
+      services.power-profiles-daemon.enable = mkDefault true;
+      services.system-config-printer.enable = mkIf config.services.printing.enable (mkDefault true);
+      programs.fuse.enable = true;
+      services.udisks2.enable = true;
+      services.upower.enable = config.powerManagement.enable;
+      services.libinput.enable = mkDefault true;
+      services.geoclue2.enable = mkDefault true;
+      services.fwupd.enable = mkDefault true;
+
+      # Extra UDEV rules used by Solid
+      services.udev.packages = [
+        # libmtp has "bin", "dev", "out" outputs. UDEV rules file is in "out".
+        pkgs.libmtp.out
+        pkgs.media-player-info
+      ];
+
+      xdg.icons.enable = true;
+
+      xdg.portal.enable = true;
+      xdg.portal.extraPortals = [
+        kdePackages.xdg-desktop-portal-kde
+        pkgs.xdg-desktop-portal-gtk
+      ];
+      xdg.portal.configPackages = mkDefault [ kdePackages.plasma-workspace ];
+      services.pipewire.enable = mkDefault true;
+
+      # Enable screen reader by default
+      services.orca.enable = mkDefault true;
+
+      services.displayManager = {
+        sessionPackages = [ kdePackages.plasma-workspace.sessions ];
+        defaultSession = mkDefault "plasma";
+      };
+      services.displayManager.sddm = {
+        package = kdePackages.sddm;
+        theme = mkDefault "breeze";
+        wayland = mkDefault {
+          enable = true;
+          compositor = "kwin";
+        };
+        extraPackages = builtins.attrValues {
+          inherit (kdePackages)
+            breeze-icons
+            kirigami
+            libplasma
+            plasma5support
+            qtsvg
+            qtvirtualkeyboard
+            ;
+        };
+      };
+
+      security.pam.services = {
+        kde = {
+          allowNullPassword = true;
+          # "kde" must not have fingerprint authentication otherwise it can block password login.
+          # See https://github.com/NixOS/nixpkgs/issues/239770 and https://invent.kde.org/plasma/kscreenlocker/-/merge_requests/163.
+          fprintAuth = false;
+          p11Auth = false;
+        };
+        kde-fingerprint = mkIf config.services.fprintd.enable {
+          fprintAuth = true;
+          p11Auth = false;
+        };
+        kde-smartcard = mkIf config.security.pam.p11.enable {
+          p11Auth = true;
+          fprintAuth = false;
+        };
+      };
+
+      security.wrappers = {
+        kwin_wayland = {
+          owner = "root";
+          group = "root";
+          capabilities = "cap_sys_nice+ep";
+          source = "${getBin pkgs.kdePackages.kwin}/bin/kwin_wayland";
+        };
+        # FIXME: this should likely be conditional on having the appropriate hardware
+        # however, there is no obvious comprehensive way to check this
+        ksystemstats_intel_helper = {
+          owner = "root";
+          group = "root";
+          capabilities = "cap_perfmon+ep";
+          source = "${pkgs.kdePackages.ksystemstats}/libexec/ksystemstats_intel_helper";
+        };
+
+        ksgrd_network_helper = {
+          owner = "root";
+          group = "root";
+          capabilities = "cap_net_raw+ep";
+          source = "${pkgs.kdePackages.libksysguard}/libexec/ksysguard/ksgrd_network_helper";
+        };
+      };
+
+      # Upstream recommends allowing set-timezone and set-ntp so that the KCM and
+      # the automatic timezone logic work without user interruption.
+      # However, on NixOS NTP cannot be overwritten via dbus, and timezone
+      # can only be set if `time.timeZone` is set to `null`. So, we only allow
+      # set-timezone, and we only allow it when the timezone can actually be set.
+      security.polkit.extraConfig = mkIf (config.time.timeZone != null) ''
+        polkit.addRule(function(action, subject) {
+          if (action.id == "org.freedesktop.timedate1.set-timezone" && subject.active) {
+            return polkit.Result.YES;
+          }
+        });
+      '';
+
+      programs.kdeconnect.package = kdePackages.kdeconnect-kde;
+      programs.partition-manager.package = kdePackages.partitionmanager;
+
+    })
+    (mkIf cfg.themes.breeze.enable {
+      environment.systemPackages = builtins.attrValues {
         inherit (kdePackages)
+          breeze
           breeze-icons
-          kirigami
-          libplasma
-          plasma5support
-          qtsvg
-          qtvirtualkeyboard
+          ocean-sound-theme
+          qqc2-breeze-style
+          qqc2-desktop-style
           ;
       };
-    };
-
-    security.pam.services = {
-      login.kwallet = {
-        enable = true;
-        package = kdePackages.kwallet-pam;
+      qt = {
+        platformTheme = "kde";
+        style = "breeze";
       };
-      kde = {
-        allowNullPassword = true;
-        kwallet = {
+      xdg.icons.fallbackCursorThemes = [ "breeze_cursors" ];
+    })
+    (mkIf cfg.themes.gtk.enable {
+      environment.systemPackages = [
+        kdePackages.kde-gtk-config
+      ]
+      ++ optionals cfg.themes.gtk.setBreeze [
+        kdePackages.breeze-gtk
+      ];
+      programs = {
+        dconf = {
+          enable = true;
+          profiles.user.databases = mkIf cfg.themes.gtk.setBreeze [
+            {
+              settings = {
+                "org/gnome/desktop/interface".gtk-theme = "Breeze";
+                # FIXME: Some cases when setting dconf settings like above can remove this typically expected behaviour.
+                # Ideally this would not be secretly set under this option, But atleast this way it breaks less expected behaviour over all.
+                "org/gnome/desktop/wm/preferences".button-layout = ":minimize,maximize,close";
+              };
+            }
+          ];
+        };
+        # Enable GTK applications to load SVG icons
+        gdk-pixbuf.modulePackages = [ pkgs.librsvg ];
+      };
+    })
+    (mkIf cfg.services.drkonqi.enable {
+      systemd = {
+        packages = [ kdePackages.drkonqi ];
+        services."drkonqi-coredump-processor@".wantedBy = [ "systemd-coredump@.service" ];
+      };
+      environment = {
+        systemPackages = [ kdePackages.drkonqi ];
+        pathsToLink = [ "/libexec" ];
+      };
+    })
+    (mkIf cfg.services.plasma-browser-integration.enable {
+      environment.systemPackages = [ kdePackages.plasma-browser-integration ];
+      programs = {
+        firefox.nativeMessagingHosts.packages = [ kdePackages.plasma-browser-integration ];
+        chromium = {
+          enablePlasmaBrowserIntegration = true;
+          plasmaBrowserIntegrationPackage = kdePackages.plasma-browser-integration;
+        };
+      };
+    })
+    (mkIf cfg.services.kwallet.enable {
+      security.pam.services = {
+        login.kwallet = {
           enable = true;
           package = kdePackages.kwallet-pam;
         };
-        # "kde" must not have fingerprint authentication otherwise it can block password login.
-        # See https://github.com/NixOS/nixpkgs/issues/239770 and https://invent.kde.org/plasma/kscreenlocker/-/merge_requests/163.
-        fprintAuth = false;
-        p11Auth = false;
+        kde.kwallet = {
+          enable = true;
+          package = kdePackages.kwallet-pam;
+        };
       };
-      kde-fingerprint = mkIf config.services.fprintd.enable {
-        fprintAuth = true;
-        p11Auth = false;
+      environment.systemPackages = [
+        kdePackages.kwallet
+        kdePackages.kwallet-pam
+        kdePackages.kwalletmanager
+      ];
+      xdg.portal.extraPortals = [ kdePackages.kwallet ];
+    })
+    (mkIf cfg.services.kwallet.unlock-with-luks {
+      # FIXME: assert boot.initrd.systemd.enable = true
+      # or at minimum, warn the user that it is expected to be enabled for this option
+      systemd.services.plasmalogin.serviceConfig.KeyringMode = "inherit";
+      security.pam.services.plasmalogin-autologin.rules.auth = {
+        systemd_loadkey = {
+          order = 0;
+          control = "optional";
+          modulePath = "${pkgs.systemd}/lib/security/pam_systemd_loadkey.so";
+        };
+        plasmalogin = {
+          order = 1;
+          control = "include";
+          modulePath = "plasmalogin";
+        };
       };
-      kde-smartcard = mkIf config.security.pam.p11.enable {
-        p11Auth = true;
-        fprintAuth = false;
-      };
-    };
-
-    security.wrappers = {
-      kwin_wayland = {
-        owner = "root";
-        group = "root";
-        capabilities = "cap_sys_nice+ep";
-        source = "${getBin pkgs.kdePackages.kwin}/bin/kwin_wayland";
-      };
-
-      ksystemstats_intel_helper = {
-        owner = "root";
-        group = "root";
-        capabilities = "cap_perfmon+ep";
-        source = "${pkgs.kdePackages.ksystemstats}/libexec/ksystemstats_intel_helper";
-      };
-
-      ksgrd_network_helper = {
-        owner = "root";
-        group = "root";
-        capabilities = "cap_net_raw+ep";
-        source = "${pkgs.kdePackages.libksysguard}/libexec/ksysguard/ksgrd_network_helper";
-      };
-    };
-
-    # Upstream recommends allowing set-timezone and set-ntp so that the KCM and
-    # the automatic timezone logic work without user interruption.
-    # However, on NixOS NTP cannot be overwritten via dbus, and timezone
-    # can only be set if `time.timeZone` is set to `null`. So, we only allow
-    # set-timezone, and we only allow it when the timezone can actually be set.
-    security.polkit.extraConfig = mkIf (config.time.timeZone != null) ''
-      polkit.addRule(function(action, subject) {
-        if (action.id == "org.freedesktop.timedate1.set-timezone" && subject.active) {
-          return polkit.Result.YES;
-        }
-      });
-    '';
-
-    programs.dconf.enable = true;
-
-    programs.firefox.nativeMessagingHosts.packages = [ kdePackages.plasma-browser-integration ];
-
-    programs.chromium = {
-      enablePlasmaBrowserIntegration = true;
-      plasmaBrowserIntegrationPackage = pkgs.kdePackages.plasma-browser-integration;
-    };
-
-    programs.kdeconnect.package = kdePackages.kdeconnect-kde;
-    programs.partition-manager.package = kdePackages.partitionmanager;
-
-    # FIXME: ugly hack. See #292632 for details.
-    system.userActivationScripts.rebuildSycoca = activationScript;
-    systemd.user.services.nixos-rebuild-sycoca = {
-      description = "Rebuild KDE system configuration cache";
-      wantedBy = [ "graphical-session-pre.target" ];
-      serviceConfig.Type = "oneshot";
-      script = activationScript;
-    };
-  };
+    })
+    (
+      let
+        activationScript = ''
+          # will be rebuilt automatically
+          rm -fv "''${XDG_CACHE_HOME:-$HOME/.cache}/ksycoca"*
+        '';
+      in
+      mkIf cfg.services.rebuild-cache-service {
+        # FIXME: ugly hack. See #292632 for details.
+        system.userActivationScripts.rebuildSycoca = activationScript;
+        systemd.user.services.nixos-rebuild-sycoca = {
+          description = "Rebuild KDE system configuration cache";
+          wantedBy = [ "graphical-session-pre.target" ];
+          serviceConfig.Type = "oneshot";
+          script = activationScript;
+        };
+      }
+    )
+  ];
 }

--- a/nixos/modules/services/desktop-managers/plasma6.nix
+++ b/nixos/modules/services/desktop-managers/plasma6.nix
@@ -244,7 +244,7 @@ in
                 qtvirtualkeyboard # used by plasma-keyboard KCM
 
                 # experimental(?) Union theme
-                union
+                # union
                 ;
             })
             ++ [ (getBin kdePackages.qttools) ] # Expose qdbus in PATH

--- a/nixos/modules/services/desktop-managers/plasma6.nix
+++ b/nixos/modules/services/desktop-managers/plasma6.nix
@@ -71,128 +71,135 @@ in
     qt.enable = true;
     programs.xwayland.enable = true;
     environment.systemPackages =
-      with kdePackages;
       let
-        requiredPackages = [
-          qtwayland # Hack? To make everything run on Wayland
-          qtsvg # Needed to render SVG icons
+        requiredPackages =
+          (builtins.attrValues {
+            inherit (kdePackages)
+              qtwayland # Hack? To make everything run on Wayland
+              qtsvg # Needed to render SVG icons
 
-          # Frameworks with globally loadable bits
-          frameworkintegration # provides Qt plugin
-          kauth # provides helper service
-          kcoreaddons # provides extra mime type info
-          kded # provides helper service
-          kfilemetadata # provides Qt plugins
-          kguiaddons # provides geo URL handlers
-          kiconthemes # provides Qt plugins
-          kimageformats # provides Qt plugins
-          qtimageformats # provides optional image formats such as .webp and .avif
-          kio # provides helper service + a bunch of other stuff
-          kio-admin # managing files as admin
-          kio-extras # stuff for MTP, AFC, etc
-          kio-fuse # fuse interface for KIO
-          knighttime # night mode switching daemon
-          kpackage # provides kpackagetool tool
-          kservice # provides kbuildsycoca6 tool
-          kunifiedpush # provides a background service and a KCM
-          kwallet # provides helper service
-          kwallet-pam # provides helper service
-          kwalletmanager # provides KCMs and stuff
-          plasma-activities # provides plasma-activities-cli tool
-          solid # provides solid-hardware6 tool
-          phonon-vlc # provides Phonon plugin
+              # Frameworks with globally loadable bits
+              frameworkintegration # provides Qt plugin
+              kauth # provides helper service
+              kcoreaddons # provides extra mime type info
+              kded # provides helper service
+              kfilemetadata # provides Qt plugins
+              kguiaddons # provides geo URL handlers
+              kiconthemes # provides Qt plugins
+              kimageformats # provides Qt plugins
+              qtimageformats # provides optional image formats such as .webp and .avif
+              kio # provides helper service + a bunch of other stuff
+              kio-admin # managing files as admin
+              kio-extras # stuff for MTP, AFC, etc
+              kio-fuse # fuse interface for KIO
+              knighttime # night mode switching daemon
+              kpackage # provides kpackagetool tool
+              kservice # provides kbuildsycoca6 tool
+              kunifiedpush # provides a background service and a KCM
+              kwallet # provides helper service
+              kwallet-pam # provides helper service
+              kwalletmanager # provides KCMs and stuff
+              plasma-activities # provides plasma-activities-cli tool
+              solid # provides solid-hardware6 tool
+              phonon-vlc # provides Phonon plugin
 
-          # Core Plasma parts
-          kwin
-          kscreen
-          libkscreen
-          kscreenlocker
-          kactivitymanagerd
-          kde-cli-tools
-          kglobalacceld # keyboard shortcut daemon
-          kwrited # wall message proxy, not to be confused with kwrite
-          baloo # system indexer
-          milou # search engine atop baloo
-          kdegraphics-thumbnailers # pdf etc thumbnailer
-          polkit-kde-agent-1 # polkit auth ui
-          plasma-desktop
-          plasma-workspace
-          drkonqi # crash handler
-          kde-inotify-survey # warns the user on low inotifywatch limits
+              # Core Plasma parts
+              kwin
+              kscreen
+              libkscreen
+              kscreenlocker
+              kactivitymanagerd
+              kde-cli-tools
+              kglobalacceld # keyboard shortcut daemon
+              kwrited # wall message proxy, not to be confused with kwrite
+              baloo # system indexer
+              milou # search engine atop baloo
+              kdegraphics-thumbnailers # pdf etc thumbnailer
+              polkit-kde-agent-1 # polkit auth ui
+              plasma-desktop
+              plasma-workspace
+              drkonqi # crash handler
+              kde-inotify-survey # warns the user on low inotifywatch limits
 
-          # Application integration
-          libplasma # provides Kirigami platform theme
-          plasma-integration # provides Qt platform theme
-          kde-gtk-config # syncs KDE settings to GTK
+              # Application integration
+              libplasma # provides Kirigami platform theme
+              plasma-integration # provides Qt platform theme
+              kde-gtk-config # syncs KDE settings to GTK
 
-          # Artwork + themes
-          breeze
-          breeze-icons
-          breeze-gtk
-          ocean-sound-theme
-          pkgs.hicolor-icon-theme # fallback icons
-          qqc2-breeze-style
-          qqc2-desktop-style
+              # Artwork + themes
+              breeze
+              breeze-icons
+              breeze-gtk
+              ocean-sound-theme
+              qqc2-breeze-style
+              qqc2-desktop-style
 
-          # misc Plasma extras
-          kdeplasma-addons
-          pkgs.xdg-user-dirs # recommended upstream
+              # misc Plasma extras
+              kdeplasma-addons
 
-          # Plasma utilities
-          kmenuedit
-          kinfocenter
-          plasma-systemmonitor
-          ksystemstats
-          libksysguard
-          systemsettings
-          kcmutils
-        ];
-        optionalPackages = [
-          aurorae
-          plasma-browser-integration
-          plasma-workspace-wallpapers
-          konsole
-          kwin-x11
-          (lib.getBin qttools) # Expose qdbus in PATH
-          ark
-          elisa
-          gwenview
-          okular
-          kate
-          ktexteditor # provides elevated actions for kate
-          khelpcenter
-          dolphin
-          baloo-widgets # baloo information in Dolphin
-          dolphin-plugins
-          spectacle
-          ffmpegthumbs
-          krdp
-          kconfig # required for xdg-terminal from xdg-utils
-          qtbase # for qtpaths which is required for xdg-mime from xdg-utils
-          # touch keyboard
-          plasma-keyboard
-          qtvirtualkeyboard # used by plasma-keyboard KCM
+              # Plasma utilities
+              kmenuedit
+              kinfocenter
+              plasma-systemmonitor
+              ksystemstats
+              libksysguard
+              systemsettings
+              kcmutils
+              ;
+          })
+          ++ [
+            pkgs.hicolor-icon-theme # fallback icons
+            pkgs.xdg-user-dirs # recommended upstream
+          ];
+        optionalPackages =
+          (builtins.attrValues {
+            inherit (kdePackages)
+              aurorae
+              plasma-browser-integration
+              plasma-workspace-wallpapers
+              konsole
+              kwin-x11
+              ark
+              elisa
+              gwenview
+              okular
+              kate
+              ktexteditor # provides elevated actions for kate
+              khelpcenter
+              dolphin
+              baloo-widgets # baloo information in Dolphin
+              dolphin-plugins
+              spectacle
+              ffmpegthumbs
+              krdp
+              kconfig # required for xdg-terminal from xdg-utils
+              qtbase # for qtpaths which is required for xdg-mime from xdg-utils
+              # touch keyboard
+              plasma-keyboard
+              qtvirtualkeyboard # used by plasma-keyboard KCM
 
-          # experimental(?) Union theme
-          union
-        ]
-        ++ lib.optional config.networking.networkmanager.enable qrca
-        ++ lib.optionals config.hardware.sensor.iio.enable [
-          # This is required for autorotation in Plasma 6
-          qtsensors
-        ]
-        ++ lib.optionals (config.services.flatpak.enable || config.services.fwupd.enable) [
-          # Since PackageKit Nix support is not there yet,
-          # only install discover if flatpak or fwupd is enabled.
-          discover
-        ];
+              # experimental(?) Union theme
+              union
+              ;
+          })
+          ++ [ (lib.getBin kdePackages.qttools) ] # Expose qdbus in PATH
+          ++ lib.optional config.networking.networkmanager.enable kdePackages.qrca
+          ++ lib.optionals config.hardware.sensor.iio.enable [
+            # This is required for autorotation in Plasma 6
+            kdePackages.qtsensors
+          ]
+          ++ lib.optionals (config.services.flatpak.enable || config.services.fwupd.enable) [
+            # Since PackageKit Nix support is not there yet,
+            # only install discover if flatpak or fwupd is enabled.
+            kdePackages.discover
+          ];
       in
       requiredPackages
       ++ utils.removePackagesByName optionalPackages config.environment.plasma6.excludePackages
       ++ lib.optionals config.services.desktopManager.plasma6.enableQt5Integration [
-        breeze.qt5
-        plasma-integration.qt5
-        kwayland-integration
+        kdePackages.breeze.qt5
+        kdePackages.plasma-integration.qt5
+        kdePackages.kwayland-integration
         (
           # Only symlink the KIO plugins, so we don't accidentally pull any services
           # like KCMs or kcookiejar
@@ -205,26 +212,26 @@ in
             ln -s ${kio}/${kioPluginPath}/* $out/${kioPluginPath}
           ''
         )
-        kio-extras-kf5
+        kdePackages.kio-extras-kf5
       ]
       # Optional and hardware support features
       ++ lib.optionals config.hardware.bluetooth.enable [
-        bluedevil
-        bluez-qt
+        kdePackages.bluedevil
+        kdePackages.bluez-qt
         pkgs.openobex
         pkgs.obexftp
       ]
-      ++ lib.optional config.networking.networkmanager.enable plasma-nm
-      ++ lib.optional config.services.pulseaudio.enable plasma-pa
-      ++ lib.optional config.services.pipewire.pulse.enable plasma-pa
-      ++ lib.optional config.powerManagement.enable powerdevil
-      ++ lib.optional config.services.printing.enable print-manager
-      ++ lib.optional config.hardware.sane.enable skanpage
-      ++ lib.optional config.services.colord.enable colord-kde
-      ++ lib.optional config.services.hardware.bolt.enable plasma-thunderbolt
-      ++ lib.optional config.services.samba.enable kdenetwork-filesharing
-      ++ lib.optional config.services.xserver.wacom.enable wacomtablet
-      ++ lib.optional config.services.flatpak.enable flatpak-kcm;
+      ++ lib.optional config.networking.networkmanager.enable kdePackages.plasma-nm
+      ++ lib.optional config.services.pulseaudio.enable kdePackages.plasma-pa
+      ++ lib.optional config.services.pipewire.pulse.enable kdePackages.plasma-pa
+      ++ lib.optional config.powerManagement.enable kdePackages.powerdevil
+      ++ lib.optional config.services.printing.enable kdePackages.print-manager
+      ++ lib.optional config.hardware.sane.enable kdePackages.skanpage
+      ++ lib.optional config.services.colord.enable kdePackages.colord-kde
+      ++ lib.optional config.services.hardware.bolt.enable kdePackages.plasma-thunderbolt
+      ++ lib.optional config.services.samba.enable kdePackages.kdenetwork-filesharing
+      ++ lib.optional config.services.xserver.wacom.enable kdePackages.wacomtablet
+      ++ lib.optional config.services.flatpak.enable kdePackages.flatpak-kcm;
 
     environment.pathsToLink = [
       # FIXME: modules should link subdirs of `/share` rather than relying on this
@@ -318,14 +325,16 @@ in
         enable = true;
         compositor = "kwin";
       };
-      extraPackages = with kdePackages; [
-        breeze-icons
-        kirigami
-        libplasma
-        plasma5support
-        qtsvg
-        qtvirtualkeyboard
-      ];
+      extraPackages = builtins.attrValues {
+        inherit (kdePackages)
+          breeze-icons
+          kirigami
+          libplasma
+          plasma5support
+          qtsvg
+          qtvirtualkeyboard
+          ;
+      };
     };
 
     security.pam.services = {

--- a/nixos/modules/services/desktop-managers/plasma6.nix
+++ b/nixos/modules/services/desktop-managers/plasma6.nix
@@ -10,11 +10,15 @@ let
 
   inherit (pkgs) kdePackages;
   inherit (lib)
+    getBin
     literalExpression
     mkDefault
     mkIf
     mkOption
     mkPackageOption
+    mkRenamedOptionModule
+    optional
+    optionals
     types
     ;
 
@@ -53,15 +57,15 @@ in
   };
 
   imports = [
-    (lib.mkRenamedOptionModule
+    (mkRenamedOptionModule
       [ "services" "xserver" "desktopManager" "plasma6" "enable" ]
       [ "services" "desktopManager" "plasma6" "enable" ]
     )
-    (lib.mkRenamedOptionModule
+    (mkRenamedOptionModule
       [ "services" "xserver" "desktopManager" "plasma6" "enableQt5Integration" ]
       [ "services" "desktopManager" "plasma6" "enableQt5Integration" ]
     )
-    (lib.mkRenamedOptionModule
+    (mkRenamedOptionModule
       [ "services" "xserver" "desktopManager" "plasma6" "notoPackage" ]
       [ "services" "desktopManager" "plasma6" "notoPackage" ]
     )
@@ -182,13 +186,13 @@ in
               union
               ;
           })
-          ++ [ (lib.getBin kdePackages.qttools) ] # Expose qdbus in PATH
-          ++ lib.optional config.networking.networkmanager.enable kdePackages.qrca
-          ++ lib.optionals config.hardware.sensor.iio.enable [
+          ++ [ (getBin kdePackages.qttools) ] # Expose qdbus in PATH
+          ++ optional config.networking.networkmanager.enable kdePackages.qrca
+          ++ optionals config.hardware.sensor.iio.enable [
             # This is required for autorotation in Plasma 6
             kdePackages.qtsensors
           ]
-          ++ lib.optionals (config.services.flatpak.enable || config.services.fwupd.enable) [
+          ++ optionals (config.services.flatpak.enable || config.services.fwupd.enable) [
             # Since PackageKit Nix support is not there yet,
             # only install discover if flatpak or fwupd is enabled.
             kdePackages.discover
@@ -196,7 +200,7 @@ in
       in
       requiredPackages
       ++ utils.removePackagesByName optionalPackages config.environment.plasma6.excludePackages
-      ++ lib.optionals config.services.desktopManager.plasma6.enableQt5Integration [
+      ++ optionals config.services.desktopManager.plasma6.enableQt5Integration [
         kdePackages.breeze.qt5
         kdePackages.plasma-integration.qt5
         kdePackages.kwayland-integration
@@ -215,23 +219,23 @@ in
         kdePackages.kio-extras-kf5
       ]
       # Optional and hardware support features
-      ++ lib.optionals config.hardware.bluetooth.enable [
+      ++ optionals config.hardware.bluetooth.enable [
         kdePackages.bluedevil
         kdePackages.bluez-qt
         pkgs.openobex
         pkgs.obexftp
       ]
-      ++ lib.optional config.networking.networkmanager.enable kdePackages.plasma-nm
-      ++ lib.optional config.services.pulseaudio.enable kdePackages.plasma-pa
-      ++ lib.optional config.services.pipewire.pulse.enable kdePackages.plasma-pa
-      ++ lib.optional config.powerManagement.enable kdePackages.powerdevil
-      ++ lib.optional config.services.printing.enable kdePackages.print-manager
-      ++ lib.optional config.hardware.sane.enable kdePackages.skanpage
-      ++ lib.optional config.services.colord.enable kdePackages.colord-kde
-      ++ lib.optional config.services.hardware.bolt.enable kdePackages.plasma-thunderbolt
-      ++ lib.optional config.services.samba.enable kdePackages.kdenetwork-filesharing
-      ++ lib.optional config.services.xserver.wacom.enable kdePackages.wacomtablet
-      ++ lib.optional config.services.flatpak.enable kdePackages.flatpak-kcm;
+      ++ optional config.networking.networkmanager.enable kdePackages.plasma-nm
+      ++ optional config.services.pulseaudio.enable kdePackages.plasma-pa
+      ++ optional config.services.pipewire.pulse.enable kdePackages.plasma-pa
+      ++ optional config.powerManagement.enable kdePackages.powerdevil
+      ++ optional config.services.printing.enable kdePackages.print-manager
+      ++ optional config.hardware.sane.enable kdePackages.skanpage
+      ++ optional config.services.colord.enable kdePackages.colord-kde
+      ++ optional config.services.hardware.bolt.enable kdePackages.plasma-thunderbolt
+      ++ optional config.services.samba.enable kdePackages.kdenetwork-filesharing
+      ++ optional config.services.xserver.wacom.enable kdePackages.wacomtablet
+      ++ optional config.services.flatpak.enable kdePackages.flatpak-kcm;
 
     environment.pathsToLink = [
       # FIXME: modules should link subdirs of `/share` rather than relying on this
@@ -353,11 +357,11 @@ in
         fprintAuth = false;
         p11Auth = false;
       };
-      kde-fingerprint = lib.mkIf config.services.fprintd.enable {
+      kde-fingerprint = mkIf config.services.fprintd.enable {
         fprintAuth = true;
         p11Auth = false;
       };
-      kde-smartcard = lib.mkIf config.security.pam.p11.enable {
+      kde-smartcard = mkIf config.security.pam.p11.enable {
         p11Auth = true;
         fprintAuth = false;
       };
@@ -368,7 +372,7 @@ in
         owner = "root";
         group = "root";
         capabilities = "cap_sys_nice+ep";
-        source = "${lib.getBin pkgs.kdePackages.kwin}/bin/kwin_wayland";
+        source = "${getBin pkgs.kdePackages.kwin}/bin/kwin_wayland";
       };
 
       ksystemstats_intel_helper = {
@@ -391,7 +395,7 @@ in
     # However, on NixOS NTP cannot be overwritten via dbus, and timezone
     # can only be set if `time.timeZone` is set to `null`. So, we only allow
     # set-timezone, and we only allow it when the timezone can actually be set.
-    security.polkit.extraConfig = lib.mkIf (config.time.timeZone != null) ''
+    security.polkit.extraConfig = mkIf (config.time.timeZone != null) ''
       polkit.addRule(function(action, subject) {
         if (action.id == "org.freedesktop.timedate1.set-timezone" && subject.active) {
           return polkit.Result.YES;


### PR DESCRIPTION
## Things done

modularize various services.

- breeze themes inclusion and setting,
- gtk handling and breeze theme setting,
- drkonqi,
- plasma-browser-integration,
- kwallet,
- rebuild-cache-service

add options under `services.desktopManager.plasma6`
```
themes {
  breeze.enable
  gtk.enable
  gtk.setBreeze
}
services {
  drkonqi.enable
  plasma-browser-integration.enable
  kwallet.enable
  kwallet.unlock-with-luks
  rebuild-cache-service
}
```
and `environment.plasma6`
```
excludeRequiredPackages
```

## TODO:
- [ ] address added "FIXME"s
  - [ ] warn the user effectively about the potential danger of `excludeRequiredPackages`
  - [ ] conditional security wrapper helpers
  - [ ] dconf setting inconsistently removing expected defaults such as `button-layout`
  - [ ] assert boot.initrd.systemd.enable for the `kwallet.unlock-with-luks` option
- [ ] further modularization 
  - [ ] setting `systemsettings` menus viability as relevant
  ( `environment.etc "xdg/kdeglobals"` `[KDE Control Module Restrictions][$i]` )
    - [ ] users editor when users are immutable, this fail silently otherwise
    - [ ] there are many more examples of this, List to be updated.
  - [ ] baloo/milou
  - [ ] fuse / kio-fuse
  - [ ] timezone etc, polkit exceptions,  hide related settings when not relevant
- [x] enable a exclude option for "required" packages 
( although removing these can break many features, a good amount of them can be safely removed with proper understanding )

user testing would be greatly appreciated as I'm aware my use case is quite limited in scope.
testing can be as simple as
```nix
disabledModules = [ "${modulesPath}/services/desktop-managers/plasma6.nix" ];
imports = [ "${inputs.fsnkty-nixpkgs}/nixos/modules/services/desktop-managers/plasma6.nix" ];
```
thought likely, if you are on nixos-unstable, it will fail to eval as the `union` package is not yet available there as of writing.
hand testing real use cases feels important so while this PR is a draft, or until unstable has the `union` package, the PR wont include it.



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

## official testing & contribution compliance
- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] ~~x86_64-darwin~~
  - [ ] ~~aarch64-darwin~~
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  screen.png looks fine
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [-] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
1 failure, `nixosTests.simple-container`, log file doesn't exist, just a link to a deleted store file.
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [-] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
( fails on a i686 linux eval test? otherwise fine.)  
- [X] Follows the [automation/AI policy].
No LLM/AI written code included or referenced in any commit
No LLM/AI influenced testing or debugging.
LLM/AI assisted research limited to at most duckduckgo search automatic prompts used at most to link to relevant media. unsure if I did or did not follow anything from it. 

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
