### PR TITLE
python3Packages.blasthttp: init at 0.9.0, python3Packages.badsecrets: 0.13.47 -> 1.2.0

### DIFF
--- a/pkgs/development/python-modules/badsecrets/default.nix
+++ b/pkgs/development/python-modules/badsecrets/default.nix
@@ -1,49 +1,48 @@
 {
   lib,
+  blasthttp,
   buildPythonPackage,
   colorama,
   django,
   fetchFromGitHub,
   flask-unsign,
-  poetry-core,
-  poetry-dynamic-versioning,
+  hatchling,
   pycryptodome,
   pyjwt,
   requests,
-  viewstate,
+  yara-python,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "badsecrets";
-  version = "0.13.47";
+  version = "1.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "blacklanternsecurity";
     repo = "badsecrets";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-Yvd9AGbVDOfXep8y+XzwYP2EpTvy+rwyz5hRIe7v4oc=";
+    tag = finalAttrs.version;
+    hash = "sha256-fhRQvVb+JUP1DyTMAV7leIAKD/L4kRhGFYtD78cYABI=";
   };
 
   pythonRelaxDeps = [
     "django"
-    "viewstate"
+    "pyjwt"
   ];
 
-  build-system = [
-    poetry-core
-    poetry-dynamic-versioning
-  ];
+  build-system = [ hatchling ];
 
   dependencies = [
+    blasthttp
     colorama
     django
     flask-unsign
     pycryptodome
     pyjwt
     requests
-    viewstate
-  ];
+    yara-python
+  ]
+  ++ pyjwt.optional-dependencies.crypto;
 
   pythonImportsCheck = [ "badsecrets" ];
 

--- a/pkgs/development/python-modules/blasthttp/default.nix
+++ b/pkgs/development/python-modules/blasthttp/default.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  buildPythonPackage,
+  cargo,
+  fetchPypi,
+  nix-update-script,
+  openssl,
+  pkg-config,
+  pytest-asyncio,
+  pytestCheckHook,
+  rustc,
+  rustPlatform,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "blasthttp";
+  version = "0.9.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-JuoGy+QdBsVPMtD0T4Y/NSoeJcO7dwg3HmpqHxTxCIc=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-1+OFAD9n8JntZSV+PZbYLPRM/XDlFwgrEMFGv/LzTN8=";
+  };
+
+  postPatch = ''
+    # The bundled .cargo/config.toml sets OPENSSL_DIR to a relative path
+    rm .cargo/config.toml
+  '';
+
+  env = {
+    OPENSSL_NO_VENDOR = "1";
+  };
+
+  build-system = [
+    cargo
+    pkg-config
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+    rustc
+  ];
+
+  buildInputs = [ openssl ];
+
+  nativeCheckInputs = [
+    openssl
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "blasthttp" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Offensive-first HTTP library";
+    homepage = "https://pypi.org/project/blasthttp";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+})

--- a/pkgs/development/python-modules/blasthttp/default.nix
+++ b/pkgs/development/python-modules/blasthttp/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   cargo,
   fetchPypi,
@@ -34,6 +35,8 @@ buildPythonPackage (finalAttrs: {
     rm .cargo/config.toml
   '';
 
+  __darwinAllowLocalNetworking = true;
+
   env = {
     OPENSSL_NO_VENDOR = "1";
   };
@@ -55,6 +58,16 @@ buildPythonPackage (finalAttrs: {
   ];
 
   pythonImportsCheck = [ "blasthttp" ];
+
+  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
+    "tests/python/test_ssl_verify.py"
+    "tests/python/test_response_api.py"
+  ];
+
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+    "test_redirect_onto_proxied_host_reevaluates_no_proxy"
+    "test_redirect_onto_no_proxy_host_reevaluates_to_direct"
+  ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2142,6 +2142,8 @@ self: super: with self; {
 
   blake3 = callPackage ../development/python-modules/blake3 { };
 
+  blasthttp = callPackage ../development/python-modules/blasthttp { };
+
   ble-serial = callPackage ../development/python-modules/ble-serial { };
 
   bleach = callPackage ../development/python-modules/bleach { };


### PR DESCRIPTION
Changelog: https://github.com/blacklanternsecurity/badsecrets/releases/tag/1.2.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
, 
- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
