### PR TITLE
nixos/test/php: migrate to nspawn, modernize

### DIFF
--- a/nixos/tests/php/fpm-modular.nix
+++ b/nixos/tests/php/fpm-modular.nix
@@ -7,7 +7,7 @@
     aanderse
   ];
 
-  nodes.machine =
+  containers.machine =
     { config, pkgs, ... }:
     {
       environment.systemPackages = [ php ];
@@ -56,14 +56,14 @@
       };
     };
   testScript =
-    { ... }:
+    # python
     ''
       machine.wait_for_unit("nginx.service")
       machine.wait_for_unit("php-fpm.service")
 
       # Check so we get an evaluated PHP back
-      response = machine.succeed("curl -fvvv -s http://127.0.0.1:80/")
-      assert "PHP Version ${php.version}" in response, "PHP version not detected"
+      response = machine.wait_until_succeeds("curl -fvvv -s http://127.0.0.1:80/")
+      t.assertIn("PHP Version ${php.version}", response, "PHP version not detected")
 
       # Check so we have database and some other extensions loaded
       for ext in ["json", "opcache", "pdo_mysql", "pdo_pgsql", "pdo_sqlite", "apcu"]:

--- a/nixos/tests/php/fpm.nix
+++ b/nixos/tests/php/fpm.nix
@@ -3,7 +3,7 @@
   name = "php-${php.version}-fpm-nginx-test";
   meta.maintainers = lib.teams.php.members;
 
-  nodes.machine =
+  containers.machine =
     { config, pkgs, ... }:
     {
       environment.systemPackages = [ php ];
@@ -47,14 +47,14 @@
       };
     };
   testScript =
-    { ... }:
+    # python
     ''
       machine.wait_for_unit("nginx.service")
       machine.wait_for_unit("phpfpm-foobar.service")
 
       # Check so we get an evaluated PHP back
-      response = machine.succeed("curl -fvvv -s http://127.0.0.1:80/")
-      assert "PHP Version ${php.version}" in response, "PHP version not detected"
+      response = machine.wait_until_succeeds("curl -fvvv -s http://127.0.0.1:80/")
+      t.assertIn("PHP Version ${php.version}", response, "PHP version not detected")
 
       # Check so we have database and some other extensions loaded
       for ext in ["json", "opcache", "pdo_mysql", "pdo_pgsql", "pdo_sqlite", "apcu"]:

--- a/nixos/tests/php/httpd.nix
+++ b/nixos/tests/php/httpd.nix
@@ -7,7 +7,7 @@
   name = "php-${php.version}-httpd-test";
   meta.maintainers = lib.teams.php.members;
 
-  nodes.machine =
+  containers.machine =
     {
       config,
       pkgs,
@@ -32,13 +32,13 @@
       };
     };
   testScript =
-    { ... }:
+    # python
     ''
       machine.wait_for_unit("httpd.service")
 
       # Check so we get an evaluated PHP back
-      response = machine.succeed("curl -fvvv -s http://127.0.0.1:80/")
-      assert "PHP Version ${php.version}" in response, "PHP version not detected"
+      response = machine.wait_until_succeeds("curl -fvvv -s http://127.0.0.1:80/")
+      t.assertIn("PHP Version ${php.version}", response, "PHP version not detected")
 
       # Check so we have database and some other extensions loaded
       for ext in ["json", "opcache", "pdo_mysql", "pdo_pgsql", "pdo_sqlite"]:

--- a/nixos/tests/php/pcre.nix
+++ b/nixos/tests/php/pcre.nix
@@ -11,7 +11,7 @@ in
   name = "php-${php.version}-httpd-pcre-jit-test";
   meta.maintainers = lib.teams.php.members;
 
-  nodes.machine =
+  containers.machine =
     { pkgs, ... }:
     {
       time.timeZone = "UTC";
@@ -50,12 +50,13 @@ in
         pcntl_wait($pid);
       '';
     in
+    # python
     ''
       machine.wait_for_unit("httpd.service")
       # Ensure php evaluation by matching on the var_dump syntax
-      response = machine.succeed("curl -fvvv -s http://127.0.0.1:80/index.php")
+      response = machine.wait_until_succeeds("curl -fvvv -s http://127.0.0.1:80/index.php")
       expected = 'string(${toString (builtins.stringLength testString)}) "${testString}"'
-      assert expected in response, "Does not appear to be able to use subgroups."
-      machine.succeed("${php}/bin/php -f ${pcreJitSeallocForkIssue}")
+      t.assertIn(expected, response, "Does not appear to be able to use subgroups.")
+      machine.succeed("${lib.getExe php} -f ${pcreJitSeallocForkIssue}")
     '';
 }


### PR DESCRIPTION
They boot up quicker now, which is why the curl needs a retry mechanism.

Also uses proper unittest asserts, which provide good feedback on error.

I care about these, because some of them are in unstable-small, and making that go brrrrrm is just very cool.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
