### PR TITLE
[haskell-updates] stack: patch for semaphore-compat >= 2.0

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -161,29 +161,6 @@ with haskellLib;
     hackage-db-unstable
     ;
 
-  # Stack uses pure nix-shells for certain operations including HTTPS requests
-  # This patch makes stack add pkgs.cacert, so the certificate DB is available.
-  # https://github.com/commercialhaskell/stack/pull/6854 krank:ignore-line
-  stack =
-    appendPatches
-      [
-        (pkgs.fetchpatch {
-          name = "stack-add-cacert-to-pure-shells.patch";
-          url = "https://github.com/commercialhaskell/stack/commit/e869263cbd84a9e59ce1fa467e82993c8e7fb1dd.patch";
-          hash = "sha256-O7GaNgcGBY6m6GHqVtejqOu2HCWWKWXARPnr/upT1RQ=";
-          includes = [ "src/Stack/Nix.hs" ];
-        })
-      ]
-      (
-        overrideCabal (drv: {
-          # Stack's source files use CRLF
-          prePatch = ''
-            ${drv.prePatch or ""}
-            sed -i -e 's/\r$//' src/Stack/Nix.hs
-          '';
-        }) super.stack
-      );
-
   # Extensions wants a specific version of Cabal for its list of Haskell
   # language extensions.
   extensions = doJailbreak (

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -161,6 +161,46 @@ with haskellLib;
     hackage-db-unstable
     ;
 
+  stack =
+    appendPatches
+      [
+        # Bug fix that is also necessary for the following patches to apply
+        (pkgs.fetchpatch {
+          name = "stack-dep-without-main-library.patch";
+          url = "https://github.com/commercialhaskell/stack/commit/591b6eb225b4cd2cfa4d282089fdb33e86bb14ad.patch";
+          hash = "sha256-GTUBGZ1KWQii60Yt9JpKcwMkzuIuSTdKLGd3aM0jXWw=";
+        })
+        # FIXME(@sternenseemann): these URLs are not stable (yet)
+        # Pick patches to support semaphore-compat >= 2.0
+        # from https://github.com/commercialhaskell/stack/pull/6935
+        # c.f. https://github.com/commercialhaskell/stack/issues/693
+        (pkgs.fetchpatch {
+          name = "stack-semaphore-compat-2.0.patch";
+          url = "https://github.com/commercialhaskell/stack/commit/c9e3cbc3f460de65d5abeffb583242255b41be23.patch";
+          includes = [ "src/**" ];
+          hash = "sha256-flf1f/QoBZAw9VRTzdNJQu+Zt1b+9q/pi7+1ukCad6c=";
+        })
+        (pkgs.fetchpatch {
+          name = "stack-semaphore-compat-compiler-paths.patch";
+          url = "https://github.com/commercialhaskell/stack/commit/02fa193245fc7210c6ce88646b2fa94ab39b9fc4.patch";
+          hash = "sha256-oE0GfXADSYlPceurzeZbq1Ix14gOtZEBssA8ZINv2qs=";
+        })
+        (pkgs.fetchpatch {
+          name = "stack-semaphore-ghc-compat-map.patch";
+          url = "https://github.com/commercialhaskell/stack/commit/960e704b9cd61094b75fad4689f0034b4435a268.patch";
+          hash = "sha256-zYIsttG3z4gbpfXgQsKz0PlkAEzODlLYiYdPpfBohvM=";
+        })
+      ]
+      (
+        overrideCabal (drv: {
+          # Stack's source files use CRLF
+          prePatch = ''
+            ${drv.prePatch or ""}
+            find doc src -type f -exec sed -i -e 's/\r$//' '{}' '+'
+          '';
+        }) super.stack
+      );
+
   # Extensions wants a specific version of Cabal for its list of Haskell
   # language extensions.
   extensions = doJailbreak (

--- a/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
@@ -75,51 +75,6 @@ in
   # “Unfortunately we are unable to support GHC 9.10.”
   apply-refact = dontDistribute (markBroken super.apply-refact);
 
-  stack =
-    # Setup.hs depends on Cabal-syntax >= 3.14
-    overrideCabal
-      (drv: {
-        setupHaskellDepends = drv.setupHaskellDepends or [ ] ++ [
-          self.Cabal-syntax_3_14_2_0
-          self.Cabal_3_14_2_0
-        ];
-        # We need to tell GHC to ignore the Cabal core libraries while
-        # compiling Setup.hs since it depends on Cabal >= 3.14.
-        # ATTN: This override assumes we are using GHC 9.10.3 since we need
-        # to give an exact Cabal version at the GHC (!) command line.
-        # FIXME(@sternenseemann): make direct argument to generic-builder.nix
-        env = drv.env or { } // {
-          setupCompileFlags = lib.concatStringsSep " " [
-            "-hide-package"
-            "Cabal-syntax-3.12.1.0"
-            "-hide-package"
-            "Cabal-3.12.1.0"
-          ];
-        };
-      })
-
-      # Stack itself depends on Cabal >= 3.14 which also needs to be updated for deps
-      (
-        super.stack.overrideScope (
-          sself: ssuper:
-          let
-            upgradeCabal =
-              drv:
-              lib.pipe drv [
-                (addBuildDepends [ sself.Cabal_3_14_2_0 ])
-                (appendConfigureFlags [ "--constraint=Cabal>=3.14" ])
-              ];
-          in
-          {
-            pantry = upgradeCabal ssuper.pantry;
-            rio-prettyprint = upgradeCabal ssuper.rio-prettyprint;
-            hackage-security = upgradeCabal ssuper.hackage-security;
-            hpack = upgradeCabal sself.hpack_0_39_1;
-            stack = upgradeCabal ssuper.stack;
-          }
-        )
-      );
-
   #
   # Version upgrades
   #


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

If we want to build stack wtih GHC 9.12.5, we'll have to work around https://github.com/commercialhaskell/stack/issues/6934 somehow.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
