### PR TITLE
kate-code: init at 0-unstable-2026-03-07

### DIFF
--- a/pkgs/by-name/ka/kate-code/package.nix
+++ b/pkgs/by-name/ka/kate-code/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  kdePackages,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "kate-code";
+  version = "0-unstable-2026-03-07";
+
+  src = fetchFromGitHub {
+    owner = "undefinedopcode";
+    repo = "kate-code";
+    rev = "e422f681e205d24ff69d75acf28fad2f7c3d6a9a";
+    hash = "sha256-pxQN47GrqRpGjS2TPCtWmjCMqhJ3qlODuEln17aLkvA=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    kdePackages.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    kdePackages.ktexteditor
+    kdePackages.ki18n
+    kdePackages.kcoreaddons
+    kdePackages.qtwebengine
+    kdePackages.kpty
+    kdePackages.kxmlgui
+  ];
+
+  meta = {
+    description = "A Claude Code plugin for the Kate Editor leveraging Zed Industries claude-code-acp";
+    homepage = "https://github.com/undefinedopcode/kate-code";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pasqui23 ];
+    mainProgram = "kate-code";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
