### PR TITLE
darktable: 5.4.1 -> 5.6.0

### DIFF
--- a/pkgs/by-name/da/darktable/package.nix
+++ b/pkgs/by-name/da/darktable/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  withAi ? false,
 
   # nativeBuildInputs
   cmake,
@@ -34,6 +35,7 @@
   lensfun,
   lerc,
   libaom,
+  libarchive,
   libavif,
   libdatrie,
   libepoxy,
@@ -53,12 +55,14 @@
   libwebp,
   libxml2,
   lua5_4,
+  onnxruntime,
   util-linux,
   openexr,
   openjpeg,
   osm-gps-map,
   pcre2,
   portmidi,
+  potrace,
   pugixml,
   sqlite,
   # Linux only
@@ -81,12 +85,12 @@ let
   pugixml-shared = pugixml.override { shared = true; };
 in
 stdenv.mkDerivation rec {
-  version = "5.4.1";
+  version = "5.6.0";
   pname = "darktable";
 
   src = fetchurl {
     url = "https://github.com/darktable-org/darktable/releases/download/release-${version}/darktable-${version}.tar.xz";
-    hash = "sha256-r9x8iKM4qM0vrDHIRQ0Hbtv3PpVuQwcmDIPrwZX4ReQ=";
+    hash = "sha256-FX1tOEevivyr54lERUeG9zqIbgilBLS9YRTCBl/gBuQ=";
   };
 
   nativeBuildInputs = [
@@ -144,8 +148,13 @@ stdenv.mkDerivation rec {
     osm-gps-map
     pcre2
     portmidi
+    potrace
     pugixml-shared
     sqlite
+  ]
+  ++ lib.optionals withAi [
+    libarchive
+    onnxruntime
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     alsa-lib
@@ -166,6 +175,10 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DBUILD_USERMANUAL=False"
   ]
+  ++ lib.optionals withAi [
+    (lib.cmakeBool "USE_AI" true)
+    (lib.cmakeBool "ONNXRUNTIME_OFFLINE" true)
+  ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     "-DUSE_COLORD=OFF"
     "-DUSE_KWALLET=OFF"
@@ -179,7 +192,9 @@ stdenv.mkDerivation rec {
     let
       libPathEnvVar = if stdenv.hostPlatform.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH";
       libPathPrefix =
-        "$out/lib/darktable" + lib.optionalString stdenv.hostPlatform.isLinux ":${ocl-icd}/lib";
+        "$out/lib/darktable"
+        + lib.optionalString (withAi && stdenv.hostPlatform.isLinux) ":${lib.getLib onnxruntime}/lib"
+        + lib.optionalString stdenv.hostPlatform.isLinux ":${ocl-icd}/lib";
     in
     ''
       for f in $out/share/darktable/kernels/*.cl; do


### PR DESCRIPTION
Update darktable from 5.4.1 to 5.6.0.

 Changelog: https://github.com/darktable-org/darktable/releases/tag/release-5.6.0

Adds `potrace` as a build input required by the 5.6.0 build.

Also adds `withAi ? false` opt-in support for upstream's optional AI subsystem. The default build keeps AI disabled; users can enable it with `darktable.override { withAi = true; }`, which uses nixpkgs `onnxruntime` with `ONNXRUNTIME_OFFLINE=ON`.

 Closes #534268

 Assisted-by: pi coding agent / Mika (OpenAI GPT-5.5)

 ## Things done

 <!-- Please check what applies. Note that these are not hard requirements but merely serve
 as information for reviewers. -->

 - Built on platform:
   - [x] x86_64-linux
   - [ ] aarch64-linux
   - [ ] x86_64-darwin
   - [ ] aarch64-darwin
 - Tested, as applicable:
   - [ ] [NixOS tests] in [nixos/tests].
   - [ ] [Package tests] at `passthru.tests`.
   - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
 - [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
 - [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
 - Nixpkgs Release Notes
   - [ ] Package update: when the change is major or breaking.
 - NixOS Release Notes
   - [ ] Module addition: when adding a new NixOS module.
   - [ ] Module update: when the change is significant.
 - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
 - [x] Follows the [automation/AI policy].

 [NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
 [Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
 [nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

 [CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
 [automation/AI policy]:
 https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
 [lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
 [maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
 [nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
 [pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
 [pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

