### PR TITLE
upsun: 5.9.0 -> 5.10.7

### DIFF
--- a/pkgs/by-name/up/upsun/package.nix
+++ b/pkgs/by-name/up/upsun/package.nix
@@ -61,7 +61,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Unified tool for managing your Upsun services from the command line";
-    homepage = "https://github.com/platformsh/cli";
+    homepage = "https://github.com/upsun/cli";
     license = lib.licenses.mit;
     mainProgram = "upsun";
     maintainers = with lib.maintainers; [ spk ];

--- a/pkgs/by-name/up/upsun/update.sh
+++ b/pkgs/by-name/up/upsun/update.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl jq
+#!nix-shell -i bash -p curl jq nix
 #shellcheck shell=bash
 
 set -eu -o pipefail
 
 version=$(curl -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
-    https://api.github.com/repos/platformsh/cli/releases/latest | jq -e -r ".tag_name")
+    https://api.github.com/repos/upsun/cli/releases/latest | jq -e -r ".tag_name" | sed 's/^v//')
 
-linux_arm64_url=https://github.com/platformsh/cli/releases/download/$version/upsun_${version}_linux_arm64.tar.gz
-linux_amd64_url=https://github.com/platformsh/cli/releases/download/$version/upsun_${version}_linux_amd64.tar.gz
-darwin_all_url=https://github.com/platformsh/cli/releases/download/$version/upsun_${version}_darwin_all.tar.gz
-linux_arm64_hash=$(nix --extra-experimental-features nix-command hash to-sri --type sha256 $(nix-prefetch-url --type sha256 "$linux_arm64_url"))
-linux_amd64_hash=$(nix --extra-experimental-features nix-command hash to-sri --type sha256 $(nix-prefetch-url --type sha256 "$linux_amd64_url"))
-darwin_all_hash=$(nix --extra-experimental-features nix-command hash to-sri --type sha256 $(nix-prefetch-url --type sha256 "$darwin_all_url"))
+linux_arm64_url=https://github.com/upsun/cli/releases/download/v$version/upsun_${version}_linux_arm64.tar.gz
+linux_amd64_url=https://github.com/upsun/cli/releases/download/v$version/upsun_${version}_linux_amd64.tar.gz
+darwin_all_url=https://github.com/upsun/cli/releases/download/v$version/upsun_${version}_darwin_all.tar.gz
+linux_arm64_hash=$(nix store prefetch-file --json "$linux_arm64_url" | jq -r .hash)
+linux_amd64_hash=$(nix store prefetch-file --json "$linux_amd64_url" | jq -r .hash)
+darwin_all_hash=$(nix store prefetch-file --json "$darwin_all_url" | jq -r .hash)
 jq -n \
     --arg version "$version" \
     --arg darwin_all_hash "$darwin_all_hash" \

--- a/pkgs/by-name/up/upsun/versions.json
+++ b/pkgs/by-name/up/upsun/versions.json
@@ -1,19 +1,19 @@
 {
-  "version": "5.9.0",
+  "version": "5.10.7",
   "darwin-amd64": {
-    "hash": "sha256-B1F+01ltzErGujECC1CM8tPRuVMUOIkcKSpypqlRG2M=",
-    "url": "https://github.com/platformsh/cli/releases/download/5.9.0/upsun_5.9.0_darwin_all.tar.gz"
+    "hash": "sha256-EczhSmIDcG7K8L+BtOOHRT1cmvsB86IvkSWa3A5bwjk=",
+    "url": "https://github.com/upsun/cli/releases/download/v5.10.7/upsun_5.10.7_darwin_all.tar.gz"
   },
   "darwin-arm64": {
-    "hash": "sha256-B1F+01ltzErGujECC1CM8tPRuVMUOIkcKSpypqlRG2M=",
-    "url": "https://github.com/platformsh/cli/releases/download/5.9.0/upsun_5.9.0_darwin_all.tar.gz"
+    "hash": "sha256-EczhSmIDcG7K8L+BtOOHRT1cmvsB86IvkSWa3A5bwjk=",
+    "url": "https://github.com/upsun/cli/releases/download/v5.10.7/upsun_5.10.7_darwin_all.tar.gz"
   },
   "linux-amd64": {
-    "hash": "sha256-J8A4h39dEgMAJHKLwmgWBsj4Al9STIccUAal6JctPyQ=",
-    "url": "https://github.com/platformsh/cli/releases/download/5.9.0/upsun_5.9.0_linux_amd64.tar.gz"
+    "hash": "sha256-SF9GkeQlh9jdONO24zQ7LC6419txRXyl+x4q0Gfvntk=",
+    "url": "https://github.com/upsun/cli/releases/download/v5.10.7/upsun_5.10.7_linux_amd64.tar.gz"
   },
   "linux-arm64": {
-    "hash": "sha256-gyVqD4cBYo6L1Y0xMLl06WK4/sKvudFXLiqvEmcrRPE=",
-    "url": "https://github.com/platformsh/cli/releases/download/5.9.0/upsun_5.9.0_linux_arm64.tar.gz"
+    "hash": "sha256-F8YfXhTd0fU75InxLgZ02hrLrx3ELDhkRpRvYNrRGu4=",
+    "url": "https://github.com/upsun/cli/releases/download/v5.10.7/upsun_5.10.7_linux_arm64.tar.gz"
   }
 }


### PR DESCRIPTION
Upstream moved the repository from `platformsh/cli` to `upsun/cli`.
This updates source URLs, homepage, and the update script accordingly.

Also modernizes `update.sh` to use `nix store prefetch-file` instead of the deprecated `nix-prefetch-url` + `nix hash to-sri` combination.

https://github.com/upsun/cli/releases/tag/v5.10.7

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test