### PR TITLE
ringboard: 0.16.2-unstable-2026-05-10 -> 0.17.0

### DIFF
--- a/pkgs/by-name/ri/ringboard/package.nix
+++ b/pkgs/by-name/ri/ringboard/package.nix
@@ -24,18 +24,17 @@ assert lib.assertOneOf "displayServer" displayServer [
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ringboard" + lib.optionalString (displayServer == "wayland") "-wayland";
 
-  # release version needs nightly, so we use a custom tree, see:
-  # https://github.com/SUPERCILEX/clipboard-history/issues/22#issuecomment-3676256971
-  version = "0.16.2-unstable-2026-05-10";
+  version = "0.17.0";
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "SUPERCILEX";
     repo = "clipboard-history";
-    rev = "0719d4398034efa32c3f093e06a2fdb033afbc22";
-    hash = "sha256-/LDxZ3bsuVwMiRzLTuLIs6y7jAS/84sXhTRhovXV8zM=";
+    tag = finalAttrs.version;
+    hash = "sha256-qLYQeZTrtUUn4JSzK3SX687xV4FO6h7GshVdQi8Qkbk=";
   };
 
-  cargoHash = "sha256-ARSvWjeVWXksZ27lRJn67wXpgr8epagflOAULKmYaQ8=";
+  cargoHash = "sha256-T65TxIes0171uDxDE72SnFeRVAgw5FR2z6yTcmH3Z6k=";
 
   nativeBuildInputs = [
     makeWrapper
@@ -103,13 +102,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   passthru = {
     tests.nixos = nixosTests.ringboard;
-    updateScript = nix-update-script { extraArgs = [ "--version=branch=stable" ]; };
+    updateScript = nix-update-script { };
   };
 
   meta = {
     description = "Fast, efficient, and composable clipboard manager for Linux";
     homepage = "https://github.com/SUPERCILEX/clipboard-history";
-    changelog = "https://github.com/SUPERCILEX/clipboard-history/releases/tag/${finalAttrs.version}";
+    changelog = "https://github.com/SUPERCILEX/clipboard-history/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.magnetophon ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
