### PR TITLE
van: init at 0.8.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9821,6 +9821,12 @@
     githubId = 67984144;
     name = "Gerhard Schwanzer";
   };
+  germanphoneguy = {
+    email = "germanTECH@web.de";
+    github = "germanphoneguy";
+    githubId = 249116663;
+    name = "germanphoneguy";
+  };
   gernotfeichter = {
     email = "gernotfeichter@gmail.com";
     github = "gernotfeichter";

--- a/pkgs/by-name/va/van/package.nix
+++ b/pkgs/by-name/va/van/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  openssl,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "van";
+  version = "0.8.5";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "germanphoneguy";
+    repo = "van";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-xguz5jS4uln4BMKSgQMHKztSKpyNoMQqL+psDPPJO60=";
+  };
+
+  cargoHash = "sha256-KaMr6LEZMBZM2dFydW63ubd3ZqN+/SK+p56LeKXELPA=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ];
+
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  meta = {
+    description = "Simple rust code editor with advanced vim-like features";
+    homepage = "https://github.com/germanphoneguy/van";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ germanphoneguy ];
+    mainProgram = "van";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
