### PR TITLE
ci: nudge and draft stale merge-conflicted PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,7 @@ jobs:
               'ci/github-script/prepare.js',
               'ci/github-script/reviewers.js',
               'ci/github-script/reviews.js',
+              'ci/github-script/stale-conflict.js',
               'ci/github-script/supportedSystems.js',
               'ci/github-script/withRateLimit.js',
               'ci/pinned.json',

--- a/ci/github-script/bot.js
+++ b/ci/github-script/bot.js
@@ -6,6 +6,7 @@ module.exports = async ({ github, context, core, dry }) => {
   const { classify } = require('../supportedBranches.js')
   const { handleMerge } = require('./merge.js')
   const { handleReviewers } = require('./reviewers.js')
+  const { handleStaleConflict } = require('./stale-conflict.js')
 
   const artifactClient = new DefaultArtifactClient()
 
@@ -566,30 +567,35 @@ module.exports = async ({ github, context, core, dry }) => {
 
       const latest_event_at = new Date(
         events
-          .filter(({ event }) =>
-            [
-              // These events are hand-picked from:
-              //   https://docs.github.com/en/rest/using-the-rest-api/issue-event-types?apiVersion=2022-11-28
-              // Each of those causes a PR/issue to *not* be considered as stale anymore.
-              // Most of these use created_at.
-              'assigned',
-              'commented', // uses updated_at, because that could be > created_at
-              'committed', // uses committer.date
-              ...(item.labels.some(({ name }) => name === '5.scope: tracking')
-                ? ['cross-referenced']
-                : []),
-              'head_ref_force_pushed',
-              'milestoned',
-              'pinned',
-              'ready_for_review',
-              'renamed',
-              'reopened',
-              'review_dismissed',
-              'review_requested',
-              'reviewed', // uses submitted_at
-              'unlocked',
-              'unmarked_as_duplicate',
-            ].includes(event),
+          .filter(
+            ({ event, user }) =>
+              [
+                // These events are hand-picked from:
+                //   https://docs.github.com/en/rest/using-the-rest-api/issue-event-types?apiVersion=2022-11-28
+                // Each of those causes a PR/issue to *not* be considered as stale anymore.
+                // Most of these use created_at.
+                'assigned',
+                'commented', // uses updated_at, because that could be > created_at
+                'committed', // uses committer.date
+                ...(item.labels.some(({ name }) => name === '5.scope: tracking')
+                  ? ['cross-referenced']
+                  : []),
+                'head_ref_force_pushed',
+                'milestoned',
+                'pinned',
+                'ready_for_review',
+                'renamed',
+                'reopened',
+                'review_dismissed',
+                'review_requested',
+                'reviewed', // uses submitted_at
+                'unlocked',
+                'unmarked_as_duplicate',
+              ].includes(event) &&
+              // The bot's own comments (e.g. the stale merge-conflict nudge)
+              // must not reset the timer, or a nudged PR would never stay stale
+              // long enough to be drafted.
+              !(event === 'commented' && user?.login === 'nixpkgs-ci[bot]'),
           )
           .map(
             ({ created_at, updated_at, committer, submitted_at }) =>
@@ -617,6 +623,17 @@ module.exports = async ({ github, context, core, dry }) => {
             itemLabels,
             await handlePullRequest({ item, stats, events }),
           )
+        } else {
+          // Stale PRs skip the labeling above, but those stuck on a merge
+          // conflict get nudged and eventually drafted.
+          await handleStaleConflict({
+            github,
+            context,
+            log,
+            dry,
+            item,
+            events,
+          })
         }
       } else {
         stats.issues++

--- a/ci/github-script/stale-conflict.js
+++ b/ci/github-script/stale-conflict.js
@@ -1,0 +1,126 @@
+// Two-step handling of stale PRs stuck on a merge conflict:
+//   1. Once the merge-conflict label has been present for > MERGE_CONFLICT_DAYS,
+//      post a single comment nudging the author to rebase.
+//   2. If that nudge is older than NUDGE_TO_DRAFT_DAYS, convert the PR to a draft.
+// Step 2 can only run after step 1, because its timer starts at the nudge.
+
+const MERGE_CONFLICT_DAYS = 30 // conflicted this long before nudging (~1 month)
+const NUDGE_TO_DRAFT_DAYS = 15 // nudge this old before drafting (~2 weeks)
+const DAY_MS = 24 * 60 * 60 * 1000
+const MERGE_CONFLICT_LABEL = '2.status: merge conflict'
+// Hidden marker to recognise our own nudge on later runs (cf. merge.js).
+const NUDGE_MARKER = '<!-- nixpkgs-ci: stale-merge-conflict-nudge -->'
+
+// Date since when the merge-conflict label has been continuously present, or
+// null if it isn't currently set / can't be determined from the timeline.
+function mergeConflictSince(events) {
+  let since = null
+  for (const { event, label, created_at } of [...events].sort(
+    (a, b) => new Date(a.created_at) - new Date(b.created_at),
+  )) {
+    if (label?.name !== MERGE_CONFLICT_LABEL) continue
+    if (event === 'labeled') since = new Date(created_at)
+    else if (event === 'unlabeled') since = null
+  }
+  return since
+}
+
+async function handleStaleConflict({
+  github,
+  context,
+  log,
+  dry,
+  item,
+  events,
+}) {
+  // Only PRs can be merge-conflicted or drafted. Staleness is the caller's job.
+  if (!(item.pull_request || context.payload.pull_request)) return
+  if (!item.labels.some(({ name }) => name === MERGE_CONFLICT_LABEL)) return
+  // Don't nudge or draft PRs the author has already parked as a draft.
+  if (item.draft) return log('stale-conflict', 'already a draft', true)
+
+  const conflict_since = mergeConflictSince(events)
+  // Conservative: don't act if we can't prove how long the conflict has lasted.
+  if (!conflict_since)
+    return log('stale-conflict', 'merge conflict duration unknown', true)
+
+  const conflict_age_days = (Date.now() - conflict_since) / DAY_MS
+  log('stale-conflict - conflicted for (days)', conflict_age_days.toFixed(1))
+  if (conflict_age_days < MERGE_CONFLICT_DAYS)
+    return log('stale-conflict', 'merge conflict too recent', true)
+
+  const nudge = events.find(
+    ({ event, body }) => event === 'commented' && body?.includes(NUDGE_MARKER),
+  )
+
+  if (!nudge) {
+    const body = [
+      NUDGE_MARKER,
+      `@${item.user?.login} This pull request is marked as stale and has had a merge conflict with its target branch for over a month.`,
+      '',
+      'To get it moving again:',
+      '',
+      '- Rebase it against the target branch and resolve the merge conflict. See [How to create pull requests](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#how-to-create-pull-requests) part 7.',
+      '- If the PR is ready but has not been reviewed, see [I opened a PR, how do I get it merged?](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#i-opened-a-pr-how-do-i-get-it-merged).',
+      '',
+      `If no action is taken, this pull request will be automatically marked as a draft in ${NUDGE_TO_DRAFT_DAYS} days. You can un-draft at any time, once you believe the PR is ready to be merged.`,
+    ].join('\n')
+
+    if (dry) return log('stale-conflict', 'would post rebase nudge (dry)')
+    await github.rest.issues.createComment({
+      ...context.repo,
+      issue_number: item.number,
+      body,
+    })
+    return log('stale-conflict', 'posted rebase nudge')
+  }
+
+  const nudged_at = new Date(nudge.created_at)
+
+  // Already drafted after the nudge: nothing left to do.
+  if (
+    events.some(
+      ({ event, created_at }) =>
+        event === 'convert_to_draft' && new Date(created_at) > nudged_at,
+    )
+  )
+    return log('stale-conflict', 'already converted to draft after nudge', true)
+
+  if ((Date.now() - nudged_at) / DAY_MS < NUDGE_TO_DRAFT_DAYS)
+    return log('stale-conflict', 'grace period after nudge not over yet', true)
+
+  if (dry) return log('stale-conflict', 'would convert to draft (dry)')
+
+  try {
+    await github.graphql(
+      `mutation($id: ID!) {
+        convertPullRequestToDraft(input: { pullRequestId: $id }) {
+          clientMutationId
+        }
+      }`,
+      { id: item.node_id },
+    )
+  } catch (e) {
+    // Don't fail the whole bot run over a single PR (e.g. already a draft).
+    return log(
+      'stale-conflict',
+      `convert to draft failed: ${e.message ?? e}`,
+      true,
+    )
+  }
+
+  await github.rest.issues.createComment({
+    ...context.repo,
+    issue_number: item.number,
+    body: [
+      'This pull request has been marked as a draft because the merge conflict was not resolved after the previous reminder.',
+      '',
+      'You can un-draft at any time, once you believe the PR is ready to be merged.',
+    ].join('\n'),
+  })
+  log('stale-conflict', 'converted to draft')
+}
+
+module.exports = {
+  handleStaleConflict,
+}


### PR DESCRIPTION
Stale PRs that have carried the merge-conflict label for over a month now get a single comment asking the author to rebase and pointing to review/help resources. If nothing happens within 15 days of that comment, the bot converts the PR to a draft.

The conversion strictly follows the comment: its timer starts at the bot's own nudge, so a PR is always warned first. To make this possible, the bot's own comments no longer reset the staleness timer.

Assisted-by: claude-code with claude-opus-4-8[1m]-high

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
