### PR TITLE
shiru: add darwin support

### DIFF
--- a/pkgs/by-name/sh/shiru/package.nix
+++ b/pkgs/by-name/sh/shiru/package.nix
@@ -65,7 +65,12 @@ stdenv.mkDerivation (finalAttrs: {
 
     ./node_modules/.bin/electron-builder --dir \
       --c.electronDist=electron-dist \
-      --c.electronVersion=${electron.version}
+      --c.electronVersion=${electron.version} \
+      ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+        --c.npmRebuild=false \
+        --c.mac.identity=null \
+        --c.mac.notarize=false \
+      ''}
 
     runHook postBuild
   '';
@@ -73,6 +78,8 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
+  ''
+  + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     mkdir -p "$out/share/lib/shiru"
     cp -r dist/*-unpacked/{locales,resources{,.pak}} "$out/share/lib/shiru"
 
@@ -82,7 +89,18 @@ stdenv.mkDerivation (finalAttrs: {
       --add-flags "$out/share/lib/shiru/resources/app.asar" \
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ stdenv.cc.cc.lib ]}" \
       --inherit-argv0
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir -p "$out/Applications"
+    cp -r dist/mac*/Shiru.app "$out/Applications/"
 
+    mkdir -p "$out/bin"
+    makeWrapper \
+      "$out/Applications/Shiru.app/Contents/MacOS/Shiru" \
+      "$out/bin/shiru" \
+      --set-default ELECTRON_IS_DEV 0
+  ''
+  + ''
     runHook postInstall
   '';
 
@@ -116,7 +134,10 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       naomieow
     ];
-    platforms = [ "x86_64-linux" ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-darwin"
+    ];
     mainProgram = "shiru";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add darwin support. set `npmRebuild=false` on darwin, otherwise will try to fetch network in sandbox.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
