### PR TITLE
Revert "linux_6_12: 6.12.93 -> 6.12.94"

### DIFF
--- a/pkgs/os-specific/linux/kernel/kernels-org.json
+++ b/pkgs/os-specific/linux/kernel/kernels-org.json
@@ -25,8 +25,8 @@
         "lts": true
     },
     "6.12": {
-        "version": "6.12.94",
-        "hash": "sha256:1ln83ljmc7wr1nrjjq1hp1m1vx54j7i6i15m3hqb73a1p4ra5679",
+        "version": "6.12.93",
+        "hash": "sha256:18sg154hqw8l98pfim2hjm1y604h5dwn9gj3gyncas8bgjl4h9j9",
         "lts": true
     },
     "6.18": {


### PR DESCRIPTION
This reverts commit 2fe2a70111d704638186ee46f2ca71e0bc1f2974.
For now.  It caused -small channel blocking issues; see:
https://github.com/NixOS/nixpkgs/pull/533282#issuecomment-4767071391
