### PR TITLE
nixos/foot: only modify the prompt when running inside foot

### DIFF
--- a/nixos/modules/programs/foot/bashrc
+++ b/nixos/modules/programs/foot/bashrc
@@ -1,3 +1,8 @@
+case "$TERM" in
+  foot*) : ;;
+  *) return 0 ;;
+esac
+
 osc7_cwd() {
     local strlen=${#PWD}
     local encoded=""

--- a/nixos/modules/programs/foot/config.fish
+++ b/nixos/modules/programs/foot/config.fish
@@ -1,3 +1,7 @@
+if ! string match -q "foot*" "$TERM"
+  return 0
+end
+
 function update_cwd_osc --on-variable PWD --description 'Notify terminals when $PWD changes'
     if status --is-command-substitution || set -q INSIDE_EMACS
         return

--- a/nixos/modules/programs/foot/zshrc
+++ b/nixos/modules/programs/foot/zshrc
@@ -1,3 +1,8 @@
+case "$TERM" in
+  foot*) : ;;
+  *) return 0 ;;
+esac
+
 function osc7-pwd() {
     emulate -L zsh # also sets localoptions for us
     setopt extendedglob


### PR DESCRIPTION
Without this, these integration scripts will mess with the prompt even when not running a shell inside of foot. This can break:

1. Terminals that don't understand these sequences (e.g., gnome-terminal and likely other vte based terminals).
2. Anything that tries to parse the prompt (Emacs packages like bash-completion).

This patch relies on the TERM variable (against upstream's recommendation [1]) because:

1. Only Fish [2] has built-in support for querying things like XTVERSION. Querying terminal features manually is non-trivial and requires writing to STDOUT, which I'd like to avoid.

2. Even in Fish, this XTVERSION may only be queried after the first prompt has been displayed ([2]), which is too late.

This patch does not explicitly check if the terminal is interactive as the modified files are only sourced by interactive shells anyway.

[1]: https://codeberg.org/dnkl/foot#programmatically-checking-if-running-in-foot
[2]: https://fishshell.com/docs/current/cmds/status.html#status-terminal

fixes #374613

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Tested with all combinations of Alacritty/foot and fish/zsh/bash. The environment is modified as expected when run under foot but not when run under Alacritty.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

<!-- Message of single commit: -->