### PR TITLE
factorio: 2.0.76 -> 2.0.77, factorio-experimental: 2.0.76 -> 2.1.8

### DIFF
--- a/pkgs/by-name/fa/factorio/versions.json
+++ b/pkgs/by-name/fa/factorio/versions.json
@@ -3,99 +3,99 @@
     "alpha": {
       "experimental": {
         "candidateHashFilenames": [
-          "factorio_linux_2.0.76.tar.xz"
+          "factorio_linux_2.1.8.tar.xz"
         ],
-        "name": "factorio_alpha_x64-2.0.76.tar.xz",
+        "name": "factorio_alpha_x64-2.1.8.tar.xz",
         "needsAuth": true,
-        "sha256": "b1e50891bdc69cce3fdaee4f840cbe4658e18d465309ac87915b6fc41900754c",
+        "sha256": "307016173b824ddfa1a1be4067526273f3aafe6dc8a9c49aff7b2250c466b0b0",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.76/alpha/linux64",
-        "version": "2.0.76"
+        "url": "https://factorio.com/get-download/2.1.8/alpha/linux64",
+        "version": "2.1.8"
       },
       "stable": {
         "candidateHashFilenames": [
-          "factorio_linux_2.0.76.tar.xz"
+          "factorio_linux_2.0.77.tar.xz"
         ],
-        "name": "factorio_alpha_x64-2.0.76.tar.xz",
+        "name": "factorio_alpha_x64-2.0.77.tar.xz",
         "needsAuth": true,
-        "sha256": "b1e50891bdc69cce3fdaee4f840cbe4658e18d465309ac87915b6fc41900754c",
+        "sha256": "2e7c26d999c140335abb82c5e642cdd4c98db559633562d7ad9844aff4f273ff",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.76/alpha/linux64",
-        "version": "2.0.76"
+        "url": "https://factorio.com/get-download/2.0.77/alpha/linux64",
+        "version": "2.0.77"
       }
     },
     "demo": {
       "experimental": {
         "candidateHashFilenames": [
-          "factorio-demo_linux_2.0.76.tar.xz"
+          "factorio-demo_linux_2.0.77.tar.xz"
         ],
-        "name": "factorio_demo_x64-2.0.76.tar.xz",
+        "name": "factorio_demo_x64-2.0.77.tar.xz",
         "needsAuth": false,
-        "sha256": "d5caee49636290b678d35adc59d2fc80ecbdbad8bf420731f1317971c89f941b",
+        "sha256": "f2fc889de1924b551cf52ca2ce2c73251f9c20ee2ae38cc8e973415baffef2a1",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.76/demo/linux64",
-        "version": "2.0.76"
+        "url": "https://factorio.com/get-download/2.0.77/demo/linux64",
+        "version": "2.0.77"
       },
       "stable": {
         "candidateHashFilenames": [
-          "factorio-demo_linux_2.0.76.tar.xz"
+          "factorio-demo_linux_2.0.77.tar.xz"
         ],
-        "name": "factorio_demo_x64-2.0.76.tar.xz",
+        "name": "factorio_demo_x64-2.0.77.tar.xz",
         "needsAuth": false,
-        "sha256": "d5caee49636290b678d35adc59d2fc80ecbdbad8bf420731f1317971c89f941b",
+        "sha256": "f2fc889de1924b551cf52ca2ce2c73251f9c20ee2ae38cc8e973415baffef2a1",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.76/demo/linux64",
-        "version": "2.0.76"
+        "url": "https://factorio.com/get-download/2.0.77/demo/linux64",
+        "version": "2.0.77"
       }
     },
     "expansion": {
       "experimental": {
         "candidateHashFilenames": [
-          "factorio-space-age_linux_2.0.76.tar.xz"
+          "factorio-space-age_linux_2.1.8.tar.xz"
         ],
-        "name": "factorio_expansion_x64-2.0.76.tar.xz",
+        "name": "factorio_expansion_x64-2.1.8.tar.xz",
         "needsAuth": true,
-        "sha256": "dc24bbbc1b6a619e4425d9a720bcfafce3463d908ab369a6cd1bee1a99332b4f",
+        "sha256": "92ec753d96eab63fc60f45ac45259a9427268f74bab0c15b63263f10aae0e786",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.76/expansion/linux64",
-        "version": "2.0.76"
+        "url": "https://factorio.com/get-download/2.1.8/expansion/linux64",
+        "version": "2.1.8"
       },
       "stable": {
         "candidateHashFilenames": [
-          "factorio-space-age_linux_2.0.76.tar.xz"
+          "factorio-space-age_linux_2.0.77.tar.xz"
         ],
-        "name": "factorio_expansion_x64-2.0.76.tar.xz",
+        "name": "factorio_expansion_x64-2.0.77.tar.xz",
         "needsAuth": true,
-        "sha256": "dc24bbbc1b6a619e4425d9a720bcfafce3463d908ab369a6cd1bee1a99332b4f",
+        "sha256": "068cd4778459569cb46e8a8acde1c404969ad533d7e479789af9fce0d29f10a4",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.76/expansion/linux64",
-        "version": "2.0.76"
+        "url": "https://factorio.com/get-download/2.0.77/expansion/linux64",
+        "version": "2.0.77"
       }
     },
     "headless": {
       "experimental": {
         "candidateHashFilenames": [
-          "factorio-headless_linux_2.0.76.tar.xz",
-          "factorio_headless_x64_2.0.76.tar.xz"
+          "factorio-headless_linux_2.1.8.tar.xz",
+          "factorio_headless_x64_2.1.8.tar.xz"
         ],
-        "name": "factorio_headless_x64-2.0.76.tar.xz",
+        "name": "factorio_headless_x64-2.1.8.tar.xz",
         "needsAuth": false,
-        "sha256": "ef3663f66146d76342f7c09a3f743792636f8cd95c39ea26cfca5bd2e0e92430",
+        "sha256": "16b122cd5f48118cd44bcaf1d27fd933aea60b9902bbd426fd26359440759f12",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.76/headless/linux64",
-        "version": "2.0.76"
+        "url": "https://factorio.com/get-download/2.1.8/headless/linux64",
+        "version": "2.1.8"
       },
       "stable": {
         "candidateHashFilenames": [
-          "factorio-headless_linux_2.0.76.tar.xz",
-          "factorio_headless_x64_2.0.76.tar.xz"
+          "factorio-headless_linux_2.0.77.tar.xz",
+          "factorio_headless_x64_2.0.77.tar.xz"
         ],
-        "name": "factorio_headless_x64-2.0.76.tar.xz",
+        "name": "factorio_headless_x64-2.0.77.tar.xz",
         "needsAuth": false,
-        "sha256": "ef3663f66146d76342f7c09a3f743792636f8cd95c39ea26cfca5bd2e0e92430",
+        "sha256": "c4efc11529f74d37c96933e291e0db73fd9f5aa4738913d9301b24680b3e947f",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.76/headless/linux64",
-        "version": "2.0.76"
+        "url": "https://factorio.com/get-download/2.0.77/headless/linux64",
+        "version": "2.0.77"
       }
     }
   }


### PR DESCRIPTION
Updates Factorio stable from 2.0.76 to 2.0.77 and Factorio experimental from 2.0.76 to 2.1.7

Closes https://github.com/NixOS/nixpkgs/issues/534662

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
