### PR TITLE
keymapper: add darwin support

### DIFF
--- a/pkgs/by-name/ke/keymapper/package.nix
+++ b/pkgs/by-name/ke/keymapper/package.nix
@@ -17,13 +17,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "keymapper";
-  version = "5.3.1";
+  version = "5.6.0";
 
   src = fetchFromGitHub {
     owner = "houmain";
     repo = "keymapper";
     tag = finalAttrs.version;
-    hash = "sha256-YKfKgsrjDrskLEoYCSRMYco7+7E/sgXFAMEwwm7rs7w=";
+    hash = "sha256-0GadjBGgawn0V+PV04R6ULmanNUF7R14N/jHhObcTzM=";
   };
 
   # all the following must be in nativeBuildInputs

--- a/pkgs/by-name/ke/keymapper/package.nix
+++ b/pkgs/by-name/ke/keymapper/package.nix
@@ -13,6 +13,10 @@
   libxkbcommon,
   gtk3,
   libayatana-appindicator,
+  asio_1_32_0,
+  apple-sdk_15,
+  karabiner-dk,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -26,10 +30,32 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-0GadjBGgawn0V+PV04R6ULmanNUF7R14N/jHhObcTzM=";
   };
 
+  # Darwin sandbox prevents downloads during build (FetchContent).
+  # Replace upstream's FetchContent_Declare for asio with a vendored copy
+  # and wrap the dead code in if(FALSE).
+  # The launchd script references hardcoded system paths for the Karabiner
+  # driver daemon; point them at the nix store instead.
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail '  include(FetchContent)' '  include_directories(${asio_1_32_0}/include)' \
+      --replace-fail '  FetchContent_Declare(asio' $'  if(FALSE)\n  FetchContent_Declare(asio' \
+      --replace-fail '  include_directories(''${asio_SOURCE_DIR}/asio/include)' '  endif()'
+
+    substituteInPlace extra/keymapper-launchd \
+      --replace-fail \
+        'karabiner_path="/Library/Application Support/org.pqrs/Karabiner-DriverKit-VirtualHIDDevice/Applications/Karabiner-VirtualHIDDevice-Daemon.app/Contents/MacOS/Karabiner-VirtualHIDDevice-Daemon"' \
+        'karabiner_path="${karabiner-dk}/Library/Application Support/org.pqrs/Karabiner-DriverKit-VirtualHIDDevice/Applications/Karabiner-VirtualHIDDevice-Daemon.app/Contents/MacOS/Karabiner-VirtualHIDDevice-Daemon"' \
+      --replace-fail \
+        'karabiner_manager_path="/Applications/.Karabiner-VirtualHIDDevice-Manager.app/Contents/MacOS/Karabiner-VirtualHIDDevice-Manager"' \
+        'karabiner_manager_path="${karabiner-dk}/Applications/.Karabiner-VirtualHIDDevice-Manager.app/Contents/MacOS/Karabiner-VirtualHIDDevice-Manager"'
+  '';
+
   # all the following must be in nativeBuildInputs
   nativeBuildInputs = [
     cmake
     pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     dbus
     wayland
     wayland-scanner
@@ -39,7 +65,39 @@ stdenv.mkDerivation (finalAttrs: {
     libxkbcommon
     gtk3
     libayatana-appindicator
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk_15 ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "VERSION" finalAttrs.version)
   ];
+
+  postInstall = ''
+    chmod +x $out/bin/keymapper-launchd
+  '';
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    status=0
+    $out/bin/keymapper --help > keymapper-help.txt || status=$?
+    test "$status" -eq 1
+    grep -F 'Usage: keymapper [-options]' keymapper-help.txt > /dev/null
+
+    status=0
+    $out/bin/keymapperd --help > keymapperd-help.txt || status=$?
+    test "$status" -eq 1
+    grep -F 'Usage: keymapperd [-options]' keymapperd-help.txt > /dev/null
+
+    status=0
+    $out/bin/keymapperctl --help > keymapperctl-help.txt || status=$?
+    test "$status" -eq 2
+    grep -F 'Usage: keymapperctl [--operation]' keymapperctl-help.txt > /dev/null
+
+    runHook postInstallCheck
+  '';
 
   meta = {
     changelog = "https://github.com/houmain/keymapper/blob/${finalAttrs.src.rev}/CHANGELOG.md";
@@ -47,8 +105,21 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/houmain/keymapper";
     license = lib.licenses.gpl3Only;
     mainProgram = "keymapper";
-    maintainers = [
-    ];
-    platforms = lib.platforms.linux;
+    maintainers = [ ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+
+  passthru = {
+    updateScript = nix-update-script { };
+
+    darwinDriverVersion = "6.2.0"; # needs to be updated if karabiner-driverkit changes
+    darwinDriver =
+      if stdenv.hostPlatform.isDarwin then
+        (karabiner-dk.override {
+          driver-version = finalAttrs.passthru.darwinDriverVersion;
+        })
+      else
+        null;
+
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add darwin support for keymapper.

the `passthru.darwinDriver` is imitating https://github.com/NixOS/nixpkgs/blob/4f37c4255bdda56a3f07878d6063299fe68a7def/pkgs/by-name/ka/kanata/package.nix#L61-L67

## Questions:

1. I saw a not yet merged bot PR bumping the current ver of 5.3.1 -> 5.6.0. what should I do about it?
2. this app contains a script to generate launchd plist file to autostart its driver and itself: `sudo keymapper-launchd add` per its readme. Should I add this script to out/bin?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
