### PR TITLE
bellepoule: 5.5 -> 5.7

### DIFF
--- a/pkgs/by-name/be/bellepoule/package.nix
+++ b/pkgs/by-name/be/bellepoule/package.nix
@@ -19,13 +19,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "bellepoule";
-  version = "5.5";
+  version = "5.7";
 
   src =
     (fetchgit {
       url = "https://git.launchpad.net/bellepoule";
-      rev = finalAttrs.version;
-      hash = "sha256-SNL6yaaKk/GU8+EvHki4ysMuCHEQxFjPd3iwVIdJtCs=";
+      # No tag available on launchpad for this version
+      rev = "06516d698fde9662d95cf6a8758eb1fbcc89e983";
+      hash = "sha256-9bbFzi9JPryJK2zv4O1TUDaeoB9GVV7LRNn6Xl8lajg=";
     }).overrideAttrs
       (oldAttrs: {
         env = oldAttrs.env or { } // {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Updated bellepoule to 5.7
  - of note here, upstream repo did not tag the 5.7 release. So [the ref](https://git.launchpad.net/bellepoule/commit/?h=5.0/master&id=06516d698fde9662d95cf6a8758eb1fbcc89e983) is used instead.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
