### PR TITLE
python3Packages.executorch: fix CUDA build

### DIFF
--- a/pkgs/development/python-modules/executorch/default.nix
+++ b/pkgs/development/python-modules/executorch/default.nix
@@ -111,12 +111,15 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
     # But the build script is sensitive to this env variable.
     # Fixes:
     #  Some binaries contain forbidden references to /build/. Check the error above!
-    CMAKE_ARGS = lib.concatStringsSep " " [
+    CMAKE_ARGS = toString [
       (lib.cmakeBool "CMAKE_SKIP_BUILD_RPATH" true)
 
       # For some cmake-tier reason, cmakeBool does not work here
       (lib.cmakeFeature "EXECUTORCH_BUILD_CUDA" (if cudaSupport then "ON" else "OFF"))
     ];
+  }
+  // lib.optionalAttrs cudaSupport {
+    TORCH_CUDA_ARCH_LIST = lib.concatStringsSep ";" torch.cudaCapabilities;
   };
 
   build-system = [
@@ -140,6 +143,7 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
   buildInputs = lib.optionals cudaSupport [
     cudaPackages.cuda_cudart
     cudaPackages.cuda_nvrtc
+    cudaPackages.libcurand
   ];
 
   pythonRemoveDeps = [


### PR DESCRIPTION
## Things done

Fixes https://hydra.nixos-cuda.org/build/490279/nixlog/4.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
