### PR TITLE
zennotes: init at 2.5.0

### DIFF
--- a/pkgs/applications/editors/zennotes/default.nix
+++ b/pkgs/applications/editors/zennotes/default.nix
@@ -1,0 +1,20 @@
+{ lib, appimageTools, fetchurl }:
+
+appimageTools.wrapType2 {
+  pname = "zennotes";
+  version = "2.5.0";
+
+  src = fetchurl {
+    url = "https://github.com/ZenNotes/zennotes/releases/download/v2.5.0/ZenNotes-2.5.0-linux-x86_64.AppImage";
+    hash = "sha256-ikXfCxLtz2zicmJeie3Jp6X6hVsE2b9PHc3Rjv3o+0k=";
+  };
+
+  meta = with lib; {
+    description = "ZenNotes markdown note-taking application";
+    homepage = "https://zennotes.org";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "zennotes";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3134,6 +3134,8 @@ with pkgs;
     nvidiaSupport = true;
   };
 
+  zennotes = callPackage ../applications/editors/zennotes { };
+
   zellijPlugins = recurseIntoAttrs (callPackage ../by-name/ze/zellij/plugins { });
 
   zstd = callPackage ../tools/compression/zstd {


### PR DESCRIPTION
ZenNotes is a vim motions first markdown note-taking application built with Electron.
Homepage: https://zennotes.org

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

