### PR TITLE
firefox-unwrapped: 152.0.1 -> 152.0.2

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,1859 +1,1859 @@
 {
-  version = "152.0.1";
+  version = "152.0.2";
   sources = [
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ach/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/ach/firefox-152.0.2.tar.xz";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "8de0b24eb92f17c27b5cf7b0005a13cc94d72ac05f1e557d8f4b491b449645f9";
+      sha256 = "cd1464a0d69d24980a7fa2b847d9f9a6fabcde598babe3d15c6b93f56785f473";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/af/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/af/firefox-152.0.2.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "f67b2f9955513cf1a0281247ac1988f4306678ab0aa57ab2895f3db20d7eda10";
+      sha256 = "cfcdce7774c8750f363f787c0b1a0688fdd9874fd0414a2f615bcca65e2568ef";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/an/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/an/firefox-152.0.2.tar.xz";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "c9a97857bb183d49c6385c831bd7f46f4ba2bc942ed78ea136053a047f1227af";
+      sha256 = "5054a311c6629c0a50b82a80711ac4438a33a201f7b3e898643f48d9d7989abc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ar/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/ar/firefox-152.0.2.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "fecd3068932f9d5886b4424cae645cb01e3f9875bad199b094afca23f9a601c6";
+      sha256 = "4d8e45b5f51364ace090cfb659b8940dc6b48af8f3de9a2eb8f7ea564f53365d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ast/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/ast/firefox-152.0.2.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "c855a732862e2999b23c08886ea66e734d5e868c185e229a2458149dd2d196e2";
+      sha256 = "a3043021ea97e712648aab571f1c5265d5c0bad8c9b442e4d86efe392f805969";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/az/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/az/firefox-152.0.2.tar.xz";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "220f9bbbe8f2ee3c26edca52b2bec5bdfdadaf82431b6db808ef976e63ab4319";
+      sha256 = "9a3c2e1366adcb506f3eacf9d627543403dc943faf15071fe97e3e85dc60091f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/be/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/be/firefox-152.0.2.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "ef2c931aeed16f31118b92969faad1b2f173cbab7b74a55b37b5eba3a3e6d252";
+      sha256 = "bc7b3261d106c255b17ad9598543ac6f2191cb60cb8f9e2bfdfa3054d1c7def4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/bg/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/bg/firefox-152.0.2.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "7920f2fcad9a5d9166175b1a609bf9a45cb903e460e69134ce72b33c6727f294";
+      sha256 = "def15f4465157f6018648baff8cc8d63af887c6e6f3ceb86296b7ea5d0ad9daf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/bn/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/bn/firefox-152.0.2.tar.xz";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "f5db6117e54029b05b508d4442ddfd05bb4f0ae0272c2c4124bc9cced3c0e3ef";
+      sha256 = "43658b054499e27e9c502b1b37204b78d190f4ffa9a111001d90cb80bb1bfd40";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/br/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/br/firefox-152.0.2.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "e50cff8c75079d61c74991c55fca5db701bca5719ffc7e1692f4f338ece41752";
+      sha256 = "3e9195aed6fa0714e4d8fcd86b63663613dad091068b926a573cdcf2466c2a33";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/bs/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/bs/firefox-152.0.2.tar.xz";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "d18fe74ce0bca7d44a2207abc2a739f349a15d76fc086147ec4b8e9c03bc9a45";
+      sha256 = "8776dbb3f0a515660ae6db28ad75cc4107c8d8b2cd6aed00be0f5fa8fdd1130e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ca-valencia/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/ca-valencia/firefox-152.0.2.tar.xz";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "104bc5a0e543ba9066f84efbf1328a335f6a46f22edba17dd9ddd8b85620b505";
+      sha256 = "8f442c5a0bf6ab983e5e81edfb8426b4a5433c1e5bde95fa1b52734645ce51d1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ca/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/ca/firefox-152.0.2.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "aed5308e20d7aebf24746e4feb13753bbe404f735b0fcb3eb9d32c42bfa702d7";
+      sha256 = "632501ef22ed7de469fd59958be1d8b3c730d50282455de70ea140405ca83669";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/cak/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/cak/firefox-152.0.2.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "b2ed0425c1ee90adbdbda303bb32eee07e139d70eaabe72da942d900ca876a0d";
+      sha256 = "b7485e261017b9a1c11d135caad74a014782dd445c412ad9e4a44f627cf82ef2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/cs/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/cs/firefox-152.0.2.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "bee74b9ffaf355b3f0ac9e93739d508ccd7d41c075d9f652ff467cf11a4f3555";
+      sha256 = "f3b072b3c9830f2fdaa755278e25a229df5b665bd3017954953028492100ff98";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/cy/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/cy/firefox-152.0.2.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "0b6c00902e26a2988db954cb1958ec06ac8abdc5c702d95b5af4989d4459ea89";
+      sha256 = "a708dafc1bd9391ac03cf013a2882c1cbb2a3501ad25ddb71e2834c1fd2828bb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/da/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/da/firefox-152.0.2.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "9ffbc66f2ed0fdb17b3359036fa98e883bf088901393b353d9ac1684f665cfd0";
+      sha256 = "8724f0ee08556d19855bf6acef1b3708e665ba5ee704428e9010033f3cdaf258";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/de/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/de/firefox-152.0.2.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "d7f8f2efea29ea2b9e4e17b6c49a16007eba724a8bebc1aca0fc4c268673c728";
+      sha256 = "f253e47ef51f4ad48391410744a1b04aed4742161489896bac860077d34b1e90";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/dsb/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/dsb/firefox-152.0.2.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "00c44e2a3c3986525f0035f3e64a609714ce5008bcc6a472b29e35d04e55495b";
+      sha256 = "1fe39a0cde54f0e9e4855e391ca84e28bb1c852d1a0215a2fa3fc7b63a4df279";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/el/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/el/firefox-152.0.2.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "d54b6c213bd208bf8eacc7d795763117747625f81a71ec0c29e55589bf7725fd";
+      sha256 = "bb3b9812c0ad90468ccc633111166fcb8888bf83e08af2d98d5f7f95eb429695";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/en-CA/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/en-CA/firefox-152.0.2.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "2f4f7e4b130da176e4a68e359359504e18fbcac635610280ce7fd6cdab76057a";
+      sha256 = "2d910dacfff9191a298f929960da9c3c0dcd42015d4eac849e81de799f67963d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/en-GB/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/en-GB/firefox-152.0.2.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "340ab737ea69010cc6153874d506d9a9ca0638bf5af29efabbc24d6f7da48e14";
+      sha256 = "ce85ec2e9a06e7aa5fd7bf93fb6ba9e3f422b8a161a183ec1142d70f565c748c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/en-US/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/en-US/firefox-152.0.2.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "04efc89d4127bc4c9c56e471532be46606cb3776f2fd6252d459a83bc11c9b2d";
+      sha256 = "9e830c68115cdccaf8dcb7b5f93119bcbde9ebb074f8cb2fba34af14fe335e70";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/eo/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/eo/firefox-152.0.2.tar.xz";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "0ccea386ae972d104bacb893607ea5da06bf45237ab94fcc08a3ba7aed51c0b4";
+      sha256 = "5e6a13ea4f3363f459c08a7f27a1357434f76bf96316f6ba8d7295312e2de537";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/es-AR/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/es-AR/firefox-152.0.2.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "a6814db65e8f1c2b0a98297d843871b91c9609284842d1b28acc489e37fef4c7";
+      sha256 = "a68efd2ac28186d543facb1e9cec5816fb4391e67b7ecf222040a9159ac9376e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/es-CL/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/es-CL/firefox-152.0.2.tar.xz";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "5e84ea6769266352ba9540d74baf428a518686e84b453864f9f0ba1e290c405d";
+      sha256 = "187b77bb443c1ba29b1682c028f427e6c94683219f03deb91d87d040a4f58df3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/es-ES/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/es-ES/firefox-152.0.2.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "32378327f6771c99c93d9bc49958f8f04c8dad8e1107ac0f348723a76c93e14d";
+      sha256 = "30f0dc652ca5b8d2ecc521306f1c86b92010040eda42124002ea4eb7deedf276";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/es-MX/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/es-MX/firefox-152.0.2.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "96ffa98bf3d78d15f32d0336e17ce0a2b9d1c183ea6a043090b36c3e2f9240e8";
+      sha256 = "8ead7b6797919a5b8735578cc7681c6ca877e1207b16f33663e5d7b14f48fe30";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/et/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/et/firefox-152.0.2.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "e4083f3112ac0a5f79d9ed1790ad6e198d0d053603a1ef72896892b6fc78fb1d";
+      sha256 = "652fdaa5bdc14539440b4c5b02f8164316261209700fcb3066e51c9ab288c339";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/eu/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/eu/firefox-152.0.2.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "541c5fcae2f8906dd919e2f776c64c0816618722132218a29d3d43df2b7feadf";
+      sha256 = "3ef4e32e8eb7de2023e22f8058869823e12b7dfea4514db62238bd7e63534605";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/fa/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/fa/firefox-152.0.2.tar.xz";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "8483301e8b34c6300a32195272409a1897655afb6e54e2c1f8a85d29b9177208";
+      sha256 = "81f63f1e5b47753befc286616f8c889a0dd3c37da77aeba841e14e6b1494dbbc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ff/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/ff/firefox-152.0.2.tar.xz";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "ee18c36c7632efdba4696b667f4d86c4e4c6964f558d1b3337ea271cf9d65245";
+      sha256 = "dae435039b15631520c4e8b4bafa5dc3c9e634531216b229fafdc3f01377a698";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/fi/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/fi/firefox-152.0.2.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "90d243e68fc845dc5ad552c472e1b96b19cc2998029714f2aa3bc17816d59859";
+      sha256 = "e637968825a824eca60d269c303338b0304cfd7f3081b391b1650e69458219cc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/fr/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/fr/firefox-152.0.2.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "e8ddabead201e6ff45cdc17268f783702508098b8a40e7b29cd8d29950a79b4a";
+      sha256 = "1413e0f1c5a58af177f2b07d6fc1dd4a43e18d5a032acc64521a9e5afb653c4d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/fur/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/fur/firefox-152.0.2.tar.xz";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "be8c3a6be69494dd4912eaac8d1adff21f0883399db8ef7d847c5d8b79487b65";
+      sha256 = "8a7c64f1c5f1937d065fbbb393555cef25f4268ed4a45f8005e78f3d2f7736a2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/fy-NL/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/fy-NL/firefox-152.0.2.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "e58ac987ddf6a6b26eb28d0a19d68544fb190efc84982e9ef25736490d158cca";
+      sha256 = "f65cc072eff7ec492afe1e9abc9f2c8005deab40cdd1032a865c4e59ba012dcd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ga-IE/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/ga-IE/firefox-152.0.2.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "834ebee6b4c581d767232243aaa089380f8cab8a8dba48e179e402a29be0eb7f";
+      sha256 = "370eefa54a4847c4707325b024beaca319032069f23e6e9b6334d02340d2a699";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/gd/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/gd/firefox-152.0.2.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "0adff16834f86f6190510c77898e2068dee71c5cf9da03f6eebfaa3b36496143";
+      sha256 = "02a43dac08b010f9ff36aef84a09d1b897fcd2cca704921e013c4368498bae7e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/gl/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/gl/firefox-152.0.2.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "6dc5a9c1c333e85bc7ebaa4d13972525f718166510121b658b061abd60f75735";
+      sha256 = "f4cdb871f9e6a1e313a404bd31f6054a812ac62b5d726357c348ce7f176f408a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/gn/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/gn/firefox-152.0.2.tar.xz";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "358a964bd788e3b62d460fb9fa5989de919e0a6dc478cc3047694bef6eb5fb16";
+      sha256 = "489d42d1cce2148c268b08844083039bab4675341e3d1044e7461a25ee2d73dc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/gu-IN/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/gu-IN/firefox-152.0.2.tar.xz";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "1498e53ce59a6bb9873b9e68af3e1b22db3b78f11018dc17fb930655a99ea6ae";
+      sha256 = "cfb3be6e3f3ec83294c3211ff653fa56f89c7ed8319592c23a4cbe751b1bb26a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/he/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/he/firefox-152.0.2.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "65290c279ba969a0536242ee24f7572434a7e0478a987ebe6ab9c81a1591cb66";
+      sha256 = "be80c748dc1b75cbf7d316f2981e5979f4d8cffb5c45c0b46a2304fe360a95bc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/hi-IN/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/hi-IN/firefox-152.0.2.tar.xz";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "465eaeeff57171447cfeaf2c1a4826eb28abe5c65ab8ab6bcbd6ccc1a0311084";
+      sha256 = "8065346d35282305e6f37a2af0f1c564bc520ae96523159b6ed131bf119ac664";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/hr/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/hr/firefox-152.0.2.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "0def94adcdf670eaaa89eba5c28d5fd675e9f33f38590bf767d8daa846502d36";
+      sha256 = "fe8a539fc8583d329f963f798263e3e57f89e9928ad79a48ca6d78f96235d54d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/hsb/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/hsb/firefox-152.0.2.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "e1a9663d8167c41064cff55baa6258ad18a185ddc53e1ad82a4b7191687aa380";
+      sha256 = "9a5e92c176c5da7876990ed568ecb915337b4e9f836225d5fdd3775292b5f107";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/hu/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/hu/firefox-152.0.2.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "29b7c76b30762879caa835c59c44c0667d6bfd60cb2f4149b3927950f9d0a190";
+      sha256 = "0f96b9017350195a548889e27f47e5170d7383832ac8519e7993d6a286f81e7e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/hy-AM/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/hy-AM/firefox-152.0.2.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "d105eb9f6cbf181b44609c2077988f0e326bb3b81cffdd7a9c012c8494080cbc";
+      sha256 = "ffc143cef790eb5f5b4feef8854c85e5a8a8267f3b01b91383823f9ffe5e839a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ia/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/ia/firefox-152.0.2.tar.xz";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "a89d1a5aa7398d7b1ed0c3028c05c223a72f652f1325ac7b7e78431dbbec5392";
+      sha256 = "337c3323598744dfde7f68986053af87703beb4bf21ec4731c9d8047206bbf59";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/id/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/id/firefox-152.0.2.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "47c458c089881ca9dc0427701a9ea642dfa21ff736018620d7bb64e2cc11958e";
+      sha256 = "47b3e38cf745cdcf7132fc27582325cce410b60dc44298ac7459d68183d313cf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/is/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/is/firefox-152.0.2.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "1b2d991c14d7815dc60a553eb215bcf57ed4a6f60795810f9ae8b8949f3ed427";
+      sha256 = "0013d4ca3bbce703047f6fb3b0756fc02b91ac46af4f47fae746789efd92caf2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/it/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/it/firefox-152.0.2.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "f561803bbe77632c2bda29bbb44841cdd0c5a2382d4b96622d5ab1973ccb50a9";
+      sha256 = "ba51686964337e8773eac80c87bb2a77efa9c45e489e8e525b3ea870ecbb138f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ja/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/ja/firefox-152.0.2.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "2c93ed744647df780518ed36598a5c757a41bab5ef5279a2e7bcf737ff44170f";
+      sha256 = "9cff6f2f19eec0cad69ac66e452b6e4f52721a6b2a2537ffc574cffa80964f08";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ka/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/ka/firefox-152.0.2.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "bdb1661d395d7f7a25b2a733699d5514b1809d43fe142bab13b5a4dedfc8f017";
+      sha256 = "05a00df8fb25403ca256e40c16067cff327c6031a99ec1aebcf7e45ce6292dce";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/kab/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/kab/firefox-152.0.2.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "21b40bc284fbd3d28c714cad2caf8f0f9cdfd05bbed78063f5a61791ae717708";
+      sha256 = "2c4e341264109c460d2707295dfffa84cc7ba92fa9ebae5f0f1a24f10d00bcb3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/kk/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/kk/firefox-152.0.2.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "d0bbfe1990a10af033b7e6e8bcec3cc944b87ccc5b1eb50692f3b17723a383ee";
+      sha256 = "d8a3950920d276f38b06ede9c29967d71f77b21be749653299662607f1644bdd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/km/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/km/firefox-152.0.2.tar.xz";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "0dd570c27ee5fc985ca87752b57fd718502f3cd3738a7b94a0e59510ce65afb8";
+      sha256 = "0794f8a14db3830bdbf82fa6fcd10ac882430c92c018076bdcc573510c76eb22";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/kn/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/kn/firefox-152.0.2.tar.xz";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "010246daf4a3acf0052ffe79733162b86183d4d4b72951194b4959792e4ab768";
+      sha256 = "8ec08ab22c43d6aa00aa481839cb0bfcfa6e2be9536dd1c4d6ec41414ee3b49d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ko/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/ko/firefox-152.0.2.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "77c9e20756eb39c7482aea884963cab3195687f9c2daed73a710bc2f12c6a1ea";
+      sha256 = "71e2c736cd19b0d58e3428a0825fc23640d64dbbe2f78e72550e1d6cb4add793";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/lij/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/lij/firefox-152.0.2.tar.xz";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "d91bb0643b565acfd6193200f4d9d4f08613ae2a46f1aa59aadf294c955638c4";
+      sha256 = "c6b295b33e37834380549e360e5255d2bd94ffc7359e1f8d70bc21552549305f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/lt/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/lt/firefox-152.0.2.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "9946c8b62469fb050d9c77bd232b328730b1ab50a312584a4a038e7aeb6cae6b";
+      sha256 = "8c4d359fa3a251c0b234bbd2286fa902cfc51c95487ec213bcf56960f464ff14";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/lv/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/lv/firefox-152.0.2.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "d897427b87d345afbc5b783bcd336a130e425a7f34572ffa4ccec111d8f17475";
+      sha256 = "fbefb8eab5d657ee934b984d0a9997365ba0605d414976a962c2904abe048424";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/mk/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/mk/firefox-152.0.2.tar.xz";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "a865b32e2a533a5cb2e1326149d449038a23b3a97cbd725a6997d29d95435867";
+      sha256 = "eb3aaa45eb9c57d2405f8f79118294dce67b64f8cef4325dfe5b323cb76b5f75";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/mr/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/mr/firefox-152.0.2.tar.xz";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "02919ffb5f9181870f2eab22177b49f3dc99406580045de2559df7a474963ebb";
+      sha256 = "c8f7e749151d1918438fe91124ee341210edae0b7ec9490c7a2fd76ca08b94ac";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ms/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/ms/firefox-152.0.2.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "026f2217d264af4acf30bef87be30361d2b8923a202779461268ea4423e85a01";
+      sha256 = "446d6170967f3216da2d7d8ec408396b4c5a671108a815d0b2bfec3b42a67a63";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/my/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/my/firefox-152.0.2.tar.xz";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "f9b18234026c92cfe22c99e41e4935676b7602faa8ca3277001d314c649e41eb";
+      sha256 = "7434de7c02bb4b837963b27987ed80e29b510f0e9befc4e8651d0846084956dc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/nb-NO/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/nb-NO/firefox-152.0.2.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "33637a549d8aaeccd72fa88d14995de701e6dc43198942e1c0ec1ccbb0531ec5";
+      sha256 = "0a18e3134eaa9b1d6984456b2b12274feb75afae770f635af8abb37e80953752";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ne-NP/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/ne-NP/firefox-152.0.2.tar.xz";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "e7df83acc744593d1285221e4650aba827a1e1ac32b5960eb1d04c2a9c9bb9cc";
+      sha256 = "a1761758fcc7be7c1cac11ad5c608075b4a2c6ac62b9659e1e1fa5bc3fabb282";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/nl/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/nl/firefox-152.0.2.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "803760a9411070680fcd4b24474eadf897d99813efd9020c153ca23ee03dcbe1";
+      sha256 = "9ea52bcc4f31d883d26c679a9cb629db656f251a0cff32629e02b486aebc7f63";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/nn-NO/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/nn-NO/firefox-152.0.2.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "30415eec15adbd6d249f1f35fc782bee66328da644bd75a0940f6de958e76cb2";
+      sha256 = "ed27c24e2f70951dc043e2dacaf4ab3d13760ca9f2e2233c6252ce583349f164";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/oc/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/oc/firefox-152.0.2.tar.xz";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "24673361cec55de24bcd69132e2abe7430a8057f00825f2563885f9f7c6acbbf";
+      sha256 = "93a7a26c49c009033fc304a4095a5206bd6277b93edd5417c783527253d83574";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/pa-IN/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/pa-IN/firefox-152.0.2.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "69df264baa6a758376f935e6c328def4cb9f40e88754bc3d5f3befe6a4f581b9";
+      sha256 = "d3b45e6857fa02bd4964ad949782197f6d39769a21a0b82d740ee24c69701a8d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/pl/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/pl/firefox-152.0.2.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "220a35c8baaf207c6d41e4935850ef0fd9cb78618ef7c1eff2b08be727745861";
+      sha256 = "0734cc6b5a49496f884a8c0365eed1cc67be46e765ab6145db9f6d3421338bc2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/pt-BR/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/pt-BR/firefox-152.0.2.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "b735ca170d21fdbc848ca11bcdfae8155314ed152573f485edab8c8e1abd9c03";
+      sha256 = "1874abfd6b483e01209a5909aba17d1335db2cdeadece887f60e6e4ed42d628f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/pt-PT/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/pt-PT/firefox-152.0.2.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "cf17cf2375c2b38837cec5282eb4533d4a3c36d2ae65b4dc6210d723f92b73c4";
+      sha256 = "96996115235f3b229eaa5398512d15f253bbe3bb8fa954c8acd3802f4812ed3f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/rm/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/rm/firefox-152.0.2.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "82d2752d5d87bd19ab209e5f64cfbc95c79d5c5d4209b63cd8a89b7d0f087526";
+      sha256 = "8cec45cc317d8cbb336cfd2e2a7275b2e7679ba6df33d145084715c72f60807b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ro/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/ro/firefox-152.0.2.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "793add59809e638b981d67cdb8060f2fe2e22557eb547940564e185bd25399fa";
+      sha256 = "ce9dce42d4f8d5f3d63c2d7e817177a89108696aa4d27b5d049783bd2cdf2fc4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ru/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/ru/firefox-152.0.2.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "446be317a9169760ab407eeb6734d3a01603aa88ae1c818f75caf47d7665ec00";
+      sha256 = "0c2615efaa8bee7fc23781593c28473e63702f0f2c73a5cf4709684ce0b8f423";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/sat/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/sat/firefox-152.0.2.tar.xz";
       locale = "sat";
       arch = "linux-x86_64";
-      sha256 = "17e145189e3d53a4edf8c870e163501714e96907c42f3374e533ca47f3c89e4c";
+      sha256 = "c0967d46a30d5d574381fac54fc7bcf659f5f8659c0c783f39cf394faa2eb721";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/sc/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/sc/firefox-152.0.2.tar.xz";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "ef652d448b9aab658c2872895b4105c961e7deeefc8eb1a4ea536638f2058e62";
+      sha256 = "8f458413d13811427390a127b1a3eff9ace49136c81792656ca8453f5c7e9caf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/sco/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/sco/firefox-152.0.2.tar.xz";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "2762a365a8fee59ecbb7dc86b1e32074a6cbf35a9f2c07276e68d7caeac209c4";
+      sha256 = "955040cb90bc39b4d3f843281729a9f5fb1eb3d43963eb3d5c20c589351005a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/si/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/si/firefox-152.0.2.tar.xz";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "de60b474181495093e462b6da07b6ed2c96c5cb890c2c0f2df538e5852627981";
+      sha256 = "92041467f19ec5f2fca6b394cb0d560f31cb969f771d98e9e347bbe42a2207d5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/sk/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/sk/firefox-152.0.2.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "aec21ad67da6ac2ffbc1f9bae1ca1e3cda450e17437924e322eaac09b6e492ba";
+      sha256 = "5ac190c6e3018074b82dd7d13f48423102a01ee9b2201e1a112bcd549129ca0d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/skr/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/skr/firefox-152.0.2.tar.xz";
       locale = "skr";
       arch = "linux-x86_64";
-      sha256 = "17c6224ffd937178d4d08dd7a07e35b1f7d6144a7b3414c0d54c92f4d6190570";
+      sha256 = "fdd5225bd03501cf796c41b38f52c20535d217cd3027e1f259bbfb952fc08bd7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/sl/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/sl/firefox-152.0.2.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "22d8b832db8ee333cd5685b57fdb684527797bd4a54e90657f80a9793d4fdfd0";
+      sha256 = "ad6d75438698eac8c14e1ab598e9d79a963e8c5b1d71e9e12157ea5ab3da6328";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/son/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/son/firefox-152.0.2.tar.xz";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "aa5b94d392ae293a319d507b913cb155b0ff14ce6b1f33f49a8509656931d5c8";
+      sha256 = "b8e7920fed9d0c6ba3954d0950ef3d4b5ee246eb6f911de07b213978f88a9856";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/sq/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/sq/firefox-152.0.2.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "f3a5c28d3be98ba1826449f2d0cc46b18640a282ff214b071a843232facf1c0e";
+      sha256 = "8267ae1ce2b6a8a2131dfa38929c697c28f61730adbcdde9460212e57a41ab21";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/sr/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/sr/firefox-152.0.2.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "c86697a64723325ff3f8c1ace45fe9507e46ef1231016e4995780b8c31de4353";
+      sha256 = "c121c8c66760308c8ed5433c140c06437b054d598d4881d9fcdd7bf596414fc6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/sv-SE/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/sv-SE/firefox-152.0.2.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "a4b6a1c0263874e1c67a03fb47955b61245fe1997166b0dbe48e8a7bb7a24599";
+      sha256 = "7f17e61b7d1ea4a7ca659b7e315f0c70e6604144122387fb8aa01a4d6ea19b8a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/szl/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/szl/firefox-152.0.2.tar.xz";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "2e426e9811518c3610fa00fee1c84bb85ea30754a3b1542ec49359b606d319c8";
+      sha256 = "5208c5855d673c9d18a6d912154ea4a44807565ccb07f35d99f0a77caa34234f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ta/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/ta/firefox-152.0.2.tar.xz";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "5eedf2eb50c83271ae466f6dd6c2f5b1918c7b4a3caaf29f89b98dabfbd61883";
+      sha256 = "8fe4d95516f1594ec2dd078a5794f5d768cfc8abe12d6b64069f01518b240dc7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/te/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/te/firefox-152.0.2.tar.xz";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "63b8e73b5a21738579193f572cea3bc990b74f8c98f0c89d06a80adfd8b35347";
+      sha256 = "25ac2b2e0f6f6162e91c6183be409328d52f2d7fc7b0d2b50f3f2926c99a9e78";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/tg/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/tg/firefox-152.0.2.tar.xz";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "6f2992322d37bc9c90c53b5d7105c579e9a56408297ecf43f274f462954a8d98";
+      sha256 = "a54ca0e95760fef718a368b5efb23970c951b4a637001886d25aeca53a3c862c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/th/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/th/firefox-152.0.2.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "038092ec469134d437b07038aa32e341e06c493ee36c1d0a69b7fc3718ebf29b";
+      sha256 = "445e215115bfcd7502b1fe8ec6a1a280d2756b721d54cf18f098aac42ba339b4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/tl/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/tl/firefox-152.0.2.tar.xz";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "39df25ee4835043bb86b97325b68311b9af3df25da04bb2971f69a69ff6d3059";
+      sha256 = "88f76a27052b6a44419950fb046a4550d828c7d60de9daab13a53cf382fe71b2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/tr/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/tr/firefox-152.0.2.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "189fd0ca08eea2e76073279109d730cda4fab32a041d03dc18f95831de2bde45";
+      sha256 = "2959f9ea2585c0e674a8d32042bdeb2a90e3016a1002f6b669792b68b09c8b2d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/trs/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/trs/firefox-152.0.2.tar.xz";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "5fed2d1e075070d797999d8a1d0033b3340b8faf280c56787749f2c7ff225c83";
+      sha256 = "abd39f6533ccb1d37fb5c4cfd49749cf23418cae9ec5c2b676cca5bbd643aec8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/uk/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/uk/firefox-152.0.2.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "54f3ba58021c07316dd91f0353c14b53aae65e2752ca9116197f67df159a7b82";
+      sha256 = "6f0cd5637db1a04666025115c564eb734a65ae8ddee21e8370a843cb7ed34bb5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ur/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/ur/firefox-152.0.2.tar.xz";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "6981e1b54c4201f62e5d990398db23f89c6a401f5416aa6f2f81f3701a370ffb";
+      sha256 = "caf0fa151d7e0a8a47ef55bafebf587bfb153a0cfae7755e30cdfd3a0a84b5e5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/uz/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/uz/firefox-152.0.2.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "f2c7996e943b9e75753d167e292bada86437c806ce0104e3e3084afa7e4b0066";
+      sha256 = "4b869863c41ab25405533f142765dbc20ad6dc611d692bfe4d58c09717f6f1ec";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/vi/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/vi/firefox-152.0.2.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "e726b116f8a2e87e456a428c202959c4c74a79918eff8bdad560ca8e43b1e9b3";
+      sha256 = "0a43ae34c355d5b0901d4d94134a142a35dfd8884be37c1455dac8881d642eaa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/xh/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/xh/firefox-152.0.2.tar.xz";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "e0407be8198e01e1baa3df5cfddbfdd406089136167e2c45fb2f2eac29802ecf";
+      sha256 = "aa16d71d417a35c7061f99f1f3198d29b38e0d5585d23b31b31cb274b0b0242d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/zh-CN/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/zh-CN/firefox-152.0.2.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "c04aafa32bd08c9642d46429dc55123338c76d8d9ba247366472ded3e9a3a6d1";
+      sha256 = "b08c013ce0bf740fb7329d8aff2fb9237962251ff055dac1840b88b7eae9a823";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/zh-TW/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-x86_64/zh-TW/firefox-152.0.2.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "b6802eab250e42f1e7251b130e367958463441111a9ff9ddf3e57d8bec1207b9";
+      sha256 = "d28f5d880c8e7d6a770fad1db80ecdcb6015dd9c3786cff1009da271f1dba767";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ach/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/ach/firefox-152.0.2.tar.xz";
       locale = "ach";
       arch = "linux-aarch64";
-      sha256 = "cbf19d4b84374c9ef2222e197b0246b3a812b6f861556742eec392e42690a635";
+      sha256 = "d847f95bbb780b7b634384e28fa53caaeb88078f3a67d92f4f5a950b960df3d7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/af/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/af/firefox-152.0.2.tar.xz";
       locale = "af";
       arch = "linux-aarch64";
-      sha256 = "aa335bba462415b94d5dcb93ef88d2ed28711cc639fb7cc420bfb25d0253cf95";
+      sha256 = "472ab2b6bb42a00c18a963e94f221aacdf144354055cdd11648585cc91eaa33b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/an/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/an/firefox-152.0.2.tar.xz";
       locale = "an";
       arch = "linux-aarch64";
-      sha256 = "c26c15c32ad4e96f7e0f91917c6f87c6e1beaf0dbef1885a3fd047a75a016b66";
+      sha256 = "719cb248b6a3799a424f79dea8d852658768f309350cf5d3a7dc7d775d0a6b02";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ar/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/ar/firefox-152.0.2.tar.xz";
       locale = "ar";
       arch = "linux-aarch64";
-      sha256 = "b3b027ce12fa13e4a9d2463fa82e05402c47b49d8a2fd63dbfb359ce9da3db5d";
+      sha256 = "a6bb3eccbd0e78697b367fb26ea0d2a67bcacedb70be49c63828ebab9d0e04a1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ast/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/ast/firefox-152.0.2.tar.xz";
       locale = "ast";
       arch = "linux-aarch64";
-      sha256 = "fd6b397f98c1d6e36f3bd3aa0df1bf220ff9bd7e345efe3fa40ebc7b2b93a875";
+      sha256 = "49ef08a5cbce3b5b2567eff387605301eb7705b211aa9404a52c4fc6c625edcb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/az/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/az/firefox-152.0.2.tar.xz";
       locale = "az";
       arch = "linux-aarch64";
-      sha256 = "60b24f096dffcb89c306c923645c3cab1a92a3aa9ac8c234ab0f01b01d9f300e";
+      sha256 = "cbe711cf857dfa17128703f4434f8ee5b11fce2b9a7033187b62f18ad8d570cf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/be/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/be/firefox-152.0.2.tar.xz";
       locale = "be";
       arch = "linux-aarch64";
-      sha256 = "35af196289becf2f0688272ddcbb70552e939bc37dcf064361058e257b4ab6db";
+      sha256 = "9956c2ff4d58daab7ae247705d9fdb5d6d4cffa99c5410347716988dd20e0d21";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/bg/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/bg/firefox-152.0.2.tar.xz";
       locale = "bg";
       arch = "linux-aarch64";
-      sha256 = "fed7d6ae6cc31fe7bc4e545afb3c74dc38bc04d2bd4b04bf9012c6e4994292cc";
+      sha256 = "15c965adea6f39e13726d21c68e15dec15de895f7a7b394d51c59587a9c44245";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/bn/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/bn/firefox-152.0.2.tar.xz";
       locale = "bn";
       arch = "linux-aarch64";
-      sha256 = "c3cbb79d0cab97ff162a08293eba1bf2eaa10610fd7ed8aa0a49f6c9305cc46f";
+      sha256 = "06a22bc248c38245bd36f0001626f3cb101f33c2967bda66b967be5ae3675f96";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/br/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/br/firefox-152.0.2.tar.xz";
       locale = "br";
       arch = "linux-aarch64";
-      sha256 = "a36e7359cacd21b1aef60bd6657f94bcaf818f66b8d96dc3e8e321cb4e0dcdcf";
+      sha256 = "49fdb53ca17142435cf164753cc7eb4a7482e7738d4059f7cb305892f8047b92";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/bs/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/bs/firefox-152.0.2.tar.xz";
       locale = "bs";
       arch = "linux-aarch64";
-      sha256 = "a9298e271de07dbdc5c17d0b938a1298e4a1f3ba9eae14127836a3f4ea314c81";
+      sha256 = "4fad26b8af8d6803e7ffaf69eb24b0fb838262daf9d9b3ecc2be89b22aa91b13";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ca-valencia/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/ca-valencia/firefox-152.0.2.tar.xz";
       locale = "ca-valencia";
       arch = "linux-aarch64";
-      sha256 = "8cfb78e6955c5c698446cf73cebea6685bec70658e76dae031477f75a2a4d530";
+      sha256 = "2404f824a33287a06004c5a5f86896326504680bc7777c11764a9d68365f5e97";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ca/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/ca/firefox-152.0.2.tar.xz";
       locale = "ca";
       arch = "linux-aarch64";
-      sha256 = "b2b7c8c59e5a653c639bdcd2e9624f1d86501aa06a82f115400edd2e49343f8f";
+      sha256 = "21232c40fe8533a618aa8c446d860f7591e939e3815057924e3518509a701c67";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/cak/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/cak/firefox-152.0.2.tar.xz";
       locale = "cak";
       arch = "linux-aarch64";
-      sha256 = "472925fd62908977b8f1bf467a56145ab0a57c74249d0b110ff48a7d6892d265";
+      sha256 = "3172993eae57fe3cfe2de51254b7d05d84c1b4f0dc7ea8fc0ebe213a324a06de";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/cs/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/cs/firefox-152.0.2.tar.xz";
       locale = "cs";
       arch = "linux-aarch64";
-      sha256 = "9fd1f9e7622eb203df9c236dabc66fbd9ffdad55b9fa3ed683f09395a792ca85";
+      sha256 = "40df128162db45f2c3d019b53170fb1c5992a9351939adaeacad8b685effe716";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/cy/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/cy/firefox-152.0.2.tar.xz";
       locale = "cy";
       arch = "linux-aarch64";
-      sha256 = "26e6408f1b1d53a5b4a0203ca86a83c922b1259f8e0ccaf6dbc21d7098c186a2";
+      sha256 = "7ef1e048861b969b8d52d387b148941b2ba0b9ad0fba6734f4d6ac3b6fe7de5e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/da/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/da/firefox-152.0.2.tar.xz";
       locale = "da";
       arch = "linux-aarch64";
-      sha256 = "633b8f0774053f754e255c72a716a3f981c30ac2045b6093d55384540ae19b6b";
+      sha256 = "9e85eae7124e64a7086908a9f91553834809a6b07d6baf8fc33f780ff9a38306";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/de/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/de/firefox-152.0.2.tar.xz";
       locale = "de";
       arch = "linux-aarch64";
-      sha256 = "ae21e0dade3602d5ac0b41634e6b616ffe4006593ab65db4fab8e11ea2c02621";
+      sha256 = "2dac9ca6d07754bd1e3387c9558d8102799aab6323edc043b8c191eb9f4e745b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/dsb/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/dsb/firefox-152.0.2.tar.xz";
       locale = "dsb";
       arch = "linux-aarch64";
-      sha256 = "95c4501fcff86da1f3a1d2f08402df723b0d95c5b0c00404a9f446a3c6848ee8";
+      sha256 = "f7f8181accd65c1990081afb14c3a3754b0780cd58902e1a668a937afa495af7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/el/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/el/firefox-152.0.2.tar.xz";
       locale = "el";
       arch = "linux-aarch64";
-      sha256 = "ebcadae6d4a85cf2b88f5b5d5623f2bb644aa2a907b9916d27484da47bd4d2f9";
+      sha256 = "b8ecbfa04175235104c16fe530c66418f1bc098d909437e308390fce2d02534e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/en-CA/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/en-CA/firefox-152.0.2.tar.xz";
       locale = "en-CA";
       arch = "linux-aarch64";
-      sha256 = "3adb7c37539e3ab2cd3211f3aa38cdbbb6edeab0e45a42445b5f352707b00cc8";
+      sha256 = "cb8a4c44b49668c6b40ef9ac639069dfd93c0a8dd9bb2989e822bd7fcd582f9f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/en-GB/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/en-GB/firefox-152.0.2.tar.xz";
       locale = "en-GB";
       arch = "linux-aarch64";
-      sha256 = "68e0e9717a345e017db81badd309fa67d9e646efcdf48106e8452d61105a61c8";
+      sha256 = "47da0f132d411cbd74be87536a4f643b109710d32cbd05415815fc89257c7b2e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/en-US/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/en-US/firefox-152.0.2.tar.xz";
       locale = "en-US";
       arch = "linux-aarch64";
-      sha256 = "dd8e6c39a230af96082e89c963c93f36372f5875d33d38196f9f35fab597551f";
+      sha256 = "d4adb8ad2ca193053d1ed09b35217ff18ff8a7a62fad2ae719808ca2e20972bf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/eo/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/eo/firefox-152.0.2.tar.xz";
       locale = "eo";
       arch = "linux-aarch64";
-      sha256 = "cefee603d9c6b739a263be8fc30447e26cee9089b23b721371078a8176b40645";
+      sha256 = "563d463dbb16c83042cca51188a2ae4271b48b69369d575d74058749fe28df58";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/es-AR/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/es-AR/firefox-152.0.2.tar.xz";
       locale = "es-AR";
       arch = "linux-aarch64";
-      sha256 = "3d16ee897c28eb9cf32a6f43beca90a5cd52b9ee44733768c688017a20ef165a";
+      sha256 = "8a90442cd622bb9337e30a59fddb874d614c780a2ca314eff995832f62bd2683";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/es-CL/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/es-CL/firefox-152.0.2.tar.xz";
       locale = "es-CL";
       arch = "linux-aarch64";
-      sha256 = "3799e2f68522b7ab878aeabfb1cac6100c0f86481b23ce3c1160f24adb52ead7";
+      sha256 = "e0e645802e0ad592f34a64a2de10d37d5dffeb833a934c4142318aa94a701ae2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/es-ES/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/es-ES/firefox-152.0.2.tar.xz";
       locale = "es-ES";
       arch = "linux-aarch64";
-      sha256 = "8d6cd840c12cf09e8d9296b2c01c917c09dc620ef43bebbe2be4c1b57a51c50a";
+      sha256 = "26e3f1a60c4e44f1b6bd2a576d07c01e2829e2fcbe7f317e7f9fdaf11112ea43";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/es-MX/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/es-MX/firefox-152.0.2.tar.xz";
       locale = "es-MX";
       arch = "linux-aarch64";
-      sha256 = "95448caa7b4af1e76651a707fe1c6626fc0982e4cb4086839c06ca70df1318c7";
+      sha256 = "f3c0de68918a7bb443c85ae3b3195d8ca0a48baee39a76c798df0100011261f5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/et/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/et/firefox-152.0.2.tar.xz";
       locale = "et";
       arch = "linux-aarch64";
-      sha256 = "0d32c6542345e323d902e7fee882bcbb930f2900fb361ecba00630d2b692bf8e";
+      sha256 = "26d824b34548c326689ddfdb6f445e56e943fcda8acb9000d766b51f21b291d8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/eu/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/eu/firefox-152.0.2.tar.xz";
       locale = "eu";
       arch = "linux-aarch64";
-      sha256 = "76afb67dbec1aa876077f94ed5fff648c6c5274efd0e32ed7f3d0163ca6f0ae0";
+      sha256 = "bf8ff9041512fea5340c145643b87489d8ed1ef59567912b15319db111860a8c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/fa/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/fa/firefox-152.0.2.tar.xz";
       locale = "fa";
       arch = "linux-aarch64";
-      sha256 = "7bedc5d92bb7c1731982ba6ceaf420912febdf08d82255b5661826b8f9e4be65";
+      sha256 = "bda38c8ac506590863d736c8670aa7e3c8f5190d447f0ba6c0a4ef328a9b0b2b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ff/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/ff/firefox-152.0.2.tar.xz";
       locale = "ff";
       arch = "linux-aarch64";
-      sha256 = "3049c5dcac5d87c61f62dc7ae22c0905a30b75eea32c1f30ee273c6d7c398485";
+      sha256 = "8e0a753a098eb27005f5f9e013c8433496607aad10612ddf33100543193d98d0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/fi/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/fi/firefox-152.0.2.tar.xz";
       locale = "fi";
       arch = "linux-aarch64";
-      sha256 = "c33af0ce2d62cd79831cd86a3117b04e4c8fec5f0dd6079355478dfea5b6acbf";
+      sha256 = "b50970cc9907a6149374f2123939bc0f01bccd67a6e2389e109909e64bf68d2a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/fr/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/fr/firefox-152.0.2.tar.xz";
       locale = "fr";
       arch = "linux-aarch64";
-      sha256 = "65737f1b29ac6849c6a805db9d98f11d7ec7556c8ef467fc0dc1930f5cf4f745";
+      sha256 = "39d93d9256f859711ec4a351762916699023fa6c4c14db6737415d96d5b39a20";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/fur/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/fur/firefox-152.0.2.tar.xz";
       locale = "fur";
       arch = "linux-aarch64";
-      sha256 = "a981a1c5c37015ac879bf4d009ea6cd8767f4bc9c476821b92afcae9fc16b826";
+      sha256 = "f4db616f5f925cd8a22df8ea2ea72dccdaf95f3f8899e8631b67f41a933bcbc0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/fy-NL/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/fy-NL/firefox-152.0.2.tar.xz";
       locale = "fy-NL";
       arch = "linux-aarch64";
-      sha256 = "9e8f4dc4cdfd80b7b97801b33e0eba58a422c92de5d17c21177b68770d3728c7";
+      sha256 = "ad0ffb4c02272650f925a1526c54da8dcb22c6c5c6b3b58efaf4adcf434327ed";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ga-IE/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/ga-IE/firefox-152.0.2.tar.xz";
       locale = "ga-IE";
       arch = "linux-aarch64";
-      sha256 = "27b009a81c15593162649a1c6528c04e1825ae994da0303faf08c8df9862039e";
+      sha256 = "b6bfd3441337e7739869582ed81363dcb156f2982160b85a432fd1876d2eb69b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/gd/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/gd/firefox-152.0.2.tar.xz";
       locale = "gd";
       arch = "linux-aarch64";
-      sha256 = "5a14ae1fdd939c216893c2a7e9f7cd383e46b8c69430bd0259a042bdb0e3a743";
+      sha256 = "6ad401ea24abdf21eea1b84332487580ef12e4b343fd44fa5be1424a54fc8fbc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/gl/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/gl/firefox-152.0.2.tar.xz";
       locale = "gl";
       arch = "linux-aarch64";
-      sha256 = "3d149ecdfd300e59bb483cf783b216a461578ef1a81f445b40f7ade80b31edd5";
+      sha256 = "005dea494f7ed9b1a8ca4b330ec6a47641bc042e2681af4b0085b43fc7890339";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/gn/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/gn/firefox-152.0.2.tar.xz";
       locale = "gn";
       arch = "linux-aarch64";
-      sha256 = "a0b8f3ae1ca6ee72b241ceba7ea0a0dfa1f9ab5f38c876953262cd2ea30c5d07";
+      sha256 = "83c3f73f8059c2d9ab07345d444c4c847efbb234ed8a09ad6033b6674c6b7db2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/gu-IN/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/gu-IN/firefox-152.0.2.tar.xz";
       locale = "gu-IN";
       arch = "linux-aarch64";
-      sha256 = "b517415e4e75e2f085410616069efa77f8710d47b1745fd584274127c2f942c2";
+      sha256 = "3fd06ca2bd7b060aaeb96789f8131c966d9e5bdf5bb5c07348d00a5029e30c21";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/he/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/he/firefox-152.0.2.tar.xz";
       locale = "he";
       arch = "linux-aarch64";
-      sha256 = "f93c26df9b38f1c84726e62b72bf5b7d04e110ae1e86894e91663051d5ff6c35";
+      sha256 = "83f7810d09c9095850d1b9315d8bd12f617bfefc4d1fdbd927e8f1d6dc444f85";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/hi-IN/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/hi-IN/firefox-152.0.2.tar.xz";
       locale = "hi-IN";
       arch = "linux-aarch64";
-      sha256 = "883c158dfb7c2b6f24a26cef2dc86536cfb153c5befbeaae2d5aba090625badf";
+      sha256 = "d96f0784be48c53f5099a55ef04e456e5428183ea917e04a95a0cc4e965c4cd7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/hr/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/hr/firefox-152.0.2.tar.xz";
       locale = "hr";
       arch = "linux-aarch64";
-      sha256 = "9fc54a2e04ee8680d4a2ba2e235fea47bdcd2aff6845c3c1e16f606fd2c7cb75";
+      sha256 = "0d25dd840b6a11073c1afec82996afd01ea9390af2b89d1633da709945aafb4e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/hsb/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/hsb/firefox-152.0.2.tar.xz";
       locale = "hsb";
       arch = "linux-aarch64";
-      sha256 = "90700a976b408a6e0649d95c556453670d89d647d97c56dadf33c0816c78d160";
+      sha256 = "8f284218c0956a8f76af7d6e4cc0595ea830de398496aa7494ed8fdf4f83a03d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/hu/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/hu/firefox-152.0.2.tar.xz";
       locale = "hu";
       arch = "linux-aarch64";
-      sha256 = "eba9b8baafa824e26eb33fc6c72bec40b9b82e58a03450ce02f6cfbd1cbdbe6d";
+      sha256 = "1dace22b2d708101a7b309ea5a8e5c7d36c91bd8b6f51a2f6ed9e706cfb625ab";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/hy-AM/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/hy-AM/firefox-152.0.2.tar.xz";
       locale = "hy-AM";
       arch = "linux-aarch64";
-      sha256 = "ce5d4fd77daf9f4ac902f33fa2db4c6bda51a407ff8e517f4f6f185bffb0e97d";
+      sha256 = "1d591f2bf3a2881bdcbb3be46951c517f33257768736c8603df7318844aaba25";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ia/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/ia/firefox-152.0.2.tar.xz";
       locale = "ia";
       arch = "linux-aarch64";
-      sha256 = "3972561b5e66db727c7716dce79b19f8e67c474620e9df5834c27e1088b266ec";
+      sha256 = "c04a7f5b030779269d67c0ea6d5afcda33c8e37ab2605b078f9d60c2d021bc28";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/id/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/id/firefox-152.0.2.tar.xz";
       locale = "id";
       arch = "linux-aarch64";
-      sha256 = "9b9d4ef17d768d0d75af7ce03ef77f56c52e555306f93378631da9b12f037edb";
+      sha256 = "cb23611c068013915e4361b86ee9dfc855651ffcf4b000e66430b8548ca7fe2f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/is/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/is/firefox-152.0.2.tar.xz";
       locale = "is";
       arch = "linux-aarch64";
-      sha256 = "be40bb39ba7e436e7cebe52e9fd5344f20decb94635550074139189f67a7b095";
+      sha256 = "6e3e97ffe65bbe65e894932cdbe3992f431a5ca9e9f1f37c314bc1771c257552";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/it/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/it/firefox-152.0.2.tar.xz";
       locale = "it";
       arch = "linux-aarch64";
-      sha256 = "ba55d271fb6fe06e89bebd837c2ec0b9649f185909499b9e2c75bd71805dad4c";
+      sha256 = "92a1e95bb09f67bb372683c391dce3739939ee945317f12fd75e8f060455ad58";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ja/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/ja/firefox-152.0.2.tar.xz";
       locale = "ja";
       arch = "linux-aarch64";
-      sha256 = "48812299490107900054768d40d108980f61c3e0804586d0ae047cdd66d1f882";
+      sha256 = "9ee0f01e4bacd28fa2c2e1b050a0885b641b6b4ec615eb5a8c75457f59b28b87";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ka/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/ka/firefox-152.0.2.tar.xz";
       locale = "ka";
       arch = "linux-aarch64";
-      sha256 = "44adc3bfd8e91ef9cb5eb43b5fa155a6610a72bd4fa77993d5600a1f7a2ef55d";
+      sha256 = "ff158cf627f0e697a173f5d66a09c1cc8f1ddf50d67d0c97c90284e1bbdfc3e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/kab/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/kab/firefox-152.0.2.tar.xz";
       locale = "kab";
       arch = "linux-aarch64";
-      sha256 = "f10e380073984dd14bd4659d4ce55bd01f82855cf67b47e40a4a7a8fd93a17a3";
+      sha256 = "6542108a4ec7dcaa47c9277e506fc098ff2e991f1852edb511311bacfda8c2cc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/kk/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/kk/firefox-152.0.2.tar.xz";
       locale = "kk";
       arch = "linux-aarch64";
-      sha256 = "8b17434115ff8a6f7ed8e733dcc6ac63350ed63ff06f1c70e81ec0ef02cb33cf";
+      sha256 = "353a7f58dbb0da3e0d76535df783165c20a32ee109e09258fe93a4b8933a5d7c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/km/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/km/firefox-152.0.2.tar.xz";
       locale = "km";
       arch = "linux-aarch64";
-      sha256 = "22dd538f204296e6a4c54980091c5324facb3df0c4fc1ffa8cae8f1c8adfd3f9";
+      sha256 = "d9bc8e08092631459159975623da09e813ef504936dfbe86f9f407f090a85d0d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/kn/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/kn/firefox-152.0.2.tar.xz";
       locale = "kn";
       arch = "linux-aarch64";
-      sha256 = "2afb87474fccb51d6b7081bd7cf0a8195b55a5f6a45a895c77b09f308c8ced03";
+      sha256 = "f9490acf7866ffadb02fd8a517d1c54c67f3b5bfe01caeb4bddece0a5ea8c50b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ko/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/ko/firefox-152.0.2.tar.xz";
       locale = "ko";
       arch = "linux-aarch64";
-      sha256 = "69fbca523d4b00b3e8c8e28feb3f52a9bd9537d76dff0f12b950cdecb5c92aae";
+      sha256 = "b2eb21f8850fb5c73332605f3a5ed8aee75218e604678005de12229807c5a8c3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/lij/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/lij/firefox-152.0.2.tar.xz";
       locale = "lij";
       arch = "linux-aarch64";
-      sha256 = "37c80be4eb4ac1cde954f5484a8eb8df07f46036286ae1b0688dbd2c44ebe138";
+      sha256 = "328e5028c65b26fc5c7737d166c903789994416cd470d79c4fbb17f8f99239a1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/lt/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/lt/firefox-152.0.2.tar.xz";
       locale = "lt";
       arch = "linux-aarch64";
-      sha256 = "ebfe550a9503aad363a174f3558333f80b2e7e5d2b81ccc563419762347e54c3";
+      sha256 = "6b92152cf414600b36385573086f1a6f1b1f67d682cae7d8287f1cf56d43110c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/lv/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/lv/firefox-152.0.2.tar.xz";
       locale = "lv";
       arch = "linux-aarch64";
-      sha256 = "9fb0653f1588ada25dbda0379b5dac709d717ae0fcbbf6321c490e44d8fb7bad";
+      sha256 = "55f4ad418ec69ddd893bef29c42bb20c7ad9d981e2426df8104b35dbe7a5d9af";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/mk/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/mk/firefox-152.0.2.tar.xz";
       locale = "mk";
       arch = "linux-aarch64";
-      sha256 = "005c99cb5d681314651205380788d5954046d8d3380b86d2b4de2082457fcbe0";
+      sha256 = "ce288b0f16e4b9f93f1e0a970bbe1495fe2d2d3305f4b625d30cb5af95397b28";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/mr/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/mr/firefox-152.0.2.tar.xz";
       locale = "mr";
       arch = "linux-aarch64";
-      sha256 = "54fe2944d46a605a5d825be040b177ec75e99ec540e9e6125ff8a94c2abadca6";
+      sha256 = "f726f77a166faa42887b1ea8ae7b2bd25ae4c4ae5ba9324758e5391d9be4a42c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ms/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/ms/firefox-152.0.2.tar.xz";
       locale = "ms";
       arch = "linux-aarch64";
-      sha256 = "6de95bbb652b0651124fe4b51dc8c52c3feb093d61a73b2777272b0a02a8abb6";
+      sha256 = "33c0c76cbbf62437077f39fc483580cc4f519108ac0776d6ec9ef3c4b5226069";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/my/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/my/firefox-152.0.2.tar.xz";
       locale = "my";
       arch = "linux-aarch64";
-      sha256 = "49be133f51ec3f942f1d067f49475efb949c3b09335cc939f14e17af76cf72ce";
+      sha256 = "fb4e331173d5b0cff135531bde24d1da0ac815c456a9a5ab65be0f29a76e68b8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/nb-NO/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/nb-NO/firefox-152.0.2.tar.xz";
       locale = "nb-NO";
       arch = "linux-aarch64";
-      sha256 = "ac8eb102e83e5a44305e11dc8cf4189edc11e20acd3daf00a1aebb66c9775dd3";
+      sha256 = "5f4234df0b4e62aa679064455627f7168043c114c9e232eb24e639e93fcec7d8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ne-NP/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/ne-NP/firefox-152.0.2.tar.xz";
       locale = "ne-NP";
       arch = "linux-aarch64";
-      sha256 = "8977ce3abc7518ca40c80f84fcfad6bfa5bf150782e91d11ae7a5fe771cdb9e9";
+      sha256 = "6f3757a1b5ce6f4753695428ac5f1caf0c15bc935ca075cee42844ab8178eb74";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/nl/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/nl/firefox-152.0.2.tar.xz";
       locale = "nl";
       arch = "linux-aarch64";
-      sha256 = "76e7297bb504d691501f6c7d81db622772475eb4ed5104b76e7c34352199a000";
+      sha256 = "137143bba38da817c50dd7230804c2bbea917c923d12c8a13558258940cbc525";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/nn-NO/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/nn-NO/firefox-152.0.2.tar.xz";
       locale = "nn-NO";
       arch = "linux-aarch64";
-      sha256 = "02734dc117624965b3c858464d5706375f34b0cb87741d6004ff4aefddf545cb";
+      sha256 = "1c3f291f622604e6604900cb619154b3ed91d064fde7cb951e4df871087b62d0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/oc/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/oc/firefox-152.0.2.tar.xz";
       locale = "oc";
       arch = "linux-aarch64";
-      sha256 = "a7e81e0be667523fa96b7ed8c07b6b66ae77ec0cba010f8b5936a5e63f405ff8";
+      sha256 = "84dd100fda879948122af8ac50e29c01c83216e9ada84935bb93b43d7d1a8735";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/pa-IN/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/pa-IN/firefox-152.0.2.tar.xz";
       locale = "pa-IN";
       arch = "linux-aarch64";
-      sha256 = "c48272f218b59461103488b9c07d44727af63a3261243a6bc0671faaf5d6fd9d";
+      sha256 = "cd360f7e72d79145e772325d9c8440edd5b58b26b9257a57f5c9a46951b4c71a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/pl/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/pl/firefox-152.0.2.tar.xz";
       locale = "pl";
       arch = "linux-aarch64";
-      sha256 = "f24980d76399305a488fea9b877640f27be052686ca48b71dfcca35b7096ea5e";
+      sha256 = "62e9764449963bc4c8cfe690a426e058c4bdb66df1d09ea989592b5709161b7d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/pt-BR/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/pt-BR/firefox-152.0.2.tar.xz";
       locale = "pt-BR";
       arch = "linux-aarch64";
-      sha256 = "3c5d505fde21db9ba6ac0719526f33f6e4d3d618b9b99b897e2cf2c0bd598987";
+      sha256 = "8e92a43c60e89b404dd713edb33a67592e631585ad33dc9bea7a10fed5a4ab15";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/pt-PT/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/pt-PT/firefox-152.0.2.tar.xz";
       locale = "pt-PT";
       arch = "linux-aarch64";
-      sha256 = "3a8a45dbc8c4a856c244f92c5fef9d56638cdeeb9359d1aa879a1d66f4171c4e";
+      sha256 = "cf2e705421bcebe925ee28c700d1fa31891f63df192971c84c6e0934038a7655";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/rm/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/rm/firefox-152.0.2.tar.xz";
       locale = "rm";
       arch = "linux-aarch64";
-      sha256 = "1630108515d136b968710fecd66d89648134089add490b4d4119744bc674db8f";
+      sha256 = "b02d819eb0ceaaf2f38b761bc4b69223ba6ad1ca4d700b25091784256f103857";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ro/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/ro/firefox-152.0.2.tar.xz";
       locale = "ro";
       arch = "linux-aarch64";
-      sha256 = "6a3026a5344729c83d9b365b007d7711914e26d8090a7a3c9888f0afa9667a64";
+      sha256 = "90360f3080b7e542b886b125698debc41a482673c9f0c353ff64cee97ffbe681";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ru/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/ru/firefox-152.0.2.tar.xz";
       locale = "ru";
       arch = "linux-aarch64";
-      sha256 = "a485f2f03e50e0c89ac36728afb4ba2eb3ca6616ec7fbd2f04d82b58d1bc33c7";
+      sha256 = "bc8756d9b540a280f3a833f60cce2b99a36bd9849cfc6a631ad900a2ff84e60a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/sat/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/sat/firefox-152.0.2.tar.xz";
       locale = "sat";
       arch = "linux-aarch64";
-      sha256 = "e8fd0de0e2d8409f4cec8ba11ae3e9bb16dafbc9406ce7bda3465dd30ccd92ef";
+      sha256 = "0e8fd1c6b10a21cd9fa37ded16e9417f036f4562e99738f0bbe1a906147df3ba";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/sc/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/sc/firefox-152.0.2.tar.xz";
       locale = "sc";
       arch = "linux-aarch64";
-      sha256 = "3591c1a32b4fd50556473ba1086c1706a2cc18e0001bf0a17aaeeccad41c4d8f";
+      sha256 = "3bbd410771f372cec3a5d5077f29252c28403a4811fb63b866b10d8a55f83c86";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/sco/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/sco/firefox-152.0.2.tar.xz";
       locale = "sco";
       arch = "linux-aarch64";
-      sha256 = "e9b91e7272b69a0abb0a10194b14e9c884e3ee1623319d071fc634727d454efb";
+      sha256 = "dcc1534adf144deda44a116c6e40eb8bd16c76c4a44d949682e84720dfaaf44a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/si/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/si/firefox-152.0.2.tar.xz";
       locale = "si";
       arch = "linux-aarch64";
-      sha256 = "89ec2e862d27caf3fcce6c5c30d3599fea5a487f4911c39307791bec6b9f0f2e";
+      sha256 = "eeaf7915668d0f743601dd560d129b971b793b4126e2dcdb48e1bcac4ef5512f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/sk/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/sk/firefox-152.0.2.tar.xz";
       locale = "sk";
       arch = "linux-aarch64";
-      sha256 = "28f6032517668a3a55fba1b3b9f1a63cb4a3afd941d794c3c03d4dcbb0471e60";
+      sha256 = "69bedc57242c3e10d3bd7ba471d9bf3a8839afa0217533f4d24385e3bbf28e70";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/skr/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/skr/firefox-152.0.2.tar.xz";
       locale = "skr";
       arch = "linux-aarch64";
-      sha256 = "441e6a75a599dea31f8823ecc108debbd3e87c7b0bc6cc0850330c1c83f01f0f";
+      sha256 = "925a973ba003c7c27110109112d87faff407c6de18b1a3f9ee1c38777e3383a9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/sl/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/sl/firefox-152.0.2.tar.xz";
       locale = "sl";
       arch = "linux-aarch64";
-      sha256 = "b9dedf17bc7bdfca882d10bf15683d0e627f91266ec33f29e8f311a112027589";
+      sha256 = "14f615d0b72247e3fcae8e7a9b094156f29e13f7ed5a37c98a8eb0c0410fc304";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/son/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/son/firefox-152.0.2.tar.xz";
       locale = "son";
       arch = "linux-aarch64";
-      sha256 = "b920c2b638577049afc6a192164d70c420fb9ea81f056287fcf1e831698d0e6c";
+      sha256 = "8cebabd61ebd41b922d55e564bca533e52e36dc774b6f3a623304da09b02271c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/sq/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/sq/firefox-152.0.2.tar.xz";
       locale = "sq";
       arch = "linux-aarch64";
-      sha256 = "fbf12721ee02e4ed16f3c8ab70a4c7ee3103718dc76efa17f58cc4a87d60d4ee";
+      sha256 = "d0642a88cb13dea258f72d9cf21a5deb1e757392897edd0e0c17f20d392bc2eb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/sr/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/sr/firefox-152.0.2.tar.xz";
       locale = "sr";
       arch = "linux-aarch64";
-      sha256 = "7b353fcc0461ad730343ef8f4b63084dfeb149781feed1997e44f8b642e4a18a";
+      sha256 = "e9e4971bf250bcd04024af94813b6461e9b0948695b5925cfcd20feb8865940a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/sv-SE/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/sv-SE/firefox-152.0.2.tar.xz";
       locale = "sv-SE";
       arch = "linux-aarch64";
-      sha256 = "17a9e13e0c81e87dfabee297045fe2cbea94237bcbdfae2589027a46b20855c8";
+      sha256 = "9c8a8c4f9de99cb3bec879114a91c2c18be05c1934736d8f5f6c3fbfbdb68fea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/szl/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/szl/firefox-152.0.2.tar.xz";
       locale = "szl";
       arch = "linux-aarch64";
-      sha256 = "75e12d6ddeb1412b654d29beacceaab6574bd36f46c953d86f99cbbe8a45ffb4";
+      sha256 = "73fdf71b78c86dd02b4b54e822d480a370c8e20567c11b200140ef37657fa7e1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ta/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/ta/firefox-152.0.2.tar.xz";
       locale = "ta";
       arch = "linux-aarch64";
-      sha256 = "766be6f4a93a95567c1eb847300d42ffd2d7305a9cc854ea583fbf8d83e871e9";
+      sha256 = "42facbb58cc856b36341533cffb471394c902cb0f6a7b181399405ce7a61935f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/te/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/te/firefox-152.0.2.tar.xz";
       locale = "te";
       arch = "linux-aarch64";
-      sha256 = "aee899225e016f6a78206a95dd99361afaac02b6b6642a83ccab54642771d30d";
+      sha256 = "68a9dc0e643e6dc6ae0ea15df69b9abf32bbc3afa6aacd8852a46cabe885c001";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/tg/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/tg/firefox-152.0.2.tar.xz";
       locale = "tg";
       arch = "linux-aarch64";
-      sha256 = "032cac36167b0e35be77ebe908fbbd76f06dfeeab887c253ec0f8e5cad97db57";
+      sha256 = "0177df70aee73b5bda5d2533facaeb85a1596ea2f81751c25149ede4889f57e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/th/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/th/firefox-152.0.2.tar.xz";
       locale = "th";
       arch = "linux-aarch64";
-      sha256 = "d2cda2d3247af69bdf708a8787a6699a10580eedbb444ff5eac6a6eb16971665";
+      sha256 = "899f99f42d172bef1bda0ff68cf4625f3ed9b6c017d3eff95be3674f67fe79e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/tl/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/tl/firefox-152.0.2.tar.xz";
       locale = "tl";
       arch = "linux-aarch64";
-      sha256 = "361586e1aaa289448a97076f4bb9a8cb89e1baafdc526f0cd03c2f2229322243";
+      sha256 = "62584a40e8d95a8e45a9970cf9aad7ef27f8fa76995e1a9deb39e0b132b13fd7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/tr/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/tr/firefox-152.0.2.tar.xz";
       locale = "tr";
       arch = "linux-aarch64";
-      sha256 = "a757ed0cfa25d9d806b35551febf8bc47e79fc3a2fb4719cd54a8a2997635701";
+      sha256 = "dfdcbebabaaf2c57dc57ae2b2f0d9df152d96a1bb941d90a245e042e72fe1092";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/trs/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/trs/firefox-152.0.2.tar.xz";
       locale = "trs";
       arch = "linux-aarch64";
-      sha256 = "27ba01b45f17ab7bd8c0e8c252f96214bff4500b4fdda9efff75cecaf39a0fd0";
+      sha256 = "db01a8095380a45285dcd3b029985928a66395867dd887616131ddf63eb2eeee";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/uk/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/uk/firefox-152.0.2.tar.xz";
       locale = "uk";
       arch = "linux-aarch64";
-      sha256 = "8b8b26441bfbdac02973eadd02e25266819601d4f100fa45ccc0851929e2c0b7";
+      sha256 = "6c99a23e765acb0f9ed5f7c0a2f29b1004361405f871a2c206499e2dc2f42834";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ur/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/ur/firefox-152.0.2.tar.xz";
       locale = "ur";
       arch = "linux-aarch64";
-      sha256 = "fe28ac18113f6b0f667f8db1fb4ed0dd29884a1fa9d8ecf87842c76a417bde33";
+      sha256 = "bb4bcd95fb1d91d3481a1f5c202ec3db5c6d097f11e322db00e6e582921f6d69";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/uz/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/uz/firefox-152.0.2.tar.xz";
       locale = "uz";
       arch = "linux-aarch64";
-      sha256 = "0dfde346dfa55439c80897e161f565e77bc9e6101d93ebb005ab27dc9b6f063d";
+      sha256 = "bca412e94ee7efceb4cd05df9acb6e6bec873d1ef76126ba62bfcc5ad41ffaa3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/vi/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/vi/firefox-152.0.2.tar.xz";
       locale = "vi";
       arch = "linux-aarch64";
-      sha256 = "c02702bb99fc7c6e2901d680504f81737f865d4442ba144336112e440c2f74c2";
+      sha256 = "99ed16690e4db79a478a18fc3705d83048b4839ec26d3ade27fb34eb46f2c13a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/xh/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/xh/firefox-152.0.2.tar.xz";
       locale = "xh";
       arch = "linux-aarch64";
-      sha256 = "2077f484d03bcfe867a075bcaee2a0cf0ad80528dcfaa1e3ee477f1e24149f85";
+      sha256 = "58da125810cfe24eb4a8315d24f7693e9cf0d2cdf453006e977cfbf64b6d7c04";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/zh-CN/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/zh-CN/firefox-152.0.2.tar.xz";
       locale = "zh-CN";
       arch = "linux-aarch64";
-      sha256 = "a54b2d1404569808d014a550bdd23c8414b1e6fb13e77c9e03976ae49f8df42d";
+      sha256 = "f40d878cf5fee2ac175b14a17843e6738fcaa424a3ce49d54dc010d8f4287d60";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/zh-TW/firefox-152.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/linux-aarch64/zh-TW/firefox-152.0.2.tar.xz";
       locale = "zh-TW";
       arch = "linux-aarch64";
-      sha256 = "9a8e19704b97ad131891dc26e93766ccb24f8478826792e6c08ee25cd9d59afd";
+      sha256 = "e6c56325213c1d3a64c4f3cb4ef96ec8a18bf3e93667d835de5290118434b86a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ach/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/ach/Firefox%20152.0.2.dmg";
       locale = "ach";
       arch = "mac";
-      sha256 = "a14b9ca5cae670b5f42aab2f17df613865af9493e54bd164290e3c2bdf4c40b1";
+      sha256 = "25b75e89c674b187b073e759252c6500bd0f867016a4d91489f303a8915a2466";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/af/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/af/Firefox%20152.0.2.dmg";
       locale = "af";
       arch = "mac";
-      sha256 = "31451bf4d3b7c6dd5ca888b5bb65321a19ee2058aa128cfbcb8d1b24fc4c530a";
+      sha256 = "76f046d34096207878714583f2888c3417f643322deff76b5ecb3d049e90bd0b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/an/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/an/Firefox%20152.0.2.dmg";
       locale = "an";
       arch = "mac";
-      sha256 = "08a9e820a09b870084d4a14964eda64cff12fc3f9c79a8d48d8086aeadfcd359";
+      sha256 = "a51db34ad8543327c1274bad29daad83ddc7c5a28e0fb1fb4baca146d6b56033";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ar/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/ar/Firefox%20152.0.2.dmg";
       locale = "ar";
       arch = "mac";
-      sha256 = "88429e89c9ae690844673b6aa4c1fc8bf2571b2a9ca4ca5f2d9232424f3bc385";
+      sha256 = "94b6c21a407e65b59b3faf9bac8eae91094f19d362d549d416d0bbb0790e341e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ast/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/ast/Firefox%20152.0.2.dmg";
       locale = "ast";
       arch = "mac";
-      sha256 = "d1e5f0dd0cb76ddcc463355faf3ccdd1631b40865c2ba52a6122ed35bb0e11d6";
+      sha256 = "b306cb9306fac4a218835fe85407b0c3eb2ebbf9e8fdc64782184d1ff17e1bb6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/az/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/az/Firefox%20152.0.2.dmg";
       locale = "az";
       arch = "mac";
-      sha256 = "1334ef16c5f736e35a3e0112c72090243bac4337492c779fe507a642298c1f98";
+      sha256 = "3bfd04995b5df66be1d872700c065c5a94dd8bae7db0005a389f02f6c1d74a01";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/be/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/be/Firefox%20152.0.2.dmg";
       locale = "be";
       arch = "mac";
-      sha256 = "b9b9ff3e1e7f4c0d37930385ce74b00a36d3562c12fe8fd0a2bba26c47f0714b";
+      sha256 = "0d4ffaf6d5cd63628de4b686ef2bc6ae577bcf37a1f787d9d0d0f61bb83c58a4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/bg/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/bg/Firefox%20152.0.2.dmg";
       locale = "bg";
       arch = "mac";
-      sha256 = "5d3e088b8658b8f4218f69474eff22d3495bc81ec80a2324aac98437a7c305c1";
+      sha256 = "29379238d2bf015dda7c97ac6e33d4ad4ddc6f78e4626a08cc3db0cd15ef701b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/bn/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/bn/Firefox%20152.0.2.dmg";
       locale = "bn";
       arch = "mac";
-      sha256 = "b3495a1bc5426ba1af223cdd46d4b42b0ddc425c6fb2442ccc1e9c28fb0e330d";
+      sha256 = "12fcfbba2b563de36d48b72a9b0b3144fe571a10f14a276aa958c56c39fea587";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/br/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/br/Firefox%20152.0.2.dmg";
       locale = "br";
       arch = "mac";
-      sha256 = "961ccb269cd0e15bf58929194d30f16294cb74b43475700a77d9799b9d239b7a";
+      sha256 = "15ab3833f064afaf29974c84a20bc77e39369a65d33f89b2f70b34f536e9e2b7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/bs/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/bs/Firefox%20152.0.2.dmg";
       locale = "bs";
       arch = "mac";
-      sha256 = "ae4560a9743e17d4682ab70a01de5addf8215c8351ef548ed87eb5ea13f8e3ca";
+      sha256 = "c64e05ae3af91e383a911edfeb5cfcdc84057324c3314ad21889bbe68be49a3f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ca-valencia/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/ca-valencia/Firefox%20152.0.2.dmg";
       locale = "ca-valencia";
       arch = "mac";
-      sha256 = "7cc75bc007f12a41e9b64ab522065ef652ac4c5716b471e627c498e0bf443c79";
+      sha256 = "ae03faf5e7aa16bbe231945dbc19d6b97340d924fd2e42dae1f51426418ff6ed";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ca/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/ca/Firefox%20152.0.2.dmg";
       locale = "ca";
       arch = "mac";
-      sha256 = "687aaf217f80cfdd514491ce2d454b8ff8f1b70814d11687db79ad153a17449e";
+      sha256 = "3908f65520ad76efb538583d1bc50a8a22e9a8a64b80daa59d477d8ea0673af4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/cak/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/cak/Firefox%20152.0.2.dmg";
       locale = "cak";
       arch = "mac";
-      sha256 = "1959eb7a55f1e7f0fb24d6f17e47e20a80faabd8d3104a5fb4c1279889c450e2";
+      sha256 = "1422f25b125c426eec034a3c94ef74df45f3685099e2653080c41b1acff80c63";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/cs/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/cs/Firefox%20152.0.2.dmg";
       locale = "cs";
       arch = "mac";
-      sha256 = "20bd8c084bb1eab32d0b510f2e761f36606f37c898ea9a1bda69434c844eb4f1";
+      sha256 = "d19369079e99a03b6526ed3440d1b9b1549c993af7beb158c85f1a573f75b609";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/cy/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/cy/Firefox%20152.0.2.dmg";
       locale = "cy";
       arch = "mac";
-      sha256 = "7bf4f120fde633659785aa23dfaf9a4569089cc4fcc36e27649fbbd96541991c";
+      sha256 = "d56976d13763b5cf1b0efd43e5f4d3fe52726d665285b37c1cb6a5b5a72b4840";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/da/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/da/Firefox%20152.0.2.dmg";
       locale = "da";
       arch = "mac";
-      sha256 = "f049e7934353c72e15cc72a2f35a596c79b512d20ebd999549c81fde151fafc7";
+      sha256 = "c5409e5aae65fc032c7a9ae515812ad76c584f26f95050434778d902414bfe03";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/de/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/de/Firefox%20152.0.2.dmg";
       locale = "de";
       arch = "mac";
-      sha256 = "64b0d3d180b65fa34866289a1d004f91b7fe4f04592cb2563123209753168f18";
+      sha256 = "cf22599b7552585f40634b3dec726f5b17ac593209ed9957c7feb9892ba29a0c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/dsb/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/dsb/Firefox%20152.0.2.dmg";
       locale = "dsb";
       arch = "mac";
-      sha256 = "1fdab7e1e68166b4a1998e168afd6a88cda89ba0911ad797fd71016f9fe9375f";
+      sha256 = "b948d12079b9b91f138d2fcbaf0ba6bf68c13f1e82640c46ef327f033cb59f17";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/el/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/el/Firefox%20152.0.2.dmg";
       locale = "el";
       arch = "mac";
-      sha256 = "96ea89bc4fa2e86663117365acaa713030f7ddf63e3fd1fcecddc915c7994afa";
+      sha256 = "803cec07edf0245dc512eeb1bce3078f8b4d6f998214fc3ded32d9bb4955713d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/en-CA/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/en-CA/Firefox%20152.0.2.dmg";
       locale = "en-CA";
       arch = "mac";
-      sha256 = "b43ddf56f63a8bd8c6644115fd882c0ffed775c5db10c3c58ffb1a827ee26404";
+      sha256 = "8a65e5f1acedfcfc7066e4bce540ce7b95514602109f6a9e3b3c71e000e701d4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/en-GB/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/en-GB/Firefox%20152.0.2.dmg";
       locale = "en-GB";
       arch = "mac";
-      sha256 = "f9c0d5236a17f77380cdb9a41a95dd487168c72ed4a2ca91e185552a17be97e8";
+      sha256 = "9939895e51ab1386cdcb88d374ef118d08dbf03624a92e758aba5d33db6954f9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/en-US/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/en-US/Firefox%20152.0.2.dmg";
       locale = "en-US";
       arch = "mac";
-      sha256 = "3398cb6c17077f536bd534af3a98b66ef850689532f82ddc3df05533b8018ede";
+      sha256 = "36820598ede2790d59fc18dae96d0b6f7982106f125cdf5e1799ee75e1fb5278";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/eo/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/eo/Firefox%20152.0.2.dmg";
       locale = "eo";
       arch = "mac";
-      sha256 = "a7560c946928764f2aac02ad8cd91d4f7db174d97cef586b9c33598b9b0309d0";
+      sha256 = "a433c6b217df1c89303768f6991f88d0e7a33d27099b6394417e6534d4dbaf71";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/es-AR/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/es-AR/Firefox%20152.0.2.dmg";
       locale = "es-AR";
       arch = "mac";
-      sha256 = "77da7f3a78cc28509a335232cadda12582569f1272d44ad0a6837e92c46bc838";
+      sha256 = "8816da179dacca059d09e3d0a12c1256336c1aa8fad4c981ee9e994791119e48";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/es-CL/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/es-CL/Firefox%20152.0.2.dmg";
       locale = "es-CL";
       arch = "mac";
-      sha256 = "d2e4dbd2369211ec367105137423feba3f1a8f927d528e79566f529b651e531a";
+      sha256 = "cc39476078010bb514794a1060e7e81a90652a9cf6b9943481d13e386e044288";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/es-ES/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/es-ES/Firefox%20152.0.2.dmg";
       locale = "es-ES";
       arch = "mac";
-      sha256 = "424f7bc5a67176ebac2b22f0f9348eae8db0c0dbb415112809c5092d1f4e9cab";
+      sha256 = "3490df393561475052f0032612dfe227d762f28bbcffcba1d70a363630e87e6c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/es-MX/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/es-MX/Firefox%20152.0.2.dmg";
       locale = "es-MX";
       arch = "mac";
-      sha256 = "a2988c5ba9d4c2776e080142947538788ab1a098ea609d29e8945532813f6b5d";
+      sha256 = "a3cda79274c98f616085b37f492eb276d1ec67d8f585491847a9005244fc1cb4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/et/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/et/Firefox%20152.0.2.dmg";
       locale = "et";
       arch = "mac";
-      sha256 = "1d40f73e629682f568de6cbbf9473c349bec5c0d89112bfa7d88c2e1e51c1f02";
+      sha256 = "fe99491f8d84253fb21317bc6fa8704a65436b3b55c6aee5619b2eeffbbf4fb0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/eu/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/eu/Firefox%20152.0.2.dmg";
       locale = "eu";
       arch = "mac";
-      sha256 = "008a66a53f4749c58bbc8cdf22c04cdf11bc49123f694bacef3affdd96221673";
+      sha256 = "26e81e36b7ba6f749455019abc25fb8149a3ebfc4f4fa3931ef2ecb8912a3726";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/fa/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/fa/Firefox%20152.0.2.dmg";
       locale = "fa";
       arch = "mac";
-      sha256 = "fa73a3e545e3e6c8fc9b1f0ef6b48fb684701e435721b527753ea254b6943e73";
+      sha256 = "036c2228738066bde713dc3c77e759dd648e7aec5ab1ddab583ba6b8465d67ea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ff/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/ff/Firefox%20152.0.2.dmg";
       locale = "ff";
       arch = "mac";
-      sha256 = "a50a98a681de12b15cc545b16cec96a97ac966a69a04adc5a8ce08345db27058";
+      sha256 = "96051c1be44d8cfb1ea258986c7c27c14c02d87c55fb1ca89449c53cdafd9290";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/fi/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/fi/Firefox%20152.0.2.dmg";
       locale = "fi";
       arch = "mac";
-      sha256 = "bc3f9b1d838f7876c56b0a01daa69993ae66cf5202cc95d6c169bebb4f44f731";
+      sha256 = "92f5df05051ad55d4d35a47a5cfecba34b6c6dd64399717b9d89dbe9c865758d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/fr/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/fr/Firefox%20152.0.2.dmg";
       locale = "fr";
       arch = "mac";
-      sha256 = "6bee1ba2a8d1eceb237b123f0ee22214b28ffe5561088f1a20c25d2cdbabdb38";
+      sha256 = "505806765749b5f3e406d3e6dd638d2d9348ad5e4032ae8e490e962a2715748a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/fur/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/fur/Firefox%20152.0.2.dmg";
       locale = "fur";
       arch = "mac";
-      sha256 = "ee910621eaa5607d589c4f59ee7ae07108553ced001f706d185730e0f340cd2d";
+      sha256 = "08b9e572c56bfc1df0f39ca0fcf34bc256c95ce804d68b0ee097d7a4403815b9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/fy-NL/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/fy-NL/Firefox%20152.0.2.dmg";
       locale = "fy-NL";
       arch = "mac";
-      sha256 = "af4c465481d521aede69cfe160b396e45725dde511ae4ba46a768385b0e7cf49";
+      sha256 = "4113dec413ced2e35b1d181a7e30e1722c73df27b948fbfd7f16354878f848b6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ga-IE/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/ga-IE/Firefox%20152.0.2.dmg";
       locale = "ga-IE";
       arch = "mac";
-      sha256 = "051bb6d3ef6e63846f4c531a1a6dc48b5d669887309d1682983b71de68c71362";
+      sha256 = "1d4d496f871df8d4bd59b067f78d0a97ac3d2f523c2b003cd4ecec0e293934e7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/gd/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/gd/Firefox%20152.0.2.dmg";
       locale = "gd";
       arch = "mac";
-      sha256 = "8da084fd9ca21e0c6e1b189b53b2f1caf84328695f5a8d057de5602691c5fad8";
+      sha256 = "588aafbcb3d66a6e5df935083bcf40b65c988420bee79f9a853bbd88a666bf96";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/gl/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/gl/Firefox%20152.0.2.dmg";
       locale = "gl";
       arch = "mac";
-      sha256 = "06c316481ed30b286c3bcbeb46880a7107c988bb929ce465c821cc473e204c79";
+      sha256 = "521b1a4dc036a0eb95b62be7d65b4527900863f9b259b508e7df57053d676ca0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/gn/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/gn/Firefox%20152.0.2.dmg";
       locale = "gn";
       arch = "mac";
-      sha256 = "6978c956652808c21359680bfd79ff2ada3f6519750db40d3453dc2dd8c9ea27";
+      sha256 = "709af50b5a6b54779fa6aaa60ebb7176e545361468180ecbc87e8c15c29069c2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/gu-IN/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/gu-IN/Firefox%20152.0.2.dmg";
       locale = "gu-IN";
       arch = "mac";
-      sha256 = "e8abd879a56b3aec97c21c018e9e7b187d498ce4461c753048a178b6d266bfb2";
+      sha256 = "9b3611438b708ea8f1904b3a43d88f6aff9c2bcd64837f4574fe3bd0b718651e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/he/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/he/Firefox%20152.0.2.dmg";
       locale = "he";
       arch = "mac";
-      sha256 = "030a5a8e9070f975e8ec57c9a45ed004a19acf9eaacb399e84c15d365d936a39";
+      sha256 = "a1c1e36863b57b9cf99044969c9765326a4087e2c2b2982a21725c8eb207821f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/hi-IN/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/hi-IN/Firefox%20152.0.2.dmg";
       locale = "hi-IN";
       arch = "mac";
-      sha256 = "d131e02724198992eaaf95c6c6dac27a04c4ad7cd8ef9ff7b3bb6ed7d04c329a";
+      sha256 = "68c1517ed942a8cdce43601e783953300358d224886c0ad33f6fd53096ae78c6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/hr/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/hr/Firefox%20152.0.2.dmg";
       locale = "hr";
       arch = "mac";
-      sha256 = "fe6533f418c3a496ac7230b85d868463e3e9dcdb77a72ec24ece9055be325a8a";
+      sha256 = "4ab1acb844edb48eae97978aa75b39347e9136cea7cbacb34b0df75b8378e447";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/hsb/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/hsb/Firefox%20152.0.2.dmg";
       locale = "hsb";
       arch = "mac";
-      sha256 = "fcc2be581e4e38991a51a4064bf4a46edd1dabdcaecaaef998eb43d7ee854880";
+      sha256 = "ebfafb6a67c03d869d9c2025fb4728a51893e7e952ecbe66d03d5049c934c610";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/hu/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/hu/Firefox%20152.0.2.dmg";
       locale = "hu";
       arch = "mac";
-      sha256 = "f5cb59fb3b319c13608a1300ae451051342373519d8415affb1dd45c2c024fc3";
+      sha256 = "ef3dd19b2d687c12ccb92d4edd1f2e34e30313b83d598f94f162d8073dab6605";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/hy-AM/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/hy-AM/Firefox%20152.0.2.dmg";
       locale = "hy-AM";
       arch = "mac";
-      sha256 = "4ad1ab547a850093c2bbe169eb32c8a13ec9905700c9dce6c1e8939cf4f3d937";
+      sha256 = "d565acae0b749e43b40b472b2c97645dc11d69986ae5e67b79babff0e2ffec15";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ia/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/ia/Firefox%20152.0.2.dmg";
       locale = "ia";
       arch = "mac";
-      sha256 = "e22fd59db4c8ea6f524d1fde11fbf702e5cd9f813e02c7b3c876032c26f2d172";
+      sha256 = "cc88181a1e4d81441dd90e478201a0d47005dd19038c4bb0af9b71036148abc1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/id/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/id/Firefox%20152.0.2.dmg";
       locale = "id";
       arch = "mac";
-      sha256 = "671887fe4abac1e8dcd69d42cb127e1f6956ef7c489657260b2f8bcf455b7a38";
+      sha256 = "7fd3731658746c0b62b5231ebed36953b53f06a675ec88e95e3b7036f6954d40";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/is/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/is/Firefox%20152.0.2.dmg";
       locale = "is";
       arch = "mac";
-      sha256 = "b3399c9ebe91b7bbd5483a167a342eb6ec666168ab8a9589e1731b18f8914942";
+      sha256 = "56568eb5c3cdc49ade0773e90c7061abdc8e1c84874a050b42fa8f0e8839ee8b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/it/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/it/Firefox%20152.0.2.dmg";
       locale = "it";
       arch = "mac";
-      sha256 = "8162e4806e9c0a93583ae9dc047d3a5aaead053338b3002369fb29fdcb5d60cd";
+      sha256 = "f42958437df8d1c31d7ab1c47656a4a5ae46ed3eb1259b5d9cb1d90a3d9650cc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ja-JP-mac/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/ja-JP-mac/Firefox%20152.0.2.dmg";
       locale = "ja-JP-mac";
       arch = "mac";
-      sha256 = "5e33d8738784a5bd0834de6670383c789a5d722c1603757990e84602009eaa65";
+      sha256 = "14f00d5c5b3cff8713bce6b13add03010848cfa1fb2c252ca7270dc58ef3c11f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ka/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/ka/Firefox%20152.0.2.dmg";
       locale = "ka";
       arch = "mac";
-      sha256 = "96b40509b7a2cb74d2e195278c97d77f65c7fb22c95d47877eebe25a75005a40";
+      sha256 = "da528db0bf6ef541c09d9ed408a7a9501a92516c122c4f18a5c0316ae4cc0376";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/kab/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/kab/Firefox%20152.0.2.dmg";
       locale = "kab";
       arch = "mac";
-      sha256 = "297c7cbfb71ccd28babba5c9ea074ba9826fe82a116607316ffbec543cb3171f";
+      sha256 = "6ad92c556c1cc040fb3da23a71c532ea9c67dbcfb6f5ae0c03a09d621404e8af";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/kk/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/kk/Firefox%20152.0.2.dmg";
       locale = "kk";
       arch = "mac";
-      sha256 = "118d04f727382f1c0f21e0756d07b04291ef4e74568fa34a93022d9ef123968d";
+      sha256 = "332c0b8292c8b13bfa53dd1471849be1b8de3ae18e884ce8c37805814a6659d6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/km/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/km/Firefox%20152.0.2.dmg";
       locale = "km";
       arch = "mac";
-      sha256 = "0c5a6a2946adc5713d86dceeedbfe81589d7294b70d110000db9e80105d63d38";
+      sha256 = "310d21c96e3b17d88fbc403b148683f9fd25747352ba4103e95b267d2e57926a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/kn/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/kn/Firefox%20152.0.2.dmg";
       locale = "kn";
       arch = "mac";
-      sha256 = "463d0641b1d8608916b30bef1a1cbe63dd0d41a307aa8af665340c7a0550ea2a";
+      sha256 = "678f0cdbb5781d33eb55d8fdd969b5a1589c7bb6b2e04c7fda2f958f83a50409";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ko/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/ko/Firefox%20152.0.2.dmg";
       locale = "ko";
       arch = "mac";
-      sha256 = "69b4b6fd0b8f4e2eef40e5cf6d11553131ff01476a636e961c30e27133ef9aa8";
+      sha256 = "6e94adbca4f6643c2def8faa58ad5a3f485d5de640543aa844c3cf057c369fe7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/lij/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/lij/Firefox%20152.0.2.dmg";
       locale = "lij";
       arch = "mac";
-      sha256 = "494f6a07f0f0c4721c2d7d267fa85962d82c97f1b86794d74201b5b9f48fad5d";
+      sha256 = "6aacd78eaa0d46607425aec33a1b14a60a7bf8fdc194779da34bffccaede20cd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/lt/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/lt/Firefox%20152.0.2.dmg";
       locale = "lt";
       arch = "mac";
-      sha256 = "70ec6804ee7a7e267d4a51dafd9bb1bc1c6e99f177ef5b755d30cfeb12585581";
+      sha256 = "539f11dd45d0bc4a274ca364fd105108efbc90fc3578ca8f948aee9dc3f49779";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/lv/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/lv/Firefox%20152.0.2.dmg";
       locale = "lv";
       arch = "mac";
-      sha256 = "43997b69caef9546a9d1bf9de0a4bfa958007667374219b2a329cbdc6655c183";
+      sha256 = "68894d25745934b8a48a5b631c3d21c5a4af489a7806556c2f917fd677a31e88";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/mk/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/mk/Firefox%20152.0.2.dmg";
       locale = "mk";
       arch = "mac";
-      sha256 = "a13a6dd71e40cb60c451bddb5ff25b804210ddf2b788e2ed63b87dfc5b898884";
+      sha256 = "f83b2672e04015b46e083f97f34701e2e73caf2f146485a9545de13a26418cae";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/mr/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/mr/Firefox%20152.0.2.dmg";
       locale = "mr";
       arch = "mac";
-      sha256 = "bceed32a96c98ef852a6af590d31f1d2892d5b57f420f8995700cec17eae9761";
+      sha256 = "3a674a5565dd499be1e4bbe875673b47503fc5d0e654a1a50e4817fa998880bc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ms/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/ms/Firefox%20152.0.2.dmg";
       locale = "ms";
       arch = "mac";
-      sha256 = "355962198e475d2bf92b1ed181870890cd3aa78e32b18bb85322d6c999f423a0";
+      sha256 = "c4fa9f93268bedf17b982b6814315e4e953724737dfd9d83314bd89f9ff51be7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/my/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/my/Firefox%20152.0.2.dmg";
       locale = "my";
       arch = "mac";
-      sha256 = "37ed9a2b84bc87f69658ffbb109385e5d3d09e87ec453fc0822e4e8f59f4286d";
+      sha256 = "49a665f2e1565100357e22c62ce583f54791ee04859f7428d481780416d7b4ed";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/nb-NO/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/nb-NO/Firefox%20152.0.2.dmg";
       locale = "nb-NO";
       arch = "mac";
-      sha256 = "f1156597d804b1f9fd0ea9691b11df0fa4c5316f67b6c45264d0991bfa0a83b4";
+      sha256 = "8f2f2488fe16959cd88ac5765aa487a3f1756d3c3b9ff2c8fac6202b5439571f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ne-NP/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/ne-NP/Firefox%20152.0.2.dmg";
       locale = "ne-NP";
       arch = "mac";
-      sha256 = "d22c8f9eb0f6584b3f81ba2f1f37d61392aa02d3264e7f85c79396bf1ad1f686";
+      sha256 = "726de3cfc963d320b1d8ea957d077561b46e18fe7411a02271404083bc9b41a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/nl/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/nl/Firefox%20152.0.2.dmg";
       locale = "nl";
       arch = "mac";
-      sha256 = "7c522d4e607497c22926b1ede7f6ef62d942b9c6f70f885393e5ffafcd15c518";
+      sha256 = "4691e6133f6c1341371df8a91fdb9193cde3d75e241832c37fa42853f67f9600";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/nn-NO/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/nn-NO/Firefox%20152.0.2.dmg";
       locale = "nn-NO";
       arch = "mac";
-      sha256 = "7371b6c1e6968bf26041c16257aff045a024e7cb634e31223fec7f91befae417";
+      sha256 = "f4bf0ab27fc4ccd652710fe273bd0347bb426549b6162579c826f2de0cb31f92";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/oc/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/oc/Firefox%20152.0.2.dmg";
       locale = "oc";
       arch = "mac";
-      sha256 = "883e88183afc87a7dc671b25261d95d80b614671bca6ea6504e0c1502e0a7611";
+      sha256 = "83bbcc75583b17d0baae1524d0f83303a81af56838544921f4629471e2e11c7f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/pa-IN/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/pa-IN/Firefox%20152.0.2.dmg";
       locale = "pa-IN";
       arch = "mac";
-      sha256 = "e04904260ca557b78dc77a3d004b6afb00f5f6725e67ea003c45cbf7d084cef0";
+      sha256 = "da152fb643d7a84947b2582bf3855dc5ea85c9663a11c932b655a1afaadf27ba";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/pl/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/pl/Firefox%20152.0.2.dmg";
       locale = "pl";
       arch = "mac";
-      sha256 = "fdb11e4e2ad66d7fd6c4af50dee54dc62194f6af31d9413727206e9255aad775";
+      sha256 = "57423a7e88800d1502fd105fe16befa63f47324457968357af8e0cf7e01d758b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/pt-BR/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/pt-BR/Firefox%20152.0.2.dmg";
       locale = "pt-BR";
       arch = "mac";
-      sha256 = "bdb18c290911a6b701d599be0afe8c1104ea5420d1b3e287db2d2294c8e065fe";
+      sha256 = "c7f075ab3effbc643b5895fd72eb2bfb182944b9c98185e3190246fd92cdd474";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/pt-PT/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/pt-PT/Firefox%20152.0.2.dmg";
       locale = "pt-PT";
       arch = "mac";
-      sha256 = "0765f48eb00eaa1bffecf7887da20aa66bf546933d0ac546b4cdb816b57ebabf";
+      sha256 = "f09ecd540fd256b2f7beea71384c0353a8f047209ddfdc6691098b0dfdcf9367";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/rm/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/rm/Firefox%20152.0.2.dmg";
       locale = "rm";
       arch = "mac";
-      sha256 = "e602fd0ebff4e800c3d8cb96a1dc49250d27c6902fabf14e139e88a5fc1b448e";
+      sha256 = "8debcec0fc1cb5c0a8fd9f8d5a6b10f99b44d1b7466e04991dbfe3a229f81e6f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ro/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/ro/Firefox%20152.0.2.dmg";
       locale = "ro";
       arch = "mac";
-      sha256 = "8c6552a8aedaa17533c4bdd24b5a2270093fb17a72f0515c35b9968d3de75e3a";
+      sha256 = "62e1f2f0b812ac67aa2645a52f9ca12d22e79c6da6ec8da6142319b4fa816817";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ru/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/ru/Firefox%20152.0.2.dmg";
       locale = "ru";
       arch = "mac";
-      sha256 = "32780f8c4526ba67785f1fb9f98d9bf434dc0c6080c74fc5d4deb4335fab8ecb";
+      sha256 = "068027da9c21c6b8f219a6e3ee4cd70df11b1f284230cc9b126ba5fe79f504ad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/sat/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/sat/Firefox%20152.0.2.dmg";
       locale = "sat";
       arch = "mac";
-      sha256 = "9860aac9e342b26cddfcfdcb55e881af1690a258774fde2794b6c7c0a713db48";
+      sha256 = "8631fe42002950bbba8e1490e5208d32e159202420eada739a61494bf5bc5622";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/sc/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/sc/Firefox%20152.0.2.dmg";
       locale = "sc";
       arch = "mac";
-      sha256 = "9e19dd61584eb7ec89a1003056e5c72acc44a1c314c0e9b5d4c4b50fb77f7df1";
+      sha256 = "6f7ca0b356cf6c7c13e2a0fe985eb4c2d73b6870b6d20f023a1f5d136d3e08b7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/sco/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/sco/Firefox%20152.0.2.dmg";
       locale = "sco";
       arch = "mac";
-      sha256 = "5dee3b6a01b46e53c7c1b0462c7769fe5ac975867c8b1d889e09537ec7f4ca0b";
+      sha256 = "142a174ec700972d6b33672d745747f6e2c0db68c0a0799a8ade454c7707d03e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/si/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/si/Firefox%20152.0.2.dmg";
       locale = "si";
       arch = "mac";
-      sha256 = "4bf126e6afbdb3e9ecade94db12f4fed11567d703de6b0ca238feaedb629937f";
+      sha256 = "c46f6fd548da754a3e5f53888dd50cf09b907d226ba7fbbbece6884112f8fa21";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/sk/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/sk/Firefox%20152.0.2.dmg";
       locale = "sk";
       arch = "mac";
-      sha256 = "e8050332ed989f92852326dfab12cbf744022594765fc6e3eb4ba22a02881010";
+      sha256 = "3ac79d8489b796905e3fa94371465a1a7e21025b65bbc205c94e59036537f04b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/skr/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/skr/Firefox%20152.0.2.dmg";
       locale = "skr";
       arch = "mac";
-      sha256 = "d57c0bcc4666d90982d6c67c91d2c6ac66675619420931fa13bfa173bd2f1d6a";
+      sha256 = "b9787befc258c9641d7911ebf3f666f725d4b9219a6a911c5264422f58bba9b9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/sl/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/sl/Firefox%20152.0.2.dmg";
       locale = "sl";
       arch = "mac";
-      sha256 = "10c93479689e79e51b067f502e767de517c02862d77a5366574defa306f036a2";
+      sha256 = "9060b3e1094d666ea65ab92ed27c5d40cf71dce85b5bf004cf3a29a9f792ed57";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/son/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/son/Firefox%20152.0.2.dmg";
       locale = "son";
       arch = "mac";
-      sha256 = "f41a956cb65c4d0f4e04fd4b8e224e091dd69e52e1dc19b4bf2d99921192e7a4";
+      sha256 = "b5e35e41dae8261a280f2cd72331554b49e1f46778f563a612f439a8e39bffc1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/sq/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/sq/Firefox%20152.0.2.dmg";
       locale = "sq";
       arch = "mac";
-      sha256 = "bbf8a9c86c4cdfce83e47d3ca8f161412efbe89cc9cf02d9ca3b37d447889f72";
+      sha256 = "35d34ac0f451a7616e0f0030b645a3b2b5b60988056f60c44cd33c1be78ad7ff";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/sr/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/sr/Firefox%20152.0.2.dmg";
       locale = "sr";
       arch = "mac";
-      sha256 = "98bfbfdb40da834b722a18d2149feaab81dc52c52ea2876e225ba5f2f8712715";
+      sha256 = "25f2cb28547fcf71a67fac72f57ccfbf421a6b3fad5d7941474b98037457394c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/sv-SE/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/sv-SE/Firefox%20152.0.2.dmg";
       locale = "sv-SE";
       arch = "mac";
-      sha256 = "450d102a470ec808d46840c1d7bf21ce2af32ef4c586c9c19ecedc8d8d050820";
+      sha256 = "2d0db0a66fff3e67a57641bf46a4711da88140f707c75035ca337a74e6a11d9d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/szl/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/szl/Firefox%20152.0.2.dmg";
       locale = "szl";
       arch = "mac";
-      sha256 = "c0971c39223876b35b7c6b05369f3cd2fe1caccc36bd34b25f7d3164c135ddf0";
+      sha256 = "3024f7623dd5bc497b70625be61a10c2956824381ecd9cdef568e679113ce3b9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ta/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/ta/Firefox%20152.0.2.dmg";
       locale = "ta";
       arch = "mac";
-      sha256 = "8144df52424dffcb39ccfcc621ba64aa17f307bec142e40bbbca020cdd8d78a3";
+      sha256 = "ecfdc726ece186082c4738e7aff8d04b95fb582fcf63d29734e446a6eb7fb26e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/te/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/te/Firefox%20152.0.2.dmg";
       locale = "te";
       arch = "mac";
-      sha256 = "477f540f219e125ffc110789d0af72d76f688bee804e46cbf075c9097efdf046";
+      sha256 = "8f3e831dabe8473ba71f795b832d285b41045bd8e3402b4815ace061048bf055";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/tg/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/tg/Firefox%20152.0.2.dmg";
       locale = "tg";
       arch = "mac";
-      sha256 = "c9620df254674dcdf004448737ec9b4a4d9d9a294ceca76bd255101e2db45a46";
+      sha256 = "6da4f9fed9c08250c5e94d605f07e8f7607d6a5bc9c436b8e94e39ee653e97fa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/th/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/th/Firefox%20152.0.2.dmg";
       locale = "th";
       arch = "mac";
-      sha256 = "76ad3c53dab15158a0901f9c03c62e42b1caa40b1553cdb4eefdebc25be516ad";
+      sha256 = "164a4aabe806408c47b45c40b20aa9c3918e4411d5d1570906cf1858b07d0a02";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/tl/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/tl/Firefox%20152.0.2.dmg";
       locale = "tl";
       arch = "mac";
-      sha256 = "509e2a5b10ec5ed32bbebc6a259747c8fb3234df2288ab07c88006f4d47bbe84";
+      sha256 = "d76191543e98bd87fe9fb9d773bffe7971d0279e7ab600349638af445ffa5e91";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/tr/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/tr/Firefox%20152.0.2.dmg";
       locale = "tr";
       arch = "mac";
-      sha256 = "33ccbe2385a04937fd3e76b5c4fe0786721ffe10474cd1844752ad4c40dba2ea";
+      sha256 = "5236c45e0e059c5d60cd82ec7b8b3dae7fc37417d9d890da20d309ded71a4d15";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/trs/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/trs/Firefox%20152.0.2.dmg";
       locale = "trs";
       arch = "mac";
-      sha256 = "82222fd6de57a53caded0bedfe4b83a63fb2a573e3c8b937e64d38d2d5202d19";
+      sha256 = "5d3aebc24728bf3dde5f62a2b36014813b6cd831c92c89b29ea67f55f4da11ab";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/uk/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/uk/Firefox%20152.0.2.dmg";
       locale = "uk";
       arch = "mac";
-      sha256 = "0a0efc3cb0045efaa6597b28f8d2ff0c7f1cb1664a14a9d89321f7fc871f4823";
+      sha256 = "7f7f9a83bd19145b244960d43796d25b68edb1484108371c62bbf601ac3bd92e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ur/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/ur/Firefox%20152.0.2.dmg";
       locale = "ur";
       arch = "mac";
-      sha256 = "8672dd604d381d6c2f9e7ef130b2dcc7773d1619695e6ad79dc8953236483298";
+      sha256 = "b62f211834be70546f80fc31bc8228e784da8640ac14b02818788ec4dc58697e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/uz/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/uz/Firefox%20152.0.2.dmg";
       locale = "uz";
       arch = "mac";
-      sha256 = "4d64edd496224bac99d6e13b7901f54b87b770f0cba55544317261182665bb67";
+      sha256 = "16653b5bd0d4e7952e9d3d3c79a77676e61ddb6f541e9fca971dfee7d84836e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/vi/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/vi/Firefox%20152.0.2.dmg";
       locale = "vi";
       arch = "mac";
-      sha256 = "42465e83f7c0131dd2dddab0bbc1873171c823473484a11da7c1ef6b0c7e8cd0";
+      sha256 = "c1dd51da2d50f14bc679f9e5e14d5ba745bdf465c207c04efb97e6ae668270cd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/xh/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/xh/Firefox%20152.0.2.dmg";
       locale = "xh";
       arch = "mac";
-      sha256 = "81e3552691097d4b10b9180a6e71a5b61b4196a29aa51003478f1cef3c567f60";
+      sha256 = "ec3f0bb254f0767ef8a7a8ebfb89037fb388b3981a79be5da3e99ab47e3fca16";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/zh-CN/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/zh-CN/Firefox%20152.0.2.dmg";
       locale = "zh-CN";
       arch = "mac";
-      sha256 = "31b89bfdb6293a8bb4f7be953a8f31a3ba89aeddb2ecf060cfe67dc091f3c39b";
+      sha256 = "91d1ef13fcb1bbb791ef4e2dc1e878c19bc9ad3c6342eb2c65902d739de23041";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/zh-TW/Firefox%20152.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.2/mac/zh-TW/Firefox%20152.0.2.dmg";
       locale = "zh-TW";
       arch = "mac";
-      sha256 = "d52aa6bf280e7aad52f83fd02551db207b51bdc8915f129aa21a6d355b68b663";
+      sha256 = "d99e6b0cf6fe48fc83b4c9a772a490502d8308f6b8e01aadf5fb6852952f8881";
     }
   ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages/firefox.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages/firefox.nix
@@ -9,10 +9,10 @@
 
 buildMozillaMach rec {
   pname = "firefox";
-  version = "152.0.1";
+  version = "152.0.2";
   src = fetchurl {
     url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-    sha512 = "9b2595148ed977040ea2b21e7d6ece70f0e53fac9b96b3115b113bea76ead6c0422f6e94b1540283b430fed5e8e9a227771a6357bf16f56d530a7fae7dc7553a";
+    sha512 = "e4e54cffffcfd5751eac5817a7b74b0ef0aa43fc00ef29397cc9df9aa52572b2272b96e60373a70d712be4dc849170d8d5c1b449f3ea978b4ab28dee19056b03";
   };
 
   meta = {


### PR DESCRIPTION
https://www.firefox.com/en-US/firefox/152.0.2/releasenotes/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
