### PR TITLE
nixos/nix: add systemd credential support

### DIFF
--- a/nixos/modules/config/nix.nix
+++ b/nixos/modules/config/nix.nix
@@ -153,7 +153,11 @@ in
 
       extraOptions = mkOption {
         type = types.lines;
-        default = "";
+        default = ''
+          # /etc/nix/provision.conf provisioned by the org.nixos.nix.settings
+          # systemd credential. It is ignored when it does not exist.
+          !include /etc/nix/provision.conf
+        '';
         example = ''
           keep-outputs = true
           keep-derivations = true
@@ -372,6 +376,21 @@ in
       trusted-users = [ "root" ];
       substituters = mkAfter [ "https://cache.nixos.org/" ];
       system-features = defaultSystemFeatures;
+    };
+
+    systemd.services.systemd-tmpfiles-setup = {
+      serviceConfig.ImportCredential = [ "org.nixos.nix.settings" ];
+    };
+
+    systemd.services.systemd-tmpfiles-resetup = {
+      serviceConfig.ImportCredential = [ "org.nixos.nix.settings" ];
+    };
+
+    systemd.tmpfiles.settings."nix-provision"."/etc/nix/provision.conf"."f^" = {
+      user = "root";
+      group = "root";
+      mode = "0644";
+      argument = "org.nixos.nix.settings";
     };
   };
 }

--- a/nixos/tests/nix-config.nix
+++ b/nixos/tests/nix-config.nix
@@ -9,6 +9,12 @@
         extra-nix-path = [ "extra=/etc/value.nix" ];
       };
       environment.etc."value.nix".text = "42";
+
+      users.users.alice.isNormalUser = true;
+
+      virtualisation.credentials."org.nixos.nix.settings".text = ''
+        extra-nix-path = credential=/etc/value.nix
+      '';
     };
   testScript = ''
     start_all()
@@ -17,5 +23,7 @@
     # unset NIX_PATH because environtment overrides the config
     print(machine.succeed("env -u NIX_PATH nix-instantiate --find-file extra"))
     print(machine.succeed("env -u NIX_PATH nix-instantiate --find-file nonextra"))
+    print(machine.succeed("env -u NIX_PATH nix-instantiate --find-file credential"))
+    print(machine.succeed("su - alice -c 'env -u NIX_PATH nix-instantiate --find-file credential'"))
   '';
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I'm working on integrating `systemd-imdsd` with NixOS to replace all our bespoke cloud images with a single cloud image that works on all public clouds.

It allows cloud providers to provide systemd system credentials to spawned instances. We can then use these credentials to configure partitioning, various system components, nix itself and  drive a nixos-rebuild switch.

This will replace all the bespoke user-data scripts we have

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
