### PR TITLE
ci: add llakala as codeowner of performance-critical files

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -63,11 +63,11 @@
 /pkgs/top-level/packages-info.nix                @jopejoe1
 /pkgs/top-level/release-lib.nix                  @jopejoe1
 /pkgs/top-level/release.nix                      @jopejoe1
-/pkgs/stdenv                                     @philiptaron @NixOS/stdenv
-/pkgs/stdenv/generic                             @Ericson2314 @NixOS/stdenv
-/pkgs/stdenv/generic/problems.nix                @infinisil
+/pkgs/stdenv                                     @philiptaron @NixOS/stdenv @llakala
+/pkgs/stdenv/generic                             @Ericson2314 @NixOS/stdenv @llakala
+/pkgs/stdenv/generic/problems.nix                @infinisil @llakala
 /pkgs/test/problems                              @infinisil
-/pkgs/stdenv/generic/check-meta.nix              @infinisil @Ericson2314 @adisbladis @NixOS/stdenv
+/pkgs/stdenv/generic/check-meta.nix              @infinisil @Ericson2314 @adisbladis @NixOS/stdenv @llakala
 /pkgs/stdenv/cross                               @Ericson2314 @NixOS/stdenv
 /pkgs/build-support                              @philiptaron
 /pkgs/build-support/cc-wrapper                   @Ericson2314

--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -25,27 +25,27 @@
 /shell.nix @infinisil @NixOS/Security
 
 # Libraries
-/lib                        @infinisil @hsjobeki
-/lib/generators.nix         @infinisil @hsjobeki
-/lib/cli.nix                @infinisil @hsjobeki
-/lib/debug.nix              @infinisil @hsjobeki
-/lib/asserts.nix            @infinisil @hsjobeki
-/lib/path/*                 @infinisil @hsjobeki
-/lib/fileset                @infinisil @hsjobeki
-/maintainers/github-teams.json @infinisil
-/maintainers/computed-team-list.nix @infinisil
+/lib                        @infinisil @hsjobeki @llakala
+/lib/generators.nix         @infinisil @hsjobeki @llakala
+/lib/cli.nix                @infinisil @hsjobeki @llakala
+/lib/debug.nix              @infinisil @hsjobeki @llakala
+/lib/asserts.nix            @infinisil @hsjobeki @llakala
+/lib/path/*                 @infinisil @hsjobeki @llakala
+/lib/fileset                @infinisil @hsjobeki @llakala
+/maintainers/github-teams.json @infinisil @llakala
+/maintainers/computed-team-list.nix @infinisil @llakala
 ## Standard environment–related libraries
-/lib/customisation.nix      @alyssais @NixOS/stdenv
-/lib/derivations.nix        @NixOS/stdenv
-/lib/fetchers.nix           @alyssais @NixOS/stdenv
-/lib/meta.nix               @alyssais @NixOS/stdenv
-/lib/meta-types.nix         @infinisil @adisbladis @NixOS/stdenv
-/lib/source-types.nix       @alyssais @NixOS/stdenv
-/lib/systems                @alyssais @NixOS/stdenv
+/lib/customisation.nix      @alyssais @NixOS/stdenv @llakala
+/lib/derivations.nix        @NixOS/stdenv @llakala
+/lib/fetchers.nix           @alyssais @NixOS/stdenv @llakala
+/lib/meta.nix               @alyssais @NixOS/stdenv @llakala
+/lib/meta-types.nix         @infinisil @adisbladis @NixOS/stdenv @llakala
+/lib/source-types.nix       @alyssais @NixOS/stdenv @llakala
+/lib/systems                @alyssais @NixOS/stdenv @llakala
 ## Libraries / Module system
-/lib/modules.nix            @infinisil @roberth @hsjobeki
-/lib/types.nix              @infinisil @roberth @hsjobeki
-/lib/options.nix            @infinisil @roberth @hsjobeki
+/lib/modules.nix            @infinisil @roberth @hsjobeki @llakala
+/lib/types.nix              @infinisil @roberth @hsjobeki @llakala
+/lib/options.nix            @infinisil @roberth @hsjobeki @llakala
 /lib/tests/modules.sh       @infinisil @roberth @hsjobeki
 /lib/tests/modules          @infinisil @roberth @hsjobeki
 
@@ -272,7 +272,7 @@ pkgs/development/python-modules/buildcatrust/ @ajs124 @lukegb @mweinelt
 /pkgs/applications/editors/jetbrains @leona-ya @theCapypara
 
 # Licenses
-/lib/licenses @alyssais @emilazy @jopejoe1
+/lib/licenses @alyssais @emilazy @jopejoe1 @llakala
 
 # Qt
 /pkgs/development/libraries/qt-5 @K900 @NickCao @SuperSandro2000


### PR DESCRIPTION
I've been doing lots of nixpkgs performance work recently, and have been seeing seemingly-trivial PRs that result in very large performance regressions. I've been attempting to protect it by searching recent PRs manually. Adding myself to ensure I get pinged on these things.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
