### PR TITLE
auto-patchelf & patchelf: add options to generate relative RPATHs ($ORIGIN)

### DIFF
--- a/pkgs/by-name/au/auto-patchelf/source/auto-patchelf.py
+++ b/pkgs/by-name/au/auto-patchelf/source/auto-patchelf.py
@@ -310,7 +310,7 @@ class Logger:
 
 
 
-def auto_patchelf_file(logger: Logger, path: Path, runtime_deps: list[Path], append_rpaths: list[Path] = [], keep_libc: bool = False, preserve_origin: bool = False, extra_args: list[str] = []) -> list[Dependency]:
+def auto_patchelf_file(logger: Logger, path: Path, runtime_deps: list[Path], append_rpaths: list[Path] = [], keep_libc: bool = False, preserve_origin: bool = False, relative_rpaths: bool = False, extra_args: list[str] = []) -> list[Dependency]:
     try:
         with open_elf(path) as elf:
 
@@ -425,6 +425,36 @@ def auto_patchelf_file(logger: Logger, path: Path, runtime_deps: list[Path], app
             if "$ORIGIN" in existing_rpath:
                 rpath.append(Path(existing_rpath))
 
+    if relative_rpaths:
+        # Determine the store directory to identify which absolute paths can be made relative.
+        # Check NIX_STORE environment variable first, then fall back dynamically to libc_lib's grandparent
+        # (which is guaranteed to point to the store when main() is running successfully).
+        store_dir_env = os.environ.get('NIX_STORE')
+        store_path = Path(store_dir_env) if store_dir_env else libc_lib.parent.parent
+        if store_path == Path('/'):
+            store_path = None
+
+        relative_rpath = []
+        for r in rpath:
+            if not r.is_absolute():
+                relative_rpath.append(r)
+            else:
+                in_store = True
+                if store_path:
+                    try:
+                        path.relative_to(store_path)
+                        r.relative_to(store_path)
+                    except ValueError:
+                        in_store = False
+
+                if in_store:
+                    # Construct relative path starting with $ORIGIN
+                    rel = os.path.relpath(r, path.parent)
+                    relative_rpath.append(Path(f"$ORIGIN/{rel}"))
+                else:
+                    relative_rpath.append(r)
+        rpath = relative_rpath
+
     # Dedup the rpath
     rpath_str = ":".join(dict.fromkeys(map(Path.as_posix, rpath)))
 
@@ -447,6 +477,7 @@ def auto_patchelf(
         append_rpaths: list[Path] = [],
         keep_libc: bool = False,
         preserve_origin: bool = False,
+        relative_rpaths: bool = False,
         add_existing: bool = True,
         extra_args: list[str] = []) -> None:
 
@@ -463,7 +494,7 @@ def auto_patchelf(
     dependencies = []
     for path in chain.from_iterable(glob(p, '*', recursive) for p in paths_to_patch):
         if not path.is_symlink() and path.is_file():
-            dependencies += auto_patchelf_file(logger, path, runtime_deps, append_rpaths, keep_libc, preserve_origin, extra_args)
+            dependencies += auto_patchelf_file(logger, path, runtime_deps, append_rpaths, keep_libc, preserve_origin, relative_rpaths, extra_args)
 
     missing = [dep for dep in dependencies if not dep.found]
 
@@ -550,6 +581,12 @@ def main() -> None:
         help="When possible, replace absolute RPATH entries with original $ORIGIN entries that resolve to the same directory.",
     )
     parser.add_argument(
+        "--relative-rpaths",
+        dest="relative_rpaths",
+        action="store_true",
+        help="When possible, replace absolute RPATH entries with relative paths starting with $ORIGIN.",
+    )
+    parser.add_argument(
         "--ignore-existing",
         dest="add_existing",
         action="store_false",
@@ -586,6 +623,7 @@ def main() -> None:
         append_rpaths=args.append_rpaths,
         keep_libc=args.keep_libc,
         preserve_origin=args.preserve_origin,
+        relative_rpaths=args.relative_rpaths,
         add_existing=args.add_existing,
         extra_args=args.extra_args)
 

--- a/pkgs/by-name/au/auto-patchelf/source/auto-patchelf.py
+++ b/pkgs/by-name/au/auto-patchelf/source/auto-patchelf.py
@@ -427,12 +427,9 @@ def auto_patchelf_file(logger: Logger, path: Path, runtime_deps: list[Path], app
 
     if relative_rpaths:
         # Determine the store directory to identify which absolute paths can be made relative.
-        # Check NIX_STORE environment variable first, then fall back dynamically to libc_lib's grandparent
-        # (which is guaranteed to point to the store when main() is running successfully).
         store_dir_env = os.environ.get('NIX_STORE')
-        store_path = Path(store_dir_env) if store_dir_env else libc_lib.parent.parent
-        if store_path == Path('/'):
-            store_path = None
+        assert store_dir_env, "NIX_STORE environment variable is not set."
+        store_path = Path(store_dir_env)
 
         relative_rpath = []
         for r in rpath:

--- a/pkgs/by-name/au/autoPatchelfHook/auto-patchelf.sh
+++ b/pkgs/by-name/au/autoPatchelfHook/auto-patchelf.sh
@@ -59,6 +59,10 @@ autoPatchelf() {
     concatTo patchelfFlagsArray patchelfFlags
     concatTo autoPatchelfFlagsArray autoPatchelfFlags
 
+    if [[ -n "${autoPatchelfRelativeRpaths-}" ]]; then
+        autoPatchelfFlagsArray+=("--relative-rpaths")
+    fi
+
     # Check if ignoreMissingDepsArray contains "1" and if so, replace it with
     # "*", printing a deprecation warning.
     for dep in "${ignoreMissingDepsArray[@]}"; do

--- a/pkgs/development/tools/misc/patchelf/setup-hook.sh
+++ b/pkgs/development/tools/misc/patchelf/setup-hook.sh
@@ -16,5 +16,39 @@ patchELF() {
         if ! isELF "$i"; then continue; fi
         echo "shrinking $i"
         patchelf --shrink-rpath "$i" || true
+
+        if [[ -n "${patchelfRelativeRpaths-}" ]]; then
+            local rpath
+            if rpath=$(patchelf --print-rpath "$i") && [ -n "$rpath" ]; then
+                local store_path="${NIX_STORE:-/nix/store}"
+                local new_rpath=""
+                local r
+                local rpath_arr
+                # Split by ':'
+                IFS=':' read -r -a rpath_arr <<< "$rpath"
+                for r in "${rpath_arr[@]}"; do
+                    # Only convert to relative if both the binary and the dependency are in the store
+                    if [[ "$i" == "$store_path"/* && "$r" == "$store_path"/* ]]; then
+                        local rel
+                        rel=$(realpath -m --relative-to="$(dirname "$i")" "$r")
+                        rpath_entry='$ORIGIN/'"$rel"
+                    else
+                        rpath_entry="$r"
+                    fi
+
+                    if [ -z "$new_rpath" ]; then
+                        new_rpath="$rpath_entry"
+                    else
+                        new_rpath="$new_rpath:$rpath_entry"
+                    fi
+                done
+
+                # Check if the RPATH has actually changed to avoid redundant writes
+                if [ "$rpath" != "$new_rpath" ]; then
+                    echo "setting RPATH to: $new_rpath"
+                    patchelf --set-rpath "$new_rpath" "$i"
+                fi
+            fi
+        fi
     done < <(find "$dir" -type f -print0)
 }

--- a/pkgs/test/auto-patchelf-hook-relative-rpaths/default.nix
+++ b/pkgs/test/auto-patchelf-hook-relative-rpaths/default.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  stdenv,
+  tests,
+  autoPatchelfHook,
+  patchelf,
+}:
+
+let
+  foo = tests.stdenv-inputs.foo;
+  bar = tests.stdenv-inputs.bar;
+
+  # We build a simple binary that links against foo and bar.
+  # But we don't set any rpath during compilation so that it needs to be patched.
+  lib-check = stdenv.mkDerivation {
+    name = "lib-check-unpatched";
+
+    buildInputs = [
+      foo
+      bar
+    ];
+
+    buildCommand = ''
+      $CC -lfoo -lbar -o lib-check ${../auto-patchelf-hook-preserve-origin/lib-main.c}
+      mkdir -p $out/bin
+      cp lib-check $out/bin/
+    '';
+  };
+
+  # Now we run autoPatchelfHook with autoPatchelfRelativeRpaths = true
+  lib-check-autopatchelfed = stdenv.mkDerivation {
+    name = "lib-check-autopatchelfed";
+
+    nativeBuildInputs = [
+      autoPatchelfHook
+    ];
+
+    buildInputs = [
+      foo
+      bar
+    ];
+
+    autoPatchelfRelativeRpaths = true;
+
+    dontUnpack = true;
+
+    installPhase = ''
+      mkdir -p $out/bin $out/libexec
+      cp ${lib-check}/bin/lib-check $out/libexec/lib-check
+      ln -s ../libexec/lib-check $out/bin/lib-check
+    '';
+  };
+in
+stdenv.mkDerivation {
+  name = "auto-patchelf-hook-relative-rpaths";
+
+  nativeBuildInputs = [
+    patchelf
+  ];
+
+  buildCommand = ''
+    symlink="${lib-check-autopatchelfed}/bin/lib-check"
+    real_binary="${lib-check-autopatchelfed}/libexec/lib-check"
+
+    # Ensure the symlink executes successfully (verifies glibc resolves $ORIGIN relative to the real binary)
+    $symlink
+
+    # Print the rpath of the real binary to verify it contains $ORIGIN-based relative paths instead of absolute store paths
+    runpath=$(patchelf --print-rpath "$real_binary")
+    echo "Runpath is: $runpath"
+
+    # Verify that runpath contains $ORIGIN/../../ and does not contain absolute nix store paths of foo/bar
+    if [[ "$runpath" != *'$ORIGIN/../../'* ]]; then
+      echo "Error: Runpath does not contain relative $ORIGIN entry" >&2
+      exit 1
+    fi
+
+    if [[ "$runpath" == *"${foo}"* || "$runpath" == *"${bar}"* ]]; then
+      echo "Error: Runpath contains absolute store path of dependencies" >&2
+      exit 1
+    fi
+
+    touch $out
+  '';
+
+  meta.platforms = lib.platforms.all;
+  passthru = {
+    inherit lib-check lib-check-autopatchelfed;
+  };
+}

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -244,6 +244,8 @@ in
 
   auto-patchelf-hook-preserve-origin = callPackage ./auto-patchelf-hook-preserve-origin { };
 
+  auto-patchelf-hook-relative-rpaths = callPackage ./auto-patchelf-hook-relative-rpaths { };
+
   # Accumulate all passthru.tests from arrayUtilities into a single attribute set.
   arrayUtilities = recurseIntoAttrs (
     concatMapAttrs (

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -246,6 +246,8 @@ in
 
   auto-patchelf-hook-relative-rpaths = callPackage ./auto-patchelf-hook-relative-rpaths { };
 
+  patchelf-relative-rpaths = callPackage ./patchelf-relative-rpaths { };
+
   # Accumulate all passthru.tests from arrayUtilities into a single attribute set.
   arrayUtilities = recurseIntoAttrs (
     concatMapAttrs (

--- a/pkgs/test/patchelf-relative-rpaths/default.nix
+++ b/pkgs/test/patchelf-relative-rpaths/default.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  stdenv,
+  tests,
+  patchelf,
+}:
+
+let
+  foo = tests.stdenv-inputs.foo;
+  bar = tests.stdenv-inputs.bar;
+
+  # A simple binary compiled from source using stdenv.mkDerivation.
+  # We set a RUNPATH pointing to foo and bar.
+  lib-check = stdenv.mkDerivation {
+    name = "lib-check-patchelfed";
+
+    buildInputs = [
+      foo
+      bar
+    ];
+
+    # Enable relative RPATHs in the patchelf setup hook!
+    patchelfRelativeRpaths = true;
+
+    dontUnpack = true;
+
+    installPhase = ''
+      # Compile binary with absolute RUNPATH pointing to the store locations of foo and bar
+      $CC -lfoo -lbar -Wl,-rpath,${lib.getLib foo}/lib -Wl,-rpath,${lib.getLib bar}/lib -o lib-check ${../auto-patchelf-hook-preserve-origin/lib-main.c}
+
+      mkdir -p $out/bin $out/libexec
+      cp lib-check $out/libexec/lib-check
+      ln -s ../libexec/lib-check $out/bin/lib-check
+    '';
+  };
+in
+stdenv.mkDerivation {
+  name = "patchelf-relative-rpaths-test";
+
+  nativeBuildInputs = [
+    patchelf
+  ];
+
+  buildCommand = ''
+    symlink="${lib-check}/bin/lib-check"
+    real_binary="${lib-check}/libexec/lib-check"
+
+    # Ensure the symlink executes successfully (verifies glibc resolves $ORIGIN relative to the real binary)
+    $symlink
+
+    # Print the rpath of the real binary to verify it contains $ORIGIN-based relative paths instead of absolute store paths
+    runpath=$(patchelf --print-rpath "$real_binary")
+    echo "Runpath is: $runpath"
+
+    # Verify that runpath contains $ORIGIN/../../ and does not contain absolute nix store paths of foo/bar
+    if [[ "$runpath" != *'$ORIGIN/../../'* ]]; then
+      echo "Error: Runpath does not contain relative $ORIGIN entry" >&2
+      exit 1
+    fi
+
+    if [[ "$runpath" == *"${foo}"* || "$runpath" == *"${bar}"* ]]; then
+      echo "Error: Runpath contains absolute store path of dependencies" >&2
+      exit 1
+    fi
+
+    touch $out
+  '';
+
+  meta.platforms = lib.platforms.all;
+  passthru = {
+    inherit lib-check;
+  };
+}


### PR DESCRIPTION
This PR introduces support for generating relative RPATHs (using `$ORIGIN`) for both **`auto-patchelf`** (via `autoPatchelfHook`) and **`patchelf`** (via its own setup hook during `stdenv`'s `fixupPhase`).

When enabled, absolute Nix store paths in the final RPATH are translated to relative paths starting with `$ORIGIN/`. Paths outside of the discovered Nix store (such as `/run/opengl-driver/lib` or other system paths) are preserved as absolute paths to prevent regressions.

### Proposed Changes

 1. **`auto-patchelf`**:
     - Added the `--relative-rpaths` flag to the `auto-patchelf` Python script.
     - Exposed it via the `autoPatchelfRelativeRpaths` environment variable in the `autoPatchelfHook` setup hook.
 2. **`patchelf` setup hook**:
    - Added the `patchelfRelativeRpaths` boolean option to `setup-hook.sh`. When `patchelfRelativeRpaths = true;` is set on a derivation, the `fixupPhase` automatically converts absolute Nix store RPATH entries to relative ones.

## Motivation
This is an important step towards enabling fully relocatable binaries in Nix.
- Blog post: https://fzakaria.com/2026/06/21/nix-needs-relocatable-binaries
- Kernel discussion: https://lore.kernel.org/linux-mm/20260622043934.179879-1-farid.m.zakaria@gmail.com/T/#m794063929f1d44cf95f1ddc76dd86dc2a36f9ffb

## Validation
Added an integration test `tests.auto-patchelf-hook-relative-rpaths`. Building the test package’s intermediate binary:

```
$ nix-build -A tests.auto-patchelf-hook-relative-rpaths.lib-check-autopatchelfed
$ patchelf --print-rpath result/bin/lib-check
    $ORIGIN/../../i41qls6r4h8liynp69s848rcv7m59zlq-foo-test/lib:$ORIGIN/../../rkbip9jaw6piq9lasd531xg1l37yr8zz-bar-test-dev/lib
```

```
$ nix-build -A tests.patchelf-relative-rpaths.lib-check
$ patchelf --print-rpath result/libexec/lib-check
    $ORIGIN/../../i41qls6r4h8liynp69s848rcv7m59zlq-foo-test/lib:$ORIGIN/../../rkbip9jaw6piq9lasd531xg1l37yr8zz-bar-test-
```
Assisted-by: Antigravity:Gemini-Pro


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
