### PR TITLE
decent-sampler: Add expat to tagetPkgs, fix #534590

### DIFF
--- a/pkgs/by-name/de/decent-sampler/package.nix
+++ b/pkgs/by-name/de/decent-sampler/package.nix
@@ -81,6 +81,7 @@ buildFHSEnv {
     freetype
     nghttp2
     libx11
+    expat
   ];
 
   runScript = "decent-sampler";


### PR DESCRIPTION
I have added `expat` to the `targetPkgs` making the shared object reachable by the VST plugin. 

## Things done

This is a very minor change and my first pull-request. Any help in improving it is welcome as I'm a bit overwhelmed by all of the information.

I have tested this change locally, and it resolves #534590.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].
