### PR TITLE
url-parser: 2.1.17 -> 2.1.19

### DIFF
--- a/pkgs/by-name/ur/url-parser/package.nix
+++ b/pkgs/by-name/ur/url-parser/package.nix
@@ -6,16 +6,23 @@
 
 buildGoModule (finalAttrs: {
   pname = "url-parser";
-  version = "2.1.17";
+  version = "2.1.19";
 
   src = fetchFromGitHub {
     owner = "thegeeklab";
     repo = "url-parser";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-/lXMqeiPAf8YLA7ZRkzXYCHztd9YXNM8RHJwsKwxeJY=";
+    hash = "sha256-mHQ93vi10nEJWeAbi3nvBVA2E5EQX/992qGsyJglmmU=";
   };
 
-  vendorHash = "sha256-smSFWfuQ3wq/ZfDwUBIUdb4DBu9TPKtJ5Ttys5xFAsE=";
+  vendorHash = "sha256-2IHNuj4q6aVKmGlXysvieHaP2fqKDGRaYUN0/I1byuI=";
+
+  # buildGoModule puts go in the passthru. NOTE this can be removed once
+  # https://github.com/NixOS/nixpkgs/pull/527289 reaches master.
+  postPatch = ''
+    substituteInPlace go.mod \
+      --replace-fail "go 1.26.4" "go ${finalAttrs.finalPackage.passthru.go.version}"
+  '';
 
   ldflags = [
     "-s"


### PR DESCRIPTION
update to 2.1.19

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
