### PR TITLE
bashquote: init at 1.0.0

### DIFF
--- a/pkgs/by-name/bq/bashquote/package.nix
+++ b/pkgs/by-name/bq/bashquote/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  makeWrapper,
+  coreutils,
+  ncurses,
+  gnugrep,
+  gawk,
+  gnused,
+}:
+
+stdenv.mkDerivation rec {
+
+  pname = "bashquote";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "harbiinger";
+    repo = "bashquote";
+    tag = version;
+    hash = "sha256-B3cnFairWgdQ6PmXVlEOhSA/nJGkIhv9/7/i6bKSzf4=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/bashquote/quotes
+
+    cp -r quotes/* $out/share/bashquote/quotes/
+
+    cp bashquote $out/bin/bashquote
+    chmod +x $out/bin/bashquote
+
+    wrapProgram $out/bin/bashquote \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          ncurses
+          gnugrep
+          gawk
+          gnused
+        ]
+      }
+  '';
+
+  meta = with lib; {
+    description = "Print a quote when you open a terminal";
+    mainProgram = "bashquote";
+    maitnainers = with maintainers; [ harbiinger ];
+    license = licenses.gpl3;
+  };
+
+}
+


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
[bashquote](https://github.com/Harbiinger/bashquote) is a bash script to print quotes when a terminal is opened. 

## Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
