### PR TITLE
tcia-data-retriever: init at 0.16.0-20260529

### DIFF
--- a/pkgs/by-name/tc/tcia-data-retriever/package.nix
+++ b/pkgs/by-name/tc/tcia-data-retriever/package.nix
@@ -1,0 +1,109 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  npmHooks,
+  nodejs,
+  wails,
+  webkitgtk_4_1,
+  glib-networking,
+  pkg-config,
+  copyDesktopItems,
+  makeDesktopItem,
+  autoPatchelfHook,
+  wrapGAppsHook3,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "tcia-data-retriever";
+  version = "0.16.0-20260529";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "TCIA";
+    repo = "data-retriever";
+    tag = finalAttrs.version;
+    hash = "sha256-TLuhs0rHjPlbd/8TfUCYBNVhGudcwviuGOei6aPNn6U=";
+  };
+
+  # The Angular production build inlines Google Fonts by fetching them over the
+  # network, which fails in the sandbox. Disable font inlining (the fonts are
+  # already vendored under frontend/src/assets).
+  postPatch = ''
+    substituteInPlace frontend/angular.json \
+      --replace-fail '"outputHashing": "all"' '"outputHashing": "all",
+              "optimization": { "fonts": false }'
+  '';
+
+  vendorHash = "sha256-dGlDC8VxO8+q+h9WcBBSJTzl3vjNxVnsqaS3PY49SdI=";
+
+  env = {
+    CGO_ENABLED = 1;
+    npmDeps = fetchNpmDeps {
+      src = "${finalAttrs.src}/frontend";
+      hash = "sha256-b4O4Qf7DHM/dG177yVeduBUNEk2hWkqfel9Aliry/dc=";
+    };
+    npmRoot = "frontend";
+  };
+
+  nativeBuildInputs = [
+    wails
+    pkg-config
+    autoPatchelfHook
+    nodejs
+    npmHooks.npmConfigHook
+    copyDesktopItems
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    webkitgtk_4_1
+    glib-networking
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    wails build -m -trimpath -tags webkit2_41 -o tcia-data-retriever
+
+    runHook postBuild
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "tcia-data-retriever";
+      exec = "tcia-data-retriever %U";
+      icon = "tcia-data-retriever";
+      desktopName = "TCIA Data Retriever";
+      genericName = "Cancer Imaging Archive downloader";
+      comment = "Download medical imaging data from The Cancer Imaging Archive";
+      categories = [
+        "Network"
+        "Science"
+      ];
+      startupWMClass = "TCIA_Data_Retriever";
+      terminal = false;
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm0755 build/bin/tcia-data-retriever $out/bin/tcia-data-retriever
+    install -Dm0644 frontend/src/assets/AppIcon.iconset/icon_512x512.png \
+      $out/share/icons/hicolor/512x512/apps/tcia-data-retriever.png
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Desktop GUI and CLI for downloading data from The Cancer Imaging Archive";
+    homepage = "https://github.com/TCIA/data-retriever";
+    license = lib.licenses.asl20;
+    mainProgram = "tcia-data-retriever";
+    maintainers = [ ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Adds [TCIA Data Retriever](https://github.com/TCIA/data-retriever), a cross-platform desktop GUI (with a CLI mode in the same binary) for downloading medical imaging data from The Cancer Imaging Archive. It is a Wails v2 application (Go backend + Angular frontend), licensed Apache-2.0.

Notes:
- Packaged as a `by-name` package following the `tiny-rdm` Wails pattern (`buildGoModule` + `fetchNpmDeps` + `wails build -tags webkit2_41`).
- The Angular production build inlines Google Fonts over the network; disabled via a small `postPatch` setting `optimization.fonts = false` (fonts are already vendored in-tree), so the build works in the sandbox.
- Linux only, matching the other Wails packages in nixpkgs (`webkitgtk_4_1`).
- `meta.maintainers` is currently empty; happy to take a maintainer suggestion.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR (`nixpkgs-review rev HEAD`): 1 package added, `tcia-data-retriever` built successfully.
- [x] Tested basic functionality of `./result/bin/tcia-data-retriever` (CLI mode runs; binary links against webkitgtk via autoPatchelf).
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

## AI assistance disclosure

Per the [automation/AI policy], this contribution was assisted by **Claude Code using Claude Opus 4.8 (claude-opus-4-8)** (disclosed via the `Assisted-by:` commit trailer and here for the PR summary). The packaging, the three FOD hashes, and the build were reviewed and verified by the human submitter: hashes were independently recomputed with `nix hash path`, and the package builds cleanly under `nixpkgs-review`.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

🤖 Generated with [Claude Code](https://claude.com/claude-code)