### PR TITLE
katvan: init at 0.12.1

### DIFF
--- a/pkgs/by-name/co/corrosion/package.nix
+++ b/pkgs/by-name/co/corrosion/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cargo,
   cmake,
   rustc,
@@ -18,6 +19,14 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "v${finalAttrs.version}";
     hash = "sha256-ppuDNObfKhneD9AlnPAvyCRHKW3BidXKglD1j/LE9CM=";
   };
+  patches = [
+    # Fix for this hard to debug issue in dependent packages:
+    # https://github.com/corrosion-rs/corrosion/issues/588
+    (fetchpatch {
+      url = "https://github.com/corrosion-rs/corrosion/commit/7dab832903ddfb0f644cbd014252d477e692012b.patch";
+      hash = "sha256-T9ILTfAd/i63v45YJQsz8F/P3NBwrP1mL2bKNU0NaLw=";
+    })
+  ];
 
   buildInputs = lib.optional stdenv.hostPlatform.isDarwin libiconv;
 

--- a/pkgs/by-name/ka/katvan/package.nix
+++ b/pkgs/by-name/ka/katvan/package.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  # nativeBuildInputs
+  cmake,
+  pkg-config,
+  python3,
+  rustPlatform,
+  rustc,
+  cargo,
+
+  # buildInputs
+  qt6,
+  libarchive,
+  corrosion,
+  hunspell,
+
+  # checkInputs
+  gtest,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "katvan";
+  version = "0.12.1";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "IgKh";
+    repo = "katvan";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-WyPiRj/5So/1vjAytnXoldwYMG++tuLl0B0v31BeJxY=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      cargoRoot
+      ;
+    hash = "sha256-p5cMFCuDy17uMoy99R8l+e6iQcbNXSavFj0sBRRsMwo=";
+  };
+
+  # The CMakeLists files used by upstream issue a `cargo install` command to
+  # install a rust tool (cxxbridge-cmd) that is supposed to be included in the Cargo.toml's and
+  # `Cargo.lock` files of upstream. Setting CARGO_HOME like that helps `cargo
+  # install` find the dependencies we prefetched. See also:
+  # https://github.com/GothenburgBitFactory/taskwarrior/issues/3705
+  postUnpack = ''
+    export CARGO_HOME=$PWD/.cargo
+  '';
+
+  cargoRoot = "typstdriver/rust";
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    qt6.wrapQtAppsHook
+    qt6.qttools
+    rustPlatform.cargoSetupHook
+    rustc
+    cargo
+    (python3.withPackages (ps: [
+      ps.mistletoe
+    ]))
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    libarchive
+    corrosion
+    hunspell
+  ];
+
+  checkInputs = [
+    gtest
+  ];
+
+  cmakeFlags = [
+    # Don't set this to an absolute path, as it breaks upstream rpath settings
+    # for the final executable, see: https://github.com/IgKh/katvan/issues/46
+    (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "lib")
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "bare-bones editor for Typst files, with a bias for Right-to-Left editing";
+    homepage = "https://github.com/IgKh/katvan";
+    changelog = "https://github.com/IgKh/katvan/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ doronbehar ];
+    mainProgram = "katvan";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
A draft because waiting for upstream reply here:

- https://github.com/IgKh/katvan/pull/45

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test