### PR TITLE
xadrian: init at 1.5.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8703,6 +8703,12 @@
     name = "Fábio Batista";
     keys = [ { fingerprint = "D2D8 69D8 5EEC 30AD D327  B4A5 6CD5 5257 DB01 8B72"; } ];
   };
+  FabricSoul = {
+    name = "FabricSoul";
+    github = "FabricSoul";
+    githubId = 114606360;
+    email = "fabric.soul7@gmail.com";
+  };
   fallenbagel = {
     name = "fallenbagel";
     github = "fallenbagel";

--- a/pkgs/by-name/xa/xadrian/package.nix
+++ b/pkgs/by-name/xa/xadrian/package.nix
@@ -1,0 +1,111 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  jdk8,
+  makeWrapper,
+  makeBinaryWrapper,
+  makeDesktopItem,
+  copyDesktopItems,
+  unzip,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "xadrian";
+  version = "1.5.1";
+
+  # The source release (tag xadrian-1.5.1) cannot be built: it depends on
+  # de.ailis:oneinstance, which was only published to nexus.ailis.de (now
+  # offline) and is not on Maven Central. The upstream release instead ships
+  # prebuilt, self-contained artifacts, which we repackage here.
+  src =
+    if stdenvNoCC.hostPlatform.isDarwin then
+      fetchurl {
+        url = "https://github.com/kayahr/xadrian/releases/download/xadrian-${finalAttrs.version}/xadrian-${finalAttrs.version}-macosx.zip";
+        hash = "sha256-nCkhlC/nrTxCMd2jO+avkFlXD98a+rFvD6uoCfcZ3PU=";
+      }
+    else
+      fetchurl {
+        url = "https://github.com/kayahr/xadrian/releases/download/xadrian-${finalAttrs.version}/xadrian-${finalAttrs.version}-unix.tar.bz2";
+        hash = "sha256-MVWvYbI9V9s0CbmM6DXmWZEu0kdn9ZIpNcnJZhkDsjU=";
+      };
+
+  sourceRoot = if stdenvNoCC.hostPlatform.isDarwin then "." else "xadrian-${finalAttrs.version}";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  # Xadrian must run on a Java 8 runtime: it uses javax.xml.bind (JAXB), which
+  # was bundled in the JDK only through Java 8 and removed in Java 11+.
+  nativeBuildInputs = [
+    unzip
+  ]
+  # A macOS .app's CFBundleExecutable must be a real binary, so use
+  # makeBinaryWrapper on Darwin; makeWrapper's shell script is fine elsewhere.
+  ++ lib.optionals stdenvNoCC.hostPlatform.isDarwin [ makeBinaryWrapper ]
+  ++ lib.optionals (!stdenvNoCC.hostPlatform.isDarwin) [
+    makeWrapper
+    copyDesktopItems
+  ];
+
+  desktopItems = lib.optionals (!stdenvNoCC.hostPlatform.isDarwin) [
+    (makeDesktopItem {
+      name = "xadrian";
+      desktopName = "Xadrian";
+      exec = "xadrian";
+      icon = "xadrian";
+      comment = finalAttrs.meta.description;
+      categories = [ "Game" ];
+      startupWMClass = "Xadrian";
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+  ''
+  + (
+    if stdenvNoCC.hostPlatform.isDarwin then
+      ''
+        mkdir -p $out/Applications
+        cp -R Xadrian.app $out/Applications/
+        appdir=$out/Applications/Xadrian.app
+        chmod -R u+w "$appdir"
+
+        # The bundled JavaApplicationStub is Apple's long-removed Java 6
+        # launcher (no arm64, broken on modern macOS); replace it with a JRE
+        # wrapper so the .app actually launches.
+        rm -f "$appdir/Contents/MacOS/JavaApplicationStub"
+        makeWrapper ${jdk8}/bin/java "$appdir/Contents/MacOS/JavaApplicationStub" \
+          --add-flags "-jar $appdir/Contents/Resources/Java/xadrian.jar"
+
+        makeWrapper ${jdk8}/bin/java $out/bin/xadrian \
+          --add-flags "-jar $appdir/Contents/Resources/Java/xadrian.jar"
+      ''
+    else
+      ''
+        # Keep the jars co-located so xadrian.jar's relative Class-Path resolves.
+        install -Dm644 -t $out/share/xadrian lib/*.jar
+
+        # The application icon is embedded in the jar.
+        unzip -p $out/share/xadrian/xadrian.jar de/ailis/xadrian/images/xadrian-64.png \
+          > xadrian.png
+        install -Dm644 xadrian.png $out/share/icons/hicolor/64x64/apps/xadrian.png
+
+        makeWrapper ${jdk8}/bin/java $out/bin/xadrian \
+          --add-flags "-jar $out/share/xadrian/xadrian.jar"
+      ''
+  )
+  + ''
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Factory complex calculator for X3: Terran Conflict and X3: Albion Prelude";
+    homepage = "https://github.com/kayahr/xadrian";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    maintainers = with lib.maintainers; [ FabricSoul ];
+    mainProgram = "xadrian";
+    platforms = jdk8.meta.platforms;
+  };
+})


### PR DESCRIPTION
Adds Xadrian, a factory complex calculator for the games X3: Terran Conflict and X3: Albion Prelude. Homepage: https://github.com/kayahr/xadrian

The 1.5.1 *source* release cannot be built: it depends on `de.ailis:oneinstance`, only ever published to `nexus.ailis.de` (now offline) and absent from Maven Central. This packages the upstream **prebuilt release artifacts** instead — the `-unix.tar.bz2` jars on Linux, the `.app` bundle on Darwin — wrapped with a nixpkgs JRE (`sourceProvenance = [ binaryBytecode ]`). On Darwin the bundle's obsolete Apple Java 6 `JavaApplicationStub` (broken on modern macOS, no arm64) is replaced with a `makeBinaryWrapper` JRE launcher.

> **AI disclosure:** this contribution (package, commits, and this summary) was prepared with the assistance of Claude Code (Claude Opus 4.8). All output was reviewed and tested by the submitter, who is accountable for it. Commits carry `Assisted-by:` trailers.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR (`1 package built: xadrian` on x86_64-linux; aarch64-darwin verified separately on real Apple Silicon hardware).
- [x] Tested basic functionality of all binary files (GUI launches: under Xvfb on x86_64-linux; via `open` of the `.app` in a real aarch64-darwin desktop session).
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
