### PR TITLE
modctl: init at 0.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9722,6 +9722,12 @@
     githubId = 16470252;
     name = "Gemini Lasswell";
   };
+  gbhu753 = {
+    email = "me@gurjotbhullar.com";
+    github = "GBHU753";
+    githubId = 100983240;
+    name = "Gurjot Bhullar";
+  };
   gbtb = {
     email = "goodbetterthebeast3@gmail.com";
     github = "gbtb";

--- a/pkgs/by-name/mo/modctl/package.nix
+++ b/pkgs/by-name/mo/modctl/package.nix
@@ -2,9 +2,11 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   __structuredAttrs = true;
   pname = "modctl";
   version = "0.2.2";
@@ -12,7 +14,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "modelpack";
     repo = "modctl";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-A7s2jM+hR5WgeiWzPjjfS/AJy35x6kzewIucz713zLc=";
   };
 
@@ -20,24 +22,23 @@ buildGoModule rec {
 
   ldflags = [
     "-s"
-    "-w"
-    "-X github.com/modelpack/modctl/pkg/version.GitVersion=v${version}"
+    "-X github.com/modelpack/modctl/pkg/version.GitVersion=v${finalAttrs.version}"
   ];
 
   doInstallCheck = true;
-  installCheckPhase = ''
-    runHook preInstallCheck
-    $out/bin/modctl --help > /dev/null
-    $out/bin/modctl version --log-dir="$TMPDIR" --storage-dir="$TMPDIR" 2>&1 | grep -q "v${version}"
-    runHook postInstallCheck
-  '';
+  nativeInstallCheckInputs = [
+    writableTmpDirAsHomeHook
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "version";
+  versionCheckKeepEnvironment = [ "HOME" ];
 
   meta = {
     description = "CLI tool for managing OCI model artifacts based on Model Spec";
     homepage = "https://github.com/modelpack/modctl";
-    changelog = "https://github.com/modelpack/modctl/releases/tag/v${version}";
+    changelog = "https://github.com/modelpack/modctl/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ gbhu753 ];
     mainProgram = "modctl";
   };
-}
+})

--- a/pkgs/by-name/mo/modctl/package.nix
+++ b/pkgs/by-name/mo/modctl/package.nix
@@ -28,7 +28,7 @@ buildGoModule rec {
   installCheckPhase = ''
     runHook preInstallCheck
     $out/bin/modctl --help > /dev/null
-    $out/bin/modctl version 2>&1 | grep -q "v${version}"
+    $out/bin/modctl version --log-dir="$TMPDIR" --storage-dir="$TMPDIR" 2>&1 | grep -q "v${version}"
     runHook postInstallCheck
   '';
 

--- a/pkgs/by-name/mo/modctl/package.nix
+++ b/pkgs/by-name/mo/modctl/package.nix
@@ -3,7 +3,6 @@
   buildGoModule,
   fetchFromGitHub,
   versionCheckHook,
-  writableTmpDirAsHomeHook,
 }:
 
 buildGoModule (finalAttrs: {
@@ -26,12 +25,25 @@ buildGoModule (finalAttrs: {
   ];
 
   doInstallCheck = true;
-  nativeInstallCheckInputs = [
-    writableTmpDirAsHomeHook
-    versionCheckHook
-  ];
+  nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "version";
-  versionCheckKeepEnvironment = [ "HOME" ];
+
+  # modctl's cobra commands invoke config.NewRoot(), which uses
+  # os/user.Current() to find the home directory. On darwin os/user
+  # bypasses $HOME and resolves it via getpwuid (returning /var/empty,
+  # not writable), so the install check fails. versionCheckHook only
+  # accepts a single argument, so wrap the binary and point
+  # --log-dir/--storage-dir at TMPDIR to keep the check working on all
+  # platforms.
+  preVersionCheck = ''
+    wrapper="$NIX_BUILD_TOP/modctl-version-check"
+    cat > "$wrapper" <<EOF
+    #!/bin/sh
+    exec "$out/bin/modctl" "\$@" --log-dir="$TMPDIR" --storage-dir="$TMPDIR"
+    EOF
+    chmod +x "$wrapper"
+    versionCheckProgram="$wrapper"
+  '';
 
   meta = {
     description = "CLI tool for managing OCI model artifacts based on Model Spec";

--- a/pkgs/by-name/mo/modctl/package.nix
+++ b/pkgs/by-name/mo/modctl/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  __structuredAttrs = true;
+  pname = "modctl";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "modelpack";
+    repo = "modctl";
+    rev = "v${version}";
+    hash = "sha256-A7s2jM+hR5WgeiWzPjjfS/AJy35x6kzewIucz713zLc=";
+  };
+
+  vendorHash = "sha256-S1ygAZO3bTFi/3pwmNYE7P/Vqg7AVHpH5YRJ3yzzvyo=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/modelpack/modctl/pkg/version.GitVersion=v${version}"
+  ];
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/bin/modctl --help > /dev/null
+    $out/bin/modctl version 2>&1 | grep -q "v${version}"
+    runHook postInstallCheck
+  '';
+
+  meta = {
+    description = "CLI tool for managing OCI model artifacts based on Model Spec";
+    homepage = "https://github.com/modelpack/modctl";
+    changelog = "https://github.com/modelpack/modctl/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ gbhu753 ];
+    mainProgram = "modctl";
+  };
+}


### PR DESCRIPTION
modctl is a CLI tool for managing OCI model artifacts based on Model Spec.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
