### PR TITLE
cosmic: sort and refactor package attrs, fix libcosmicAppHook wrapping

### DIFF
--- a/nixos/modules/services/desktop-managers/cosmic.nix
+++ b/nixos/modules/services/desktop-managers/cosmic.nix
@@ -20,7 +20,7 @@ let
     with pkgs;
     [
       cosmic-applets
-      cosmic-applibrary
+      cosmic-app-library
       cosmic-bg
       cosmic-comp
       cosmic-files

--- a/pkgs/by-name/co/cosmic-app-library/package.nix
+++ b/pkgs/by-name/co/cosmic-app-library/package.nix
@@ -10,7 +10,7 @@
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "cosmic-applibrary";
+  pname = "cosmic-app-library";
   version = "1.1.0";
 
   # nixpkgs-update: no auto update

--- a/pkgs/by-name/co/cosmic-comp/package.nix
+++ b/pkgs/by-name/co/cosmic-comp/package.nix
@@ -32,8 +32,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-ki+unf58rXBCpj5PCpBcg/6FWo16+MdPQWae+w1YkJ8=";
 
-  separateDebugInfo = true;
+  # Only default feature is systemd
+  buildNoDefaultFeatures = !useSystemd;
 
+  separateDebugInfo = true;
   __structuredAttrs = true;
 
   nativeBuildInputs = [
@@ -50,9 +52,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     udev
   ]
   ++ lib.optional useSystemd systemd;
-
-  # Only default feature is systemd
-  buildNoDefaultFeatures = !useSystemd;
 
   makeFlags = [
     "prefix=${placeholder "out"}"

--- a/pkgs/by-name/co/cosmic-edit/package.nix
+++ b/pkgs/by-name/co/cosmic-edit/package.nix
@@ -26,14 +26,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-5DsnhaiJgmTakn+q9o2Q7IeuakAC/j0Ck3F3pfFx/EA=";
   };
 
-  cargoHash = "sha256-2E+98uWtahyQufoZTzdUtkwbuISsUHwlqOmMSpyi1O8=";
-
-  separateDebugInfo = true;
-
   postPatch = ''
     substituteInPlace justfile --replace-fail '#!/usr/bin/env' "#!$(command -v env)"
   '';
 
+  cargoHash = "sha256-2E+98uWtahyQufoZTzdUtkwbuISsUHwlqOmMSpyi1O8=";
+
+  separateDebugInfo = true;
   __structuredAttrs = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/co/cosmic-edit/package.nix
+++ b/pkgs/by-name/co/cosmic-edit/package.nix
@@ -35,6 +35,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   separateDebugInfo = true;
   __structuredAttrs = true;
 
+  env.VERGEN_GIT_SHA = finalAttrs.src.tag;
+
   nativeBuildInputs = [
     just
     pkg-config

--- a/pkgs/by-name/co/cosmic-ext-tweaks/package.nix
+++ b/pkgs/by-name/co/cosmic-ext-tweaks/package.nix
@@ -26,6 +26,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = "sha256-mC19GLLHrjqYXl052HoNFscz9zzQWVBBm0OxzXoUd8U=";
 
   separateDebugInfo = true;
+  __structuredAttrs = true;
 
   nativeBuildInputs = [
     libcosmicAppHook

--- a/pkgs/by-name/co/cosmic-ext-tweaks/package.nix
+++ b/pkgs/by-name/co/cosmic-ext-tweaks/package.nix
@@ -28,6 +28,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   separateDebugInfo = true;
   __structuredAttrs = true;
 
+  env.VERGEN_GIT_SHA = finalAttrs.src.tag;
+
   nativeBuildInputs = [
     libcosmicAppHook
     just

--- a/pkgs/by-name/co/cosmic-files/package.nix
+++ b/pkgs/by-name/co/cosmic-files/package.nix
@@ -27,6 +27,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   separateDebugInfo = true;
   __structuredAttrs = true;
 
+  env.VERGEN_GIT_SHA = finalAttrs.src.tag;
+
   nativeBuildInputs = [
     just
     libcosmicAppHook

--- a/pkgs/by-name/co/cosmic-greeter/package.nix
+++ b/pkgs/by-name/co/cosmic-greeter/package.nix
@@ -29,15 +29,19 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-oxXCAvBISkZu76VpvQ9AliFRJ8r5Ay7mjWf4sEwV0Xs=";
   };
 
+  postPatch = ''
+    substituteInPlace src/greeter.rs --replace-fail '/usr/bin/env' '${lib.getExe' coreutils "env"}'
+    substituteInPlace src/greeter.rs --replace-fail '/usr/bin/orca' '${lib.getExe orca}'
+  '';
+
   cargoHash = "sha256-mfY2hsMxBooRjmTB2jgUIKyKHBpGfZ9Qslwv+2aEQyg=";
-
-  separateDebugInfo = true;
-
-  env.VERGEN_GIT_SHA = finalAttrs.src.tag;
 
   cargoBuildFlags = [ "--all" ];
 
+  separateDebugInfo = true;
   __structuredAttrs = true;
+
+  env.VERGEN_GIT_SHA = finalAttrs.src.tag;
 
   nativeBuildInputs = [
     rustPlatform.bindgenHook
@@ -65,11 +69,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "cargo-target-dir"
     "target/${stdenv.hostPlatform.rust.cargoShortTarget}"
   ];
-
-  postPatch = ''
-    substituteInPlace src/greeter.rs --replace-fail '/usr/bin/env' '${lib.getExe' coreutils "env"}'
-    substituteInPlace src/greeter.rs --replace-fail '/usr/bin/orca' '${lib.getExe orca}'
-  '';
 
   preFixup = ''
     libcosmicAppWrapperArgs+=(

--- a/pkgs/by-name/co/cosmic-icons/package.nix
+++ b/pkgs/by-name/co/cosmic-icons/package.nix
@@ -24,15 +24,15 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ just ];
 
+  propagatedBuildInputs = [
+    pop-icon-theme
+    hicolor-icon-theme
+  ];
+
   justFlags = [
     "--set"
     "prefix"
     (placeholder "out")
-  ];
-
-  propagatedBuildInputs = [
-    pop-icon-theme
-    hicolor-icon-theme
   ];
 
   dontDropIconThemeCache = true;

--- a/pkgs/by-name/co/cosmic-idle/package.nix
+++ b/pkgs/by-name/co/cosmic-idle/package.nix
@@ -26,6 +26,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-0tcrOfVT5b57ev3b5F2U78F2QPGFwp94bqFVNyKH0Yk=";
   };
 
+  postPatch = ''
+    substituteInPlace src/main.rs --replace-fail '"/bin/sh"' '"${lib.getExe' bash "sh"}"'
+  '';
+
   cargoHash = "sha256-wAjFC6qAC3nllbnZf0KVaZTEztNYo6GTvwcp5FYmXLw=";
 
   separateDebugInfo = true;
@@ -47,10 +51,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "cargo-target-dir"
     "target/${stdenv.hostPlatform.rust.cargoShortTarget}"
   ];
-
-  postPatch = ''
-    substituteInPlace src/main.rs --replace-fail '"/bin/sh"' '"${lib.getExe' bash "sh"}"'
-  '';
 
   passthru = {
     tests = {

--- a/pkgs/by-name/co/cosmic-initial-setup/package.nix
+++ b/pkgs/by-name/co/cosmic-initial-setup/package.nix
@@ -47,7 +47,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   separateDebugInfo = true;
   __structuredAttrs = true;
 
-  env.DISABLE_IF_EXISTS = "/iso/nix-store.squashfs";
+  env = {
+    VERGEN_GIT_SHA = finalAttrs.src.tag;
+    DISABLE_IF_EXISTS = "/iso/nix-store.squashfs";
+  };
 
   nativeBuildInputs = [
     libcosmicAppHook

--- a/pkgs/by-name/co/cosmic-initial-setup/package.nix
+++ b/pkgs/by-name/co/cosmic-initial-setup/package.nix
@@ -24,9 +24,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-UABqbmbwW2ZBOO7mq16/h0s55VCWRF2yyf/1TaubC88=";
   };
 
-  cargoHash = "sha256-DESnl5NjakU4++Ep6CHxDZzHn+o0Gi0eREpXk5BN5iY=";
+  postPatch = ''
+    # Installs in $out/etc/xdg/autostart instead of /etc/xdg/autostart
+    substituteInPlace justfile \
+      --replace-fail \
+      "autostart-dst := rootdir / 'etc' / 'xdg' / 'autostart' / desktop-entry" \
+      "autostart-dst := prefix / 'etc' / 'xdg' / 'autostart' / desktop-entry"
+  '';
 
-  separateDebugInfo = true;
+  cargoHash = "sha256-DESnl5NjakU4++Ep6CHxDZzHn+o0Gi0eREpXk5BN5iY=";
 
   buildFeatures = [ "nixos" ];
 
@@ -38,7 +44,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # https://github.com/rust-secure-code/cargo-auditable/issues/225
   auditable = false;
 
+  separateDebugInfo = true;
   __structuredAttrs = true;
+
+  env.DISABLE_IF_EXISTS = "/iso/nix-store.squashfs";
 
   nativeBuildInputs = [
     libcosmicAppHook
@@ -52,18 +61,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     udev
   ];
 
-  postPatch = ''
-    # Installs in $out/etc/xdg/autostart instead of /etc/xdg/autostart
-    substituteInPlace justfile \
-      --replace-fail \
-      "autostart-dst := rootdir / 'etc' / 'xdg' / 'autostart' / desktop-entry" \
-      "autostart-dst := prefix / 'etc' / 'xdg' / 'autostart' / desktop-entry"
-  '';
-
-  preFixup = ''
-    libcosmicAppWrapperArgs+=(--prefix PATH : ${lib.makeBinPath [ killall ]})
-  '';
-
   dontUseJustBuild = true;
   dontUseJustCheck = true;
 
@@ -76,7 +73,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "target/${stdenv.hostPlatform.rust.cargoShortTarget}"
   ];
 
-  env.DISABLE_IF_EXISTS = "/iso/nix-store.squashfs";
+  preFixup = ''
+    libcosmicAppWrapperArgs+=(--prefix PATH : ${lib.makeBinPath [ killall ]})
+  '';
 
   passthru = {
     tests = {

--- a/pkgs/by-name/co/cosmic-launcher/package.nix
+++ b/pkgs/by-name/co/cosmic-launcher/package.nix
@@ -26,6 +26,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   separateDebugInfo = true;
   __structuredAttrs = true;
 
+  env."CARGO_TARGET_${stdenv.hostPlatform.rust.cargoEnvVarTarget}_RUSTFLAGS" = "--cfg tokio_unstable";
+
   nativeBuildInputs = [
     just
     libcosmicAppHook
@@ -42,8 +44,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "cargo-target-dir"
     "target/${stdenv.hostPlatform.rust.cargoShortTarget}"
   ];
-
-  env."CARGO_TARGET_${stdenv.hostPlatform.rust.cargoEnvVarTarget}_RUSTFLAGS" = "--cfg tokio_unstable";
 
   passthru = {
     tests = {

--- a/pkgs/by-name/co/cosmic-osd/package.nix
+++ b/pkgs/by-name/co/cosmic-osd/package.nix
@@ -30,6 +30,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   separateDebugInfo = true;
   __structuredAttrs = true;
 
+  env.POLKIT_AGENT_HELPER_1 = "/run/wrappers/bin/polkit-agent-helper-1";
+
   nativeBuildInputs = [
     just
     libcosmicAppHook
@@ -54,8 +56,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "cargo-target-dir"
     "target/${stdenv.hostPlatform.rust.cargoShortTarget}"
   ];
-
-  env.POLKIT_AGENT_HELPER_1 = "/run/wrappers/bin/polkit-agent-helper-1";
 
   passthru = {
     tests = {

--- a/pkgs/by-name/co/cosmic-player/package.nix
+++ b/pkgs/by-name/co/cosmic-player/package.nix
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: Lily Foster <lily@lily.flowers>
+# Portions of this code are adapted from nixos-cosmic
+# https://github.com/lilyinstarlight/nixos-cosmic
 {
   lib,
   stdenv,
@@ -40,9 +44,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     rustPlatform.bindgenHook
   ];
 
-  # Largely based on lilyinstarlight's work linked below
-  # https://github.com/lilyinstarlight/nixos-cosmic/blob/main/pkgs/cosmic-player/package.nix
-
   buildInputs = [
     alsa-lib
     ffmpeg
@@ -67,7 +68,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "target/${stdenv.hostPlatform.rust.cargoShortTarget}"
   ];
 
-  postInstall = ''
+  preFixup = ''
     libcosmicAppWrapperArgs+=(--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0")
   '';
 

--- a/pkgs/by-name/co/cosmic-player/package.nix
+++ b/pkgs/by-name/co/cosmic-player/package.nix
@@ -37,6 +37,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   separateDebugInfo = true;
   __structuredAttrs = true;
 
+  env.VERGEN_GIT_SHA = finalAttrs.src.tag;
+
   nativeBuildInputs = [
     just
     pkg-config

--- a/pkgs/by-name/co/cosmic-protocols/package.nix
+++ b/pkgs/by-name/co/cosmic-protocols/package.nix
@@ -21,8 +21,9 @@ stdenv.mkDerivation {
   __structuredAttrs = true;
   strictDeps = true;
 
-  makeFlags = [ "PREFIX=${placeholder "out"}" ];
   nativeBuildInputs = [ wayland-scanner ];
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
   passthru = {
     tests = {

--- a/pkgs/by-name/co/cosmic-reader/package.nix
+++ b/pkgs/by-name/co/cosmic-reader/package.nix
@@ -33,6 +33,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   separateDebugInfo = true;
   __structuredAttrs = true;
 
+  env.VERGEN_GIT_SHA = finalAttrs.src.rev;
+
   nativeBuildInputs = [
     just
     libcosmicAppHook
@@ -63,8 +65,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "cargo-target-dir"
     "target/${stdenv.hostPlatform.rust.cargoShortTarget}"
   ];
-
-  env.VERGEN_GIT_SHA = finalAttrs.src.rev;
 
   passthru.updateScript = nix-update-script {
     extraArgs = [

--- a/pkgs/by-name/co/cosmic-session/package.nix
+++ b/pkgs/by-name/co/cosmic-session/package.nix
@@ -22,22 +22,24 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-FphY53MaOUUR2oQfZak3HbT+kvysUnw2AIc4L9O+TcU=";
   };
 
+  postPatch = ''
+    substituteInPlace data/start-cosmic \
+      --replace-fail '/usr/bin/cosmic-session' "$out/bin/cosmic-session" \
+      --replace-fail '/usr/bin/dbus-run-session' "${lib.getBin dbus}/bin/dbus-run-session"
+    substituteInPlace data/cosmic.desktop \
+      --replace-fail '/usr/bin/start-cosmic' "$out/bin/start-cosmic"
+  '';
+
   cargoHash = "sha256-5dLG40X+yxJo566guyHqOCLNp+uNSE+HONS8GIDm58A=";
 
   separateDebugInfo = true;
-
-  postPatch = ''
-    substituteInPlace data/start-cosmic \
-      --replace-fail '/usr/bin/cosmic-session' "${placeholder "out"}/bin/cosmic-session" \
-      --replace-fail '/usr/bin/dbus-run-session' "${lib.getBin dbus}/bin/dbus-run-session"
-    substituteInPlace data/cosmic.desktop \
-      --replace-fail '/usr/bin/start-cosmic' "${placeholder "out"}/bin/start-cosmic"
-  '';
-
   __structuredAttrs = true;
 
-  buildInputs = [ bash ];
+  env.ORCA = "orca"; # get orca from $PATH
+
   nativeBuildInputs = [ just ];
+
+  buildInputs = [ bash ];
 
   dontUseJustBuild = true;
 
@@ -52,8 +54,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "cargo-target-dir"
     "target/${stdenv.hostPlatform.rust.cargoShortTarget}"
   ];
-
-  env.ORCA = "orca"; # get orca from $PATH
 
   passthru = {
     providedSessions = [ "cosmic" ];

--- a/pkgs/by-name/co/cosmic-store/package.nix
+++ b/pkgs/by-name/co/cosmic-store/package.nix
@@ -30,6 +30,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   separateDebugInfo = true;
   __structuredAttrs = true;
 
+  env.VERGEN_GIT_SHA = finalAttrs.src.tag;
+
   nativeBuildInputs = [
     just
     pkg-config

--- a/pkgs/by-name/co/cosmic-term/package.nix
+++ b/pkgs/by-name/co/cosmic-term/package.nix
@@ -30,6 +30,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   separateDebugInfo = true;
   __structuredAttrs = true;
 
+  env.VERGEN_GIT_SHA = finalAttrs.src.tag;
+
   nativeBuildInputs = [
     just
     pkg-config

--- a/pkgs/by-name/co/cosmic-wallpapers/package.nix
+++ b/pkgs/by-name/co/cosmic-wallpapers/package.nix
@@ -19,10 +19,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     hash = "sha256-m2cYppfitpBDKK8CC9i/lUrC9rfSYTuqUSZSyIKKGyg=";
   };
 
-  makeFlags = [ "prefix=${placeholder "out"}" ];
-
   __structuredAttrs = true;
   strictDeps = true;
+
+  makeFlags = [ "prefix=${placeholder "out"}" ];
 
   passthru.updateScript = nix-update-script {
     extraArgs = [

--- a/pkgs/by-name/co/cosmic-workspaces-epoch/package.nix
+++ b/pkgs/by-name/co/cosmic-workspaces-epoch/package.nix
@@ -27,7 +27,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = "sha256-Z5dC3W8QoDBZWBjHwRj9MC8EScDjQwUiUcOPTRDToDA=";
 
   separateDebugInfo = true;
-
   __structuredAttrs = true;
 
   nativeBuildInputs = [
@@ -41,12 +40,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
     udev
   ];
 
-  dontCargoInstall = true;
-
   makeFlags = [
     "prefix=${placeholder "out"}"
     "CARGO_TARGET_DIR=target/${stdenv.hostPlatform.rust.cargoShortTarget}"
   ];
+
+  dontCargoInstall = true;
 
   passthru = {
     tests = {

--- a/pkgs/by-name/li/libcosmicAppHook/libcosmic-app-hook.sh
+++ b/pkgs/by-name/li/libcosmicAppHook/libcosmic-app-hook.sh
@@ -5,24 +5,25 @@
 
 # shellcheck shell=bash
 libcosmicAppWrapperArgs=()
+libcosmicAppWrapHookRanFor=()
 
 libcosmicAppVergenHook() {
-  if [ -z "${VERGEN_GIT_COMMIT_DATE-}" ]; then
-    # shellcheck disable=SC2155
-    export VERGEN_GIT_COMMIT_DATE="$(date --utc --date=@"$SOURCE_DATE_EPOCH" '+%Y-%m-%d')"
-  fi
+    if [ -z "${VERGEN_GIT_COMMIT_DATE-}" ]; then
+        # shellcheck disable=SC2155
+        export VERGEN_GIT_COMMIT_DATE="$(date --utc --date=@"$SOURCE_DATE_EPOCH" '+%Y-%m-%d')"
+    fi
 }
 
 libcosmicAppLinkerArgsHook() {
-  # Force linking to certain libraries like libEGL, which are always dlopen()ed
-  local flags="CARGO_TARGET_@cargoLinkerVar@_RUSTFLAGS"
+    # Force linking to certain libraries like libEGL, which are always dlopen()ed
+    local flags="CARGO_TARGET_@cargoLinkerVar@_RUSTFLAGS"
 
-  export "$flags"="${!flags-} -C link-arg=-Wl,--push-state,--no-as-needed"
-  # shellcheck disable=SC2043
-  for lib in @cargoLinkLibs@; do
-      export "$flags"="${!flags} -C link-arg=-l${lib}"
-  done
-  export "$flags"="${!flags} -C link-arg=-Wl,--pop-state"
+    export "$flags"="${!flags-} -C link-arg=-Wl,--push-state,--no-as-needed"
+    # shellcheck disable=SC2043
+    for lib in @cargoLinkLibs@; do
+        export "$flags"="${!flags} -C link-arg=-l${lib}"
+    done
+    export "$flags"="${!flags} -C link-arg=-Wl,--pop-state"
 }
 
 preConfigurePhases+=" libcosmicAppVergenHook libcosmicAppLinkerArgsHook"
@@ -51,9 +52,18 @@ wrapLibcosmicApp() {
 
 # Note: $libcosmicAppWrapperArgs still gets defined even if ${dontWrapLibcosmicApp-} is set
 libcosmicAppWrapHook() {
-    # guard against running multiple times (e.g. due to propagation)
-    [ -z "$libcosmicAppWrapHookHasRun" ] || return 0
-    libcosmicAppWrapHookHasRun=1
+    # guard against running multiple times for the same prefix (e.g. due to propagation)
+    for _ranFor in "${libcosmicAppWrapHookRanFor[@]}"; do
+        if [[ "$_ranFor" == "$prefix" ]]; then
+            echo "[libcosmicAppWrapHook] already ran for prefix='${prefix}', returning early"
+            return 0
+        fi
+    done
+    libcosmicAppWrapHookRanFor+=("$prefix")
+
+    echo "[libcosmicAppWrapHook] prefix='${prefix}'"
+    echo "[libcosmicAppWrapHook] dontWrapLibcosmicApp='${dontWrapLibcosmicApp:-}'"
+    echo "[libcosmicAppWrapHook] libcosmicAppWrapperArgs=(${libcosmicAppWrapperArgs[*]})"
 
     if [[ -z "${dontWrapLibcosmicApp:-}" ]]; then
         targetDirsThatExist=()
@@ -61,35 +71,47 @@ libcosmicAppWrapHook() {
 
         # wrap binaries
         targetDirs=("${prefix}/bin" "${prefix}/libexec")
+        echo "[libcosmicAppWrapHook] checking targetDirs: ${targetDirs[*]}"
         for targetDir in "${targetDirs[@]}"; do
+            echo "[libcosmicAppWrapHook] checking targetDir='${targetDir}' exists=$([ -d "${targetDir}" ] && echo yes || echo no)"
             if [[ -d "${targetDir}" ]]; then
                 targetDirsThatExist+=("${targetDir}")
                 targetDirsRealPath+=("$(realpath "${targetDir}")/")
+                echo "[libcosmicAppWrapHook] finding executables in '${targetDir}'"
                 find "${targetDir}" -type f -executable -print0 |
                     while IFS= read -r -d '' file; do
-                        echo "Wrapping program '${file}'"
+                        echo "[libcosmicAppWrapHook] wrapping program '${file}'"
                         wrapLibcosmicApp "${file}"
                     done
             fi
         done
 
+        echo "[libcosmicAppWrapHook] targetDirsThatExist=(${targetDirsThatExist[*]})"
+        echo "[libcosmicAppWrapHook] targetDirsRealPath=(${targetDirsRealPath[*]})"
+
         # wrap links to binaries that point outside targetDirs
         # Note: links to binaries within targetDirs do not need
         #       to be wrapped as the binaries have already been wrapped
         if [[ ${#targetDirsThatExist[@]} -ne 0 ]]; then
+            echo "[libcosmicAppWrapHook] finding symlinks in targetDirs"
             find "${targetDirsThatExist[@]}" -type l -xtype f -executable -print0 |
                 while IFS= read -r -d '' linkPath; do
                     linkPathReal=$(realpath "${linkPath}")
+                    echo "[libcosmicAppWrapHook] checking link '${linkPath}' -> '${linkPathReal}'"
                     for targetPath in "${targetDirsRealPath[@]}"; do
                         if [[ "$linkPathReal" == "$targetPath"* ]]; then
-                            echo "Not wrapping link: '$linkPath' (already wrapped)"
+                            echo "[libcosmicAppWrapHook] not wrapping link: '$linkPath' (already wrapped)"
                             continue 2
                         fi
                     done
-                    echo "Wrapping link: '$linkPath'"
+                    echo "[libcosmicAppWrapHook] wrapping link: '$linkPath'"
                     wrapLibcosmicApp "${linkPath}"
                 done
+        else
+            echo "[libcosmicAppWrapHook] no targetDirs exist, skipping symlink wrapping"
         fi
+    else
+        echo "[libcosmicAppWrapHook] dontWrapLibcosmicApp is set, skipping all wrapping"
     fi
 }
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -576,6 +576,7 @@ mapAliases {
   cordless = throw "'cordless' has been removed due to being archived upstream. Consider using 'discordo' instead."; # Added 2025-06-07
   corepack_latest = throw "'corepack_latest' has been removed, use 'corepack.override { nodejs-slim = pkgs.nodejs-slim_latest; }' instead"; # Added 2025-10-25
   coreth = throw "'coreth' has been moved to 'avalanchego' by upstream"; # Added 2026-01-15
+  cosmic-applibrary = warnAlias "'cosmic-applibrary' has been renamed to 'cosmic-app-library'" cosmic-app-library; # Added 2026-07-01
   cosmic-tasks = throw "'cosmic-tasks' has been renamed to/replaced by 'tasks'"; # Converted to throw 2025-10-27
   cotton = throw "'cotton' has been removed since it is vulnerable to CVE-2025-62518 and upstream is unmaintained"; # Added 2025-10-26
   cpp-ipfs-api = throw "'cpp-ipfs-api' has been renamed to/replaced by 'cpp-ipfs-http-client'"; # Converted to throw 2025-10-27


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- **libcosmicAppHook**:
   fix binary wrapping being silently skipped for packages with `separateDebugInfo = true;` (introduced in #518637).
   The hook's bool guard fired on the debug output first (which has no `bin/`), then skipped the real output.
   Replaced with a per-prefix guard so each derivation output is wrapped independently. Also adds debug logging throughout the hook.
   This also fixes `cosmic-player` failing to open video files - `GST_PLUGIN_SYSTEM_PATH_1_0` was never being set because the wrapping was silently skipped on the real output.
   
   Example output before and after for `cosmic-player`:
   ```sh
   nix build .#cosmic-player
   # Before
   $ tree -a result/bin
   result/bin
   └── cosmic-player
   # After
   $ tree -a result/bin
   result/bin
   ├── cosmic-player
   └── .cosmic-player-wrapped
   ```
- **cosmic-***:
   Sort package attributes into a consistent order across packages.
   The sorting is somewhat arbitrary (inspired by cosmic-applets) and opinionated, I admit. That being said, I think it cleans up the code and makes it easier to inspect at a glance.
- **cosmic-{edit,ext-tweaks,files,initial-setup,player,store,term}**:
   Add missing `env.VERGEN_GIT_SHA`
- **cosmic-app-library**:
   Fix naming (cosmic-applibrary -> cosmic-app-library)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
