### PR TITLE
pinchflat: correct esbuild symlink name on Darwin

### DIFF
--- a/pkgs/by-name/pi/pinchflat/package.nix
+++ b/pkgs/by-name/pi/pinchflat/package.nix
@@ -58,10 +58,13 @@ beamPackages.mixRelease rec {
     patchShebangs ~/assets/node_modules
 
     # phoenixframework expects platform-specific tailwind/esbuild binaries in a specific location:
-    # https://github.com/phoenixframework/tailwind/blob/194ab0f979782e4ccf2fe796042bf8e20967df93/lib/tailwind.ex#L243-L251
-    targets="linux-x64 linux-arm64 macos-x64 macos-arm64"
-    for target in $targets; do
+    # tailwind: https://github.com/phoenixframework/tailwind/blob/194ab0f979782e4ccf2fe796042bf8e20967df93/lib/tailwind.ex#L243-L251
+    for target in linux-x64 linux-arm64 macos-x64 macos-arm64; do
       ln -s "${tailwindcss}/bin/tailwindcss" "_build/tailwind-$target"
+    done
+
+    # esbuild: https://github.com/phoenixframework/esbuild/blob/v0.10.0/lib/esbuild.ex#L270-L300
+    for target in linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
       ln -s "${esbuild}/bin/esbuild" "_build/esbuild-$target"
     done
 


### PR DESCRIPTION
The tailwind and esbuild libraries expect different Darwin target names (`macos-*` and `darwin-*`), so each binary has to be symlinked under the name its own library looks for.

The esbuild binary was instead symlinked under tailwind's `macos-*` name, so the esbuild library did not find it and fell back to downloading esbuild from npm at build time; that download fails in sandboxed and offline builds such as nixpkgs-review (no network or CA bundle).

Assisted-by: Claude Code (Claude Opus 4.8)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
