### PR TITLE
darcs: patch incompatibilities with Stackage Nightly and Cabal 3.14

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2005,6 +2005,10 @@ with haskellLib;
     # GHC 9.10 patch plus lifted constraints for hashable
     # https://hub.darcs.net/darcs/darcs-reviewed/patch/32646b190e019de21a103e950c4eccdd66f7eadc
     ./patches/darcs-stackage-lts-23.patch
+    # Support Cabal 3.14's Symbolic Path API
+    ./patches/darcs-cabal-3.14.patch
+    # Lift bounds for GHC 9.12 / Stackage Nightly 2026-06-16
+    ./patches/darcs-stackage-nightly-2026-06-16.patch
   ] super.darcs;
 
   # 2025-02-11: Too strict bounds on hedgehog < 1.5, hspec-hedgehog < 0.2

--- a/pkgs/development/haskell-modules/patches/darcs-cabal-3.14.patch
+++ b/pkgs/development/haskell-modules/patches/darcs-cabal-3.14.patch
@@ -1,0 +1,85 @@
+diff -rN -u old-darcs.net/darcs.cabal new-darcs.net/darcs.cabal
+--- old-darcs.net/darcs.cabal	2025-09-13 02:45:32.790227974 +0200
++++ new-darcs.net/darcs.cabal	2025-09-13 02:45:32.791227985 +0200
+@@ -124,7 +124,7 @@
+ 
+ custom-setup
+     setup-depends: base      >= 4.10 && < 4.21,
+-                   Cabal     >= 2.4 && < 3.13,
++                   Cabal     >= 2.4 && < 3.15,
+                    process   >= 1.2.3.0 && < 1.7,
+                    filepath  >= 1.4.1 && < 1.5.0.0,
+                    directory >= 1.2.7 && < 1.4
+--- old-darcs.net/Setup.hs	2026-06-22 14:55:26.775706597 +0200
++++ new-darcs.net/Setup.hs	2026-06-22 14:56:31.996746207 +0200
+--- tmp2.hs	2026-06-22 14:55:26.775706597 +0200
++++ /home/lukas/tmp.hs	2026-06-22 15:25:23.957579360 +0200
+--- tmp2.hs	2026-06-22 14:55:26.775706597 +0200
++++ /home/lukas/tmp.hs	2026-06-22 15:28:17.448848236 +0200
+@@ -2,6 +2,7 @@
+ -- portions copyright (c) 2008 David Roundy
+ -- portions copyright (c) 2007-2009 Judah Jacobson
+ {-# OPTIONS_GHC -Wall #-}
++{-# LANGUAGE CPP #-}
+ import Distribution.Simple
+          ( defaultMainWithHooks, UserHooks(..), simpleUserHooks )
+ import Distribution.PackageDescription ( PackageDescription )
+@@ -25,8 +26,17 @@
+ import System.IO ( openFile, IOMode(..) )
+ import System.Process (callProcess, runProcess)
+ import Data.List( isInfixOf )
++#if MIN_VERSION_Cabal_syntax(3,14,0)
++import Distribution.Utils.Path ( (</>), interpretSymbolicPathCWD, makeRelativePathEx )
++#else
+ import System.FilePath ( (</>) )
+ 
++-- Shims so we can use the Cabal >= 3.14 API
++interpretSymbolicPathCWD, makeRelativePathEx :: FilePath -> FilePath
++interpretSymbolicPathCWD = id
++makeRelativePathEx = id
++#endif
++
+ import qualified Control.Exception as Exception
+ 
+ catchAny :: IO a -> (Exception.SomeException -> IO a) -> IO a
+@@ -73,22 +83,26 @@
+ 
+ buildManpage :: LocalBuildInfo -> IO ()
+ buildManpage lbi = do
+-  have_darcs_exe_dir <- doesDirectoryExist (buildDir lbi </> "darcs")
++  have_darcs_exe_dir <- doesDirectoryExist
++    $ interpretSymbolicPathCWD (buildDir lbi </> makeRelativePathEx "darcs")
+   when have_darcs_exe_dir $ do
+-    let darcs = buildDir lbi </> "darcs/darcs"
+-        manpage = buildDir lbi </> "darcs/darcs.1"
++    let darcs = interpretSymbolicPathCWD
++          $ buildDir lbi </> makeRelativePathEx "darcs/darcs"
++        manpage = interpretSymbolicPathCWD
++          $ buildDir lbi </> makeRelativePathEx "darcs/darcs.1"
+     manpageHandle <- openFile manpage WriteMode
+     void $ runProcess darcs ["help","manpage"]
+             Nothing Nothing Nothing (Just manpageHandle) Nothing
+ 
+ installManpage :: PackageDescription -> LocalBuildInfo -> Verbosity -> CopyDest -> IO ()
+ installManpage pkg lbi verbosity copy = do
+-  have_manpage <- doesFileExist (buildDir lbi </> "darcs" </> "darcs.1")
++  have_manpage <- doesFileExist
++    $ interpretSymbolicPathCWD (buildDir lbi </> makeRelativePathEx "darcs/darcs.1")
+   when have_manpage $
+     copyFiles
+       verbosity
+       (mandir (absoluteInstallDirs pkg lbi copy) </> "man1")
+-      [(buildDir lbi </> "darcs", "darcs.1")]
++      [(interpretSymbolicPathCWD (buildDir lbi </> makeRelativePathEx "darcs"), "darcs.1")]
+ 
+ -- ---------------------------------------------------------------------
+ -- version module
+@@ -124,7 +138,7 @@
+ 
+ generateVersionModule :: Verbosity -> LocalBuildInfo -> String -> String -> IO ()
+ generateVersionModule verbosity lbi version state = do
+-  let dir = autogenPackageModulesDir lbi
++  let dir = interpretSymbolicPathCWD (autogenPackageModulesDir lbi)
+   createDirectoryIfMissingVerbose verbosity True dir
+   ctx <- context verbosity
+   hash <- weakhash verbosity

--- a/pkgs/development/haskell-modules/patches/darcs-stackage-nightly-2026-06-16.patch
+++ b/pkgs/development/haskell-modules/patches/darcs-stackage-nightly-2026-06-16.patch
@@ -1,0 +1,29 @@
+--- old-darcs.net/darcs.cabal	1970-01-01 01:00:01.000000000 +0100
++++ new-darcs.net/darcs.cabal	2026-06-22 16:10:41.137461887 +0200
+@@ -416,7 +416,7 @@
+       build-depends:  unix              >= 2.7.1.0 && < 2.9,
+                       directory         >= 1.2.7 && < 1.4
+ 
+-    build-depends:    base              >= 4.10 && < 4.21,
++    build-depends:    base              >= 4.10 && < 4.22,
+                       safe              >= 0.3.20 && < 0.4,
+                       stm               >= 2.1 && < 2.6,
+                       binary            >= 0.5 && < 0.11,
+@@ -436,7 +436,7 @@
+                       base16-bytestring >= 1.0 && < 1.1,
+                       utf8-string       >= 1 && < 1.1,
+                       vector            >= 0.11 && < 0.14,
+-                      tar               >= 0.5 && < 0.7,
++                      tar               >= 0.5 && < 0.8,
+                       data-ordlist      == 0.4.*
+ 
+     if impl(ghc < 8.10)
+@@ -462,7 +462,7 @@
+                       network           >= 2.6 && < 3.3,
+                       conduit           >= 1.3.0 && < 1.4,
+                       http-conduit      >= 2.3 && < 2.4,
+-                      http-types        >= 0.12.1 && < 0.12.5,
++                      http-types        >= 0.12.1 && < 0.13,
+                       exceptions        >= 0.6 && < 0.11,
+                       terminal-size     >= 0.3.4 && < 0.4
+ 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Patches are my own this time, so maybe deserve a closer look. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
