### PR TITLE
[Backport release-26.05] spire: 1.14.6 -> 1.15.1

### DIFF
--- a/pkgs/by-name/sp/spire/package.nix
+++ b/pkgs/by-name/sp/spire/package.nix
@@ -8,7 +8,7 @@
 
 buildGoModule (finalAttrs: {
   pname = "spire";
-  version = "1.14.6";
+  version = "1.15.0";
 
   outputs = [
     "out"
@@ -21,12 +21,12 @@ buildGoModule (finalAttrs: {
     owner = "spiffe";
     repo = "spire";
     tag = "v${finalAttrs.version}";
-    sha256 = "sha256-3NboIbLRxs4yPjQUKdK7B+Rhl08SxEDPuj5N8lWd1gA=";
+    sha256 = "sha256-mOYPVvumMIXgfJGQeStU62DlBOIwI0Sav5cQonU28r0=";
   };
 
   # Needed for github.co/google/go-tpm-tools/simulator  which contains non-go files that `go mod vendor` strips
   proxyVendor = true;
-  vendorHash = "sha256-Ajoxxpf6oWW6jioMTgeyaIszVhp4j7E2+msE0nhfKpk=";
+  vendorHash = "sha256-F9M7Tvo/yF1QVnjB7Gp3mbZc7159Dx7wgttjstkA/1w=";
 
   buildInputs = [ openssl ];
 

--- a/pkgs/by-name/sp/spire/package.nix
+++ b/pkgs/by-name/sp/spire/package.nix
@@ -8,7 +8,7 @@
 
 buildGoModule (finalAttrs: {
   pname = "spire";
-  version = "1.15.0";
+  version = "1.15.1";
 
   outputs = [
     "out"
@@ -21,12 +21,12 @@ buildGoModule (finalAttrs: {
     owner = "spiffe";
     repo = "spire";
     tag = "v${finalAttrs.version}";
-    sha256 = "sha256-mOYPVvumMIXgfJGQeStU62DlBOIwI0Sav5cQonU28r0=";
+    sha256 = "sha256-7SmHj/st2r3ks8Bh6gVRlKoay5mHqpovH25qMxG9s40=";
   };
 
   # Needed for github.co/google/go-tpm-tools/simulator  which contains non-go files that `go mod vendor` strips
   proxyVendor = true;
-  vendorHash = "sha256-F9M7Tvo/yF1QVnjB7Gp3mbZc7159Dx7wgttjstkA/1w=";
+  vendorHash = "sha256-wKVBqjid/PQi5JBB37c3h68Q8kUqbyaiDbLssO7Yo7A=";
 
   buildInputs = [ openssl ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Manual Backport for #525637 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
