### PR TITLE
libre-bodoni: switch to googlefonts fork, build from source, use installFonts

### DIFF
--- a/pkgs/by-name/li/libre-bodoni/package.nix
+++ b/pkgs/by-name/li/libre-bodoni/package.nix
@@ -2,26 +2,34 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  installFonts,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "libre-bodoni";
-  version = "2.000";
+  version = "2.005-unstable-2023-02-08";
+
+  outputs = [
+    "out"
+    "webfont"
+    "doc"
+  ];
 
   src = fetchFromGitHub {
-    owner = "impallari";
+    owner = "googlefonts";
     repo = "Libre-Bodoni";
-    rev = "995a40e8d6b95411d660cbc5bb3f726ffd080c7d";
-    hash = "sha256-yfqVeT/JiAT+fsqkXUxqlz4sEEFwEJUdvFTAzuqejtk=";
+    rev = "37d048938a8a32e6ba3992072cb3857659a7828f";
+    hash = "sha256-wqdeJ0prag8BbT3hhXmSUk4X170ytSwPaJHBHMQH7bo=";
   };
 
-  installPhase = ''
-    runHook preInstall
+  nativeBuildInputs = [ installFonts ];
 
-    install -m444 -Dt $out/share/fonts/opentype */v2000\ -\ initial\ glyphs\ migration/OTF/*.otf
-    install -m444 -Dt $out/share/doc/${pname}-${version} README.md FONTLOG.txt
+  preInstall = ''
+    rm -r old
+  '';
 
-    runHook postInstall
+  postInstall = ''
+    install -Dm444 README.md FONTLOG.txt -t $doc/share/doc/${finalAttrs.pname}-${finalAttrs.version}
   '';
 
   meta = {
@@ -42,4 +50,4 @@ stdenvNoCC.mkDerivation rec {
     maintainers = [ ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/li/libre-bodoni/package.nix
+++ b/pkgs/by-name/li/libre-bodoni/package.nix
@@ -3,6 +3,7 @@
   stdenvNoCC,
   fetchFromGitHub,
   installFonts,
+  python3Packages,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -22,7 +23,23 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     hash = "sha256-wqdeJ0prag8BbT3hhXmSUk4X170ytSwPaJHBHMQH7bo=";
   };
 
-  nativeBuildInputs = [ installFonts ];
+  env.PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION = "python";
+
+  nativeBuildInputs = [
+    python3Packages.gftools
+    installFonts
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    # clean out the prebuilt files
+    rm -r fonts
+    gftools builder sources/config.yaml
+    runHook postBuild
+  '';
+
+  dontUseNinjaBuild = true;
+  dontUseNinjaInstall = true;
 
   preInstall = ''
     rm -r old

--- a/pkgs/by-name/li/libre-bodoni/package.nix
+++ b/pkgs/by-name/li/libre-bodoni/package.nix
@@ -67,7 +67,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     '';
     homepage = "https://github.com/impallari/Libre-Bodoni";
     license = lib.licenses.ofl;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ pancaek ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/li/libre-bodoni/package.nix
+++ b/pkgs/by-name/li/libre-bodoni/package.nix
@@ -65,7 +65,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       Libre Bodoni currently features four styles: Regular, Italic, Bold and
       Bold Italic.
     '';
-    homepage = "https://github.com/impallari/Libre-Bodoni";
+    homepage = "https://github.com/googlefonts/Libre-Bodoni";
     license = lib.licenses.ofl;
     maintainers = with lib.maintainers; [ pancaek ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/li/libre-bodoni/package.nix
+++ b/pkgs/by-name/li/libre-bodoni/package.nix
@@ -16,6 +16,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     "doc"
   ];
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "googlefonts";
     repo = "Libre-Bodoni";


### PR DESCRIPTION
Part of #495640
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
