### PR TITLE
python3Packages.cattrs: 25.3.0 -> 26.1.0

### DIFF
--- a/pkgs/development/python-modules/cattrs/default.nix
+++ b/pkgs/development/python-modules/cattrs/default.nix
@@ -16,6 +16,8 @@
   pytestCheckHook,
   pythonAtLeast,
   pyyaml,
+  tomli,
+  tomli-w,
   tomlkit,
   typing-extensions,
   ujson,
@@ -23,7 +25,7 @@
 
 buildPythonPackage rec {
   pname = "cattrs";
-  version = "25.3.0";
+  version = "26.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -43,6 +45,15 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
+  optional-dependencies = {
+    tomllib = [
+      tomli-w
+    ]
+    ++ lib.optionals (!pythonAtLeast "3.11") [
+      tomli
+    ];
+  };
+
   nativeCheckInputs = [
     cbor2
     hypothesis
@@ -56,7 +67,8 @@ buildPythonPackage rec {
     pyyaml
     tomlkit
     ujson
-  ];
+  ]
+  ++ optional-dependencies.tomllib;
 
   postPatch = ''
     substituteInPlace pyproject.toml \


### PR DESCRIPTION
Changelog: https://github.com/python-attrs/cattrs/blob/v26.1.0/HISTORY.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
