### PR TITLE
testers.hasPkgConfigModules: Fix meta propagation

### DIFF
--- a/pkgs/build-support/testers/hasPkgConfigModules/tester.nix
+++ b/pkgs/build-support/testers/hasPkgConfigModules/tester.nix
@@ -30,7 +30,7 @@ runCommand testName
       broken = throw "unused";
       insecure = throw "unused";
       license = throw "unused";
-      maintainers = throw "unused";
+      nonTeamMaintainers = throw "unused";
       teams = throw "unused";
       platforms = throw "unused";
       unfree = throw "unused";


### PR DESCRIPTION
Needs to forward `nonTeamMaintainers` instead of `maintainers`, because the latter is autopopulated from the former, which in case of teams means all teams members would be added as well.

This is what caused an update to curlMinimal to request individual team members instead of just the team itself: https://github.com/NixOS/nixpkgs/pull/534906


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- [x] Tested that `nix-instantiate --eval -A tests.pkg-config.defaultPkgConfigPackages.libcurl.meta.nonTeamMaintainers` now only contains the single non-team maintainer of libcurl.