### PR TITLE
snmalloc: 0.7.4 -> 0.7.5

### DIFF
--- a/pkgs/by-name/sn/snmalloc/package.nix
+++ b/pkgs/by-name/sn/snmalloc/package.nix
@@ -9,12 +9,12 @@
 
 clangStdenv.mkDerivation (finalAttrs: {
   pname = "snmalloc";
-  version = "0.7.4";
+  version = "0.7.5";
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "snmalloc";
     tag = finalAttrs.version;
-    hash = "sha256-+UCqUrfvhnB4leiYCnGJ8ORfVkTaGimaErP56XCJ5PM=";
+    hash = "sha256-1wgQilYHYjmKqhUhxA0wXF+OBPRH+hDPgVGMgVxqj4Y=";
   };
 
   outputs = [


### PR DESCRIPTION
nothing special happened...

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all libraries.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
