### PR TITLE
fluffychat: 2.6.0 -> 2.7.2

### DIFF
--- a/pkgs/by-name/fl/fluffychat/package.nix
+++ b/pkgs/by-name/fl/fluffychat/package.nix
@@ -3,18 +3,15 @@
   stdenv,
   fetchFromGitHub,
   fetchzip,
-  imagemagick,
   libgbm,
   libdrm,
-  flutter341,
+  flutter344,
   pulseaudio,
   webkitgtk_4_1,
   copyDesktopItems,
   makeDesktopItem,
-
   callPackage,
-  vodozemac-wasm ? callPackage ./vodozemac-wasm.nix { flutter = flutter341; },
-
+  vodozemac-wasm ? callPackage ./vodozemac-wasm.nix { flutter = flutter344; },
   targetFlutterPlatform ? "linux",
 }:
 
@@ -24,28 +21,33 @@ let
     libdrm
   ];
   pubspecLock = lib.importJSON ./pubspec.lock.json;
-  libwebrtc = fetchzip {
-    url = "https://github.com/flutter-webrtc/flutter-webrtc/releases/download/v1.4.0/libwebrtc.zip";
-    sha256 = "sha256-OvqUF6RuytDorJE+C58EnIxPHfcphs8iPiPjt7SDrU0=";
-  };
+  libwebrtc_version = "m144.7559.09";
+  libwebrtc =
+    {
+      x86_64-linux = fetchzip {
+        url = "https://github.com/webrtc-sdk/libwebrtc/releases/download/libwebrtc.${libwebrtc_version}/libwebrtc-linux-x64-release.zip";
+        sha256 = "sha256-uzS07voCGM1zs663UalYpb8pWiYpkrKMxKt/wB4rcB4=";
+      };
+      aarch64-linux = fetchzip {
+        url = "https://github.com/webrtc-sdk/libwebrtc/releases/download/libwebrtc.${libwebrtc_version}/libwebrtc-linux-arm64-release.zip";
+        sha256 = "sha256-nMMU/HrCN4zSB4vO1O4TfJRBtK87OX+zYbxZRq8Q4Us=";
+      };
+    }
+    .${stdenv.hostPlatform.system};
 in
-flutter341.buildFlutterApplication (
+flutter344.buildFlutterApplication (
   rec {
     pname = "fluffychat-${targetFlutterPlatform}";
-    version = "2.6.0";
+    version = "2.7.2";
 
     src = fetchFromGitHub {
       owner = "krille-chan";
       repo = "fluffychat";
       tag = "v${version}";
-      hash = "sha256-iAHJjpDd2RNYPtEqyotFNvW/nybW1ozNtvMTT+wQVVY=";
+      hash = "sha256-faBXPpmcVa2Bes2TITWoHLyFlIAztbI99W7TjdbFxrU=";
     };
 
     inherit pubspecLock;
-
-    gitHashes = {
-      webcrypto = "sha256-yPhL0LoSIaJ9e9wrLtdPuTBRvXft1DQM9KR7WdNcj68=";
-    };
 
     inherit targetFlutterPlatform;
 
@@ -71,7 +73,6 @@ flutter341.buildFlutterApplication (
   }
   // lib.optionalAttrs (targetFlutterPlatform == "linux") {
     nativeBuildInputs = [
-      imagemagick
       copyDesktopItems
       webkitgtk_4_1
     ];
@@ -79,6 +80,7 @@ flutter341.buildFlutterApplication (
     runtimeDependencies = [ pulseaudio ];
 
     env.NIX_LDFLAGS = "-rpath-link ${libwebrtcRpath}";
+    env.CXXFLAGS = "-include cstdint";
 
     desktopItems = [
       (makeDesktopItem {
@@ -105,8 +107,15 @@ flutter341.buildFlutterApplication (
           inherit (src) passthru;
 
           postPatch = ''
+            # Since we directly supply the binary distribution of libwebrtc instead of letting the builder download it we need to check that we still provide the correct version.
+            # nixpkgs forbids import from derivation, so we cannot simply read the contents to fetch the correct version
+            if ! grep -q "binary_version = libwebrtc.${libwebrtc_version}" third_party/libwebrtc_version.ini; then
+              echo -en "\nWrong libwebrtc version is in use!\n\t'libwebrtc.${libwebrtc_version}' was supplied, but cannot be found in 'third_party/libwebrtc_version.ini'.\nflutter_webrtc expects the following version:\n\t"
+              grep "binary_version" third_party/libwebrtc_version.ini; echo
+              false # triggers the build failure
+            fi
             substituteInPlace third_party/CMakeLists.txt \
-              --replace-fail "\''${CMAKE_CURRENT_LIST_DIR}/downloads/libwebrtc.zip" ${libwebrtc}
+              --replace-fail "\''${CMAKE_CURRENT_LIST_DIR}/downloads/\''${LIBWEBRTC_ASSET}.zip" ${libwebrtc}
               ln -s ${libwebrtc} third_party/libwebrtc
           '';
 
@@ -121,24 +130,11 @@ flutter341.buildFlutterApplication (
         };
     };
 
-    # Temporary fix for json deprecation error
-    # https://github.com/juliansteenbakker/flutter_secure_storage/issues/965
-    postPatch = ''
-      substituteInPlace linux/CMakeLists.txt \
-        --replace-fail \
-        "PRIVATE -Wall -Werror" \
-        "PRIVATE -Wall -Werror -Wno-deprecated"
-    '';
-
     postInstall = ''
-      FAV=$out/app/fluffychat-linux/data/flutter_assets/assets/favicon.png
       ICO=$out/share/icons
 
-      for size in 24 32 42 64 128 256 512; do
-        D=$ICO/hicolor/''${size}x''${size}/apps
-        mkdir -p $D
-        magick $FAV -resize ''${size}x''${size} $D/fluffychat.png
-      done
+      mkdir -p $ICO/hicolor/scalable/apps
+      cp $src/assets/logo/vector/logo_standalone.svg $ICO/hicolor/scalable/apps/fluffychat.png
 
       patchelf --add-rpath ${libwebrtcRpath} $out/app/fluffychat-linux/lib/libwebrtc.so
     '';

--- a/pkgs/by-name/fl/fluffychat/pubspec.lock.json
+++ b/pkgs/by-name/fl/fluffychat/pubspec.lock.json
@@ -10,6 +10,16 @@
       "source": "hosted",
       "version": "93.0.0"
     },
+    "analysis_server_plugin": {
+      "dependency": "transitive",
+      "description": {
+        "name": "analysis_server_plugin",
+        "sha256": "5f3920acbd5765764ec9ef6c5bbdd102015424281232ee4fb4f5431c87abb4eb",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.3.7"
+    },
     "analyzer": {
       "dependency": "transitive",
       "description": {
@@ -74,11 +84,11 @@
       "dependency": "transitive",
       "description": {
         "name": "audio_session",
-        "sha256": "8f96a7fecbb718cb093070f868b4cdcb8a9b1053dce342ff8ab2fde10eb9afb7",
+        "sha256": "7217b229db57cc4dc577a8abb56b7429a5a212b978517a5be578704bfe5e568b",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.2.2"
+      "version": "0.2.3"
     },
     "badges": {
       "dependency": "direct main",
@@ -144,11 +154,21 @@
       "dependency": "transitive",
       "description": {
         "name": "canonical_json",
-        "sha256": "d6be1dd66b420c6ac9f42e3693e09edf4ff6edfee26cb4c28c1c019fdb8c0c15",
+        "sha256": "618db0b1ea4238a3ef2f325908beee6269550d73b69dc5220456b75ce3cec072",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.1.2"
+      "version": "1.1.3"
+    },
+    "change_case": {
+      "dependency": "transitive",
+      "description": {
+        "name": "change_case",
+        "sha256": "e41ef3df58521194ef8d7649928954805aeb08061917cf658322305e61568003",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.2.0"
     },
     "characters": {
       "dependency": "transitive",
@@ -184,11 +204,11 @@
       "dependency": "direct main",
       "description": {
         "name": "chewie",
-        "sha256": "53dadd2c5b6748742d7744072b38a417ad22691ca55715850300ee793dc7cb27",
+        "sha256": "5b8f00a9373252ddd2296d0d734b3b754380e6b4728ba848aff40e97fabad339",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.13.1"
+      "version": "1.14.1"
     },
     "cli_config": {
       "dependency": "transitive",
@@ -304,21 +324,21 @@
       "dependency": "transitive",
       "description": {
         "name": "cupertino_icons",
-        "sha256": "ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6",
+        "sha256": "41e005c33bd814be4d3096aff55b1908d419fde52ca656c8c47719ec745873cd",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.0.8"
+      "version": "1.0.9"
     },
     "dart_code_linter": {
       "dependency": "direct dev",
       "description": {
         "name": "dart_code_linter",
-        "sha256": "f0a63317198a495d04cccf98643fa6c2e8838805e370808b11b883a3efee0380",
+        "sha256": "204603d62841d1ca63be9a1b6e4f2da4089d4070d4ca3ef98dd627e79eb49331",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.0.3"
+      "version": "4.1.2"
     },
     "dart_earcut": {
       "dependency": "transitive",
@@ -384,31 +404,31 @@
       "dependency": "transitive",
       "description": {
         "name": "desktop_webview_window",
-        "sha256": "57cf20d81689d5cbb1adfd0017e96b669398a669d927906073b0e42fc64111c0",
+        "sha256": "b6fdae2cbf9571879b1761c12f27facaf82e22d0bdc74d049907c2a09a432957",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.2.3"
+      "version": "0.3.0"
     },
     "device_info_plus": {
       "dependency": "direct main",
       "description": {
         "name": "device_info_plus",
-        "sha256": "b4fed1b2835da9d670d7bed7db79ae2a94b0f5ad6312268158a9b5479abbacdd",
+        "sha256": "6a642e1daa10190af89ba6cb6386c0df7d071a3592080bfe1e44faa63ae1df65",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "12.4.0"
+      "version": "13.1.0"
     },
     "device_info_plus_platform_interface": {
       "dependency": "transitive",
       "description": {
         "name": "device_info_plus_platform_interface",
-        "sha256": "e1ea89119e34903dca74b883d0dd78eb762814f97fb6c76f35e9ff74d261a18f",
+        "sha256": "04b173a92e2d9161dfead145667037c8d834db725ce2e7b942bfe18fd2f45a46",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "7.0.3"
+      "version": "8.1.0"
     },
     "dynamic_color": {
       "dependency": "direct main",
@@ -450,6 +470,16 @@
       "source": "hosted",
       "version": "2.2.0"
     },
+    "ffi_leak_tracker": {
+      "dependency": "transitive",
+      "description": {
+        "name": "ffi_leak_tracker",
+        "sha256": "4093d4ef9ca06ffe2786e73bfb25e22aa92112b9bb4ec941f11e3e6b61489a97",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.1.2"
+    },
     "file": {
       "dependency": "transitive",
       "description": {
@@ -464,11 +494,11 @@
       "dependency": "direct main",
       "description": {
         "name": "file_picker",
-        "sha256": "f13a03000d942e476bc1ff0a736d2e9de711d2f89a95cd4c1d88f861c3348387",
+        "sha256": "fdc6a37f715d19f35b131decf1ce39242eeed5ddae18c0818c3eccb731ab76be",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "11.0.2"
+      "version": "12.0.0-beta.7"
     },
     "file_selector": {
       "dependency": "direct main",
@@ -484,11 +514,11 @@
       "dependency": "transitive",
       "description": {
         "name": "file_selector_android",
-        "sha256": "51e8fd0446de75e4b62c065b76db2210c704562d072339d333bd89c57a7f8a7c",
+        "sha256": "89243030ea4b3463fb402b44d5eeacc4ccb1c46a88870cb2a5080d693200c1ed",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.5.2+4"
+      "version": "0.5.2+6"
     },
     "file_selector_ios": {
       "dependency": "transitive",
@@ -582,6 +612,16 @@
       "source": "hosted",
       "version": "9.2.2"
     },
+    "flutter_launcher_icons": {
+      "dependency": "direct dev",
+      "description": {
+        "name": "flutter_launcher_icons",
+        "sha256": "10f13781741a2e3972126fae08393d3c4e01fa4cd7473326b94b72cf594195e7",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.14.4"
+    },
     "flutter_linkify": {
       "dependency": "direct main",
       "description": {
@@ -606,41 +646,51 @@
       "dependency": "direct main",
       "description": {
         "name": "flutter_local_notifications",
-        "sha256": "0d9035862236fe38250fe1644d7ed3b8254e34a21b2c837c9f539fbb3bba5ef1",
+        "sha256": "a0d7141f14cabcee42967470a858dfc99dd6cfb70d3cab404bacfcafa9e84e70",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "21.0.0"
+      "version": "22.0.1"
     },
     "flutter_local_notifications_linux": {
       "dependency": "transitive",
       "description": {
         "name": "flutter_local_notifications_linux",
-        "sha256": "e0f25e243c6c44c825bbbc6b2b2e76f7d9222362adcfe9fd780bf01923c840bd",
+        "sha256": "9ca97e63776f29ab1b955725c09999fc2c150523269db150c39274f2a43c5a8b",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "8.0.0"
+      "version": "8.0.1"
     },
     "flutter_local_notifications_platform_interface": {
       "dependency": "transitive",
       "description": {
         "name": "flutter_local_notifications_platform_interface",
-        "sha256": "e7db3d5b49c2b7ecc68deba4aaaa67a348f92ee0fef34c8e4b4459dbef0d7307",
+        "sha256": "ff0013eae795e8dc8fad4a8992a209e64d3ba2fbd8bf5e43c36bf448f95bd814",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "11.0.0"
+      "version": "12.0.0"
+    },
+    "flutter_local_notifications_web": {
+      "dependency": "transitive",
+      "description": {
+        "name": "flutter_local_notifications_web",
+        "sha256": "516afaf97a2d1e67a036c6617321b00d205d72f7a67b6eccf936cd565f985878",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.0"
     },
     "flutter_local_notifications_windows": {
       "dependency": "transitive",
       "description": {
         "name": "flutter_local_notifications_windows",
-        "sha256": "3a2654ba104fbb52c618ebed9def24ef270228470718c43b3a6afcd5c81bef0c",
+        "sha256": "6f43bdd03b171b7a90f22647506fea33e2bb12294b7c7c7a3d690e960a382945",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.0.0"
+      "version": "3.1.1"
     },
     "flutter_localizations": {
       "dependency": "direct main",
@@ -658,16 +708,6 @@
       "source": "hosted",
       "version": "8.3.0"
     },
-    "flutter_native_splash": {
-      "dependency": "direct dev",
-      "description": {
-        "name": "flutter_native_splash",
-        "sha256": "4fb9f4113350d3a80841ce05ebf1976a36de622af7d19aca0ca9a9911c7ff002",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.4.7"
-    },
     "flutter_new_badger": {
       "dependency": "direct main",
       "description": {
@@ -682,11 +722,11 @@
       "dependency": "transitive",
       "description": {
         "name": "flutter_plugin_android_lifecycle",
-        "sha256": "ee8068e0e1cd16c4a82714119918efdeed33b3ba7772c54b5d094ab53f9b7fd1",
+        "sha256": "38d1c268de9097ff59cf0e844ac38759fc78f76836d37edad06fa21e182055a0",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.0.33"
+      "version": "2.0.34"
     },
     "flutter_rust_bridge": {
       "dependency": "transitive",
@@ -702,31 +742,31 @@
       "dependency": "direct main",
       "description": {
         "name": "flutter_secure_storage",
-        "sha256": "6848263f9744072d0977347c383fb8b57d9780319a6bf5238b5a2866a029de62",
+        "sha256": "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "10.2.0"
+      "version": "10.3.1"
     },
     "flutter_secure_storage_darwin": {
       "dependency": "transitive",
       "description": {
         "name": "flutter_secure_storage_darwin",
-        "sha256": "67cd1ff671add31dc13e45194398187a04bb63804b37fa47866afae296d73fcb",
+        "sha256": "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.3.1"
+      "version": "0.3.2"
     },
     "flutter_secure_storage_linux": {
       "dependency": "transitive",
       "description": {
         "name": "flutter_secure_storage_linux",
-        "sha256": "2b5c76dce569ab752d55a1cee6a2242bcc11fdba927078fb88c503f150767cda",
+        "sha256": "a5f35ddab43cf5c8215d2feb4ce1957851f28c5c37e6f04335066a0602087bf5",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.0.0"
+      "version": "3.0.1"
     },
     "flutter_secure_storage_platform_interface": {
       "dependency": "transitive",
@@ -752,11 +792,11 @@
       "dependency": "transitive",
       "description": {
         "name": "flutter_secure_storage_windows",
-        "sha256": "3b7c8e068875dfd46719ff57c90d8c459c87f2302ed6b00ff006b3c9fcad1613",
+        "sha256": "471951813a97006d899db4948acc654a4f28c440083ea08178935ce20b173ec1",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.1.0"
+      "version": "4.2.2"
     },
     "flutter_shortcuts_new": {
       "dependency": "direct main",
@@ -788,11 +828,11 @@
       "dependency": "direct main",
       "description": {
         "name": "flutter_web_auth_2",
-        "sha256": "d354998934ddc338e69b999b2abaeb33c6fd09999d3a5f92ead1a6b49b49712e",
+        "sha256": "8f9303471dcd96670878c9b7c0c4e14c37595b2add67465f6a868f17a5872dfc",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "5.0.2"
+      "version": "5.0.3"
     },
     "flutter_web_auth_2_platform_interface": {
       "dependency": "transitive",
@@ -814,11 +854,11 @@
       "dependency": "direct main",
       "description": {
         "name": "flutter_webrtc",
-        "sha256": "c7b0a67ca2c878575fc5c146d801cd874f58f5f1ef5fa6e8eb0c93d413beb948",
+        "sha256": "c4e8db6ed337b8c30d76cd7cd8c91693f5495e1aeb556cbcb73f1e5d5bdcf020",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.4.1"
+      "version": "1.5.1"
     },
     "frontend_server_client": {
       "dependency": "transitive",
@@ -850,41 +890,41 @@
       "dependency": "direct main",
       "description": {
         "name": "geolocator",
-        "sha256": "79939537046c9025be47ec645f35c8090ecadb6fe98eba146a0d25e8c1357516",
+        "sha256": "e146a6d63776582651e97a79cbe459f8e1211b100101fadcd84db83361fa599f",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "14.0.2"
+      "version": "14.0.3"
     },
     "geolocator_android": {
       "dependency": "transitive",
       "description": {
         "name": "geolocator_android",
-        "sha256": "179c3cb66dfa674fc9ccbf2be872a02658724d1c067634e2c427cf6df7df901a",
+        "sha256": "86ea1654e4f61ff51466848e91c116b422d6010ea269fda0fbe1af7e9e742ce1",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "5.0.2"
+      "version": "5.0.3"
     },
     "geolocator_apple": {
       "dependency": "transitive",
       "description": {
         "name": "geolocator_apple",
-        "sha256": "dbdd8789d5aaf14cf69f74d4925ad1336b4433a6efdf2fce91e8955dc921bf22",
+        "sha256": "853803d6bb1713c094e935b4a5ae5f19c0308acf81da13fa9ff84fb4c70c0b73",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.3.13"
+      "version": "2.3.14"
     },
     "geolocator_linux": {
       "dependency": "transitive",
       "description": {
         "name": "geolocator_linux",
-        "sha256": "d64112a205931926f4363bb6bd48f14cb38e7326833041d170615586cd143797",
+        "sha256": "3da7420f11c3496511a5bd3c18fd67b88e5659f12e46b7ce00a788f6996e850a",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.2.4"
+      "version": "0.2.6"
     },
     "geolocator_platform_interface": {
       "dependency": "transitive",
@@ -900,11 +940,11 @@
       "dependency": "transitive",
       "description": {
         "name": "geolocator_web",
-        "sha256": "b1ae9bdfd90f861fde8fd4f209c37b953d65e92823cb73c7dee1fa021b06f172",
+        "sha256": "19e485a0f8d6a88abcf9c53cba3a4105e14b7435ed8ac1c108c067b938fe8429",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.1.3"
+      "version": "4.1.4"
     },
     "geolocator_windows": {
       "dependency": "transitive",
@@ -930,11 +970,11 @@
       "dependency": "direct main",
       "description": {
         "name": "go_router",
-        "sha256": "92d8cee7c57dff0a6c409c05597b460002434eccf7424a712283225b3962d03f",
+        "sha256": "5922b2861e2235a3504896f0d6fa07d84141b480cf52eecd2f42cd25585a9e8a",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "17.2.3"
+      "version": "17.3.0"
     },
     "gsettings": {
       "dependency": "transitive",
@@ -970,11 +1010,11 @@
       "dependency": "transitive",
       "description": {
         "name": "hooks",
-        "sha256": "7a08a0d684cb3b8fb604b78455d5d352f502b68079f7b80b831c62220ab0a4f6",
+        "sha256": "025f060e86d2d4c3c47b56e33caf7f93bf9283340f26d23424ebcfccf34f621e",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.0.1"
+      "version": "1.0.3"
     },
     "html": {
       "dependency": "direct main",
@@ -1050,11 +1090,11 @@
       "dependency": "transitive",
       "description": {
         "name": "image_picker_android",
-        "sha256": "518a16108529fc18657a3e6dde4a043dc465d16596d20ab2abd49a4cac2e703d",
+        "sha256": "d5b3e1774af29c9ab00103afb0d4614070f924d2e0057ac867ec98800114793f",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.8.13+13"
+      "version": "0.8.13+17"
     },
     "image_picker_for_web": {
       "dependency": "transitive",
@@ -1142,6 +1182,26 @@
       "source": "hosted",
       "version": "1.0.5"
     },
+    "jni": {
+      "dependency": "transitive",
+      "description": {
+        "name": "jni",
+        "sha256": "c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.0"
+    },
+    "jni_flutter": {
+      "dependency": "transitive",
+      "description": {
+        "name": "jni_flutter",
+        "sha256": "8b59e590786050b1cd866677dddaf76b1ade5e7bc751abe04b86e84d379d3ba6",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.1"
+    },
     "js": {
       "dependency": "transitive",
       "description": {
@@ -1156,11 +1216,11 @@
       "dependency": "transitive",
       "description": {
         "name": "json_annotation",
-        "sha256": "805fa86df56383000f640384b282ce0cb8431f1a7a2396de92fb66186d8c57df",
+        "sha256": "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.10.0"
+      "version": "4.12.0"
     },
     "just_audio": {
       "dependency": "direct main",
@@ -1262,25 +1322,15 @@
       "source": "hosted",
       "version": "6.1.0"
     },
-    "lists": {
-      "dependency": "transitive",
-      "description": {
-        "name": "lists",
-        "sha256": "4ca5c19ae4350de036a7e996cdd1ee39c93ac0a2b840f4915459b7d0a7d4ab27",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "1.0.1"
-    },
     "logger": {
       "dependency": "transitive",
       "description": {
         "name": "logger",
-        "sha256": "a7967e31b703831a893bbc3c3dd11db08126fe5f369b5c648a36f821979f5be3",
+        "sha256": "25aee487596a6257655a1e091ec2ae66bc30e7af663592cc3a27e6591e05035c",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.6.2"
+      "version": "2.7.0"
     },
     "logging": {
       "dependency": "transitive",
@@ -1296,11 +1346,11 @@
       "dependency": "transitive",
       "description": {
         "name": "markdown",
-        "sha256": "935e23e1ff3bc02d390bad4d4be001208ee92cc217cb5b5a6c19bc14aaa318c1",
+        "sha256": "ee85086ad7698b42522c6ad42fe195f1b9898e4d974a1af4576c1a3a176cada9",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "7.3.0"
+      "version": "7.3.1"
     },
     "matcher": {
       "dependency": "transitive",
@@ -1326,31 +1376,31 @@
       "dependency": "direct main",
       "description": {
         "name": "matrix",
-        "sha256": "734eae63fa4b707999ee9165e0fc7e1205d1fcb37fef9727bb4f79cda460e1ab",
+        "sha256": "e3b629ed935783d3e1b5d348575d10986eb80fb478a0186f21cd5470db710b6f",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "7.1.2"
+      "version": "7.2.4"
     },
     "meta": {
       "dependency": "transitive",
       "description": {
         "name": "meta",
-        "sha256": "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394",
+        "sha256": "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.17.0"
+      "version": "1.18.0"
     },
     "mgrs_dart": {
       "dependency": "transitive",
       "description": {
         "name": "mgrs_dart",
-        "sha256": "fb89ae62f05fa0bb90f70c31fc870bcbcfd516c843fb554452ab3396f78586f7",
+        "sha256": "385e7168ecc77eb545220223c49eef8ab249da7bf57f22781c40a04d23fb196f",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.0.0"
+      "version": "3.0.0"
     },
     "mime": {
       "dependency": "direct main",
@@ -1376,11 +1426,21 @@
       "dependency": "transitive",
       "description": {
         "name": "native_toolchain_c",
-        "sha256": "89e83885ba09da5fdf2cdacc8002a712ca238c28b7f717910b34bcd27b0d03ac",
+        "sha256": "6ba77bb18063eebe9de401f5e6437e95e1438af0a87a3a39084fbd37c90df572",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.17.4"
+      "version": "0.17.6"
+    },
+    "native_toolchain_cmake": {
+      "dependency": "transitive",
+      "description": {
+        "name": "native_toolchain_cmake",
+        "sha256": "cd4865568c57f03c7ab1f138cc5032c5f77825d27083d6f5a3e9bbb3e8014a87",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.2.5"
     },
     "nested": {
       "dependency": "transitive",
@@ -1412,6 +1472,86 @@
       "source": "hosted",
       "version": "9.3.0"
     },
+    "open_file": {
+      "dependency": "direct main",
+      "description": {
+        "name": "open_file",
+        "sha256": "4f9b00d42565249ed4346976bc0d57f91303bec391f6b0b217921277cf8e6e4f",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.0.0"
+    },
+    "open_file_android": {
+      "dependency": "transitive",
+      "description": {
+        "name": "open_file_android",
+        "sha256": "f48a342b0347bf82bebf68c752f5cfce162965ce8449c5ecdafc406d294aa63d",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.0"
+    },
+    "open_file_ios": {
+      "dependency": "transitive",
+      "description": {
+        "name": "open_file_ios",
+        "sha256": "0e3e67dcd12f69888128f533cacc092039627dd4f1d7a95a2826b814ae4ea8aa",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.0"
+    },
+    "open_file_linux": {
+      "dependency": "transitive",
+      "description": {
+        "name": "open_file_linux",
+        "sha256": "efd9c1f9679745cf35a54d21d809a1fe5a1196d4a1353fe2d205ba298ae86dc9",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.0"
+    },
+    "open_file_mac": {
+      "dependency": "transitive",
+      "description": {
+        "name": "open_file_mac",
+        "sha256": "1abe00e65f792b9baa1e15fdf4d44af5e813b1696ac307d71535543122a01e30",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.0"
+    },
+    "open_file_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "open_file_platform_interface",
+        "sha256": "dc302e4bd5c1d77acec4240bd0dbc1d9f2ee6882b1ce52bca5298369da7acf12",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.0"
+    },
+    "open_file_web": {
+      "dependency": "transitive",
+      "description": {
+        "name": "open_file_web",
+        "sha256": "4945221c9ee98a5a6cdf26730fe0fabb3a36c1e423148bff4c32c283079ee532",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.0"
+    },
+    "open_file_windows": {
+      "dependency": "transitive",
+      "description": {
+        "name": "open_file_windows",
+        "sha256": "6a97d8f2a5966fb0a7f613a901f1d502f93456f64e8a7519d3204184413aab79",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.0"
+    },
     "opus_caf_converter_dart": {
       "dependency": "direct main",
       "description": {
@@ -1436,41 +1576,41 @@
       "dependency": "direct main",
       "description": {
         "name": "package_info_plus",
-        "sha256": "468c26b4254ab01979fa5e4a98cb343ea3631b9acee6f21028997419a80e1a20",
+        "sha256": "4bf625947f6c7713ee242296a682e23e44823c09cf9d79e4f1238923c92db852",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "9.0.1"
+      "version": "10.1.0"
     },
     "package_info_plus_platform_interface": {
       "dependency": "transitive",
       "description": {
         "name": "package_info_plus_platform_interface",
-        "sha256": "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086",
+        "sha256": "db762cb2f4f25ee60fb6359773861b0f199e00b90d237bd85a76a1e806b46ef4",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.2.1"
+      "version": "4.1.0"
     },
     "pana": {
       "dependency": "transitive",
       "description": {
         "name": "pana",
-        "sha256": "d7bd85f18a14909f0baab69a13895dc4ff163be51c9884f73a506982adeac57d",
+        "sha256": "847ee5df6ac13fdc6c53d641095de1b25886c973d0b0f0469c73521ebe4602fa",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.23.10"
+      "version": "0.23.12"
     },
     "particles_network": {
       "dependency": "direct main",
       "description": {
         "name": "particles_network",
-        "sha256": "f35f4e2bbd6872c6cff1d13628853d2fb2df6cc83b88c4f4757afe70333f5c6a",
+        "sha256": "afa9c9c70d7f13dcb2a4059edde4b6baa3b9a69ab899712522cbbd68bbd59095",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.9.4"
+      "version": "1.9.5"
     },
     "pasteboard": {
       "dependency": "direct main",
@@ -1496,21 +1636,21 @@
       "dependency": "direct main",
       "description": {
         "name": "path_provider",
-        "sha256": "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd",
+        "sha256": "a7f4874f987173da295a61c181b8ee71dab59b332a486b391babf26a1b884825",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.5"
+      "version": "2.1.6"
     },
     "path_provider_android": {
       "dependency": "transitive",
       "description": {
         "name": "path_provider_android",
-        "sha256": "f2c65e21139ce2c3dad46922be8272bb5963516045659e71bb16e151c93b580e",
+        "sha256": "69cbd515a62b94d32a7944f086b2f82b4ac40a1d45bebfc00813a430ab2dabcd",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.2.22"
+      "version": "2.3.1"
     },
     "path_provider_foundation": {
       "dependency": "transitive",
@@ -1596,11 +1736,11 @@
       "dependency": "transitive",
       "description": {
         "name": "posix",
-        "sha256": "6323a5b0fa688b6a010df4905a56b00181479e6d10534cecfecede2aa55add61",
+        "sha256": "185ef7606574f789b40f289c233efa52e96dead518aed988e040a10737febb07",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.0.3"
+      "version": "6.5.0"
     },
     "pretty_qr_code": {
       "dependency": "direct main",
@@ -1626,11 +1766,11 @@
       "dependency": "transitive",
       "description": {
         "name": "proj4dart",
-        "sha256": "c8a659ac9b6864aa47c171e78d41bbe6f5e1d7bd790a5814249e6b68bc44324e",
+        "sha256": "ddcedc1f7876e62717de43ab3491e2829bdad0b028261805f94aa080967e5859",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.0"
+      "version": "3.0.0"
     },
     "provider": {
       "dependency": "direct main",
@@ -1696,11 +1836,11 @@
       "dependency": "direct main",
       "description": {
         "name": "qr_code_scanner_plus",
-        "sha256": "dae0596b2763c2fd0294f5cfddb1d3a21577ae4dc7fc1449eb5aafc957872f61",
+        "sha256": "2bcf9df32aa639fba07c183b1ab9c3f03eb6b1d688ab4f4f6bc868a75afd824d",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.1"
+      "version": "2.1.2"
     },
     "qr_image": {
       "dependency": "direct main",
@@ -1791,6 +1931,16 @@
       },
       "source": "hosted",
       "version": "1.6.0"
+    },
+    "record_use": {
+      "dependency": "transitive",
+      "description": {
+        "name": "record_use",
+        "sha256": "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.6.0"
     },
     "record_web": {
       "dependency": "transitive",
@@ -1916,21 +2066,21 @@
       "dependency": "direct main",
       "description": {
         "name": "share_plus",
-        "sha256": "223873d106614442ea6f20db5a038685cc5b32a2fba81cdecaefbbae0523f7fa",
+        "sha256": "a857d8b1479250aff6b57a51b2c02d31ca05848d441817c43f1640c885c286c0",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "12.0.2"
+      "version": "13.1.0"
     },
     "share_plus_platform_interface": {
       "dependency": "transitive",
       "description": {
         "name": "share_plus_platform_interface",
-        "sha256": "88023e53a13429bd65d8e85e11a9b484f49d4c190abbd96c7932b74d6927cc9a",
+        "sha256": "7f7ae28cf400d13f811e297ff37742dba83b79e0a6f5dce14eec0248274e6ce9",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.1.0"
+      "version": "7.1.0"
     },
     "shared_preferences": {
       "dependency": "direct main",
@@ -1946,11 +2096,11 @@
       "dependency": "transitive",
       "description": {
         "name": "shared_preferences_android",
-        "sha256": "cbc40be9be1c5af4dab4d6e0de4d5d3729e6f3d65b89d21e1815d57705644a6f",
+        "sha256": "e8d4762b1e2e8578fc4d0fd548cebf24afd24f49719c08974df92834565e2c53",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.4.20"
+      "version": "2.4.23"
     },
     "shared_preferences_foundation": {
       "dependency": "transitive",
@@ -1976,11 +2126,11 @@
       "dependency": "transitive",
       "description": {
         "name": "shared_preferences_platform_interface",
-        "sha256": "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80",
+        "sha256": "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.4.1"
+      "version": "2.4.2"
     },
     "shared_preferences_web": {
       "dependency": "transitive",
@@ -2042,6 +2192,16 @@
       "source": "hosted",
       "version": "3.0.0"
     },
+    "simple_sparse_list": {
+      "dependency": "transitive",
+      "description": {
+        "name": "simple_sparse_list",
+        "sha256": "aa648fd240fa39b49dcd11c19c266990006006de6699a412de485695910fbc1f",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.1.4"
+    },
     "sky_engine": {
       "dependency": "transitive",
       "description": "flutter",
@@ -2092,11 +2252,11 @@
       "dependency": "transitive",
       "description": {
         "name": "sqflite_common",
-        "sha256": "6ef422a4525ecc601db6c0a2233ff448c731307906e92cabc9ba292afaae16a6",
+        "sha256": "1581ffbf7a0e333b380d6a30737d78516b826cb35beb7fb0bf8a3ea0c678b465",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.5.6"
+      "version": "2.5.8"
     },
     "sqflite_common_ffi": {
       "dependency": "direct main",
@@ -2192,11 +2352,11 @@
       "dependency": "transitive",
       "description": {
         "name": "synchronized",
-        "sha256": "c254ade258ec8282947a0acbbc90b9575b4f19673533ee46f2f6e9b3aeefd7c0",
+        "sha256": "63896c27e81b28f8cb4e69ead0d3e8f03f1d1e5fc531a3e579cabed6a2c7c9e5",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.4.0"
+      "version": "3.4.0+1"
     },
     "term_glyph": {
       "dependency": "transitive",
@@ -2212,31 +2372,31 @@
       "dependency": "transitive",
       "description": {
         "name": "test",
-        "sha256": "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7",
+        "sha256": "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.30.0"
+      "version": "1.31.0"
     },
     "test_api": {
       "dependency": "transitive",
       "description": {
         "name": "test_api",
-        "sha256": "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a",
+        "sha256": "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.7.10"
+      "version": "0.7.11"
     },
     "test_core": {
       "dependency": "transitive",
       "description": {
         "name": "test_core",
-        "sha256": "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51",
+        "sha256": "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.6.16"
+      "version": "0.6.17"
     },
     "timezone": {
       "dependency": "transitive",
@@ -2272,11 +2432,11 @@
       "dependency": "transitive",
       "description": {
         "name": "unicode",
-        "sha256": "0f69e46593d65245774d4f17125c6084d2c20b4e473a983f6e21b7d7762218f1",
+        "sha256": "a6f7bcfc8ea1d5ce1f6c0b1c39117a9919f4953edd9fd7a64090a9796c499b57",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.3.1"
+      "version": "1.1.9"
     },
     "unifiedpush": {
       "dependency": "direct main",
@@ -2372,11 +2532,11 @@
       "dependency": "transitive",
       "description": {
         "name": "unorm_dart",
-        "sha256": "5b35bff83fce4d76467641438f9e867dc9bcfdb8c1694854f230579d68cd8f4b",
+        "sha256": "0c69186b03ca6addab0774bcc0f4f17b88d4ce78d9d4d8f0619e30a99ead58e7",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.2.0"
+      "version": "0.3.2"
     },
     "url_launcher": {
       "dependency": "direct main",
@@ -2392,11 +2552,11 @@
       "dependency": "transitive",
       "description": {
         "name": "url_launcher_android",
-        "sha256": "767344bf3063897b5cf0db830e94f904528e6dd50a6dfaf839f0abf509009611",
+        "sha256": "17bc677f0b301615530dd1d67e0a9828cafa2d0b6b6eae4cd3679b7eac4a273c",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.3.28"
+      "version": "6.3.30"
     },
     "url_launcher_ios": {
       "dependency": "transitive",
@@ -2442,11 +2602,11 @@
       "dependency": "transitive",
       "description": {
         "name": "url_launcher_web",
-        "sha256": "d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f",
+        "sha256": "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.4.2"
+      "version": "2.4.3"
     },
     "url_launcher_windows": {
       "dependency": "transitive",
@@ -2462,11 +2622,11 @@
       "dependency": "transitive",
       "description": {
         "name": "uuid",
-        "sha256": "a11b666489b1954e01d992f3d601b1804a33937b5a8fe677bd26b8a9f96f96e8",
+        "sha256": "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.5.2"
+      "version": "4.5.3"
     },
     "vector_math": {
       "dependency": "transitive",
@@ -2502,31 +2662,31 @@
       "dependency": "transitive",
       "description": {
         "name": "video_player_android",
-        "sha256": "e726b33894526cf96a3eefe61af054b0c3e7d254443b3695b3c142dc277291be",
+        "sha256": "877a6c7ba772456077d7bfd71314629b3fe2b73733ce503fc77c3314d43a0ca0",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.9.3"
+      "version": "2.9.5"
     },
     "video_player_avfoundation": {
       "dependency": "transitive",
       "description": {
         "name": "video_player_avfoundation",
-        "sha256": "f93b93a3baa12ca0ff7d00ca8bc60c1ecd96865568a01ff0c18a99853ee201a5",
+        "sha256": "9338f3ec22774f88146b22f13273a446719b1da010fd200c4d1d97802156ac58",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.9.3"
+      "version": "2.9.7"
     },
     "video_player_platform_interface": {
       "dependency": "transitive",
       "description": {
         "name": "video_player_platform_interface",
-        "sha256": "57c5d73173f76d801129d0531c2774052c5a7c11ccb962f1830630decd9f24ec",
+        "sha256": "16eaed5268c571c31840dc58ef8da5f0cd4db2a98490c3b8f1cf70122546c6e0",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.6.0"
+      "version": "6.7.0"
     },
     "video_player_web": {
       "dependency": "transitive",
@@ -2542,11 +2702,11 @@
       "dependency": "transitive",
       "description": {
         "name": "vm_service",
-        "sha256": "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60",
+        "sha256": "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "15.0.2"
+      "version": "15.2.0"
     },
     "vodozemac": {
       "dependency": "transitive",
@@ -2562,21 +2722,21 @@
       "dependency": "direct main",
       "description": {
         "name": "wakelock_plus",
-        "sha256": "ddf3db70eaa10c37558ff817519b85d527dbd21034fd5d8e1c2e85f31588f1c1",
+        "sha256": "824c5bba0f800e86d32e57d3d1843c531f090005cc89d9a837933e6601093d53",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.5.2"
+      "version": "1.6.1"
     },
     "wakelock_plus_platform_interface": {
       "dependency": "transitive",
       "description": {
         "name": "wakelock_plus_platform_interface",
-        "sha256": "24b84143787220a403491c2e5de0877fbbb87baf3f0b18a2a988973863db4b03",
+        "sha256": "b13f99e992e7ae6a152e16c5559d3c07ff445b13330192662494e614ca3e7d7b",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.4.0"
+      "version": "1.5.1"
     },
     "watcher": {
       "dependency": "transitive",
@@ -2619,15 +2779,14 @@
       "version": "3.0.3"
     },
     "webcrypto": {
-      "dependency": "direct overridden",
+      "dependency": "transitive",
       "description": {
-        "path": ".",
-        "ref": "master",
-        "resolved-ref": "dcc7ba78c9721de56a800fda9a9e2bc759b9cad3",
-        "url": "https://github.com/google/webcrypto.dart.git"
+        "name": "webcrypto",
+        "sha256": "9885ed99a846191542dd6ca820c83a098117df56be57453832233a3fef68f3f2",
+        "url": "https://pub.dev"
       },
-      "source": "git",
-      "version": "0.6.0"
+      "source": "hosted",
+      "version": "0.6.1"
     },
     "webdriver": {
       "dependency": "transitive",
@@ -2673,21 +2832,21 @@
       "dependency": "transitive",
       "description": {
         "name": "win32",
-        "sha256": "d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e",
+        "sha256": "ba6f4bba816c8d7e3c1580e170f3786d216951cc6b94babc3b814c08d2cb2738",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "5.15.0"
+      "version": "6.3.0"
     },
     "win32_registry": {
       "dependency": "transitive",
       "description": {
         "name": "win32_registry",
-        "sha256": "6f1b564492d0147b330dd794fee8f512cec4977957f310f9951b5f9d83618dae",
+        "sha256": "73b1d78920a9d6e03f8b4e43e612b87bf3152a0e5c5e5150267762b7c4116904",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.0"
+      "version": "3.0.3"
     },
     "window_manager": {
       "dependency": "transitive",
@@ -2748,10 +2907,20 @@
       },
       "source": "hosted",
       "version": "3.1.3"
+    },
+    "yaml_edit": {
+      "dependency": "transitive",
+      "description": {
+        "name": "yaml_edit",
+        "sha256": "07c9e63ba42519745182b88ca12264a7ba2484d8239958778dfe4d44fe760488",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.2.4"
     }
   },
   "sdks": {
     "dart": ">=3.11.1 <4.0.0",
-    "flutter": ">=3.38.4"
+    "flutter": ">=3.41.0"
   }
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Update fluffychat to 2.7.0 and additional steps to make it work:
- update to flutter344 from flutter341
- flutter-webrtc used to bundle libwebrtc releases with major versions but no longer seems to do so, instead pull libwebrtc directly from source. The necessary version is specified in flutter-webrtc/third-party/libwebrtc_version.ini (Potentially annoying side-effect: libwebrtc releases now depend on the host-platform)
- remove unnecessary webcrypto override (https://github.com/krille-chan/fluffychat/commit/4ff3bb6feadf8b35b2a768e9a5aec6d4882af36c)
- update patch for flutter_webrtc
- https://github.com/juliansteenbakker/flutter_secure_storage/issues/965 was closed and as far as I can tell the patch is no longer necessary
- the icons we relied on before are no longer available; instead install the scalable svg

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
