### PR TITLE
python3Packages.jupyterlite-core: 0.7.6 -> 0.8.0

### DIFF
--- a/pkgs/development/python-modules/jupyterlite-core/default.nix
+++ b/pkgs/development/python-modules/jupyterlite-core/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "jupyterlite-core";
-  version = "0.7.6";
+  version = "0.8.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -22,7 +22,7 @@ buildPythonPackage (finalAttrs: {
     owner = "jupyterlite";
     repo = "jupyterlite";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-TSy0GUI/7NLsLOayBwZ/raTtOtFgs/t4v1ByytVG960=";
+    hash = "sha256-LERWOeOvGdefbgQxbA8GAFZq1OD/Hhl2Q9hNVCS3Et4=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/py/jupyterlite-core";

--- a/pkgs/development/python-modules/jupyterlite-sphinx/default.nix
+++ b/pkgs/development/python-modules/jupyterlite-sphinx/default.nix
@@ -59,6 +59,10 @@ buildPythonPackage (finalAttrs: {
     ];
   };
 
+  pythonRelaxDeps = [
+    "jupyterlite-core"
+  ];
+
   # upstream has no tests
   doCheck = false;
 


### PR DESCRIPTION
Supersedes and closes https://github.com/NixOS/nixpkgs/pull/534784

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
