### PR TITLE
livekit-cli: 2.16.4 ->  2.16.6

### DIFF
--- a/pkgs/by-name/li/livekit-cli/package.nix
+++ b/pkgs/by-name/li/livekit-cli/package.nix
@@ -4,20 +4,28 @@
   fetchFromGitHub,
   nix-update-script,
   testers,
+  pkg-config,
+  portaudio,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "livekit-cli";
-  version = "2.16.4";
+  version = "2.16.6";
 
   src = fetchFromGitHub {
     owner = "livekit";
     repo = "livekit-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-D3moluv7tWi9BIvhHq4NDgDmCBNtWPEJPIbvpaAHtao=";
+    hash = "sha256-lsvbnc2YGPX2OYmdH6ZW0a6eNF+o3S8Y0eLuYsb4dUs=";
   };
 
-  vendorHash = "sha256-/vhISkzvfsPswsM0g4/RuyTZxqEEtfbtyAQV8YDRmu8=";
+  vendorHash = "sha256-BzEv2wpcXX7at6jJdgy9DtErbIU8ZPL+ollK1rlUWSA=";
+
+  # Use nixpkgs portaudio package + pkg-config rather than relying on a vendored
+  # git submodule, similar to the homebrew solution
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ portaudio ];
+  tags = [ "portaudio_system" ];
 
   subPackages = [ "cmd/lk" ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bump version to v2.16.6 and use `portaudio` from `nixpkgs` instead of relying on git submodule-vendored version (source recently switched to using a git submodule for building portaudio which causes the include statement to fail when building, so we instead switch over to the version included in `nixpkgs`)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
