### PR TITLE
deno: keep denort in a separate output

### DIFF
--- a/pkgs/by-name/de/deno/package.nix
+++ b/pkgs/by-name/de/deno/package.nix
@@ -35,6 +35,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "deno";
   version = "2.8.3";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "denoland";
     repo = "deno";

--- a/pkgs/by-name/de/deno/package.nix
+++ b/pkgs/by-name/de/deno/package.nix
@@ -279,6 +279,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       jk
       ofalvai
       mynacol
+      anish
     ];
     maxSilent = 14400; # 4h, double the default of 7200s; sometimes needed for x86_64-darwin on hydra
     platforms = [

--- a/pkgs/by-name/de/deno/package.nix
+++ b/pkgs/by-name/de/deno/package.nix
@@ -37,6 +37,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   __structuredAttrs = true;
 
+  outputs = [
+    "out"
+    "denort"
+  ];
+
   src = fetchFromGitHub {
     owner = "denoland";
     repo = "deno";
@@ -227,7 +232,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   postInstall = ''
-    # Remove non-essential binaries like denort and test_server
+    moveToOutput "bin/denort" "$denort"
+
+    # Remove non-essential binaries like test_server
     find $out/bin/* -not -name "deno" -delete
 
     # Do what `deno x --install-alias` would do (it doesn't work with Nix-packaged Deno)


### PR DESCRIPTION
`deno compile` embeds a stripped runtime, denort, into the standalone binaries it produces. We were already building it, but deleting it in `postInstall`:
                    
 ```nix                                                                                                                        
# Remove non-essential binaries like denort and test_server                                                                 
find $out/bin/* -not -name "deno" -delete                                                                                   
 ```                                                                                                                           

This was from #110156 (2021), when deno had no way to be pointed at a pre-existing denort and would always try to download `denort-<target>.zip`. deno now honors `DENORT_BIN` (and discovers a denort placed next to the deno binary, denoland/deno#27052), so we can now keep it in a dedicated denort output.

Downstream `deno compile` builds can then run fully offline:
                                                         
```nix                                                                                                                        
DENORT_BIN = "${deno.denort}/bin/denort";                                                                                   
```

This partially supersedes #445232, which tried to make this change, but bundled an esbuild test change that's failing for a reason unrelated to this. Also, I opted to use denort as the output name over rt because that's deno's own term for it.

cc @06kellyjac @ofalvai 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
