### PR TITLE
cmdg: init at 1.05-unstable-2026-06-11

### DIFF
--- a/pkgs/by-name/cm/cmdg/package.nix
+++ b/pkgs/by-name/cm/cmdg/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  lynx,
+  gnupg,
+  less,
+  nano,
+  makeBinaryWrapper,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "cmdg";
+  version = "1.05-unstable-2026-06-11";
+
+  src = fetchFromGitHub {
+    owner = "ThomasHabets";
+    repo = "cmdg";
+    rev = "069abc1f2c249ffef49cb3910e8f901639de7618";
+    hash = "sha256-wUC90UucAHkNvjvU2vEp35tpOAzNavLi8qJCgIG14Bc=";
+  };
+
+  vendorHash = "sha256-r6gjZOWcztX0N9BualwRFulxo/zlA3fvF1CNjIeSZd0=";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  subPackages = [ "cmd/cmdg" ];
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  postFixup = ''
+    wrapProgram $out/bin/cmdg  \
+      --prefix PATH : "${
+        lib.makeBinPath [
+          lynx
+          gnupg
+        ]
+      }"  \
+      --set-default PAGER "${lib.getExe less}"  \
+      --set-default EDITOR "${lib.getExe nano}"
+  '';
+
+  meta = {
+    description = "Command line Gmail client";
+    homepage = "https://github.com/ThomasHabets/cmdg";
+    mainProgram = "cmdg";
+    platforms = lib.platforms.unix;
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ castorNova2 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds [cmdg](https://github.com/ThomasHabets/cmdg) which is a command line Gmail client.

Users must create Google OAuth desktop credentials and complete the setup flow described in the [upstream](https://github.com/ThomasHabets/cmdg/blob/master/README.md), this writes ~/.cmdg/cmdg.conf.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
