### PR TITLE
python3Packages.matplot2tikz: init at 0.5.4

### DIFF
--- a/pkgs/development/python-modules/matplot2tikz/default.nix
+++ b/pkgs/development/python-modules/matplot2tikz/default.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  setuptools-scm,
+
+  matplotlib,
+  numpy,
+  pillow,
+  webcolors,
+  typing-extensions,
+
+  pytestCheckHook,
+  pytest-cov-stub,
+  astropy,
+  pandas,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "matplot2tikz";
+  version = "0.5.4";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "ErwindeGelder";
+    repo = "matplot2tikz";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-pILvB0E61zMT7rrxQqDlz49Dk/nDkb7ytH09A0cExzQ=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    matplotlib
+    numpy
+    pillow
+    webcolors
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+    astropy
+    pandas
+  ];
+
+  pythonImportsCheck = [ "matplot2tikz" ];
+
+  meta = {
+    description = "Convert matplotlib figures into TikZ/PGFPlots";
+    homepage = "https://github.com/ErwindeGelder/matplot2tikz";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.haansn08 ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9772,6 +9772,8 @@ self: super: with self; {
 
   mathutils = callPackage ../development/python-modules/mathutils { };
 
+  matplot2tikz = callPackage ../development/python-modules/matplot2tikz { };
+
   matplotlib = callPackage ../development/python-modules/matplotlib {
     stdenv = if stdenv.hostPlatform.isDarwin then pkgs.clangStdenv else pkgs.stdenv;
   };


### PR DESCRIPTION
[matplot2tikz](https://github.com/ErwindeGelder/matplot2tikz) is a Python package for converting matplotlib figures into PGFPlots (PGF/TikZ) figures for native inclusion into LaTeX or ConTeXt documents.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
