### PR TITLE
postgresqlPackages.vectorchord: rename upstream github owner & mark broken on pg19

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/vectorchord/package.nix
+++ b/pkgs/servers/sql/postgresql/ext/vectorchord/package.nix
@@ -15,8 +15,8 @@ buildPgrxExtension (finalAttrs: {
   version = "1.1.1";
 
   src = fetchFromGitHub {
-    owner = "tensorchord";
-    repo = "vectorchord";
+    owner = "supervc-stack";
+    repo = "VectorChord";
     tag = finalAttrs.version;
     hash = "sha256-QL9XGSQFOcrpww03Y5F0JuDbpo0v8oidUqucLxggkqE=";
   };
@@ -24,7 +24,7 @@ buildPgrxExtension (finalAttrs: {
   cargoHash = "sha256-IXOCzKJArNOcb/2TcJbLz1XdCquUpyF/cLHYU5vmlko=";
 
   # Include upgrade scripts in the final package
-  # https://github.com/tensorchord/VectorChord/blob/0.5.0/crates/make/src/main.rs#L366
+  # https://github.com/supervc-stack/VectorChord/blob/0.5.0/crates/make/src/main.rs#L366
   postInstall = ''
     cp sql/upgrade/* $out/share/postgresql/extension/
   '';
@@ -89,9 +89,9 @@ buildPgrxExtension (finalAttrs: {
   };
 
   meta = {
-    changelog = "https://github.com/tensorchord/VectorChord/releases/tag/${finalAttrs.version}";
+    changelog = "https://github.com/supervc-stack/VectorChord/releases/tag/${finalAttrs.version}";
     description = "Scalable, fast, and disk-friendly vector search in Postgres, the successor of pgvecto.rs";
-    homepage = "https://github.com/tensorchord/VectorChord";
+    homepage = "https://github.com/supervc-stack/VectorChord";
     license = lib.licenses.OR [
       lib.licenses.agpl3Only
       lib.licenses.elastic20

--- a/pkgs/servers/sql/postgresql/ext/vectorchord/package.nix
+++ b/pkgs/servers/sql/postgresql/ext/vectorchord/package.nix
@@ -89,6 +89,12 @@ buildPgrxExtension (finalAttrs: {
   };
 
   meta = {
+    # PostgreSQL 19 is not yet supported
+    # See https://github.com/supervc-stack/VectorChord/issues/464
+    # Check after next package update.
+    broken = lib.warnIf (
+      finalAttrs.version != "1.1.1"
+    ) "Is postgresql19Packages.vectorchord still broken?" (lib.versionAtLeast postgresql.version "19");
     changelog = "https://github.com/supervc-stack/VectorChord/releases/tag/${finalAttrs.version}";
     description = "Scalable, fast, and disk-friendly vector search in Postgres, the successor of pgvecto.rs";
     homepage = "https://github.com/supervc-stack/VectorChord";


### PR DESCRIPTION
The repository has been moved from https://github.com/tensorchord/VectorChord to https://github.com/supervc-stack/VectorChord.

Also marks the package as broken on pg 19: https://hydra.nixos.org/build/331686152


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
