### PR TITLE
rufin: init at 0.7.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24912,6 +24912,12 @@
     githubId = 149248;
     name = "Christian Rackerseder";
   };
+  screwys = {
+    email = "screwygit@proton.me";
+    github = "screwys";
+    githubId = 254296947;
+    name = "screwy";
+  };
   Scriptkiddi = {
     email = "nixos@scriptkiddi.de";
     matrix = "@fritz.otlinghaus:helsinki-systems.de";

--- a/pkgs/by-name/ru/rufin/package.nix
+++ b/pkgs/by-name/ru/rufin/package.nix
@@ -1,0 +1,104 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  cacert,
+  gdk-pixbuf,
+  gettext,
+  gst_all_1,
+  gtk4,
+  libadwaita,
+  pkg-config,
+  wrapGAppsHook4,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rufin";
+  version = "0.7.8";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "screwys";
+    repo = "Rufin";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-TgPjv3s0ERLSnncbtzyr+K1cVscr0PbPxFuDuiPwuV4=";
+  };
+
+  cargoHash = "sha256-hddBiTzJBSk37/Lq7GQ+kTOx6ikLh641B0ISWN2Z2qI=";
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    gettext
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    gdk-pixbuf
+    gettext
+    gtk4
+    libadwaita
+  ]
+  ++ (with gst_all_1; [
+    gstreamer
+    gst-plugins-base
+    gst-plugins-good
+    gst-plugins-bad
+    gst-plugins-ugly
+    gst-libav
+  ]);
+
+  cargoBuildFlags = [
+    "-p"
+    "rufin"
+  ];
+
+  doCheck = false;
+
+  postInstall = ''
+    install -Dm644 data/io.github.screwys.Rufin.desktop \
+      "$out/share/applications/io.github.screwys.Rufin.desktop"
+    substituteInPlace "$out/share/applications/io.github.screwys.Rufin.desktop" \
+      --replace-fail "Exec=rufin" "Exec=$out/bin/rufin"
+    install -Dm644 data/io.github.screwys.Rufin.metainfo.xml \
+      "$out/share/metainfo/io.github.screwys.Rufin.metainfo.xml"
+    install -Dm644 data/icons/hicolor/scalable/apps/io.github.screwys.Rufin.svg \
+      "$out/share/icons/hicolor/scalable/apps/io.github.screwys.Rufin.svg"
+    install -Dm644 -t "$out/share/icons/hicolor/scalable/actions" \
+      data/icons/hicolor/scalable/actions/*.svg
+    install -Dm644 -t "$out/share/icons/hicolor/scalable/status" \
+      data/icons/hicolor/scalable/status/*.svg
+    install -Dm644 -t "$out/share/icons/hicolor/512x512/apps" \
+      data/icons/hicolor/512x512/apps/*.png
+    install -Dm644 -t "$out/share/icons/hicolor/64x64/apps" \
+      data/icons/hicolor/64x64/apps/*.png
+
+    for po_file in locales/*.po; do
+      if [ -f "$po_file" ]; then
+        lang="$(basename "$po_file" .po)"
+        mkdir -p "$out/share/locale/$lang/LC_MESSAGES"
+        msgfmt "$po_file" -o "$out/share/locale/$lang/LC_MESSAGES/rufin.mo"
+      fi
+    done
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --set-default RUFIN_LOCALEDIR "$out/share/locale"
+      --set-default SSL_CERT_FILE "${cacert}/etc/ssl/certs/ca-bundle.crt"
+      --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0"
+    )
+  '';
+
+  meta = {
+    description = "Native GTK music client for Jellyfin";
+    homepage = "https://github.com/screwys/Rufin";
+    changelog = "https://github.com/screwys/Rufin/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ screwys ];
+    mainProgram = "rufin";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
[Rufin](https://github.com/screwys/Rufin) is native GTK4/libadwaita music client for Jellyfin, Subsonic, Navidrome and local libraries written in Rust. It is available in Flathub and AUR as well. I have nix available but I'm not using NixOS, therefore I haven't tested the package in NixOS.

**AI Disclosure:** I used OpenAI Codex (GPT-5) for packaging help and verification, opened this PR myself from GitHub, and included `Assisted-by` trailers in the commits.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

