### PR TITLE
dictDBCollector: support packages bundling multiple dictionaries

### DIFF
--- a/nixos/tests/dictd.nix
+++ b/nixos/tests/dictd.nix
@@ -13,6 +13,9 @@
         DBs = with pkgs.dictdDBs; [
           jpn2eng
           eng2jpn
+          # A single package bundling several dictionaries; the collector must
+          # register every one of them. Regression test for #29149.
+          mueller_eng2rus_pkg
         ];
       };
     };
@@ -25,5 +28,11 @@
     machine.succeed("dict --dbs | grep '${pkgs.dictdDBs.jpn2eng.name}'")
     machine.succeed("dict -d '${pkgs.dictdDBs.jpn2eng.name}' 例え | grep example")
     machine.succeed("dict -d '${pkgs.dictdDBs.eng2jpn.name}' example | grep 例え")
+
+    # The bundled mueller-eng-rus package ships multiple databases; check that
+    # each one was registered and is queryable.
+    machine.succeed("dict --dbs | grep mueller-base")
+    machine.succeed("dict --dbs | grep mueller-abbrev")
+    machine.succeed("dict -d mueller-base time")
   '';
 }

--- a/pkgs/servers/dict/dictd-db-collector.nix
+++ b/pkgs/servers/dict/dictd-db-collector.nix
@@ -37,20 +37,12 @@
       cd $out/share/dictd
       echo "${databases}" >databases.names
       echo "${accessSection}" > dictd.conf
-      for j in ${toString link_arguments}; do
-        name="$(egrep '  '"$j"\$ databases.names)"
-        name=''${name%  $j}
-        if test -d "$j"; then
-          if test -d "$j"/share/dictd ; then
-            echo "Got store path $j"
-            j="$j"/share/dictd
-          fi
-          echo "Directory reference: $j"
-          i=$(ls "$j""/"*.index)
-          i="''${i%.index}";
-        else
-          i="$j";
-        fi
+
+      # Process a single dictionary given its basename (path without the
+      # .index/.dict[.dz] extension) and the database name to register it under.
+      processDict() {
+        local i="$1" name="$2"
+        local locale base source_date
         echo "Basename is $i"
         locale=$(cat "$(dirname "$i")"/locale)
         base="$(basename "$i")"
@@ -74,6 +66,31 @@
         echo "  index_word $out/share/dictd/$base.word" >> dictd.conf
         echo "  index_suffix $out/share/dictd/$base.suffix" >> dictd.conf
         echo "}" >> dictd.conf
+      }
+
+      for j in ${toString link_arguments}; do
+        name="$(egrep '  '"$j"\$ databases.names)"
+        name=''${name%  $j}
+        if test -d "$j"; then
+          if test -d "$j"/share/dictd ; then
+            echo "Got store path $j"
+            j="$j"/share/dictd
+          fi
+          echo "Directory reference: $j"
+          # A directory may contain several dictionaries (e.g. the bundled
+          # mueller-eng-rus database ships abbrev/base/dict/geo/names), so
+          # process every .index file rather than assuming there is only one.
+          indexes=("$j"/*.index)
+          if test "''${#indexes[@]}" -eq 1; then
+            processDict "''${indexes[0]%.index}" "$name"
+          else
+            for idx in "''${indexes[@]}"; do
+              processDict "''${idx%.index}" "$(basename "''${idx%.index}")"
+            done
+          fi
+        else
+          processDict "$j" "$name"
+        fi
       done
     '';
 


### PR DESCRIPTION
The collector assumed each dictlist entry contained exactly one dictionary, recovering the basename with `i=$(ls "$j"/*.index)`. A package shipping several dictionaries (e.g. dictdDBs.mueller_eng2rus_pkg, which bundles abbrev/base/dict/geo/names) therefore collapsed five index paths into a single broken string, failing the build with a bogus `cat`.

Process every .index file in a directory reference instead, registering each dictionary under its own basename. Single-dictionary packages keep their previous database name, so existing configurations are unaffected.

Extend the NixOS test with mueller_eng2rus_pkg as a regression guard.

Closes #29149

Assisted-by: claude-code with claude-opus-4-8[1m]-high

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
