### PR TITLE
ark: init at 0.1.252

### DIFF
--- a/pkgs/applications/editors/jupyter-kernels/r-ark/default.nix
+++ b/pkgs/applications/editors/jupyter-kernels/r-ark/default.nix
@@ -1,0 +1,31 @@
+{ ark }:
+
+# Jupyter notebook:
+# nix shell --impure --expr 'with import ./. {}; [ (jupyter.override { definitions.r = r-ark-kernel.definition; }) ]' -c jupyter-notebook
+
+{
+  definition = {
+    displayName = "Ark R Kernel";
+    argv = [
+      "${ark}/bin/ark"
+      "--connection_file"
+      "{connection_file}"
+      "--session-mode"
+      "notebook"
+    ];
+    language = "R";
+    # Ark logs at INFO to stderr by default, which includes Jupyter messages.
+    # The notebook forwards this to the cell output, so quiet it to warnings.
+    #
+    # The `ark::console::console_comm=error` directive additionally silences a
+    # per-cell "UI comm is absent during dispatch" warning: after every execute,
+    # ark unconditionally tries to push an environment-pane update over the
+    # Positron-only `positron.ui` comm, which a plain Jupyter frontend never
+    # opens.
+    env = {
+      RUST_LOG = "ark=warn,ark::console::console_comm=error";
+    };
+    logo32 = null;
+    logo64 = null;
+  };
+}

--- a/pkgs/by-name/ar/ark/package.nix
+++ b/pkgs/by-name/ar/ark/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  cmake,
+  makeBinaryWrapper,
+  R,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ark";
+  version = "0.1.252";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "posit-dev";
+    repo = "ark";
+    rev = finalAttrs.version;
+    hash = "sha256-AI8i15UMI+KSmweXkS/UYITZBOEDx/knjpK9SA2M+Ns=";
+  };
+
+  cargoHash = "sha256-z9l0dgmZO6f63I/2pms4VMXMxO/9SAZSq1OFubGHIpw=";
+
+  # The amalthea crate bundles libzmq via the zeromq-src crate, which builds it
+  # with CMake.
+  nativeBuildInputs = [
+    cmake
+    makeBinaryWrapper
+  ];
+
+  # Only build the `ark` binary, not the whole workspace's test/dev crates.
+  cargoBuildFlags = [
+    "--package"
+    "ark"
+  ];
+
+  # Tests require a running R installation and network access.
+  doCheck = false;
+
+  # Ark loads R dynamically at runtime, locating it via `R_HOME` or by running
+  # `R RHOME`. Put R on PATH so the kernel works out of the box.
+  postInstall = ''
+    wrapProgram $out/bin/ark \
+      --suffix PATH : ${lib.makeBinPath [ R ]}
+  '';
+
+  meta = {
+    description = "R kernel for Jupyter applications, powering Positron's R support";
+    homepage = "https://github.com/posit-dev/ark";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ thomasjm ];
+    mainProgram = "ark";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2327,6 +2327,7 @@ with pkgs;
     definitions = {
       clojure = clojupyter.definition;
       octave = octave-kernel.definition;
+      r = r-ark-kernel.definition;
       # wolfram = wolfram-for-jupyter-kernel.definition; # unfree
     };
   };
@@ -4556,6 +4557,8 @@ with pkgs;
   };
 
   octave-kernel = recurseIntoAttrs (callPackage ../applications/editors/jupyter-kernels/octave { });
+
+  r-ark-kernel = callPackage ../applications/editors/jupyter-kernels/r-ark { };
 
   octavePackages = recurseIntoAttrs octave.pkgs;
 


### PR DESCRIPTION
Ark is a Jupyter kernel for R, used to power the Positron notebook. It can also be used with normal JupyterLab or Jupyter Notebook.

This PR adds Ark to Nixpkgs at 0.1.252. It also adds a Jupyter kernel definition to make it easy to use.

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
