### PR TITLE
python3Packages.dissect-target: 3.24 -> 3.25.1

### DIFF
--- a/pkgs/development/python-modules/dissect-evidence/default.nix
+++ b/pkgs/development/python-modules/dissect-evidence/default.nix
@@ -6,20 +6,22 @@
   fetchFromGitHub,
   setuptools,
   setuptools-scm,
+  pycryptodome,
   pytestCheckHook,
   pythonAtLeast,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "dissect-evidence";
-  version = "3.12";
+  version = "3.13";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "fox-it";
     repo = "dissect.evidence";
     tag = finalAttrs.version;
-    hash = "sha256-kSM2fXaK3H6os/RexwOGg2d8UptoAlHnYK7FlMTg2bI=";
+    fetchLFS = true;
+    hash = "sha256-oix0CSsVqBM5udzePa/leabw5sOB8VfLFTB9e46sTD0=";
   };
 
   build-system = [
@@ -32,7 +34,14 @@ buildPythonPackage (finalAttrs: {
     dissect-util
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  optional-dependencies = {
+    full = [ pycryptodome ];
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ]
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
 
   disabledTests = lib.optionals (pythonAtLeast "3.14") [
     # https://github.com/fox-it/dissect.evidence/issues/46

--- a/pkgs/development/python-modules/dissect-hypervisor/default.nix
+++ b/pkgs/development/python-modules/dissect-hypervisor/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  backports-zstd,
   buildPythonPackage,
   defusedxml,
   dissect-cstruct,
@@ -10,18 +11,20 @@
   pytestCheckHook,
   setuptools,
   setuptools-scm,
+  zstandard,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "dissect-hypervisor";
-  version = "3.20";
+  version = "3.21";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "fox-it";
     repo = "dissect.hypervisor";
     tag = finalAttrs.version;
-    hash = "sha256-/b/7u3b0G3XRqXxjyhHn5dYzueQOPoacYGeDYv21I0w=";
+    fetchLFS = true;
+    hash = "sha256-T6dv8TtGTwjOVoGplgBJgRmFRst4Q0EMYgPheGSAEU4=";
   };
 
   patches = [
@@ -51,11 +54,15 @@ buildPythonPackage (finalAttrs: {
 
   optional-dependencies = {
     full = [
+      backports-zstd
       pycryptodome
     ];
   };
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytestCheckHook
+  ]
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
 
   pythonImportsCheck = [ "dissect.hypervisor" ];
 

--- a/pkgs/development/python-modules/dissect-target/default.nix
+++ b/pkgs/development/python-modules/dissect-target/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   asn1crypto,
+  backports-zstd,
   buildPythonPackage,
   defusedxml,
   dissect-btrfs,
@@ -40,19 +41,18 @@
   setuptools-scm,
   structlog,
   yara-python,
-  zstandard,
 }:
 
 buildPythonPackage rec {
   pname = "dissect-target";
-  version = "3.24";
+  version = "3.25.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "fox-it";
     repo = "dissect.target";
     tag = version;
-    hash = "sha256-i1oA7UVo880dHJkf19YRcmPV3Lwp1a8RokfRNDZ9gG0=";
+    hash = "sha256-vFVKnzlzXWvNt2/oNsV2oBBHX+LHzAAzP6gz5fFNTWY=";
     fetchLFS = true;
   };
 
@@ -86,6 +86,7 @@ buildPythonPackage rec {
   optional-dependencies = {
     full = [
       asn1crypto
+      backports-zstd
       dissect-btrfs
       dissect-cim
       dissect-clfs
@@ -104,7 +105,6 @@ buildPythonPackage rec {
       pycryptodome
       ruamel-yaml
       yara-python
-      zstandard
     ];
     yara = [ yara-python ] ++ optional-dependencies.full;
     smb = [ impacket ] ++ optional-dependencies.full;


### PR DESCRIPTION
Diff: https://github.com/fox-it/dissect.target/compare/3.24...3.25.1

Changelog: https://github.com/fox-it/dissect.target/releases/tag/3.25.1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
