### PR TITLE
[26.05] lix: remove broken perf patch from curl

### DIFF
--- a/pkgs/tools/package-management/lix/common-lix.nix
+++ b/pkgs/tools/package-management/lix/common-lix.nix
@@ -126,6 +126,19 @@ let
       ''
         substitute $inputPath $out --replace-fail @deps@ "$(cat ${deps})"
       '';
+
+  # https://github.com/NixOS/nixpkgs/pull/525953 backported a performance patch
+  # that /somehow/ breaks Lix unit tests.
+  # FIXME revert when the patch is gone in curl drv
+  curl-fixed = curl.overrideAttrs (
+    {
+      patches ? [ ],
+      ...
+    }:
+    {
+      patches = lib.filter (patch: !lib.strings.hasSuffix "fix-wakeup-consumption.patch" patch) patches;
+    }
+  );
 in
 # gcc miscompiles coroutines at least until 13.2, possibly longer
 # do not remove this check unless you are sure you (or your users) will not report bugs to Lix upstream about GCC miscompilations.
@@ -243,14 +256,14 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals stdenv.hostPlatform.isLinux [ util-linuxMinimal ]
   ++ lib.optionals (lib.versionAtLeast version "2.94") [ zstd ]
   ++ lib.optionals (withPlugins && finalAttrs.doInstallCheck) [
-    curl
+    curl-fixed
   ];
 
   buildInputs = [
     boost
     brotli
     bzip2
-    curl
+    curl-fixed
     capnproto
     editline
     openssl


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/534713

(cherry picked from commit 3f596088797d2e3a62e20cae2d2936e8548a690e)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
