### PR TITLE
python3Packages.pydantic-yaml: init at 1.8.0

### DIFF
--- a/pkgs/development/python-modules/pydantic-yaml/default.nix
+++ b/pkgs/development/python-modules/pydantic-yaml/default.nix
@@ -1,0 +1,60 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+
+  # build system
+  hatchling,
+  hatch-vcs,
+
+  # dependencies
+  pydantic,
+  ruamel-yaml,
+  typing-extensions,
+
+  # test dependencies
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pydantic-yaml";
+  version = "1.8.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "NowanIlfideme";
+    repo = "pydantic-yaml";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-H4qRYfAGDUhD0pHb+Z5Pi13sXyxv6x+JnW7zPNYHW4s=";
+  };
+
+  build-system = [
+    hatchling
+    hatch-vcs
+  ];
+
+  dependencies = [
+    pydantic
+    ruamel-yaml
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [ "pydantic_yaml" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = {
+    changelog = "https://github.com/pydantic/pydantic-core/releases/tag/${finalAttrs.src.tag}";
+    description = "YAML reading/writing for Pydantic models";
+    homepage = "https://github.com/NowanIlfideme/pydantic-yaml";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      de11n
+      despsyched
+    ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13920,6 +13920,8 @@ self: super: with self; {
 
   pydantic-settings = callPackage ../development/python-modules/pydantic-settings { };
 
+  pydantic-yaml = callPackage ../development/python-modules/pydantic-yaml { };
+
   pydantic-zarr = callPackage ../development/python-modules/pydantic-zarr { };
 
   pydantic_1 = callPackage ../development/python-modules/pydantic/1.nix { };


### PR DESCRIPTION
Re-init after it was removed in #443998. This is required downstream, so it's helpful to be added back in.

Supersedes #468105

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
