### PR TITLE
retch: init at 0.3.22

### DIFF
--- a/pkgs/by-name/re/retch/package.nix
+++ b/pkgs/by-name/re/retch/package.nix
@@ -1,12 +1,15 @@
-{ lib
-, rustPlatform
-, fetchFromGitHub
-, pkg-config
-, installShellFiles
-, mandown
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  installShellFiles,
+  mandown,
 }:
 
 rustPlatform.buildRustPackage rec {
+  __structuredAttrs = true;
+
   pname = "retch";
   version = "0.3.22";
 
@@ -42,12 +45,12 @@ rustPlatform.buildRustPackage rec {
       --fish <($out/bin/retch --completions fish)
   '';
 
-  meta = with lib; {
+  meta = {
     description = "A fast, feature-rich system information fetcher written in Rust";
     homepage = "https://github.com/l1a/retch";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ ];
+    license = lib.licenses.gpl3Only;
+    maintainers = [ ];
     mainProgram = "retch";
-    platforms = platforms.unix ++ platforms.windows;
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
   };
 }

--- a/pkgs/by-name/re/retch/package.nix
+++ b/pkgs/by-name/re/retch/package.nix
@@ -1,0 +1,53 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, installShellFiles
+, mandown
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "retch";
+  version = "0.3.22";
+
+  src = fetchFromGitHub {
+    owner = "l1a";
+    repo = "retch";
+    rev = "v${version}";
+    hash = "sha256-koKT/pk1wLBhnu2TmzG0c2XmiTz6wJ3qDLdm1a3RUB8=";
+  };
+
+  cargoHash = "sha256-YMPoKz1gr/yxgEwnVYCLfvesZXp9m2avqpbiMtFvbl4=";
+
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+    mandown
+  ];
+
+  postBuild = ''
+    # Generate man page
+    DATE="June 2026"
+    mandown docs/retch.1.md RETCH 1 | sed -e 's/\\fB\\fB/\\fB/g' -e 's/\\fP\\fP/\\fP/g' -e "s/\\.TH \"RETCH\" 1/\\.TH \"RETCH\" \"1\" \"$DATE\" \"retch ${version}\" \"System Information Fetcher\"/" > docs/retch.1
+  '';
+
+  postInstall = ''
+    # Install man page
+    installManPage docs/retch.1
+
+    # Generate and install shell completions
+    installShellCompletion --cmd retch \
+      --bash <($out/bin/retch --completions bash) \
+      --zsh <($out/bin/retch --completions zsh) \
+      --fish <($out/bin/retch --completions fish)
+  '';
+
+  meta = with lib; {
+    description = "A fast, feature-rich system information fetcher written in Rust";
+    homepage = "https://github.com/l1a/retch";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ ];
+    mainProgram = "retch";
+    platforms = platforms.unix ++ platforms.windows;
+  };
+}


### PR DESCRIPTION
##### Checklist
- [x] Fits the `by-name` directory structure (placed under `pkgs/by-name/re/retch/package.nix`)

##### Description
This PR packages `retch` (version `0.3.22`), a fast, feature-rich system information fetcher written in Rust. It utilizes scoped threads to run slow external queries (GPU, battery, network, motherboard, cameras, etc.) in parallel.

For more details:
- Project Homepage: https://github.com/l1a/retch
- License: GPLv3