### PR TITLE
allmytoes: wrap for mime database

### DIFF
--- a/pkgs/by-name/al/allmytoes/package.nix
+++ b/pkgs/by-name/al/allmytoes/package.nix
@@ -2,6 +2,8 @@
   lib,
   nix-update-script,
   rustPlatform,
+  makeWrapper,
+  shared-mime-info,
   fetchFromGitLab,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -15,7 +17,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-BYKcDJN/uKESj0pnb2xvrx1lO6rOGdi+PVT6ywZqjbQ=";
   };
 
+  nativeBuildInputs = [ makeWrapper ];
+
   cargoHash = "sha256-Pzbruv1E4mMohw//lf1JBoK+4BHDJVr4/9xXE4FrWbA==";
+
+  postInstall = ''
+    wrapProgram "$out/bin/allmytoes" --prefix XDG_DATA_DIRS : "${shared-mime-info}/share"
+  '';
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
Wrap the allmytoes binary so that it can access the shared mime database to detect mime types for files.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `e74437b00ed74893c81835ec4358793b3f205c73`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>allmytoes</li>
  </ul>
</details>
