### PR TITLE
cruise: 1.1.0 -> 2.2.2

### DIFF
--- a/pkgs/by-name/cr/cruise/package.nix
+++ b/pkgs/by-name/cr/cruise/package.nix
@@ -7,13 +7,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "cruise";
-  version = "1.1.0";
+  version = "2.2.2";
 
   src = fetchFromGitHub {
     owner = "NucleoFusion";
     repo = "cruise";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-0xIugbLlKlMODbMvsFzQXjKNNGY61tF4P/0loPlfs6o=";
+    hash = "sha256-AhLSzynNvtHK3URTd1034/2ToGcJUDp7rGMtr3kyees=";
   };
 
   vendorHash = "sha256-Zx1rZl5ljlsBNV1eQKPtQ+SgJV9l5rS8hwBe8nX9dYQ=";
@@ -23,7 +23,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "TUI for managing Docker containers, images, volumes, networks, and more";
     homepage = "https://github.com/NucleoFusion/cruise";
-    license = lib.licenses.mit;
+    license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ greatnatedev ];
     mainProgram = "cruise";
     platforms = lib.platforms.linux;


### PR DESCRIPTION
Updates `cruise` to 2.2.2.

Changelog: https://github.com/NucleoFusion/cruise/releases/tag/v2.2.2

Supersedes and closes #496724 by addressing the review-requested license metadata change to Apache-2.0.

Assisted-by: pi coding agent / Mika (OpenAI GPT-5.5)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
