### PR TITLE
teams.matrix: reform

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -510,6 +510,7 @@ with lib.maintainers;
       dandellion
       nickcao
       teutat3s
+      transcaffeine
     ];
     scope = "Maintain the ecosystem around Matrix, a decentralized messenger.";
     shortName = "Matrix";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -506,8 +506,6 @@ with lib.maintainers;
   matrix = {
     members = [
       ma27
-      mguentner
-      dandellion
       nickcao
       teutat3s
       transcaffeine

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -512,7 +512,7 @@ with lib.maintainers;
       teutat3s
       transcaffeine
     ];
-    scope = "Maintain the ecosystem around Matrix, a decentralized messenger.";
+    scope = "Maintain the foundational packages of the Matrix ecosystem.";
     shortName = "Matrix";
   };
 

--- a/nixos/modules/services/matrix/dendrite.nix
+++ b/nixos/modules/services/matrix/dendrite.nix
@@ -341,5 +341,4 @@ in
       };
     };
   };
-  meta.teams = [ lib.teams.matrix ];
 }

--- a/nixos/tests/matrix/pantalaimon.nix
+++ b/nixos/tests/matrix/pantalaimon.nix
@@ -31,9 +31,6 @@ let
 in
 {
   name = "pantalaimon";
-  meta = {
-    maintainers = pkgs.lib.teams.matrix.members;
-  };
 
   nodes.machine =
     { pkgs, ... }:

--- a/pkgs/applications/networking/instant-messengers/hydrogen-web/unwrapped.nix
+++ b/pkgs/applications/networking/instant-messengers/hydrogen-web/unwrapped.nix
@@ -64,7 +64,6 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Lightweight matrix client with legacy and mobile browser support";
     homepage = "https://github.com/element-hq/hydrogen-web";
-    teams = [ lib.teams.matrix ];
     license = lib.licenses.asl20;
     platforms = lib.platforms.all;
     inherit (olm.meta) knownVulnerabilities;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* Add @transcaffeine to the maintainer team

  She's been tirelessly keeping Synapse up-to-date and also worked quite a
  lot on the Element packages, so having her officially part of this makes
  sense. I confirmed with her in private that she's interested.

* Rescope what the team is for

  It's absolutely not reasonable to have us maintain random homeserver
  implementations and Matrix clients. I don't think anyone is actually
  operating and focusing on >1 of these implementations, so restricting
  ourselves to the core things & reference implementations makes more
  sense to me.

* Remove inactive people

  This list reflects the current reality better.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
