### PR TITLE
genimage: 19 -> 20

### DIFF
--- a/pkgs/by-name/ge/genimage/package.nix
+++ b/pkgs/by-name/ge/genimage/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   autoreconfHook,
   pkg-config,
   libconfuse,
@@ -10,11 +10,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "genimage";
-  version = "19";
+  version = "20";
 
-  src = fetchurl {
-    url = "https://public.pengutronix.de/software/genimage/genimage-${finalAttrs.version}.tar.xz";
-    sha256 = "sha256-fsT8uGVmKosv8gKEgZBE/6hBN788oW+3SXASkbwB8Qg=";
+  src = fetchFromGitHub {
+    owner = "pengutronix";
+    repo = "genimage";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6pKqvpoEQWebubl6K5FzEAv2aUsBXgOBEAdcCwARkrU=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Change the source from a tarball to fetchFromGitHub because version 20 is only available on the official GitHub repository.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
