### PR TITLE
ramalama: add smoke tests for supported backends; make mlx-lm dependency darwin only

### DIFF
--- a/pkgs/by-name/ra/ramalama/package.nix
+++ b/pkgs/by-name/ra/ramalama/package.nix
@@ -1,5 +1,7 @@
 {
   lib,
+  stdenv,
+  callPackage,
   python3Packages,
   fetchFromGitHub,
   go-md2man,
@@ -80,9 +82,29 @@ python3Packages.buildPythonApplication (finalAttrs: {
   '';
 
   passthru = {
+    updateScript = ./update.sh;
+
     tests = {
+      nocontainer = callPackage ./tests/nocontainer.nix {
+        ramalama = finalAttrs.finalPackage;
+      };
+
       withoutPodman = ramalama.override {
         withPodman = false;
+      };
+    }
+    //
+      lib.optionalAttrs
+        (
+          stdenv.hostPlatform.isDarwin
+          || (stdenv.hostPlatform.isLinux && (stdenv.hostPlatform.isx86_64 || stdenv.hostPlatform.isAarch64))
+        )
+        {
+          podman = callPackage ./tests/podman.nix { };
+        }
+    // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+      mlx = callPackage ./tests/mlx.nix {
+        ramalama = finalAttrs.finalPackage;
       };
     };
   };

--- a/pkgs/by-name/ra/ramalama/package.nix
+++ b/pkgs/by-name/ra/ramalama/package.nix
@@ -54,11 +54,9 @@ python3Packages.buildPythonApplication (finalAttrs: {
     let
       binPackages = [
         llama-cpp-vulkan
+        python3Packages.huggingface-hub
       ]
-      ++ (with python3Packages; [
-        huggingface-hub
-        mlx-lm
-      ])
+      ++ lib.optional stdenv.hostPlatform.isDarwin python3Packages.mlx-lm
       ++ lib.optional withPodman podman;
     in
     ''

--- a/pkgs/by-name/ra/ramalama/tests/common.nix
+++ b/pkgs/by-name/ra/ramalama/tests/common.nix
@@ -1,0 +1,128 @@
+{
+  curl,
+  lib,
+  ramalama,
+  runCommand,
+  writableTmpDirAsHomeHook,
+  writeShellScriptBin,
+}:
+
+let
+  mkServeTestRunner =
+    {
+      model,
+      runtime ? "llama.cpp",
+      port,
+      host ? "127.0.0.1",
+      nocontainer ? false,
+      image ? null,
+      extraCheck ? "",
+    }:
+
+    let
+      ramalamaExe = lib.getExe ramalama;
+      modelArg = lib.escapeShellArg model;
+      serveOptions = lib.concatStringsSep " " (
+        [
+          # Models and container images are preloaded; serving must stay offline.
+          "--pull never"
+        ]
+        # Nix's macOS builders cannot initialize Metal.
+        ++ lib.optional nocontainer ''--runtime-args "--device none"''
+        ++ lib.optional (image != null) "--image ${image}"
+      );
+    in
+    writeShellScriptBin "ramalama-serve-test" ''
+      set -euo pipefail
+
+      test_store="''${TMPDIR:-/tmp}/store"
+      test_log="''${TMPDIR:-/tmp}/ramalama.log"
+      test_url="http://127.0.0.1:${toString port}"
+
+      ${ramalamaExe} \
+        --store "$test_store" \
+        pull \
+        ${modelArg}
+
+      ${ramalamaExe} ${lib.optionalString nocontainer "--nocontainer"} \
+        --runtime ${runtime} \
+        --store "$test_store" \
+        serve \
+        --host ${host} \
+        --port ${toString port} \
+        ${serveOptions} \
+        ${modelArg} \
+        >"$test_log" 2>&1 &
+      ramalama_pid=$!
+      trap 'kill "$ramalama_pid" 2>/dev/null || true' EXIT
+
+      ready=0
+      for _ in {1..120}; do
+        if ${lib.getExe curl} --fail --silent --max-time 2 "$test_url/health" >/dev/null 2>&1; then
+          ready=1
+          break
+        fi
+        kill -0 "$ramalama_pid" 2>/dev/null || break
+        sleep 1
+      done
+
+      if (( ! ready )); then
+        cat "$test_log"
+        exit 1
+      fi
+
+      ${extraCheck}
+
+      chat_response=$(
+        ${ramalamaExe} --runtime ${runtime} chat \
+          --url "$test_url/v1" \
+          --max-tokens 16 \
+          --temp 0 \
+          "Hello"
+      )
+
+      if [[ "''${chat_response,,}" != *hello* ]]; then
+        echo "chat response did not contain hello:" >&2
+        printf '%s\n' "$chat_response" >&2
+        exit 1
+      fi
+    '';
+in
+{
+  inherit mkServeTestRunner;
+
+  mkServeTest =
+    {
+      name,
+      model,
+      runtime ? "llama.cpp",
+      port,
+      setup ? "",
+      nocontainer ? false,
+    }:
+
+    runCommand name
+      {
+        nativeBuildInputs = [
+          writableTmpDirAsHomeHook
+        ];
+
+        __darwinAllowLocalNetworking = true;
+      }
+      ''
+        ${setup}
+
+        ${
+          mkServeTestRunner {
+            inherit
+              model
+              runtime
+              port
+              nocontainer
+              ;
+          }
+        }/bin/ramalama-serve-test
+
+        touch "$out"
+      '';
+}

--- a/pkgs/by-name/ra/ramalama/tests/llama-cpp-model.nix
+++ b/pkgs/by-name/ra/ramalama/tests/llama-cpp-model.nix
@@ -1,0 +1,8 @@
+{ fetchurl }:
+
+"file://${
+  fetchurl {
+    url = "https://huggingface.co/bartowski/SmolLM2-135M-Instruct-GGUF/resolve/main/SmolLM2-135M-Instruct-Q4_K_M.gguf";
+    hash = "sha256-LoBAzq54Favg3LNUC5mV6qH6DSyp55fQpjWuRDPGjC0=";
+  }
+}"

--- a/pkgs/by-name/ra/ramalama/tests/mlx-model-files.json
+++ b/pkgs/by-name/ra/ramalama/tests/mlx-model-files.json
@@ -1,0 +1,22 @@
+{
+  "repo": "mlx-community/SmolLM2-135M-Instruct-8bit",
+  "revision": "0f0d9b8218915bc34d401e1a340b8c049d300d5e",
+  "files": [
+    {
+      "name": "config.json",
+      "hash": "sha256-XakZBe/f3pBfVm121AMebKfEyyoB3E44EqcLhVGI/HM="
+    },
+    {
+      "name": "model.safetensors",
+      "hash": "sha256-7Facdx5WQkY2vpliWrqQMavFJaaKX0qxbWeOypb+8Sw="
+    },
+    {
+      "name": "tokenizer.json",
+      "hash": "sha256-fSfEk8cppm7O/INygLBdlIse1Q0TDuvb+RGxs2zzjtc="
+    },
+    {
+      "name": "tokenizer_config.json",
+      "hash": "sha256-on9ji9KDH1w96mVKdYOJMPKxH75VDE1OHV170HFXsu4="
+    }
+  ]
+}

--- a/pkgs/by-name/ra/ramalama/tests/mlx.nix
+++ b/pkgs/by-name/ra/ramalama/tests/mlx.nix
@@ -1,0 +1,50 @@
+{
+  callPackage,
+  fetchurl,
+  lib,
+  ramalama,
+}:
+
+let
+  modelData = builtins.fromJSON (builtins.readFile ./mlx-model-files.json);
+
+  modelFiles = map (file: {
+    inherit (file) name;
+    src = fetchurl {
+      url = "https://huggingface.co/${modelData.repo}/resolve/${modelData.revision}/${file.name}";
+      inherit (file) hash;
+    };
+  }) modelData.files;
+
+  refFile = builtins.toJSON {
+    version = "v1.0.1";
+    hash = modelData.revision;
+    path = "";
+    files = map (file: {
+      hash = file.name;
+      inherit (file) name;
+      type = if lib.hasSuffix ".safetensors" file.name then "safetensor" else "other";
+    }) modelData.files;
+  };
+in
+(callPackage ./common.nix { inherit ramalama; }).mkServeTest {
+  name = "ramalama-mlx-test";
+  runtime = "mlx";
+  port = 18081;
+  model = "hf://${modelData.repo}";
+
+  setup = ''
+    modelBase="$TMPDIR/store/store/huggingface/${modelData.repo}"
+    snapshot="$modelBase/snapshots/${modelData.revision}"
+    mkdir -p "$modelBase/blobs" "$modelBase/refs" "$snapshot"
+
+    ${lib.concatMapStrings (file: ''
+      ln -s ${file.src} "$modelBase/blobs/${file.name}"
+      ln -s "$modelBase/blobs/${file.name}" "$snapshot/${file.name}"
+    '') modelFiles}
+
+    cat >"$modelBase/refs/latest.json" <<'EOF'
+    ${refFile}
+    EOF
+  '';
+}

--- a/pkgs/by-name/ra/ramalama/tests/nocontainer.nix
+++ b/pkgs/by-name/ra/ramalama/tests/nocontainer.nix
@@ -1,0 +1,11 @@
+{
+  callPackage,
+  ramalama,
+}:
+
+(callPackage ./common.nix { inherit ramalama; }).mkServeTest {
+  name = "ramalama-nocontainer-test";
+  port = 18080;
+  model = callPackage ./llama-cpp-model.nix { };
+  nocontainer = true;
+}

--- a/pkgs/by-name/ra/ramalama/tests/podman-images.json
+++ b/pkgs/by-name/ra/ramalama/tests/podman-images.json
@@ -1,0 +1,15 @@
+{
+  "imageName": "quay.io/ramalama/ramalama",
+  "imageTag": "0.22",
+  "imageDigest": "sha256:01f652adb2d7bed7c3eb960ee3fe1dc9b6addff003ed58932048cee01db78302",
+  "images": {
+    "x86_64-linux": {
+      "arch": "amd64",
+      "hash": "sha256-Llykx761YUa50nsckZELxNSbjeDxBElWWshT7KQd5pE="
+    },
+    "aarch64-linux": {
+      "arch": "arm64",
+      "hash": "sha256-9It9EuYxmZ2UThQYr9FD63C/uBVS1ufP7bnZeA9psqI="
+    }
+  }
+}

--- a/pkgs/by-name/ra/ramalama/tests/podman.nix
+++ b/pkgs/by-name/ra/ramalama/tests/podman.nix
@@ -1,0 +1,66 @@
+{
+  callPackage,
+  dockerTools,
+  stdenv,
+  testers,
+}:
+
+let
+  imageInfo = builtins.fromJSON (builtins.readFile ./podman-images.json);
+
+  inherit (imageInfo) imageName imageTag;
+
+  system = if stdenv.hostPlatform.isDarwin then "aarch64-linux" else stdenv.hostPlatform.system;
+  imagePin = imageInfo.images.${system};
+
+  ramalamaImage = dockerTools.pullImage {
+    inherit imageName;
+    inherit (imageInfo) imageDigest;
+    inherit (imagePin) hash arch;
+    finalImageTag = imageTag;
+  };
+
+  port = 18082;
+in
+testers.runNixOSTest {
+  name = "ramalama-podman-test";
+
+  nodes.machine =
+    { pkgs, ... }:
+    let
+      serveTestRunner = (pkgs.callPackage ./common.nix { }).mkServeTestRunner {
+        model = pkgs.callPackage ./llama-cpp-model.nix { };
+        inherit port;
+        host = "0.0.0.0";
+        image = "${imageName}:${imageTag}";
+        extraCheck = ''
+          podman ps --format '{{.Image}}' | grep -Fx ${imageName}:${imageTag}
+        '';
+      };
+    in
+    {
+      # Not strictly required on Linux, but on darwin case-insensitive file
+      # systems, libxt_mark.so may be renamed to libxt_mark.so~nix~case~hack~1
+      # which breaks netavark networking inside the machine. Workaround with
+      # nftables.
+      networking.nftables.enable = true;
+
+      virtualisation = {
+        cores = 2;
+        # Podman expands the pinned image under /var/lib/containers/storage.
+        diskSize = 10 * 1024;
+        podman.enable = true;
+      };
+
+      environment.systemPackages = [
+        serveTestRunner
+      ];
+    };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+    machine.succeed("podman load -i ${ramalamaImage}")
+
+    machine.succeed("ramalama-serve-test")
+  '';
+}

--- a/pkgs/by-name/ra/ramalama/tests/update-mlx-model-files.sh
+++ b/pkgs/by-name/ra/ramalama/tests/update-mlx-model-files.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+metadata_file="$script_dir/mlx-model-files.json"
+
+repo="$(jq --raw-output '.repo' "$metadata_file")"
+model_json="$(curl --fail --silent --show-error "https://huggingface.co/api/models/$repo/revision/main")"
+resolved_revision="$(jq --raw-output '.sha' <<<"$model_json")"
+base_url="https://huggingface.co/$repo/resolve/$resolved_revision"
+
+files=$(
+    jq --raw-output '
+      .siblings[].rfilename
+      # Keep the test closure to files needed by MLX at runtime. Hugging Face
+      # repos often also contain docs, examples, or alternate model formats.
+      | select(
+          . == "config.json"
+          or . == "tokenizer.json"
+          or . == "tokenizer_config.json"
+          or (startswith("model") and endswith(".safetensors"))
+        )
+    ' <<<"$model_json"
+)
+
+files_json="$(mktemp)"
+trap 'rm -f "$files_json"' EXIT
+
+while IFS= read -r name; do
+    url="$base_url/$name"
+    hash32="$(nix-prefetch-url "$url")"
+    hash="$(nix hash convert --hash-algo sha256 --to sri "$hash32")"
+
+    jq --null-input \
+      --arg name "$name" \
+      --arg hash "$hash" \
+      '{name: $name, hash: $hash}' \
+      >>"$files_json"
+done <<<"$files"
+
+jq --slurp \
+  --arg revision "$resolved_revision" \
+  '. as $inputs
+  | $inputs[0]
+  | .revision = $revision
+  | .files = $inputs[1:]' \
+  "$metadata_file" \
+  "$files_json" \
+  >"$metadata_file.tmp"
+
+mv "$metadata_file.tmp" "$metadata_file"

--- a/pkgs/by-name/ra/ramalama/update.sh
+++ b/pkgs/by-name/ra/ramalama/update.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p jq nix-prefetch-docker nix-update nixfmt
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+podman_images="pkgs/by-name/ra/ramalama/tests/podman-images.json"
+
+if [[ $# -gt 0 ]]; then
+  nix-update --format --version "${1#v}" ramalama
+else
+  nix-update --format --use-github-releases ramalama
+fi
+
+version="$(nix-instantiate --eval -A ramalama.version | jq --raw-output .)"
+
+image_name="quay.io/ramalama/ramalama"
+image_tag="${version%.*}"
+
+prefetch_image() {
+  local arch="$1"
+  nix-prefetch-docker \
+    --json \
+    --quiet \
+    --arch "$arch" \
+    "$image_name" \
+    "$image_tag"
+}
+
+amd64_image="$(prefetch_image amd64)"
+arm64_image="$(prefetch_image arm64)"
+
+jq \
+  --null-input \
+  --arg imageName "$image_name" \
+  --arg imageTag "$image_tag" \
+  --argjson amd64 "$amd64_image" \
+  --argjson arm64 "$arm64_image" \
+  'if $amd64.imageDigest != $arm64.imageDigest then
+    error("image digest differs between architectures")
+  else {
+    imageName: $imageName,
+    imageTag: $imageTag,
+    imageDigest: $amd64.imageDigest,
+    images: {
+      "x86_64-linux": {
+        arch: "amd64",
+        hash: $amd64.hash
+      },
+      "aarch64-linux": {
+        arch: "arm64",
+        hash: $arm64.hash
+      }
+    }
+  } end' >"$podman_images.tmp"
+mv "$podman_images.tmp" "$podman_images"


### PR DESCRIPTION
Add smoke tests for each of supported ramalama backends: podman (on Linux only), "nocontainer" and mlx (on Darwin).

Also, mark mlx-lm as darwin only dependency because ramalama explicitly forbids using mlx-lm on non-MacOS machines.

---

One thing I'm not entirely sure about is the placement of the NixOS test. In general, the rule is to put those under `nixos/tests` and then link via `passthru.tests`. But in this case, the test relies on the tester script that is reused for non-NixOS tests (for other backends and/or Darwin). So keeping all flavors of effectively the same test scenario in the same place (under the package) seems reasonable.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
