### PR TITLE
aws-ofi-nccl: init at 1.19.2

### DIFF
--- a/pkgs/by-name/aw/aws-ofi-nccl/package.nix
+++ b/pkgs/by-name/aw/aws-ofi-nccl/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  autoAddDriverRunpath,
+  autoreconfHook,
+  numactl,
+  libuuid,
+  rdma-core,
+  libfabric,
+  hwloc,
+  cudaPackages,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "aws-ofi-nccl";
+  version = "1.19.2";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "aws";
+    repo = "aws-ofi-nccl";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-1gPIuZzS53cMRckiBkRRzMw3RzoAvu3v0xzt0rwyysk=";
+  };
+
+  nativeBuildInputs = [
+    autoAddDriverRunpath
+    autoreconfHook
+  ];
+
+  buildInputs = [
+    numactl
+    libuuid
+    rdma-core
+    libfabric
+    hwloc
+  ]
+  ++ (with cudaPackages; [
+    cuda_cudart
+    nccl
+  ]);
+
+  postPatch = ''
+    patchShebangs m4
+    echo "$version" > .release_version
+  '';
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
+
+  configureFlags = [
+    "--enable-platform-aws"
+    "--with-cuda=${cudaPackages.cuda_nvcc}"
+    "--with-libfabric=${libfabric}"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "This is a plugin which lets EC2 developers use libfabric as network provider while running NCCL applications";
+    homepage = "https://github.com/aws/aws-ofi-nccl";
+    changelog = "https://github.com/aws/aws-ofi-nccl/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jlesquembre ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

There is a similar PR here: https://github.com/NixOS/nixpkgs/pull/374089, but it seems abandoned. I'm happy to close mine in favor of the previous one if @P-E-Meunier wants to resume their work.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
