### PR TITLE
python3Packages.xmodem: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/xmodem/default.nix
+++ b/pkgs/development/python-modules/xmodem/default.nix
@@ -8,16 +8,18 @@
   lrzsz,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "xmodem";
   version = "0.4.7";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "tehmaze";
     repo = "xmodem";
-    tag = version;
-    sha256 = "sha256-kwPA/lYiv6IJSKGRuH13tBofZwp19vebwQniHK7A/i8=";
+    tag = finalAttrs.version;
+    hash = "sha256-kwPA/lYiv6IJSKGRuH13tBofZwp19vebwQniHK7A/i8=";
   };
 
   build-system = [ setuptools ];
@@ -32,10 +34,12 @@ buildPythonPackage rec {
     pytest
   '';
 
+  pythonImportsCheck = [ "xmodem" ];
+
   meta = {
     description = "Pure python implementation of the XMODEM protocol";
     maintainers = with lib.maintainers; [ emantor ];
     homepage = "https://github.com/tehmaze/xmodem";
     license = lib.licenses.mit;
   };
-}
+})

--- a/pkgs/development/python-modules/xmodem/default.nix
+++ b/pkgs/development/python-modules/xmodem/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
   pytest,
   which,
   lrzsz,
@@ -10,7 +11,7 @@
 buildPythonPackage rec {
   pname = "xmodem";
   version = "0.4.7";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tehmaze";
@@ -18,6 +19,8 @@ buildPythonPackage rec {
     tag = version;
     sha256 = "sha256-kwPA/lYiv6IJSKGRuH13tBofZwp19vebwQniHK7A/i8=";
   };
+
+  build-system = [ setuptools ];
 
   nativeCheckInputs = [
     pytest


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
