### PR TITLE
Fix segger jlink update script and update

### DIFF
--- a/pkgs/by-name/se/segger-jlink/source.nix
+++ b/pkgs/by-name/se/segger-jlink/source.nix
@@ -1,33 +1,33 @@
 {
-  version = "874";
+  version = "952";
   x86_64-linux = {
     os = "Linux";
     name = "x86_64";
     ext = "tgz";
-    hash = "sha256-7Ny7G0DXhYTf6MYLmEUT7meYPNMrGLPDdvrVuYyETWA=";
+    hash = "sha256-Nhsu/5RX/c/uSVw9im0K204TjOvm4B7zKFILOmGG7w8=";
   };
   i686-linux = {
     os = "Linux";
     name = "i386";
     ext = "tgz";
-    hash = "sha256-pJ/2KSfoxvXMqAtlXbSXbxGh3zQec0zfZsEbdRw+CMU=";
+    hash = "sha256-4nxRdHjX2iU+v4yE3nhPT1BV/edEmOgV7itmWukWRyw=";
   };
   aarch64-linux = {
     os = "Linux";
     name = "arm64";
     ext = "tgz";
-    hash = "sha256-IgX30NgPAkQ4nsJRbVqTcW7y8XN8prmpG+/S0dpJriE=";
+    hash = "sha256-MFBQpgtE9PA6sXbQV+YOEavvB2vtZ9NOP59EhccLWHw=";
   };
   armv7l-linux = {
     os = "Linux";
     name = "arm";
     ext = "tgz";
-    hash = "sha256-ZU4ibaO0Kg6/fVCthsV+scWdJuENcUHi187XN8OOdcw=";
+    hash = "sha256-KoSgRi8+EQakf+IF5jUx9OWha9cQWbFBC5Rn1Awy9zg=";
   };
   aarch64-darwin = {
     os = "MacOSX";
     name = "arm64";
     ext = "pkg";
-    hash = "sha256-wfK9cV2Ul3LGmqTwerS1+BR0BuhmCFZdXtWykwJqWCM=";
+    hash = "sha256-uglfWXxoKC4yZ/2N4LUFp6ZZin//yWkdtO6LyFv/MkE=";
   };
 }

--- a/pkgs/by-name/se/segger-jlink/update.py
+++ b/pkgs/by-name/se/segger-jlink/update.py
@@ -30,7 +30,7 @@ def find_latest_jlink_version() -> str:
 
     soup = BeautifulSoup(response.text, 'html.parser')
 
-    jlink_download_tile = soup.find(lambda tag: tag.name == 'tbody' and "J-Link Software and Documentation pack" in tag.text)
+    jlink_download_tile = soup.find(lambda tag: tag.name == 'tbody' and "J-Link Software and Documentation Pack" in tag.text)
     version_select = jlink_download_tile.find('select')
     version = next(o.text for o in version_select.find_all('option'))
 


### PR DESCRIPTION
The update.py script was slightly broken. It could not parse the provided webpage correctly because there was a typo in the text it was searching for. Therefore the version was really far behind. So I fixed the script and updated the version.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
