### PR TITLE
ghost-complete: 0.16.0 -> 0.18.0

### DIFF
--- a/pkgs/by-name/gh/ghost-complete/package.nix
+++ b/pkgs/by-name/gh/ghost-complete/package.nix
@@ -5,16 +5,15 @@
   nix-update-script,
   versionCheckHook,
 }:
-
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ghost-complete";
-  version = "0.16.0";
+  version = "0.18.0";
 
   src = fetchFromGitHub {
     owner = "StanMarek";
     repo = "ghost-complete";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-SL0PRGppuiglP/BStlvc//6dn2lP472lLfhz3Hq7ZVw=";
+    hash = "sha256-AOhH98qGHISf8AZw3MSMnS5ADL6wQJ5jlo4PXsw7CAo=";
   };
 
   __structuredAttrs = true;
@@ -27,7 +26,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace-fail '"-C", "link-arg=-fuse-ld=/usr/bin/ld",' ""
   '';
 
-  cargoHash = "sha256-F568kxHWcbBQuAwUpkT1AwAr/u486/k094wVmB9SiqY=";
+  cargoHash = "sha256-l1Gp9FVtrGhzobM2Wdq110y1W7V6PNsQsJLBJ3sgOEs=";
 
   cargoBuildFlags = [ "--package=ghost-complete" ];
 


### PR DESCRIPTION
Bumps `ghost-complete` from 0.16.0 to 0.18.0, matching the upstream release.

Fixes #531891

### Release notes
https://github.com/StanMarek/ghost-complete/releases/tag/v0.18.0

### Build verification
Built locally on aarch64-darwin:
```
Finished `release` profile [optimized] target(s) in 59m 12s
ghost-complete 0.18.0
```