### PR TITLE
WIP pixelfed: consolidate php env

### DIFF
--- a/nixos/modules/services/web-apps/pixelfed.nix
+++ b/nixos/modules/services/web-apps/pixelfed.nix
@@ -20,23 +20,7 @@ let
     gifsicle
     ffmpeg
   ];
-  # Ensure PHP extensions: https://github.com/pixelfed/pixelfed/blob/dev/app/Console/Commands/Installer.php#L135-L147
-  phpPackage = cfg.phpPackage.buildEnv {
-    extensions =
-      { enabled, all }:
-      enabled
-      ++ (with all; [
-        bcmath
-        ctype
-        curl
-        mbstring
-        gd
-        intl
-        zip
-        redis
-        imagick
-      ]);
-  };
+  phpPackage = cfg.phpPackage;
   configFile = pkgs.writeText "pixelfed-env" (lib.generators.toKeyValue { } cfg.settings);
   # Management script
   pixelfed-manage = pkgs.writeShellScriptBin "pixelfed-manage" ''
@@ -66,7 +50,12 @@ in
     pixelfed = {
       enable = mkEnableOption "a Pixelfed instance";
       package = mkPackageOption pkgs "pixelfed" { };
-      phpPackage = mkPackageOption pkgs "php83" { };
+      phpPackage = mkOption {
+        type = types.package;
+        default = cfg.package.phpPackage;
+        defaultText = lib.literalExpression "config.services.pixelfed.package.phpPackage";
+        description = "The PHP package to use for Pixelfed.";
+      };
 
       user = mkOption {
         type = types.str;

--- a/pkgs/by-name/pi/pixelfed/package.nix
+++ b/pkgs/by-name/pi/pixelfed/package.nix
@@ -8,9 +8,27 @@
   runtimeDir ? "/run/pixelfed",
 }:
 let
-  php' = php.withExtensions ({ enabled, all }: enabled ++ (with all; [ ffi ]));
+  # Ensure php extensions
+  # https://github.com/pixelfed/pixelfed/blob/dev/app/Console/Commands/Installer.php#L135-L147
+  phpPackage = php.buildEnv {
+    extensions =
+      { enabled, all }:
+      enabled
+      ++ (with all; [
+        bcmath
+        ctype
+        curl
+        mbstring
+        gd
+        intl
+        zip
+        redis
+        imagick
+        ffi
+      ]);
+  };
 in
-php'.buildComposerProject2 (finalAttrs: {
+phpPackage.buildComposerProject2 (finalAttrs: {
   pname = "pixelfed";
   version = "0.12.7";
 
@@ -38,6 +56,7 @@ php'.buildComposerProject2 (finalAttrs: {
   '';
 
   passthru = {
+    inherit phpPackage;
     tests = { inherit (nixosTests.pixelfed) standard; };
     updateScript = nix-update-script { };
   };


### PR DESCRIPTION
This allows ngi-forge to consume the php package.

Slightly increases the closure size of the pixelfed package but.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
