### PR TITLE
authentik,authentik-outposts: 2025.12.5 -> 2026.5.3, add updateScript

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -38,6 +38,10 @@
 
 - Python 2 has been removed from the top-level package set, as it is long past end-of-life. The `python2`, `python27`, `python2Full`, `python27Full`, `python2Packages`, and `python27Packages` attributes, along with the legacy `python`, `pythonFull`, and `pythonPackages` aliases, now throw an error directing you to `python3`. The `isPy2` and `isPy27` package flags have been removed accordingly. The only remaining Python 2 interpreter is vendored inside the `resholve` package for its `oil` dependency and is not exposed for general use.
 
+- `authentik` has bee updated to `2026.5`, which changes the default service listen settings:
+  - The default listen address has changed from `0.0.0.0` to `[::]`. This might impact IPv4 only setups.
+  - `AUTHENTIK_LISTEN__HTTP` now default to the same address for the server and worker. It must be set to different values or the services will crash.
+
 - `security.polkit.enablePkexecWrapper` has been introduced, making the `pkexec` setuid wrapper opt-in.
 
 - `systemd.user.extraConfig` has been removed in favor of the structured [](#opt-systemd.user.settings.Manager) option. Use `systemd.user.settings.Manager` to set any `systemd-user.conf(5)` option directly. For example, replace `systemd.user.extraConfig = "DefaultTimeoutStartSec=60";` with `systemd.user.settings.Manager.DefaultTimeoutStartSec = 60;`.

--- a/pkgs/by-name/au/authentik/README.md
+++ b/pkgs/by-name/au/authentik/README.md
@@ -1,0 +1,38 @@
+# authentik
+
+## Update Procedure
+
+This section describes a rough outline of the steps needed to update the `authentik` packages.
+
+For minor updates, this could be all that is required for an update, but major version updates
+usually involve updates to the build process and internal dependencies.
+
+- Run `update.py`:
+
+  This will update the version and hashes of the build in two stages:
+
+  1) Update the version and fetch the sources
+
+  2) Try to build all FOD dependencies for `aarch64-linux` and `x86_64-linux`
+
+  For the second step to succeed, you must ensure `nix` can build packages for both systems.
+
+  The script will pass everything after the first `--` and the `NIX_BUILD_ARGS` environment variable
+  to `nix build`, so you can add builders for other systems like so:
+
+  ```
+  -- --builders 'aarch64-builder aarch64-linux - 2 25'
+  ```
+
+  If some of the builds fail, you can restart the script and it will only rebuild the missing ones.
+
+  **Note:**  For the script to function correctly, all FOD's must be independent of another.
+
+  E.g. the `server` component depends on `authentik-django` via `postPatch` and therefore indirectly on `webui` and
+  `webui-deps`. This has to be avoided with `overrideModAttrs.postPatch = ""` for the `goModules` FOD build.
+
+- Ensure the `project.dependencies` from `${src}/pyproject.toml` match the `authentik-django` dependencies.
+
+- Ensure other packages from the `authentik-community` are up-to-date. At the time of writing, this includes:
+
+  - `python-kadmin-rs`

--- a/pkgs/by-name/au/authentik/client-go-config.patch
+++ b/pkgs/by-name/au/authentik/client-go-config.patch
@@ -1,9 +1,0 @@
-diff --git a/config.yaml b/config.yaml
-index 2f07ea7..0f90432 100644
---- a/config.yaml
-+++ b/config.yaml
-@@ -4,3 +4,4 @@ additionalProperties:
-   packageName: api
-   enumClassPrefix: true
-   useOneOfDiscriminatorLookup: true
-+  disallowAdditionalPropertiesIfNotPresent: false

--- a/pkgs/by-name/au/authentik/ldap.nix
+++ b/pkgs/by-name/au/authentik/ldap.nix
@@ -1,24 +1,9 @@
 {
   buildGoModule,
-  authentik,
-  apiGoVendorHook,
-  vendorHash,
+  mkGoOutpost,
 }:
+mkGoOutpost buildGoModule (finalAttrs: {
+  outpostName = "ldap";
 
-buildGoModule {
-  pname = "authentik-ldap-outpost";
-  inherit (authentik) version src;
-  inherit vendorHash;
-
-  nativeBuildInputs = [ apiGoVendorHook ];
-
-  env.CGO_ENABLED = 0;
-
-  subPackages = [ "cmd/ldap" ];
-
-  meta = authentik.meta // {
-    description = "Authentik ldap outpost. Needed for the external ldap API";
-    homepage = "https://goauthentik.io/docs/providers/ldap/";
-    mainProgram = "ldap";
-  };
-}
+  meta.description = "Authentik ldap outpost which is used for the external ldap API";
+})

--- a/pkgs/by-name/au/authentik/outposts.nix
+++ b/pkgs/by-name/au/authentik/outposts.nix
@@ -1,11 +1,8 @@
 {
   callPackage,
-  authentik,
-  apiGoVendorHook ? authentik.apiGoVendorHook,
-  vendorHash ? authentik.proxy.vendorHash,
 }:
 {
-  ldap = callPackage ./ldap.nix { inherit apiGoVendorHook vendorHash; };
-  proxy = callPackage ./proxy.nix { inherit apiGoVendorHook vendorHash; };
-  radius = callPackage ./radius.nix { inherit apiGoVendorHook vendorHash; };
+  ldap = callPackage ./ldap.nix { };
+  proxy = callPackage ./proxy.nix { };
+  radius = callPackage ./radius.nix { };
 }

--- a/pkgs/by-name/au/authentik/package.nix
+++ b/pkgs/by-name/au/authentik/package.nix
@@ -1,653 +1,780 @@
 {
   lib,
-  stdenvNoCC,
-  callPackages,
-  cacert,
+  applyPatches,
   fetchFromGitHub,
-  buildGoModule,
-  bash,
-  chromedriver,
+  newScope,
   nodejs_24,
-  python3,
-  makeWrapper,
-  openapi-generator-cli,
-  go,
-  typescript,
-  makeSetupHook,
-  writeShellScript,
+  python314,
 }:
+# Use makeScope to allow overriding the attributes of all dependencies.
+#
+# Example overlays:
+#
+# ```
+# (final: prev: {
+#   authentik = prev.authentik.overrideScope (finalScope: prevScope: {
+#     core = prevScope.core.overrideAttrs { ... };
+#   });
+# })
+# ```
+#
+# ```
+# (final: prev: {
+#   authentik = prev.authentik.appendPythonDependencies (ps: [ps.pillow]);
+# })
+# ```
+(lib.makeScope newScope (
+  scope:
+  let
+    source = lib.fromJSON (lib.readFile ./source.json);
 
-let
-  nodejs = nodejs_24;
+    inherit (scope) callPackage;
 
-  version = "2025.12.6";
+    mkPackageBuilder =
+      exts: mkDerivation: userFn:
+      mkDerivation (lib.extends (lib.composeManyExtensions exts) userFn);
 
-  src = fetchFromGitHub {
-    owner = "goauthentik";
-    repo = "authentik";
-    tag = "version/${version}";
-    hash = "sha256-uIg47z4LaCawF/5ir4mKE6DpDnEpQ8DuObCNaq6TcYk=";
-  };
+    # Set some meta defaults
+    defaultsLayer = finalAttrs: prevAttrs: {
+      version = prevAttrs.version or scope.version;
+      pos = builtins.unsafeGetAttrPos "pname" prevAttrs;
+      meta = prevAttrs.meta or { } // {
+        description = prevAttrs.meta.description or "Authentication glue you need";
+        changelog =
+          prevAttrs.meta.changelog
+            or "https://github.com/goauthentik/authentik/releases/tag/version%2F${finalAttrs.version}";
+        homepage = prevAttrs.meta.homepage or "https://goauthentik.io/";
+        license = prevAttrs.meta.license or lib.licenses.mit;
+        platforms =
+          prevAttrs.meta.platforms or [
+            "aarch64-linux"
+            "x86_64-linux"
+          ];
+        maintainers =
+          prevAttrs.meta.maintainers or (with lib.maintainers; [
+            jvanbruegge
+            risson
+          ]);
+      };
+    };
 
-  meta = {
-    description = "Authentication glue you need";
-    changelog = "https://github.com/goauthentik/authentik/releases/tag/version%2F${version}";
-    homepage = "https://goauthentik.io/";
-    license = lib.licenses.mit;
-    platforms = [
-      "aarch64-linux"
-      "x86_64-linux"
+    # Apply the final source tree and sourceRoot
+    sourceLayer = finalAttrs: prevAttrs: {
+      src = scope.patchedSrc;
+      sourceRoot =
+        if prevAttrs ? sourceDir then "${scope.patchedSrc.name}/${prevAttrs.sourceDir}" else "";
+      sourceDir = null;
+    };
+
+    # Replace the bundled API clients with source build ones.
+    withClientsLayer = finalAttrs: prevAttrs: {
+      postUnpack =
+        let
+          packages = "${finalAttrs.src.name}/packages";
+          webPackages = "${finalAttrs.src.name}/web/packages";
+        in
+        (prevAttrs.postUnpack or "")
+        + ''
+          chmod u+w ${packages}
+          chmod -R u+w ${packages}/client-{go,rust,ts}
+          rm -rf ${packages}/client-{go,rust,ts}
+          cp -r ${scope.client-go} ${packages}/client-go
+          cp -r ${scope.client-rust} ${packages}/client-rust
+          cp -r ${scope.client-ts} ${packages}/client-ts
+
+          chmod u+w ${webPackages}
+          chmod -R u+w ${webPackages}/client-ts
+          rm -rf ${webPackages}/client-ts
+          cp -r ${scope.client-ts} ${webPackages}/client-ts
+        '';
+    };
+
+    # Apply defaults shared by all Go outposts
+    goOutpostLayer = finalAttrs: prevAttrs: {
+      outpostName = null;
+
+      pos = builtins.unsafeGetAttrPos "outpostName" prevAttrs;
+
+      pname = "authentik-${prevAttrs.outpostName}-outpost";
+
+      inherit (scope.server) vendorHash;
+
+      env.CGO_ENABLED = 0;
+
+      subPackages = [ "cmd/${prevAttrs.outpostName}" ];
+
+      meta = prevAttrs.meta or { } // {
+        homepage =
+          prevAttrs.meta.homepage or "https://goauthentik.io/docs/providers/${prevAttrs.outpostName}/";
+        mainProgram = prevAttrs.meta.mainProgram or prevAttrs.outpostName;
+      };
+    };
+  in
+  {
+    mkComponent = mkPackageBuilder [
+      defaultsLayer
+      sourceLayer
     ];
-    maintainers = with lib.maintainers; [
-      jvanbruegge
-      risson
-    ];
-  };
 
-  client-go = stdenvNoCC.mkDerivation {
-    pname = "authentik-client-go";
-    version = "3.${version}";
-    inherit meta;
+    mkComponentWithClients = mkPackageBuilder [
+      defaultsLayer
+      sourceLayer
+      withClientsLayer
+    ];
+
+    mkGoOutpost = mkPackageBuilder [
+      defaultsLayer
+      sourceLayer
+      withClientsLayer
+      goOutpostLayer
+    ];
+
+    nodejs = nodejs_24;
+
+    inherit (source.authentik) version;
 
     src = fetchFromGitHub {
       owner = "goauthentik";
-      repo = "client-go";
-      tag = "v3.2025.12.4";
-      hash = "sha256-+/CfOE2HkBU+ZddvdXGenB/z8xNFk8cujpZpMXyh3cY=";
+      repo = "authentik";
+      tag = "version/${source.authentik.version}";
+      hash = source.authentik.hash;
     };
 
-    patches = [
-      ./client-go-config.patch
-    ];
-
-    postPatch = ''
-      substituteInPlace ./config.yaml \
-        --replace-fail '/local' "$(pwd)"
-    '';
-
-    nativeBuildInputs = [
-      openapi-generator-cli
-      go
-    ];
-
-    buildPhase = ''
-      runHook preBuild
-
-      openapi-generator-cli generate \
-        -i ${src}/schema.yml -o $out \
-        -g go \
-        -c ./config.yaml
-
-      gofmt -w $out
-
-      runHook postBuild
-    '';
-
-    installPhase = ''
-      runHook preInstall
-
-      cp go.mod go.sum $out
-
-      cd $out
-      rm -rf test
-      rm -f .travis.yml git_push.sh
-
-      runHook postInstall
-    '';
-  };
-
-  client-ts = stdenvNoCC.mkDerivation {
-    pname = "authentik-client-ts";
-    inherit version src meta;
-
-    postPatch = ''
-      substituteInPlace ./scripts/api/ts-config.yaml \
-        --replace-fail '/local' "$(pwd)"
-    '';
-
-    nativeBuildInputs = [
-      nodejs
-      openapi-generator-cli
-      typescript
-    ];
-
-    buildPhase = ''
-      runHook preBuild
-
-      openapi-generator-cli generate \
-        -i ./schema.yml -o $out \
-        -g typescript-fetch \
-        -c ./scripts/api/ts-config.yaml \
-        --additional-properties=npmVersion=${version} \
-        --git-repo-id authentik --git-user-id goauthentik
-
-      cd $out
-      npm run build
-
-      runHook postBuild
-    '';
-  };
-
-  # prefetch-npm-deps does not save all dependencies even though the lockfile is fine
-  website-deps = stdenvNoCC.mkDerivation {
-    pname = "authentik-website-deps";
-    inherit src version meta;
-
-    sourceRoot = "${src.name}/website";
-
-    outputHash =
-      {
-        "aarch64-linux" = "sha256-EbLneRDCyLLLBOZ2DUDpf2TbZoTL8QMXP4WlAZEzS90=";
-        "x86_64-linux" = "sha256-yDjwN/+lX2i9WYDXq4yWwf9o8nA4342iHDDQH4Jt7eQ=";
-      }
-      .${stdenvNoCC.hostPlatform.system} or (throw "authentik-website-deps: unsupported host platform");
-
-    outputHashMode = "recursive";
-
-    nativeBuildInputs = [
-      nodejs
-      cacert
-    ];
-
-    buildPhase = ''
-      npm ci --cache ./cache
-
-      rm -r ./cache node_modules/.package-lock.json
-    '';
-
-    # dependencies of workspace projects are installed into separate node_modules folders with
-    # symlinks between them, so we have to copy all of them
-    installPhase = ''
-      mkdir $out
-      echo "Copying node_modules folders:"
-      find -type d -name node_modules -prune -print -exec mkdir -p $out/{} \; -exec cp -rT {} $out/{} \;
-    '';
-
-    dontCheckForBrokenSymlinks = true;
-    dontPatchShebangs = true;
-  };
-
-  website = stdenvNoCC.mkDerivation {
-    pname = "authentik-website";
-    inherit src version meta;
-
-    nativeBuildInputs = [ nodejs ];
-
-    sourceRoot = "${src.name}/website";
-
-    buildPhase = ''
-      runHook preBuild
-
-      buildRoot=$PWD
-      pushd ${website-deps}
-      find -type d -name node_modules -prune -print -exec cp -rT {} $buildRoot/{} \;
-      popd
-
-      chmod -R +w node_modules
-
-      pushd node_modules/.bin
-      patchShebangs $(readlink docusaurus) $(readlink run-s)
-      popd
-      npm run build:api
-
-      runHook postBuild
-    '';
-
-    installPhase = ''
-      mkdir $out
-      cp -r api/build $out/help
-    '';
-  };
-
-  # prefetch-npm-deps does not save all dependencies even though the lockfile is fine
-  webui-deps = stdenvNoCC.mkDerivation {
-    pname = "authentik-webui-deps";
-    inherit src version meta;
-
-    sourceRoot = "${src.name}/web";
-
-    outputHash =
-      {
-        "aarch64-linux" = "sha256-J9wGQe7iMfKznNk3woqi0VNVNA/dE6TGi2f44DOlG1c=";
-        "x86_64-linux" = "sha256-9Q590Rw0mk3q5osxOKGWU7+XtKwkTyA+CLC2LxAA/3g=";
-      }
-      .${stdenvNoCC.hostPlatform.system} or (throw "authentik-webui-deps: unsupported host platform");
-    outputHashMode = "recursive";
-
-    nativeBuildInputs = [
-      nodejs
-      cacert
-    ];
-
-    buildPhase = ''
-      npm ci --cache ./cache --ignore-scripts
-
-      rm -r ./cache node_modules/.package-lock.json
-    '';
-
-    # dependencies of workspace projects are installed into separate node_modules folders with
-    # symlinks between them, so we have to copy all of them
-    installPhase = ''
-      mkdir $out
-      echo "Copying node_modules folders:"
-      find -type d -name node_modules -prune -print -exec mkdir -p $out/{} \; -exec cp -rT {} $out/{} \;
-    '';
-
-    dontCheckForBrokenSymlinks = true;
-    dontPatchShebangs = true;
-  };
-
-  webui = stdenvNoCC.mkDerivation {
-    pname = "authentik-webui";
-    inherit src version meta;
-
-    sourceRoot = "${src.name}/web";
-
-    nativeBuildInputs = [
-      nodejs
-    ];
-
-    postPatch = ''
-      substituteInPlace packages/core/version/node.js \
-        --replace-fail 'import PackageJSON from "../../../../package.json" with { type: "json" };' "" \
-        --replace-fail '(PackageJSON.version);' '"${version}";'
-    '';
-
-    buildPhase = ''
-      runHook preBuild
-
-      buildRoot=$PWD
-      pushd ${webui-deps}
-      find -type d -name node_modules -prune -print -exec cp -rT {} $buildRoot/{} \;
-      popd
-
-      chmod -R +w node_modules/@goauthentik
-      rm -R node_modules/@goauthentik/api
-      ln -sn ${client-ts} node_modules/@goauthentik/api
-
-      pushd node_modules/.bin
-      patchShebangs $(readlink rollup)
-      patchShebangs $(readlink wireit)
-      patchShebangs $(readlink lit-localize)
-      popd
-
-      npm run build
-
-      runHook postBuild
-    '';
-
-    CHROMEDRIVER_FILEPATH = lib.getExe chromedriver;
-
-    installPhase = ''
-      runHook preInstall
-      mkdir $out
-      cp -r dist $out/dist
-      cp -r authentik $out/authentik
-      runHook postInstall
-    '';
-
-    NODE_ENV = "production";
-    NODE_OPTIONS = "--openssl-legacy-provider";
-
-    npmInstallFlags = [
-      "--include=dev"
-      "--ignore-scripts"
-    ];
-  };
-
-  python = python3.override {
-    self = python;
-    packageOverrides = final: prev: {
-      # https://github.com/goauthentik/authentik/pull/16324
-      django = final.django_5;
-
-      ak-guardian = final.buildPythonPackage {
-        pname = "ak-guardian";
-        inherit version src meta;
-        pyproject = true;
-
-        sourceRoot = "${src.name}/packages/ak-guardian";
-
-        build-system = with final; [ hatchling ];
-
-        propagatedBuildInputs = with final; [
-          django
-          typing-extensions
-        ];
-      };
-
-      django-channels-postgres = final.buildPythonPackage {
-        pname = "django-channels-postgres";
-        inherit version src meta;
-        pyproject = true;
-
-        sourceRoot = "${src.name}/packages/django-channels-postgres";
-
-        build-system = with final; [ hatchling ];
-
-        propagatedBuildInputs =
-          with final;
-          [
-            channels
-            django
-            django-pgtrigger
-            msgpack
-            psycopg
-            structlog
-          ]
-          ++ psycopg.optional-dependencies.pool;
-      };
-
-      django-dramatiq-postgres = final.buildPythonPackage {
-        pname = "django-dramatiq-postgres";
-        inherit version src meta;
-        pyproject = true;
-
-        sourceRoot = "${src.name}/packages/django-dramatiq-postgres";
-
-        build-system = with final; [ hatchling ];
-
-        propagatedBuildInputs =
-          with final;
-          [
-            cron-converter
-            django
-            django-pglock
-            django-pgtrigger
-            dramatiq
-            structlog
-            tenacity
-          ]
-          ++ dramatiq.optional-dependencies.watch;
-      };
-
-      django-postgres-cache = final.buildPythonPackage {
-        pname = "django-postgres-cache";
-        inherit version src meta;
-        pyproject = true;
-
-        sourceRoot = "${src.name}/packages/django-postgres-cache";
-
-        build-system = with final; [ hatchling ];
-
-        propagatedBuildInputs = with final; [
-          django
-          django-postgres-extra
-        ];
-      };
-
-      # Running authentik currently requires a custom version.
-      # Look in `pyproject.toml` for changes to the rev in the `[tool.uv.sources]` section.
-      # See https://github.com/goauthentik/authentik/pull/14057 for latest version bump.
-      djangorestframework = final.buildPythonPackage {
-        pname = "djangorestframework";
-        version = "3.16.0";
-        format = "setuptools";
-
-        src = fetchFromGitHub {
-          owner = "authentik-community";
-          repo = "django-rest-framework";
-          rev = "896722bab969fabc74a08b827da59409cf9f1a4e";
-          hash = "sha256-YrEDEU3qtw/iyQM3CoB8wYx57zuPNXiJx6ZjrIwnCNU=";
-        };
-
-        propagatedBuildInputs = with final; [
-          django
-          pytz
-        ];
-
-        nativeCheckInputs = with final; [
-          pytest-django
-          pytest7CheckHook
-
-          # optional tests
-          coreapi
-          django-guardian
-          inflection
-          pyyaml
-          uritemplate
-        ];
-
-        disabledTests = [
-          "test_ignore_validation_for_unchanged_fields"
-          "test_invalid_inputs"
-          "test_shell_code_example_rendering"
-          "test_unique_together_condition"
-          "test_unique_together_with_source"
-        ];
-
-        pythonImportsCheck = [ "rest_framework" ];
-      };
-
-      # authentik is currently not compatible with v1.18 and fails with the following error:
-      # > AttributeError: 'Namespace' object has no attribute 'worker_fork_timeout'. Did you mean: 'worker_shutdown_timeout'?
-      dramatiq = prev.dramatiq.overrideAttrs (_: rec {
-        version = "1.17.1";
-
-        src = fetchFromGitHub {
-          owner = "Bogdanp";
-          repo = "dramatiq";
-          tag = "v${version}";
-          hash = "sha256-NeUGhG+H6r+JGd2qnJxRUbQ61G7n+3tsuDugTin3iJ4=";
-        };
-      });
-
-      authentik-django = final.buildPythonPackage {
-        pname = "authentik-django";
-        inherit version src meta;
-        pyproject = true;
-
-        postPatch = ''
-          substituteInPlace authentik/root/settings.py \
-            --replace-fail 'Path(__file__).absolute().parent.parent.parent' "Path(\"$out\")"
-          substituteInPlace authentik/lib/default.yml \
-            --replace-fail '/blueprints' "$out/blueprints"
-          substituteInPlace authentik/stages/email/utils.py \
-            --replace-fail 'web/' '${webui}/'
-          # allways allow file upload if the data directoy exists
-          substituteInPlace authentik/admin/files/backends/file.py \
-            --replace-fail "and (self._base_dir.is_mount() or (self._base_dir / self.usage.value).is_mount())" ""
-        '';
-
-        build-system = [
-          final.hatchling
-        ];
-
-        pythonRemoveDeps = [ "dumb-init" ];
-
-        pythonRelaxDeps = true;
-
-        dependencies =
-          with final;
-          [
-            ak-guardian
-            argon2-cffi
-            cachetools
-            channels
-            cryptography
-            dacite
-            deepmerge
-            defusedxml
-            django
-            django-channels-postgres
-            django-countries
-            django-cte
-            django-dramatiq-postgres
-            django-filter
-            django-model-utils
-            django-pglock
-            django-pgtrigger
-            django-postgres-cache
-            django-postgres-extra
-            django-prometheus
-            django-storages
-            django-tenants
-            djangoql
-            djangorestframework
-            docker
-            drf-orjson-renderer
-            drf-spectacular
-            duo-client
-            fido2
-            geoip2
-            geopy
-            google-api-python-client
-            gunicorn
-            gssapi
-            jsonpatch
-            jwcrypto
-            kubernetes
-            ldap3
-            lxml
-            msgraph-sdk
-            opencontainers
-            packaging
-            paramiko
-            psycopg
-            pydantic
-            pydantic-scim
-            pyjwt
-            pyrad
-            python-kadmin-rs
-            pyyaml
-            requests-oauthlib
-            scim2-filter-parser
-            sentry-sdk
-            service-identity
-            setproctitle
-            structlog
-            swagger-spec-validator
-            twilio
-            ua-parser
-            unidecode
-            urllib3
-            uvicorn
-            watchdog
-            webauthn
-            wsproto
-            xmlsec
-            zxcvbn
-          ]
-          ++ django-storages.optional-dependencies.s3
-          ++ psycopg.optional-dependencies.c
-          ++ psycopg.optional-dependencies.pool
-          ++ uvicorn.optional-dependencies.standard;
-
-        postInstall = ''
-          mkdir -p $out/web $out/website
-          cp -r lifecycle manage.py $out/${prev.python.sitePackages}/
-          cp -r blueprints $out/
-          cp -r ${webui}/dist ${webui}/authentik $out/web/
-          cp -r ${website} $out/website/help
-          ln -s $out/${prev.python.sitePackages}/authentik $out/authentik
-          ln -s $out/${prev.python.sitePackages}/lifecycle $out/lifecycle
-        '';
-      };
-    };
-  };
-
-  inherit (python.pkgs) authentik-django;
-
-  # Provide a setup-hook to configure the Go vendor directory with up-to-date API bindings.
-  # This is done to avoid the `vendorHash` depending on anything in the `client-go` build (e.g.
-  # openapi-generator-cli version updates changing the produced content) and invalidating the hash.
-  apiGoVendorHook =
-    makeSetupHook
-      {
-        name = "authentik-api-go-vendor-hook";
-      }
-      (
-        writeShellScript "authentik-api-go-vendor-hook" ''
-          authentikApiGoVendorHook() {
-            chmod -R +w vendor/goauthentik.io/api
-            rm -rf vendor/goauthentik.io/api/v3
-            cp -r ${client-go} vendor/goauthentik.io/api/v3
-
-            echo "Finished authentikApiGoVendorHook"
-          }
-
-          # don't run for FOD, e.g. the `goModules` build
-          if [ -z ''${outputHash-} ]; then
-            postConfigureHooks+=(authentikApiGoVendorHook)
-          fi
-        ''
+    patches = [ ];
+
+    # Add additional patches to apply to the authentik source tree.
+    appendPatches =
+      patches:
+      scope.overrideScope (
+        finalScope: prevScope: {
+          patches = prevScope.patches ++ patches;
+        }
       );
 
-  proxy = buildGoModule {
-    pname = "authentik-proxy";
-    inherit version src meta;
+    patchedSrc =
+      if scope.patches == [ ] then
+        scope.src
+      else
+        applyPatches {
+          name = "${scope.src.name or "authentik-source"}-patched";
+          inherit (scope) src patches;
+        };
 
-    postPatch = ''
-      substituteInPlace internal/gounicorn/gounicorn.go \
-        --replace-fail './lifecycle' "${authentik-django}/lifecycle"
-      substituteInPlace web/static.go \
-        --replace-fail './web' "${authentik-django}/web"
-      substituteInPlace internal/web/static.go \
-        --replace-fail './web' "${authentik-django}/web"
-    '';
+    extraPythonDependencies = [ ];
 
-    nativeBuildInputs = [ apiGoVendorHook ];
+    # Add additional python dependencies to the authentik environemnt.
+    # This makes them available during policy evaluation.
+    appendPythonDependencies =
+      dependenciesFn:
+      scope.overrideScope (
+        finalScope: prevScope: {
+          extraPythonDependencies =
+            prevScope.extraPythonDependencies ++ dependenciesFn finalScope.python.pkgs;
+        }
+      );
 
-    env.CGO_ENABLED = 0;
+    client-go = callPackage (
+      {
+        go,
+        mkComponent,
+        openapi-generator-cli,
+        python,
+        stdenvNoCC,
+      }:
+      mkComponent stdenvNoCC.mkDerivation (finalAttrs: {
+        pname = "authentik-client-go";
+        sourceDir = "packages/client-go";
 
-    # calculate the vendorHash without other dependencies, so it is only based on the `go.sum` file
-    overrideModAttrs.postPatch = "";
+        nativeBuildInputs = [
+          openapi-generator-cli
+          go
+          (python.withPackages (ps: [ ps.pyyaml ]))
+        ];
 
-    vendorHash = "sha256-pdQg02f1K4nOhsnadoplQYOhEybqZxn+yDQRN5RNygM=";
+        buildPhase = ''
+          runHook preBuild
 
-    postInstall = ''
-      mv $out/bin/server $out/bin/authentik
-    '';
+          python ../../scripts/api_filter_schema.py ../../schema.yml schema.yml operation_ids
+          openapi-generator-cli generate \
+            -i schema.yml -o $out \
+            -g go \
+            -c config.yaml
 
-    subPackages = [ "cmd/server" ];
-  };
+          cd $out
+          rm -r .openapi-generator api go.mod go.sum
+          gofmt -w $out
 
-in
-stdenvNoCC.mkDerivation {
-  pname = "authentik";
-  inherit src version;
+          runHook postBuild
+        '';
+      })
+    ) { };
 
-  buildInputs = [ bash ];
+    client-rust = callPackage (
+      {
+        mkComponent,
+        openapi-generator-cli,
+        python,
+        stdenvNoCC,
+      }:
+      mkComponent stdenvNoCC.mkDerivation (finalAttrs: {
+        pname = "authentik-client-rust";
+        sourceDir = "packages/client-rust";
 
-  postPatch = ''
-    rm Makefile
-    patchShebangs lifecycle/ak
+        nativeBuildInputs = [
+          openapi-generator-cli
+          (python.withPackages (ps: [ ps.pyyaml ]))
+        ];
 
-    # This causes issues in systemd services
-    substituteInPlace lifecycle/ak \
-      --replace-fail 'printf' '>&2 printf' \
-      --replace-fail '>/dev/stderr' ""
-  '';
+        buildPhase = ''
+          runHook preBuild
 
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out/bin
-    cp -r lifecycle/ak $out/bin/
+          mkdir $out
+          cp .openapi-generator-ignore Cargo.toml $out
 
-    wrapProgram $out/bin/ak \
-      --prefix PATH : ${
-        lib.makeBinPath [
-          (python.withPackages (ps: [ ps.authentik-django ]))
-          proxy
-        ]
-      } \
-      --set TMPDIR /dev/shm \
-      --set PYTHONDONTWRITEBYTECODE 1 \
-      --set PYTHONUNBUFFERED 1
-    runHook postInstall
-  '';
+          python ../../scripts/api_filter_schema.py ../../schema.yml schema.yml operation_ids
+          # openapi-generator-cli >= 7.22 enables useChrono by default. Remove once upstream has migrated.
+          openapi-generator-cli generate \
+            -i schema.yml -o $out \
+            -g rust \
+            -c config.yaml \
+            --additional-properties=packageVersion=${finalAttrs.version},useChrono=false
 
-  passthru = {
-    inherit proxy apiGoVendorHook;
-    outposts = callPackages ./outposts.nix {
-      inherit (proxy) vendorHash;
-      inherit apiGoVendorHook;
+          cd $out
+          sed -i 's/models::models::/models::/g' src/apis/*
+          rm -rf .openapi-generator api/openapi.yaml schema.yml
+
+          runHook postBuild
+        '';
+      })
+    ) { };
+
+    client-ts = callPackage (
+      {
+        mkComponent,
+        nodejs,
+        openapi-generator-cli,
+        stdenvNoCC,
+        typescript,
+      }:
+      mkComponent stdenvNoCC.mkDerivation (finalAttrs: {
+        pname = "authentik-client-ts";
+        sourceDir = "packages/client-ts";
+
+        postPatch = ''
+          substituteInPlace config.yaml \
+            --replace-fail '/local' "$(pwd)"
+        '';
+
+        nativeBuildInputs = [
+          nodejs
+          openapi-generator-cli
+          typescript
+        ];
+
+        buildPhase = ''
+          runHook preBuild
+
+          openapi-generator-cli generate \
+            -i ../../schema.yml -o $out \
+            -g typescript-fetch \
+            -c config.yaml \
+            --additional-properties=npmVersion=${finalAttrs.version} \
+            --git-repo-id authentik --git-user-id goauthentik
+
+          cd $out
+          rm -r .openapi-generator
+          npm run build
+
+          runHook postBuild
+        '';
+      })
+    ) { };
+
+    # prefetch-npm-deps does not save all dependencies even though the lockfile is fine
+    webui-deps = callPackage (
+      {
+        cacert,
+        mkComponent,
+        nodejs,
+        stdenvNoCC,
+      }:
+      mkComponent stdenvNoCC.mkDerivation (finalAttrs: {
+        pname = "authentik-webui-deps";
+        sourceDir = "web";
+
+        outputHash =
+          source.webuiHashes.${stdenvNoCC.hostPlatform.system}
+            or (throw "authentik-webui-deps: unsupported host platform");
+        outputHashMode = "recursive";
+
+        postUnpack = ''
+          chmod -R u+w $sourceRoot/..
+        '';
+
+        nativeBuildInputs = [
+          nodejs
+          cacert
+        ];
+
+        buildPhase = ''
+          npm ci --cache ./cache --ignore-scripts
+
+          rm -r ./cache node_modules/.package-lock.json
+        '';
+
+        # dependencies of workspace projects are installed into separate node_modules folders with
+        # symlinks between them, so we have to copy all of them
+        installPhase = ''
+          mkdir $out
+          echo "Copying node_modules folders:"
+          find -type d -name node_modules -prune -print -exec mkdir -p $out/{} \; -exec cp -rT {} $out/{} \;
+        '';
+
+        dontCheckForBrokenSymlinks = true;
+        dontPatchShebangs = true;
+      })
+    ) { };
+
+    webui = callPackage (
+      {
+        chromedriver,
+        mkComponentWithClients,
+        nodejs,
+        stdenvNoCC,
+        webui-deps,
+      }:
+      mkComponentWithClients stdenvNoCC.mkDerivation (finalAttrs: {
+        pname = "authentik-webui";
+        sourceDir = "web";
+
+        postPatch = ''
+          substituteInPlace packages/core/version/node.js \
+            --replace-fail 'const prerelease = ' 'const prerelease = false; // ' \
+            --replace-fail 'import PackageJSON from "../../../../package.json" with { type: "json" };' "" \
+            --replace-fail '(PackageJSON.version);' '"${finalAttrs.version}";'
+        '';
+
+        nativeBuildInputs = [
+          nodejs
+        ];
+
+        buildPhase = ''
+          runHook preBuild
+
+          buildRoot=$PWD
+          pushd ${webui-deps}
+          find -type d -name node_modules -prune -print -exec cp -rT {} $buildRoot/{} \;
+          popd
+
+          pushd node_modules/.bin
+          patchShebangs $(readlink rollup)
+          patchShebangs $(readlink wireit)
+          patchShebangs $(readlink lit-localize)
+          popd
+
+          npm run build
+
+          runHook postBuild
+        '';
+
+        CHROMEDRIVER_FILEPATH = lib.getExe chromedriver;
+
+        installPhase = ''
+          runHook preInstall
+          mkdir $out
+          cp -r dist $out/dist
+          cp -r authentik $out/authentik
+          runHook postInstall
+        '';
+
+        NODE_ENV = "production";
+        NODE_OPTIONS = "--openssl-legacy-provider";
+      })
+    ) { };
+
+    # Extract the default blueprints, so they can be customized easily. This can be done by:
+    # - using `overrideScope`, which causes some rebuilds
+    # - setting the `AUTHENTIK_BLUEPRINTS_DIR` variable for the worker service
+    #
+    # 'additionalPaths` are copied with symlinks resolved, because they can cause issues at runtime.
+    blueprints = callPackage (
+      {
+        mkComponent,
+        rsync,
+        stdenvNoCC,
+        # additional directories to copy into the output
+        additionalPaths ? [ ],
+      }:
+      mkComponent stdenvNoCC.mkDerivation (finalAttrs: {
+        pname = "authentik-blueprints";
+
+        dontBuild = true;
+
+        installPhase = ''
+          runHook preInstall
+
+          cp -rL blueprints $out
+
+          ${lib.concatMapStrings (p: ''
+            echo "Copying blueprints from ${p}"
+            ${lib.getExe rsync} -rL --info=name ${p}/ $out/
+          '') additionalPaths}
+
+          runHook postInstall
+        '';
+      })
+    ) { };
+
+    python = python314.override {
+      self = scope.python;
+      packageOverrides =
+        final: prev:
+        let
+          mkPythonComponent = scope.mkComponent final.buildPythonPackage;
+        in
+        {
+          django = final.django_5;
+
+          ak-guardian = mkPythonComponent (finalAttrs: {
+            pname = "ak-guardian";
+            sourceDir = "packages/ak-guardian";
+
+            pyproject = true;
+
+            build-system = with final; [ hatchling ];
+
+            propagatedBuildInputs = with final; [
+              django
+              typing-extensions
+            ];
+          });
+
+          django-channels-postgres = mkPythonComponent (finalAttrs: {
+            pname = "django-channels-postgres";
+            sourceDir = "packages/django-channels-postgres";
+
+            pyproject = true;
+
+            build-system = with final; [ hatchling ];
+
+            propagatedBuildInputs =
+              with final;
+              [
+                channels
+                django
+                django-pgtrigger
+                msgpack
+                psycopg
+                structlog
+              ]
+              ++ psycopg.optional-dependencies.pool;
+          });
+
+          django-dramatiq-postgres = mkPythonComponent (finalAttrs: {
+            pname = "django-dramatiq-postgres";
+            sourceDir = "packages/django-dramatiq-postgres";
+
+            pyproject = true;
+
+            build-system = with final; [ hatchling ];
+
+            propagatedBuildInputs =
+              with final;
+              [
+                cron-converter
+                django
+                django-pglock
+                django-pgtrigger
+                dramatiq
+                structlog
+                tenacity
+              ]
+              ++ dramatiq.optional-dependencies.watch;
+          });
+
+          django-postgres-cache = mkPythonComponent (finalAttrs: {
+            pname = "django-postgres-cache";
+            sourceDir = "packages/django-postgres-cache";
+
+            pyproject = true;
+
+            build-system = with final; [ hatchling ];
+
+            propagatedBuildInputs = with final; [
+              django
+              django-postgres-extra
+            ];
+          });
+
+          authentik-django = mkPythonComponent (finalAttrs: {
+            pname = "authentik-django";
+            pyproject = true;
+
+            postPatch = ''
+              substituteInPlace authentik/root/settings.py \
+                --replace-fail 'Path(__file__).absolute().parent.parent.parent' "Path(\"$out\")"
+              substituteInPlace authentik/lib/default.yml \
+                --replace-fail '/blueprints' "${scope.blueprints}"
+              substituteInPlace authentik/stages/email/utils.py \
+                --replace-fail 'web/' '${scope.webui}/'
+              # allways allow file upload if the data directoy exists
+              substituteInPlace authentik/admin/files/backends/file.py \
+                --replace-fail "and (self._base_dir.is_mount() or (self._base_dir / self.usage.value).is_mount())" ""
+            '';
+
+            build-system = [
+              final.hatchling
+            ];
+
+            pythonRemoveDeps = [ "dumb-init" ];
+
+            pythonRelaxDeps = true;
+
+            dependencies =
+              with final;
+              [
+                ak-guardian
+                argon2-cffi
+                cachetools
+                channels
+                cryptography
+                dacite
+                deepmerge
+                defusedxml
+                django
+                django-channels-postgres
+                django-countries
+                django-dramatiq-postgres
+                django-filter
+                django-model-utils
+                django-pglock
+                django-pgtrigger
+                django-postgres-cache
+                django-postgres-extra
+                django-prometheus
+                django-storages
+                django-tenants
+                djangoql
+                djangorestframework
+                docker
+                drf-orjson-renderer
+                drf-spectacular
+                duo-client
+                fido2
+                geoip2
+                geopy
+                google-api-python-client
+                gssapi
+                gunicorn
+                jsonpatch
+                jwcrypto
+                kubernetes
+                ldap3
+                lxml
+                msgraph-sdk
+                opencontainers
+                packaging
+                paramiko
+                psycopg
+                pydantic
+                pydantic-scim
+                pyjwt
+                pyrad
+                python-kadmin-rs
+                pyyaml
+                requests-oauthlib
+                scim2-filter-parser
+                sentry-sdk
+                service-identity
+                setproctitle
+                structlog
+                swagger-spec-validator
+                twilio
+                ua-parser
+                unidecode
+                urllib3
+                uvicorn
+                watchdog
+                webauthn
+                wsproto
+                xmlsec
+                zxcvbn
+              ]
+              ++ django-storages.optional-dependencies.s3
+              ++ psycopg.optional-dependencies.c
+              ++ psycopg.optional-dependencies.pool
+              ++ uvicorn.optional-dependencies.standard;
+
+            postInstall = ''
+              mkdir -p $out/web
+              cp -r lifecycle manage.py $out/${prev.python.sitePackages}/
+              cp -r ${scope.webui}/dist ${scope.webui}/authentik $out/web/
+              ln -s $out/${prev.python.sitePackages}/authentik $out/authentik
+              ln -s $out/${prev.python.sitePackages}/lifecycle $out/lifecycle
+            '';
+          });
+        };
     };
-  };
 
-  nativeBuildInputs = [ makeWrapper ];
+    server = callPackage (
+      {
+        buildGoModule,
+        mkComponentWithClients,
+        python,
+      }:
+      mkComponentWithClients buildGoModule (finalAttrs: {
+        pname = "authentik-server";
 
-  meta = meta // {
-    mainProgram = "ak";
-  };
-}
+        postPatch = ''
+          substituteInPlace internal/gounicorn/gounicorn.go \
+            --replace-fail './lifecycle' "${python.pkgs.authentik-django}/lifecycle"
+          substituteInPlace web/static.go \
+            --replace-fail './web' "${python.pkgs.authentik-django}/web"
+          substituteInPlace internal/web/static.go \
+            --replace-fail './web' "${python.pkgs.authentik-django}/web"
+        '';
+
+        env.CGO_ENABLED = 0;
+
+        # calculate the vendorHash without other dependencies, so it is only based on the `go.sum` file
+        overrideModAttrs.postPatch = "";
+
+        vendorHash = source.serverVendorHash;
+
+        postInstall = ''
+          mv $out/bin/server $out/bin/authentik-server
+        '';
+
+        subPackages = [ "cmd/server" ];
+
+        meta.mainProgram = "authentik-server";
+      })
+    ) { };
+
+    core = callPackage (
+      {
+        clang,
+        cmake,
+        go,
+        mkComponentWithClients,
+        perl,
+        python,
+        rustPlatform,
+      }:
+      mkComponentWithClients rustPlatform.buildRustPackage (finalAttrs: {
+        pname = "authentik-core";
+
+        nativeBuildInputs = [
+          clang
+          cmake
+          go
+          perl
+          python
+        ];
+
+        cargoHash = source.coreCargoHash;
+
+        cargoBuildNoDefaultFeatures = true;
+        cargoBuildFeatures = [ "core" ];
+
+        env.RUSTFLAGS = "--cfg tokio_unstable";
+        # See https://github.com/goauthentik/authentik/blob/version/2026.5.0/lifecycle/container/Dockerfile#L143-L144
+        env.AWS_LC_FIPS_SYS_CC = "clang";
+
+        # there are currently no tests, so dont build test dependencies
+        doCheck = false;
+
+        meta.mainProgram = "authentik";
+      })
+    ) { };
+
+    authentik = callPackage (
+      {
+        core,
+        extraPythonDependencies,
+        makeWrapper,
+        mkComponentWithClients,
+        outposts,
+        python,
+        server,
+        stdenvNoCC,
+      }:
+      mkComponentWithClients stdenvNoCC.mkDerivation (finalAttrs: {
+        pname = "authentik";
+
+        postPatch = ''
+          rm Makefile
+          patchShebangs lifecycle/ak
+        '';
+
+        installPhase = ''
+          runHook preInstall
+          mkdir -p $out/bin
+          cp -r lifecycle/ak $out/bin/
+
+          wrapProgram $out/bin/ak \
+            --prefix PATH : ${
+              lib.makeBinPath [
+                (python.withPackages (ps: [ ps.authentik-django ] ++ extraPythonDependencies))
+                core
+                server
+              ]
+            } \
+            --set TMPDIR /dev/shm \
+            --set PYTHONDONTWRITEBYTECODE 1 \
+            --set PYTHONUNBUFFERED 1
+          runHook postInstall
+        '';
+
+        nativeBuildInputs = [ makeWrapper ];
+
+        passthru.components = scope;
+        passthru.outposts = outposts;
+        passthru.tests.updateScript-lint = callPackage (
+          {
+            runCommand,
+            python,
+          }:
+          runCommand "authentik-updateScript-lint"
+            {
+              buildInputs = [
+                (python.withPackages (ps: [
+                  ps.pydantic
+                  ps.ruff
+                  ps.stackprinter
+                  ps.ty
+                  ps.types-requests
+                ]))
+              ];
+            }
+            ''
+              echo "# run ty"
+              ty check --error-on-warning ${./update.py}
+              echo "# run ruff check"
+              ruff check ${./update.py}
+              echo "# run ruff format"
+              ruff format --check --diff ${./update.py}
+
+              touch $out
+            ''
+        ) { };
+        passthru.updateScript = {
+          command = [ ./update.py ];
+          supportedFeatures = [ "commit" ];
+        };
+
+        meta.mainProgram = "ak";
+      })
+      // {
+        overrideScope = f: (scope.overrideScope f).authentik;
+
+        appendPatches = patches: (scope.appendPatches patches).authentik;
+
+        appendPythonDependencies =
+          dependenciesFn: (scope.appendPythonDependencies dependenciesFn).authentik;
+      }
+    ) { };
+
+    outposts = scope.callPackage ./outposts.nix { };
+  }
+)).authentik

--- a/pkgs/by-name/au/authentik/proxy.nix
+++ b/pkgs/by-name/au/authentik/proxy.nix
@@ -1,24 +1,9 @@
 {
   buildGoModule,
-  authentik,
-  apiGoVendorHook,
-  vendorHash,
+  mkGoOutpost,
 }:
+mkGoOutpost buildGoModule (finalAttrs: {
+  outpostName = "proxy";
 
-buildGoModule {
-  pname = "authentik-proxy-outpost";
-  inherit (authentik) version src;
-  inherit vendorHash;
-
-  nativeBuildInputs = [ apiGoVendorHook ];
-
-  env.CGO_ENABLED = 0;
-
-  subPackages = [ "cmd/proxy" ];
-
-  meta = authentik.meta // {
-    description = "Authentik proxy outpost which is used for HTTP reverse proxy authentication";
-    homepage = "https://goauthentik.io/docs/providers/proxy/";
-    mainProgram = "proxy";
-  };
-}
+  meta.description = "Authentik proxy outpost which is used for HTTP reverse proxy authentication";
+})

--- a/pkgs/by-name/au/authentik/radius.nix
+++ b/pkgs/by-name/au/authentik/radius.nix
@@ -1,24 +1,9 @@
 {
   buildGoModule,
-  authentik,
-  apiGoVendorHook,
-  vendorHash,
+  mkGoOutpost,
 }:
+mkGoOutpost buildGoModule (finalAttrs: {
+  outpostName = "radius";
 
-buildGoModule {
-  pname = "authentik-radius-outpost";
-  inherit (authentik) version src;
-  inherit vendorHash;
-
-  nativeBuildInputs = [ apiGoVendorHook ];
-
-  env.CGO_ENABLED = 0;
-
-  subPackages = [ "cmd/radius" ];
-
-  meta = authentik.meta // {
-    description = "Authentik radius outpost which is used for the external radius API";
-    homepage = "https://goauthentik.io/docs/providers/radius/";
-    mainProgram = "radius";
-  };
-}
+  meta.description = "Authentik radius outpost which is used for the external radius API";
+})

--- a/pkgs/by-name/au/authentik/source.json
+++ b/pkgs/by-name/au/authentik/source.json
@@ -1,0 +1,12 @@
+{
+  "authentik": {
+    "version": "2026.5.3",
+    "hash": "sha256-nmAX8nwZpdDcFAPvC9hAEp0x43RnFtGLUTAm7NcvNZo="
+  },
+  "coreCargoHash": "sha256-KExlNyT9G3R5rnt99beT2pYrWxezMLhGw+Q9T1X2kj4=",
+  "serverVendorHash": "sha256-EVDOZ4USaJoIBDB8mM4ZSBfsSc1d/NOm1Qv/hUJ+8f4=",
+  "webuiHashes": {
+    "aarch64-linux": "sha256-41xZEfLul92vJATZqyVnd7Pp++NzLL/u8NeJJPHpXrw=",
+    "x86_64-linux": "sha256-FpfOl6wNCgXLg86+vbjnYkcOnpaOZBCNxJiFDRT5W3s="
+  }
+}

--- a/pkgs/by-name/au/authentik/update.py
+++ b/pkgs/by-name/au/authentik/update.py
@@ -1,0 +1,533 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i python3 -p nix nix-prefetch-github "python3.withPackages (ps: [ ps.pydantic ps.requests ps.stackprinter ])"
+
+import argparse
+import base64
+import binascii
+import functools
+import os
+import re
+import shlex
+import subprocess
+import sys
+from concurrent.futures import Executor, ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any, Callable, Generator, List, Tuple
+
+import requests
+import stackprinter
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    GetCoreSchemaHandler,
+    PositiveInt,
+    RootModel,
+    TypeAdapter,
+)
+from pydantic_core import CoreSchema, core_schema
+from requests.adapters import HTTPAdapter, Retry
+
+stackprinter.set_excepthook(style="darkbg2")
+
+
+eprint = functools.partial(print, file=sys.stderr)
+json_path = Path(__file__).parent / "source.json"
+hash_re = re.compile(r"\bgot:\s+(\S+)")
+version_re = re.compile(r"version/(\d{4})\.(\d{1,2})\.(\d+)")
+
+
+class Hash(str):
+    """A Nix sha256 SRI hash.
+
+    The content is validated on construction to always contain a valid hash.
+
+    An empty input string will be replaced with the "all zero" fake hash.
+    """
+
+    FAKE: "Hash"
+
+    def __new__(cls, v: str) -> "Hash":
+        return str.__new__(cls, Hash.validate(v))
+
+    def is_fake(self) -> bool:
+        return self == self.FAKE
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: Any, handler: GetCoreSchemaHandler
+    ) -> CoreSchema:
+        return core_schema.no_info_after_validator_function(cls, handler(str))
+
+    @staticmethod
+    def validate(v: object) -> str:
+        if not isinstance(v, str):
+            raise ValueError(f"Expected str, go {type(v)}")
+
+        if not v:
+            return Hash.FAKE
+
+        if not v.startswith("sha256-"):
+            raise ValueError("Expected hash to start with 'sha256-'")
+
+        try:
+            b = base64.b64decode(v.removeprefix("sha256-"), validate=True)
+        except binascii.Error as e:
+            raise ValueError(f"Invalid hash content: {e}")
+        except ValueError as e:
+            raise ValueError(f"Invalid hash content: {e}")
+
+        if len(b) != 32:
+            raise ValueError(f"Invalid hash length: {len(b) * 8} bits")
+
+        return v
+
+
+Hash.FAKE = Hash("sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+
+
+class Model(BaseModel):
+    """Custom BaseModel with shared config values"""
+
+    model_config = ConfigDict(serialize_by_alias=True)
+
+
+def create_http_session() -> requests.Session:
+    retries = Retry(total=5, backoff_factor=0.5, status_forcelist=[500, 502, 503, 504])
+    session = requests.Session()
+    session.headers["User-Agent"] = (
+        "nixpkgs-authentik-update/1 (https://github.com/NixOS/nixpkgs)"
+    )
+    session.mount("http://", HTTPAdapter(max_retries=retries))
+    session.mount("https://", HTTPAdapter(max_retries=retries))
+    return session
+
+
+def run_command_text(args: list[str], *, stderr_prefix: str = "") -> str:
+    eprint(f"{stderr_prefix}# {shlex.join(args)}")
+    process = subprocess.run(args, capture_output=True, check=True, text=True)
+    for line in process.stderr.splitlines():
+        eprint(f"{stderr_prefix}{line}")
+
+    return process.stdout
+
+
+def get_or_update_component_hash(
+    current: Hash, component: str, extra_args: list[str], *, system: str | None = None
+) -> Hash:
+    if not current.is_fake():
+        return current
+
+    system_args = []
+    if s := system:
+        system_args = ["--argstr", "system", s]
+
+    if system is not None:
+        prefix = f"{component}({system}): "
+    else:
+        prefix = f"{component}: "
+
+    args = [
+        "nix-build",
+        "--keep-going",
+        "--no-link",
+        "-A",
+        f"authentik.components.{component}",
+        *system_args,
+        *extra_args,
+    ]
+    eprint(f"{prefix}# {shlex.join(args)}")
+    with subprocess.Popen(
+        args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+    ) as process:
+        hashes = []
+        for line in process.stdout or ():
+            eprint(f"{prefix}{line}", end="")
+            if match := hash_re.search(line):
+                hashes.append(match[1])
+
+    eprint(prefix)
+    if len(hashes) == 1:
+        eprint(f"{prefix}Found the new hash {hashes[0]}")
+        return Hash(hashes[0])
+    else:
+        eprint(f"{prefix}Unable to determine the new hash (found {hashes})")
+        return Hash.FAKE
+
+
+class NixPrefetchGithubOutput(Model):
+    owner: str
+    repo: str
+    rev: str
+    hash: Hash
+
+
+class Authentik(Model):
+    version: str = ""
+    hash: Hash = Hash.FAKE
+
+    def update_to(self, new_version: str, *, force: bool = False) -> "Authentik":
+        hash = self.hash
+        if self.version != new_version or self.hash.is_fake() or force:
+            args = [
+                "nix-prefetch-github",
+                "goauthentik",
+                "authentik",
+                "--rev",
+                f"version/{new_version}",
+                "-v",
+            ]
+            output = run_command_text(args, stderr_prefix="nix-prefetch-github: ")
+            hash = NixPrefetchGithubOutput.model_validate_json(output).hash
+
+        return Authentik(version=new_version, hash=hash)
+
+
+class Systems(Model):
+    aarch64Linux: Hash = Field(alias="aarch64-linux", default=Hash.FAKE)
+    x86_64Linux: Hash = Field(alias="x86_64-linux", default=Hash.FAKE)
+
+    def is_any_hash_fake(self) -> bool:
+        return self.aarch64Linux.is_fake() or self.x86_64Linux.is_fake()
+
+
+Worker = Callable[[], Hash]
+Updater = Callable[["State", Hash], Any]
+
+
+class State(Model):
+    authentik: Authentik = Field(default_factory=lambda: Authentik())
+    coreCargoHash: Hash = Hash.FAKE
+    serverVendorHash: Hash = Hash.FAKE
+    webuiHashes: Systems = Field(default_factory=lambda: Systems())
+
+    def update_core_cargo_hash(self, extra_args: list[str]) -> tuple[Worker, Updater]:
+        return (
+            lambda: get_or_update_component_hash(
+                self.coreCargoHash, "core.cargoDeps", extra_args
+            ),
+            lambda state, hash: setattr(state, "coreCargoHash", hash),
+        )
+
+    def update_server_vendor_hash(
+        self, extra_args: list[str]
+    ) -> tuple[Worker, Updater]:
+        return (
+            lambda: get_or_update_component_hash(
+                self.serverVendorHash, "server.goModules", extra_args
+            ),
+            lambda state, hash: setattr(state, "serverVendorHash", hash),
+        )
+
+    def update_webui_hash(
+        self, attr: str, extra_args: list[str]
+    ) -> tuple[Worker, Updater]:
+        system = Systems.model_fields[attr].alias
+        hash = getattr(self.webuiHashes, attr)
+        return (
+            lambda: get_or_update_component_hash(
+                hash, "webui-deps", extra_args, system=system
+            ),
+            lambda state, hash: setattr(state.webuiHashes, attr, hash),
+        )
+
+    def update_hashes(self, executor: Executor, extra_args: list[str]) -> "State":
+        fns = [
+            self.update_core_cargo_hash(extra_args),
+            self.update_server_vendor_hash(extra_args),
+            self.update_webui_hash("aarch64Linux", extra_args),
+            self.update_webui_hash("x86_64Linux", extra_args),
+        ]
+        future_to_update = {executor.submit(work): update for work, update in fns}
+        state = self.model_copy()
+        for future in as_completed(future_to_update):
+            future_to_update[future](state, future.result())
+        return state
+
+    def is_any_hash_fake(self) -> bool:
+        return (
+            self.authentik.hash.is_fake()
+            or self.coreCargoHash.is_fake()
+            or self.serverVendorHash.is_fake()
+            or self.webuiHashes.is_any_hash_fake()
+        )
+
+
+class GithubRelease(Model):
+    """Minimal subset of attributes required of a release.
+
+    All other attributes are discarded during validation."""
+
+    tag_name: str
+
+
+class GithubReleases(RootModel[List[GithubRelease]]):
+    def lastest_version(
+        self, *, same_minor: Tuple[int, int] | None = None
+    ) -> str | None:
+        if version := next(
+            iter(sorted(self.versions(same_minor=same_minor), reverse=True)), None
+        ):
+            return ".".join(map(str, version))
+
+        return None
+
+    def versions(
+        self, *, same_minor: Tuple[int, int] | None = None
+    ) -> Generator[Tuple[int, int, int]]:
+        for release in self.root:
+            if match := version_re.fullmatch(release.tag_name):
+                version = (int(match[1]), int(match[2]), int(match[3]))
+                if same_minor is not None and same_minor != version[:2]:
+                    continue
+                yield version
+
+        return None
+
+
+class UpdateNixChange(Model):
+    """A subset of the attributes expected by `update.nix` for a change entry."""
+
+    attrPath: str
+    newVersion: str
+
+
+class UpdateNixChanges(RootModel[List[UpdateNixChange]]):
+    """Toplevel structure expected by `update.nix` in `commit` mode."""
+
+    pass
+
+
+def parse_version(s: str) -> tuple[int, int] | tuple[int, int, int]:
+    it = map(int, s.split("."))
+    major, minor, patch = next(it), next(it), next(it, None)
+    if next(it, None) is not None:
+        raise ValueError(f"Invalid version string '{s}'")
+
+    if patch is not None:
+        return (major, minor, patch)
+    return (major, minor)
+
+
+def strip_common_whitespace_prefix(s: str) -> str:
+    """Strip leading whitespace from each line in a multiline string.
+
+    The length of whitespace removed is ths smallest indentation of all lines which do not entirely consist of whitespace.
+
+    This is intended to be similar to Nix indented (''...'') strings.
+    """
+
+    if not s:
+        return ""
+    min_common = -1
+    for line in s.splitlines():
+        stripped = line.lstrip(" ")
+        # ignore whitespace only lines in the calculation
+        if not stripped:
+            continue
+        diff = len(line) - len(stripped)
+        if min_common == -1:
+            min_common = diff
+        else:
+            min_common = min(min_common, diff)
+
+    def remove_prefix(line: str) -> str:
+        if min_common == -1 or len(line) < min_common:
+            return line.lstrip(" ")
+        return line[min_common:]
+
+    return "".join(remove_prefix(line) for line in s.splitlines(keepends=True))
+
+
+assert strip_common_whitespace_prefix("") == ""
+assert strip_common_whitespace_prefix("    ") == ""
+assert strip_common_whitespace_prefix(" \n  ") == "\n"
+assert strip_common_whitespace_prefix("  a\n  b") == "a\nb"
+assert strip_common_whitespace_prefix("  a\n\n  b") == "a\n\nb"
+assert strip_common_whitespace_prefix("  a\n  \n  b") == "a\n\nb"
+assert strip_common_whitespace_prefix("    a\n  \n  b") == "  a\n\nb"
+assert strip_common_whitespace_prefix("  a\n  \n    b") == "a\n\n  b"
+
+
+class HelpFormatter(
+    argparse.RawDescriptionHelpFormatter, argparse.ArgumentDefaultsHelpFormatter
+):
+    """Help message formatter which retains any formatting in descriptions and
+    adds default values to argument help."""
+
+    pass
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="update.py",
+        formatter_class=HelpFormatter,
+        description=strip_common_whitespace_prefix("""
+            Authentik updater script
+
+            Create and update the `source.json` file for the `authentik` package.
+
+            The script tries to only update missing component hashes if possible.
+            If the `authentik.version` or `authentik.hash` changes, all other hashes are considered missing.
+
+            To assist with building dependencies for different architectures (aarch64-linux and x86_64-linux at the moment),
+            the `NIX_BUILD_ARGS` environment variable and all remaining arguments after the first `--` will be passed
+            to the `nix-build` commands.
+
+            For example: --builders "buildhost aarch64-linux - 2"
+        """).strip(),
+    )
+    parser.add_argument(
+        "-P",
+        "--parallel",
+        type=TypeAdapter(PositiveInt).validate_python,
+        default=5,
+        help="The number of parallel `nix-build` processes to run",
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("-a", "--authentik", help="Update to this specific version")
+    group.add_argument(
+        "-p",
+        "--patch",
+        action="store_true",
+        help="Update to the lastest patch of the current minor version",
+    )
+    group.add_argument(
+        "-g",
+        "--generate",
+        action="store_true",
+        help="Don't update the version and only generate missing hashes",
+    )
+    parser.add_argument(
+        "-f", "--force", action="store_true", help="Force recalculation of all hashes"
+    )
+    parser.add_argument(
+        "nix_build_args",
+        nargs="*",
+        default=[],
+        help="Additional arguments passed to `nix-build`",
+    )
+
+    return parser
+
+
+def determine_new_version(
+    state: State, *, version: str, generate: bool, patch: bool
+) -> str:
+    # Fixed version. Any invalid input will fail during `nix-prefetch-github`
+    if version:
+        parse_version(version)
+        return version
+
+    # Don't update, only generate hashes
+    elif generate:
+        if state.authentik.version:
+            return state.authentik.version
+        else:
+            eprint(
+                "Can't perform hash generation without current `source.json` (missing `authentik.version`)"
+            )
+            sys.exit(1)
+
+    # Latest version based on github releases
+    else:
+        session = create_http_session()
+        releases_content = session.get(
+            "https://api.github.com/repos/goauthentik/authentik/releases"
+        ).text
+        releases = GithubReleases.model_validate_json(releases_content)
+
+        same_minor = None
+        if patch:
+            # Limit version selection to the same minor as currently in use
+            if v := state.authentik.version:
+                same_minor = parse_version(v)[:2]
+            else:
+                eprint(
+                    "Can't perform patch version update without current `source.json` (missing `authentik.version`)"
+                )
+                sys.exit(1)
+
+        target_version = releases.lastest_version(same_minor=same_minor)
+        if not target_version:
+            s = ""
+            if same_minor:
+                s = f" for minor version {'.'.join(map(str, same_minor))}"
+            eprint(
+                f"Could not determine the latest version{s}. Found the following tags on github:\n"
+                f"{'\n'.join(r.tag_name for r in releases.root)}"
+            )
+            sys.exit(1)
+
+        return target_version
+
+
+def save_state(state: State, note: str) -> None:
+    content = state.model_dump_json(indent=2)
+    json_path.write_text(f"{content}\n")
+    eprint(f"Wrote new `source.json` {note}:\n{content}")
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+
+    nix_build_args = (
+        shlex.split(os.environ.get("NIX_BUILD_ARGS", "")) + args.nix_build_args
+    )
+
+    # Load current source.json. Validation errors are fatal.
+    try:
+        with json_path.open() as jsonFile:
+            current_state = State.model_validate_json(jsonFile.read())
+    except FileNotFoundError:
+        # Start with an empty state if the file does not exist
+        current_state = State()
+
+    current_version = current_state.authentik.version
+    new_version = determine_new_version(
+        current_state, version=args.authentik, generate=args.generate, patch=args.patch
+    )
+    if new_version != current_version:
+        if current_version:
+            eprint(
+                f"Updating `source.json` from '{current_version}' to '{new_version}'"
+            )
+        else:
+            eprint(f"Generating new `source.json` for '{new_version}'")
+
+    # Update the source hash, if necessary
+    new_authentik = current_state.authentik.update_to(new_version, force=args.force)
+    # If the version/hash changed (or force is set), clear all other hashes
+    if current_state.authentik != new_authentik or args.force:
+        next_state = State(authentik=new_authentik)
+    else:
+        next_state = current_state.model_copy(update={"authentik": new_authentik})
+
+    # Save current state, so the following hash generation uses the (potentially) new source hash
+    save_state(next_state, "after version/source hash generation")
+
+    # Run the hash generation in parallel
+    with ThreadPoolExecutor(max_workers=args.parallel) as executor:
+        final_state = next_state.update_hashes(executor, nix_build_args)
+
+    save_state(final_state, "after component hash generation")
+
+    # if any hash is unknown, ensure update.nix doesn't commit the changes
+    if final_state.is_any_hash_fake():
+        eprint("\nCould not determine all hashes. Automatic update failed.")
+        sys.exit(1)
+
+    # using UPDATE_NIX_ATTR_PATH to detect if this is being called from update.nix
+    if os.environ.get("UPDATE_NIX_ATTR_PATH"):
+        changes = UpdateNixChanges(
+            [
+                UpdateNixChange(
+                    attrPath="authentik,authentik-outposts", newVersion=new_version
+                )
+            ]
+        )
+        print(f"{changes.model_dump_json(indent=2)}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1284,7 +1284,7 @@ with pkgs;
 
   arpack-mpi = arpack.override { useMpi = true; };
 
-  authentik-outposts = recurseIntoAttrs (callPackages ../by-name/au/authentik/outposts.nix { });
+  authentik-outposts = recurseIntoAttrs authentik.outposts;
 
   autoflake = with python3.pkgs; toPythonApplication autoflake;
 


### PR DESCRIPTION
This is my next attempt of making the authentik build process more modular and adding an update-script. After some comments in #492436, I rewrote the script from bash to python, which makes it more user friendly and also includes more features. The PR also include the latest update to `2026.5.3`.

Changes from the current `2025.12.5` build:

- Move all derivations into a new scope.
  This makes the build more modular (see #334356) and is required by the update-script to build individual components. It also makes it easier to build and test each component in isolation.

- Remove the `website` build.
  After having some trouble with rebuilding the `website-deps` hashes, I looked into the official image build process in `lifecycle/container/Dockerfile` and realized, the `website` is never really used. The folder is copied into the `node-builder` step, but it is never read by another build step. This coincides with the fact, that every link I found in the admin view points to the official documentation subdomains like https://integrations.goauthentik.io. I have not checked since when the `website` was unused, but it could be a few versions back.

- Rename the `proxy` component to `server`.
  The Go part of the authentik service has been renamed to `authentik-server`. This follows the change and also avoids some name ambiguity with the `proxy` outpost.

- Remove `apiGoVendorHook`.
  The Go API bindings are no longer vendored, so this step isn't needed anymore.

- Build all language API clients from source.
  Technically, it would only be necessary to build the typescript client, as it is always source built by the official build process. But I also added a derivation for the Go and Rust bindings, because this makes it possible to patch the `schema.yml` and always build against the correct API.

- Add a `blueprints` component.
  This makes it easier to add custom blueprints to an authentik instance, either with `overrideScope` or by setting the `AUTHENTIK_BLUEPRINTS_DIR` to a custom `buleprints` build.

- Switch to `python314`.
  It's the upstream default and the service doesn't work properly otherwise.

- Add the new Rust server `core` build.
  With `2026.5`, authentik switched to a new rust based server, wich is responsible for request routing.

- Add an `updateScript`.
  The script makes it easier to rebuild and update the different dependency hashes. Since the first iteration in bash, the new python based script also allows to perform patch version updates and force recalculating all hashes.

- Add "layered" build helpers.
  All components are now build with composable builders. The process is heavily inspired by the Nix modular components layout:  https://github.com/NixOS/nixpkgs/blob/9c89d15a864edab2a2528e0ab8581b52095f6ef8/pkgs/tools/package-management/nix/modular/packaging/components.nix
  This makes it possible to define common build steps in a single position, while still being independent from the language/toolchain used to build the component.

I'm already running this authentik build for a while now and have not encountered any issues so far.

If anyone wants to test the new version, I have updated my [authentik demo gist](https://gist.github.com/B4dM4n/615c73b304b0a20c91deeba22445e778) with this branch.

Resolves #334356
Conflicts with #523484

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
