### PR TITLE
reticulum-go: 0.9.5 -> 0.9.6

### DIFF
--- a/pkgs/by-name/re/reticulum-go/package.nix
+++ b/pkgs/by-name/re/reticulum-go/package.nix
@@ -7,7 +7,7 @@
 
 buildGoModule (finalAttrs: {
   pname = "reticulum-go";
-  version = "0.9.5";
+  version = "0.9.6";
   strictDeps = true;
   __structuredAttrs = true;
 
@@ -15,8 +15,14 @@ buildGoModule (finalAttrs: {
     owner = "Quad4-Software";
     repo = "Reticulum-Go";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-LszknSPyZRE/uGy5jSmKAmi+oBargjN+AgbT8QJ3hug=";
+    hash = "sha256-Rji6MJQAN48zKsLHQS8ukbi9pWjHPEbezXJu/700HZs=";
   };
+
+  # TODO: Remove this when https://github.com/NixOS/nixpkgs/pull/527289 has landed in `master`
+  postPatch = ''
+    substituteInPlace go.mod \
+      --replace-fail "1.26.4" "1.26.3"
+  '';
 
   vendorHash = null;
 

--- a/pkgs/by-name/re/reticulum-go/package.nix
+++ b/pkgs/by-name/re/reticulum-go/package.nix
@@ -44,5 +44,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/Quad4-Software/Reticulum-Go";
     license = lib.licenses.asl20;
     mainProgram = "reticulum-go";
+    maintainers = with lib.maintainers; [ drupol ];
   };
 })


### PR DESCRIPTION
Diff: https://github.com/Quad4-Software/Reticulum-Go/compare/v0.9.5...v0.9.6

Changelog: https://github.com/Quad4-Software/Reticulum-Go/releases/tag/v0.9.6


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
