### PR TITLE
ocamlPackages.pbrt: 2.4 → 4.1

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-protoc/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-protoc/default.nix
@@ -1,7 +1,10 @@
 {
+  lib,
+  ocaml,
   buildDunePackage,
   pbrt,
   stdlib-shims,
+  pbrt_services,
 }:
 
 buildDunePackage {
@@ -12,7 +15,8 @@ buildDunePackage {
   buildInputs = [ stdlib-shims ];
   propagatedBuildInputs = [ pbrt ];
 
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "5.1";
+  checkInputs = [ pbrt_services ];
 
   meta = pbrt.meta // {
     description = "Protobuf Compiler for OCaml";

--- a/pkgs/development/ocaml-modules/pbrt/default.nix
+++ b/pkgs/development/ocaml-modules/pbrt/default.nix
@@ -6,15 +6,13 @@
 
 buildDunePackage (finalAttrs: {
   pname = "pbrt";
-  version = "2.4";
-
-  minimalOCamlVersion = "4.03";
+  version = "4.1";
 
   src = fetchFromGitHub {
     owner = "mransan";
     repo = "ocaml-protoc";
-    rev = "${finalAttrs.version}.0";
-    hash = "sha256-EXugdcjALukSjB31zAVG9WiN6GMGXi2jlhHWaZ+p+uM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-UrgrzI5Pgi79C/OhqYxwSNfqsoBULUZ13XVaB71fGes=";
   };
 
   meta = {

--- a/pkgs/development/ocaml-modules/pbrt/services.nix
+++ b/pkgs/development/ocaml-modules/pbrt/services.nix
@@ -1,0 +1,19 @@
+{
+  buildDunePackage,
+  pbrt,
+  pbrt_yojson,
+}:
+
+buildDunePackage {
+  pname = "pbrt_services";
+  inherit (pbrt) version src;
+
+  propagatedBuildInputs = [
+    pbrt
+    pbrt_yojson
+  ];
+
+  meta = pbrt.meta // {
+    description = "Runtime library for ocaml-protoc to support RPC services";
+  };
+}

--- a/pkgs/development/ocaml-modules/pbrt/yojson.nix
+++ b/pkgs/development/ocaml-modules/pbrt/yojson.nix
@@ -1,0 +1,21 @@
+{
+  buildDunePackage,
+  pbrt,
+  base64,
+  yojson,
+}:
+
+buildDunePackage {
+  pname = "pbrt_yojson";
+  inherit (pbrt) version src;
+
+  propagatedBuildInputs = [
+    pbrt
+    base64
+    yojson
+  ];
+
+  meta = pbrt.meta // {
+    description = "Runtime library for ocaml-protoc to support JSON encoding/decoding";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1721,6 +1721,10 @@ let
 
         pbrt = callPackage ../development/ocaml-modules/pbrt { };
 
+        pbrt_services = callPackage ../development/ocaml-modules/pbrt/services.nix { };
+
+        pbrt_yojson = callPackage ../development/ocaml-modules/pbrt/yojson.nix { };
+
         pcre2 = callPackage ../development/ocaml-modules/pcre2 {
           inherit (pkgs) pcre2;
         };


### PR DESCRIPTION
ocamlPackages.ocaml-protoc: 2.4 → 4.1

ocamlPackages.pbrt_services: init at 4.1
ocamlPackages.pbrt_yojson: init at 4.1

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
