### PR TITLE
python3Packages.scikit-bio: reduce openmp threads during tests

### DIFF
--- a/pkgs/development/python-modules/captum/default.nix
+++ b/pkgs/development/python-modules/captum/default.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   buildPythonPackage,
   pytestCheckHook,
   setuptools,
@@ -52,6 +51,10 @@ buildPythonPackage rec {
     parameterized
     scikit-learn
   ];
+
+  preCheck = ''
+    export OMP_NUM_THREADS=1
+  '';
 
   disabledTestPaths =
     lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/development/python-modules/linearmodels/default.nix
+++ b/pkgs/development/python-modules/linearmodels/default.nix
@@ -67,6 +67,8 @@ buildPythonPackage (finalAttrs: {
 
   preCheck = ''
     rm linearmodels/__init__.py
+
+    export OMP_NUM_THREADS=1
   '';
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/mace-torch/default.nix
+++ b/pkgs/development/python-modules/mace-torch/default.nix
@@ -82,6 +82,10 @@ buildPythonPackage (finalAttrs: {
     writableTmpDirAsHomeHook
   ];
 
+  preCheck = ''
+    export OMP_NUM_THREADS=1
+  '';
+
   disabledTests = [
     # _pickle.PickleError: ScriptFunction cannot be pickled
     "test_run_eval_fail_with_wrong_model"

--- a/pkgs/development/python-modules/rq/default.nix
+++ b/pkgs/development/python-modules/rq/default.nix
@@ -76,6 +76,10 @@ buildPythonPackage (finalAttrs: {
       # PermissionError: [Errno 13] Permission denied: '/tmp/rq-tests.txt'
       "test_deleted_jobs_arent_executed"
       "test_suspend_worker_execution"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      # no delay between reaping worker and checking; racy
+      "test_reap_workers"
     ];
 
   pythonImportsCheck = [ "rq" ];

--- a/pkgs/development/python-modules/scikit-bio/default.nix
+++ b/pkgs/development/python-modules/scikit-bio/default.nix
@@ -62,6 +62,10 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
   ];
 
+  preCheck = ''
+    export OMP_NUM_THREADS=1
+  '';
+
   # only the $out dir contains the built cython extensions, so we run the tests inside there
   enabledTestPaths = [ "${placeholder "out"}/${python.sitePackages}/skbio" ];
 

--- a/pkgs/development/python-modules/torch-geometric/default.nix
+++ b/pkgs/development/python-modules/torch-geometric/default.nix
@@ -185,6 +185,10 @@ buildPythonPackage (finalAttrs: {
     writableTmpDirAsHomeHook
   ];
 
+  preCheck = ''
+    export OMP_NUM_THREADS=1
+  '';
+
   pytestFlags = [
     # DeprecationWarning: Failing to pass a value to the 'type_params' parameter of
     # 'typing._eval_type' is deprecated, as it leads to incorrect behaviour when calling

--- a/pkgs/development/python-modules/x-transformers/default.nix
+++ b/pkgs/development/python-modules/x-transformers/default.nix
@@ -42,6 +42,10 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  preCheck = ''
+    export OMP_NUM_THREADS=1
+  '';
+
   # RuntimeError: torch.compile is not supported on Python 3.14+
   disabledTests = lib.optionals (pythonAtLeast "3.14") [ "test_up" ];
 


### PR DESCRIPTION
The tests finish quickly enough (4m36s for me) with just a single OpenMP thread and this prevents it from becoming a scheduling nightmare on hydra.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
