### PR TITLE
tailscale-gui: 1.92.3 -> 1.98.5

### DIFF
--- a/pkgs/by-name/ta/tailscale-gui/package.nix
+++ b/pkgs/by-name/ta/tailscale-gui/package.nix
@@ -5,15 +5,20 @@
   xar,
   cpio,
   pbzx,
+  writeShellApplication,
+  cacert,
+  curl,
+  jq,
+  common-updater-scripts,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "tailscale-gui";
-  version = "1.92.3";
+  version = "1.98.5";
 
   src = fetchurl {
     url = "https://pkgs.tailscale.com/stable/Tailscale-${finalAttrs.version}-macos.pkg";
-    hash = "sha256-K5tJHyFhqnxV4KHzr7YOHRoH33vk+dq+EVWyUo88nuI=";
+    hash = "sha256-r7e8aKNWaX1psI0a3sohTUv8xmUv8oebH/ndjeHLoVA=";
   };
 
   dontUnpack = true;
@@ -39,13 +44,30 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
+  passthru.updateScript = lib.getExe (writeShellApplication {
+    name = "tailscale-gui-update-script";
+    runtimeInputs = [
+      cacert
+      curl
+      jq
+      common-updater-scripts
+    ];
+    text = ''
+      version=$(curl --silent "https://pkgs.tailscale.com/stable/?mode=json&os=darwin" | jq -r '.MacZipsVersion')
+      update-source-version tailscale-gui "$version"
+    '';
+  });
+
   meta = {
     description = "Tailscale GUI client for macOS";
     homepage = "https://tailscale.com";
     changelog = "https://tailscale.com/changelog#client";
     license = lib.licenses.unfree;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    maintainers = with lib.maintainers; [ anish ];
+    maintainers = with lib.maintainers; [
+      anish
+      Br1ght0ne
+    ];
     platforms = lib.platforms.darwin;
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://tailscale.com/changelog#2026-06-01
## Things done
- updated version
- added `updateScript`
- added myself as maintainer

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
