### PR TITLE
chromium,chromedriver: 149.0.7827.155 -> 149.0.7827.196

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,10 +1,10 @@
 {
   "chromium": {
-    "version": "149.0.7827.155",
+    "version": "149.0.7827.196",
     "chromedriver": {
-      "version": "149.0.7827.156",
-      "hash_darwin": "sha256-V7ZBijHsPzyphJPipWlIcU5Mb9l1OWzLc6PzxFKFuR8=",
-      "hash_darwin_aarch64": "sha256-sUG2Qg+nPIrYQC0iKNK78O1l92qTSDbRnJFfrqJMpts="
+      "version": "149.0.7827.197",
+      "hash_darwin": "sha256-tN7s6s/pbfAGRCMcoT3QWYHD8QRq2gcHfFSXoSG9V5Y=",
+      "hash_darwin_aarch64": "sha256-DZ8CZ4Obp67Zo2m4iyqUnShyhTK8+/75cJ/WmZZqQhE="
     },
     "deps": {
       "depot_tools": {
@@ -21,8 +21,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "07b52360cc15066f987c910ab34dfbcd4a8778d2",
-        "hash": "sha256-D9RKH0kzEfaMsCDnFFIGCGLyfhghnGMOLA0XmOa9MtI=",
+        "rev": "43eb30368c6ca3d14d540487954abb2780aeae3a",
+        "hash": "sha256-pwSfASgR4SiQTJBERhOVyR8mANYJk67f+u2pmCCW6ko=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -92,8 +92,8 @@
       },
       "src/third_party/angle": {
         "url": "https://chromium.googlesource.com/angle/angle.git",
-        "rev": "591ee1999d950f2bc54be89651eb62c8d7925314",
-        "hash": "sha256-crooDCkJ6voJyDBIUvtjmXnA4xOx7YmGltuf2ulTLIk="
+        "rev": "355cc61af2aadd8f0494800325b2bf9908138108",
+        "hash": "sha256-fgaCyO0oaz90aTaWMHH8ocySA0hXDHsPEl6vtMj4BY0="
       },
       "src/third_party/angle/third_party/glmark2/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glmark2/glmark2",
@@ -132,8 +132,8 @@
       },
       "src/third_party/dawn": {
         "url": "https://dawn.googlesource.com/dawn.git",
-        "rev": "5f4c5ef509c5ffa65822302341cf9b2ccad471f9",
-        "hash": "sha256-h+0Gep+RWTTEVoRrXCRDCtHdbYlSYdNK1botahtqUX0="
+        "rev": "54b4153cfef88e048f365f99b962478f0087dfe8",
+        "hash": "sha256-Bv30zz/pCNVzUl+mKCpusWc94poytv9ZFelZIcs+2B8="
       },
       "src/third_party/dawn/third_party/glfw3/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glfw/glfw",
@@ -817,8 +817,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "6511f6cfab1f24c360d0fb737d205c27da48a623",
-        "hash": "sha256-Dpe0Z/zjdPlOlqi85c9QSr7rLs7dww+a/BY68B2MTCw="
+        "rev": "933ce636c562cd54d68e7f7c93ab5cdffd685fca",
+        "hash": "sha256-zYArO6QS9nDIVWPINRVaDN1uX8X/wchBDeZHPZnwHYk="
       }
     }
   },


### PR DESCRIPTION
https://chromereleases.googleblog.com/2026/06/stable-channel-update-for-desktop_0482630350.html

This update includes 18 security fixes.

CVEs:
CVE-2026-13028 CVE-2026-13032 CVE-2026-13033 CVE-2026-13038
CVE-2026-13021 CVE-2026-13022 CVE-2026-13023 CVE-2026-13024
CVE-2026-13025 CVE-2026-13026 CVE-2026-13027 CVE-2026-13029
CVE-2026-13030 CVE-2026-13031 CVE-2026-13034 CVE-2026-13035
CVE-2026-13036 CVE-2026-13037

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
