### PR TITLE
[release-25.11 backport] nodejs_24: 24.17.0 -> 24.18.0

### DIFF
--- a/pkgs/development/web/nodejs/v24.nix
+++ b/pkgs/development/web/nodejs/v24.nix
@@ -25,8 +25,8 @@ let
 in
 buildNodejs {
   inherit enableNpm;
-  version = "24.17.0";
-  sha256 = "a7ab562ed2369a29c68b72fa00e3103bcdfe37063dff799c6acc8e404e275fcd";
+  version = "24.18.0";
+  sha256 = "e94afde24db08e0c564ee7110a2d5aab51ee0059382c9fd8233c54eec47b28f9";
   patches =
     (
       if (stdenv.hostPlatform.emulatorAvailable buildPackages) then


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/534840