### PR TITLE
rdup: 1.1.15 -> 1.1.16-unstable-2024-03-05

### DIFF
--- a/pkgs/by-name/rd/rdup/package.nix
+++ b/pkgs/by-name/rd/rdup/package.nix
@@ -5,28 +5,37 @@
   pkg-config,
   autoreconfHook,
   glib,
-  pcre,
+  pcre2,
+  coreutils,
 }:
 
 stdenv.mkDerivation {
   pname = "rdup";
-  version = "1.1.15";
+  version = "1.1.16-unstable-2024-03-05";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+  enableParallelBuilding = true;
 
   src = fetchFromGitHub {
     owner = "miekg";
     repo = "rdup";
-    rev = "d66e4320cd0bbcc83253baddafe87f9e0e83caa6";
-    sha256 = "0bzyv6qmnivxnv9nw7lnfn46k0m1dlxcjj53zcva6v8y8084l1iw";
+    rev = "fa1c753a107c12b3797204c41779ce2c8d5da45a";
+    hash = "sha256-k+386SrXE0IULP02/aOa5E/F/HWhnD/ttGzFStric5M=";
   };
 
   nativeBuildInputs = [
     autoreconfHook
     pkg-config
+    glib
   ];
+
   buildInputs = [
     glib
-    pcre
+    pcre2
   ];
+
+  installFlags = [ "INSTALL=${coreutils}/bin/install" ];
 
   meta = {
     description = "Only backup program that doesn't make backups";


### PR DESCRIPTION
Upstream has no intention to tag a release (see https://github.com/miekg/rdup/issues/52), so update to get rid of the PCRE dependency. Do other fixups while in the area.

Tracking: #356387.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
