### PR TITLE
orca-slicer: 2.3.2 -> 2.4.0

### DIFF
--- a/pkgs/by-name/or/orca-slicer/package.nix
+++ b/pkgs/by-name/or/orca-slicer/package.nix
@@ -13,7 +13,7 @@
   curl,
   dbus,
   draco,
-  eigen,
+  eigen_5,
   expat,
   ffmpeg,
   gcc-unwrapped,
@@ -36,7 +36,7 @@
   systemd,
   onetbb,
   webkitgtk_4_1,
-  wxwidgets_3_1,
+  wxwidgets_3_3,
   libx11,
   libnoise,
   withSystemd ? stdenv.hostPlatform.isLinux,
@@ -44,8 +44,7 @@
 }:
 let
   wxGTK' =
-    (wxwidgets_3_1.override {
-      withCurl = true;
+    (wxwidgets_3_3.override {
       withPrivateFonts = true;
       withWebKit = true;
       withEGL = false;
@@ -61,13 +60,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "orca-slicer";
-  version = "2.3.2";
+  version = "2.4.0";
 
   src = fetchFromGitHub {
     owner = "OrcaSlicer";
     repo = "OrcaSlicer";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-c1WTODLrXGtyJWkEueOz5jHhPbA/JFcMeAwhpvoKnKo=";
+    hash = "sha256-ogo+Xuz7yBz9POVKfLofnxwIQavkApPzTIdp/Phu/UU=";
   };
 
   nativeBuildInputs = [
@@ -94,7 +93,7 @@ stdenv.mkDerivation (finalAttrs: {
     curl
     dbus
     draco
-    eigen
+    eigen_5
     expat
     ffmpeg
     gcc-unwrapped
@@ -132,11 +131,11 @@ stdenv.mkDerivation (finalAttrs: {
     ./patches/dont-link-opencv-world-orca.patch
     # The changeset from https://github.com/OrcaSlicer/OrcaSlicer/pull/7650, can be removed when that PR gets merged
     # Allows disabling the update nag screen
-    (fetchpatch {
-      name = "pr-7650-configurable-update-check.patch";
-      url = "https://github.com/OrcaSlicer/OrcaSlicer/commit/d10a06ae11089cd1f63705e87f558e9392f7a167.patch";
-      hash = "sha256-t4own5AwPsLYBsGA15id5IH1ngM0NSuWdFsrxMRXmTk=";
-    })
+    #(fetchpatch {
+    #  name = "pr-7650-configurable-update-check.patch";
+    #  url = "https://github.com/OrcaSlicer/OrcaSlicer/commit/d10a06ae11089cd1f63705e87f558e9392f7a167.patch";
+    #  hash = "sha256-t4own5AwPsLYBsGA15id5IH1ngM0NSuWdFsrxMRXmTk=";
+    #})
 
     # Pick https://github.com/prusa3d/PrusaSlicer/pull/14207 to remove unused and insecure ilmbase dependency
     ./patches/no-ilmbase.patch

--- a/pkgs/by-name/wx/wxwidgets_3_3/package.nix
+++ b/pkgs/by-name/wx/wxwidgets_3_3/package.nix
@@ -27,6 +27,8 @@
   compat32 ? true,
   withMesa ? !stdenv.hostPlatform.isDarwin,
   withWebKit ? true,
+  withEGL ? true,
+  withPrivateFonts ? false,
   webkitgtk_4_1,
 }:
 
@@ -85,6 +87,8 @@ stdenv.mkDerivation (finalAttrs: {
     (if compat32 then "--enable-compat32" else "--disable-compat32")
   ]
   ++ lib.optional withMesa "--with-opengl"
+  ++ lib.optional (!withEGL) "--disable-glcanvasegl"
+  ++ lib.optional withPrivateFonts "--enable-privatefonts"
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     "--with-macosx-version-min=${stdenv.hostPlatform.darwinMinVersion}"
     "--with-osx_cocoa"
@@ -115,7 +119,12 @@ stdenv.mkDerivation (finalAttrs: {
   enableParallelBuilding = true;
 
   passthru = {
-    inherit compat30 compat32;
+    inherit
+      compat30
+      compat32
+      withEGL
+      withPrivateFonts
+      ;
   };
 
   meta = {


### PR DESCRIPTION
Changelog : https://github.com/SoftFever/OrcaSlicer/releases/tag/v2.4.0
Diff : https://github.com/OrcaSlicer/OrcaSlicer/compare/v2.3.2...v2.4.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
