### PR TITLE
space-station-14-launcher: migrate over to Space-Wizards-Federation repo

### DIFF
--- a/pkgs/by-name/sp/space-station-14-launcher/package.nix
+++ b/pkgs/by-name/sp/space-station-14-launcher/package.nix
@@ -39,7 +39,7 @@
 }:
 let
   pname = "space-station-14-launcher";
-  version = "0.38.0";
+  version = "0.38.1.0";
 in
 buildDotnetModule rec {
   inherit pname;
@@ -49,10 +49,10 @@ buildDotnetModule rec {
   name = "${pname}-${version}";
 
   src = fetchFromGitHub {
-    owner = "space-wizards";
+    owner = "Space-Wizards-Federation";
     repo = "SS14.Launcher";
     tag = "v${version}";
-    hash = "sha256-/FPNCNDC09NMg1bTSZHNFfzabxYQ2FhV1t6Ire9WBtg=";
+    hash = "sha256-QdSgDLPsoNcipwg2ZwkptF7N+TVbbpQzIBkXPE51brM=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
This is a bit of a different one. Technically, this PR is trivial.

Socially however, it is complex. The Space Station 14 community has undergone a bit of a schism, with, as far as I can tell, some portion of the community splitting away. This includes some devs, moderation staff, infrastructure team, and servers. It's not a standard fork, both sides are claiming their version is the official one. This change follows the new repo, instead of the original one. 

There is no precedent as far as I am aware, no other distro has is packaging the game so no other distro has this issue. Steam page for the game and the original website are in control of the original team.

I am creating this for tracking, I recommend to wait indefinitely before merging, to see how the dust settles, but I had some free time so I wrote this up, and I thought its a good excuse to see how to contribute to nixpkgs. 

For more information, one can visit:

- The Space Station 14 Discord (new team) - https://discord.gg/ss14
- The Space Station 14 Page (new team) - https://playss14.com/about/faq/
- The Space Station 14 Page (original team) - https://spacestation14.com/
- The Space Station 14 Forums (original team) - https://forum.spacestation14.com/c/announcements/5/none

However, I believe that any information is purely informative, to reiterate, nixpkgs should just wait

Note that I am using "original" and "new", but, while the original team is provably more senior, the new team has a numerical majority AFAIK.

I tested the PR and it is running correctly as far as I can tell.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
