### PR TITLE
home-assistant-custom-lovelace-modules.fold-entity-row: init at 2.3.2

### DIFF
--- a/pkgs/servers/home-assistant/custom-lovelace-modules/fold-entity-row/add-babel-core-dependency.patch
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/fold-entity-row/add-babel-core-dependency.patch
@@ -1,0 +1,12 @@
+diff --git a/package.json b/package.json
+index 1ec793b..74e538e 100644
+--- a/package.json
++++ b/package.json
+@@ -12,6 +12,7 @@
+   "author": "Thomas Lovén",
+   "license": "MIT",
+   "devDependencies": {
++    "@babel/core": "^7.0.0",
+     "@rollup/plugin-babel": "^6.0.4",
+     "@rollup/plugin-json": "^6.1.0",
+     "@rollup/plugin-node-resolve": "^16.0.1",

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/fold-entity-row/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/fold-entity-row/package.nix
@@ -1,0 +1,41 @@
+{
+  buildNpmPackage,
+  fetchFromGitHub,
+  lib,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "fold-entity-row";
+  version = "2.3.2";
+
+  src = fetchFromGitHub {
+    owner = "thomasloven";
+    repo = "lovelace-fold-entity-row";
+    tag = "v.${finalAttrs.version}";
+    hash = "sha256-pbH2XNVrZEq3U9Kugq0X5U/CT9LNaWP9su4qWk6oob0=";
+  };
+
+  patches = [ ./add-babel-core-dependency.patch ];
+
+  npmDepsFetcherVersion = 2;
+  npmFlags = [ "--legacy-peer-deps" ];
+  npmDepsHash = "sha256-/pm5K088cOa1M/NqlOJ7RtrxKik95Me/d68yzem9ktI=";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp fold-entity-row.js $out
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Fold away and hide rows in lovelace entities cards.";
+    homepage = "https://github.com/thomasloven/lovelace-fold-entity-row";
+    changelog = "https://github.com/thomasloven/lovelace-fold-entity-row/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ rhoriguchi ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Patch is needed for this error.

```
> [!] Error: Cannot find package '@babel/core' imported from /build/source/node_modules/@rollup/plugin-babel/dist/es/index.js
>     at Object.getPackageJSONURL (node:internal/modules/package_json_reader:301:9)
>     at packageResolve (node:internal/modules/esm/resolve:764:81)
>     at moduleResolve (node:internal/modules/esm/resolve:855:18)
>     at defaultResolve (node:internal/modules/esm/resolve:988:11)
>     at ModuleLoader.#cachedDefaultResolve (node:internal/modules/esm/loader:697:20)
>     at ModuleLoader.#resolveAndMaybeBlockOnLoaderThread (node:internal/modules/esm/loader:714:38)
>     at ModuleLoader.resolveSync (node:internal/modules/esm/loader:746:52)
>     at ModuleLoader.#resolve (node:internal/modules/esm/loader:679:17)
>     at ModuleLoader.getOrCreateModuleJob (node:internal/modules/esm/loader:599:35)
>     at ModuleJob.syncLink (node:internal/modules/esm/module_job:162:33)
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
