### PR TITLE
zxing-cpp: 2.3.0 -> 3.0.2

### DIFF
--- a/pkgs/by-name/pa/paperless-ngx/package.nix
+++ b/pkgs/by-name/pa/paperless-ngx/package.nix
@@ -122,6 +122,7 @@ pythonPackages.buildPythonApplication (finalAttrs: {
     "scikit-learn"
     "tika-client"
     "tqdm"
+    "zxing-cpp"
     # requested by maintainer
     "imap-tools"
     "ocrmypdf"

--- a/pkgs/by-name/zx/zxing-cpp/package.nix
+++ b/pkgs/by-name/zx/zxing-cpp/package.nix
@@ -6,25 +6,31 @@
   python3,
   stdenv,
   libzint,
+  pkg-config,
+  stb,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "zxing-cpp";
-  version = "2.3.0";
+  version = "3.0.2";
 
   src = fetchFromGitHub {
     owner = "zxing-cpp";
     repo = "zxing-cpp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-e3nSxjg8p+1DEUbZOh4C2zfnA6iGhNJMPiIe2oJEbRo=";
+    hash = "sha256-ZtjvHBnuPJkc9kU998jH7IPlX3jF/RGtLNWDzsb0v4A=";
   };
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     cmake
+    pkg-config
   ];
 
   buildInputs = [
     libzint
+    stb
   ];
 
   cmakeFlags = [

--- a/pkgs/by-name/zx/zxing-cpp/package.nix
+++ b/pkgs/by-name/zx/zxing-cpp/package.nix
@@ -57,7 +57,10 @@ stdenv.mkDerivation (finalAttrs: {
       formats.
     '';
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ lukegb ];
+    maintainers = with lib.maintainers; [
+      lukegb
+      qweered
+    ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/development/python-modules/zxing-cpp/default.nix
+++ b/pkgs/development/python-modules/zxing-cpp/default.nix
@@ -6,16 +6,17 @@
   pillow,
   pybind11,
   libzxing-cpp,
+  pyprojectVersionPatchHook,
   pytestCheckHook,
   libzint,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "zxing-cpp";
-  inherit (libzxing-cpp) src version meta;
+  inherit (libzxing-cpp) src version;
   pyproject = true;
 
-  sourceRoot = "${src.name}/wrappers/python";
+  sourceRoot = "${libzxing-cpp.src.name}/wrappers/python";
 
   # we don't need pybind11 in the root environment
   # https://pybind11.readthedocs.io/en/stable/installing.html#include-with-pypi
@@ -25,7 +26,7 @@ buildPythonPackage rec {
 
     substituteInPlace setup.py \
       --replace-fail "cfg = 'Debug' if self.debug else 'Release'" "cfg = 'Release'" \
-      --replace-fail " '-DVERSION_INFO=' + self.distribution.get_version()]" " '-DVERSION_INFO=' + self.distribution.get_version(), '-DZXING_DEPENDENCIES=LOCAL', '-DZXING_USE_BUNDLED_ZINT=OFF']"
+      --replace-fail "f'-DPython_EXECUTABLE={sys.executable}'," "f'-DPython_EXECUTABLE={sys.executable}', '-DZXING_DEPENDENCIES=LOCAL', '-DZXING_USE_BUNDLED_ZINT=OFF',"
   '';
 
   dontUseCmakeConfigure = true;
@@ -39,6 +40,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     cmake
+    pyprojectVersionPatchHook
   ];
 
   buildInputs = [ libzint ];
@@ -51,4 +53,16 @@ buildPythonPackage rec {
   enabledTestPaths = [ "test.py" ];
 
   pythonImportsCheck = [ "zxingcpp" ];
+
+  meta = {
+    inherit (libzxing-cpp.meta)
+      homepage
+      changelog
+      description
+      longDescription
+      license
+      maintainers
+      platforms
+      ;
+  };
 }


### PR DESCRIPTION
Supercedes and closes #500446 (mine pr have strictDeps and correct buildInputs)
Closes #408656

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
