### PR TITLE
gitlab: 18.11.5 -> 18.11.6

### DIFF
--- a/pkgs/by-name/gi/gitaly/package.nix
+++ b/pkgs/by-name/gi/gitaly/package.nix
@@ -7,7 +7,7 @@
 }:
 
 let
-  version = "18.11.5";
+  version = "18.11.6";
   package_version = "v${lib.versions.major version}";
   gitaly_package = "gitlab.com/gitlab-org/gitaly/${package_version}";
 
@@ -21,7 +21,7 @@ let
       owner = "gitlab-org";
       repo = "gitaly";
       rev = "v${version}";
-      hash = "sha256-i2DgcNoGPR/B6qya+jYFU5noOSabSlwu9P7p5KwR6jI=";
+      hash = "sha256-fsr8ttV2q2iedTA5yn4iHry92Mgu775K1GW3JBz5N1U=";
     };
 
     vendorHash = "sha256-/RJnCcmUoqGy08MSGEVM/taV1qZK65kiZw19n6S3ZQ0=";

--- a/pkgs/by-name/gi/gitlab-pages/package.nix
+++ b/pkgs/by-name/gi/gitlab-pages/package.nix
@@ -6,14 +6,14 @@
 
 buildGoModule (finalAttrs: {
   pname = "gitlab-pages";
-  version = "18.11.5";
+  version = "18.11.6";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitlab-pages";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-jSTXLbzYCiCpqrbs9kAmW6um2X5hA1OFiA6fSZrQ2RI=";
+    hash = "sha256-D/AlIXbcgvPyP2TX/lXVYlnG2HXKZlxOhqRTfTXsaew=";
   };
 
   vendorHash = "sha256-PUW4cgAiM1GTtvja894OZ4pe0SWChf5JsL4/fkns2kI=";

--- a/pkgs/by-name/gi/gitlab/data.json
+++ b/pkgs/by-name/gi/gitlab/data.json
@@ -1,17 +1,17 @@
 {
-  "version": "18.11.5",
-  "repo_hash": "sha256-/RIUqxfRjq3+TOvapYMfl0uVqQLp1adpE6bR303rH6g=",
+  "version": "18.11.6",
+  "repo_hash": "sha256-bdnBX6M4BtuA03CP/N0teKnuey3V9qHseBoxTIGXE5Q=",
   "yarn_hash": "sha256-og09R28lwYvDk4pe7z1dRMaanYiTsUSx+SUKoWc53do=",
   "frontend_islands_yarn_hash": "sha256-EvGQin+5DqqIgM36jlVkVI49WcJzVvceYnkSS9ybfcY=",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v18.11.5-ee",
+  "rev": "v18.11.6-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "18.11.5",
-    "GITLAB_KAS_VERSION": "18.11.5",
-    "GITLAB_PAGES_VERSION": "18.11.5",
+    "GITALY_SERVER_VERSION": "18.11.6",
+    "GITLAB_KAS_VERSION": "18.11.6",
+    "GITLAB_PAGES_VERSION": "18.11.6",
     "GITLAB_SHELL_VERSION": "14.50.0",
     "GITLAB_ELASTICSEARCH_INDEXER_VERSION": "5.14.7",
-    "GITLAB_WORKHORSE_VERSION": "18.11.5"
+    "GITLAB_WORKHORSE_VERSION": "18.11.6"
   }
 }

--- a/pkgs/by-name/gi/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/by-name/gi/gitlab/gitlab-workhorse/default.nix
@@ -10,7 +10,7 @@ in
 buildGoModule (finalAttrs: {
   pname = "gitlab-workhorse";
 
-  version = "18.11.5";
+  version = "18.11.6";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitLab {

--- a/pkgs/by-name/gi/gitlab/rubyEnv/Gemfile.lock
+++ b/pkgs/by-name/gi/gitlab/rubyEnv/Gemfile.lock
@@ -537,7 +537,7 @@ GEM
       thor (>= 0.19, < 2)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    devfile (0.5.0)
+    devfile (0.5.2)
     device_detector (1.1.3)
     devise (4.9.4)
       bcrypt (~> 3.0)
@@ -2678,7 +2678,7 @@ CHECKSUMS
   declarative_policy (2.1.0) sha256=f9ab705da726174bde97785c319311a4abf6143c07862f882bd8bc1b69361eea
   derailed_benchmarks (2.2.1) sha256=654280664fded41c9cd8fc27fc0fcfaf096023afab90eb4ac1185ba70c5d4439
   descendants_tracker (0.0.4) sha256=e9c41dd4cfbb85829a9301ea7e7c48c2a03b26f09319db230e6479ccdc780897
-  devfile (0.5.0) sha256=6a7e3be19e3e6b4b698b64ec4d6fd85b6653ce810c65cee611907d47ebb4cccf
+  devfile (0.5.2) sha256=2398cc38726f7bce03088eb74e4157f7839b353e36a488565e3fcc7739cd613d
   device_detector (1.1.3) sha256=c5fe3fe42cab2e8aa01f193b2074b8bb1510373ce47127206f28c7dea75a9c79
   devise (4.9.4) sha256=920042fe5e704c548aa4eb65ebdd65980b83ffae67feb32c697206bfd975a7f8
   devise-pbkdf2-encryptable (0.0.0)

--- a/pkgs/by-name/gi/gitlab/rubyEnv/gemset.nix
+++ b/pkgs/by-name/gi/gitlab/rubyEnv/gemset.nix
@@ -1621,10 +1621,10 @@ src: {
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1kycnkmlfzch27kcwr8ch7756rjvv1plvv34idllnsrykvhknzka";
+      sha256 = "0gb1rlwpgk1zbrb8i91n7qsrp0zpax0lxdwf101wwyvgf8wcr613";
       type = "gem";
     };
-    version = "0.5.0";
+    version = "0.5.2";
   };
   device_detector = {
     groups = [ "default" ];


### PR DESCRIPTION
https://docs.gitlab.com/releases/patches/patch-release-gitlab-19-1-1-released/?nav=18.11.6


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
