### PR TITLE
jbang: enable __structuredAttrs and strictDeps

### DIFF
--- a/pkgs/by-name/jb/jbang/package.nix
+++ b/pkgs/by-name/jb/jbang/package.nix
@@ -4,6 +4,7 @@
   fetchzip,
   jdk,
   makeWrapper,
+  bashNonInteractive,
   coreutils,
   curl,
 }:
@@ -12,12 +13,19 @@ stdenv.mkDerivation rec {
   version = "0.136.0";
   pname = "jbang";
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   src = fetchzip {
     url = "https://github.com/jbangdev/jbang/releases/download/v${version}/${pname}-${version}.tar";
     sha256 = "sha256-MsP4iLquOwJWlV7EPxSuAPWuyTv1PPSyQCrVdq4lPlM=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [
+    bashNonInteractive
+  ];
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
Both are required for new packages, so it is good to enable them for existing packages.

Since jbang is a bash script, this requires adding a dependency on bash explictly.

## Things done

Checked that the build output is equal to previous build (module store prefix change).

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy]: none used

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
