### PR TITLE
netbird: 0.74.3 -> 0.75.0

### DIFF
--- a/nixos/modules/services/networking/netbird.nix
+++ b/nixos/modules/services/networking/netbird.nix
@@ -341,7 +341,7 @@ in
                             "$out/share/applications/${mkBin "netbird"}.desktop" \
                           --replace-fail 'Name=Netbird' "Name=NetBird @ ${client.service.name}" \
                           --replace-fail 'Icon=netbird' "Icon=${cfg.ui.package}/share/icons/hicolor/256x256/apps/netbird.png" \
-                          --replace-fail 'Exec=netbird-ui' "Exec=${mkBin "netbird-ui"}"
+                          --replace-fail 'netbird-ui' "${mkBin "netbird-ui"}"
                       '')
                     ];
                   };

--- a/pkgs/by-name/ne/netbird-dashboard/package.nix
+++ b/pkgs/by-name/ne/netbird-dashboard/package.nix
@@ -6,13 +6,13 @@
 
 buildNpmPackage rec {
   pname = "netbird-dashboard";
-  version = "2.90.3";
+  version = "2.90.6";
 
   src = fetchFromGitHub {
     owner = "netbirdio";
     repo = "dashboard";
     rev = "v${version}";
-    hash = "sha256-S/bXB2O5Y+WWDNRtsPrzTSDd5TGpGDxCBCVf3akV8So=";
+    hash = "sha256-QYAodRipH9aS/AiuhecXC0SdTvdYGhjW4uIeTOGhkcQ=";
   };
 
   npmDepsHash = "sha256-A6zXrOPdxLepi7XPn67YsY673iFOAgJqCEynn4SYco8=";

--- a/pkgs/by-name/ne/netbird/package.nix
+++ b/pkgs/by-name/ne/netbird/package.nix
@@ -6,12 +6,12 @@
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
-  pkg-config,
-  gtk3,
-  libayatana-appindicator,
-  libx11,
-  libxcursor,
-  libxxf86vm,
+  wails3,
+  imagemagick,
+  fetchPnpmDeps,
+  nodejs,
+  pnpmConfigHook,
+  pnpm_11,
   versionCheckHook,
   netbird-management,
   netbird-proxy,
@@ -73,39 +73,69 @@ let
 in
 buildGoModule (finalAttrs: {
   pname = "netbird-${componentName}";
-  version = "0.74.3";
+  version = "0.75.0";
 
   src = fetchFromGitHub {
     owner = "netbirdio";
     repo = "netbird";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-JXmtoHe0CwO1nKOPi82+cxhJ3tf3XZUCpDstk8U6s94=";
+    hash = "sha256-1nFpeOWkWZIajjQU1jlSjQoxq+lyvR+rlsAxSV0vJZc=";
   };
 
   overrideModAttrs = final: prev: {
     # override output name so that we don't download the same modules every time
     # for every component of the monorepo
     name = "netbird-${finalAttrs.version}-go-modules";
+
+    # don't call pnpm when building modules
+    dontPnpmConfigure = true;
+    preBuild = null;
   };
 
-  vendorHash = "sha256-5dZu6lmfwaUHusAlFS1qqorFbpa4anCUQDtg4Tv5mxw=";
+  proxyVendor = true;
+  vendorHash = "sha256-KVGCV89qGHrg2GQVw6MnftQswbdihcqozptjf5vs5BA=";
 
-  nativeBuildInputs = [ installShellFiles ] ++ lib.optional (componentName == "ui") pkg-config;
-
-  buildInputs = lib.optionals (stdenv.hostPlatform.isLinux && componentName == "ui") [
-    gtk3
-    libayatana-appindicator
-    libx11
-    libxcursor
-    libxxf86vm
+  nativeBuildInputs = [
+    installShellFiles
+  ]
+  ++ lib.optionals (componentName == "ui") [
+    nodejs
+    pnpmConfigHook
+    pnpm_11
+    wails3
+    # to convert the icons
+    imagemagick
   ];
+
+  pnpmRoot = "client/ui/frontend";
+
+  pnpmDeps = fetchPnpmDeps {
+    pname = "netbird";
+    inherit (finalAttrs)
+      version
+      src
+      ;
+
+    sourceRoot = "${finalAttrs.src.name}/client/ui/frontend";
+
+    pnpm = pnpm_11;
+    fetcherVersion = 4;
+    hash = "sha256-T4E4GJgsoMZnLokJRuDm1L43OrYF99PLF4x/4HRIB4E=";
+  };
+
+  preBuild = lib.optionalString (componentName == "ui") ''
+    pushd client/ui/frontend
+    pnpm run bindings
+    pnpm build
+    popd
+  '';
 
   subPackages = [ component.module ];
 
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/netbirdio/netbird/version.version=v${finalAttrs.version}"
+    "-X github.com/netbirdio/netbird/version.version=${finalAttrs.version}"
     "-X main.builtBy=nix"
   ];
 
@@ -116,7 +146,7 @@ buildGoModule (finalAttrs: {
     # make it compatible with systemd's RuntimeDirectory
     substituteInPlace client/cmd/root.go \
       --replace-fail 'unix:///var/run/netbird.sock' 'unix:///var/run/netbird/sock'
-    substituteInPlace client/ui/client_ui.go \
+    substituteInPlace client/ui/grpc.go \
       --replace-fail 'unix:///var/run/netbird.sock' 'unix:///var/run/netbird/sock'
   '';
 
@@ -138,11 +168,16 @@ buildGoModule (finalAttrs: {
         ''
     # assemble & adjust netbird.desktop files for the GUI
     + lib.optionalString (stdenv.hostPlatform.isLinux && componentName == "ui") ''
-      install -Dm644 "$src/client/ui/assets/netbird-systemtray-connected.png" "$out/share/icons/hicolor/256x256/apps/netbird.png"
-      install -Dm644 "$src/client/ui/build/netbird.desktop" "$out/share/applications/netbird.desktop"
+      install -Dm644 $src/client/ui/build/linux/netbird.desktop $out/share/applications/netbird.desktop
+
+      for RES in 16 24 32 48 64 128 256 512 1024
+      do
+        mkdir -p $out/share/icons/hicolor/"$RES"x"$RES"/apps
+        convert $src/client/ui/build/appicon.png -resize "$RES"x"$RES" $out/share/icons/hicolor/"$RES"x"$RES"/apps/netbird.png
+      done
 
       substituteInPlace $out/share/applications/netbird.desktop \
-        --replace-fail "Exec=/usr/bin/netbird-ui" "Exec=${component.binaryName}"
+        --replace-fail "/usr/bin/netbird-ui" "${component.binaryName}"
     '';
 
   nativeInstallCheckInputs = lib.lists.optionals (component ? versionCheckProgramArg) [

--- a/pkgs/by-name/wa/wails3/package.nix
+++ b/pkgs/by-name/wa/wails3/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  pkg-config,
+  wrapGAppsHook4,
+  webkitgtk_6_0,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "wails3";
+  version = "3.0.0-alpha2.117";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "wailsapp";
+    repo = "wails";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-lGMY+xlhclf+1YWJHiZI8/VVOz8e5bCOAw4XUDzecNI=";
+  };
+
+  proxyVendor = true;
+  vendorHash = "sha256-HXUC9f8B+NA74I6wPf+VdqVpcyE+QoRaVWbYLQqOi1o=";
+
+  subPackages = [ "v3/cmd/wails3" ];
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ webkitgtk_6_0 ];
+
+  # Abuse propagation math a little bit, so when nativeBuildInputs = [ wails3 ],
+  # we also get nativeBuildInputs = [ pkg-config wrapGAppsHook4 ], buildInputs = [ webkitgtk_6_0 ].
+  propagatedBuildInputs = [
+    pkg-config
+    wrapGAppsHook4
+  ];
+  depsTargetTargetPropagated = [ webkitgtk_6_0 ];
+
+  meta = {
+    description = "Build desktop applications using Go & Web Technologies, v3 alpha";
+    homepage = "https://wails.io";
+    license = lib.licenses.mit;
+    mainProgram = "wails3";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Love it when things add alpha dependencies.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
