### PR TITLE
kdePackages.plasma-workspace-wallpapers: support all platforms

### DIFF
--- a/pkgs/kde/plasma/plasma-workspace-wallpapers/default.nix
+++ b/pkgs/kde/plasma/plasma-workspace-wallpapers/default.nix
@@ -1,9 +1,11 @@
 {
+  lib,
   mkKdeDerivation,
   extra-cmake-modules,
 }:
 mkKdeDerivation {
   pname = "plasma-workspace-wallpapers";
-
   extraBuildInputs = [ extra-cmake-modules ];
+
+  meta.platforms = lib.platforms.all;
 }


### PR DESCRIPTION
## Things done

adjusted the meta.platforms on plasma-workspace-wallpapers to also support darwin. they're just wallpapers. it should work fine.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].


i do not have a mac to test this on, unfortunately.

i'm inspired ot make this change by my own config, having a derivation based on the wallpapers, that fails due to not being able to use the wallpapers on aarch64-darwin. 