### PR TITLE
debcraft: init at 0.9.2

### DIFF
--- a/pkgs/by-name/de/debcraft/package.nix
+++ b/pkgs/by-name/de/debcraft/package.nix
@@ -1,0 +1,52 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  help2man,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "debcraft";
+  version = "0.9.2";
+
+  src = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "debian";
+    repo = "debcraft";
+    tag = "debian/${finalAttrs.version}";
+    hash = "sha256-U8qWT26qno2zpfdsLqlqZg0SipvHCN6dUjUCjGuyrkY=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [ help2man ];
+  makeFlags = [ "DESTDIR=$(out)" ];
+
+  # debcraft ships with some scripts it'll execute inside a docker/podman container
+  # this'd patch the shebangs of the scripts executed in the container too, breaking them.
+  dontPatchShebangs = true;
+
+  postPatch = ''
+    substituteInPlace debcraft.sh --replace-fail \
+      'DEBCRAFT_LIB_DIR="/usr/share/debcraft"' \
+      "DEBCRAFT_LIB_DIR=\"$out/share/debcraft\""
+
+    # their Makefile installs in DESTDIR/usr for some reason
+    substituteInPlace Makefile --replace-fail '$(DESTDIR)/usr' '$(DESTDIR)'
+  '';
+
+  preBuild = ''
+    # the makefile runs help2man on the script, which needs it to be executable
+    # (and the shebang would need to be patched later anyways)
+    patchShebangs debcraft.sh
+  '';
+
+  meta = {
+    description = "Easy, fast and secure way to build Debian packages";
+    homepage = "https://salsa.debian.org/debian/debcraft";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.gilice ];
+    platforms = lib.platforms.unix;
+    mainProgram = "debcraft";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- debcraft is a way to build .deb packages for debian: https://salsa.debian.org/debian/debcraft
- prior art @ https://github.com/algorithmiker/debcraft-nix

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
