### PR TITLE
python3Packages.tables: 3.10.2 -> 3.11.1

### DIFF
--- a/pkgs/development/python-modules/tables/default.nix
+++ b/pkgs/development/python-modules/tables/default.nix
@@ -1,49 +1,49 @@
 {
   lib,
-  stdenv,
-  fetchPypi,
-  fetchpatch,
+  fetchFromGitHub,
   buildPythonPackage,
+  stdenv,
+
+  # build-system
+  cython,
+  setuptools,
+  sphinx,
+
+  # build-inputs
   blosc2,
   bzip2,
   c-blosc,
-  cython,
   hdf5,
   lzo,
-  numpy,
-  numexpr,
-  packaging,
   pkg-config,
-  setuptools,
-  sphinx,
+
+  # dependencies
+  numexpr,
+  numpy,
+  packaging, # uses packaging.version at runtime
+  py-cpuinfo,
   typing-extensions,
+
   # Test inputs
   python,
-  pytest,
-  py-cpuinfo,
+  writableTmpDirAsHomeHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "tables";
-  version = "3.10.2";
+  version = "3.11.1";
   pyproject = true;
+  __structuredAttrs = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-JUSBKnGG+tuoMdbdNOtJzNeI1qg/TkwrQxuDW2eWyRA=";
+  src = fetchFromGitHub {
+    owner = "PyTables";
+    repo = "PyTables";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ImzfUc+B5odozROkwhnDUY2a9XDXn8Il2wKuLzOvKAg=";
+    fetchSubmodules = true;
   };
 
-  patches = [
-    # should be included in next release
-    (fetchpatch {
-      name = "numexpr-2.13.0-compat.patch";
-      url = "https://github.com/PyTables/PyTables/commit/41270019ce1ffd97ce8f23b21d635e00e12b0ccb.patch";
-      hash = "sha256-CaDBYKiABVtlM5e9ChCsf8dWOwEnMPOIXQ100JTnlnE=";
-    })
-  ];
-
   build-system = [
-    blosc2
     cython
     setuptools
     sphinx
@@ -54,6 +54,7 @@ buildPythonPackage rec {
   ];
 
   buildInputs = [
+    blosc2
     bzip2
     c-blosc
     blosc2.c-blosc2
@@ -63,6 +64,8 @@ buildPythonPackage rec {
 
   dependencies = [
     blosc2
+    c-blosc
+    blosc2.c-blosc2
     py-cpuinfo
     numpy
     numexpr
@@ -70,41 +73,36 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  # When doing `make distclean`, ignore docs
   postPatch = ''
     # Force test suite to error when unittest runner fails
     substituteInPlace tables/tests/test_suite.py \
       --replace-fail "return 0" "assert result.wasSuccessful(); return 0" \
       --replace-fail "return 1" "assert result.wasSuccessful(); return 1"
+    # Hard-code the blosc2 path to avoid issues with blosc2.c-blosc2
     substituteInPlace tables/__init__.py \
-      --replace-fail 'find_library("blosc2")' '"${lib.getLib c-blosc}/lib/libblosc${stdenv.hostPlatform.extensions.sharedLibrary}"'  '';
+      --replace-fail "ctypes.CDLL(str(lib_path))" \
+      "ctypes.CDLL('"${lib.getLib c-blosc}/lib/libblosc${stdenv.hostPlatform.extensions.sharedLibrary}"')"
+  '';
 
   env = {
     HDF5_DIR = lib.getDev hdf5;
+    LZO_DIR = lib.getDev lzo;
+    BZIP2_DIR = lib.getDev bzip2;
+    BLOSC_DIR = lib.getDev c-blosc;
+    BLOSC2_DIR = lib.getDev blosc2.c-blosc2;
   };
 
-  # Regenerate C code with Cython
-  preBuild = ''
-    make distclean
-  '';
-
-  pypaBuildFlags = [
-    "--config-setting=--build-option=--hdf5=${lib.getDev hdf5}"
-    "--config-setting=--build-option=--lzo=${lib.getDev lzo}"
-    "--config-setting=--build-option=--bzip2=${lib.getDev bzip2}"
-    "--config-setting=--build-option=--blosc=${lib.getDev c-blosc}"
-    "--config-setting=--build-option=--blosc2=${lib.getDev blosc2.c-blosc2}"
+  nativeCheckInputs = [
+    python
+    writableTmpDirAsHomeHook
   ];
 
-  nativeCheckInputs = [ pytest ];
-
   preCheck = ''
-    export HOME=$(mktemp -d)
-    cd ..
+    cd tables/tests
   '';
 
   # Runs the light (yet comprehensive) subset of the test suite.
-  # The whole "heavy" test suite supposedly takes ~4 hours to run.
+  # Pass `--heavy` for the whole "heavy" test suite (hour+ runtime).
   checkPhase = ''
     runHook preCheck
     ${python.interpreter} -m tables.tests.test_all
@@ -116,8 +114,8 @@ buildPythonPackage rec {
   meta = {
     description = "Hierarchical datasets for Python";
     homepage = "https://www.pytables.org/";
-    changelog = "https://github.com/PyTables/PyTables/releases/tag/v${version}";
+    changelog = "https://github.com/PyTables/PyTables/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd2;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ sarahec ];
   };
-}
+})


### PR DESCRIPTION
Version bump with:
1. Build from pypi -> github
2. Add `sarahec` as maintainer (was empty)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
