### PR TITLE
tcl: fix mingw build

### DIFF
--- a/pkgs/development/interpreters/tcl/generic.nix
+++ b/pkgs/development/interpreters/tcl/generic.nix
@@ -7,6 +7,7 @@
   tzdata,
   zip,
   zlib,
+  buildPackages,
 
   # Version specific stuff
   release,
@@ -28,27 +29,38 @@ let
 
     setOutputFlags = false;
 
-    postPatch = ''
-      substituteInPlace library/clock.tcl \
-        --replace "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo" \
-        --replace "/usr/share/lib/zoneinfo" "" \
-        --replace "/usr/lib/zoneinfo" "" \
-        --replace "/usr/local/etc/zoneinfo" ""
-    ''
-    + extraPatch;
+    postPatch =
+      lib.optionalString stdenv.hostPlatform.isUnix ''
+        substituteInPlace library/clock.tcl \
+          --replace "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo" \
+          --replace "/usr/share/lib/zoneinfo" "" \
+          --replace "/usr/lib/zoneinfo" "" \
+          --replace "/usr/local/etc/zoneinfo" ""
+      ''
+      + extraPatch;
 
-    nativeBuildInputs = lib.optionals (lib.versionAtLeast version "9.0") [
-      # Only used to detect the presence of zlib. Could be replaced with a stub.
-      zip
-    ];
+    nativeBuildInputs =
+      lib.optionals (lib.versionAtLeast version "9.0") [
+        # Only used to detect the presence of zlib. Could be replaced with a stub.
+        zip
+      ]
+      ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform && stdenv.hostPlatform.isMinGW) [
+        buildPackages.tcl
+      ];
 
     buildInputs = lib.optionals (lib.versionAtLeast version "9.0") [
       zlib
     ];
 
-    preConfigure = ''
-      cd unix
-    '';
+    preConfigure =
+      if stdenv.hostPlatform.isMinGW then
+        ''
+          cd win
+        ''
+      else
+        ''
+          cd unix
+        '';
 
     # Note: pre-9.0 flags are temporarily interspersed to avoid a mass rebuild.
     configureFlags =
@@ -108,14 +120,21 @@ let
       let
         dllExtension = stdenv.hostPlatform.extensions.sharedLibrary;
         staticExtension = stdenv.hostPlatform.extensions.staticLibrary;
+        releaseBinFormat =
+          if stdenv.hostPlatform.isMinGW then
+            "${builtins.replaceStrings [ "." ] [ "" ] release}.exe"
+          else
+            release;
       in
       ''
         make install-private-headers
-        ln -s $out/bin/tclsh${release} $out/bin/tclsh
-        if [[ -e $out/lib/libtcl${release}${staticExtension} ]]; then
-          ln -s $out/lib/libtcl${release}${staticExtension} $out/lib/libtcl${staticExtension}
-        fi
-        ${lib.optionalString (!stdenv.hostPlatform.isStatic) ''
+        ln -s $out/bin/tclsh${releaseBinFormat} $out/bin/tclsh
+        ${lib.optionalString (!stdenv.hostPlatform.isMinGW) ''
+          if [[ -e $out/lib/libtcl${release}${staticExtension} ]]; then
+            ln -s $out/lib/libtcl${release}${staticExtension} $out/lib/libtcl${staticExtension}
+          fi
+        ''}
+        ${lib.optionalString (!stdenv.hostPlatform.isStatic && !stdenv.hostPlatform.isMinGW) ''
           ln -s $out/lib/libtcl${release}${dllExtension} $out/lib/libtcl${dllExtension}
         ''}
       '';


### PR DESCRIPTION

Fixes TCL for MinGW. So that we can fix the broken builds of sqlite which is used in nix for MinGW.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
