### PR TITLE
canaille: 0.2.7 -> 0.3.6

### DIFF
--- a/nixos/modules/services/security/canaille.nix
+++ b/nixos/modules/services/security/canaille.nix
@@ -15,6 +15,7 @@ let
     mkPackageOption
     types
     getExe
+    getExe'
     optional
     converge
     filterAttrsRecursive
@@ -28,26 +29,32 @@ let
   # Remove null values, so we can document optional/forbidden values that don't end up in the generated TOML file.
   filterConfig = converge (filterAttrsRecursive (_: v: v != null));
 
-  finalPackage = cfg.package.overridePythonAttrs (old: {
-    dependencies =
-      old.dependencies
-      ++ old.optional-dependencies.front
-      ++ old.optional-dependencies.oidc
-      ++ old.optional-dependencies.scim
-      ++ old.optional-dependencies.ldap
-      ++ old.optional-dependencies.sentry
-      ++ old.optional-dependencies.postgresql
-      ++ old.optional-dependencies.otp
-      ++ old.optional-dependencies.sms;
-    makeWrapperArgs = (old.makeWrapperArgs or [ ]) ++ [
-      "--set CANAILLE_CONFIG /etc/canaille/config.toml"
-      "--set SECRETS_DIR \"${secretsDir}\""
-    ];
-  });
+  finalPackage = cfg.package.python.pkgs.toPythonModule (
+    cfg.package.overridePythonAttrs (old: {
+      dependencies =
+        old.dependencies
+        ++ old.optional-dependencies.front
+        ++ old.optional-dependencies.oidc
+        ++ old.optional-dependencies.scim
+        ++ old.optional-dependencies.ldap
+        ++ old.optional-dependencies.sentry
+        ++ old.optional-dependencies.postgresql
+        ++ old.optional-dependencies.otp
+        ++ old.optional-dependencies.sms;
+      makeWrapperArgs = (old.makeWrapperArgs or [ ]) ++ [
+        "--set CANAILLE_CONFIG /etc/canaille/config.toml"
+        "--set SECRETS_DIR \"${secretsDir}\""
+      ];
+    })
+  );
   inherit (finalPackage) python;
   pythonEnv = python.buildEnv.override {
     extraLibs = with python.pkgs; [
-      (toPythonModule finalPackage)
+      finalPackage
+      (gunicorn.overridePythonAttrs (old: {
+        # Allows Gunicorn to set a meaningful process name
+        dependencies = (old.dependencies or [ ]) ++ old.optional-dependencies.setproctitle;
+      }))
       celery
     ];
   };
@@ -308,19 +315,12 @@ in
       };
       serviceConfig = commonServiceConfig // {
         Restart = "on-failure";
-        ExecStart =
-          let
-            gunicorn = python.pkgs.gunicorn.overridePythonAttrs (old: {
-              # Allows Gunicorn to set a meaningful process name
-              dependencies = (old.dependencies or [ ]) ++ old.optional-dependencies.setproctitle;
-            });
-          in
-          ''
-            ${getExe gunicorn} \
-              --name=canaille \
-              --bind='unix:///run/canaille.socket' \
-              'canaille:create_app()'
-          '';
+        ExecStart = ''
+          ${getExe' pythonEnv "gunicorn"} \
+            --name=canaille \
+            --bind='unix:///run/canaille.socket' \
+            'canaille:create_app()'
+        '';
       };
       restartTriggers = [ "/etc/canaille/config.toml" ];
     };

--- a/pkgs/by-name/ca/canaille/package.nix
+++ b/pkgs/by-name/ca/canaille/package.nix
@@ -2,7 +2,6 @@
   lib,
   python3,
   fetchFromGitLab,
-  fetchpatch2,
   openldap,
   nixosTests,
   postgresql,
@@ -11,31 +10,17 @@
 let
   python = python3;
 in
-python.pkgs.buildPythonApplication rec {
+python.pkgs.buildPythonApplication (finalAttrs: {
   pname = "canaille";
-  version = "0.2.7";
+  version = "0.3.4";
   pyproject = true;
 
   src = fetchFromGitLab {
     owner = "yaal";
     repo = "canaille";
-    tag = version;
-    hash = "sha256-hreEjMrD6mRapgrSDPRWcmqfLxfsOpK7dC8lHJkAY7Y=";
+    tag = finalAttrs.version;
+    hash = "sha256-xxfwozkcaWSaY/ohw5FeIN23zAbF6B+1S/Vkq49O0EM=";
   };
-
-  patches = [
-    # Backport authlib 1.7 compatibility.
-    (fetchpatch2 {
-      url = "https://gitlab.com/yaal/canaille/-/commit/b356baa82109a7fdf61a8258572d199ffd3c9604.diff";
-      hash = "sha256-/U6S3h6qIl763ZsGpOm6CVk4NaY3A7mq3PkT193aLEs=";
-    })
-    # Update OIDC tests for authlib 1.7 behavior.
-    (fetchpatch2 {
-      url = "https://gitlab.com/yaal/canaille/-/commit/c1b6d103ebf374cd6a21d9af8376c910c2d0d5d9.diff";
-      hash = "sha256-MjwkUb54ikt1+xUXBTOIBi9E+DmPdwYhw0W0c0prF/Q=";
-      includes = [ "tests/oidc/*" ];
-    })
-  ];
 
   build-system = with python.pkgs; [
     hatchling
@@ -79,7 +64,7 @@ python.pkgs.buildPythonApplication rec {
       time-machine
       pytest-scim2-server
     ]
-    ++ (lib.concatLists (builtins.attrValues optional-dependencies));
+    ++ (lib.concatLists (builtins.attrValues finalAttrs.passthru.optional-dependencies));
 
   postInstall = ''
     mkdir -p $out/etc/schema
@@ -115,14 +100,13 @@ python.pkgs.buildPythonApplication rec {
       flask-talisman
       flask-themer
       isodate
-      pycountry
       pytz
-      tomlkit
       zxcvbn-rs-py
     ];
     oidc = [
       authlib
       joserfc
+      tomlkit
     ];
     scim = [
       authlib
@@ -172,11 +156,11 @@ python.pkgs.buildPythonApplication rec {
   meta = {
     description = "Lightweight Identity and Authorization Management";
     homepage = "https://canaille.readthedocs.io/en/latest/index.html";
-    changelog = "https://gitlab.com/yaal/canaille/-/blob/${src.tag}/CHANGES.rst";
+    changelog = "https://gitlab.com/yaal/canaille/-/blob/${finalAttrs.src.tag}/CHANGES.rst";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ erictapen ];
     mainProgram = "canaille";
   };
 
-}
+})

--- a/pkgs/development/python-modules/periodiq/default.nix
+++ b/pkgs/development/python-modules/periodiq/default.nix
@@ -5,13 +5,12 @@
   uv-build,
   dramatiq,
   pendulum,
-  setuptools,
   pytest-mock,
   pytestCheckHook,
   versionCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "periodiq";
   version = "0.14.0";
   pyproject = true;
@@ -19,7 +18,7 @@ buildPythonPackage rec {
   src = fetchFromGitLab {
     owner = "bersace";
     repo = "periodiq";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-XYQ0cR0gdiX7GePqpMDG/Ml0CK+SBcNbsNB99FZ/D3I=";
   };
 
@@ -28,7 +27,6 @@ buildPythonPackage rec {
   dependencies = [
     dramatiq
     pendulum
-    setuptools
   ];
 
   nativeCheckInputs = [
@@ -37,15 +35,14 @@ buildPythonPackage rec {
     versionCheckHook
   ];
 
-  enabledTestPaths = [ "tests/unit" ];
-
   pythonImportsCheck = [ "periodiq" ];
 
   meta = {
     description = "Simple Scheduler for Dramatiq Task Queue";
     mainProgram = "periodiq";
     homepage = "https://gitlab.com/bersace/periodiq";
+    changelog = "https://gitlab.com/bersace/periodiq/-/blob/${finalAttrs.src.tag}/CHANGELOG.md?ref_type=tags";
     license = lib.licenses.lgpl3Only;
     maintainers = with lib.maintainers; [ traxys ];
   };
-}
+})

--- a/pkgs/development/python-modules/wtforms/default.nix
+++ b/pkgs/development/python-modules/wtforms/default.nix
@@ -18,25 +18,25 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "wtforms";
-  version = "3.2.1";
+  version = "3.3.0b3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "wtforms";
     repo = "wtforms";
-    tag = version;
-    hash = "sha256-jwjP/wkk8MdNJbPE8MlkrH4DyR304Ju41nN4lMo3jFs=";
+    tag = finalAttrs.version;
+    hash = "sha256-h+rzhFPN+N4Jxs9lugvWqNy2eXkXtSCpMW3wp2KgrFk=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     babel
     hatchling
     setuptools
   ];
 
-  propagatedBuildInputs = [ markupsafe ];
+  dependencies = [ markupsafe ];
 
   optional-dependencies = {
     email = [ email-validator ];
@@ -45,14 +45,14 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ]
-  ++ lib.concatAttrValues optional-dependencies;
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
 
   pythonImportsCheck = [ "wtforms" ];
 
   meta = {
     description = "Flexible forms validation and rendering library for Python";
     homepage = "https://github.com/wtforms/wtforms";
-    changelog = "https://github.com/wtforms/wtforms/blob/${version}/CHANGES.rst";
+    changelog = "https://github.com/wtforms/wtforms/blob/${finalAttrs.version}/CHANGES.rst";
     license = lib.licenses.bsd3;
   };
-}
+})


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/pull/518111

Changelog: https://gitlab.com/yaal/canaille/-/blob/0.3.1/CHANGES.rst

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
