### PR TITLE
fish: 4.7.1 -> 4.8.0

### DIFF
--- a/pkgs/by-name/fi/fish/nix-darwin-path.patch
+++ b/pkgs/by-name/fi/fish/nix-darwin-path.patch
@@ -1,12 +1,12 @@
 diff --git a/share/config.fish b/share/config.fish
-index 73148ac25..1964e30be 100644
+index b246916a5..05252c35f 100644
 --- a/share/config.fish
 +++ b/share/config.fish
-@@ -175,6 +175,7 @@ and __fish_set_locale
+@@ -132,6 +132,7 @@ and __fish_set_locale
+ # This used to be in etc/config.fish - keep it here to keep the semantics
  #
- if status --is-login
-     if command -sq /usr/libexec/path_helper
-+        and not set -q __NIX_DARWIN_SET_ENVIRONMENT_DONE
-         __fish_macos_set_env PATH /etc/paths '/etc/paths.d'
-         if test -n "$MANPATH"
-             __fish_macos_set_env MANPATH /etc/manpaths '/etc/manpaths.d'
+ if status is-login && command -sq /usr/libexec/path_helper
++    and not set -q __NIX_DARWIN_SET_ENVIRONMENT_DONE
+     __fish_macos_set_env PATH /etc/paths '/etc/paths.d'
+     if test -n "$MANPATH"
+         __fish_macos_set_env MANPATH /etc/manpaths '/etc/manpaths.d'

--- a/pkgs/by-name/fi/fish/package.nix
+++ b/pkgs/by-name/fi/fish/package.nix
@@ -150,13 +150,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "fish";
-  version = "4.7.1";
+  version = "4.8.0";
 
   src = fetchFromGitHub {
     owner = "fish-shell";
     repo = "fish-shell";
     tag = finalAttrs.version;
-    hash = "sha256-u0mBdWkxP4zI6NUhJ0LJrEDrbAAfTDi8IapsWWC9yWc=";
+    hash = "sha256-ttjLM1uBY8sL+jVcxdHUnHYlRFe5jGjnkgBLy17qGso=";
   };
 
   env = {
@@ -169,7 +169,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src patches;
-    hash = "sha256-d4YA9fnDQyfyK675nP+tiTqJ1o2jqjwPHU1trXd8MCA=";
+    hash = "sha256-w8MuabpZ5ronQL3iaXbLErxPlTe1Mg8OsRb5foR59II=";
   };
 
   patches = [


### PR DESCRIPTION
Changelog: https://github.com/fish-shell/fish-shell/releases/tag/4.8.0
Diff: https://github.com/fish-shell/fish-shell/compare/4.7.1...4.8.0

Would appreciate someone testing darwin, had to adjust the patch a little for the build to succeed.

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
