### PR TITLE
Reapply "pkgs-lib/formats: Use .attrs.json directly for TOML"

### DIFF
--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -477,14 +477,12 @@ optionalAttrs allowAliases aliases
           runCommand name
             {
               nativeBuildInputs = [ json2x ];
-              value = builtins.toJSON value;
+              inherit value;
               preferLocalBuild = true;
               __structuredAttrs = true;
             }
             ''
-              valuePath="$TMPDIR/value"
-              printf "%s" "$value" > "$valuePath"
-              json2x toml "$valuePath" "$out"
+              json2x toml --unwrap value "$NIX_ATTRS_JSON_FILE" "$out"
             ''
         ) { };
 

--- a/pkgs/pkgs-lib/formats/json2x/src/main.rs
+++ b/pkgs/pkgs-lib/formats/json2x/src/main.rs
@@ -10,6 +10,9 @@ use argh::{FromArgValue, FromArgs};
 /// Convert a JSON file to another format
 #[derive(FromArgs)]
 struct Args {
+    /// convert only value of this attribute
+    #[argh(option)]
+    unwrap: Option<String>,
     /// format of the output file, possible values: toml
     #[argh(positional)]
     format: Format,
@@ -29,16 +32,27 @@ enum Format {
 fn main() -> anyhow::Result<()> {
     let args: Args = argh::from_env();
 
-    let input = read_to_string(&args.input)
+    let json_text = read_to_string(&args.input)
         .with_context(|| format!("failed to read {}", args.input.display()))?;
-    let input: serde_json::Value = serde_json::from_str(&input)
+    let parsed_json: serde_json::Value = serde_json::from_str(&json_text)
         .with_context(|| format!("failed to parse {}", args.input.display()))?;
+    let output_value = if let Some(unwrap_key) = args.unwrap {
+        parsed_json
+            .as_object()
+            .ok_or_else(|| anyhow::anyhow!("{} does not contain an object", args.input.display()))?
+            .get(&unwrap_key)
+            // The key is missing from structured attrs when the value is null, treat missing value as Value::Null.
+            .unwrap_or(&serde_json::Value::Null)
+    } else {
+        &parsed_json
+    };
     let mut output = File::create(&args.output)
         .with_context(|| format!("failed to create {}", args.output.display()))?;
 
     match args.format {
         Format::Toml => {
-            let content = toml::to_string(&input).context("failed to serialize value to toml")?;
+            let content =
+                toml::to_string(output_value).context("failed to serialize value to toml")?;
             output
                 .write_all(content.as_bytes())
                 .with_context(|| format!("failed to write to {}", args.output.display()))?;

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -845,6 +845,11 @@ runBuildTests {
     '';
   };
 
+  tomlNull = shouldFail {
+    format = formats.toml { };
+    input = null;
+  };
+
   cdnAtoms = shouldPass {
     format = formats.cdn { };
     input = {


### PR DESCRIPTION
This reverts https://github.com/NixOS/nixpkgs/pull/530338 that reverted https://github.com/NixOS/nixpkgs/pull/528060 in haste since TOML cannot serialize null value anyway.
Rearrange `json2x` to default to null if value is missing, making it produce the same error as before for null values.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
