### PR TITLE
ory-talos: init at 26.2.0

### DIFF
--- a/pkgs/by-name/or/ory-talos/package.nix
+++ b/pkgs/by-name/or/ory-talos/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  installShellFiles,
+}:
+buildGoModule (finalAttrs: {
+  pname = "talos";
+  version = "26.2.0";
+  src = fetchFromGitHub {
+    owner = "ory";
+    repo = "talos";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MgjKOfiwU0b3ha2rXewl5c4lGO2En7AgE2y5KtSIhPk=";
+  };
+  vendorHash = "sha256-uSJHR/GDdCRh8sgw7GEUYUEnkwc9UAA4Qeyc+Ww4z1Q=";
+  __structuredAttrs = true;
+  env = {
+    CGO_ENABLED = 0;
+  };
+  # equivalent to `go (build|test) ./...`
+  subPackages = [ "..." ];
+  ldflags = [
+    "-s"
+    "-X github.com/ory/talos/internal/version.Version=${finalAttrs.src.tag}"
+    "-X github.com/ory/talos/internal/version.Commit=${finalAttrs.src.rev}"
+  ];
+  nativeBuildInputs = [ installShellFiles ];
+  __darwinAllowLocalNetworking = true;
+  checkFlags =
+    let
+      skippedTests = [
+        # --- FAIL: TestConfigSchemaKeysMatchConstants (0.00s)
+        #     schema_keys_test.go:25:
+        #                 Error Trace:    github.com/ory/talos/internal/configschema/schema_keys_test.go:125
+        #                                   github.com/ory/talos/internal/configschema/schema_keys_test.go:25
+        #                 Error:          Received unexpected error:
+        #                                 open github.com/ory/talos/internal/config/keys.go: no such file or directory
+        #                 Test:           TestConfigSchemaKeysMatchConstants
+        "TestConfigSchemaKeysMatchConstants"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd talos \
+      --bash <($out/bin/talos completion bash) \
+      --fish <($out/bin/talos completion fish) \
+      --zsh <($out/bin/talos completion zsh)
+  '';
+  meta = {
+    description = "Server for issuing, verifying, and managing API keys";
+    longDescription = ''
+      It follows [cloud architecture best practices](https://www.ory.com/docs/ecosystem/software-architecture-philosophy) and focuses on:
+
+      - Issuing, verifying, and revoking API keys at scale
+      - Importing externally-issued API keys for unified verification
+      - Deriving short-lived JWT and macaroon tokens from long-lived keys
+      - Side-car deployment for fast API key verification
+      - Low-latency verification with caching and eventual revocation
+      - Predictable operations through structured logging, metrics, and tracing
+    '';
+    homepage = "https://github.com/ory/talos";
+    changelog = "https://github.com/ory/talos/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    sourceProvenance = [
+      lib.sourceTypes.fromSource
+    ];
+    maintainers = with lib.maintainers; [
+      debtquity
+    ];
+    mainProgram = "talos";
+  };
+})


### PR DESCRIPTION
Add another component from the Ory identity access management, an API key server

* homepage: https://github.com/ory/talos
* changelog: https://github.com/ory/talos/releases/tag/v26.2.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
