### PR TITLE
stump: refactor code to use finalAttrs more & enable auto update PRs

### DIFF
--- a/pkgs/by-name/st/stump/package.nix
+++ b/pkgs/by-name/st/stump/package.nix
@@ -17,19 +17,20 @@
   pkg-config,
   makeWrapper,
 }:
-let
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "stump";
   version = "0.1.5";
 
   src = fetchFromGitHub {
     owner = "stumpapp";
     repo = "stump";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-kstMk4HJopLHW22ynVZF0itWUixwiDkbsMUpYMvw1Ag=";
   };
 
-  frontend = stdenv.mkDerivation (finalAttrs: {
+  frontend = stdenv.mkDerivation (_: {
     pname = "stump-frontend";
-    inherit src version;
+    inherit (finalAttrs) src version;
 
     yarnOfflineCache = fetchYarnDeps {
       yarnLock = finalAttrs.src + "/yarn.lock";
@@ -55,10 +56,6 @@ let
       mv ./apps/web/dist $out
     '';
   });
-in
-rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "stump";
-  inherit src version;
 
   __structuredAttrs = true;
 
@@ -71,7 +68,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "stump_server"
   ];
 
-  env.GIT_REV = "v${version}";
+  env.GIT_REV = "v${finalAttrs.version}";
 
   nativeBuildInputs = [
     pkg-config
@@ -97,7 +94,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   postInstall = ''
     wrapProgram $out/bin/stump_server \
       --set-default STUMP_CONFIG_DIR /var/lib/stump/config \
-      --set-default STUMP_CLIENT_DIR ${frontend} \
+      --set-default STUMP_CLIENT_DIR ${finalAttrs.frontend} \
       --set-default STUMP_PORT 10001 \
       --set-default STUMP_PROFILE release \
       --set-default PDFIUM_PATH ${pdfium-binaries}/lib/libpdfium.so \

--- a/pkgs/by-name/st/stump/package.nix
+++ b/pkgs/by-name/st/stump/package.nix
@@ -16,6 +16,7 @@
   cacert,
   pkg-config,
   makeWrapper,
+  nix-update-script,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "stump";
@@ -101,7 +102,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --set-default API_VERSION v1
   '';
 
-  passthru.tests = nixosTests.stump;
+  passthru = {
+    tests = nixosTests.stump;
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--subpackage"
+        "frontend"
+      ];
+    };
+  };
 
   meta = {
     homepage = "https://stumpapp.dev/";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

While the functional behaviour was introduced, the stump package hasn't been using it much and instead utilized a let-in block.
The contents of the let-in block has been moved inside and the derivation function and the `finalAttrs` argument has been used where needed.
This enables easier automatic updates using nix-update-script.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
