### PR TITLE
nixos/glusterfs: fix dangling glusterfind hook symlink and install group presets

### DIFF
--- a/nixos/modules/services/network-filesystems/glusterfs.nix
+++ b/nixos/modules/services/network-filesystems/glusterfs.nix
@@ -180,7 +180,9 @@ in
       # Excludes one hook due to missing SELinux binaries.
       + ''
         mkdir -p /var/lib/glusterd/hooks/
-        ${rsync}/bin/rsync -a --exclude="S10selinux-label-brick.sh" ${glusterfs}/var/lib/glusterd/hooks/ /var/lib/glusterd/hooks/
+        # --copy-unsafe-links: the glusterfind hook is a symlink into the package's
+        # libexec that would dangle once copied verbatim into / (#257863).
+        ${rsync}/bin/rsync -a --copy-unsafe-links --exclude="S10selinux-label-brick.sh" ${glusterfs}/var/lib/glusterd/hooks/ /var/lib/glusterd/hooks/
 
         ${tlsCmd}
       ''

--- a/nixos/modules/services/network-filesystems/glusterfs.nix
+++ b/nixos/modules/services/network-filesystems/glusterfs.nix
@@ -191,6 +191,12 @@ in
       + ''
         mkdir -p /var/lib/glusterd/glusterfind/.keys
         mkdir -p /var/lib/glusterd/hooks/1/delete/post/
+      ''
+      # Volume option presets, installed by upstream under $out/var; copy them so
+      # `gluster volume set <vol> group <name>` works (#33159).
+      + ''
+        mkdir -p /var/lib/glusterd/groups/
+        ${rsync}/bin/rsync -a ${glusterfs}/var/lib/glusterd/groups/ /var/lib/glusterd/groups/
       '';
 
       serviceConfig = {

--- a/nixos/tests/glusterfs.nix
+++ b/nixos/tests/glusterfs.nix
@@ -49,6 +49,14 @@ in
     server1.wait_for_unit("glusterd.service")
     server2.wait_for_unit("glusterd.service")
 
+    # The glusterfind delete hook must be a real file, not the dangling
+    # symlink it used to be after being copied out of the package (#257863).
+    server1.succeed("test -f /var/lib/glusterd/hooks/1/delete/post/S57glusterfind-delete-post")
+    server1.fail("test -L /var/lib/glusterd/hooks/1/delete/post/S57glusterfind-delete-post")
+
+    # The volume option presets must be installed (#33159).
+    server1.succeed("test -f /var/lib/glusterd/groups/metadata-cache")
+
     server1.wait_until_succeeds("gluster peer status")
     server2.wait_until_succeeds("gluster peer status")
 
@@ -63,6 +71,9 @@ in
     server2.succeed("mkdir -p /data/vg0")
     server1.succeed("gluster volume create gv0 server1:/data/vg0 server2:/data/vg0")
     server1.succeed("gluster volume start gv0")
+
+    # Applying a group preset needs /var/lib/glusterd/groups populated (#33159).
+    server1.succeed("gluster volume set gv0 group metadata-cache")
 
     # test clients
     client1.wait_for_unit("gluster.mount")


### PR DESCRIPTION
See individual commits

Closes #33159
Closes #257863

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
