### PR TITLE
github-copilot-cli: 1.0.61 -> 1.0.73

### DIFF
--- a/pkgs/by-name/gi/github-copilot-cli/package.nix
+++ b/pkgs/by-name/gi/github-copilot-cli/package.nix
@@ -10,20 +10,30 @@
   bash,
   nodejs,
   versionCheckHook,
-  nix-update-script,
 }:
-
+let
+  arch =
+    if stdenv.hostPlatform.isx86_64 then
+      "x64"
+    else if stdenv.hostPlatform.isAarch64 then
+      "arm64"
+    else
+      throw "Unsupported arch: ${stdenv.hostPlatform.system}";
+  platform = if stdenv.hostPlatform.isDarwin then "darwin-${arch}" else "linux-${arch}";
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "github-copilot-cli";
-  version = "1.0.61";
+  version = "1.0.73";
 
-  # GitHub provide platform-specific SEA binaries as well as a "universal"
-  # package.  Use the universal package as it gives us a bit more flexibility
-  # about how it's configured.  In particular, the SEA binary has fixed ideas
-  # about how paths should be set up which don't reliably hold when using Nix.
   src = fetchurl {
-    url = "https://github.com/github/copilot-cli/releases/download/v${finalAttrs.version}/github-copilot-${finalAttrs.version}.tgz";
-    hash = "sha256-8Lks8lHa5XF9ZrC+fU/9VlzD1W32MbRZ7PZtL5YWLTA=";
+    url = "https://github.com/github/copilot-cli/releases/download/v${finalAttrs.version}/github-copilot-${finalAttrs.version}-${platform}.tgz";
+    hash =
+      {
+        "aarch64-darwin" = "sha256-Uua3Zl+Q+Dw64qlU8b9OPlF0dba4Ej1y2fqYRG622gg=";
+        "x86_64-linux" = "sha256-Bh2PVfVXYCoLmU7p8FNnAXRiFAXwTfuyqilIaaSw8cE=";
+        "aarch64-linux" = "sha256-EOOiFueqIcAEknmWCtSUiox8Sin862icvr5X6Nmsmbw=";
+      }
+      .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
   };
 
   nativeBuildInputs = [
@@ -48,6 +58,16 @@ stdenv.mkDerivation (finalAttrs: {
     "libpng16.so.16"
     "libpipewire-0.3.so.0"
     "libei.so.1"
+    "libwebkit2gtk-4.1.so.0"
+    "libjavascriptcoregtk-4.1.so.0"
+    "libgtk-3.so.0"
+    "libgdk-3.so.0"
+    "libcairo.so.2"
+    "libgdk_pixbuf-2.0.so.0"
+    "libsoup-3.0.so.0"
+    "libwayland-client.so.0"
+    "libdbus-1.so.3"
+    "libxdo.so.3"
   ];
 
   installPhase = ''
@@ -58,10 +78,6 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   postInstall = ''
-    # Upstream bundles linuxmusl prebuilds in the universal tarball; they are
-    # not needed on glibc systems and make autoPatchelf fail on musl libc deps.
-    find "$out"/lib/github-copilot-cli -depth -path '*/linuxmusl-*' -exec rm -rf '{}' +
-
     makeWrapper ${nodejs}/bin/node "$out"/bin/copilot \
       --add-flag "$out"/lib/github-copilot-cli/index.js \
       --add-flag --no-auto-update \
@@ -71,15 +87,8 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];
-  # TODO are these errors still present after moving to using the "universal"
-  # package?
-  doInstallCheck = !stdenv.hostPlatform.isDarwin; # skip on Darwin - OpenSSL errors in sandbox
 
-  # Looks like GitHub use tags for both pre-release and actually released
-  # versions, but only the actual versions will be available as a GitHub
-  # release, so use the release endpoint rather than nix-update-script`'s
-  # default of looking for tags.
-  passthru.updateScript = nix-update-script { extraArgs = [ "--use-github-releases" ]; };
+  passthru.updateScript = ./update.sh;
 
   meta = {
     description = "GitHub Copilot CLI brings the power of Copilot coding agent directly to your terminal";

--- a/pkgs/by-name/gi/github-copilot-cli/update.sh
+++ b/pkgs/by-name/gi/github-copilot-cli/update.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p common-updater-scripts nix jq curl gnused
+
+set -euo pipefail
+
+currentVersion=$(nix-instantiate --eval -E "with import ./. {}; github-copilot-cli.version or (lib.getVersion github-copilot-cli)" | tr -d '"')
+latestVersion=$(curl ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} -sL https://api.github.com/repos/github/copilot-cli/releases/latest | jq --raw-output .tag_name | sed 's/^v//')
+
+if [[ "$currentVersion" == "$latestVersion" ]]; then
+  echo "package is up-to-date: $currentVersion"
+  exit 0
+fi
+
+update-source-version github-copilot-cli $latestVersion || true
+
+declare -a systems=(x86_64-linux aarch64-linux aarch64-darwin)
+for system in "${systems[@]}"; do
+  tmp=$(mktemp -d)
+  curl -fsSL -o "$tmp"/github-copilot-cli "$(nix-instantiate --eval -E "with import ./. {}; github-copilot-cli.src.url" --system "$system" | tr -d '"')"
+  hash=$(nix --extra-experimental-features nix-command hash file "$tmp"/github-copilot-cli)
+  update-source-version github-copilot-cli "$latestVersion" "$hash" --system="$system" --ignore-same-version
+  rm -rf "$tmp"
+done


### PR DESCRIPTION
During the discussion of #531383  , github-copilot-cli was updated.
In version 1.0.64, the look and feel changed compared to earlier versions — for example, it became possible to browse PRs and issues.
Additionally, the way universal packages are provided seems to have changed.
Therefore, I modified the package to fetch per-system packages based on https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/ib/ibmcloud-cli/package.nix and also created an update.sh script.
Upstream release notes:
- https://github.com/github/copilot-cli/releases/tag/v1.0.64

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
