### PR TITLE
civetweb: Add configurable build flags

### DIFF
--- a/pkgs/by-name/ci/civetweb/package.nix
+++ b/pkgs/by-name/ci/civetweb/package.nix
@@ -4,6 +4,12 @@
   fetchFromGitHub,
   fetchpatch,
   cmake,
+  zlib,
+  versionCheckHook,
+
+  withZlib ? true,
+  withUnixSockets ? true,
+  withWebSockets ? true,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -32,10 +38,17 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   strictDeps = true;
+  __structuredAttrs = true;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "-I";
 
   nativeBuildInputs = [
     cmake
   ];
+
+  buildInputs = lib.optional withZlib zlib;
 
   # The existence of the "build" script causes `mkdir -p build` to fail:
   #   mkdir: cannot create directory 'build': File exists
@@ -60,12 +73,25 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Workaround CMake 4 compat
     (lib.cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.5")
-  ];
+
+    # Support for listening for HTTP requests on a Unix domain socket.
+    "-DCMAKE_C_FLAGS=-DUSE_X_DOM_SOCKET"
+
+    (lib.cmakeBool "CIVETWEB_ENABLE_WEBSOCKETS" withWebSockets)
+
+    (lib.cmakeBool "CIVETWEB_ENABLE_ZLIB" withZlib)
+  ]
+
+  # Support for listening for HTTP requests on a Unix domain socket.
+  ++ lib.optional withUnixSockets "-DCMAKE_C_FLAGS=-DUSE_X_DOM_SOCKET";
+  # NOTE Once 1.17 is released, we can use a CMake flag:
+  # (lib.cmakeBool "CIVETWEB_ENABLE_X_DOM_SOCKET" withUnixSockets)
 
   meta = {
     description = "Embedded C/C++ web server";
     mainProgram = "civetweb";
     homepage = "https://github.com/civetweb/civetweb";
     license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jlesquembre ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
