### PR TITLE
lenovo-legion: 0.0.20-unstable-2025-07-11 -> 0.0.20-unstable-2026-05-12

### DIFF
--- a/pkgs/by-name/le/lenovo-legion/package.nix
+++ b/pkgs/by-name/le/lenovo-legion/package.nix
@@ -9,14 +9,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "lenovo-legion-app";
-  version = "0.0.20-unstable-2025-07-11";
+  version = "0.0.20-unstable-2026-05-12";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "johnfanv2";
     repo = "LenovoLegionLinux";
-    rev = "f559df04cc0705b2b181dfd0404110a4d1d6e2a9";
-    hash = "sha256-WXGDlykH6aBUVotmDcGZ8Y/zC8iBAv57u3hXRnfTaSo=";
+    rev = "7c19579d13ce686cf1e237699b9a78e80d03c977";
+    hash = "sha256-gTlUrbNKCUQ+g70StlqspDn90wKW2scssKPZqaegzTY=";
   };
 
   sourceRoot = "${src.name}/python/legion_linux";
@@ -38,10 +38,6 @@ python3.pkgs.buildPythonApplication rec {
 
   postPatch = ''
     # only fixup application (legion-linux-gui), service (legiond) currently not installed so do not fixup
-    # version
-    substituteInPlace ./setup.cfg \
-      --replace-fail "_VERSION" "${builtins.head (lib.splitString "-" version)}"
-
     # /etc
     substituteInPlace ./legion_linux/legion.py \
       --replace-fail "/etc/legion_linux" "$out/share/legion_linux"


### PR DESCRIPTION
   Update `lenovo-legion` to the latest upstream `main` commit from 2026-05-12.

   This also updates the shared source used by `linuxPackages.lenovo-legion-module`. The old
 `_VERSION` substitution is no longer needed because upstream now carries the package
 version directly in `setup.cfg`.

   Changelog:
 https://github.com/johnfanv2/LenovoLegionLinux/compare/f559df04cc0705b2b181dfd0404110a4d1d6e2a9...7c19579d13ce686cf1e237699b9a78e80d03c977

   Closes #525082

   Assisted-by: pi coding agent / Mika (OpenAI GPT-5.5)

   ## Things done

   - Built on platform:
     - [x] x86_64-linux
     - [ ] aarch64-linux
     - [ ] x86_64-darwin
     - [ ] aarch64-darwin
   - Tested, as applicable:
     - [ ] [NixOS tests] in [nixos/tests].
     - [ ] [Package tests] at `passthru.tests`.
     - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
   - [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
   - [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
   - Nixpkgs Release Notes
     - [ ] Package update: when the change is major or breaking.
   - NixOS Release Notes
     - [ ] Module addition: when adding a new NixOS module.
     - [ ] Module update: when the change is significant.
   - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other
 READMEs.
   - [x] Follows the [automation/AI policy].

   [NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
   [Package tests]:
 https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
   [nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

   [CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
   [automation/AI policy]:
 https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
   [lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
   [maintainers/README.md]:
 https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
   [nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
   [pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
   [pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test