### PR TITLE
nvidia-container-toolkit: 1.18.2 -> 1.19.1

### DIFF
--- a/pkgs/by-name/nv/nvidia-container-toolkit/0001-Add-dlopen-discoverer.patch
+++ b/pkgs/by-name/nv/nvidia-container-toolkit/0001-Add-dlopen-discoverer.patch
@@ -1,20 +1,20 @@
-From e4449f06a8989ff22947309151855b388c311aed Mon Sep 17 00:00:00 2001
+From 0db315c9ca1e8f2144edf020aa4dd309e889d4d1 Mon Sep 17 00:00:00 2001
 From: Jared Baur <jaredbaur@fastmail.com>
 Date: Mon, 22 Jan 2024 20:42:48 -0800
 Subject: [PATCH] Add dlopen discoverer
 
 ---
- internal/lookup/dlopen.go  | 57 ++++++++++++++++++++++++++++++++++++++
- internal/lookup/library.go |  3 ++
- 2 files changed, 60 insertions(+)
- create mode 100644 internal/lookup/dlopen.go
+ pkg/lookup/dlopen.go  | 63 +++++++++++++++++++++++++++++++++++++++++++
+ pkg/lookup/library.go |  1 +
+ 2 files changed, 64 insertions(+)
+ create mode 100644 pkg/lookup/dlopen.go
 
-diff --git a/internal/lookup/dlopen.go b/internal/lookup/dlopen.go
+diff --git a/pkg/lookup/dlopen.go b/pkg/lookup/dlopen.go
 new file mode 100644
-index 00000000..7cd84522
+index 0000000..7af8ca0
 --- /dev/null
-+++ b/internal/lookup/dlopen.go
-@@ -0,0 +1,57 @@
++++ b/pkg/lookup/dlopen.go
+@@ -0,0 +1,63 @@
 +package lookup
 +
 +// #cgo LDFLAGS: -ldl
@@ -35,11 +35,17 @@ index 00000000..7cd84522
 +	file
 +}
 +
-+// NewDlopenLocator creats a locator that can be used for locating libraries
++// NewDlopenLocator creates a locator that can be used for locating libraries
 +// through the dlopen mechanism.
 +func NewDlopenLocator(opts ...Option) Locator {
-+	f := newFileLocator(opts...)
-+	d := dlopenLocator{file: *f}
++	o := NewFactory(opts...)
++	f := file{
++		logger:   o.logger,
++		filter:   o.filter,
++		count:    o.count,
++		prefixes: getSearchPrefixes(o.root, o.searchPaths...),
++	}
++	d := dlopenLocator{file: f}
 +	return &d
 +}
 +
@@ -72,19 +78,18 @@ index 00000000..7cd84522
 +
 +	return []string{libAbsolutePath}, nil
 +}
-diff --git a/internal/lookup/library.go b/internal/lookup/library.go
-index 7f5cf7c8..916edde2 100644
---- a/internal/lookup/library.go
-+++ b/internal/lookup/library.go
-@@ -61,7 +61,10 @@ func NewLibraryLocator(opts ...Option) Locator {
- 	// We construct a symlink locator for expected library locations.
- 	symlinkLocator := NewSymlinkLocator(opts...)
- 
-+	dlopenLocator := NewDlopenLocator(opts...)
-+
- 	l := First(
-+		dlopenLocator,
- 		symlinkLocator,
- 		newLdcacheLocator(opts...),
+diff --git a/pkg/lookup/library.go b/pkg/lookup/library.go
+index e57bd0e..adeff77 100644
+--- a/pkg/lookup/library.go
++++ b/pkg/lookup/library.go
+@@ -51,6 +51,7 @@ func NewLibraryLocator(opts ...Option) Locator {
+ 		}...),
  	)
---
+ 	l := First(
++		NewDlopenLocator(opts...),
+ 		NewSymlinkLocator(opts...),
+ 		f.newLdcacheLocator(),
+ 	)
+-- 
+2.54.0
+

--- a/pkgs/by-name/nv/nvidia-container-toolkit/package.nix
+++ b/pkgs/by-name/nv/nvidia-container-toolkit/package.nix
@@ -13,13 +13,13 @@ let
 in
 buildGoModule (finalAttrs: {
   pname = "nvidia-container-toolkit";
-  version = "1.18.2";
+  version = "1.19.1";
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "nvidia-container-toolkit";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-OMM7IQ65jPr9I5YUwVR3SXbuARnLjS2GSVq2j4J8uFY=";
+    hash = "sha256-0ivgJA5JY/17FIoOrOvUF7NjMMu7aXfh39sMQcabCm8=";
 
   };
 
@@ -33,11 +33,15 @@ buildGoModule (finalAttrs: {
   patches = [
     # This patch causes library lookups to first attempt loading via dlopen
     # before falling back to the regular symlink location and ldcache location.
+    # Required on NixOS, where the driver libraries live outside the ldcache and
+    # the FHS paths that the upstream locators search. Upstream tried to add an
+    # equivalent locator but reverted it; tracked in
+    # https://github.com/NVIDIA/nvidia-container-toolkit/issues/1677
     ./0001-Add-dlopen-discoverer.patch
   ];
 
   postPatch = ''
-    substituteInPlace internal/config/config.go \
+    substituteInPlace api/config/v1/config.go \
       --replace-fail '/usr/bin/nvidia-container-runtime-hook' "$tools/bin/nvidia-container-runtime-hook" \
       --replace-fail '/sbin/ldconfig' '${lib.getBin glibc}/sbin/ldconfig'
 


### PR DESCRIPTION
Bumps `nvidia-container-toolkit` 1.18.2 -> 1.19.1.

Changelogs: [v1.19.1](https://github.com/NVIDIA/nvidia-container-toolkit/releases/tag/v1.19.1), [v1.19.0](https://github.com/NVIDIA/nvidia-container-toolkit/releases/tag/v1.19.0). 1.19.0 is a feature release (IGX 2.0 Thor, CUDA forward-compat on Tegra/Orin, new device-access modes, read-only rootfs); 1.19.1 is bugfixes. No breaking changes for the package.

The carried `0001-Add-dlopen-discoverer.patch` is rebased: 1.19.x made the `lookup` package public (`internal/lookup` -> `pkg/lookup`) and reworked its locator factory, so `NewDlopenLocator` is reconstructed against the new `Factory` API. `postPatch` is retargeted from the removed `internal/config/config.go` to `api/config/v1/config.go`.

The dlopen locator isn't upstream... NVIDIA added an equivalent (NVIDIA/nvidia-container-toolkit#1646) then reverted it (NVIDIA/nvidia-container-toolkit#1676) due to a cgo crash in their go-nvml implementation; tracked in NVIDIA/nvidia-container-toolkit#1677. This is the independent raw-cgo locator nixpkgs has carried since 2024 (rebased from @jmbaur's original). Supersedes #499306.

I deployed to a real **Jetson Orin Nano (JetPack 6)**: `nvidia-ctk` reports `1.19.1`, the CDI generator runs clean, and `nvidia-smi` works inside a stock `ubuntu:22.04` container (`GPU 0: Orin`, CUDA 12.6), with a healthy generated CDI spec.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
 
cc @cpcloud @christoph-heiss

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

### `x86_64-linux`
<details>
  <summary>✅ 7 packages built:</summary>
  <ul>
    <li>apptainer</li>
    <li>apptainer-overriden-nixos</li>
    <li>nvidia-container-toolkit (nvidiaCtkPackages.nvidia-container-toolkit-docker)</li>
    <li>nvidia-docker</li>
    <li>singularity</li>
    <li>singularity-overriden-nixos</li>
    <li>udocker</li>
  </ul>
</details>

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
