### PR TITLE
lttng-ust: fix musl crashes

### DIFF
--- a/pkgs/by-name/lt/lttng-ust/package.nix
+++ b/pkgs/by-name/lt/lttng-ust/package.nix
@@ -67,7 +67,15 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs .
   '';
 
-  configureFlags = [ "--disable-examples" ];
+  configureFlags = [
+    "--disable-examples"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isMusl [
+    # lttng-ust puts a single array on the stack that's the size of
+    # musl's whole default stack.
+    # https://review.lttng.org/c/lttng-ust/+/18160
+    "CFLAGS=-Wl,-z,stack-size=2097152"
+  ];
 
   doCheck = true;
 


### PR DESCRIPTION
Caught by the tests.  I've linked to my submitted upstream patch, but I'm not confident enough in it to apply it here without upstream review, so for now just build with an increased stack size across the board.  We can remove it if upstream does something to address the stack size issue.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
