### PR TITLE
busybox: fix tests

### DIFF
--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -225,13 +225,6 @@ stdenv.mkDerivation (finalAttrs: {
       ];
 
       preCheck = ''
-        # Replace hard-coded dependencies on /bin
-        sed -i 's|/bin/date|${lib.getExe' coreutils "date"}|' testsuite/date/date-works-1
-
-        # wget tests rely on network access, use simple-http-server instead
-        simple-http-server --index &
-        sed -i 's|http://www.google.com|http://127.0.0.1:8000|' testsuite/wget/*
-
         skip-files() {
           for file in "$@"; do
             echo "echo SKIPPED $file; exit 0" > $file
@@ -251,6 +244,13 @@ stdenv.mkDerivation (finalAttrs: {
         # Fix/skip tests
 
         pushd testsuite
+
+        # Replace hard-coded dependencies on /bin
+        sed -i 's|/bin/date|${lib.getExe' coreutils "date"}|' date/date-works-1
+
+        # wget tests rely on network access, use simple-http-server instead
+        simple-http-server --index &
+        sed -i 's|http://www.google.com|http://127.0.0.1:8000|' wget/*
 
         # /usr/bin doesn't exist in the sandbox, so use /nix/store instead
         sed -i "s|/usr/bin|/nix/store|" cpio.tests

--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -20,6 +20,8 @@
   zip,
   which,
   simple-http-server,
+  fakeroot,
+  writeShellScriptBin,
 }:
 
 assert stdenv.hostPlatform.libc == "musl" -> useMusl;
@@ -60,6 +62,11 @@ let
 
   pname = "busybox";
   version = "1.37.0";
+
+  # To use as an alternative for /bin/false in the testsuite
+  falseAlt = writeShellScriptBin "false-alt" ''
+    exit 1
+  '';
 in
 
 stdenv.mkDerivation (finalAttrs: {
@@ -214,6 +221,7 @@ stdenv.mkDerivation (finalAttrs: {
         zip
         which
         simple-http-server
+        fakeroot
       ];
 
       preCheck = ''
@@ -240,28 +248,32 @@ stdenv.mkDerivation (finalAttrs: {
         # There are some semi-expected locale-related issues, disable tests that rely on it
         export CONFIG_UNICODE_USING_LOCALE=y
 
-        # DISABLE SOME TESTS
-        # TODO(balsoft): fix the tests instead of skipping
+        # Fix/skip tests
 
         pushd testsuite
 
-        # Weird failures, may or may not be related to locales
-        skip-files du/du-{h,k,l}-works
+        # /usr/bin doesn't exist in the sandbox, so use /nix/store instead
+        sed -i "s|/usr/bin|/nix/store|" cpio.tests
+        sed -i "s/usr/nix/g" cpio.tests
+
+        # Run only the cpio metadata testcase under fakeroot so the test can create and observe setuid/setgid bits on the sandbox
+        mv cpio.tests cpio.tests.orig
+        cat > cpio.tests <<'EOF'
+        #!${stdenv.shell}
+        fakeroot cpio.tests.orig -- "$@"
+        EOF
+        chmod +x cpio.tests
 
         # Relies on a default PATH (/bin/ls in particular)
         skip-files which/which-uses-default-path
 
-        # Hangs indefinitely if run from sandbox
-        skip-files md5sum.tests
+        # busybox 'yes' is not compatible with the SIGPIPE behavior of the sandbox, which causes the test to hang
+        # Use coreutils 'yes' instead
+        sed -i 's|yes "$text"|${lib.getExe' coreutils "yes"} "$text"|' md5sum.tests
 
-        # Doesn't work with coreutils's "false"
-        skip-testcase start-stop-daemon.tests "start-stop-daemon with both -x and -a"
-
-        # Relies on /usr/bin
-        skip-testcase cpio.tests "cpio -p with absolute paths"
-
-        # Relies on suid/guid bits
-        skip-testcase cpio.tests "cpio restores suid/sgid bits"
+        # start-stop-daemon test with '-a' option doesn't work with a multicall binary such as busybox, coreutils, ...
+        # Use a custom script that exits with 1 instead
+        sed -i 's|/bin/false|${lib.getExe' falseAlt "false-alt"}|' start-stop-daemon.tests
 
         # Weird failures, looks related to our sandbox
         skip-testcase tar.tests "tar does not extract into symlinks"


### PR DESCRIPTION
This PR fixes and enables previously disabled tests (#529790).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
