### PR TITLE
oxicloud: 0.6.0 -> 0.8.1

### DIFF
--- a/pkgs/by-name/ox/oxicloud/package.nix
+++ b/pkgs/by-name/ox/oxicloud/package.nix
@@ -5,10 +5,12 @@
   openssl,
   pkg-config,
   rustPlatform,
+  buildNpmPackage,
+  nix-update-script,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "oxicloud";
-  version = "0.6.0";
+  version = "0.8.1";
 
   __structuredAttrs = true;
 
@@ -16,14 +18,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "AtalayaLabs";
     repo = "OxiCloud";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-7alpcK0KYg+ZusK2K7FPdQMLdPrawvL5wsfB6NpSXQw=";
+    hash = "sha256-vfVh1yqVYQD43RsTqUn2gVR6MldYG0MC0cdRWPZ6rRk=";
   };
 
-  cargoHash = "sha256-4gxpTCsS1W2CmRzdnRcsuRe+kr+TgG4hjkzdgihop5I=";
+  cargoHash = "sha256-sEO8Q980S/jXR8SoI1hTPA+gvV7pNZ8ZD7re5qlSJwY=";
 
   nativeBuildInputs = [
-    makeBinaryWrapper
     pkg-config
+    makeBinaryWrapper
   ];
   buildInputs = [ openssl ];
 
@@ -35,15 +37,40 @@ rustPlatform.buildRustPackage (finalAttrs: {
     rm -f .cargo/config.toml
   '';
 
+  oxicloud-front = buildNpmPackage (frontFinalAttrs: {
+    pname = "oxicloud-front";
+    inherit (finalAttrs) version src;
+    sourceRoot = "${frontFinalAttrs.src.name}/frontend";
+
+    npmDepsHash = "sha256-dn9vEk84AYaqfhBhf2obsfQBYUPkE5qyjXalFNNziXw=";
+
+    postPatch = ''
+      substituteInPlace svelte.config.js \
+        --replace "'../static-dist'" "'static-dist'"
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      cp -r static-dist $out
+      runHook postInstall
+    '';
+  });
+
   postInstall = ''
     mkdir -p $out/share/oxicloud
-    cp -r static-dist $out/share/oxicloud/static
   '';
 
   postFixup = ''
     wrapProgram $out/bin/oxicloud \
-      --set-default OXICLOUD_STATIC_PATH $out/share/oxicloud/static
+      --set-default OXICLOUD_STATIC_PATH ${finalAttrs.oxicloud-front}
   '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--subpackage"
+      "oxicloud-front"
+    ];
+  };
 
   meta = {
     description = "Ultra-fast, secure & lightweight self-hosted cloud storage";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Updated package to 0.8.1
Migrated to the new frontend

Closes #532090

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
