### PR TITLE
Reapply "pkgs-lib/formats: Use .attrs.json where possible"

### DIFF
--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -146,14 +146,14 @@ optionalAttrs allowAliases aliases
           runCommand name
             {
               nativeBuildInputs = [ jq ];
-              value = toJSON value;
+              inherit value;
               preferLocalBuild = true;
               __structuredAttrs = true;
             }
+            # NIX_ATTRS_JSON_FILE won't have `value` if it's null, but jq returns null for missing properties anyway
+            # jsonNull test keeps this in check
             ''
-              valuePath="$TMPDIR/value"
-              printf "%s" "$value" > "$valuePath"
-              jq . "$valuePath" > $out
+              jq .value "$NIX_ATTRS_JSON_FILE" > $out
             ''
         ) { };
 
@@ -171,14 +171,16 @@ optionalAttrs allowAliases aliases
           runCommand name
             {
               nativeBuildInputs = [ remarshal_0_17 ];
-              value = toJSON value;
+              inherit value;
               preferLocalBuild = true;
               __structuredAttrs = true;
             }
             ''
-              valuePath="$TMPDIR/value"
-              printf "%s" "$value" > "$valuePath"
-              json2yaml "$valuePath" "$out"
+              json2yaml ${
+                # attributes with null values are omitted from the JSON with structured attrs
+                # yaml_1_1Null test keeps this in check
+                if value == null then ''<(echo "null")'' else ''--unwrap value "$NIX_ATTRS_JSON_FILE"''
+              } "$out"
             ''
         ) { };
 
@@ -196,14 +198,16 @@ optionalAttrs allowAliases aliases
           runCommand name
             {
               nativeBuildInputs = [ remarshal ];
-              value = toJSON value;
+              inherit value;
               preferLocalBuild = true;
               __structuredAttrs = true;
             }
             ''
-              valuePath="$TMPDIR/value"
-              printf "%s" "$value" > "$valuePath"
-              json2yaml "$valuePath" "$out"
+              json2yaml ${
+                # attributes with null values are omitted from the JSON with structured attrs
+                # yaml_1_2Null test keeps this in check
+                if value == null then ''<(echo "null")'' else ''--unwrap value "$NIX_ATTRS_JSON_FILE"''
+              } "$out"
             ''
         ) { };
 
@@ -960,8 +964,10 @@ optionalAttrs allowAliases aliases
                 python3
                 black
               ];
-              imports = toJSON (value._imports or [ ]);
-              value = toJSON (removeAttrs value [ "_imports" ]);
+              imports = value._imports or [ ];
+              # value must be an attrset, type would verify that,
+              # otherwise removeAttrs will fail.
+              value = removeAttrs value [ "_imports" ];
               pythonGen = pkgs.writeText "pythonGen" ''
                 import json
                 import os
@@ -984,26 +990,20 @@ optionalAttrs allowAliases aliases
                     else:
                         return repr(value)
 
-                with open(os.environ["importsPath"], "r") as f:
-                    imports = json.load(f)
-                    if imports is not None:
-                        for i in imports:
+                with open(os.environ["NIX_ATTRS_JSON_FILE"], "r") as f:
+                    attrs = json.load(f)
+                    if attrs["imports"] is not None:
+                        for i in attrs["imports"]:
                             print(f"import {i}")
                         print()
 
-                with open(os.environ["valuePath"], "r") as f:
-                    for key, value in json.load(f).items():
+                    for key, value in attrs["value"].items():
                         print(f"{key} = {recursive_repr(value)}")
               '';
               preferLocalBuild = true;
               __structuredAttrs = true;
             }
             ''
-              export importsPath="$TMPDIR/imports"
-              printf "%s" "$imports" > "$importsPath"
-              export valuePath="$TMPDIR/value"
-              printf "%s" "$value" > "$valuePath"
-              cat "$valuePath"
               python3 "$pythonGen" > $out
               black $out
             ''
@@ -1039,14 +1039,16 @@ optionalAttrs allowAliases aliases
                   python3Packages.xmltodict
                   libxml2Python
                 ];
-                value = toJSON value;
+                inherit value;
                 pythonGen = pkgs.writeText "pythonGen" ''
                   import json
                   import os
                   import xmltodict
 
-                  with open(os.environ["valuePath"], "r") as f:
-                      print(xmltodict.unparse(json.load(f), full_document=${
+                  with open(os.environ["NIX_ATTRS_JSON_FILE"], "r") as f:
+                      value = json.load(f).get("value")
+                      assert type(value) is dict, "value must be an attrset"
+                      print(xmltodict.unparse(value, full_document=${
                         if withHeader then "True" else "False"
                       }, pretty=True, indent=" " * 2))
                 '';
@@ -1054,8 +1056,6 @@ optionalAttrs allowAliases aliases
                 __structuredAttrs = true;
               }
               ''
-                export valuePath="$TMPDIR/value"
-                printf "%s" "$value" > "$valuePath"
                 python3 "$pythonGen" > $out
                 xmllint $out > /dev/null
               ''

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -1017,7 +1017,13 @@ optionalAttrs allowAliases aliases
     }:
     if format == "badgerfish" then
       {
-        type = serializableValueWith { typeName = "XML"; };
+        type =
+          attrsOf (serializableValueWith {
+            typeName = "XML";
+          })
+          // {
+            description = "XML value";
+          };
 
         generate =
           name: value:

--- a/pkgs/pkgs-lib/formats/configobj/default.nix
+++ b/pkgs/pkgs-lib/formats/configobj/default.nix
@@ -3,10 +3,6 @@
   pkgs,
 }:
 let
-  inherit (lib)
-    toJSON
-    ;
-
   inherit (lib.types)
     serializableValueWith
     ;
@@ -25,12 +21,12 @@ in
               (pkgs.python3.withPackages (ps: [ ps.configobj ]))
             ];
 
-            valuesJSON = toJSON value;
+            inherit value;
             __structuredAttrs = true;
             strictDeps = true;
           }
           ''
-            printf "%s" "$valuesJSON" | python3 ${./generate.py} > "$out"
+            python3 ${./generate.py} > "$out"
           '';
     };
 }

--- a/pkgs/pkgs-lib/formats/configobj/generate.py
+++ b/pkgs/pkgs-lib/formats/configobj/generate.py
@@ -1,7 +1,10 @@
 import json
+import os
 import sys
 from configobj import ConfigObj
 
 config = ConfigObj(interpolation=False, encoding="UTF8")
-config.update(json.load(sys.stdin))
+with open(os.environ["NIX_ATTRS_JSON_FILE"]) as f:
+    value = json.load(f).get("value")
+config.update(value)
 config.write(sys.stdout.buffer)

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -142,6 +142,14 @@ runBuildTests {
     '';
   };
 
+  jsonNull = shouldPass {
+    format = formats.json { };
+    input = null;
+    expected = ''
+      null
+    '';
+  };
+
   yaml_1_1Atoms = shouldPass {
     format = formats.yaml_1_1 { };
     input = {
@@ -176,6 +184,15 @@ runBuildTests {
     '';
   };
 
+  yaml_1_1Null = shouldPass {
+    format = formats.yaml_1_1 { };
+    input = null;
+    expected = ''
+      null
+      ...
+    '';
+  };
+
   yaml_1_2Atoms = shouldPass {
     format = formats.yaml_1_2 { };
     input = {
@@ -207,6 +224,16 @@ runBuildTests {
       str: foo
       time: 22:30:00
       'true': true
+    '';
+  };
+
+  yaml_1_2Null = shouldPass {
+    format = formats.yaml_1_2 { };
+    input = null;
+    # nixfmt insists on removing indentation, so force it with ${"  "}
+    expected = ''
+
+      ${"  "}null
     '';
   };
 
@@ -879,6 +906,14 @@ runBuildTests {
     '';
   };
 
+  cdnNull = shouldPass {
+    format = formats.cdn { };
+    input = null;
+    expected = ''
+      null: null
+    '';
+  };
+
   # This test is responsible for
   #   1. testing type coercions
   #   2. providing a more readable example test
@@ -989,6 +1024,14 @@ runBuildTests {
     '';
   };
 
+  luaNull = shouldPass {
+    format = formats.lua { };
+    input = null;
+    expected = ''
+      return nil
+    '';
+  };
+
   nixConfAtoms = shouldPass {
     format = formats.nixConf {
       package = pkgs.nix;
@@ -1012,6 +1055,15 @@ runBuildTests {
 
       ignore-try = false
     '';
+  };
+
+  nixConfNull = shouldFail {
+    format = formats.nixConf {
+      package = pkgs.nix;
+      version = pkgs.nix.version;
+      extraOptions = "ignore-try = false";
+    };
+    input = null;
   };
 
   phpAtoms = shouldPass rec {
@@ -1040,6 +1092,16 @@ runBuildTests {
       declare(strict_types=1);
       $config = ['attrs' => ['foo' => null], 'false' => false, 'float' => 3.141000, 'int' => 10, 'list' => [null, null], 'mixed' => [10, 3.141000, 'attrs' => ['foo' => null], 'str' => 'foo'], 'null' => null, 'raw' => random_function(), 'str' => 'foo', 'str_special' => 'foo
       testhello\'\'\'${"'"}, 'true' => true];
+    '';
+  };
+
+  phpNull = shouldPass {
+    format = formats.php { finalVariable = "config"; };
+    input = null;
+    expected = ''
+      <?php
+      declare(strict_types=1);
+      $config = null;
     '';
   };
 
@@ -1100,6 +1162,11 @@ runBuildTests {
     }
   );
 
+  pythonVarsNull = shouldFail {
+    format = formats.pythonVars { };
+    input = null;
+  };
+
   phpReturn = shouldPass {
     format = formats.php { };
     input = {
@@ -1143,6 +1210,11 @@ runBuildTests {
         <nulltest></nulltest>
       </root>
     '';
+  };
+
+  xmlNull = shouldFail {
+    format = formats.xml { };
+    input = null;
   };
 
   PlistGenerate = shouldPass {
@@ -1217,6 +1289,17 @@ runBuildTests {
       ''\t<key>true</key>
       ''\t<true/>
       </dict>
+      </plist>'';
+  };
+
+  PlistNull = shouldPass {
+    format = formats.plist { };
+    input = null;
+    expected = ''
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+
       </plist>'';
   };
 


### PR DESCRIPTION
This expands on https://github.com/NixOS/nixpkgs/pull/498928 that introduced __structuredAttrs here by actually using data in `.attrs.json` when it makes sense, instead of relying on environment variables.
Also add tests for null values for formats that support it and are tested.

This reverts commit bf6ada5d786e8aa4faff128e7e73a4792c2e99fe from https://github.com/NixOS/nixpkgs/pull/530238
This reapplies commit 691dc02df0111c320cd6697aacd4b113ba632e40 from https://github.com/NixOS/nixpkgs/pull/524404

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
