### PR TITLE
tylax: init at 0.3.8

### DIFF
--- a/pkgs/by-name/ty/tylax/package.nix
+++ b/pkgs/by-name/ty/tylax/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tylax";
+  version = "0.3.7";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "scipenai";
+    repo = "tylax";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-XwgSBEJ0Y9Tuxivlizht7uGaRJMI45vZhaXZBVXxbTI=";
+  };
+
+  cargoHash = "sha256-AI1RXI1U7x7xU5GuzPsKpF3f5KeoXB7kYVxWITue9Xs=";
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "High-performance bidirectional LaTeX and Typst converter";
+    homepage = "https://github.com/scipenai/tylax";
+    changelog = "https://github.com/scipenai/tylax/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    mainProgram = "t2l";
+    maintainers = with lib.maintainers; [ kilianar ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
This PR adds [tylax](https://github.com/scipenai/tylax/) to nixpkgs, a bidrectional converter between typst and LaTeX.


## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
