### PR TITLE
nixosTests.wakapi: migrate to systemd-nspawn

### DIFF
--- a/nixos/tests/wakapi.nix
+++ b/nixos/tests/wakapi.nix
@@ -2,8 +2,8 @@
 {
   name = "Wakapi";
 
-  nodes = {
-    wakapiPsql =
+  containers = {
+    psql =
       { pkgs, ... }:
       {
         services.wakapi = {
@@ -32,7 +32,7 @@
         };
       };
 
-    wakapiSqlite =
+    sqlite =
       { pkgs, ... }:
       {
         services.wakapi = {
@@ -61,16 +61,16 @@
   # catch very basic mistakes in the module.
   testScript = ''
     with subtest("Test Wakapi with postgresql backend"):
-      wakapiPsql.start()
-      wakapiPsql.wait_for_unit("wakapi.service")
-      wakapiPsql.wait_for_open_port(3000)
-      wakapiPsql.succeed("curl --fail http://localhost:3000")
+      psql.start()
+      psql.wait_for_unit("wakapi.service")
+      psql.wait_for_open_port(3000)
+      psql.succeed("curl --fail http://localhost:3000")
 
     with subtest("Test Wakapi with sqlite3 backend"):
-      wakapiSqlite.start()
-      wakapiSqlite.wait_for_unit("wakapi.service")
-      wakapiSqlite.wait_for_open_port(3001)
-      wakapiSqlite.succeed("curl --fail http://localhost:3001")
+      sqlite.start()
+      sqlite.wait_for_unit("wakapi.service")
+      sqlite.wait_for_open_port(3001)
+      sqlite.succeed("curl --fail http://localhost:3001")
   '';
 
   meta.maintainers = [ lib.maintainers.NotAShelf ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
