### PR TITLE
nixos/wivrn: Fix application starter

### DIFF
--- a/nixos/modules/services/video/wivrn.nix
+++ b/nixos/modules/services/video/wivrn.nix
@@ -24,6 +24,7 @@ let
     getExe
     types
     maintainers
+    makeBinPath
     ;
   cfg = config.services.wivrn;
   configFormat = pkgs.formats.json { };
@@ -63,13 +64,24 @@ let
   enabledConfig = optionalString cfg.config.enable "-f ${configFile}";
 
   # Manage server executables and flags
-  serverExec = concatStringsSep " " (
+  serverCmdline = concatStringsSep " " (
     [
       serverPackageExe
       enabledConfig
     ]
     ++ cfg.extraServerFlags
   );
+  serverExec =
+    if cfg.steam.enable then
+      lib.getExe (
+        pkgs.writeShellScriptBin "start-wivrn-server" ''
+          # The server needs Steam in PATH to open Steam games from the application launcher
+          export PATH="${makeBinPath [ cfg.steam.package ]}:$PATH"
+          exec -a wivrn-server ${serverCmdline}
+        ''
+      )
+    else
+      serverCmdline;
 in
 {
   imports = [
@@ -184,6 +196,11 @@ in
             IPC_EXIT_ON_DISCONNECT = "off";
             PRESSURE_VESSEL_IMPORT_OPENXR_1_RUNTIMES = mkIf cfg.steam.importOXRRuntimes "1";
           } cfg.monadoEnvironment;
+          # WiVRn scans for .desktop files in $XDG_DATA_DIRS for the application launcher,
+          # which will execute the command in Exec when selected in the headset. If the
+          # Exec path isn't absolute, it will be resolved relative to $PATH, so we must
+          # not override the value of $PATH.
+          enableDefaultPath = false;
           serviceConfig = (
             if cfg.highPriority then
               {
@@ -211,8 +228,6 @@ in
                 RestrictSUIDSGID = true;
               }
           );
-          # Needs Steam in the PATH to allow launching games from the headset
-          path = mkIf cfg.steam.enable [ cfg.steam.package ];
           wantedBy = mkIf cfg.autoStart [ "default.target" ];
           restartTriggers = [
             cfg.package


### PR DESCRIPTION
WiVRn scans for .desktop files in `$XDG_DATA_DIRS` for the application launcher, which will execute the command in Exec when selected in the headset.
If the Exec path isn't absolute, it will be resolved relative to `$PATH`, so we must not override the value of `$PATH`.

I chose to use a shell script to wrap the server process and prefix `$PATH` when Steam support is enabled, I couldn't seem to find any other way to do this, if there's any better method please let me know! I considered just editing the derivation to prefix `$PATH` with steam in the wivrn-server wrapper, however I think that would cause the package to depend on Steam which is an unfree package.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
