### PR TITLE
*: update maintenanceship

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -82,10 +82,6 @@
 # Nixpkgs build-support
 /pkgs/build-support/writers @lassulus
 
-# Nixpkgs make-disk-image
-/doc/build-helpers/images/makediskimage.section.md  @raitobezarius
-/nixos/lib/make-disk-image.nix                 @raitobezarius
-
 # Nix, the package manager
 # @raitobezarius is not "code owner", but is listed here to be notified of changes
 # pertaining to the Nix package manager.
@@ -238,9 +234,7 @@ nixos/modules/installer/tools/nix-fallback-paths.nix  @Artturin @Ericson2314 @lo
 # C compilers
 /pkgs/development/compilers/gcc
 /pkgs/development/compilers/llvm @NixOS/llvm
-/pkgs/development/compilers/emscripten @raitobezarius
 /doc/toolchains/llvm.chapter.md @NixOS/llvm
-/doc/languages-frameworks/emscripten.section.md @raitobezarius
 
 # Audio
 /nixos/modules/services/audio/botamusique.nix @mweinelt
@@ -332,11 +326,6 @@ pkgs/development/python-modules/buildcatrust/ @ajs124 @lukegb @mweinelt
 /nixos/tests/babeld.nix @mweinelt
 /nixos/tests/kea.nix @mweinelt
 /nixos/tests/knot.nix @mweinelt
-
-# Web servers
-/doc/packages/nginx.section.md @raitobezarius
-/pkgs/servers/http/nginx/ @raitobezarius
-/nixos/modules/services/web-servers/nginx/ @raitobezarius
 
 # D
 /pkgs/build-support/dlang @jtbx @TomaSajt

--- a/nixos/modules/services/matrix/hebbot.nix
+++ b/nixos/modules/services/matrix/hebbot.nix
@@ -25,7 +25,7 @@ let
     };
 in
 {
-  meta.maintainers = [ lib.maintainers.raitobezarius ];
+  meta.maintainers = [ ];
   options.services.hebbot = {
     enable = mkEnableOption "hebbot";
     package = lib.mkPackageOption pkgs "hebbot" { };

--- a/nixos/modules/system/boot/systemd/journald-gateway.nix
+++ b/nixos/modules/system/boot/systemd/journald-gateway.nix
@@ -28,7 +28,7 @@ in
     )
   ];
 
-  meta.maintainers = [ lib.maintainers.raitobezarius ];
+  meta.maintainers = [ ];
   options.services.journald.gateway = {
     enable = lib.mkEnableOption "the HTTP gateway to the journal";
 

--- a/nixos/modules/system/boot/systemd/journald-remote.nix
+++ b/nixos/modules/system/boot/systemd/journald-remote.nix
@@ -16,7 +16,7 @@ let
   };
 in
 {
-  meta.maintainers = [ lib.maintainers.raitobezarius ];
+  meta.maintainers = [ ];
   options.services.journald.remote = {
     enable = lib.mkEnableOption "receiving systemd journals from the network";
 

--- a/nixos/modules/system/boot/systemd/journald-upload.nix
+++ b/nixos/modules/system/boot/systemd/journald-upload.nix
@@ -10,7 +10,7 @@ let
   format = pkgs.formats.systemd { };
 in
 {
-  meta.maintainers = [ lib.maintainers.raitobezarius ];
+  meta.maintainers = [ ];
   options.services.journald.upload = {
     enable = lib.mkEnableOption "uploading the systemd journal to a remote server";
 

--- a/nixos/tests/listmonk.nix
+++ b/nixos/tests/listmonk.nix
@@ -2,7 +2,7 @@ import ./make-test-python.nix (
   { lib, ... }:
   {
     name = "listmonk";
-    meta.maintainers = with lib.maintainers; [ raitobezarius ];
+    meta.maintainers = [ ];
 
     nodes.machine =
       { pkgs, ... }:

--- a/nixos/tests/netdata.nix
+++ b/nixos/tests/netdata.nix
@@ -6,7 +6,6 @@
   meta = with pkgs.lib.maintainers; {
     maintainers = [
       cransom
-      raitobezarius
     ];
   };
 

--- a/nixos/tests/systemd-journal-gateway.nix
+++ b/nixos/tests/systemd-journal-gateway.nix
@@ -4,7 +4,6 @@
   meta = with pkgs.lib.maintainers; {
     maintainers = [
       minijackson
-      raitobezarius
     ];
   };
 

--- a/nixos/tests/systemd-journal-upload.nix
+++ b/nixos/tests/systemd-journal-upload.nix
@@ -4,7 +4,6 @@
   meta = with pkgs.lib.maintainers; {
     maintainers = [
       minijackson
-      raitobezarius
     ];
   };
 

--- a/nixos/tests/web-apps/netbox-upgrade.nix
+++ b/nixos/tests/web-apps/netbox-upgrade.nix
@@ -18,7 +18,6 @@ in
 
   meta.maintainers = with lib.maintainers; [
     minijackson
-    raitobezarius
   ];
 
   node.pkgsReadOnly = false;

--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -270,7 +270,6 @@ edk2.mkDerivation projectDscPath (finalAttrs: {
     platforms = metaPlatforms;
     maintainers = with lib.maintainers; [
       adamcstephens
-      raitobezarius
       mjoerg
       sigmasquadron
     ];

--- a/pkgs/by-name/ca/cairo-lang/package.nix
+++ b/pkgs/by-name/ca/cairo-lang/package.nix
@@ -45,6 +45,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     description = "Turing-complete language for creating provable programs for general computation";
     homepage = "https://github.com/starkware-libs/cairo";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ raitobezarius ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/ci/circom/package.nix
+++ b/pkgs/by-name/ci/circom/package.nix
@@ -24,6 +24,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/iden3/circom";
     changelog = "https://github.com/iden3/circom/blob/${finalAttrs.src.rev}/RELEASES.md";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ raitobezarius ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/cp/cppcodec/package.nix
+++ b/pkgs/by-name/cp/cppcodec/package.nix
@@ -41,7 +41,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       panicgh
-      raitobezarius
     ];
   };
 })

--- a/pkgs/by-name/cr/cryptsetup/package.nix
+++ b/pkgs/by-name/cr/cryptsetup/package.nix
@@ -115,7 +115,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "cryptsetup";
     maintainers = with lib.maintainers; [
       numinit
-      raitobezarius
     ];
     platforms = with lib.platforms; linux;
     identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "cryptsetup_project" finalAttrs.version;

--- a/pkgs/by-name/di/diffoscope/package.nix
+++ b/pkgs/by-name/di/diffoscope/package.nix
@@ -359,7 +359,6 @@ python.pkgs.buildPythonApplication rec {
     maintainers = with lib.maintainers; [
       danielfullmer
       mdaniels5757
-      raitobezarius
     ];
     platforms = lib.platforms.unix;
     mainProgram = "diffoscope";

--- a/pkgs/by-name/gi/git-pw/package.nix
+++ b/pkgs/by-name/gi/git-pw/package.nix
@@ -51,6 +51,6 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     description = "Tool for integrating Git with Patchwork, the web-based patch tracking system";
     homepage = "https://github.com/getpatchwork/git-pw";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ raitobezarius ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/li/libnitrokey/package.nix
+++ b/pkgs/by-name/li/libnitrokey/package.nix
@@ -51,7 +51,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.lgpl3;
     maintainers = with lib.maintainers; [
       panicgh
-      raitobezarius
     ];
   };
 })

--- a/pkgs/by-name/li/listmonk/package.nix
+++ b/pkgs/by-name/li/listmonk/package.nix
@@ -78,7 +78,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/knadh/listmonk";
     changelog = "https://github.com/knadh/listmonk/releases/tag/v${finalAttrs.version}";
     maintainers = with lib.maintainers; [
-      raitobezarius
       hougo
     ];
     license = lib.licenses.agpl3Only;

--- a/pkgs/by-name/ne/netbox_4_4/package.nix
+++ b/pkgs/by-name/ne/netbox_4_4/package.nix
@@ -128,7 +128,6 @@ py.pkgs.buildPythonApplication rec {
     ];
     maintainers = with lib.maintainers; [
       minijackson
-      raitobezarius
       transcaffeine
     ];
   };

--- a/pkgs/by-name/ne/netbox_4_5/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/package.nix
@@ -141,7 +141,6 @@ py.pkgs.buildPythonApplication rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       minijackson
-      raitobezarius
       transcaffeine
     ];
   };

--- a/pkgs/by-name/pe/pesign/package.nix
+++ b/pkgs/by-name/pe/pesign/package.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Signing tools for PE-COFF binaries. Compliant with the PE and Authenticode specifications";
     homepage = "https://github.com/rhboot/pesign";
     license = lib.licenses.gpl2Only;
-    maintainers = with lib.maintainers; [ raitobezarius ];
+    maintainers = [ ];
     # efivar is currently Linux-only.
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/ri/ripe-atlas-tools/package.nix
+++ b/pkgs/by-name/ri/ripe-atlas-tools/package.nix
@@ -100,6 +100,6 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     homepage = "https://github.com/RIPE-NCC/ripe-atlas-tools";
     changelog = "https://github.com/RIPE-NCC/ripe-atlas-tools/blob/v${finalAttrs.version}/CHANGES.rst";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ raitobezarius ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/sb/sbctl/package.nix
+++ b/pkgs/by-name/sb/sbctl/package.nix
@@ -68,7 +68,6 @@ buildGoModule (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       Pokeylooted
-      raitobezarius
       Scrumplex
     ];
     # go-uefi does not support darwin at the moment:

--- a/pkgs/by-name/sh/shim-unsigned/package.nix
+++ b/pkgs/by-name/sh/shim-unsigned/package.nix
@@ -73,7 +73,6 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     maintainers = with lib.maintainers; [
       baloo
-      raitobezarius
     ];
   };
 })

--- a/pkgs/by-name/sq/sq/package.nix
+++ b/pkgs/by-name/sq/sq/package.nix
@@ -54,6 +54,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://sq.io/";
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ raitobezarius ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/st/stuffbin/package.nix
+++ b/pkgs/by-name/st/stuffbin/package.nix
@@ -27,7 +27,7 @@ buildGoModule (finalAttrs: {
     description = "Compress and embed static files and assets into Go binaries and access them with a virtual file system in production";
     homepage = "https://github.com/knadh/stuffbin";
     changelog = "https://github.com/knadh/stuffbin/releases/tag/v${finalAttrs.version}";
-    maintainers = with lib.maintainers; [ raitobezarius ];
+    maintainers = [ ];
     license = lib.licenses.mit;
   };
 })

--- a/pkgs/by-name/th/thelounge/package.nix
+++ b/pkgs/by-name/th/thelounge/package.nix
@@ -88,7 +88,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/thelounge/thelounge/releases/tag/v${finalAttrs.version}";
     maintainers = with lib.maintainers; [
       winter
-      raitobezarius
     ];
     license = lib.licenses.mit;
     inherit (nodejs-slim.meta) platforms;

--- a/pkgs/development/compilers/emscripten/default.nix
+++ b/pkgs/development/compilers/emscripten/default.nix
@@ -209,7 +209,6 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [
       qknight
-      raitobezarius
       willcohen
     ];
     license = lib.licenses.ncsa;

--- a/pkgs/development/python-modules/amarna/default.nix
+++ b/pkgs/development/python-modules/amarna/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     mainProgram = "amarna";
     homepage = "https://github.com/crytic/amarna";
     license = lib.licenses.agpl3Only;
-    maintainers = with lib.maintainers; [ raitobezarius ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/bubop/default.nix
+++ b/pkgs/development/python-modules/bubop/default.nix
@@ -47,6 +47,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/bergercookie/bubop";
     changelog = "https://github.com/bergercookie/bubop/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ raitobezarius ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/changefinder/default.nix
+++ b/pkgs/development/python-modules/changefinder/default.nix
@@ -42,6 +42,6 @@ buildPythonPackage {
     description = "Online Change-Point Detection library based on ChangeFinder algorithm";
     homepage = "https://github.com/shunsukeaihara/changefinder";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ raitobezarius ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/django-pgpubsub/default.nix
+++ b/pkgs/development/python-modules/django-pgpubsub/default.nix
@@ -42,6 +42,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/PaulGilmartin/django-pgpubsub";
     changelog = "https://github.com/PaulGilmartin/django-pgpubsub/blob/${src.rev}/CHANGELOG.md";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ raitobezarius ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/django-pgtrigger/default.nix
+++ b/pkgs/development/python-modules/django-pgtrigger/default.nix
@@ -34,7 +34,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/Opus10/django-pgtrigger/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
-      raitobezarius
       pyrox0
     ];
   };

--- a/pkgs/development/python-modules/item-synchronizer/default.nix
+++ b/pkgs/development/python-modules/item-synchronizer/default.nix
@@ -38,6 +38,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/bergercookie/item_synchronizer";
     changelog = "https://github.com/bergercookie/item_synchronizer/blob/${src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ raitobezarius ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/netdata-pandas/default.nix
+++ b/pkgs/development/python-modules/netdata-pandas/default.nix
@@ -38,6 +38,6 @@ buildPythonPackage rec {
     description = "Library to pull data from the netdata REST API into a pandas dataframe";
     homepage = "https://github.com/netdata/netdata-pandas";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ raitobezarius ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/recordlinkage/default.nix
+++ b/pkgs/development/python-modules/recordlinkage/default.nix
@@ -58,6 +58,6 @@ buildPythonPackage rec {
     homepage = "https://recordlinkage.readthedocs.io/";
     changelog = "https://github.com/J535D165/recordlinkage/releases/tag/v${version}";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ raitobezarius ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/ripe-atlas-cousteau/default.nix
+++ b/pkgs/development/python-modules/ripe-atlas-cousteau/default.nix
@@ -46,6 +46,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/RIPE-NCC/ripe-atlas-cousteau";
     changelog = "https://github.com/RIPE-NCC/ripe-atlas-cousteau/blob/v${version}/CHANGES.rst";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ raitobezarius ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/ripe-atlas-sagan/default.nix
+++ b/pkgs/development/python-modules/ripe-atlas-sagan/default.nix
@@ -46,6 +46,6 @@ buildPythonPackage rec {
     description = "Parsing library for RIPE Atlas measurements results";
     homepage = "https://github.com/RIPE-NCC/ripe-atlas-sagan";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ raitobezarius ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/rustworkx/default.nix
+++ b/pkgs/development/python-modules/rustworkx/default.nix
@@ -85,6 +85,6 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://github.com/Qiskit/rustworkx";
     changelog = "https://github.com/Qiskit/rustworkx/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ raitobezarius ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/development/python-modules/socketio-client/default.nix
+++ b/pkgs/development/python-modules/socketio-client/default.nix
@@ -34,6 +34,6 @@ buildPythonPackage rec {
     description = "Socket.io client library for protocol 1.x";
     homepage = "https://github.com/invisibleroads/socketIO-client";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ raitobezarius ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/taskw-ng/default.nix
+++ b/pkgs/development/python-modules/taskw-ng/default.nix
@@ -51,6 +51,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/bergercookie/taskw-ng";
     changelog = "https://github.com/bergercookie/taskw-ng/blob/${src.tag}/CHANGELOG.rst";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ raitobezarius ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -317,7 +317,6 @@ stdenv.mkDerivation {
           das_j
           fpletz
           helsinki-Jo
-          raitobezarius
         ];
       };
 }


### PR DESCRIPTION
I'm not active anymore in:

- emscripten
- make-disk-image
- NGINX
- journald uploading systems
- various Cairo ecosystem packages
- various ZKP ecosystem packages
- Netbox
- some Secure Boot related programs which I am not using regularly anymore
- The Lounge
- Listmonk
- Nitrokey ecosystem
- RIPE ATLAS tooling (I don't use it often enough)
- various Python packages (rustworkx, taskw-ng, etc.)
- netdata

I contribute and maintain things mostly for my work or for Lix these days.

- Built on platform:
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
