### PR TITLE
jchempaint: 3.4-SNAPSHOT-2025-10-15 -> 3.4-SNAPSHOT-2026-04-24

### DIFF
--- a/pkgs/by-name/jc/jchempaint/package.nix
+++ b/pkgs/by-name/jc/jchempaint/package.nix
@@ -13,16 +13,16 @@
 
 maven.buildMavenPackage {
   pname = "jchempaint";
-  version = "3.4-SNAPSHOT-2025-10-15"; # "3.4-SNAPSHOT" is the version given in the pom.xml
+  version = "3.4-SNAPSHOT-2026-04-24"; # "3.4-SNAPSHOT" is the version given in the pom.xml
 
   src = fetchFromGitHub {
     owner = "JChemPaint";
     repo = "jchempaint";
-    rev = "de023b6ddc1a13f5af48fa2acc8a2633c36a30fa";
-    hash = "sha256-1wcJ1qP8yZg1qe4YkpCRGidHUXc1/1eUabR3NoM6kjc=";
+    rev = "f128d0d15be1bac4d324463f269cf130d2211253";
+    hash = "sha256-pcHX6PdnD/jkLxAMSV/Ts8VVrK9xy2NWiMVVJ7jTrQc=";
   };
 
-  mvnHash = "sha256-AGDyXyEEDMjPHMlbcxninkciZ7V/ALMUS/OkgBnni18=";
+  mvnHash = "sha256-VpYSTN5u9IhCakak48HhbwnT3FhMpPKlwRZztiNGEIw=";
 
   nativeBuildInputs = [
     makeWrapper


### PR DESCRIPTION
Bumps `jchempaint` from the 2025-10-15 nightly to the 2026-04-24 nightly.

Extracted from #527061, where `nixpkgs-review` flagged `jchempaint` as failing to build. The failure is unrelated to that PR. The previously pinned nightly depended on `org.openscience.cdk:*:2.12-SNAPSHOT` artifacts, which are no longer published in the upstream Sonatype snapshots repository, so the `fetchedMavenDeps` fixed-output derivation could no longer resolve them.

The current nightly bumped CDK to the released `2.12` (available on Maven Central), so the dependency set is now stable and the build is reproducible again.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
