### PR TITLE
kikit: fix version

### DIFF
--- a/pkgs/by-name/ki/kikit/default.nix
+++ b/pkgs/by-name/ki/kikit/default.nix
@@ -2,8 +2,9 @@
   bc,
   zip,
   lib,
-  fetchFromGitHub,
   bats,
+  fetchFromGitHub,
+  python,
   buildPythonApplication,
   callPackage,
   kicad,
@@ -19,6 +20,7 @@
   versioneer,
   shapely,
   setuptools,
+  versionCheckHook,
   nix-update-script,
 }:
 let
@@ -36,7 +38,10 @@ buildPythonApplication (finalAttrs: {
     hash = "sha256-QhtdQgMgHaB0xj2hQ4MCptr5DDgCOfRClUSyYzrFQis=";
     # Upstream uses versioneer, which relies on gitattributes substitution.
     # This leads to non-reproducible archives on GitHub.
-    # See https://github.com/NixOS/nixpkgs/issues/84312
+    # See
+    # https://github.com/NixOS/nixpkgs/issues/84312
+    # https://github.com/NixOS/nixpkgs/pull/395213
+    # https://github.com/python-versioneer/python-versioneer/issues/217
     postFetch = ''
       rm "$out/kikit/_version.py"
     '';
@@ -72,6 +77,7 @@ buildPythonApplication (finalAttrs: {
 
   nativeCheckInputs = [
     pytestCheckHook
+    versionCheckHook
     bats
   ];
 
@@ -79,9 +85,10 @@ buildPythonApplication (finalAttrs: {
     "kikit"
   ];
 
-  postPatch = ''
-    # Recreate _version.py, deleted at fetch time due to non-reproducibility.
-    echo 'def get_versions(): return {"version": "${finalAttrs.version}"}' > kikit/_version.py
+  # Recreate _version.py, deleted at fetch time due to non-reproducibility.
+  # should be done in postInstall to overwrite what versioneer generates again during the build phase
+  postInstall = ''
+    echo 'def get_versions(): return {"version": "${finalAttrs.version}"}' > $out/${python.sitePackages}/kikit/_version.py
   '';
 
   preCheck = ''
@@ -96,14 +103,15 @@ buildPythonApplication (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
+    changelog = "https://github.com/yaqwsx/KiKit/releases/tag/${finalAttrs.src.tag}";
     description = "Automation for KiCAD boards";
     homepage = "https://github.com/yaqwsx/KiKit/";
-    changelog = "https://github.com/yaqwsx/KiKit/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    mainProgram = "kikit";
     maintainers = with lib.maintainers; [
       jfly
       matusf
     ];
     teams = with lib.teams; [ ngi ];
-    license = lib.licenses.mit;
   };
 })


### PR DESCRIPTION
`postPatch` doesn't help here, maybe the behavior changed but the versioneer step runs and overwrites the overwritten `_version.py` with `0+unknown`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
  - No llms used

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
