### PR TITLE
complexipy: init at 5.6.1

### DIFF
--- a/pkgs/by-name/co/complexipy/package.nix
+++ b/pkgs/by-name/co/complexipy/package.nix
@@ -1,0 +1,3 @@
+{ python3Packages }:
+
+python3Packages.toPythonApplication python3Packages.complexipy

--- a/pkgs/development/python-modules/complexipy/default.nix
+++ b/pkgs/development/python-modules/complexipy/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  rustPlatform,
+  pytestCheckHook,
+  tomli,
+  typer,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "complexipy";
+  version = "5.6.1";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "rohaquinlop";
+    repo = "complexipy";
+    tag = finalAttrs.version;
+    hash = "sha256-YfLkKJghUEm0RmJihxOYg+pbhU65irb27kkUVCszhRQ=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-bSJCH41jJTxRhCsth1CzJ4dR2O7uLkoIuU+IkxknNjY=";
+  };
+
+  build-system = [
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+  ];
+
+  dependencies = [
+    tomli
+    typer
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    rm -r complexipy
+  '';
+
+  pythonImportsCheck = [ "complexipy" ];
+
+  meta = {
+    description = "Fast Python cognitive complexity analyzer written in Rust";
+    mainProgram = "complexipy";
+    homepage = "https://rohaquinlop.github.io/complexipy/";
+    changelog = "https://github.com/rohaquinlop/complexipy/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ euank ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3112,6 +3112,8 @@ self: super: with self; {
 
   compit-inext-api = callPackage ../development/python-modules/compit-inext-api { };
 
+  complexipy = callPackage ../development/python-modules/complexipy { };
+
   compliance-trestle = callPackage ../development/python-modules/compliance-trestle { };
 
   complycube = callPackage ../development/python-modules/complycube { };


### PR DESCRIPTION
This is a dependency of anki 26.05, so we need to package this to update that.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
