### PR TITLE
home-assistant: backport pyjwt 2.13.0 support

### DIFF
--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -324,6 +324,9 @@ python3Packages.buildPythonApplication rec {
     (replaceVars ./patches/ffmpeg-path.patch {
       ffmpeg = "${lib.getExe ffmpeg-headless}";
     })
+
+    # https://github.com/home-assistant/core/pull/172893
+    ./patches/pyjwt-2.13-compat.patch
   ];
 
   postPatch = ''

--- a/pkgs/servers/home-assistant/patches/pyjwt-2.13-compat.patch
+++ b/pkgs/servers/home-assistant/patches/pyjwt-2.13-compat.patch
@@ -1,0 +1,48 @@
+diff --git a/homeassistant/auth/__init__.py b/homeassistant/auth/__init__.py
+index d4b86febd1d..0edd0edd69b 100644
+--- a/homeassistant/auth/__init__.py
++++ b/homeassistant/auth/__init__.py
+@@ -656,6 +656,8 @@ class AuthManager:
+         try:
+             unverif_claims = jwt_wrapper.unverified_hs256_token_decode(token)
+         except jwt.InvalidTokenError:
++            # PyJWT 2.13 raises InvalidKeyError (not an InvalidTokenError) when
++            # the refresh token's key has been removed and is therefore empty.
+             return None
+ 
+         refresh_token = self.async_get_refresh_token(
+@@ -673,7 +675,7 @@ class AuthManager:
+             jwt_wrapper.verify_and_decode(
+                 token, jwt_key, leeway=10, issuer=issuer, algorithms=["HS256"]
+             )
+-        except jwt.InvalidTokenError:
++        except jwt.InvalidTokenError, jwt.InvalidKeyError:
+             return None
+ 
+         if refresh_token is None or not refresh_token.user.is_active:
+diff --git a/homeassistant/components/html5/notify.py b/homeassistant/components/html5/notify.py
+index 24b395748d8..3424749e86d 100644
+--- a/homeassistant/components/html5/notify.py
++++ b/homeassistant/components/html5/notify.py
+@@ -327,7 +327,7 @@ class HTML5PushCallbackView(HomeAssistantView):
+         if target_check.get(ATTR_TARGET) in self.registrations:
+             possible_target = self.registrations[target_check[ATTR_TARGET]]
+             key = possible_target["subscription"]["keys"]["auth"]
+-            with suppress(jwt.exceptions.DecodeError), warnings.catch_warnings():
++            with suppress(jwt.exceptions.DecodeError, jwt.exceptions.InvalidKeyError), warnings.catch_warnings():
+                 warnings.simplefilter("ignore", InsecureKeyLengthWarning)
+                 return jwt.decode(token, key, algorithms=["ES256", "HS256"])
+ 
+diff --git a/tests/components/elmax/conftest.py b/tests/components/elmax/conftest.py
+index 02f01036996..c9c3f13e9e3 100644
+--- a/tests/components/elmax/conftest.py
++++ b/tests/components/elmax/conftest.py
+@@ -82,7 +82,7 @@ def httpx_mock_direct_fixture(base_uri: str) -> Generator[respx.MockRouter]:
+         expiration = datetime.now() + timedelta(hours=1)
+         decoded_jwt["payload"]["exp"] = int(expiration.timestamp())
+         jws_string = jwt.encode(
+-            payload=decoded_jwt["payload"], algorithm="HS256", key=""
++            payload=decoded_jwt["payload"], algorithm="HS256", key="test"
+         )
+         login_json["token"] = f"JWT {jws_string}"
+         login_route.return_value = Response(200, json=login_json)


### PR DESCRIPTION
The pyjwt 2.13 security update in staging-next breaks home-assistant.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
