### PR TITLE
openbsd: bump sources to 7.9

### DIFF
--- a/pkgs/os-specific/bsd/openbsd/default.nix
+++ b/pkgs/os-specific/bsd/openbsd/default.nix
@@ -20,7 +20,7 @@ makeScopeWithSplicing' {
       directory = ./pkgs;
     }
     // {
-      version = "7.5";
+      version = "7.9";
 
       stdenvLibcMinimal = stdenvNoLibc.override (old: {
         cc = old.cc.override {

--- a/pkgs/os-specific/bsd/openbsd/pkgs/libcMinimal/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/libcMinimal/package.nix
@@ -60,6 +60,7 @@ mkDerivation {
   env.NIX_CFLAGS_COMPILE = toString [
     "-B${csu}/lib"
     "-Wno-error"
+    "-fno-builtin"
   ];
 
   # Suppress lld >= 16 undefined version errors
@@ -72,6 +73,11 @@ mkDerivation {
     "COMPILER_VERSION=clang"
     "LIBC_TAGS=no"
   ];
+
+  # -fret-clean requires OpenBSD-specific patches to the compiler.
+  postPatch = ''
+    find . -type f -exec sed -i 's/-fret-clean//g' {} \;
+  '';
 
   postInstall = ''
     pushd ${include}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/rtld/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/rtld/package.nix
@@ -17,6 +17,13 @@ mkDerivation {
 
   NIX_CFLAGS_COMPILE = "-Wno-error";
 
+  makeFlags = [ "STACK_PROTECTOR=1" ];
+
+  # -fret-clean requires OpenBSD-specific patches to the compiler.
+  postPatch = ''
+    find . -type f -exec sed -i 's/-fret-clean//g' {} \;
+  '';
+
   # DESTDIR is overridden in bsdSetupHook, just fixup afterwards
   postInstall = ''
     mv $out/bin $out/libexec

--- a/pkgs/os-specific/bsd/openbsd/pkgs/source.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/source.nix
@@ -7,6 +7,6 @@
 fetchcvs {
   cvsRoot = "anoncvs@anoncvs.fr.openbsd.org/cvs";
   module = "src";
-  tag = "OPENBSD_${lib.replaceStrings [ "." ] [ "_" ] version}-RELEASE";
-  sha256 = "sha256-hzdATew6h/FQV72SWtg3YvUXdPoGjm2SoUS7m3c3fSU=";
+  tag = "OPENBSD_${lib.replaceStrings [ "." ] [ "_" ] version}_BASE";
+  sha256 = "sha256-n6pkgjCvqAGpZzLZnsO8FT7HMtBH3i7SLfhFBqQ9jmE=";
 }


### PR DESCRIPTION
Upgrades the OpenBSD sources to the latest release. Both static and dynamic binaries have been tested on a x86_64-openbsd machine and seem to work fine.

Static linking doesn't work out of the box (requires compilation with PIE), fixing this is outside the scope of this PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
