### PR TITLE
nixos/tests: Load root profile in nspawn tests

### DIFF
--- a/nixos/lib/test-driver/src/test_driver/machine/__init__.py
+++ b/nixos/lib/test-driver/src/test_driver/machine/__init__.py
@@ -1587,7 +1587,7 @@ class NspawnMachine(BaseMachine):
         # NOTE If the test calls switch-to-configuration (with a differently configured specialization)
         # this will use the /etc/profile of the new specialisation while `QemuMachine` nodes
         # will continue to use the original /etc/profile.
-        command = f"set -eo pipefail; source /etc/profile; set -u; {command}"
+        command = f"set -eo pipefail; USER=root HOME=/root source /etc/profile; set -u; {command}"
 
         cp = subprocess.run(
             [

--- a/nixos/tests/simple-container.nix
+++ b/nixos/tests/simple-container.nix
@@ -1,11 +1,16 @@
 {
   name = "simple-container";
 
-  containers.machine = { };
+  containers = {
+    machine = { pkgs, ... }: {
+      users.users.root.packages = [ pkgs.hello ];
+    };
+    noprofile = { };
+  };
 
   testScript = ''
     start_all()
-    machine.wait_for_unit("multi-user.target")
-    machine.shutdown()
+    machine.succeed("hello")
+    noprofile.fail("hello")
   '';
 }


### PR DESCRIPTION
@mweinelt rightly remarked that nspawn container test scripts (running as root) should have access to root's profile, i.e. `users.users.root.packages` should be available in PATH.

This quick fix by @e1mo addresses this. Precedent for setting USER and HOME can be found in [`test-instrumentation.nix`](https://github.com/NixOS/nixpkgs/blob/3cdc8d1165a768c020acfead666b09cb147f6d89/nixos/modules/testing/test-instrumentation.nix#L29) in the backdoor service.

A more elegant fix would build upon @arianvp's #480686 and make VMs and nspawn containers provide a running login shell on a console socket file with which the test driver could uniformly interact (and drop `nsenter` from `_execute` entirely). @e1mo told me she's looking into this.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
