### PR TITLE
config: make `allowBroken` actully allow everything marked as broken

### DIFF
--- a/pkgs/stdenv/generic/problems.nix
+++ b/pkgs/stdenv/generic/problems.nix
@@ -118,16 +118,12 @@ rec {
         config:
         let
           # TODO: Consider deprecating this or making it generic for all problems
-          allowBroken = config.allowBroken || builtins.getEnv "NIXPKGS_ALLOW_BROKEN" == "1";
-
           allowBrokenPredicate =
             lib.warnIf (lib.oldestSupportedReleaseIsAtLeast 2605)
               "config.allowBrokenPredicate is deprecated, use config.problems.handlers.myPackage.broken = \"warn\" for individual packages instead."
               config.allowBrokenPredicate;
         in
-        if allowBroken then
-          attrs: false
-        else if config ? allowBrokenPredicate then
+        if config ? allowBrokenPredicate then
           attrs: attrs ? meta.broken && attrs.meta.broken && !allowBrokenPredicate attrs
         else
           attrs: attrs ? meta.broken && attrs.meta.broken;

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -514,7 +514,8 @@ in
     problems.matchers = [
       {
         kind = "broken";
-        handler = "error";
+        handler =
+          if config.allowBroken || builtins.getEnv "NIXPKGS_ALLOW_BROKEN" == "1" then "ignore" else "error";
       }
       # Be loud and clear about package removals
       {


### PR DESCRIPTION
Noticed this while working on https://github.com/NixOS/nixpkgs/pull/533355

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
