### PR TITLE
python3Packages.ipinfo: init at 5.3.0

### DIFF
--- a/pkgs/development/python-modules/ipinfo/default.nix
+++ b/pkgs/development/python-modules/ipinfo/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  aiohttp,
+  cachetools,
+  requests,
+}:
+
+buildPythonPackage rec {
+  pname = "ipinfo";
+  version = "5.3.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-eVP2ak/Sio8oCLNTQC5ZXYMQpFUAj5VOGoeMzntOcTM=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "ipinfo" ];
+
+  dependencies = [
+    aiohttp
+    cachetools
+    requests
+  ];
+
+  meta = {
+    homepage = "https://github.com/ipinfo/python";
+    description = "Official Python Library for IPinfo API";
+    license = lib.licenses.apsl20;
+    platforms = lib.platforms.all;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7811,6 +7811,8 @@ self: super: with self; {
 
   ipfshttpclient = callPackage ../development/python-modules/ipfshttpclient { };
 
+  ipinfo = callPackage ../development/python-modules/ipinfo { };
+
   iplotx = callPackage ../development/python-modules/iplotx { };
 
   ipsw-parser = callPackage ../development/python-modules/ipsw-parser { };


### PR DESCRIPTION
Add a python module for the ipinfo python API. This API provides IP address geolocation estimates. https://github.com/ipinfo/python

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
