### PR TITLE
python3Packages.beets: 2.11.0 -> 2.12.0

### DIFF
--- a/pkgs/development/python-modules/beets-alternatives/default.nix
+++ b/pkgs/development/python-modules/beets-alternatives/default.nix
@@ -38,6 +38,11 @@ buildPythonPackage rec {
       url = "https://github.com/geigerzaehler/beets-alternatives/commit/84fdb0fa15225cce1e881b07bddcb52715677915.patch";
       hash = "sha256-rURvP7aNJ+I9bPjk43t8rYujOK1iUS1J4RFMAHfa5AU=";
     })
+    # Fix for Beets 2.12; see https://github.com/geigerzaehler/beets-alternatives/pull/234
+    (fetchpatch {
+      url = "https://github.com/geigerzaehler/beets-alternatives/commit/e27772bb627d1b0763685d7add209d40987f2b95.patch";
+      hash = "sha256-47HhaYWzHQakGlbUWdfG5qkfvbadbow1i+O74JnKPwM=";
+    })
   ];
 
   build-system = [

--- a/pkgs/development/python-modules/beets-filetote/default.nix
+++ b/pkgs/development/python-modules/beets-filetote/default.nix
@@ -1,11 +1,10 @@
 {
   lib,
   fetchFromGitHub,
-  fetchpatch2,
   buildPythonPackage,
 
   # build-system
-  poetry-core,
+  uv-build,
 
   # nativeBuildInputs
   beets-minimal,
@@ -22,31 +21,23 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "beets-filetote";
-  version = "1.3.5";
+  version = "1.3.6";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "gtronset";
     repo = "beets-filetote";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-qMHjcBrXkVG7U5a1E0yRwNgmg7XinRnK3gnV7jAZLTk=";
+    hash = "sha256-ZrF9Z3Eaem8ZzNJgQoW45MvsNOCoLsd7l/yLQ2pldR0=";
   };
-  # needed to keep beetsplug a namespace package, othwise other plugins will not be found
-  # can be removed with next version
-  patches = [
-    (fetchpatch2 {
-      url = "https://github.com/gtronset/beets-filetote/commit/762cf0c4b60b8f6b38cf39b027de4241f12cef37.patch?full_index=1";
-      hash = "sha256-c7qIECcqwoV4ZOaA/8JYsM6Aym34peWPh7ZLWUxIYSI=";
-      excludes = [ "CHANGELOG.md" ];
-    })
-  ];
 
+  # https://github.com/gtronset/beets-filetote/issues/328
   postPatch = ''
-    substituteInPlace pyproject.toml --replace-fail "poetry-core<2.0.0" "poetry-core"
+    substituteInPlace pyproject.toml --replace-fail "uv_build>=0.11.21,<0.12" "uv-build"
   '';
 
   build-system = [
-    poetry-core
+    uv-build
   ];
 
   nativeBuildInputs = [
@@ -55,9 +46,6 @@ buildPythonPackage (finalAttrs: {
 
   dependencies = [
     mediafile
-    reflink
-    toml
-    typeguard
   ];
 
   nativeCheckInputs = [
@@ -70,10 +58,12 @@ buildPythonPackage (finalAttrs: {
     writableTmpDirAsHomeHook
   ];
 
-  pytestFlags = [
-    # This is the same as:
-    #   -r fEs
-    "-rfEs"
+  disabledTestPaths = [
+    # Tests fail for Beets 2.12.x, see:
+    # https://github.com/gtronset/beets-filetote/issues/328
+    "tests/test_exclude.py::TestExclude::test_exclude_strseq_of_filenames_by_string"
+    "tests/test_exclude.py::TestExclude::test_exclude_strseq_of_filenames_by_list"
+    "tests/test_printignored.py::TestPrintIgnored::test_print_ignored"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/beets-filetote/default.nix
+++ b/pkgs/development/python-modules/beets-filetote/default.nix
@@ -14,7 +14,6 @@
   pytestCheckHook,
   beets-audible,
   mediafile,
-  pytest,
   reflink,
   toml,
   typeguard,

--- a/pkgs/development/python-modules/beets/default.nix
+++ b/pkgs/development/python-modules/beets/default.nix
@@ -113,12 +113,12 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "beets";
-  version = "2.11.0";
+  version = "2.12.0";
   src = fetchFromGitHub {
     owner = "beetbox";
     repo = "beets";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-fi6D0P2GtEO41VL6UKAArRedZVxw97yqDUAoilktUho=";
+    hash = "sha256-u2qoZ0/qWq9YUcwbOpsqtIjX5BZ2z2wj00X59Pf+/fk=";
   };
   pyproject = true;
 


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test