### PR TITLE
tikz-editor: init at 0.5.2

### DIFF
--- a/pkgs/by-name/ti/tikz-editor/package.nix
+++ b/pkgs/by-name/ti/tikz-editor/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  nodejs,
+  npmHooks,
+  fetchNpmDeps,
+  cargo-tauri,
+  pkg-config,
+  wrapGAppsHook4,
+  webkitgtk_4_1,
+  apple-sdk_15,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tikz-editor";
+  version = "0.5.2";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    name = "${finalAttrs.pname}-${finalAttrs.version}-source";
+    owner = "DominikPeters";
+    repo = "tikz-editor";
+    tag = "app-v${finalAttrs.version}";
+    hash = "sha256-6aTxRLENjFb0UzHsRS50oVvnremmhS+wesLNy0KCKQo=";
+  };
+
+  npmDeps = fetchNpmDeps {
+    name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
+    inherit (finalAttrs) src;
+    hash = "sha256-sWOlLLs83AKPW+e79+4wiC3INERZVaKKTb/MJOj7Gt0=";
+  };
+
+  cargoRoot = "apps/desktop/src-tauri";
+  cargoHash = "sha256-Mf06pOdUiex+JJumA8tlK2mPJSR7usGHQJ3EGR3dDnM=";
+
+  preBuild = ''
+    patchShebangs --build apps/desktop/node_modules
+    buildAndTestSubdir=$cargoRoot
+  '';
+
+  tauriBuildFlags = [ "--no-sign" ];
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    nodejs
+    npmHooks.npmConfigHook
+    pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ wrapGAppsHook4 ];
+
+  buildInputs =
+    lib.optionals stdenv.hostPlatform.isLinux [
+      webkitgtk_4_1
+    ]
+    # macOS 15 SDK: the Tauri/objc2 stack references AXPrefersNonBlinkingTextInsertionIndicator, a macOS 15 Accessibility symbol absent from the default SDK.
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      apple-sdk_15
+    ];
+
+  meta = {
+    description = "WYSIWYG editor for TikZ diagrams in LaTeX";
+    homepage = "https://tikz.dev/editor/";
+    changelog = "https://github.com/DominikPeters/tikz-editor/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.haansn08 ];
+    mainProgram = "tikz-editor";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
TikZ Editor is a WYSIWYG editor for TikZ diagrams in LaTeX: https://tikz.dev/editor/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
