### PR TITLE
c3nav: init at 39c3; nixos/c3nav: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1626,6 +1626,7 @@
   ./services/web-apps/bluesky-pds.nix
   ./services/web-apps/bookstack.nix
   ./services/web-apps/c2fmzq-server.nix
+  ./services/web-apps/c3nav.nix
   ./services/web-apps/calibre-web.nix
   ./services/web-apps/castopod.nix
   ./services/web-apps/changedetection-io.nix

--- a/nixos/modules/services/web-apps/c3nav.nix
+++ b/nixos/modules/services/web-apps/c3nav.nix
@@ -1,0 +1,486 @@
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
+
+let
+  cfg = config.services.c3nav;
+  format = pkgs.formats.ini { };
+
+  configFile = format.generate "c3nav.cfg" cfg.settings;
+
+  pythonEnv = cfg.package.pythonPackages.python.buildEnv.override {
+    extraLibs = with cfg.package.pythonPackages; [
+      (toPythonModule cfg.package)
+      gunicorn
+    ];
+  };
+
+  commonEnvironment = {
+    C3NAV_CONFIG = configFile;
+    C3NAV_DATA_DIR = cfg.settings.filesystem.data;
+    C3NAV_VERSION = cfg.package.version;
+  };
+
+  c3navManageWrapper = pkgs.writeShellApplication {
+    name = "c3nav-manage";
+    runtimeInputs = with pkgs; [
+      util-linux
+    ];
+    text = ''
+      cd ${cfg.settings.filesystem.data}
+      set -a
+      ${lib.concatMapStringsSep "\n" (file: ''
+        . ${lib.escapeShellArg file}
+      '') cfg.environmentFiles}
+      set +a
+      ${lib.concatMapAttrsStringSep "\n" (n: v: "export ${n}=${v}") commonEnvironment}
+      exec runuser ${
+        lib.cli.toCommandLineShellGNU { } {
+          inherit (cfg) user;
+          preserve-environment = true;
+        }
+      } -- ${lib.getExe' pythonEnv "c3nav-manage"} "$@"
+    '';
+    excludeShellChecks = [
+      # Not following: /run/agenix/c3nav-env was not specified as input
+      "SC1091"
+    ];
+  };
+in
+
+{
+  meta.maintainers = pkgs.c3nav.meta.maintainers;
+
+  options.services.c3nav = {
+    enable = lib.mkEnableOption "c3nav";
+
+    package = lib.mkPackageOption pkgs "c3nav" { };
+
+    environmentFiles = lib.mkOption {
+      description = ''
+        Environment files that allow passing secret configuration values.
+
+        Each line must follow the `C3NAV_SECTION_KEY=value` pattern.
+      '';
+      type = lib.types.listOf lib.types.path;
+      default = [ ];
+      example = [ "/run/secrets/c3nav/env" ];
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "c3nav";
+      description = "Group under which c3nav should run.";
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "c3nav";
+      description = "User under which c3nav should run.";
+    };
+
+    gunicorn.extraArgs = lib.mkOption {
+      type = with lib.types; listOf str;
+      default = [
+        "--name=c3nav"
+      ];
+      example = [
+        "--name=c3nav"
+        "--workers=4"
+        "--max-requests=1200"
+        "--max-requests-jitter=50"
+        "--log-level=info"
+      ];
+      description = ''
+        Extra arguments to pass to gunicorn.
+      '';
+      apply = lib.escapeShellArgs;
+    };
+
+    celery = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        example = false;
+        description = ''
+          Whether to set up celery as an asynchronous task runner.
+        '';
+      };
+
+      extraArgs = lib.mkOption {
+        type = with lib.types; listOf str;
+        default = [ ];
+        description = ''
+          Extra arguments to pass to celery.
+
+          See <https://docs.celeryq.dev/en/stable/reference/cli.html#celery-worker> for more info.
+        '';
+        apply = utils.escapeSystemdExecArgs;
+      };
+    };
+
+    nginx = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        example = false;
+        description = ''
+          Whether to set up an nginx virtual host.
+        '';
+      };
+
+      domain = lib.mkOption {
+        type = lib.types.str;
+        example = "maps.example.com";
+        description = ''
+          The domain name under which to set up the virtual host.
+        '';
+      };
+    };
+
+    database.createLocally = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      example = false;
+      description = ''
+        Whether to automatically set up the database on the local DBMS instance.
+
+        Currently only supported for PostgreSQL. Not required for sqlite.
+      '';
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = format.type;
+        options = {
+          database = {
+            backend = lib.mkOption {
+              type = lib.types.enum [
+                "postgresql"
+              ];
+              default = "postgresql";
+              description = ''
+                Database backend to use.
+
+                Currently only PostgreSQL gets tested, and as such we don't support any other Database.
+              '';
+              readOnly = true; # only postgres supported right now
+            };
+
+            host = lib.mkOption {
+              type = with lib.types; nullOr types.path;
+              default = if cfg.settings.database.backend == "postgresql" then "/run/postgresql" else null;
+              defaultText = lib.literalExpression ''
+                if config.services.c3nav.settings..database.backend == "postgresql" then "/run/postgresql"
+                else null
+              '';
+              description = ''
+                Database host or socket path.
+              '';
+            };
+
+            name = lib.mkOption {
+              type = lib.types.str;
+              default = "c3nav";
+              description = ''
+                Database name.
+              '';
+            };
+
+            user = lib.mkOption {
+              type = lib.types.str;
+              default = "c3nav";
+              description = ''
+                Database username.
+              '';
+            };
+          };
+
+          files = {
+            upload_limit = lib.mkOption {
+              type = lib.types.ints.positive;
+              default = 10;
+              example = 50;
+              description = ''
+                Maximum file upload size in MiB.
+              '';
+            };
+          };
+
+          filesystem = {
+            data = lib.mkOption {
+              type = lib.types.path;
+              default = "/var/lib/c3nav";
+              description = ''
+                Base path for all other storage paths.
+              '';
+            };
+            logs = lib.mkOption {
+              type = lib.types.path;
+              default = "/var/log/c3nav";
+              description = ''
+                Path to the log directory, that c3nav logs message to.
+              '';
+            };
+            static = lib.mkOption {
+              type = lib.types.path;
+              default = "${cfg.package}/${cfg.package.pythonPackages.python.sitePackages}/c3nav/static.dist/";
+              defaultText = "\${config.services.c3nav.package}/\${config.services.c3nav.package.pythonPackages.python.sitePackages}/c3nav/static.dist/";
+              readOnly = true;
+              description = ''
+                Path to the directory that contains static files.
+              '';
+            };
+          };
+
+          celery = {
+            backend = lib.mkOption {
+              type = with lib.types; nullOr str;
+              default = lib.optionalString cfg.celery.enable "redis+socket://${config.services.redis.servers.c3nav.unixSocket}?virtual_host=1";
+              defaultText = lib.literalExpression ''
+                optionalString config.services.c3nav.celery.enable "redis+socket://''${config.services.redis.servers.c3nav.unixSocket}?virtual_host=1"
+              '';
+              description = ''
+                URI to the celery backend used for the asynchronous job queue.
+              '';
+            };
+
+            broker = lib.mkOption {
+              type = with lib.types; nullOr str;
+              default = lib.optionalString cfg.celery.enable "redis+socket://${config.services.redis.servers.c3nav.unixSocket}?virtual_host=2";
+              defaultText = lib.literalExpression ''
+                optionalString config.services.c3nav.celery.enable "redis+socket://''${config.services.redis.servers.c3nav.unixSocket}?virtual_host=2"
+              '';
+              description = ''
+                URI to the celery broker used for the asynchronous job queue.
+              '';
+            };
+          };
+
+          redis = {
+            location = lib.mkOption {
+              type = with lib.types; nullOr str;
+              default = "unix://${config.services.redis.servers.c3nav.unixSocket}?db=0";
+              defaultText = lib.literalExpression ''
+                "unix://''${config.services.redis.servers.c3nav.unixSocket}?db=0"
+              '';
+              description = ''
+                URI to the redis server, used to speed up locking, caching and session storage.
+              '';
+            };
+
+            session = lib.mkOption {
+              type = lib.types.bool;
+              default = true;
+              example = false;
+              description = ''
+                Whether to use redis as the session storage.
+              '';
+            };
+          };
+
+          site = {
+            url = lib.mkOption {
+              type = lib.types.str;
+              default = "https://${cfg.nginx.domain}";
+              defaultText = lib.literalExpression "https://\${config.services.c3nav.nginx.domain}";
+              example = "https://talks.example.com";
+              description = ''
+                The base URI below which your c3nav instance will be reachable.
+              '';
+            };
+          };
+        };
+      };
+      default = { };
+      description = ''
+        C3nav configuration as a Nix attribute set. All settings can also be passed
+        from the environment.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      c3navManageWrapper
+    ];
+
+    services.logrotate.settings.c3nav = {
+      files = "${cfg.settings.filesystem.logs}/*.log";
+      su = "${cfg.user} ${cfg.group}";
+      frequency = "weekly";
+      rotate = "12";
+      copytruncate = true;
+      compress = true;
+    };
+
+    services = {
+      nginx = lib.mkIf cfg.nginx.enable {
+        enable = true;
+        recommendedGzipSettings = lib.mkDefault true;
+        recommendedOptimisation = lib.mkDefault true;
+        recommendedProxySettings = lib.mkDefault true;
+        recommendedTlsSettings = lib.mkDefault true;
+        upstreams.c3nav.servers."unix:/run/c3nav/c3nav.sock" = { };
+        virtualHosts.${cfg.nginx.domain} = {
+          extraConfig = ''
+            more_set_headers "Referrer-Policy: same-origin";
+            more_set_headers "X-Content-Type-Options: nosniff";
+          '';
+          locations = {
+            "/".proxyPass = "http://c3nav";
+            "/static/" = {
+              alias = cfg.settings.filesystem.static;
+              extraConfig = ''
+                access_log off;
+                more_set_headers Cache-Control "public";
+                expires 365d;
+              '';
+            };
+          };
+        };
+      };
+
+      postgresql =
+        lib.mkIf (cfg.database.createLocally && cfg.settings.database.backend == "postgresql")
+          {
+            enable = true;
+            ensureUsers = [
+              {
+                name = cfg.settings.database.user;
+                ensureDBOwnership = true;
+              }
+            ];
+            ensureDatabases = [ cfg.settings.database.name ];
+          };
+
+      redis.servers.c3nav.enable = true;
+    };
+
+    systemd.services =
+      let
+        commonUnitConfig = {
+          environment = commonEnvironment;
+          serviceConfig = {
+            User = "c3nav";
+            Group = "c3nav";
+            EnvironmentFile = cfg.environmentFiles;
+            StateDirectory = [ "c3nav" ];
+            StateDirectoryMode = "0750";
+            LogsDirectory = "c3nav";
+            WorkingDirectory = cfg.settings.filesystem.data;
+            SupplementaryGroups = [ "redis-c3nav" ];
+            AmbientCapabilities = "";
+            CapabilityBoundingSet = [ "" ];
+            DevicePolicy = "closed";
+            LockPersonality = true;
+            MemoryDenyWriteExecute = true;
+            NoNewPrivileges = true;
+            PrivateDevices = true;
+            PrivateTmp = true;
+            ProcSubset = "pid";
+            ProtectControlGroups = true;
+            ProtectHome = true;
+            ProtectHostname = true;
+            ProtectKernelLogs = true;
+            ProtectKernelModules = true;
+            ProtectKernelTunables = true;
+            ProtectProc = "invisible";
+            ProtectSystem = "strict";
+            RemoveIPC = true;
+            RestrictAddressFamilies = [
+              "AF_INET"
+              "AF_INET6"
+              "AF_UNIX"
+            ];
+            RestrictNamespaces = true;
+            RestrictRealtime = true;
+            RestrictSUIDSGID = true;
+            SystemCallArchitectures = "native";
+            SystemCallFilter = [
+              "@system-service"
+              "~@privileged"
+              "@chown"
+            ];
+            UMask = "0027";
+          };
+        };
+      in
+      {
+        c3nav-web = lib.recursiveUpdate commonUnitConfig {
+          description = "c3nav web service";
+          after = [
+            "network.target"
+            "redis-c3nav.service"
+          ]
+          ++ lib.optionals (cfg.settings.database.backend == "postgresql") [
+            "postgresql.target"
+          ];
+          wantedBy = [ "multi-user.target" ];
+          path = with pkgs; [ librsvg ];
+          preStart =
+            let
+              versionString = "c3nav-${cfg.package.version}";
+            in
+            ''
+              versionFile="${cfg.settings.filesystem.data}/.version"
+              version="$(cat "$versionFile" 2>/dev/null || echo 0)"
+
+              if [[ "$version" != "${versionString}" ]]; then
+                ${lib.getExe' pythonEnv "c3nav-manage"} migrate
+
+                echo "${versionString}" > "$versionFile"
+              fi
+            '';
+          serviceConfig = {
+            ExecStart = "${lib.getExe' pythonEnv "gunicorn"} --bind unix:/run/c3nav/c3nav.sock ${cfg.gunicorn.extraArgs} c3nav.wsgi";
+            RuntimeDirectory = "c3nav";
+          };
+        };
+
+        c3nav-clear-sessions = lib.recursiveUpdate commonUnitConfig {
+          description = "c3nav session pruning";
+          startAt = [ "monthly" ];
+          serviceConfig = {
+            Type = "oneshot";
+            ExecStart = "${lib.getExe' pythonEnv "c3nav-manage"} clearsessions";
+          };
+        };
+
+        c3nav-worker = lib.mkIf cfg.celery.enable (
+          lib.recursiveUpdate commonUnitConfig {
+            description = "c3nav asynchronous job runner";
+            after = [
+              "network.target"
+              "redis-c3nav.service"
+            ]
+            ++ lib.optionals (cfg.settings.database.backend == "postgresql") [
+              "postgresql.target"
+            ];
+            wantedBy = [ "multi-user.target" ];
+            serviceConfig.ExecStart = "${lib.getExe' pythonEnv "celery"} -A c3nav.celery worker ${cfg.celery.extraArgs}";
+          }
+        );
+
+        nginx.serviceConfig.SupplementaryGroups = lib.mkIf cfg.nginx.enable [ "c3nav" ];
+      };
+
+    systemd.sockets.c3nav-web.socketConfig = {
+      ListenStream = "/run/c3nav/c3nav.sock";
+      SocketUser = "nginx";
+    };
+
+    users = {
+      groups.${cfg.group} = { };
+      users.${cfg.user} = {
+        extraGroups = [ config.services.redis.servers.c3nav.group ];
+        isSystemUser = true;
+        inherit (cfg) group;
+      };
+    };
+  };
+}

--- a/pkgs/by-name/c3/c3nav/fix-read-only-assignment.diff
+++ b/pkgs/by-name/c3/c3nav/fix-read-only-assignment.diff
@@ -1,0 +1,12 @@
+diff --git a/src/c3nav/mapdata/utils/cache/maphistory.py b/src/c3nav/mapdata/utils/cache/maphistory.py
+index 94ba7b43..f80e0338 100644
+--- a/src/c3nav/mapdata/utils/cache/maphistory.py
++++ b/src/c3nav/mapdata/utils/cache/maphistory.py
+@@ -65,6 +65,7 @@ def simplify(self):
+         new_updates = ((i, update, (self.data == i)) for i, update in enumerate(self.updates))
+         new_updates, new_affected = zip(*((update, affected) for i, update, affected in new_updates
+                                           if i == 0 or affected.any()))
++        self.data = self.data.copy()
+         self.updates = list(new_updates)
+         for i, affected in enumerate(new_affected):
+             self.data[affected] = i

--- a/pkgs/by-name/c3/c3nav/package.nix
+++ b/pkgs/by-name/c3/c3nav/package.nix
@@ -1,0 +1,134 @@
+{
+  lib,
+  fetchFromGitHub,
+  gettext,
+  python3Packages,
+}:
+let
+  pythonPackages = python3Packages.overrideScope (
+    final: prev: {
+      django = prev.django_6;
+    }
+  );
+
+  dependencies = with pythonPackages; [
+    # https://github.com/c3nav/c3nav/blob/39c3/docker/Dockerfile#L77-L87
+    # src/requirements/production.txt
+    django
+    django-bootstrap3
+    django-compressor
+    django-cors-headers
+    csscompressor
+    django-ninja
+    pydantic-extra-types
+    types-shapely
+    django-pydantic-field
+    django-filter
+    django-environ
+    shapely
+    pybind11
+    meshpy
+    rtree
+    celery
+    requests
+    pillow
+    qrcode
+    matplotlib
+    scipy
+    django-libsass
+    channels
+    daphne
+    pyzstd
+    pyproj
+    # src/requirements/htmlmin.txt
+    django-htmlmin
+    # src/requirements/postgres.txt
+    psycopg2
+    # src/requirements/redis.txt
+    redis
+    hiredis
+    channels-redis
+    # src/requirements/memcached.txt
+    pylibmc
+    # src/requirements/rsvg-pygobject.txt
+    pygobject3
+    pycairo
+    # src/requirements/sentry.txt
+    sentry-sdk
+    # src/requirements/metrics.txt
+    django-prometheus
+    # src/requirements/uwu.txt
+    uwuipy
+    polib
+    # src/requirements/sso.txt
+    social-auth-app-django
+    social-auth-core
+    # src/requirements/server-asgi.txt
+    starlette
+    uvicorn
+    gunicorn
+  ];
+in
+pythonPackages.buildPythonApplication (finalAttrs: {
+  pname = "c3nav";
+  version = "39c3";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "c3nav";
+    repo = "c3nav";
+    tag = finalAttrs.version;
+    hash = "sha256-OOF635TkCUYsBQyfvo3twnyV25O3eyqs6Nd1mgSF1rg=";
+  };
+
+  patches = [
+    ./fix-read-only-assignment.diff
+  ];
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    gettext
+    (pythonPackages.python.withPackages (_: dependencies))
+  ];
+
+  inherit dependencies;
+
+  buildPhase = ''
+    pushd src
+    # https://github.com/c3nav/c3nav/blob/39c3/docker/Dockerfile#L112-L116
+    python manage.py makemessages --ignore "site-packages" -l en_UW
+    python genuwu.py
+    python manage.py compilemessages --ignore "site-packages"
+    popd
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/${pythonPackages.python.sitePackages}/
+    cp -r src/c3nav $out/${pythonPackages.python.sitePackages}/c3nav
+    cp src/manage.py $out/bin/c3nav-manage
+
+    pushd $out/${pythonPackages.python.sitePackages}/c3nav
+    PYTHONPATH=$PYTHONPATH:$PWD/.. python $out/bin/c3nav-manage collectstatic -l --no-input
+    PYTHONPATH=$PYTHONPATH:$PWD/.. python $out/bin/c3nav-manage compress
+    rm -r ../data
+    popd
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    inherit pythonPackages;
+  };
+
+  meta = {
+    description = "Indoor navigation for the Chaos Communication Congress and other events";
+    homepage = "https://c3nav.de/";
+    downloadPage = "https://github.com/c3nav/c3nav/";
+    license = lib.licenses.asl20;
+    mainProgram = "c3nav-manage";
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+  };
+})

--- a/pkgs/development/python-modules/django-htmlmin/default.nix
+++ b/pkgs/development/python-modules/django-htmlmin/default.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  argparse,
+  beautifulsoup4,
+  buildPythonPackage,
+  django,
+  fetchFromGitHub,
+  html5lib,
+  pytest-django,
+  pytestCheckHook,
+  setuptools,
+  six,
+}:
+
+buildPythonPackage rec {
+  pname = "django-htmlmin";
+  version = "0.11.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "cobrateam";
+    repo = "django-htmlmin";
+    tag = version;
+    hash = "sha256-1HtTIvB3UKFW/w5fomcRbOwLFAYVKe8Bpfjhqkbdx6M=";
+  };
+
+  postPatch = ''
+    substituteInPlace htmlmin/tests/pico_django.py \
+      --replace-fail "from django.conf.urls import url" "from django.urls import re_path as url"
+
+    substituteInPlace htmlmin/tests/test_decorator.py \
+      --replace-fail "assertEquals" "assertEqual"
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    argparse
+    django
+    beautifulsoup4
+    html5lib
+    six
+  ];
+
+  nativeCheckInputs = [
+    pytest-django
+    pytestCheckHook
+  ];
+
+  env = {
+    DJANGO_SETTINGS_MODULE = "htmlmin.tests.mock_settings";
+  };
+
+  pythonImportsCheck = [ "htmlmin" ];
+
+  meta = {
+    description = "HTML minifier for Python frameworks";
+    homepage = "https://github.com/cobrateam/django-htmlmin/";
+    changelog = "https://github.com/cobrateam/django-htmlmin/tag/${src.tag}";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+  };
+}

--- a/pkgs/development/python-modules/meshpy/default.nix
+++ b/pkgs/development/python-modules/meshpy/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  matplotlib,
+  meson-python,
+  numpy,
+  pybind11,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "meshpy";
+  version = "2026.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "inducer";
+    repo = "meshpy";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-mqkhCsozS2PkmIiLIS8A7vZXpESDsiIF5hC90m0QO64=";
+  };
+
+  build-system = [
+    meson-python
+    numpy
+    pybind11
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    # avoid import shadow
+    rm -r meshpy
+  '';
+
+  pytestFlags = [
+    "./test"
+  ];
+
+  pythonImportsCheck = [ "meshpy" ];
+
+  meta = {
+    description = "2D/3D simplicial mesh generator interface";
+    homepage = "https://github.com/inducer/meshpy/";
+    license = with lib.licenses; [
+      unfree # Triangle License
+      agpl3Plus # TetGen License
+      mit # Wrapper licenses
+    ];
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+  };
+})

--- a/pkgs/development/python-modules/pytest-django/default.nix
+++ b/pkgs/development/python-modules/pytest-django/default.nix
@@ -12,13 +12,13 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pytest-django";
-  version = "4.11.1";
+  version = "4.12.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "pytest_django";
     inherit (finalAttrs) version;
-    hash = "sha256-qUkUGh7hA8sOeiDxRR01X4P15KXQe91Nz90f0P8ieZE=";
+    hash = "sha256-35TsgZqDyJecj23hPZzfvnbowh05Rzz+K0DJ/Jvjx1g=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/types-shapely/default.nix
+++ b/pkgs/development/python-modules/types-shapely/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  numpy,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "types-shapely";
+  version = "2.1.0.20260603";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "types_shapely";
+    inherit version;
+    hash = "sha256-A3PvccqowXr/C4ELgVX3RM6u7oAvbxQ40J3RyRlhIYA=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "'shapely-stubs' = [" "'*' = [" \
+      --replace-fail "setuptools>=82.0.1" "setuptools"
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [ numpy ];
+
+  # Module doesn't have tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "shapely-stubs" ];
+
+  meta = {
+    description = "Typing stubs for shapely";
+    homepage = "https://github.com/python/typeshed";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+  };
+}

--- a/pkgs/development/python-modules/uwuipy/default.nix
+++ b/pkgs/development/python-modules/uwuipy/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  pytestCheckHook,
+}:
+
+buildPythonPackage {
+  pname = "uwuipy";
+  version = "1.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Cuprum77";
+    repo = "uwuipy";
+    # https://github.com/Cuprum77/uwuipy/issues/14
+    rev = "faa2857cded0b7174c956b56d432f6e99f155d71";
+    hash = "sha256-IpiJFq1IF32klGXgEHy/4rYbInMGetPqZnsc8FVizkw=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "uwuipy" ];
+
+  meta = {
+    description = "Allows the easy implementation of uwuifying words for applications like Discord bots and websites";
+    homepage = "https://github.com/Cuprum77/uwuipy/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20855,6 +20855,8 @@ self: super: with self; {
 
   types-setuptools = callPackage ../development/python-modules/types-setuptools { };
 
+  types-shapely = callPackage ../development/python-modules/types-shapely { };
+
   types-six = callPackage ../development/python-modules/types-six { };
 
   types-tabulate = callPackage ../development/python-modules/types-tabulate { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4270,6 +4270,8 @@ self: super: with self; {
 
   django-hijack = callPackage ../development/python-modules/django-hijack { };
 
+  django-htmlmin = callPackage ../development/python-modules/django-htmlmin { };
+
   django-htmx = callPackage ../development/python-modules/django-htmx { };
 
   django-i18nfield = callPackage ../development/python-modules/django-i18nfield { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21205,6 +21205,8 @@ self: super: with self; {
 
   uwsgi-chunked = callPackage ../development/python-modules/uwsgi-chunked { };
 
+  uwuipy = callPackage ../development/python-modules/uwuipy { };
+
   uxsim = callPackage ../development/python-modules/uxsim { };
 
   vaa = callPackage ../development/python-modules/vaa { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9969,6 +9969,8 @@ self: super: with self; {
 
   meshlabxml = callPackage ../development/python-modules/meshlabxml { };
 
+  meshpy = callPackage ../development/python-modules/meshpy { };
+
   meshtastic = callPackage ../development/python-modules/meshtastic { };
 
   meson = toPythonModule (


### PR DESCRIPTION
Depends on https://github.com/NixOS/nixpkgs/pull/534531

Happened on Saltsprint

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
