### PR TITLE
tree-sitter: support building grammars to WebAssembly

### DIFF
--- a/pkgs/by-name/tr/tree-sitter/grammars/README.md
+++ b/pkgs/by-name/tr/tree-sitter/grammars/README.md
@@ -109,6 +109,18 @@ This includes build-related flags and metadata.
 }
 ```
 
+## Building WebAssembly Parsers
+
+`buildGrammar` builds a native `$out/parser`.
+To build grammars as WebAssembly instead, use the `wasi32` cross package set, which installs `$out/parser.wasm`:
+
+```nix
+pkgsCross.wasi32.tree-sitter.builtGrammars.tree-sitter-nix
+```
+
+The Wasm build compiles `parser.c` and a C `scanner.c`.
+Grammars with C++ external scanners are rejected; use the native `buildGrammar` for those.
+
 ## Updating
 
 All grammar sources have a default update script defined.

--- a/pkgs/by-name/tr/tree-sitter/grammars/build-grammar.nix
+++ b/pkgs/by-name/tr/tree-sitter/grammars/build-grammar.nix
@@ -16,6 +16,11 @@
   ...
 }@args:
 
+let
+  isWasi = stdenv.hostPlatform.isWasi;
+  parserOutput = if isWasi then "parser.wasm" else "parser";
+  exportSymbol = "tree_sitter_${lib.replaceStrings [ "-" ] [ "_" ] language}";
+in
 stdenv.mkDerivation (
   {
     pname = "tree-sitter-${language}";
@@ -32,11 +37,18 @@ stdenv.mkDerivation (
 
     CFLAGS = [
       "-Isrc"
-      "-O2"
+      # Match upstream `tree-sitter build --wasm`
+      (if isWasi then "-Os" else "-O2")
+    ]
+    ++ lib.optionals isWasi [
+      "-fvisibility=hidden"
     ];
     CXXFLAGS = [
       "-Isrc"
-      "-O2"
+      (if isWasi then "-Os" else "-O2")
+    ]
+    ++ lib.optionals isWasi [
+      "-fvisibility=hidden"
     ];
 
     stripDebugList = [ "parser" ];
@@ -90,25 +102,44 @@ stdenv.mkDerivation (
       tree-sitter generate
     '';
 
-    # When both scanner.{c,cc} exist, we should not link both since they may be the same but in
-    # different languages. Just randomly prefer C++ if that happens.
-    buildPhase = ''
-      runHook preBuild
-      if [[ -e src/scanner.cc ]]; then
-        $CXX -fPIC -c src/scanner.cc -o scanner.o $CXXFLAGS
-      elif [[ -e src/scanner.c ]]; then
-        $CC -fPIC -c src/scanner.c -o scanner.o $CFLAGS
-      fi
-      $CC -fPIC -c src/parser.c -o parser.o $CFLAGS
-      rm -rf parser
-      $CXX -shared -o parser *.o
-      runHook postBuild
-    '';
+    buildPhase =
+      if isWasi then
+        ''
+          runHook preBuild
+          if [[ -e src/scanner.cc || -e src/scanner.cpp ]]; then
+            nixErrorLog "tree-sitter wasm grammars only support C external scanners"
+            exit 1
+          fi
+          if [[ -e src/scanner.c ]]; then
+            $CC -fPIC -c src/scanner.c -o scanner.o $CFLAGS
+          fi
+          $CC -fPIC -c src/parser.c -o parser.o $CFLAGS
+          rm -rf parser.wasm
+          $CC -shared -o parser.wasm *.o \
+            -Wl,--export=${exportSymbol} \
+            -Wl,--allow-undefined \
+            -Wl,--no-entry \
+            -nostdlib
+          runHook postBuild
+        ''
+      else
+        ''
+          runHook preBuild
+          if [[ -e src/scanner.cc ]]; then
+            $CXX -fPIC -c src/scanner.cc -o scanner.o $CXXFLAGS
+          elif [[ -e src/scanner.c ]]; then
+            $CC -fPIC -c src/scanner.c -o scanner.o $CFLAGS
+          fi
+          $CC -fPIC -c src/parser.c -o parser.o $CFLAGS
+          rm -rf parser
+          $CXX -shared -o parser *.o
+          runHook postBuild
+        '';
 
     installPhase = ''
       runHook preInstall
       mkdir $out
-      mv parser $out/
+      mv ${parserOutput} $out/
       if [[ -f tree-sitter.json ]]; then
         cp tree-sitter.json $out/
       fi

--- a/pkgs/by-name/tr/tree-sitter/grammars/default.nix
+++ b/pkgs/by-name/tr/tree-sitter/grammars/default.nix
@@ -6,13 +6,14 @@
   fetchpatch,
   fetchFromCodeberg,
   nix-update-script,
+  stdenv,
 }:
 
 let
   /**
     Set of grammar sources. See ./grammar-sources.nix to define a new grammar.
   */
-  grammar-sources = import ./grammar-sources.nix { inherit lib fetchpatch; };
+  grammar-sources = import ./grammar-sources.nix { inherit lib fetchpatch stdenv; };
 
   /**
     Parse a flakeref style string to { type, owner, repo, ref }

--- a/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
+++ b/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
@@ -1,4 +1,8 @@
-{ fetchpatch, lib }:
+{
+  fetchpatch,
+  lib,
+  stdenv,
+}:
 
 {
 
@@ -1758,6 +1762,8 @@
     url = "github:nvim-neorg/tree-sitter-norg";
     hash = "sha256-z3h5qMuNKnpQgV62xZ02F5vWEq4VEnm5lxwEnIFu+Rw=";
     meta = {
+      # Uses a C++ external scanner, unsupported by the WASM grammar build.
+      broken = stdenv.hostPlatform.isWasi;
       license = lib.licenses.mit;
     };
   };

--- a/pkgs/by-name/tr/tree-sitter/package.nix
+++ b/pkgs/by-name/tr/tree-sitter/package.nix
@@ -10,6 +10,7 @@
   nix-update-script,
   which,
   rustPlatform,
+  runCommand,
   emscripten,
   openssl,
   pkg-config,
@@ -111,6 +112,8 @@ let
     );
 
   allGrammars = lib.filter (p: !(p.meta.broken or false)) (lib.attrValues builtGrammars);
+
+  isWasi = stdenv.hostPlatform.isWasi;
 
 in
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -246,6 +249,19 @@ rustPlatform.buildRustPackage (finalAttrs: {
     tests = {
       # make sure all grammars build
       builtGrammars = lib.recurseIntoAttrs builtGrammars;
+    }
+    // lib.optionalAttrs isWasi {
+      wasmGrammar =
+        let
+          grammar = builtGrammars.tree-sitter-nix;
+        in
+        runCommand "tree-sitter-wasm-grammar-test" { } ''
+          test -f ${grammar}/parser.wasm
+          # WebAssembly binaries start with "\0asm".
+          test "$(od -An -tx1 -N4 ${grammar}/parser.wasm | tr -d ' \n')" = "0061736d"
+          test ! -e ${grammar}/parser
+          touch $out
+        '';
     };
   };
 

--- a/pkgs/by-name/tr/tree-sitter/package.nix
+++ b/pkgs/by-name/tr/tree-sitter/package.nix
@@ -61,6 +61,7 @@ let
       fetchFromSourcehut
       fetchFromCodeberg
       fetchpatch
+      stdenv
       ;
   };
 

--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -121,6 +121,9 @@ let
     gmp = nativePlatforms;
     boehmgc = nativePlatforms;
     hello = nativePlatforms;
+    tree-sitter.builtGrammars =
+      mapAttrs (_: _: nativePlatforms)
+        (pkgsForCross systems.examples.wasi32 (builtins.head supportedSystems)).tree-sitter.builtGrammars;
     zlib = nativePlatforms;
   };
 


### PR DESCRIPTION
`buildGrammar` is parameterized on the build platform instead of gaining a new entry point. Building a grammar under the `wasi32` cross set emits `$out/parser.wasm`; the native build is untouched.

The Wasm path wires tree-sitter build --wasm to the nixpkgs wasi32 toolchain and fails early for C++ scanner grammars, which upstream does not include in Wasm builds.

Add a passthru test and grammar docs so consumers can verify the opt-in Wasm path.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
