### PR TITLE
[haskell-updates] git-annex: unbreak

### DIFF
--- a/pkgs/development/haskell-modules/cabal2nix-unstable/cabal2nix.nix
+++ b/pkgs/development/haskell-modules/cabal2nix-unstable/cabal2nix.nix
@@ -35,10 +35,10 @@
 }:
 mkDerivation {
   pname = "cabal2nix";
-  version = "2.21.3-unstable-2026-03-30";
+  version = "2.21.3-unstable-2026-06-23";
   src = fetchzip {
-    url = "https://github.com/NixOS/cabal2nix/archive/41239bcc0622a0975c6705a03a44dfeffeb56f23.tar.gz";
-    sha256 = "01qj6cvaif0810v83r6izcj1bbfpcqqxw4wybq04qsq92sqybpw2";
+    url = "https://github.com/NixOS/cabal2nix/archive/bb97bf4294097812718ab9a3f244c9d58c833ae1.tar.gz";
+    sha256 = "0bp5m83hzcsr3ga9zz5kq1jjs0n44mlh93x5j55avgw1rxvpfw32";
   };
   postUnpack = "sourceRoot+=/cabal2nix; echo source root reset to $sourceRoot";
   isLibrary = true;
@@ -106,5 +106,5 @@ mkDerivation {
   '';
   homepage = "https://github.com/nixos/cabal2nix#readme";
   description = "Convert Cabal files into Nix build instructions";
-  license = lib.licensesSpdx."BSD-3-Clause";
+  license = lib.meta.getLicenseFromSpdxId "BSD-3-Clause";
 }

--- a/pkgs/development/haskell-modules/cabal2nix-unstable/distribution-nixpkgs.nix
+++ b/pkgs/development/haskell-modules/cabal2nix-unstable/distribution-nixpkgs.nix
@@ -18,10 +18,10 @@
 }:
 mkDerivation {
   pname = "distribution-nixpkgs";
-  version = "1.7.1.1-unstable-2026-03-30";
+  version = "1.7.1.1-unstable-2026-06-23";
   src = fetchzip {
-    url = "https://github.com/NixOS/cabal2nix/archive/41239bcc0622a0975c6705a03a44dfeffeb56f23.tar.gz";
-    sha256 = "01qj6cvaif0810v83r6izcj1bbfpcqqxw4wybq04qsq92sqybpw2";
+    url = "https://github.com/NixOS/cabal2nix/archive/bb97bf4294097812718ab9a3f244c9d58c833ae1.tar.gz";
+    sha256 = "0bp5m83hzcsr3ga9zz5kq1jjs0n44mlh93x5j55avgw1rxvpfw32";
   };
   postUnpack = "sourceRoot+=/distribution-nixpkgs; echo source root reset to $sourceRoot";
   enableSeparateDataOutput = true;
@@ -49,5 +49,5 @@ mkDerivation {
   ];
   homepage = "https://github.com/NixOS/cabal2nix/tree/master/distribution-nixpkgs#readme";
   description = "Types and functions to manipulate the Nixpkgs distribution";
-  license = lib.licensesSpdx."BSD-3-Clause";
+  license = lib.meta.getLicenseFromSpdxId "BSD-3-Clause";
 }

--- a/pkgs/development/haskell-modules/cabal2nix-unstable/hackage-db.nix
+++ b/pkgs/development/haskell-modules/cabal2nix-unstable/hackage-db.nix
@@ -16,10 +16,10 @@
 }:
 mkDerivation {
   pname = "hackage-db";
-  version = "2.1.3-unstable-2026-03-30";
+  version = "2.1.3-unstable-2026-06-23";
   src = fetchzip {
-    url = "https://github.com/NixOS/cabal2nix/archive/41239bcc0622a0975c6705a03a44dfeffeb56f23.tar.gz";
-    sha256 = "01qj6cvaif0810v83r6izcj1bbfpcqqxw4wybq04qsq92sqybpw2";
+    url = "https://github.com/NixOS/cabal2nix/archive/bb97bf4294097812718ab9a3f244c9d58c833ae1.tar.gz";
+    sha256 = "0bp5m83hzcsr3ga9zz5kq1jjs0n44mlh93x5j55avgw1rxvpfw32";
   };
   postUnpack = "sourceRoot+=/hackage-db; echo source root reset to $sourceRoot";
   isLibrary = true;
@@ -38,5 +38,5 @@ mkDerivation {
   ];
   homepage = "https://github.com/NixOS/cabal2nix/tree/master/hackage-db#readme";
   description = "Access cabal-install's Hackage database via Data.Map";
-  license = lib.licensesSpdx."BSD-3-Clause";
+  license = lib.meta.getLicenseFromSpdxId "BSD-3-Clause";
 }

--- a/pkgs/development/haskell-modules/cabal2nix-unstable/language-nix.nix
+++ b/pkgs/development/haskell-modules/cabal2nix-unstable/language-nix.nix
@@ -14,10 +14,10 @@
 }:
 mkDerivation {
   pname = "language-nix";
-  version = "2.3.0-unstable-2026-03-30";
+  version = "2.3.0-unstable-2026-06-23";
   src = fetchzip {
-    url = "https://github.com/NixOS/cabal2nix/archive/41239bcc0622a0975c6705a03a44dfeffeb56f23.tar.gz";
-    sha256 = "01qj6cvaif0810v83r6izcj1bbfpcqqxw4wybq04qsq92sqybpw2";
+    url = "https://github.com/NixOS/cabal2nix/archive/bb97bf4294097812718ab9a3f244c9d58c833ae1.tar.gz";
+    sha256 = "0bp5m83hzcsr3ga9zz5kq1jjs0n44mlh93x5j55avgw1rxvpfw32";
   };
   postUnpack = "sourceRoot+=/language-nix; echo source root reset to $sourceRoot";
   libraryHaskellDepends = [
@@ -39,5 +39,5 @@ mkDerivation {
   ];
   homepage = "https://github.com/NixOS/cabal2nix/tree/master/language-nix#readme";
   description = "Data types and functions to represent the Nix language";
-  license = lib.licensesSpdx."BSD-3-Clause";
+  license = lib.meta.getLicenseFromSpdxId "BSD-3-Clause";
 }

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -687,6 +687,8 @@ with haskellLib;
         # TODO(@sternenseemann): submit upstreamable patch resolving this
         # (this should be possible by also taking PREFIX into account).
         ./patches/git-annex-no-usr-prefix.patch
+        # Fix build with http-types >= 0.12.5, will be part of next release
+        ./patches/git-annex-http-types-0.12.5.patch
       ];
 
       postPatch = ''

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -672,7 +672,7 @@ with haskellLib;
         name = "git-annex-${super.git-annex.version}-src";
         url = "git://git-annex.branchable.com/";
         tag = super.git-annex.version;
-        sha256 = "sha256-PoO1vAUVZsHHFAusoxBJeSW4y9tn3/kKXFDGzr8hZh4=";
+        sha256 = "sha256-VB0IC2cT2FFwZcE5P/epIHMCpYeZrG8TjdC+o2zl5vc=";
         # delete android and Android directories which cause issues on
         # darwin (case insensitive directory). Since we don't need them
         # during the build process, we can delete it to prevent a hash

--- a/pkgs/development/haskell-modules/patches/git-annex-http-types-0.12.5.patch
+++ b/pkgs/development/haskell-modules/patches/git-annex-http-types-0.12.5.patch
@@ -1,0 +1,55 @@
+From cc9d0a2e9fd90d0a6f5d228aa17ebf26424ce1f9 Mon Sep 17 00:00:00 2001
+From: Joey Hess <joeyh@joeyh.name>
+Date: Sat, 6 Jun 2026 11:09:11 -0400
+Subject: [PATCH] Fix build with http-types-0.12.5
+
+Depend on http-types >= 0.9, which added 3 headers to
+Network.HTTP.Types.Headers. In 0.12.5, those are exported
+from Network.HTTP.Types, which conflicted with the
+definitions in Utility.Url.
+---
+
+diff --git a/Utility/Url.hs b/Utility/Url.hs
+index 40fa4832a1..3acbf31e3c 100644
+--- a/Utility/Url.hs
++++ b/Utility/Url.hs
+@@ -56,6 +56,7 @@ import qualified Utility.FileIO as F
+ 
+ import Network.URI
+ import Network.HTTP.Types
++import Network.HTTP.Types.Header (hAcceptEncoding, hContentDisposition, hContentRange)
+ import qualified System.FilePath.Posix as UrlPath
+ import qualified Data.CaseInsensitive as CI
+ import qualified Data.ByteString as B
+@@ -670,15 +671,6 @@ parseRequestRelaxed u = case uriAuthority u of
+ 			u { uriAuthority = Just $ ua { uriPort = "" } }
+ 	_ -> parseRequest (show u)
+ 
+-hAcceptEncoding :: CI.CI B.ByteString
+-hAcceptEncoding = "Accept-Encoding"
+-
+-hContentDisposition :: CI.CI B.ByteString
+-hContentDisposition = "Content-Disposition"
+-
+-hContentRange :: CI.CI B.ByteString
+-hContentRange = "Content-Range"
+-
+ resumeFromHeader :: FileSize -> Header
+ resumeFromHeader sz = (hRange, renderByteRanges [ByteRangeFrom sz])
+ 
+diff --git a/git-annex.cabal b/git-annex.cabal
+index a3557cbfef..bae89052e7 100644
+--- a/git-annex.cabal
++++ b/git-annex.cabal
+@@ -233,7 +233,7 @@ Executable git-annex
+    resourcet,
+    http-client (>= 0.5.3),
+    http-client-tls (>= 0.3.2),
+-   http-types (>= 0.7),
++   http-types (>= 0.9),
+    http-conduit (>= 2.3.0),
+    http-client-restricted (>= 0.0.2),
+    conduit,
+-- 
+2.54.0
+


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
