### PR TITLE
sbom-compliance-tool: init at 0.0.11

### DIFF
--- a/pkgs/by-name/lo/lookup-license/package.nix
+++ b/pkgs/by-name/lo/lookup-license/package.nix
@@ -1,0 +1,3 @@
+{ python3Packages }:
+
+python3Packages.toPythonApplication python3Packages.lookup-license

--- a/pkgs/by-name/sb/sbom-compliance-tool/package.nix
+++ b/pkgs/by-name/sb/sbom-compliance-tool/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitea,
+  cyclonedx-python,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "sbom-compliance-tool";
+  version = "0.0.11";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "software-compliance-org";
+    repo = "sbom-compliance-tool";
+    tag = finalAttrs.version;
+    hash = "sha256-6ZaHY1EKjJ78PrCov0wenj5doc93Ot9/yN4hEaagSmE=";
+  };
+
+  postPatch = ''
+    # https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#finding-namespace-packages
+    substituteInPlace setup.py \
+      --replace-fail \
+        "packages=['sbom_compliance_tool']" \
+        "packages=setuptools.find_namespace_packages(include=['sbom_compliance_tool*'])"
+  '';
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    cyclonedx-python
+    foss-flame
+    licomp
+    licomp-toolkit
+    lookup-license
+  ];
+
+  # upstream has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "sbom_compliance_tool"
+    "sbom_compliance_tool.reader"
+  ];
+
+  meta = {
+    description = "Tool to assist your compliance work with SBoM";
+    homepage = "https://codeberg.org/software-compliance-org/sbom-compliance-tool";
+    mainProgram = "sbom_compliance_tool";
+    license = with lib.licenses; [
+      gpl3Only
+      gpl3Plus
+    ];
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/development/python-modules/lookup-license/default.nix
+++ b/pkgs/development/python-modules/lookup-license/default.nix
@@ -1,0 +1,89 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  appdirs,
+  cachetools,
+  diskcache,
+  foss-flame,
+  license-expression,
+  packageurl-python,
+  python-magic,
+  requests,
+  scancode-toolkit,
+  xmltodict,
+
+  # tests
+  pytestCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "lookup-license";
+  version = "0.1.30";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "hesa";
+    repo = "lookup-license";
+    tag = finalAttrs.version;
+    hash = "sha256-zFDqh62bjYkO3Duze3suS8LlrlzuqQes7ZaH+9G+yQ4=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    appdirs
+    cachetools
+    diskcache
+    foss-flame
+    license-expression
+    packageurl-python
+    python-magic
+    requests
+    scancode-toolkit
+    xmltodict
+  ];
+
+  pythonRelaxDeps = [
+    "requests"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    writableTmpDirAsHomeHook
+  ];
+
+  disabledTests = [
+    # UnboundLocalError: cannot access local variable 'ret' where it is not associated with a value
+    "test_lookup_license_url_bad"
+    "test_lookup_license_url_good"
+  ];
+
+  pythonImportsCheck = [
+    "lookup_license"
+  ];
+
+  meta = {
+    description = "Python tool to identify license from license text";
+    homepage = "https://github.com/hesa/lookup-license";
+    changelog = "https://github.com/hesa/lookup-license/releases/tag/${finalAttrs.src.tag}";
+    mainProgram = "lookup-license";
+    license = with lib.licenses; [
+      gpl3Only
+      asl20
+      cc-by-40
+      gpl3Plus
+    ];
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9514,6 +9514,8 @@ self: super: with self; {
 
   london-tube-status = callPackage ../development/python-modules/london-tube-status { };
 
+  lookup-license = callPackage ../development/python-modules/lookup-license { };
+
   lookyloo-models = callPackage ../development/python-modules/lookyloo-models { };
 
   loompy = callPackage ../development/python-modules/loompy { };


### PR DESCRIPTION
[`sbom-compliance`](https://codeberg.org/software-compliance-org/sbom-compliance-tool) is a tool to assist compliance work with SBoM.

Tracking: https://github.com/ngi-nix/projects/issues/1029
Closes: https://github.com/ngi-nix/projects/issues/1104

> [!NOTE]
> Work done as part of the [Nix@NGI](https://nixos.org/community/teams/ngi) packaging effort 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
