### PR TITLE
min: 0.45.0 -> 0.48.1

### DIFF
--- a/pkgs/by-name/mi/min/lock.json
+++ b/pkgs/by-name/mi/min/lock.json
@@ -2,51 +2,63 @@
   "depends": [
     {
       "method": "fetchzip",
-      "path": "/nix/store/6aph9sfwcws7pd2725fwjnibdfrv7qmw-source",
-      "rev": "f8f6bd34bfa3fe12c64b919059ad856a96efcba0",
-      "sha256": "11m1rb6rzk70kvskppf97ddzgf5fnh9crjziqc6hib0jgsm5d615",
-      "url": "https://github.com/nim-lang/checksums/archive/f8f6bd34bfa3fe12c64b919059ad856a96efcba0.tar.gz",
-      "ref": "v0.2.1",
       "packages": [
         "checksums"
       ],
-      "srcDir": "src"
+      "path": "/nix/store/lf1rh0lxv9wgvplp3p1qvwix1mfg46jv-source",
+      "ref": "v0.2.2",
+      "rev": "0845c735a9746188b2257ee2cff672eb6ec26e8a",
+      "sha256": "0bi3kd41zjhx6kk1v7cxrgqdbsw2hf19q7zhqbfs2vk1axvaixf1",
+      "srcDir": "src",
+      "url": "https://github.com/nim-lang/checksums/archive/0845c735a9746188b2257ee2cff672eb6ec26e8a.tar.gz"
     },
     {
       "method": "fetchzip",
-      "path": "/nix/store/9iz31kiizzg76vpcc5jq53rf0wzjvbh8-source",
-      "rev": "21c8e279e257b0bc2a063b34e2304ea3aade21ec",
-      "sha256": "05g7w61ql9kgrmnpm64y94lkiwj36i551c387gc71lz3dpllcn6q",
-      "url": "https://github.com/guzba/zippy/archive/21c8e279e257b0bc2a063b34e2304ea3aade21ec.tar.gz",
-      "ref": "0.5.14",
       "packages": [
         "zippy"
       ],
-      "srcDir": "src"
+      "path": "/nix/store/9iz31kiizzg76vpcc5jq53rf0wzjvbh8-source",
+      "ref": "0.5.14",
+      "rev": "21c8e279e257b0bc2a063b34e2304ea3aade21ec",
+      "sha256": "05g7w61ql9kgrmnpm64y94lkiwj36i551c387gc71lz3dpllcn6q",
+      "srcDir": "src",
+      "url": "https://github.com/guzba/zippy/archive/21c8e279e257b0bc2a063b34e2304ea3aade21ec.tar.gz"
     },
     {
       "method": "fetchzip",
-      "path": "/nix/store/mys0888vyyd12h0qhzg709jk9jb6rmxa-source",
-      "rev": "83e2866422788a1db1906734de056b410a49d047",
-      "sha256": "0g1mcpfx42wnv2sg551gbgfralp7bf9fv83l2inbv2bhb063fx0z",
-      "url": "https://github.com/GULPF/nimquery/archive/83e2866422788a1db1906734de056b410a49d047.tar.gz",
-      "ref": "v2.0.1",
       "packages": [
         "nimquery"
       ],
-      "srcDir": ""
+      "path": "/nix/store/mys0888vyyd12h0qhzg709jk9jb6rmxa-source",
+      "ref": "v2.0.1",
+      "rev": "83e2866422788a1db1906734de056b410a49d047",
+      "sha256": "0g1mcpfx42wnv2sg551gbgfralp7bf9fv83l2inbv2bhb063fx0z",
+      "srcDir": "",
+      "url": "https://github.com/GULPF/nimquery/archive/83e2866422788a1db1906734de056b410a49d047.tar.gz"
     },
     {
       "method": "fetchzip",
-      "path": "/nix/store/bn7iv51yqbqi0h8z1r9v2vmpqnz46yfr-source",
-      "rev": "c138b34bf3c5198c26ecfad5e251fa5d56e5ad48",
-      "sha256": "0wwfhjhwpmanjv4vv9yl0a0mami9x8qzzb5nialcfp9iasbwiqgj",
-      "url": "https://github.com/h3rald/minline/archive/c138b34bf3c5198c26ecfad5e251fa5d56e5ad48.tar.gz",
-      "ref": "v0.1.2",
       "packages": [
         "minline"
       ],
-      "srcDir": "."
+      "path": "/nix/store/bnqsg074x2qggkm4g296p5vkjfil1jap-source",
+      "ref": "v0.1.3",
+      "rev": "bb32a080e34746ee60b7af53bf32b7afefbade8e",
+      "sha256": "1s5xd8w1lgra865zi55b5v94xmg4v8513kaifrzscalcybcy0jvr",
+      "srcDir": ".",
+      "url": "https://git.sr.ht/~h3rald/minline/archive/bb32a080e34746ee60b7af53bf32b7afefbade8e.tar.gz"
+    },
+    {
+      "method": "fetchzip",
+      "packages": [
+        "htmlparser"
+      ],
+      "path": "/nix/store/sv8ydzdf509akbm3b93qlppklgvlx40x-source",
+      "ref": "v0.1.0",
+      "rev": "5ffa3021d78e79f18482192548b8bd835002f7ab",
+      "sha256": "0h3nxnjclqd1gn9q3p9lad4i6ypwdisnbqj6rafm9155ydkc724v",
+      "srcDir": "src",
+      "url": "https://github.com/nim-lang/htmlparser/archive/5ffa3021d78e79f18482192548b8bd835002f7ab.tar.gz"
     }
   ]
 }

--- a/pkgs/by-name/mi/min/package.nix
+++ b/pkgs/by-name/mi/min/package.nix
@@ -1,20 +1,20 @@
 {
   lib,
   buildNimPackage,
-  fetchFromGitHub,
+  fetchFromSourcehut,
   openssl,
   pcre,
 }:
 
 buildNimPackage (finalAttrs: {
   pname = "min";
-  version = "0.45.0";
+  version = "0.48.1";
 
-  src = fetchFromGitHub {
-    owner = "h3rald";
+  src = fetchFromSourcehut {
+    owner = "~h3rald";
     repo = "min";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-Uw03aSFn3EV3H2SkYoYzM5S/WLhEmLV8s3mRF3oT8ro=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MWeyyCZ4jB4iUG7wj2egGMoXhcktcRvam2ym6ZsaGSo=";
   };
 
   lockFile = ./lock.json;
@@ -36,7 +36,6 @@ buildNimPackage (finalAttrs: {
   meta = {
     description = "Functional, concatenative programming language with a minimalist syntax";
     homepage = "https://min-lang.org/";
-    changelog = "https://github.com/h3rald/min/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.mit;
     mainProgram = "min";
   };


### PR DESCRIPTION
Move to the new source hosted on Sourcehut. Made an attempt at removing PCRE, but I think it'll require a bit of upstream grease to be done easily.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
