### PR TITLE
opendataloader-pdf: 2.2.1 -> 2.4.7

### DIFF
--- a/pkgs/by-name/op/opendataloader-pdf/package.nix
+++ b/pkgs/by-name/op/opendataloader-pdf/package.nix
@@ -6,9 +6,9 @@
   jre,
 }:
 
-maven.buildMavenPackage rec {
+maven.buildMavenPackage (finalAttrs: {
   pname = "opendataloader-pdf";
-  version = "2.2.1";
+  version = "2.4.7";
 
   strictDeps = true;
   __structuredAttrs = true;
@@ -16,13 +16,13 @@ maven.buildMavenPackage rec {
   src = fetchFromGitHub {
     owner = "opendataloader-project";
     repo = "opendataloader-pdf";
-    tag = "v${version}";
-    hash = "sha256-5ZuVe5QIUyklNi7+pWUuUwoOHs/zv9Yv8EAkww0O7tA=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-qCU0Yb4N0KtbqVSscGLmv0xps4RwR++WxS/A44WwRlk=";
   };
 
-  sourceRoot = "${src.name}/java";
+  sourceRoot = "${finalAttrs.src.name}/java";
 
-  mvnHash = "sha256-op4c5bHt2TY3+aq9oBOhzpyay9Yajo4/Btm0Pscyvzk=";
+  mvnHash = "sha256-LK673DYibhntPsHXvCM676ZzsE7tYIWPlQ2LFoCVvpc=";
   mvnParameters = "-Dproject.build.outputTimestamp=1980-01-01T00:00:02Z";
 
   nativeBuildInputs = [
@@ -35,7 +35,7 @@ maven.buildMavenPackage rec {
     install -Dm644 opendataloader-pdf-cli/target/opendataloader-pdf-cli-0.0.0.jar $out/share/opendataloader-pdf-cli/opendataloader-pdf-cli.jar
 
     mkdir -p $out/bin
-    makeWrapper ${lib.getExe jre} $out/bin/${meta.mainProgram} \
+    makeWrapper ${lib.getExe jre} $out/bin/${finalAttrs.meta.mainProgram} \
       --add-flags "-jar $out/share/opendataloader-pdf-cli/opendataloader-pdf-cli.jar"
 
     runHook postInstall
@@ -44,10 +44,10 @@ maven.buildMavenPackage rec {
   meta = {
     description = "PDF Parser for AI-ready data";
     homepage = "https://github.com/opendataloader-project/opendataloader-pdf";
-    changelog = "https://github.com/opendataloader-project/opendataloader-pdf/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/opendataloader-project/opendataloader-pdf/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ drupol ];
     mainProgram = "opendataloader-pdf";
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
Bumps `opendataloader-pdf` from 2.2.1 to 2.4.7, and switches the derivation from `rec` to the `finalAttrs` pattern.

Extracted from #527061, where `nixpkgs-review` flagged `opendataloader-pdf` as failing to build. The failure is unrelated to that PR. 2.2.1 resolves its verapdf dependency through the version range `[1.31.0,1.32.0-RC)` against verapdf's rolling `vera-dev` repository, so the build is not reproducible. A newer verapdf dev build changed the text-chunk geometry and broke `TableBorderProcessorTest` (`expected "t" but was "st"`), failing the `fetchedMavenDeps` build.

Upstream fixed this by pinning verapdf to a fixed version (`1.31.65` as of 2.4.7), so bumping to 2.4.7 makes the dependency set deterministic and the build pass again.

Changelog: https://github.com/opendataloader-project/opendataloader-pdf/blob/v2.4.7/CHANGELOG.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
