### PR TITLE
meta: compare allowed and blocked licenses as strings

### DIFF
--- a/doc/using/configuration.chapter.md
+++ b/doc/using/configuration.chapter.md
@@ -150,6 +150,16 @@ There are several ways to tweak how Nix handles a package which has been marked 
     }
     ```
 
+    License exceptions can also be specified by their SPDX identifiers:
+
+    ```nix
+    {
+      allowlistedLicenses = [
+        "CC-BY-NC-ND-3.0-IGO"
+      ];
+    }
+    ```
+
     Note that `allowlistedLicenses` only applies to unfree licenses unless `allowUnfree` is enabled. It is not a generic allowlist for all types of licenses. `blocklistedLicenses` applies to all licenses.
 
 A complete list of licenses can be found in the file [`nixpkgs/lib/licenses/licenses.nix`](https://github.com/NixOS/nixpkgs/blob/master/lib/licenses/licenses.nix) of the nixpkgs tree.

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -67,8 +67,10 @@ let
     in
     if envVar != "" then envVar != "0" else config.allowNonSource or true;
 
-  allowlist = config.allowlistedLicenses or config.whitelistedLicenses or [ ];
-  blocklist = config.blocklistedLicenses or config.blacklistedLicenses or [ ];
+  licenseId = l: if l ? licenseType then lib.licenses.toSPDX l else l.url or l;
+
+  allowlist = map licenseId (config.allowlistedLicenses or config.whitelistedLicenses or [ ]);
+  blocklist = map licenseId (config.blocklistedLicenses or config.blacklistedLicenses or [ ]);
 
   areLicenseListsValid =
     if mutuallyExclusive allowlist blocklist then
@@ -86,11 +88,11 @@ let
     attrs ? meta.license
     && (
       if isList attrs.meta.license then
-        any (l: elem l list) attrs.meta.license
+        any (l: elem (licenseId l) list) attrs.meta.license
       else if attrs.meta.license ? "licenseType" then
         containsListLicenses attrs.meta.license
       else
-        elem attrs.meta.license list
+        elem (licenseId attrs.meta.license) list
     );
 
   hasAllowlistedLicense = hasListedLicense allowlist;


### PR DESCRIPTION
Reduce the "allowlistedLicenses" and "blocklistedLicenses" config options to lists of string identifiers and compare with package licenses using the same reduction.

This allows these options to be used without pre-importing Nixpkgs to get a license definition. It also makes it simpler to define policy for licenses that are not defined within Nixpkgs.

---

This PR is to prevent tedious PRs about missing licenses that might be used somewhere out-of-tree.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
