### PR TITLE
music-assistant-desktop: 0.3.9 -> 0.4.0

### DIFF
--- a/pkgs/by-name/mu/music-assistant-desktop/package.nix
+++ b/pkgs/by-name/mu/music-assistant-desktop/package.nix
@@ -30,30 +30,23 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "music-assistant-desktop";
-  version = "0.3.9";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "music-assistant";
     repo = "desktop-app";
     tag = finalAttrs.version;
-    hash = "sha256-fogNPPdbU8ikTxxaGDYsqR6GCcAsc2fS4qapVDkesAQ=";
+    hash = "sha256-Gx6bmipNRT5V5EHSCP6KjZ8Lgt7BcNV8zo0nrhaVmOs=";
   };
 
-  # hide update feature
-  postPatch = ''
-    substituteInPlace src-tauri/src/lib.rs \
-      --replace-fail \
-        "let update =" \
-        "// let update =" \
-      --replace-fail \
-        "&update," \
-        "// &update," \
-  '';
+  patches = [
+    ./remove-updater.diff
+  ];
 
   cargoRoot = "src-tauri";
   buildAndTestSubdir = finalAttrs.cargoRoot;
 
-  cargoHash = "sha256-xi6Clo8iHg3YFVcWNMFrN2422MZm2BhB9m/etFlyb/4=";
+  cargoHash = "sha256-PevHpvDIlah0jQw/mZkDxQ5xY3t6KicGLlDYbtPco5A=";
 
   yarnOfflineCache = fetchYarnDeps {
     yarnLock = finalAttrs.src + "/yarn.lock";
@@ -100,6 +93,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Official companion desktop app for Music Assistant";
+    changelog = "https://github.com/music-assistant/desktop-app/releases/tag/${finalAttrs.src.tag}";
     homepage = "https://github.com/music-assistant/desktop-app";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ nim65s ];

--- a/pkgs/by-name/mu/music-assistant-desktop/remove-updater.diff
+++ b/pkgs/by-name/mu/music-assistant-desktop/remove-updater.diff
@@ -1,0 +1,32 @@
+diff --git a/src-tauri/src/lib.rs b/src-tauri/src/lib.rs
+index 03cac7d..fc69f93 100644
+--- a/src-tauri/src/lib.rs
++++ b/src-tauri/src/lib.rs
+@@ -623,7 +623,6 @@ pub fn run() {
+             MacosLauncher::AppleScript,
+             None,))
+         .plugin(tauri_plugin_clipboard_manager::init())
+-        .plugin(tauri_plugin_updater::Builder::new().build())
+         .invoke_handler(tauri::generate_handler![
+             is_companion_app,
+             is_desktop_app,
+@@ -733,11 +732,6 @@ pub fn run() {
+             let separator3 = PredefinedMenuItem::separator(app)?;
+             let settings =
+                 MenuItemBuilder::with_id("settings", i18n::tr("desktop.tray.settings")).build(app)?;
+-            let update = MenuItemBuilder::with_id(
+-                "update",
+-                i18n::tr("desktop.tray.check_for_updates"),
+-            )
+-            .build(app)?;
+             let relaunch =
+                 MenuItemBuilder::with_id("relaunch", i18n::tr("desktop.tray.relaunch")).build(app)?;
+             let open_log = MenuItemBuilder::with_id(
+@@ -777,7 +771,6 @@ pub fn run() {
+                     &discord_rpc_item,
+                     &separator3,
+                     &settings,
+-                    &update,
+                     &relaunch,
+                     &open_log,
+                     &separator4,


### PR DESCRIPTION
Diff: https://github.com/music-assistant/desktop-app/compare/0.3.9...0.4.0
Changelog: https://github.com/music-assistant/desktop-app/releases/tag/0.4.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
