### PR TITLE
graphify: 0.4.23 -> 0.8.46

### DIFF
--- a/pkgs/by-name/gr/graphify/package.nix
+++ b/pkgs/by-name/gr/graphify/package.nix
@@ -7,35 +7,47 @@
 
 python3Packages.buildPythonApplication rec {
   __structuredAttrs = true;
+  # official PyPI package name is 'graphifyy', here it is renamed to be in sync with CLI binary name
   pname = "graphify";
-  version = "0.4.23";
+  version = "0.8.46";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "safishamsi";
     repo = "graphify";
     tag = "v${version}";
-    hash = "sha256-QEzB1tFBqGhpmI7oudMRC1Ia0CDcm+GYt6AgxMA5zDo=";
+    hash = "sha256-L+bno9hKc4cRbAgfgI0LltiYgQcnArV5h7eWCSmqnek=";
   };
 
   build-system = [
     python3.pkgs.setuptools
   ];
 
+  # existing grammar differ from github:amaanq/tree-sitter-groovy
+  pythonRemoveDeps = [ "tree-sitter-groovy" ];
   dependencies =
     with python3.pkgs;
     [
+      # keep-sorted start
       networkx
+      numpy
+      rapidfuzz
       tree-sitter
+      # keep-sorted end
     ]
     ++ (with python3.pkgs.tree-sitter-grammars; [
+      # keep-sorted start
+      tree-sitter-bash
       tree-sitter-c
       tree-sitter-c-sharp
       tree-sitter-cpp
       tree-sitter-elixir
+      tree-sitter-fortran
       tree-sitter-go
+      # tree-sitter-groovy
       tree-sitter-java
       tree-sitter-javascript
+      tree-sitter-json
       tree-sitter-julia
       tree-sitter-kotlin
       tree-sitter-lua
@@ -50,6 +62,7 @@ python3Packages.buildPythonApplication rec {
       tree-sitter-typescript
       tree-sitter-verilog
       tree-sitter-zig
+      # keep-sorted end
     ]);
 
   optional-dependencies = with python3.pkgs; {

--- a/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
+++ b/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
@@ -723,11 +723,14 @@
   };
 
   fortran = {
-    version = "0.5.1";
+    version = "0.6.0";
     url = "github:stadelmanma/tree-sitter-fortran";
-    hash = "sha256-6l+cfLVbs8geKIYhnfuZDac8uzmNHOZf2rFANdl4tDs=";
+    hash = "sha256-je9RlV/KozBGcCrOeFLC0f3LZ0avxZIn3nAiHzrWIoI=";
     meta = {
       license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [
+        norbertwnuk
+      ];
     };
   };
 
@@ -1409,12 +1412,15 @@
     };
   };
 
-  kotlin = rec {
-    version = "0.3.8";
-    url = "github:fwcd/tree-sitter-kotlin?ref=${version}";
-    hash = "sha256-kze1kF8naH2qQou58MKMhzmMXk0ouzcP6i3F61kOYi8=";
+  kotlin = {
+    version = "1.1.0";
+    url = "github:tree-sitter-grammars/tree-sitter-kotlin";
+    hash = "sha256-6jjK5rA/lEdsYDboU7wGfzEiRdZo44SrLlcgWci0xa4=";
     meta = {
       license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [
+        norbertwnuk
+      ];
     };
   };
 
@@ -1540,12 +1546,14 @@
   };
 
   lua = {
-    version = "0.0.19-unstable-2025-05-16";
-    url = "github:MunifTanjim/tree-sitter-lua";
-    rev = "4fbec840c34149b7d5fe10097c93a320ee4af053";
-    hash = "sha256-fO8XqlauYiPR0KaFzlAzvkrYXgEsiSzlB3xYzUpcbrs=";
+    version = "0.5.0";
+    url = "github:tree-sitter-grammars/tree-sitter-lua";
+    hash = "sha256-VzaaN5pj7jMAb/u1fyyH6XmLI+yJpsTlkwpLReTlFNY=";
     meta = {
       license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [
+        norbertwnuk
+      ];
     };
   };
 


### PR DESCRIPTION
Bumping `graphify` package and related tree-sitter grammars (fortran, kotlin, lua), to be up to date and coming from official tree-sitter-grammars repositories. The `tree-sitter-groovy` grammar was excluded due to conflict with existing grammar and still not having official tree-sitter-grammars repo. Continuation of the work started in https://github.com/NixOS/nixpkgs/pull/511402

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
