### PR TITLE
picoclaw: add picoclaw-launcher frontend

### DIFF
--- a/pkgs/by-name/pi/picoclaw/frontend.nix
+++ b/pkgs/by-name/pi/picoclaw/frontend.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildNpmPackage,
+  picoclaw,
+
+  fetchPnpmDeps,
+  nodejs,
+  pnpmConfigHook,
+  pnpm_10,
+}:
+let
+  pnpm = pnpm_10;
+in
+buildNpmPackage (finalAttrs: {
+  pname = "picoclaw-launcher-frontend";
+  inherit (picoclaw) src version;
+
+  sourceRoot = "${finalAttrs.src.name}/web/frontend";
+
+  nativeBuildInputs = [
+    nodejs
+    pnpm
+  ];
+
+  npmDeps = null;
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      sourceRoot
+      ;
+    inherit pnpm;
+    fetcherVersion = 4;
+    hash = "sha256-ECZBq/miLE9dkEOx8e8WI68tI0HBb+iFVeztwMVeeKw=";
+  };
+  npmConfigHook = pnpmConfigHook;
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r dist $out
+
+    runHook postInstall
+  '';
+
+  meta = lib.removeAttrs picoclaw.meta [ "mainProgram" ];
+})

--- a/pkgs/by-name/pi/picoclaw/package.nix
+++ b/pkgs/by-name/pi/picoclaw/package.nix
@@ -1,9 +1,11 @@
 {
   lib,
   buildGoModule,
+  callPackage,
   fetchFromGitHub,
   olm,
   versionCheckHook,
+  nix-update-script,
 }:
 
 buildGoModule (finalAttrs: {
@@ -23,6 +25,9 @@ buildGoModule (finalAttrs: {
   buildInputs = [ olm ];
 
   preBuild = ''
+    rm -rf web/backend/dist
+    cp -r ${finalAttrs.passthru.frontend} web/backend/dist
+
     go generate ./...
   '';
 
@@ -31,6 +36,12 @@ buildGoModule (finalAttrs: {
     "-w"
     "-X github.com/sipeed/picoclaw/pkg/config.Version=${finalAttrs.version}"
   ];
+
+  postInstall = ''
+    ln -sf $out/bin/{backend,picoclaw-launcher}
+    install -Dm644 web/picoclaw-launcher.png -t $out/share/icons/hicolor/256x256/apps
+    install -Dm444 web/picoclaw-launcher.desktop -t $out/share/applications
+  '';
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
@@ -48,6 +59,11 @@ buildGoModule (finalAttrs: {
       ];
     in
     [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
+
+  passthru = {
+    frontend = callPackage ./frontend.nix { picoclaw = finalAttrs.finalPackage; };
+    updateScript = nix-update-script { extraArgs = [ "--subpackage=frontend" ]; };
+  };
 
   meta = {
     description = "Tiny, Fast, and Deployable anywhere - automate the mundane, unleash your creativity";


### PR DESCRIPTION
`picoclaw-launcher` lives under `web/`, and because `subPackages` are not set, it is actually built and produces a binary named `backend`.
	

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
