### PR TITLE
mango: rename from mangowc

### DIFF
--- a/pkgs/by-name/ma/mango/package.nix
+++ b/pkgs/by-name/ma/mango/package.nix
@@ -23,7 +23,9 @@
   libGL,
 }:
 stdenv.mkDerivation (finalAttrs: {
-  pname = "mangowc";
+  __structuredAttrs = true;
+  strictDeps = true;
+  pname = "mango";
   version = "0.14.4";
 
   src = fetchFromGitHub {

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1463,6 +1463,7 @@ mapAliases {
   mailnagWithPlugins = throw "mailnagWithPlugins has been removed because mailnag has been marked as broken since 2022."; # Added 2025-10-12
   makeOverridable = warnAlias "'makeOverridable' has been removed from pkgs, use `lib.makeOverridable` instead" lib.makeOverridable; # Added 2025-10-30
   manaplus = throw "manaplus has been removed, as it was broken"; # Added 2025-08-25
+  mangowc = throw "'mangowc' has been renamed to 'mango'"; # Added 2026-06-23
   manrope = throw "'manrope' has been removed because its source has been pulled"; # Added 2025-12-20
   mariadb-client = throw "mariadb-client has been renamed to mariadb.client"; # Converted to throw 2025-10-26
   marwaita-manjaro = throw "'marwaita-manjaro' has been renamed to/replaced by 'marwaita-teal'"; # Converted to throw 2025-10-27


### PR DESCRIPTION
Renames the `mangowc` package to `mango` to match the upstream repository name and the project's own branding. The upstream repo is `mangowm/mango`, the binary is `mango`, and the project's GUID refers to it as `mango`. `mangowc` was the old name that no longer reflects upstream.

A `throw` alias is added in `aliases.nix` so existing references to `mangowc` get a helpful error message.

References:
- https://github.com/mangowm/mango
- https://mangowm.github.io/docs/installation

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [[NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests)] in [[nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)].
  - [ ] [[Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)] at `passthru.tests`.
  - [ ] Tests in [[lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests)] or [[pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [[nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [[CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)], [[pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md)], [[maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md)] and other READMEs.
- [x] Follows the [[automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy)].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test