### PR TITLE
emacs: bump elisp packages

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-generated.nix
@@ -7293,10 +7293,10 @@
     elpaBuild {
       pname = "php-fill";
       ename = "php-fill";
-      version = "1.1.1.0.20260307.232207";
+      version = "1.1.2.0.20260624.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/php-fill-1.1.1.0.20260307.232207.tar";
-        sha256 = "0vsq47s8cph31fc7ij3j34z4g3r830cr35498rkz9psrjzsr4jsy";
+        url = "https://elpa.gnu.org/devel/php-fill-1.1.2.0.20260624.0.tar";
+        sha256 = "016gy8dmvavw75h5ccyfzmhg3z634yhifwgkvydw87qnlrfm452p";
       };
       packageRequires = [ ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-generated.nix
@@ -9,10 +9,10 @@
     elpaBuild {
       pname = "a68-mode";
       ename = "a68-mode";
-      version = "1.2.0.20260129.20653";
+      version = "1.3.0.20260614.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/a68-mode-1.2.0.20260129.20653.tar";
-        sha256 = "03b4608ij5jiijasy41vndwcnzl92gwc0frh2pxs6112p7xk2sf0";
+        url = "https://elpa.gnu.org/devel/a68-mode-1.3.0.20260614.1.tar";
+        sha256 = "1b51c2v7sx8g4mm2irm43rgb741syphji6cglpv1r3j9wvcpj58k";
       };
       packageRequires = [ ];
       meta = {
@@ -52,10 +52,10 @@
     elpaBuild {
       pname = "ack";
       ename = "ack";
-      version = "1.11.0.20220924.84123";
+      version = "1.11.0.20260429.83816";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ack-1.11.0.20220924.84123.tar";
-        sha256 = "0vic2izviakj6qh2l15jd8qm8yr0h0qhy4r8sx7zdngpi9i14r5v";
+        url = "https://elpa.gnu.org/devel/ack-1.11.0.20260429.83816.tar";
+        sha256 = "106m586p8ynjbsf9yknsfjpgvss6wxivgshc5kg7l8fg61d7c0nd";
       };
       packageRequires = [ ];
       meta = {
@@ -74,10 +74,10 @@
     elpaBuild {
       pname = "activities";
       ename = "activities";
-      version = "0.8pre0.20251118.222434";
+      version = "0.80.20251118.222434";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/activities-0.8pre0.20251118.222434.tar";
-        sha256 = "0062llgn5ljf18d8fcdp4mkmn6dr67gkh8d56s8gy6rdiw354k8p";
+        url = "https://elpa.gnu.org/devel/activities-0.80.20251118.222434.tar";
+        sha256 = "19h5c1cpmxl1j0k6yicy3gw10wcnc3likb1q0frwchw8vnp7bx96";
       };
       packageRequires = [ persist ];
       meta = {
@@ -207,10 +207,10 @@
     elpaBuild {
       pname = "aggressive-completion";
       ename = "aggressive-completion";
-      version = "1.7.0.20220417.71805";
+      version = "1.8.0.20260529.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/aggressive-completion-1.7.0.20220417.71805.tar";
-        sha256 = "1nmh9as4m0xjvda1f0hda8s1wk1z973wlfxcfci768y45ffnjn0g";
+        url = "https://elpa.gnu.org/devel/aggressive-completion-1.8.0.20260529.0.tar";
+        sha256 = "0w567lldk16v5x80h7wm8vmz5947izxi842m3cwsx2hghpsp1rrq";
       };
       packageRequires = [ ];
       meta = {
@@ -249,10 +249,10 @@
     elpaBuild {
       pname = "agitate";
       ename = "agitate";
-      version = "0.0.20241021.65229";
+      version = "0.0.20260424.102016";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/agitate-0.0.20241021.65229.tar";
-        sha256 = "11f1yj937wfnn6d12845pwa8045wp5pk9mbcvzhigni3jkm8820p";
+        url = "https://elpa.gnu.org/devel/agitate-0.0.20260424.102016.tar";
+        sha256 = "1sgzy52irfd1p5nppqrlna05fhrscchmclr3wj9s5qh3wdpfwqv8";
       };
       packageRequires = [ ];
       meta = {
@@ -291,10 +291,10 @@
     elpaBuild {
       pname = "aircon-theme";
       ename = "aircon-theme";
-      version = "0.0.6.0.20240613.140459";
+      version = "0.0.6.0.20260507.72645";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/aircon-theme-0.0.6.0.20240613.140459.tar";
-        sha256 = "1npppgbs1dfixqpmdc0nfxx4vvnsvpy101q8lcf7h9i8br63mlqy";
+        url = "https://elpa.gnu.org/devel/aircon-theme-0.0.6.0.20260507.72645.tar";
+        sha256 = "1cld1ns2q4vkxpmc69s6scnhgghi36ibmscg8zjwwhbbp31ah0ir";
       };
       packageRequires = [ ];
       meta = {
@@ -333,10 +333,10 @@
     elpaBuild {
       pname = "altcaps";
       ename = "altcaps";
-      version = "1.3.0.0.20260413.54314";
+      version = "1.3.0.0.20260424.102117";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/altcaps-1.3.0.0.20260413.54314.tar";
-        sha256 = "1jj7321nhxy7gk2cchv81nyw8fzzw7zkikgwgnj6k7kki53rhp8c";
+        url = "https://elpa.gnu.org/devel/altcaps-1.3.0.0.20260424.102117.tar";
+        sha256 = "00bjfrm5hyp53779fg40yjaldlqdli4frl4dmf7371zvpd63184z";
       };
       packageRequires = [ ];
       meta = {
@@ -461,10 +461,10 @@
     elpaBuild {
       pname = "auctex";
       ename = "auctex";
-      version = "14.1.2.0.20260331.191333";
+      version = "14.1.2.0.20260623.43";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/auctex-14.1.2.0.20260331.191333.tar";
-        sha256 = "1xan7cfl5nhndngmdrgs2832xpfl7jvfb86kgjn8i8lm81djz5r9";
+        url = "https://elpa.gnu.org/devel/auctex-14.1.2.0.20260623.43.tar";
+        sha256 = "0csk0k8njms3dn2ijbsvm9g78k6yvdxgcdcibj79acllzslhnwis";
       };
       packageRequires = [ ];
       meta = {
@@ -483,10 +483,10 @@
     elpaBuild {
       pname = "auctex-cont-latexmk";
       ename = "auctex-cont-latexmk";
-      version = "0.3.0.20250115.185937";
+      version = "0.3.0.20260617.10";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/auctex-cont-latexmk-0.3.0.20250115.185937.tar";
-        sha256 = "1rdnnc7ihg12dprivywjmhfl5s2cb58bl2n3fy7gf6h2wsjw0md5";
+        url = "https://elpa.gnu.org/devel/auctex-cont-latexmk-0.3.0.20260617.10.tar";
+        sha256 = "1dcppji0h1yd75iv6ihg7iyjzwf14l6h32cf7k4aiyb58d8x2ka6";
       };
       packageRequires = [ auctex ];
       meta = {
@@ -548,10 +548,10 @@
     elpaBuild {
       pname = "auth-source-xoauth2-plugin";
       ename = "auth-source-xoauth2-plugin";
-      version = "0.3.2.0.20251113.213445";
+      version = "0.4.1.0.20260526.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/auth-source-xoauth2-plugin-0.3.2.0.20251113.213445.tar";
-        sha256 = "02g7qy4aj85jqzzsqka9ki712hbz58ygwvr8f56ncyy1xapcjpsz";
+        url = "https://elpa.gnu.org/devel/auth-source-xoauth2-plugin-0.4.1.0.20260526.0.tar";
+        sha256 = "058src50y1rynyrsfcdlrswbmsmf41ic1aa0bfkqg19dgaag81qy";
       };
       packageRequires = [ oauth2 ];
       meta = {
@@ -719,10 +719,10 @@
     elpaBuild {
       pname = "beframe";
       ename = "beframe";
-      version = "1.5.0.0.20260413.54824";
+      version = "1.5.0.0.20260605.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/beframe-1.5.0.0.20260413.54824.tar";
-        sha256 = "1nj3gn44bd867yx34d9nzzqcfk5k3fp89wg7k83lpcc7f2a6w3dw";
+        url = "https://elpa.gnu.org/devel/beframe-1.5.0.0.20260605.5.tar";
+        sha256 = "1i4dmcxbjd73gpkbj82qw6r95hc2dqm4zvcmkmka9ymwxdjamwi1";
       };
       packageRequires = [ ];
       meta = {
@@ -740,10 +740,10 @@
     elpaBuild {
       pname = "bicep-ts-mode";
       ename = "bicep-ts-mode";
-      version = "0.1.4.0.20251121.60244";
+      version = "0.1.4.0.20260619.82";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/bicep-ts-mode-0.1.4.0.20251121.60244.tar";
-        sha256 = "0423n65lcxd56xc4q1mihwb07y81y12wh2qiwgwc1n1b7wilbpkg";
+        url = "https://elpa.gnu.org/devel/bicep-ts-mode-0.1.4.0.20260619.82.tar";
+        sha256 = "0rf10gab6vfrmiwcvm6b6cb0a3vlaydc4cgfpq34na9czqn760r0";
       };
       packageRequires = [ ];
       meta = {
@@ -902,10 +902,10 @@
     elpaBuild {
       pname = "breadcrumb";
       ename = "breadcrumb";
-      version = "1.0.1.0.20260110.120308";
+      version = "1.0.1.0.20260507.73535";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/breadcrumb-1.0.1.0.20260110.120308.tar";
-        sha256 = "0g5gcq3iqvrkfi6iwbiiyrcwac36czxrfqi9gybipd9k11fqplcr";
+        url = "https://elpa.gnu.org/devel/breadcrumb-1.0.1.0.20260507.73535.tar";
+        sha256 = "1ccx08zczmkgdm9xb1bnz0v4a4yrf3zy5nnfyax57anw3m8yliz2";
       };
       packageRequires = [ project ];
       meta = {
@@ -950,10 +950,10 @@
     elpaBuild {
       pname = "buffer-env";
       ename = "buffer-env";
-      version = "0.6.0.20250516.122320";
+      version = "0.6.0.20260604.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/buffer-env-0.6.0.20250516.122320.tar";
-        sha256 = "0m1kb8h2mjjd5hznp86yxjdic0zngq89x67vd7srvikxxbj312d9";
+        url = "https://elpa.gnu.org/devel/buffer-env-0.6.0.20260604.5.tar";
+        sha256 = "0w0lbfqn3mn628w2mhcfgmsrzzl3915vsry84g64gfb1ga7r4ld3";
       };
       packageRequires = [ compat ];
       meta = {
@@ -993,10 +993,10 @@
     elpaBuild {
       pname = "bufferlo";
       ename = "bufferlo";
-      version = "1.2.0.20260314.110439";
+      version = "1.2.0.20260531.20";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/bufferlo-1.2.0.20260314.110439.tar";
-        sha256 = "0jf14ac09wrx8hc6bkrczaddf48fxglvgz7qik7bd2vb7w9dpn80";
+        url = "https://elpa.gnu.org/devel/bufferlo-1.2.0.20260531.20.tar";
+        sha256 = "04g5c2zar12k9b4jrka13zc8bd67kn4xhjsybhrjdz3fhphj5ivn";
       };
       packageRequires = [ ];
       meta = {
@@ -1106,10 +1106,10 @@
     elpaBuild {
       pname = "cape";
       ename = "cape";
-      version = "2.6.0.20260419.184703";
+      version = "2.7.0.20260519.102137";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/cape-2.6.0.20260419.184703.tar";
-        sha256 = "143b5kxykz4mgx2y7gq6vidrqnnjnc0ay809hjzbqfmpvlnf86fn";
+        url = "https://elpa.gnu.org/devel/cape-2.7.0.20260519.102137.tar";
+        sha256 = "1ilx7ka6vx2xv0xfmc4sbjf8nqsgxd4vzj5r417ckmpfb4vnpa18";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1266,6 +1266,28 @@
       };
     }
   ) { };
+  cm-mode = callPackage (
+    {
+      cl-lib ? null,
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "cm-mode";
+      ename = "cm-mode";
+      version = "1.10.0.20260518.192037";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/cm-mode-1.10.0.20260518.192037.tar";
+        sha256 = "17ck187x677s00lvk09lr76fgl9i0sx7p46dqhf033k70c46a4gj";
+      };
+      packageRequires = [ cl-lib ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/cm-mode.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   cobol-mode = callPackage (
     {
       elpaBuild,
@@ -1311,6 +1333,7 @@
   ) { };
   colorful-mode = callPackage (
     {
+      cl-lib ? null,
       compat,
       elpaBuild,
       fetchurl,
@@ -1319,12 +1342,15 @@
     elpaBuild {
       pname = "colorful-mode";
       ename = "colorful-mode";
-      version = "1.2.5.0.20260324.223335";
+      version = "1.2.5.0.20260508.152701";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/colorful-mode-1.2.5.0.20260324.223335.tar";
-        sha256 = "0gyz2n3j4ja4diknh6rm5rlzyw49pqbxin2j7ykjz0iprzr5vgnw";
+        url = "https://elpa.gnu.org/devel/colorful-mode-1.2.5.0.20260508.152701.tar";
+        sha256 = "1yif2xib8czihif7ls2kw98akjjc76ml0ic69jr3qysi73p3n6iv";
       };
-      packageRequires = [ compat ];
+      packageRequires = [
+        cl-lib
+        compat
+      ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/colorful-mode.html";
         license = lib.licenses.free;
@@ -1383,16 +1409,17 @@
       elpaBuild,
       fetchurl,
       lib,
+      posframe,
     }:
     elpaBuild {
       pname = "company";
       ename = "company";
-      version = "1.0.2.0.20260331.24502";
+      version = "1.0.2.0.20260618.138";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/company-1.0.2.0.20260331.24502.tar";
-        sha256 = "19apxj576hy09pk37rpnzybab0ffrw63j2ycad5vwz75y84dhjys";
+        url = "https://elpa.gnu.org/devel/company-1.0.2.0.20260618.138.tar";
+        sha256 = "072y63bvpq6falkg3yqv8smhkba2nqlw6crm5809pqrihfm8ybii";
       };
-      packageRequires = [ ];
+      packageRequires = [ posframe ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/company.html";
         license = lib.licenses.free;
@@ -1478,17 +1505,16 @@
       elpaBuild,
       fetchurl,
       lib,
-      seq,
     }:
     elpaBuild {
       pname = "compat";
       ename = "compat";
-      version = "30.1.0.1.0.20260411.151508";
+      version = "31.0.0.1.0.20260606.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/compat-30.1.0.1.0.20260411.151508.tar";
-        sha256 = "14vim5vlv57q6zl83lixj2palwbxz2dkbpivyvs56cjwqck41bvd";
+        url = "https://elpa.gnu.org/devel/compat-31.0.0.1.0.20260606.2.tar";
+        sha256 = "1bziwppgl138pf65q9jbw3c8xsarik9617fnqw3wnp3hlkg39b4m";
       };
-      packageRequires = [ seq ];
+      packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/compat.html";
         license = lib.licenses.free;
@@ -1504,10 +1530,10 @@
     elpaBuild {
       pname = "cond-star";
       ename = "cond-star";
-      version = "1.0.0.20260228.134355";
+      version = "1.0.0.20260523.114724";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/cond-star-1.0.0.20260228.134355.tar";
-        sha256 = "1hl7m4rjjq8c99f1xqa1b8hn3hpixx3ryzlf6wiq2lc7fn4icail";
+        url = "https://elpa.gnu.org/devel/cond-star-1.0.0.20260523.114724.tar";
+        sha256 = "15gp54pkm50dq9141fknq4gy8ya6wrbr0nyzqax15rxz57gsf6cs";
       };
       packageRequires = [ ];
       meta = {
@@ -1547,10 +1573,10 @@
     elpaBuild {
       pname = "consult";
       ename = "consult";
-      version = "3.4.0.20260421.111434";
+      version = "3.6.0.20260607.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/consult-3.4.0.20260421.111434.tar";
-        sha256 = "16gz342an0vsdj7jdy5gcrv8wwcwfqabdzsyyg1dcfzrlmvxvfja";
+        url = "https://elpa.gnu.org/devel/consult-3.6.0.20260607.1.tar";
+        sha256 = "02z3cdzf2lyis0a5kc8vcyas8ycz8gfli7hiahx6zc7dyd94mi9s";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1570,10 +1596,10 @@
     elpaBuild {
       pname = "consult-denote";
       ename = "consult-denote";
-      version = "0.4.2.0.20260423.93857";
+      version = "0.5.0.0.20260520.122738";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/consult-denote-0.4.2.0.20260423.93857.tar";
-        sha256 = "1fcf1abqg71kp9g0nsxdnmb33m6g4kn0iwgvfd1cqslyhmdkk0c8";
+        url = "https://elpa.gnu.org/devel/consult-denote-0.5.0.0.20260520.122738.tar";
+        sha256 = "19y5vd4j1ndnxr5z7fz8ghxs5ra0y9d0qca2npglcmzy5l6zsaga";
       };
       packageRequires = [
         consult
@@ -1595,10 +1621,10 @@
     elpaBuild {
       pname = "consult-hoogle";
       ename = "consult-hoogle";
-      version = "0.6.0.0.20260410.130304";
+      version = "0.7.0.0.20260430.125841";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/consult-hoogle-0.6.0.0.20260410.130304.tar";
-        sha256 = "1067wh3r087bdvg4zqbzwmzh6qssj7x7y12qs3fh96vpqrjw2a11";
+        url = "https://elpa.gnu.org/devel/consult-hoogle-0.7.0.0.20260430.125841.tar";
+        sha256 = "06kqrgbm80bpszqb9i1zx0mwaw4imi3i3lz802rwbfdfa6cg1vnh";
       };
       packageRequires = [ consult ];
       meta = {
@@ -1660,10 +1686,10 @@
     elpaBuild {
       pname = "corfu";
       ename = "corfu";
-      version = "2.9.0.20260419.183827";
+      version = "2.10.0.20260519.105314";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/corfu-2.9.0.20260419.183827.tar";
-        sha256 = "06myb0qgv8q3iak83bdpkjmd8vplqcvypl9q1y1h7qfbcy2yvssh";
+        url = "https://elpa.gnu.org/devel/corfu-2.10.0.20260519.105314.tar";
+        sha256 = "15ajzvqjw61rqp6gb275x81d4bl8dsj04lzl84cjj8khf3m1jrcp";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1835,10 +1861,10 @@
     elpaBuild {
       pname = "csv-mode";
       ename = "csv-mode";
-      version = "1.27.0.20250307.75451";
+      version = "1.27.0.20260505.161621";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/csv-mode-1.27.0.20250307.75451.tar";
-        sha256 = "089z16kqm12zs7wrs46hskmz3mc1jqx00mzilaap197xq9hqkc3m";
+        url = "https://elpa.gnu.org/devel/csv-mode-1.27.0.20260505.161621.tar";
+        sha256 = "0g166wcxh7fl8ixnbc1ap2dl5mrq9ahzkx3b5fzfcx7f6b3aw8ym";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -1877,10 +1903,10 @@
     elpaBuild {
       pname = "cursory";
       ename = "cursory";
-      version = "1.2.0.0.20260413.54607";
+      version = "1.2.0.0.20260424.102447";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/cursory-1.2.0.0.20260413.54607.tar";
-        sha256 = "00cxb53p6l3d395vkmza1zqjrpx9rq65xy5cnv410i7lricrwpfr";
+        url = "https://elpa.gnu.org/devel/cursory-1.2.0.0.20260424.102447.tar";
+        sha256 = "14yaa5bay9asyvhkq8bj3fhbzrhry6pc87vhw4gm64ixm9k499g5";
       };
       packageRequires = [ ];
       meta = {
@@ -1941,10 +1967,10 @@
     elpaBuild {
       pname = "dape";
       ename = "dape";
-      version = "0.26.0.0.20260406.153653";
+      version = "0.27.1.0.20260602.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dape-0.26.0.0.20260406.153653.tar";
-        sha256 = "0hpssk2z4i4nalmf9h0iz6iwawks3wh2lkf7il9pvsmxfyi5qb1q";
+        url = "https://elpa.gnu.org/devel/dape-0.27.1.0.20260602.5.tar";
+        sha256 = "0vy4b8p9wys1rj7rra87p9yld9d8szlg0y77ls1hnq2lqnsxvyqd";
       };
       packageRequires = [ jsonrpc ];
       meta = {
@@ -2075,10 +2101,10 @@
     elpaBuild {
       pname = "denote";
       ename = "denote";
-      version = "4.1.3.0.20260423.182534";
+      version = "4.2.3.0.20260611.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-4.1.3.0.20260423.182534.tar";
-        sha256 = "1mh9sl4rhsmxniibrnym69xdwgswij8132b4n7k65lw75y0p05j9";
+        url = "https://elpa.gnu.org/devel/denote-4.2.3.0.20260611.3.tar";
+        sha256 = "0cg6zk2sz6dbss0z6is17xri4mzqkx7m1pbxr4f2fzhh59wk93ww";
       };
       packageRequires = [ ];
       meta = {
@@ -2097,10 +2123,10 @@
     elpaBuild {
       pname = "denote-journal";
       ename = "denote-journal";
-      version = "0.2.2.0.20260328.192346";
+      version = "0.3.0.0.20260520.123338";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-journal-0.2.2.0.20260328.192346.tar";
-        sha256 = "1cp907wdx6cqy5qadq1dsp292ms7wr0qy5znf8fjj4112gxv7ymd";
+        url = "https://elpa.gnu.org/devel/denote-journal-0.3.0.0.20260520.123338.tar";
+        sha256 = "11ad50v3p81vrana2dbnqi7xm07aly4iv03rw5kxblynjcarsd1i";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2119,10 +2145,10 @@
     elpaBuild {
       pname = "denote-markdown";
       ename = "denote-markdown";
-      version = "0.2.2.0.20260423.181135";
+      version = "0.3.0.0.20260520.123211";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-markdown-0.2.2.0.20260423.181135.tar";
-        sha256 = "18l9aymn3v5i3y3g4bx81b16zw4mdgrkkz3939xq5dxy4wwmiqjk";
+        url = "https://elpa.gnu.org/devel/denote-markdown-0.3.0.0.20260520.123211.tar";
+        sha256 = "0bbf5cycmjl5p6cl81x5cjac98y97cr9jkwnrgi5sy5rgxqfpj8k";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2163,10 +2189,10 @@
     elpaBuild {
       pname = "denote-org";
       ename = "denote-org";
-      version = "0.2.1.0.20260228.191514";
+      version = "0.3.0.0.20260520.123505";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-org-0.2.1.0.20260228.191514.tar";
-        sha256 = "1x42gak4mqs6b5zw3z2akpylf3g5pnscg926b92a20naj31j71np";
+        url = "https://elpa.gnu.org/devel/denote-org-0.3.0.0.20260520.123505.tar";
+        sha256 = "12g38pk2vg1g1p9b847r4aisxxr9l36rsbgg1s4aqavd2cd3b00g";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2229,10 +2255,10 @@
     elpaBuild {
       pname = "denote-sequence";
       ename = "denote-sequence";
-      version = "0.2.0.0.20260409.181206";
+      version = "0.3.3.0.20260523.202058";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-sequence-0.2.0.0.20260409.181206.tar";
-        sha256 = "0r3b31hsnp3c4fjsjcyvbpzbbbbs465fn29zja23xwfix3x0y0rp";
+        url = "https://elpa.gnu.org/devel/denote-sequence-0.3.3.0.20260523.202058.tar";
+        sha256 = "1iyfm6y37waq2vfb210kdwkkrr8gv9l443b4wq768f1kj4bns2gg";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2251,10 +2277,10 @@
     elpaBuild {
       pname = "denote-silo";
       ename = "denote-silo";
-      version = "0.2.0.0.20260111.93458";
+      version = "0.3.0.0.20260520.122913";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-silo-0.2.0.0.20260111.93458.tar";
-        sha256 = "0f57s97k267vd4wm9ps9q57wsrq5djrcsxmmkwlqngmr1yrnnhla";
+        url = "https://elpa.gnu.org/devel/denote-silo-0.3.0.0.20260520.122913.tar";
+        sha256 = "0dx6nhjga8mq5g0db24jjzlvdy218bh2yszasjls101nf9ksc3hy";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2337,10 +2363,10 @@
     elpaBuild {
       pname = "dicom";
       ename = "dicom";
-      version = "1.3.0.20260330.63030";
+      version = "1.5.0.20260605.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dicom-1.3.0.20260330.63030.tar";
-        sha256 = "0xfvmxp1w730b5hgq3wnaa79mi2ib2v43z4as9py82ccvmcw2c40";
+        url = "https://elpa.gnu.org/devel/dicom-1.5.0.20260605.1.tar";
+        sha256 = "1lasbqwkgd74jck88525nx76da7535s2m15c47awjpr2hhbwra89";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2387,10 +2413,10 @@
     elpaBuild {
       pname = "diff-hl";
       ename = "diff-hl";
-      version = "1.10.0.0.20260328.192544";
+      version = "1.10.0.0.20260624.182";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/diff-hl-1.10.0.0.20260328.192544.tar";
-        sha256 = "1whznmdqlf3gnyq0k7n9pj71d8qb3avv27dmk86kmgvp1n2bq3c4";
+        url = "https://elpa.gnu.org/devel/diff-hl-1.10.0.0.20260624.182.tar";
+        sha256 = "1gppg1sqc4gwc9szl83zbaw1hk140zqw9sy275cl85v7bd4wdvja";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -2514,10 +2540,10 @@
     elpaBuild {
       pname = "dired-preview";
       ename = "dired-preview";
-      version = "0.6.0.0.20260413.54225";
+      version = "0.6.1.0.20260610.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dired-preview-0.6.0.0.20260413.54225.tar";
-        sha256 = "0x1s8b4swr62a833zszyk9kfnh2fx5kl5rwjdfhm4mgpib50nmcy";
+        url = "https://elpa.gnu.org/devel/dired-preview-0.6.1.0.20260610.0.tar";
+        sha256 = "061b09z60jjd8gggjln9nr5fb0r3rvip31mi8l7r9b1f49k8x730";
       };
       packageRequires = [ ];
       meta = {
@@ -2621,10 +2647,10 @@
     elpaBuild {
       pname = "dmsg";
       ename = "dmsg";
-      version = "0.2.0.20260422.105206";
+      version = "0.3.0.20260515.181304";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dmsg-0.2.0.20260422.105206.tar";
-        sha256 = "0h8l75k00hh0j2cyc2jwqkrnr7qmkz0jydbhm2qwpm3bb5pyd6bq";
+        url = "https://elpa.gnu.org/devel/dmsg-0.3.0.20260515.181304.tar";
+        sha256 = "0f95v15bcyclap8zcz5iyaf09wq63px29q12w0s6aza3j5sslz6p";
       };
       packageRequires = [ ];
       meta = {
@@ -2642,10 +2668,10 @@
     elpaBuild {
       pname = "do-at-point";
       ename = "do-at-point";
-      version = "0.2.0.0.20260302.225537";
+      version = "0.2.0.0.20260502.162532";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/do-at-point-0.2.0.0.20260302.225537.tar";
-        sha256 = "093jsdpwv4caq46fhr7q0ymh59v45w78pfr5l1mrw9rl1cjh1b37";
+        url = "https://elpa.gnu.org/devel/do-at-point-0.2.0.0.20260502.162532.tar";
+        sha256 = "07mamgs1fhx9kkfliz9c9a3cdbxjbbydc8hr9zkjf8sy0gwy65da";
       };
       packageRequires = [ ];
       meta = {
@@ -2726,10 +2752,10 @@
     elpaBuild {
       pname = "doric-themes";
       ename = "doric-themes";
-      version = "1.1.0.0.20260325.70019";
+      version = "1.1.0.0.20260618.8";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/doric-themes-1.1.0.0.20260325.70019.tar";
-        sha256 = "1775v235qd5v0zxakf992iwcmm7nwxppwm2ghx1l86iyfr4l80s4";
+        url = "https://elpa.gnu.org/devel/doric-themes-1.1.0.0.20260618.8.tar";
+        sha256 = "11ck5y66zh9lwiiqmxfh1w4s5k8irvncmd6zsanhh8wb2fd9wms8";
       };
       packageRequires = [ ];
       meta = {
@@ -2748,10 +2774,10 @@
     elpaBuild {
       pname = "drepl";
       ename = "drepl";
-      version = "0.4.0.20251012.81518";
+      version = "0.4.0.20260520.140843";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/drepl-0.4.0.20251012.81518.tar";
-        sha256 = "0xq39hhxx8fpkxqkxnihgn0dw3gxxyzaglpw4cpbn5f6zx2x26yy";
+        url = "https://elpa.gnu.org/devel/drepl-0.4.0.20260520.140843.tar";
+        sha256 = "0apa8fi1j1wkjnjxfsyyf8k21na4q7fvlg6baz2y2aaqisfykqlh";
       };
       packageRequires = [ comint-mime ];
       meta = {
@@ -2950,10 +2976,10 @@
     elpaBuild {
       pname = "ef-themes";
       ename = "ef-themes";
-      version = "2.1.0.0.20260405.133650";
+      version = "2.2.0.0.20260621.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ef-themes-2.1.0.0.20260405.133650.tar";
-        sha256 = "0mg7zxw33swrwy195cbnpjsi9waydbw0aq8hvpwf58cwf6lnszzn";
+        url = "https://elpa.gnu.org/devel/ef-themes-2.2.0.0.20260621.0.tar";
+        sha256 = "0l4qcn558wwwq29n0kf5ws8xbw834dp5n8kzdn225kg9x6h9a5dd";
       };
       packageRequires = [ modus-themes ];
       meta = {
@@ -2978,10 +3004,10 @@
     elpaBuild {
       pname = "eglot";
       ename = "eglot";
-      version = "1.23.0.20260422.80836";
+      version = "1.23.0.20260622.30";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/eglot-1.23.0.20260422.80836.tar";
-        sha256 = "1w7pfbx6m68x6anxg1038cah2wbyb3f3mdgsqsrsj0dbh9qwzzq5";
+        url = "https://elpa.gnu.org/devel/eglot-1.23.0.20260622.30.tar";
+        sha256 = "0ignlpfdlxjk0z66z8gq2paffm2r874wajf94b1r61xa1mmf63nn";
       };
       packageRequires = [
         eldoc
@@ -3054,10 +3080,10 @@
     elpaBuild {
       pname = "eldoc";
       ename = "eldoc";
-      version = "1.16.0.0.20260101.125434";
+      version = "1.16.0.0.20260514.100530";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/eldoc-1.16.0.0.20260101.125434.tar";
-        sha256 = "1c29yb3x2sfnqq690hgvw0f4wsf1aj327k137hwcz6pgc6llgg76";
+        url = "https://elpa.gnu.org/devel/eldoc-1.16.0.0.20260514.100530.tar";
+        sha256 = "00pmjqjljxwr5n69h8pqc4yxsdl9pq1d2djlzbvs0cl99xgn7sjb";
       };
       packageRequires = [ ];
       meta = {
@@ -3152,10 +3178,10 @@
     elpaBuild {
       pname = "ellama";
       ename = "ellama";
-      version = "1.13.0.0.20260410.5454";
+      version = "1.27.2.0.20260605.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ellama-1.13.0.0.20260410.5454.tar";
-        sha256 = "05pvhjagzc0nb2nsagbd1xhxfqvrfhjn734881ph6njr3ns186ai";
+        url = "https://elpa.gnu.org/devel/ellama-1.27.2.0.20260605.1.tar";
+        sha256 = "1vklfqrrygamgyr2f9ndnrwyxxvgai2431bvywxiwwgh8lk937hg";
       };
       packageRequires = [
         compat
@@ -3221,10 +3247,10 @@
     elpaBuild {
       pname = "emacs-lisp-intro-nl";
       ename = "emacs-lisp-intro-nl";
-      version = "0.0.20260419.193604";
+      version = "0.0.20260529.43";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/emacs-lisp-intro-nl-0.0.20260419.193604.tar";
-        sha256 = "1spqwayvm830vzsyy7l768yd91f3h8agpd9wpaa6g0pd5pdhh42r";
+        url = "https://elpa.gnu.org/devel/emacs-lisp-intro-nl-0.0.20260529.43.tar";
+        sha256 = "1aisy3awq830i3bwzyd508w96vcr8igy0gcv9j2mvfa8fzzh0m56";
       };
       packageRequires = [ ];
       meta = {
@@ -3243,10 +3269,10 @@
     elpaBuild {
       pname = "embark";
       ename = "embark";
-      version = "1.2.0.20260404.170203";
+      version = "1.2.0.20260609.21";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/embark-1.2.0.20260404.170203.tar";
-        sha256 = "1ppb6axy1bwxm7qa0pw9cn2k0whl3dfnq69cw2qh62pqi1rnwvh6";
+        url = "https://elpa.gnu.org/devel/embark-1.2.0.20260609.21.tar";
+        sha256 = "1b4gkqrsjv21gxz6padf27wmzj46rryfy0pp662xf0fz9fab2ngp";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3267,10 +3293,10 @@
     elpaBuild {
       pname = "embark-consult";
       ename = "embark-consult";
-      version = "1.1.0.20260404.170203";
+      version = "1.2.0.20260609.20";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/embark-consult-1.1.0.20260404.170203.tar";
-        sha256 = "1lh9jnqhb22yqwiacblcwwfj92lljxc12mamkzq6zk894hxnf9hd";
+        url = "https://elpa.gnu.org/devel/embark-consult-1.2.0.20260609.20.tar";
+        sha256 = "0507mv73swsdymlxqmqx40pr723jlrwmnwiy9qq294ihdk60npgd";
       };
       packageRequires = [
         compat
@@ -3299,10 +3325,10 @@
     elpaBuild {
       pname = "ement";
       ename = "ement";
-      version = "0.18pre0.20251117.191748";
+      version = "0.180.20251117.191748";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ement-0.18pre0.20251117.191748.tar";
-        sha256 = "04qlw00maswc152fchhpf1028426qsg37ky1ap4lsbkpay3cfhqp";
+        url = "https://elpa.gnu.org/devel/ement-0.180.20251117.191748.tar";
+        sha256 = "12464sywsxwnhc0mpkcqy0wsvjig5q6g2pqa985vnk3vygx7w9gz";
       };
       packageRequires = [
         map
@@ -3420,10 +3446,10 @@
     elpaBuild {
       pname = "erc";
       ename = "erc";
-      version = "5.6.2snapshot0.20260323.181457";
+      version = "5.70.20260605.12";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/erc-5.6.2snapshot0.20260323.181457.tar";
-        sha256 = "0i94a6g1k4gzfz3jzm975w9v21bj6kifajn6wqnnswyl4cis65n3";
+        url = "https://elpa.gnu.org/devel/erc-5.70.20260605.12.tar";
+        sha256 = "0nxvjbmy9lf4px6p4ndkwxn32540s841byn5zb8vnc238al8h2k5";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3467,10 +3493,10 @@
     elpaBuild {
       pname = "ess";
       ename = "ess";
-      version = "26.1.0.0.20260423.92659";
+      version = "26.5.0.0.20260526.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ess-26.1.0.0.20260423.92659.tar";
-        sha256 = "0fmq3fp4dya40ab3rg511i7p3pi2mhx98dvl27fs186ya79bgvgq";
+        url = "https://elpa.gnu.org/devel/ess-26.5.0.0.20260526.0.tar";
+        sha256 = "08nkdqp7in2skkvs4z5q171i2yvmjhk0ycwa15ffvsjwanf328y7";
       };
       packageRequires = [ ];
       meta = {
@@ -3539,10 +3565,10 @@
     elpaBuild {
       pname = "expreg";
       ename = "expreg";
-      version = "1.4.1.0.20250918.220913";
+      version = "1.4.1.0.20260619.7";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/expreg-1.4.1.0.20250918.220913.tar";
-        sha256 = "1fdwxr3albv7ww87w8ib8r0rid8zkibcgbl3qhp29vm8g28s89ws";
+        url = "https://elpa.gnu.org/devel/expreg-1.4.1.0.20260619.7.tar";
+        sha256 = "0dxdr7ahhj17fvsvpb0w6ylh20qkgrvy53pc9a0r6m8pv97i6mx0";
       };
       packageRequires = [ ];
       meta = {
@@ -3560,10 +3586,10 @@
     elpaBuild {
       pname = "external-completion";
       ename = "external-completion";
-      version = "0.1.0.20260101.125434";
+      version = "0.1.0.20260501.92309";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/external-completion-0.1.0.20260101.125434.tar";
-        sha256 = "0ca24q2l56i5p03l4h1r5qvrqvsc5330csc7aj205hl94wpmhz1z";
+        url = "https://elpa.gnu.org/devel/external-completion-0.1.0.20260501.92309.tar";
+        sha256 = "1jdd1dixbyxfm8k1zcajajdi2r718vyqg1phxcp2mi61npwk9li0";
       };
       packageRequires = [ ];
       meta = {
@@ -3583,10 +3609,10 @@
     elpaBuild {
       pname = "exwm";
       ename = "exwm";
-      version = "0.34.0.20260204.122929";
+      version = "0.34.0.20260623.71";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/exwm-0.34.0.20260204.122929.tar";
-        sha256 = "1bmn6d7pjgjrh265y4w0g1ip8n21sx5z6xsl0vhfhvdf6h2w3c0b";
+        url = "https://elpa.gnu.org/devel/exwm-0.34.0.20260623.71.tar";
+        sha256 = "1mwi57r477xv3wg8ninlsf7k1jdl4f38i85p55r8xqa54hsgmr8s";
       };
       packageRequires = [
         compat
@@ -3616,6 +3642,27 @@
       packageRequires = [ cl-lib ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/f90-interface-browser.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  ffs = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "ffs";
+      ename = "ffs";
+      version = "0.2.30.20260522.94521";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/ffs-0.2.30.20260522.94521.tar";
+        sha256 = "0y8rsj2b6sjs9pai9swk18g72ms71lvv28zaw55v69dl1wjchvfc";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/ffs.html";
         license = lib.licenses.free;
       };
     }
@@ -3717,10 +3764,10 @@
     elpaBuild {
       pname = "flymake";
       ename = "flymake";
-      version = "1.4.5.0.20260326.141956";
+      version = "1.4.5.0.20260512.154242";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/flymake-1.4.5.0.20260326.141956.tar";
-        sha256 = "11cjgvqzp4jilw90hm82gzca68hr3dn0smg8wvfy8k0br8qq48nx";
+        url = "https://elpa.gnu.org/devel/flymake-1.4.5.0.20260512.154242.tar";
+        sha256 = "1wsfb33ybn6kiqn7mbnpr3vwgf68vszi9566jpl9vn8vhjq8xvkd";
       };
       packageRequires = [
         eldoc
@@ -3805,14 +3852,36 @@
     elpaBuild {
       pname = "fontaine";
       ename = "fontaine";
-      version = "3.0.1.0.20260413.54632";
+      version = "3.0.1.0.20260424.102702";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/fontaine-3.0.1.0.20260413.54632.tar";
-        sha256 = "1s7wz2807a49vhcj3zv7hx75kz4l9zkhi53fvppab46j2wyaw8qs";
+        url = "https://elpa.gnu.org/devel/fontaine-3.0.1.0.20260424.102702.tar";
+        sha256 = "01nnyx1hy869yd2x3vhzp13qzy90c6rhsj8r8jkyyd5ycfzrkdnn";
       };
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/fontaine.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  forgejo = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      keymap-popup,
+      lib,
+    }:
+    elpaBuild {
+      pname = "forgejo";
+      ename = "forgejo";
+      version = "0.2.3.0.20260619.16";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/forgejo-0.2.3.0.20260619.16.tar";
+        sha256 = "1ywj3k0syc09qx267dyj313qhdm583jij2raacz6q9vrh53wwrsz";
+      };
+      packageRequires = [ keymap-popup ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/forgejo.html";
         license = lib.licenses.free;
       };
     }
@@ -3916,10 +3985,10 @@
     elpaBuild {
       pname = "futur";
       ename = "futur";
-      version = "1.4.0.20260423.160640";
+      version = "1.7.0.20260622.8";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/futur-1.4.0.20260423.160640.tar";
-        sha256 = "04z4660mjgnf5z4qyzbiwdi7cd9b42ncvxrvpxr9i9q51sky72jb";
+        url = "https://elpa.gnu.org/devel/futur-1.7.0.20260622.8.tar";
+        sha256 = "1wwkm6955wy31ig84x7kgm5sl56jvgkgi706awhbvji0nrrj2nys";
       };
       packageRequires = [ ];
       meta = {
@@ -4105,17 +4174,21 @@
       compat,
       elpaBuild,
       fetchurl,
+      keymap-popup,
       lib,
     }:
     elpaBuild {
       pname = "gnosis";
       ename = "gnosis";
-      version = "0.10.3.0.20260420.110309";
+      version = "0.10.6.0.20260508.2618";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/gnosis-0.10.3.0.20260420.110309.tar";
-        sha256 = "0inrv51wkjycbxhhlsivfig2479v18jcvps1dq2psjas0r2crsx3";
+        url = "https://elpa.gnu.org/devel/gnosis-0.10.6.0.20260508.2618.tar";
+        sha256 = "04rsg495ldyj739spfk4xwrylfzh27ffkjam9rn86c43rip2arvm";
       };
-      packageRequires = [ compat ];
+      packageRequires = [
+        compat
+        keymap-popup
+      ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/gnosis.html";
         license = lib.licenses.free;
@@ -4318,10 +4391,10 @@
     elpaBuild {
       pname = "greader";
       ename = "greader";
-      version = "0.19.0.0.20260409.233021";
+      version = "0.19.4.0.20260608.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/greader-0.19.0.0.20260409.233021.tar";
-        sha256 = "1lq10b8b3nkzf6lx9z1h3cv2537g4ymj5qw6xbclpxzrj07zalg7";
+        url = "https://elpa.gnu.org/devel/greader-0.19.4.0.20260608.0.tar";
+        sha256 = "1pzblg6k9acx8nmpg9mzb42wi7invlip6zfchy03rq8f3gbk9vwy";
       };
       packageRequires = [
         compat
@@ -4386,10 +4459,10 @@
     elpaBuild {
       pname = "guess-language";
       ename = "guess-language";
-      version = "0.0.1.0.20240528.185800";
+      version = "0.0.1.0.20260529.147";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/guess-language-0.0.1.0.20240528.185800.tar";
-        sha256 = "0hlcnd69mqs90ndp59pqcjdwl27cswnpqy6yjzaspmbya6plv3g6";
+        url = "https://elpa.gnu.org/devel/guess-language-0.0.1.0.20260529.147.tar";
+        sha256 = "05dcakya74m9q459kywfdy1qyvlpdxwhg7fhphqqahj9pwa85yd9";
       };
       packageRequires = [
         cl-lib
@@ -4580,14 +4653,35 @@
     elpaBuild {
       pname = "hyperbole";
       ename = "hyperbole";
-      version = "9.0.2pre0.20260422.74419";
+      version = "9.0.20.20260622.1172";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/hyperbole-9.0.2pre0.20260422.74419.tar";
-        sha256 = "1k6qcwb9bhf062bd0d6q69n1wbk68bkmb8d30c5hnd32s2m261xp";
+        url = "https://elpa.gnu.org/devel/hyperbole-9.0.20.20260622.1172.tar";
+        sha256 = "0590d8ww3yq2p9x85m6435acrsmnnwg7njz96jg7wrkbnadjkyx1";
       };
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/hyperbole.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  ibuffer-sidebar = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "ibuffer-sidebar";
+      ename = "ibuffer-sidebar";
+      version = "0.0.1.0.20260612.36";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/ibuffer-sidebar-0.0.1.0.20260612.36.tar";
+        sha256 = "0r6wpdcn6fqrlgvmxihiwxp6lzhijjvwzikgv8nbh25x0gmz2nqm";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/ibuffer-sidebar.html";
         license = lib.licenses.free;
       };
     }
@@ -4913,10 +5007,10 @@
     elpaBuild {
       pname = "jarchive";
       ename = "jarchive";
-      version = "0.12.0.0.20260419.91017";
+      version = "0.12.0.0.20260530.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/jarchive-0.12.0.0.20260419.91017.tar";
-        sha256 = "0mdsfvggcv2iyia0vpp1lj1xarg8kjbksvxzl6w2b2q5k8j1gl8f";
+        url = "https://elpa.gnu.org/devel/jarchive-0.12.0.0.20260530.1.tar";
+        sha256 = "022msc0a39wl29j14sf4pfy1xc8p1bm8khx49f1qhlj3ppw3zr26";
       };
       packageRequires = [ ];
       meta = {
@@ -4934,10 +5028,10 @@
     elpaBuild {
       pname = "javaimp";
       ename = "javaimp";
-      version = "0.9.1.0.20260403.224537";
+      version = "0.9.2.0.20260619.6";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/javaimp-0.9.1.0.20260403.224537.tar";
-        sha256 = "0jkw3dklylz7l7wq162c16ak8fbjpp23g38y5fmpgrinrbfjpwmd";
+        url = "https://elpa.gnu.org/devel/javaimp-0.9.2.0.20260619.6.tar";
+        sha256 = "0axf8n0ymm80gswwf8hj20rzzdln04is1qy9ri8bd1iw689lvdgd";
       };
       packageRequires = [ ];
       meta = {
@@ -4978,10 +5072,10 @@
     elpaBuild {
       pname = "jinx";
       ename = "jinx";
-      version = "2.7.0.20260330.62245";
+      version = "2.8.0.20260519.104155";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/jinx-2.7.0.20260330.62245.tar";
-        sha256 = "1js65bg2pm4ql6rri6wvm91klhfnziv75n7cmix5z3lk0836qw7d";
+        url = "https://elpa.gnu.org/devel/jinx-2.8.0.20260519.104155.tar";
+        sha256 = "0npksm6qrjnlsjrsl0szdvgim2xjbqj1az4ar7gli4s4z0pl0bkk";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5064,10 +5158,10 @@
     elpaBuild {
       pname = "jsonrpc";
       ename = "jsonrpc";
-      version = "1.0.28.0.20260416.174639";
+      version = "1.0.28.0.20260504.104721";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/jsonrpc-1.0.28.0.20260416.174639.tar";
-        sha256 = "0j7y9kcjdai6sd1634ln4ag0fg5x8ljzq50f25nc5miadaq93vw8";
+        url = "https://elpa.gnu.org/devel/jsonrpc-1.0.28.0.20260504.104721.tar";
+        sha256 = "1p33407vls4hfa109zl9z2jqp7iya7flzy0j2rc6cxi8k5m6ls3m";
       };
       packageRequires = [ ];
       meta = {
@@ -5192,10 +5286,10 @@
     elpaBuild {
       pname = "kubed";
       ename = "kubed";
-      version = "0.6.1.0.20260413.204601";
+      version = "0.7.1.0.20260619.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/kubed-0.6.1.0.20260413.204601.tar";
-        sha256 = "1q7ykifs44ywrq94fhvdz4svpxm2j3yj4vmq74lz5d57q702xz9l";
+        url = "https://elpa.gnu.org/devel/kubed-0.7.1.0.20260619.0.tar";
+        sha256 = "0lgdl06lv66zxy5qcdnhrc118hxllaj7zjr7aphdm755lckd3f3i";
       };
       packageRequires = [ ];
       meta = {
@@ -5236,10 +5330,10 @@
     elpaBuild {
       pname = "latex-table-wizard";
       ename = "latex-table-wizard";
-      version = "1.5.5.0.20260212.172924";
+      version = "1.6.0.0.20260503.212802";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/latex-table-wizard-1.5.5.0.20260212.172924.tar";
-        sha256 = "0n2zvy43lmyvygy3npfgh3897gpwdvxpjd35n6011hbnm3b05s55";
+        url = "https://elpa.gnu.org/devel/latex-table-wizard-1.6.0.0.20260503.212802.tar";
+        sha256 = "0gsqgykvfg27c9gs83rjg8aaxm44a06r5d8ify7s7wcxpasdys1p";
       };
       packageRequires = [
         auctex
@@ -5260,10 +5354,10 @@
     elpaBuild {
       pname = "leaf";
       ename = "leaf";
-      version = "4.5.5.0.20260302.65208";
+      version = "4.5.5.0.20260508.153103";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/leaf-4.5.5.0.20260302.65208.tar";
-        sha256 = "0j2m24vhgn11w3cg8f3nsmvlgb0sfk6524xgfavqrhw528si1hj7";
+        url = "https://elpa.gnu.org/devel/leaf-4.5.5.0.20260508.153103.tar";
+        sha256 = "0zps0wiyplsv8nghyjfvv8m20rn0bsx7dapdfbvx3bkiqbmf8crq";
       };
       packageRequires = [ ];
       meta = {
@@ -5333,10 +5427,10 @@
     elpaBuild {
       pname = "let-alist";
       ename = "let-alist";
-      version = "1.0.6.0.20260315.121536";
+      version = "1.0.6.0.20260523.93734";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/let-alist-1.0.6.0.20260315.121536.tar";
-        sha256 = "1qx7979xjnb1xgk8jbxdizm7cdmnxhbgk39daclhv1322lj79w2s";
+        url = "https://elpa.gnu.org/devel/let-alist-1.0.6.0.20260523.93734.tar";
+        sha256 = "0wqim4mjy59yy5ykjiy5kl91c0841yp071cdh11p7mz54liw8yrc";
       };
       packageRequires = [ ];
       meta = {
@@ -5354,10 +5448,10 @@
     elpaBuild {
       pname = "lex";
       ename = "lex";
-      version = "1.2.0.20240216.82808";
+      version = "1.3.0.20260601.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/lex-1.2.0.20240216.82808.tar";
-        sha256 = "0mh2jk838216mwv6bab28mq9nb5617c5y7s0yqynkz3vkarnnxx1";
+        url = "https://elpa.gnu.org/devel/lex-1.3.0.20260601.0.tar";
+        sha256 = "1c79jqc7292qhs542nfgqg7va20k02sldb3n75vjsbhp13q05d6w";
       };
       packageRequires = [ ];
       meta = {
@@ -5375,10 +5469,10 @@
     elpaBuild {
       pname = "lin";
       ename = "lin";
-      version = "2.0.0.0.20260413.54759";
+      version = "2.0.0.0.20260424.102712";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/lin-2.0.0.0.20260413.54759.tar";
-        sha256 = "18im9kd79wvhk92p8wm0hxf67c85g6f2rlppx3dkn0r601hmpv2w";
+        url = "https://elpa.gnu.org/devel/lin-2.0.0.0.20260424.102712.tar";
+        sha256 = "11l840kmy06f59n1p2cac59fmdwqmwqyn1d7sx10k4xfx2i8f3pp";
       };
       packageRequires = [ ];
       meta = {
@@ -5451,10 +5545,10 @@
     elpaBuild {
       pname = "llm";
       ename = "llm";
-      version = "0.30.1.0.20260417.170756";
+      version = "0.31.1.0.20260624.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/llm-0.30.1.0.20260417.170756.tar";
-        sha256 = "01dzr0qli82gdm24fdqiw7gn10w1gallgcss04v5d251idgfh87q";
+        url = "https://elpa.gnu.org/devel/llm-0.31.1.0.20260624.0.tar";
+        sha256 = "0cakiavkq25axdvpnpsj57qfwppb3g14aww0vxzdpb8w80wzf1h1";
       };
       packageRequires = [
         compat
@@ -5584,10 +5678,10 @@
     elpaBuild {
       pname = "logos";
       ename = "logos";
-      version = "1.2.0.0.20260111.105252";
+      version = "1.2.0.0.20260424.102714";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/logos-1.2.0.0.20260111.105252.tar";
-        sha256 = "0566wrazp2z0np1rx6fqv6541b6a37j1k4x9rrnylzk9sgcnr1qp";
+        url = "https://elpa.gnu.org/devel/logos-1.2.0.0.20260424.102714.tar";
+        sha256 = "0wk6b064sl8kjnqn6ihcxaps6m7cpr4h78np3ls4w4018na90rmi";
       };
       packageRequires = [ ];
       meta = {
@@ -5691,10 +5785,10 @@
     elpaBuild {
       pname = "marginalia";
       ename = "marginalia";
-      version = "2.10.0.20260330.62326";
+      version = "2.11.0.20260519.104425";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/marginalia-2.10.0.20260330.62326.tar";
-        sha256 = "1vlzmpk04q2cgaqnlzdqdn6ll58jvkb3v93hnkifrldgzqkgd40n";
+        url = "https://elpa.gnu.org/devel/marginalia-2.11.0.20260519.104425.tar";
+        sha256 = "11n680dghiyzm5sk3b4s8adxdj457lm50nac1khkr8vfbqfdd7j6";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5797,10 +5891,10 @@
     elpaBuild {
       pname = "matlab-mode";
       ename = "matlab-mode";
-      version = "8.2.0.0.20260419.100405";
+      version = "8.2.0.0.20260428.134050";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/matlab-mode-8.2.0.0.20260419.100405.tar";
-        sha256 = "114s5ra2h4d8k0qn27blb8bzxjjlcgrrkmg1y647m2kzwfbp8hx5";
+        url = "https://elpa.gnu.org/devel/matlab-mode-8.2.0.0.20260428.134050.tar";
+        sha256 = "0caab8wxwn55zk6cd20qm20z2nkwff8a1y3jrwfd41i1kx18mcg4";
       };
       packageRequires = [ ];
       meta = {
@@ -5818,10 +5912,10 @@
     elpaBuild {
       pname = "mct";
       ename = "mct";
-      version = "1.1.0.0.20260413.54251";
+      version = "1.1.0.0.20260424.102720";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/mct-1.1.0.0.20260413.54251.tar";
-        sha256 = "1wlyg28xcyig05248nic6jia4zw0q5k0rg8l3facskisbhild7dz";
+        url = "https://elpa.gnu.org/devel/mct-1.1.0.0.20260424.102720.tar";
+        sha256 = "1413vjnlm12s65yalna2lqb26a77als5h3pyxlpjaf8rb9lpgchw";
       };
       packageRequires = [ ];
       meta = {
@@ -5960,6 +6054,7 @@
   ) { };
   minimail = callPackage (
     {
+      compat,
       elpaBuild,
       fetchurl,
       lib,
@@ -5968,12 +6063,15 @@
     elpaBuild {
       pname = "minimail";
       ename = "minimail";
-      version = "0.4.2.0.20260428.192238";
+      version = "0.5.0.20260513.113502";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/minimail-0.4.2.0.20260428.192238.tar";
-        sha256 = "0wd5nay9x0sqr7l96ibi554qab5mfgh3dw493rcw7cs3cwiwsvhm";
+        url = "https://elpa.gnu.org/devel/minimail-0.5.0.20260513.113502.tar";
+        sha256 = "0b3npm8wsgl3nizvgvpb11i4kamg89js04nd52f28hb6f75mwjkh";
       };
-      packageRequires = [ transient ];
+      packageRequires = [
+        compat
+        transient
+      ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/minimail.html";
         license = lib.licenses.free;
@@ -6012,10 +6110,10 @@
     elpaBuild {
       pname = "minuet";
       ename = "minuet";
-      version = "0.7.1.0.20260424.3009";
+      version = "0.8.0.0.20260518.211153";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/minuet-0.7.1.0.20260424.3009.tar";
-        sha256 = "0g9vqm9wby07pmhc6ai31krk473lif74273qbjrfzxzqbg4iavbk";
+        url = "https://elpa.gnu.org/devel/minuet-0.8.0.0.20260518.211153.tar";
+        sha256 = "1sxfwivmlpc2cdkx5bn1nmprkpqi43m8bp8zna6ba64ajm4i2k4c";
       };
       packageRequires = [
         dash
@@ -6079,10 +6177,10 @@
     elpaBuild {
       pname = "modus-themes";
       ename = "modus-themes";
-      version = "5.2.0.0.20260418.131316";
+      version = "5.3.0.0.20260623.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/modus-themes-5.2.0.0.20260418.131316.tar";
-        sha256 = "1qcb53pp05bk2fpjmli68kbmpk4wk8b7ll6iimvmgw8nlq4qzlhb";
+        url = "https://elpa.gnu.org/devel/modus-themes-5.3.0.0.20260623.1.tar";
+        sha256 = "03cj2sgr1p1xkygxqfx00z13lnpzndn44niymipccds8rb8ipsri";
       };
       packageRequires = [ ];
       meta = {
@@ -6100,10 +6198,10 @@
     elpaBuild {
       pname = "mpdired";
       ename = "mpdired";
-      version = "4pre0.20250502.114712";
+      version = "40.20250502.114712";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/mpdired-4pre0.20250502.114712.tar";
-        sha256 = "1s831xln9vlxcchmxmis8ky751r3xwi5nlnnchdn7sjngkqjkl30";
+        url = "https://elpa.gnu.org/devel/mpdired-40.20250502.114712.tar";
+        sha256 = "1dzvv4q13xad0940yg5qc3mbznkkslh3kjcy8br6jfq9qfp85gh0";
       };
       packageRequires = [ ];
       meta = {
@@ -6421,10 +6519,10 @@
     elpaBuild {
       pname = "notmuch-indicator";
       ename = "notmuch-indicator";
-      version = "1.3.0.0.20260413.54903";
+      version = "1.3.0.0.20260424.102728";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/notmuch-indicator-1.3.0.0.20260413.54903.tar";
-        sha256 = "091rlqqp7ngff0x1f8fh6axyyzbxrdvwnjqyqly5axazv8sm846n";
+        url = "https://elpa.gnu.org/devel/notmuch-indicator-1.3.0.0.20260424.102728.tar";
+        sha256 = "0iz3rzzb4rq7j5dwvyrdfyn2j1hag882204bc7fdldglwinic5zx";
       };
       packageRequires = [ ];
       meta = {
@@ -6484,10 +6582,10 @@
     elpaBuild {
       pname = "oauth2";
       ename = "oauth2";
-      version = "0.18.4.0.20251120.214128";
+      version = "0.19.10.20260526.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/oauth2-0.18.4.0.20251120.214128.tar";
-        sha256 = "1x9v0s652al0ms37hafmqwla6wl97wpgvxh7w2ixpyrwrj206c93";
+        url = "https://elpa.gnu.org/devel/oauth2-0.19.10.20260526.1.tar";
+        sha256 = "1i1sndnrjgyrfzhll2wjhc2n0n0wyfpswwnfc5p8097jda1q27hk";
       };
       packageRequires = [ ];
       meta = {
@@ -6613,10 +6711,10 @@
     elpaBuild {
       pname = "orderless";
       ename = "orderless";
-      version = "1.6.0.20260127.172602";
+      version = "1.7.0.20260519.103644";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/orderless-1.6.0.20260127.172602.tar";
-        sha256 = "1arpnkw49vhrdgp7b9mpxbbv6q3mwnimn1d79cr3jjs97ngii980";
+        url = "https://elpa.gnu.org/devel/orderless-1.7.0.20260519.103644.tar";
+        sha256 = "0l5ylzvnlgbswlnr7nqaqrrzm88j7hya69rwawp8m9nyar10mj7q";
       };
       packageRequires = [ compat ];
       meta = {
@@ -6634,10 +6732,10 @@
     elpaBuild {
       pname = "org";
       ename = "org";
-      version = "10.0pre0.20260421.184316";
+      version = "10.0.20260622.360";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-10.0pre0.20260421.184316.tar";
-        sha256 = "0809x9rw2smb5ya3x2272qcjjj6kx6xrj8ajlzzwiz2m1wdhz5w3";
+        url = "https://elpa.gnu.org/devel/org-10.0.20260622.360.tar";
+        sha256 = "1fizzj0vsv78sg7hivsicxvkvksyl7lw0iah0djnp1sfvl54gxf8";
       };
       packageRequires = [ ];
       meta = {
@@ -6781,10 +6879,10 @@
     elpaBuild {
       pname = "org-modern";
       ename = "org-modern";
-      version = "1.13.0.20260330.62401";
+      version = "1.14.0.20260519.104634";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-modern-1.13.0.20260330.62401.tar";
-        sha256 = "1lh1n09aqi8jxqpwsdv806910bflw25z6mcblplapk4lcd6al4y2";
+        url = "https://elpa.gnu.org/devel/org-modern-1.14.0.20260519.104634.tar";
+        sha256 = "0q4iqgv18a24fhwsxrhz6f7awik0v5jxvq19brnp7k83zssw5gdj";
       };
       packageRequires = [
         compat
@@ -6853,10 +6951,10 @@
     elpaBuild {
       pname = "org-remark";
       ename = "org-remark";
-      version = "1.3.0.0.20251214.30531";
+      version = "1.3.0.0.20260531.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-remark-1.3.0.0.20251214.30531.tar";
-        sha256 = "1fs0k4a132bizm5pihp3gc7yzdgwzzfiwyqj3bawjqkzpgx2wlpl";
+        url = "https://elpa.gnu.org/devel/org-remark-1.3.0.0.20260531.4.tar";
+        sha256 = "1k69ndpwk6mrlzdcv727fpfb73glis2dgxm48kdnbgz5167blydg";
       };
       packageRequires = [ org ];
       meta = {
@@ -6961,10 +7059,10 @@
     elpaBuild {
       pname = "osm";
       ename = "osm";
-      version = "2.2.0.20260330.62455";
+      version = "2.3.0.20260623.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/osm-2.2.0.20260330.62455.tar";
-        sha256 = "0rj0zs5xmmj2swdjyk9pichljjd9c1qzbl836xaahxq2grcbqs5i";
+        url = "https://elpa.gnu.org/devel/osm-2.3.0.20260623.1.tar";
+        sha256 = "07a7vwcpqjrq5vrvsb0bmmx0vjsdxq3449pfcsnnyamws3qhrwa1";
       };
       packageRequires = [ compat ];
       meta = {
@@ -7280,10 +7378,10 @@
     elpaBuild {
       pname = "plz";
       ename = "plz";
-      version = "0.10pre0.20250318.183534";
+      version = "0.100.20250318.183534";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/plz-0.10pre0.20250318.183534.tar";
-        sha256 = "08iyw80d2431k60fkw26i3z8zw0jk9czmxr1vi7z7hdfrqmw7gc0";
+        url = "https://elpa.gnu.org/devel/plz-0.100.20250318.183534.tar";
+        sha256 = "0ai10h4fhavrb2nxcp5a59g32cf95q99cia7ck9chw6dznb73vpj";
       };
       packageRequires = [ ];
       meta = {
@@ -7302,10 +7400,10 @@
     elpaBuild {
       pname = "plz-event-source";
       ename = "plz-event-source";
-      version = "0.1.4pre0.20250413.93107";
+      version = "0.1.40.20250413.93107";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/plz-event-source-0.1.4pre0.20250413.93107.tar";
-        sha256 = "1g4bvdbdg5c0ch62l8314rv44b2wyymkbydyi0fkdjjb3a9ns4b0";
+        url = "https://elpa.gnu.org/devel/plz-event-source-0.1.40.20250413.93107.tar";
+        sha256 = "0fm2rdsrfcw0hdwycpgcwgkikl6w5ldicr3zwhqwq4vxzfzaflb6";
       };
       packageRequires = [ plz-media-type ];
       meta = {
@@ -7324,10 +7422,10 @@
     elpaBuild {
       pname = "plz-media-type";
       ename = "plz-media-type";
-      version = "0.2.5pre0.20250412.100044";
+      version = "0.2.50.20250412.100044";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/plz-media-type-0.2.5pre0.20250412.100044.tar";
-        sha256 = "1w35bdxgsv1wvqwn64miyzplbb6gqry25wnl6l7dyd2n71h2hmxl";
+        url = "https://elpa.gnu.org/devel/plz-media-type-0.2.50.20250412.100044.tar";
+        sha256 = "1dglmb2vaznrz3c4l6nrdwfs8zqz2pj3js5d1zkbw3ld2q01m9rv";
       };
       packageRequires = [ plz ];
       meta = {
@@ -7451,10 +7549,10 @@
     elpaBuild {
       pname = "polymode";
       ename = "polymode";
-      version = "0.2.2.0.20260302.104336";
+      version = "0.2.2.0.20260505.180301";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/polymode-0.2.2.0.20260302.104336.tar";
-        sha256 = "04jfj25kmh55jq7bm5dq02xp4kgfvpbgsngx825qpgfsl3lkq6yi";
+        url = "https://elpa.gnu.org/devel/polymode-0.2.2.0.20260505.180301.tar";
+        sha256 = "00h3hyaz8rkv9wyvn0afg63v4v5ghz6h6hk1rds54wi8mb1501nc";
       };
       packageRequires = [ ];
       meta = {
@@ -7493,10 +7591,10 @@
     elpaBuild {
       pname = "posframe";
       ename = "posframe";
-      version = "1.5.1.0.20260423.21349";
+      version = "1.5.2.0.20260527.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/posframe-1.5.1.0.20260423.21349.tar";
-        sha256 = "0ylxj2spphywm7851lyrki34gkcznjd24xpd75f47pa1wcplkc48";
+        url = "https://elpa.gnu.org/devel/posframe-1.5.2.0.20260527.0.tar";
+        sha256 = "1gjj04a8sbngcvmkr9kfnx335k5z0knclabl6jz8rcnswj531ac6";
       };
       packageRequires = [ ];
       meta = {
@@ -7557,10 +7655,10 @@
     elpaBuild {
       pname = "preview-auto";
       ename = "preview-auto";
-      version = "0.4.2.0.20260327.92953";
+      version = "0.4.2.0.20260617.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/preview-auto-0.4.2.0.20260327.92953.tar";
-        sha256 = "0mc0gwl3hk5fq9qfysxkphj9irzabm5bgkv8cz7m60k9s5g399rh";
+        url = "https://elpa.gnu.org/devel/preview-auto-0.4.2.0.20260617.3.tar";
+        sha256 = "1p518f3b78lxsjbq3q4vkj25hy04yrm9xk1srk9clr3jx3i8gbvr";
       };
       packageRequires = [ auctex ];
       meta = {
@@ -7601,10 +7699,10 @@
     elpaBuild {
       pname = "project";
       ename = "project";
-      version = "0.11.2.0.20260407.143459";
+      version = "0.11.2.0.20260612.29";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/project-0.11.2.0.20260407.143459.tar";
-        sha256 = "01pjihpy1496rwxyir9n1di1x2fkpmdb6c9gcmah3ygfg9gkqj7d";
+        url = "https://elpa.gnu.org/devel/project-0.11.2.0.20260612.29.tar";
+        sha256 = "19bb3v47ikpf445zz4pgxlnynkwyjacydws15lgsc853npca1df1";
       };
       packageRequires = [ xref ];
       meta = {
@@ -7664,10 +7762,10 @@
     elpaBuild {
       pname = "pulsar";
       ename = "pulsar";
-      version = "1.3.4.0.20260421.185730";
+      version = "1.3.4.0.20260426.51313";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/pulsar-1.3.4.0.20260421.185730.tar";
-        sha256 = "100nyvpnap1bjc5k4ryni0h43dpacw1nbc6kyz73q82m19m78cnx";
+        url = "https://elpa.gnu.org/devel/pulsar-1.3.4.0.20260426.51313.tar";
+        sha256 = "0nw5hpxk5v334xp43gnnv2jknq88lgba69j8sn0i1625cvwpijiq";
       };
       packageRequires = [ ];
       meta = {
@@ -7734,10 +7832,10 @@
     elpaBuild {
       pname = "python";
       ename = "python";
-      version = "0.30.0.20260307.113211";
+      version = "0.30.0.20260620.46";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/python-0.30.0.20260307.113211.tar";
-        sha256 = "0rbq19sgxf3p9dnx8fkwyki6qmdajmxygmcn34f9gbwyg1ip2m2c";
+        url = "https://elpa.gnu.org/devel/python-0.30.0.20260620.46.tar";
+        sha256 = "00vdr03pbmfv6sbvjk410x13msfgm3d3f6qs8hpkb67pg4q87xzb";
       };
       packageRequires = [ compat ];
       meta = {
@@ -7927,10 +8025,10 @@
     elpaBuild {
       pname = "realgud";
       ename = "realgud";
-      version = "1.6.0.0.20260411.181642";
+      version = "1.6.0.0.20260609.11";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/realgud-1.6.0.0.20260411.181642.tar";
-        sha256 = "11rs4xcy7xz2ckvpii33mmy04flwfladpi5j70bxc5anmhn5fh68";
+        url = "https://elpa.gnu.org/devel/realgud-1.6.0.0.20260609.11.tar";
+        sha256 = "1j598wswb1s3gn2h2sk5hvz93nphlnmx3xqpa1nr2rg3jwpmv4zr";
       };
       packageRequires = [
         load-relative
@@ -8271,10 +8369,10 @@
     elpaBuild {
       pname = "rnc-mode";
       ename = "rnc-mode";
-      version = "0.3.0.20221221.81910";
+      version = "0.4.0.20260610.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/rnc-mode-0.3.0.20221221.81910.tar";
-        sha256 = "1rdz1g440sjzxcqc4p2s0vv525ala4k470ddn4h9ghljnncqbady";
+        url = "https://elpa.gnu.org/devel/rnc-mode-0.4.0.20260610.0.tar";
+        sha256 = "1yvkmcqykpvnfzpq2qra4dc14rviwhhvch2wb19iy781v6dryxj5";
       };
       packageRequires = [ ];
       meta = {
@@ -8511,10 +8609,10 @@
     elpaBuild {
       pname = "shell-command-plus";
       ename = "shell-command+";
-      version = "2.5.0.0.20250930.194048";
+      version = "2.5.0.0.20260516.144445";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/shell-command+-2.5.0.0.20250930.194048.tar";
-        sha256 = "1p6s6rp10mg23vvnls5pxgx014jf86x6427xbqms3bbdz0fpzn5j";
+        url = "https://elpa.gnu.org/devel/shell-command+-2.5.0.0.20260516.144445.tar";
+        sha256 = "1s6zwc08jgxjrbbdz7nbw4698vyd0z3zfqmkkkqx5ihklm1i1156";
       };
       packageRequires = [ ];
       meta = {
@@ -8565,6 +8663,27 @@
       };
     }
   ) { };
+  shift-number = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "shift-number";
+      ename = "shift-number";
+      version = "0.3.0.20260621.19";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/shift-number-0.3.0.20260621.19.tar";
+        sha256 = "08wc1kb8fvccfaw1c5n5cpmpxrjhzxaamsp9076lb59aa2ffgsz8";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/shift-number.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   show-font = callPackage (
     {
       elpaBuild,
@@ -8574,10 +8693,10 @@
     elpaBuild {
       pname = "show-font";
       ename = "show-font";
-      version = "1.0.0.0.20260111.105401";
+      version = "1.0.0.0.20260424.102736";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/show-font-1.0.0.0.20260111.105401.tar";
-        sha256 = "146mmg4kv3sz9bd4b1026fsws16w3nz99m4sbkhgwaf09mrr2bkl";
+        url = "https://elpa.gnu.org/devel/show-font-1.0.0.0.20260424.102736.tar";
+        sha256 = "06kf0hivajpb7g7ba3sc8nkaz1pny6j1imsr5jqf1nawfyb24qrd";
       };
       packageRequires = [ ];
       meta = {
@@ -8851,10 +8970,10 @@
     elpaBuild {
       pname = "spacious-padding";
       ename = "spacious-padding";
-      version = "0.8.0.0.20260111.105014";
+      version = "0.8.0.0.20260505.183614";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/spacious-padding-0.8.0.0.20260111.105014.tar";
-        sha256 = "0yxml44g1lc0r2jca9qwbkqv3d2jx79nvyhw1gxx6wjj76wlwzwf";
+        url = "https://elpa.gnu.org/devel/spacious-padding-0.8.0.0.20260505.183614.tar";
+        sha256 = "0pzcfd3z5w67cfcmp9hzyjjjxx5i5pxgl5k45hhxcwrfwm4x8h4l";
       };
       packageRequires = [ ];
       meta = {
@@ -9048,10 +9167,10 @@
     elpaBuild {
       pname = "standard-themes";
       ename = "standard-themes";
-      version = "3.0.2.0.20260405.133615";
+      version = "3.0.2.0.20260424.102741";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/standard-themes-3.0.2.0.20260405.133615.tar";
-        sha256 = "0b88iyisvqqv3ziciypkqdjz9i14xcgjlymaf0n3s34yycgglbsz";
+        url = "https://elpa.gnu.org/devel/standard-themes-3.0.2.0.20260424.102741.tar";
+        sha256 = "1h3q71b4g89av2a9i1864mhkww75669051xs2qzp78aglqnm8dr6";
       };
       packageRequires = [ modus-themes ];
       meta = {
@@ -9090,10 +9209,10 @@
     elpaBuild {
       pname = "substitute";
       ename = "substitute";
-      version = "0.5.0.0.20260324.124253";
+      version = "0.5.0.0.20260424.102743";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/substitute-0.5.0.0.20260324.124253.tar";
-        sha256 = "0m5jmchrzh1cwq6zd8jd65v7kaks6cgqjvw8094ijq8bc28ni3k7";
+        url = "https://elpa.gnu.org/devel/substitute-0.5.0.0.20260424.102743.tar";
+        sha256 = "1zl5hyq0919c3mp680v22xjmfggfkdn1mz13sf1ivbahgndjbddk";
       };
       packageRequires = [ ];
       meta = {
@@ -9241,10 +9360,10 @@
     elpaBuild {
       pname = "sxhkdrc-mode";
       ename = "sxhkdrc-mode";
-      version = "1.2.0.0.20260111.105425";
+      version = "1.2.0.0.20260424.102746";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/sxhkdrc-mode-1.2.0.0.20260111.105425.tar";
-        sha256 = "07a9ykifnan2wljglkrl7yk2s3ihb8ij47bqlkq7c6w74symgz7z";
+        url = "https://elpa.gnu.org/devel/sxhkdrc-mode-1.2.0.0.20260424.102746.tar";
+        sha256 = "1cr31122688fl5cyslqzawinaca7df64hxzqvszalzv32gimzm15";
       };
       packageRequires = [ ];
       meta = {
@@ -9352,10 +9471,10 @@
     elpaBuild {
       pname = "taxy";
       ename = "taxy";
-      version = "0.11pre0.20251129.62050";
+      version = "0.110.20251129.62050";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/taxy-0.11pre0.20251129.62050.tar";
-        sha256 = "1g937immy39j8qfmcq4skxc2xlkn0h57v2w6h7g3rsjgns50l5ca";
+        url = "https://elpa.gnu.org/devel/taxy-0.110.20251129.62050.tar";
+        sha256 = "0nvrwsz87rmwnyafd1291kmxg8f4k62l9jm207my7dnyq5ks0b19";
       };
       packageRequires = [ ];
       meta = {
@@ -9421,10 +9540,10 @@
     elpaBuild {
       pname = "tempel";
       ename = "tempel";
-      version = "1.12.0.20260330.62558";
+      version = "1.13.0.20260609.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tempel-1.12.0.20260330.62558.tar";
-        sha256 = "0f2gy05isba11k2sqgv7yjiw06i72p9fjbfzgwh3nrljpvndc2cf";
+        url = "https://elpa.gnu.org/devel/tempel-1.13.0.20260609.1.tar";
+        sha256 = "1n423dfaij4ixss5w8nm519kdainipswdr38gx3qhcb59l0pywhd";
       };
       packageRequires = [ compat ];
       meta = {
@@ -9442,10 +9561,10 @@
     elpaBuild {
       pname = "termint";
       ename = "termint";
-      version = "0.2.2.0.20260411.234846";
+      version = "0.2.3.0.20260517.165016";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/termint-0.2.2.0.20260411.234846.tar";
-        sha256 = "0xsrqxgndzmxskcmfx4184nb7yvwmv9lqdy40cjhpc8f3xwmzqwq";
+        url = "https://elpa.gnu.org/devel/termint-0.2.3.0.20260517.165016.tar";
+        sha256 = "0x3sg96qwrqiclw5gplakynfgsa1cfqa3yj4a4f705in9xaaswjr";
       };
       packageRequires = [ ];
       meta = {
@@ -9506,10 +9625,10 @@
     elpaBuild {
       pname = "tex-parens";
       ename = "tex-parens";
-      version = "0.7.0.20250709.53958";
+      version = "0.7.0.20260225.9";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tex-parens-0.7.0.20250709.53958.tar";
-        sha256 = "0mbcgc17cy8imk7dzh9krwd62dy2h7fj5pzvfr1wggdczrs2zva8";
+        url = "https://elpa.gnu.org/devel/tex-parens-0.7.0.20260225.9.tar";
+        sha256 = "040997wgzhkc071hrlcidakicxm1p8fg3mdykr5476cw3ffx6ra1";
       };
       packageRequires = [ ];
       meta = {
@@ -9548,10 +9667,10 @@
     elpaBuild {
       pname = "timeout";
       ename = "timeout";
-      version = "2.1.0.20251209.235840";
+      version = "2.1.6.0.20260504.161229";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/timeout-2.1.0.20251209.235840.tar";
-        sha256 = "1i1yijhvq1i5z3mvhw587n8md3yric545r2bc5ik76gdm8rhslf0";
+        url = "https://elpa.gnu.org/devel/timeout-2.1.6.0.20260504.161229.tar";
+        sha256 = "00ygq747m4yhp1mjj083ai18av8jri76q33gp214skpac85dxdb5";
       };
       packageRequires = [ ];
       meta = {
@@ -9612,10 +9731,10 @@
     elpaBuild {
       pname = "tmr";
       ename = "tmr";
-      version = "1.3.0.0.20260423.190529";
+      version = "1.3.0.0.20260529.24";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tmr-1.3.0.0.20260423.190529.tar";
-        sha256 = "1m6ymyrv2fc8j22w12ppj2l1j6cczld8kd6hn2imbxga04knni9z";
+        url = "https://elpa.gnu.org/devel/tmr-1.3.0.0.20260529.24.tar";
+        sha256 = "0ybzzynk6prnanly0izr59p0kajp4nbm8jk8vqrg4mliidl79fmw";
       };
       packageRequires = [ ];
       meta = {
@@ -9701,10 +9820,10 @@
     elpaBuild {
       pname = "tramp";
       ename = "tramp";
-      version = "2.8.1.3.0.20260330.55054";
+      version = "2.8.1.5.0.20260530.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tramp-2.8.1.3.0.20260330.55054.tar";
-        sha256 = "01c5l03x5krzga9a9gg3klcn47k357p0k0ad09cd0g5qi4jmss5j";
+        url = "https://elpa.gnu.org/devel/tramp-2.8.1.5.0.20260530.0.tar";
+        sha256 = "1d4ksg9cw8a9kqbwpa8jafjwb29g5f8640nd5v6chd6a5lv1z9sf";
       };
       packageRequires = [ ];
       meta = {
@@ -9805,19 +9924,21 @@
       elpaBuild,
       fetchurl,
       lib,
+      llama,
       seq,
     }:
     elpaBuild {
       pname = "transient";
       ename = "transient";
-      version = "0.13.0.0.20260422.164634";
+      version = "0.13.4.0.20260617.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/transient-0.13.0.0.20260422.164634.tar";
-        sha256 = "1mqky3s852p8fw9h9s2wqn7f40fbk8zy5rz9yxwq88w55nyw2kw5";
+        url = "https://elpa.gnu.org/devel/transient-0.13.4.0.20260617.1.tar";
+        sha256 = "1y96c432kviy2xnijzp5y49fyazjfab49i8jyysgf87pbxjpylsl";
       };
       packageRequires = [
         compat
         cond-let
+        llama
         seq
       ];
       meta = {
@@ -9939,6 +10060,27 @@
       };
     }
   ) { };
+  trust-manager = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "trust-manager";
+      ename = "trust-manager";
+      version = "0.4.1.0.20260426.120509";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/trust-manager-0.4.1.0.20260426.120509.tar";
+        sha256 = "0dvn2x443czsamawylwm5ixayv77fs53ixvkkdg0yj4n6iv3kcg6";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/trust-manager.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   ulisp-repl = callPackage (
     {
       elpaBuild,
@@ -10034,10 +10176,10 @@
     elpaBuild {
       pname = "urgrep";
       ename = "urgrep";
-      version = "0.6.1snapshot0.20260321.103449";
+      version = "0.6.10.20260619.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/urgrep-0.6.1snapshot0.20260321.103449.tar";
-        sha256 = "09ijxd7nzx7xps3db408i0hmr40m7rsc2phim67dm2sma622xl57";
+        url = "https://elpa.gnu.org/devel/urgrep-0.6.10.20260619.3.tar";
+        sha256 = "1cakwsfi1caz1z30d3dshsjq348ghzh6s9z474zwcdycay94037i";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10253,10 +10395,10 @@
     elpaBuild {
       pname = "vc-jj";
       ename = "vc-jj";
-      version = "0.5.0.20260416.141453";
+      version = "0.5.0.20260531.62";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vc-jj-0.5.0.20260416.141453.tar";
-        sha256 = "0x5qj0a77wjfqxyr8wv9gswm205jj52cihlpmbkspn01a93ljr04";
+        url = "https://elpa.gnu.org/devel/vc-jj-0.5.0.20260531.62.tar";
+        sha256 = "120aln68dyj2faknjpjzfgdm6ln90ryh3v803lmgpfhpiph2w1dp";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10364,10 +10506,10 @@
     elpaBuild {
       pname = "verilog-mode";
       ename = "verilog-mode";
-      version = "2026.1.18.88738971.0.20260118.95917";
+      version = "2026.4.14.10117132.0.20260621.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/verilog-mode-2026.1.18.88738971.0.20260118.95917.tar";
-        sha256 = "1h5mp70kg1w85g0kx6ipdczkza553d7mzffxx832j4wx3wr5afql";
+        url = "https://elpa.gnu.org/devel/verilog-mode-2026.4.14.10117132.0.20260621.0.tar";
+        sha256 = "1c5jkwxv3bpc9mpsbja9dzycz8zpccsjc7wg5ws5zxlzqbi2p46q";
       };
       packageRequires = [ ];
       meta = {
@@ -10386,10 +10528,10 @@
     elpaBuild {
       pname = "vertico";
       ename = "vertico";
-      version = "2.8.0.20260419.183845";
+      version = "2.10.0.20260605.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vertico-2.8.0.20260419.183845.tar";
-        sha256 = "0mxhmknbx9sjsvxz9mc5vvg8pag9ijll0s71c2in307scdmp3lvk";
+        url = "https://elpa.gnu.org/devel/vertico-2.10.0.20260605.0.tar";
+        sha256 = "0c7fj7issnnz4m0hm9c4ggpl4siic3y67pvgjfkil9zd1z7jnh0s";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10538,10 +10680,10 @@
     elpaBuild {
       pname = "wcheck-mode";
       ename = "wcheck-mode";
-      version = "2026.0.20260412.44645";
+      version = "2026.5.0.20260529.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/wcheck-mode-2026.0.20260412.44645.tar";
-        sha256 = "0gbx80sv5kg8jnk5vzr3hr4lc25rhyl6jva14nr2c2v6bidfi97x";
+        url = "https://elpa.gnu.org/devel/wcheck-mode-2026.5.0.20260529.0.tar";
+        sha256 = "07pyq411jvpkdgwhhj0snpqdiaxjlfb2wklqqankc4c2qmck7nmv";
       };
       packageRequires = [ ];
       meta = {
@@ -10790,6 +10932,27 @@
       };
     }
   ) { };
+  with-command-redo = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "with-command-redo";
+      ename = "with-command-redo";
+      version = "0.1.0.20260504.211611";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/with-command-redo-0.1.0.20260504.211611.tar";
+        sha256 = "1k37zdj23p606mxinaics0djp8n2rdylc7k4p03sacxmjiw34fid";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/with-command-redo.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   wpuzzle = callPackage (
     {
       elpaBuild,
@@ -10884,10 +11047,10 @@
     elpaBuild {
       pname = "xelb";
       ename = "xelb";
-      version = "0.22.0.20260406.170713";
+      version = "0.22.0.20260623.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/xelb-0.22.0.20260406.170713.tar";
-        sha256 = "1np8vw3f8xp5fxbx0zq62li7bq87f20pz4zjsn1n3h4scg5albba";
+        url = "https://elpa.gnu.org/devel/xelb-0.22.0.20260623.5.tar";
+        sha256 = "0v5rwk9m76zy1irg7ii84slfwb360fy5h3kacnzdrgxlwk7aw6rj";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10994,10 +11157,10 @@
     elpaBuild {
       pname = "yaml";
       ename = "yaml";
-      version = "1.2.3.0.20260113.65351";
+      version = "1.2.4.0.20260605.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/yaml-1.2.3.0.20260113.65351.tar";
-        sha256 = "09ffagrz3qnbca8z4wm6bvxmdfnl2355sz9vgs9x3cavmy3pfy1x";
+        url = "https://elpa.gnu.org/devel/yaml-1.2.4.0.20260605.0.tar";
+        sha256 = "10hmq703w380gj1bns32k7qz2d5rvvaxd3hyyz76iahfnd574569";
       };
       packageRequires = [ ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -7159,10 +7159,10 @@
     elpaBuild {
       pname = "php-fill";
       ename = "php-fill";
-      version = "1.1.1";
+      version = "1.1.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/php-fill-1.1.1.tar";
-        sha256 = "130q6nyx5837wvhvis0nlzsqky7hic00z1jakik66asqpyrl7ncj";
+        url = "https://elpa.gnu.org/packages/php-fill-1.1.2.tar";
+        sha256 = "0r1zmin3wv8sqzgw6zbvbb7wix7d6h6s798f9r05w6g9m1vf0r5r";
       };
       packageRequires = [ ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -9,10 +9,10 @@
     elpaBuild {
       pname = "a68-mode";
       ename = "a68-mode";
-      version = "1.2";
+      version = "1.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/a68-mode-1.2.tar";
-        sha256 = "1x40j0w6kzjxxrj7qdvll1psackq526cfrihfmacmq97c9g8xwm6";
+        url = "https://elpa.gnu.org/packages/a68-mode-1.3.tar";
+        sha256 = "0x5jj95bk07wnl9aqf35hcm9ajdwbrg74xm90i5kfn6nrxmnjmyp";
       };
       packageRequires = [ ];
       meta = {
@@ -207,10 +207,10 @@
     elpaBuild {
       pname = "aggressive-completion";
       ename = "aggressive-completion";
-      version = "1.7";
+      version = "1.8";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/aggressive-completion-1.7.tar";
-        sha256 = "0d388w0yjpjzhqlar9fjrxsjxma09j8as6758sswv01r084gpdbk";
+        url = "https://elpa.gnu.org/packages/aggressive-completion-1.8.tar";
+        sha256 = "07dqw6mvb1vp4fmii1y7wc074xxi9wfwalflszjpzcjbalklcqdq";
       };
       packageRequires = [ ];
       meta = {
@@ -527,10 +527,10 @@
     elpaBuild {
       pname = "auth-source-xoauth2-plugin";
       ename = "auth-source-xoauth2-plugin";
-      version = "0.3.2";
+      version = "0.4.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/auth-source-xoauth2-plugin-0.3.2.tar";
-        sha256 = "1k48kg6n72vzxaiqidg4m0w69c2s6ynvgcr08p4i8x2fsgaigcp2";
+        url = "https://elpa.gnu.org/packages/auth-source-xoauth2-plugin-0.4.1.tar";
+        sha256 = "038wikkg4lmgjjnwkliwwx8iif55vlc6720qz55lkr7pkrzp5vas";
       };
       packageRequires = [ oauth2 ];
       meta = {
@@ -1085,10 +1085,10 @@
     elpaBuild {
       pname = "cape";
       ename = "cape";
-      version = "2.6";
+      version = "2.7";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/cape-2.6.tar";
-        sha256 = "0n4j70w1q9ix9d8s276g4shkn1k7hv8d6wqpx65wchgilwbjx07z";
+        url = "https://elpa.gnu.org/packages/cape-2.7.tar";
+        sha256 = "0543x1j4pakdqm8vba0450yl9b30z527dx8x84mzjqkhksn40pzv";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1241,6 +1241,28 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/clipboard-collector.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  cm-mode = callPackage (
+    {
+      cl-lib ? null,
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "cm-mode";
+      ename = "cm-mode";
+      version = "1.10";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/cm-mode-1.10.tar";
+        sha256 = "1lg9rzv9hk89qi43msrbmi1hyy8zgr75740h7kj7rbl41v808bd7";
+      };
+      packageRequires = [ cl-lib ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/cm-mode.html";
         license = lib.licenses.free;
       };
     }
@@ -1458,17 +1480,16 @@
       elpaBuild,
       fetchurl,
       lib,
-      seq,
     }:
     elpaBuild {
       pname = "compat";
       ename = "compat";
-      version = "30.1.0.1";
+      version = "31.0.0.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/compat-30.1.0.1.tar";
-        sha256 = "1rj5i709i0l7drr7f571gsk8d6b5slwrd2l9flayv63kwk1gizhn";
+        url = "https://elpa.gnu.org/packages/compat-31.0.0.1.tar";
+        sha256 = "1lraq5i8jk0wsrnkv66q6lxv314fm8c09hrfvm0gj2lpn8126f20";
       };
-      packageRequires = [ seq ];
+      packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/compat.html";
         license = lib.licenses.free;
@@ -1527,10 +1548,10 @@
     elpaBuild {
       pname = "consult";
       ename = "consult";
-      version = "3.4";
+      version = "3.6";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/consult-3.4.tar";
-        sha256 = "1silvwrss87fa5lss19a08bv72fwvnblkic24qn53c3z6zcd22zd";
+        url = "https://elpa.gnu.org/packages/consult-3.6.tar";
+        sha256 = "0c8pp537qv2zxkzk0nlrvzbn1v72v9ddhwf1nks3hwvwrff58db8";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1550,10 +1571,10 @@
     elpaBuild {
       pname = "consult-denote";
       ename = "consult-denote";
-      version = "0.4.2";
+      version = "0.5.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/consult-denote-0.4.2.tar";
-        sha256 = "1vz96mcfw23y84dibnj6r3d7l0qj191fcnvx2piwhm26n0j43q8m";
+        url = "https://elpa.gnu.org/packages/consult-denote-0.5.0.tar";
+        sha256 = "1qmfwmm4hi0z2lqn6ryfwckrivrlvy16y42w729q6pk0nd21j48k";
       };
       packageRequires = [
         consult
@@ -1575,10 +1596,10 @@
     elpaBuild {
       pname = "consult-hoogle";
       ename = "consult-hoogle";
-      version = "0.6.0";
+      version = "0.7.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/consult-hoogle-0.6.0.tar";
-        sha256 = "0iln71qlmcfmlys5z5bs4304av91ick0wq1ckhffh7d6xkxy0rv5";
+        url = "https://elpa.gnu.org/packages/consult-hoogle-0.7.0.tar";
+        sha256 = "17slksxs1vx19djf5q772hwq1fpaqsd0xpbh6zrrvvgv18h2ac8l";
       };
       packageRequires = [ consult ];
       meta = {
@@ -1640,10 +1661,10 @@
     elpaBuild {
       pname = "corfu";
       ename = "corfu";
-      version = "2.9";
+      version = "2.10";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/corfu-2.9.tar";
-        sha256 = "0h5vz8jyy06380m802jla9312h2rbn2k8fdskjfwkqd1v6dc0c8n";
+        url = "https://elpa.gnu.org/packages/corfu-2.10.tar";
+        sha256 = "0wp9jr1l81si8p1rxa5dkkwbx6k77rs0629q2lxk1l8lnb0j7h6n";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1900,10 +1921,10 @@
     elpaBuild {
       pname = "dape";
       ename = "dape";
-      version = "0.26.0";
+      version = "0.27.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/dape-0.26.0.tar";
-        sha256 = "0arid8qwaf7ic76hsjzj7grn41krsphnzvihmjbgm4im6b7zzb37";
+        url = "https://elpa.gnu.org/packages/dape-0.27.1.tar";
+        sha256 = "1na3080gaygw4fsaymjjx9jgh9ai5k7gb0jmlrkbqnmdypag3mb7";
       };
       packageRequires = [ jsonrpc ];
       meta = {
@@ -2034,10 +2055,10 @@
     elpaBuild {
       pname = "denote";
       ename = "denote";
-      version = "4.1.3";
+      version = "4.2.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/denote-4.1.3.tar";
-        sha256 = "197m0bx1gxrzbqlfr5h52il3ivbixzg1pkhkrf488kidww8qmpvf";
+        url = "https://elpa.gnu.org/packages/denote-4.2.3.tar";
+        sha256 = "0r5p2iy7wssm6hl4dal1sav5x4vvijq54lyzqabg49v6lsbszf74";
       };
       packageRequires = [ ];
       meta = {
@@ -2056,10 +2077,10 @@
     elpaBuild {
       pname = "denote-journal";
       ename = "denote-journal";
-      version = "0.2.2";
+      version = "0.3.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/denote-journal-0.2.2.tar";
-        sha256 = "00rav8kachy85npcr96dwzb4kbgym0p2m5aw3v3pmg278nmc73v3";
+        url = "https://elpa.gnu.org/packages/denote-journal-0.3.0.tar";
+        sha256 = "1l2zrr5nczxyqsmr73m93jqphp6s79f55grpahig0xj2kji8d6gk";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2078,10 +2099,10 @@
     elpaBuild {
       pname = "denote-markdown";
       ename = "denote-markdown";
-      version = "0.2.2";
+      version = "0.3.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/denote-markdown-0.2.2.tar";
-        sha256 = "1nb5rcjgkhw3nl2jva6lyblmfsl24cdryx3c16w8ydbx6fswhjpj";
+        url = "https://elpa.gnu.org/packages/denote-markdown-0.3.0.tar";
+        sha256 = "0adg2nr8s8rjynrpj0b37ni4jcm1igvls3zyyr313xifnrbiznym";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2122,10 +2143,10 @@
     elpaBuild {
       pname = "denote-org";
       ename = "denote-org";
-      version = "0.2.1";
+      version = "0.3.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/denote-org-0.2.1.tar";
-        sha256 = "1cs1ml38xhj0c921qdsvqhqg42lm5r0qb7nf7sj1krvw1r9913bn";
+        url = "https://elpa.gnu.org/packages/denote-org-0.3.0.tar";
+        sha256 = "0r3idn17875hzmidi1xjb9hddifzby9i23j35ywzn88h9a33845k";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2188,10 +2209,10 @@
     elpaBuild {
       pname = "denote-sequence";
       ename = "denote-sequence";
-      version = "0.2.0";
+      version = "0.3.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/denote-sequence-0.2.0.tar";
-        sha256 = "0i0vm1n48aw7j4y6laa8fvs0av5smimdky980qgp69pha6hcvph5";
+        url = "https://elpa.gnu.org/packages/denote-sequence-0.3.3.tar";
+        sha256 = "017h9bwaqv9lxv8ibbl739a9vkcknsv8ch2sqrbaybhri74a3mqk";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2210,10 +2231,10 @@
     elpaBuild {
       pname = "denote-silo";
       ename = "denote-silo";
-      version = "0.2.0";
+      version = "0.3.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/denote-silo-0.2.0.tar";
-        sha256 = "10n4xv179dl6zz1k28lcbrgyqx8k3hfh3isd7q3qg1vcahlw04vl";
+        url = "https://elpa.gnu.org/packages/denote-silo-0.3.0.tar";
+        sha256 = "1pwhn1k8cdb4n6v1l6d6ld5zm4gfzb5vl9fp1myqlfkjx756lglj";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2296,10 +2317,10 @@
     elpaBuild {
       pname = "dicom";
       ename = "dicom";
-      version = "1.3";
+      version = "1.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/dicom-1.3.tar";
-        sha256 = "05n9azzj0wskzd0jzyqhfk3blss31wjzp8wkqam79hq0j6daf6g5";
+        url = "https://elpa.gnu.org/packages/dicom-1.5.tar";
+        sha256 = "02i90769952g80f8fjj9phwwm7ln8q6w65pc065r5vln1knjm7gd";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2473,10 +2494,10 @@
     elpaBuild {
       pname = "dired-preview";
       ename = "dired-preview";
-      version = "0.6.0";
+      version = "0.6.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/dired-preview-0.6.0.tar";
-        sha256 = "1nlibx8jwyvb5n58sx8bg6vcazhnlj5dydmf36v7hzy0h4i460i0";
+        url = "https://elpa.gnu.org/packages/dired-preview-0.6.1.tar";
+        sha256 = "115cassm68rga9q8z7qr1ghi4f9j0immc8ccqwa21vnyvjj02q7a";
       };
       packageRequires = [ ];
       meta = {
@@ -2558,10 +2579,10 @@
     elpaBuild {
       pname = "dmsg";
       ename = "dmsg";
-      version = "0.2";
+      version = "0.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/dmsg-0.2.tar";
-        sha256 = "18wnbkd707n2qh9an72wizs0yp71hys6vg0y02iclqmj7igjg28k";
+        url = "https://elpa.gnu.org/packages/dmsg-0.3.tar";
+        sha256 = "18r81rdpw0jnhxca3fr7bxpalabicbj2y55z5gb2llqrh9plarq6";
       };
       packageRequires = [ ];
       meta = {
@@ -2887,10 +2908,10 @@
     elpaBuild {
       pname = "ef-themes";
       ename = "ef-themes";
-      version = "2.1.0";
+      version = "2.2.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/ef-themes-2.1.0.tar";
-        sha256 = "09rb5pkqz63mc86f8n7969f8x27jdrhz51rh6vl0v3j4nvivv3dx";
+        url = "https://elpa.gnu.org/packages/ef-themes-2.2.0.tar";
+        sha256 = "0jm3hqg53cq0dfvmszmwzwrfi9n2mgdbz176qzxhjqm16rw2bwds";
       };
       packageRequires = [ modus-themes ];
       meta = {
@@ -3089,10 +3110,10 @@
     elpaBuild {
       pname = "ellama";
       ename = "ellama";
-      version = "1.13.0";
+      version = "1.27.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/ellama-1.13.0.tar";
-        sha256 = "0i3lzb68bwyr974wc0i8dn1kiryjs49zg79hli21wycm0j7a3six";
+        url = "https://elpa.gnu.org/packages/ellama-1.27.2.tar";
+        sha256 = "09l22c29vv8bd70vq681ashvlyqcq3ajk37nmdkcj7j4ik53l4bh";
       };
       packageRequires = [
         compat
@@ -3183,10 +3204,10 @@
     elpaBuild {
       pname = "embark-consult";
       ename = "embark-consult";
-      version = "1.1";
+      version = "1.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/embark-consult-1.1.tar";
-        sha256 = "06yh6w4zgvvkfllmcr0szsgjrfhh9rpjwgmcrf6h2gai2ps9xdqr";
+        url = "https://elpa.gnu.org/packages/embark-consult-1.2.tar";
+        sha256 = "1m6i8f49qmzfvqz0mq3ga0gcdi364pqsdph6arpwl4rr59r6sfwn";
       };
       packageRequires = [
         compat
@@ -3336,10 +3357,10 @@
     elpaBuild {
       pname = "erc";
       ename = "erc";
-      version = "5.6.1";
+      version = "5.6.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/erc-5.6.1.tar";
-        sha256 = "13dzip6xhj0mf8hs8wk08pfxny5gwpbzfsqkmz146xvl2d8m621x";
+        url = "https://elpa.gnu.org/packages/erc-5.6.2.tar";
+        sha256 = "0rm7aw6p8736ssp4z7vmfmwff93h4dwcv9pz3b83f9060i2svvvn";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3383,10 +3404,10 @@
     elpaBuild {
       pname = "ess";
       ename = "ess";
-      version = "26.1.0";
+      version = "26.5.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/ess-26.1.0.tar";
-        sha256 = "1spyys37b2rzqzpa7y5ajrrjzckrsbp3hrhsvn28qav3g5d17463";
+        url = "https://elpa.gnu.org/packages/ess-26.5.0.tar";
+        sha256 = "07mfjhcnq3wn6q0dxc4yn5aqnvb9sfnwgi581b5283pfbszhxd29";
       };
       packageRequires = [ ];
       meta = {
@@ -3531,6 +3552,27 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/f90-interface-browser.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  ffs = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "ffs";
+      ename = "ffs";
+      version = "0.2.2";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/ffs-0.2.2.tar";
+        sha256 = "1mwjk877qfccdrp046j431pawr9g489gdz803wg55j0r12whh94a";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/ffs.html";
         license = lib.licenses.free;
       };
     }
@@ -3731,6 +3773,28 @@
       };
     }
   ) { };
+  forgejo = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      keymap-popup,
+      lib,
+    }:
+    elpaBuild {
+      pname = "forgejo";
+      ename = "forgejo";
+      version = "0.2.3";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/forgejo-0.2.3.tar";
+        sha256 = "0q4y474acb759vx3d0xcqgikbq666nckka4hfashi1jwnas98qcg";
+      };
+      packageRequires = [ keymap-popup ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/forgejo.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   frame-tabs = callPackage (
     {
       elpaBuild,
@@ -3830,10 +3894,10 @@
     elpaBuild {
       pname = "futur";
       ename = "futur";
-      version = "1.4";
+      version = "1.7";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/futur-1.4.tar";
-        sha256 = "036b81cp5nbzhykfsj6rkhxb5b675k38njmb32bj20g9h7pkd1vl";
+        url = "https://elpa.gnu.org/packages/futur-1.7.tar";
+        sha256 = "1zb533jkhsi6p0ikx9jc7igz4yfq7b35apz9b8w7g0yrvq5jcl4i";
       };
       packageRequires = [ ];
       meta = {
@@ -4019,17 +4083,21 @@
       compat,
       elpaBuild,
       fetchurl,
+      keymap-popup,
       lib,
     }:
     elpaBuild {
       pname = "gnosis";
       ename = "gnosis";
-      version = "0.10.3";
+      version = "0.10.6";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/gnosis-0.10.3.tar";
-        sha256 = "0642xdgpljfmzi27gfbzhngpyc82blpyyvkvqqbm6khiqac9wdxz";
+        url = "https://elpa.gnu.org/packages/gnosis-0.10.6.tar";
+        sha256 = "1g8zbvid2l7wfyagqynjd1jcjnd0m3zkh9ww0dadppj24n37k57n";
       };
-      packageRequires = [ compat ];
+      packageRequires = [
+        compat
+        keymap-popup
+      ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/gnosis.html";
         license = lib.licenses.free;
@@ -4232,10 +4300,10 @@
     elpaBuild {
       pname = "greader";
       ename = "greader";
-      version = "0.17.0";
+      version = "0.19.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/greader-0.17.0.tar";
-        sha256 = "0kz9qvwkxfl3p4fwl235vxdv19iqrz2jrp9hk06z8bmwmdvj7nxd";
+        url = "https://elpa.gnu.org/packages/greader-0.19.4.tar";
+        sha256 = "1wg25481rdzfjshsjhaf2747hsy964gn1zc5gbmqak8y1vmsjb6h";
       };
       packageRequires = [
         compat
@@ -4852,10 +4920,10 @@
     elpaBuild {
       pname = "javaimp";
       ename = "javaimp";
-      version = "0.9.1";
+      version = "0.9.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/javaimp-0.9.1.tar";
-        sha256 = "1gy7qys9mzpgbqm5798fncmblmi32b350q51ccsyydq67yh69s3z";
+        url = "https://elpa.gnu.org/packages/javaimp-0.9.2.tar";
+        sha256 = "0y756psqlb2rn0bbrdndddsy6d22arv5f4qzaxgzp5p323vzjp7w";
       };
       packageRequires = [ ];
       meta = {
@@ -4896,10 +4964,10 @@
     elpaBuild {
       pname = "jinx";
       ename = "jinx";
-      version = "2.7";
+      version = "2.8";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/jinx-2.7.tar";
-        sha256 = "0ikyr5spj7vk0xycgmywr2sqn9gy1khg6h7kdlzjgy0mrjpxl32w";
+        url = "https://elpa.gnu.org/packages/jinx-2.8.tar";
+        sha256 = "0cxgj390zylr4lqjmfd7f8898z4zsjy1ln783fcjlhcpf94jjjmx";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5110,10 +5178,10 @@
     elpaBuild {
       pname = "kubed";
       ename = "kubed";
-      version = "0.6.1";
+      version = "0.7.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/kubed-0.6.1.tar";
-        sha256 = "1filhadwzdkrw2dsma28b10nx62qnhxkp8g483r0il986ipnnshp";
+        url = "https://elpa.gnu.org/packages/kubed-0.7.1.tar";
+        sha256 = "1c8jr0wi52waa1yrz1y16gpyqabpqpyymmdf8c4apsja0i6345fk";
       };
       packageRequires = [ ];
       meta = {
@@ -5154,10 +5222,10 @@
     elpaBuild {
       pname = "latex-table-wizard";
       ename = "latex-table-wizard";
-      version = "1.5.5";
+      version = "1.6.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/latex-table-wizard-1.5.5.tar";
-        sha256 = "1fffbaqiz3f1f2ki26b8x0cmisqhaijpw5vrh73k769wqdv09g43";
+        url = "https://elpa.gnu.org/packages/latex-table-wizard-1.6.0.tar";
+        sha256 = "1zpf3x62ldqy12npypjk1x8dw7adfmqqhqj30cl2s659vq7gs4nb";
       };
       packageRequires = [
         auctex
@@ -5272,10 +5340,10 @@
     elpaBuild {
       pname = "lex";
       ename = "lex";
-      version = "1.2";
+      version = "1.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/lex-1.2.tar";
-        sha256 = "1pqjrlw558l4z4k40jmli8lmcqlzddhkr0mfm38rbycp7ghdr4zx";
+        url = "https://elpa.gnu.org/packages/lex-1.3.tar";
+        sha256 = "162y483d1gczjfcbds50y7iqbxmx7sfxi5mbdxyrhc2my6nq40lx";
       };
       packageRequires = [ ];
       meta = {
@@ -5369,10 +5437,10 @@
     elpaBuild {
       pname = "llm";
       ename = "llm";
-      version = "0.30.1";
+      version = "0.31.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/llm-0.30.1.tar";
-        sha256 = "11mmaw24dg9iwml8kx09xv8h9iyz9i9jw4m1kghq192fp9wy668i";
+        url = "https://elpa.gnu.org/packages/llm-0.31.1.tar";
+        sha256 = "1395rh5jk3c0hfszzvn9xp3qyyi48nvz1x1v3vljgx4qzzcakgh3";
       };
       packageRequires = [
         compat
@@ -5607,10 +5675,10 @@
     elpaBuild {
       pname = "marginalia";
       ename = "marginalia";
-      version = "2.10";
+      version = "2.11";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/marginalia-2.10.tar";
-        sha256 = "12did4rn4dp7km6shq7jvab2xbr0wxks4h1by19qz10rm5b0jl71";
+        url = "https://elpa.gnu.org/packages/marginalia-2.11.tar";
+        sha256 = "0h7jqgx95f5km90qc4g06ib3mi4acwggvx9yiwwirxj2mqwivifk";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5876,6 +5944,7 @@
   ) { };
   minimail = callPackage (
     {
+      compat,
       elpaBuild,
       fetchurl,
       lib,
@@ -5884,12 +5953,15 @@
     elpaBuild {
       pname = "minimail";
       ename = "minimail";
-      version = "0.4.2";
+      version = "0.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/minimail-0.4.2.tar";
-        sha256 = "1ri424g6v55405d4zr4qhnvdswd5hc9n4hs2xds40ps0h6qp05hm";
+        url = "https://elpa.gnu.org/packages/minimail-0.5.tar";
+        sha256 = "1m1yn8f9mn3zqf7zc0691qaya5l504ry3afz2nmjycavzh8hzk5h";
       };
-      packageRequires = [ transient ];
+      packageRequires = [
+        compat
+        transient
+      ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/minimail.html";
         license = lib.licenses.free;
@@ -5928,10 +6000,10 @@
     elpaBuild {
       pname = "minuet";
       ename = "minuet";
-      version = "0.7.1";
+      version = "0.8.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/minuet-0.7.1.tar";
-        sha256 = "0g18hfpjryg2kjj5gqr4jf1vgfjglaczd4w19g76233m31kd8f0n";
+        url = "https://elpa.gnu.org/packages/minuet-0.8.0.tar";
+        sha256 = "0vk118qd7g2b7vsaygj0lwnzj818p5nlsm36s1c7cm5inz1h6mfc";
       };
       packageRequires = [
         dash
@@ -5974,10 +6046,10 @@
     elpaBuild {
       pname = "modus-themes";
       ename = "modus-themes";
-      version = "5.2.0";
+      version = "5.3.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/modus-themes-5.2.0.tar";
-        sha256 = "1715x863mbvcc2lqf61lll5j50zhpc0jysdgd7v0ajznx40kqmxv";
+        url = "https://elpa.gnu.org/packages/modus-themes-5.3.0.tar";
+        sha256 = "04561ndfxq2y17drklkb3wl9kl6hdc05d4b6rrlqs3fdxcs6q6mx";
       };
       packageRequires = [ ];
       meta = {
@@ -6376,10 +6448,10 @@
     elpaBuild {
       pname = "oauth2";
       ename = "oauth2";
-      version = "0.18.4";
+      version = "0.19";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/oauth2-0.18.4.tar";
-        sha256 = "1hhfk7glp3m9f4aqf1dvqs5f7qp4s2gvbxamyxjalw3sj6pbv92n";
+        url = "https://elpa.gnu.org/packages/oauth2-0.19.tar";
+        sha256 = "0fjs2wk2ayhzh9ba8fa8pki4c5cyavcw0vqsscj93894s7xv9xgz";
       };
       packageRequires = [ ];
       meta = {
@@ -6505,10 +6577,10 @@
     elpaBuild {
       pname = "orderless";
       ename = "orderless";
-      version = "1.6";
+      version = "1.7";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/orderless-1.6.tar";
-        sha256 = "15gif01ivwg03h45azrj3kw2lgj7xnkr6p9r95m36fmfbg31csdh";
+        url = "https://elpa.gnu.org/packages/orderless-1.7.tar";
+        sha256 = "0g1klijlvv44fd7xjvlh6v97zjvca37710bxlgk629v6k4kl2rbz";
       };
       packageRequires = [ compat ];
       meta = {
@@ -6526,10 +6598,10 @@
     elpaBuild {
       pname = "org";
       ename = "org";
-      version = "9.8.3";
+      version = "9.8.6";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/org-9.8.3.tar";
-        sha256 = "0csfrn0k1fysjfwf8xmdnmizfjz62scr3kjawpafwv58gvizk32z";
+        url = "https://elpa.gnu.org/packages/org-9.8.6.tar";
+        sha256 = "0qc9c49k8fcaa8c947wb7knn5lbm2bigvzxkbx8cdbyrj15pra4j";
       };
       packageRequires = [ ];
       meta = {
@@ -6673,10 +6745,10 @@
     elpaBuild {
       pname = "org-modern";
       ename = "org-modern";
-      version = "1.13";
+      version = "1.14";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/org-modern-1.13.tar";
-        sha256 = "0cl6dqk8zq213j9ph07689dbzh1q1xr96kf512vvmgkln0himfqj";
+        url = "https://elpa.gnu.org/packages/org-modern-1.14.tar";
+        sha256 = "08rvxrr67ypvncrg7znl3in8c314l7x1a18m6hr458wqc1xb57zx";
       };
       packageRequires = [
         compat
@@ -6853,10 +6925,10 @@
     elpaBuild {
       pname = "osm";
       ename = "osm";
-      version = "2.2";
+      version = "2.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/osm-2.2.tar";
-        sha256 = "0xq5gzhgxgv52kxprik15b5ijrdw7c5262ifzdcjg3vv3qv0hwy8";
+        url = "https://elpa.gnu.org/packages/osm-2.3.tar";
+        sha256 = "0x08qbdk7y05cm8kc35f2i6k5xnd9iyyhr0f0fyi489kbvd3n1nh";
       };
       packageRequires = [ compat ];
       meta = {
@@ -7364,10 +7436,10 @@
     elpaBuild {
       pname = "posframe";
       ename = "posframe";
-      version = "1.5.1";
+      version = "1.5.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/posframe-1.5.1.tar";
-        sha256 = "1g1pcf83w4fv299ykvx7b93kxkc58fkr6yk39sxny5g16d4gl80g";
+        url = "https://elpa.gnu.org/packages/posframe-1.5.2.tar";
+        sha256 = "0ywbcwm3sh01vc4nc2ra3b09gri2lgz838gjxgsflv9g3si1918x";
       };
       packageRequires = [ ];
       meta = {
@@ -8102,10 +8174,10 @@
     elpaBuild {
       pname = "rnc-mode";
       ename = "rnc-mode";
-      version = "0.3";
+      version = "0.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/rnc-mode-0.3.tar";
-        sha256 = "1p03g451888v86k9z6g8gj375p1pcdvikgk1phxkhipwi5hbf5g8";
+        url = "https://elpa.gnu.org/packages/rnc-mode-0.4.tar";
+        sha256 = "1igg829mm6n35mpfp254276ib3x7x7wxdg9zm38yf5n3bmjq7cxf";
       };
       packageRequires = [ ];
       meta = {
@@ -8371,6 +8443,27 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/shen-mode.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  shift-number = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "shift-number";
+      ename = "shift-number";
+      version = "0.3";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/shift-number-0.3.tar";
+        sha256 = "0vqwy0ai4f1ga4j2inl2s1ly0v9i3fmqyd0p28fgyx3f23c83jqn";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/shift-number.html";
         license = lib.licenses.free;
       };
     }
@@ -9185,10 +9278,10 @@
     elpaBuild {
       pname = "tempel";
       ename = "tempel";
-      version = "1.12";
+      version = "1.13";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/tempel-1.12.tar";
-        sha256 = "1ghlnf7533i6iarzmsgyc0d366bzc3jbyvn6bq650c10ci4wjzsm";
+        url = "https://elpa.gnu.org/packages/tempel-1.13.tar";
+        sha256 = "1sxyxz799nw56wqrm7hsr0dq2yaxckr9a1rynw2jsrfhbzcxpbfp";
       };
       packageRequires = [ compat ];
       meta = {
@@ -9206,10 +9299,10 @@
     elpaBuild {
       pname = "termint";
       ename = "termint";
-      version = "0.2.2";
+      version = "0.2.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/termint-0.2.2.tar";
-        sha256 = "0iavnximqsx6vl6yx36n829h67x4pyfmm8xcp5fzjwphdmgfdann";
+        url = "https://elpa.gnu.org/packages/termint-0.2.3.tar";
+        sha256 = "1yir074lihlr2y78a58jm233a6s807j8d8fvlvv6b62wm0036frk";
       };
       packageRequires = [ ];
       meta = {
@@ -9312,10 +9405,10 @@
     elpaBuild {
       pname = "timeout";
       ename = "timeout";
-      version = "2.1";
+      version = "2.1.6";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/timeout-2.1.tar";
-        sha256 = "1mm4yp1spw512dnav1p3wnxqrsyls918i14azg03by4v32r9945p";
+        url = "https://elpa.gnu.org/packages/timeout-2.1.6.tar";
+        sha256 = "08lijbbbx2wx64jn6l5820phkmi6cagym1239zj1hx25h28b2h0r";
       };
       packageRequires = [ ];
       meta = {
@@ -9465,10 +9558,10 @@
     elpaBuild {
       pname = "tramp";
       ename = "tramp";
-      version = "2.8.1.3";
+      version = "2.8.1.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/tramp-2.8.1.3.tar";
-        sha256 = "1jjbgg48q6dlfp9rpn0pla4mlclw60079d51bgnb84q3pv3zdqwj";
+        url = "https://elpa.gnu.org/packages/tramp-2.8.1.5.tar";
+        sha256 = "04rhm5ijx3qs386ffxvp2117a4xn7zw6z5cqci77f6q07i5921zw";
       };
       packageRequires = [ ];
       meta = {
@@ -9574,10 +9667,10 @@
     elpaBuild {
       pname = "transient";
       ename = "transient";
-      version = "0.13.0";
+      version = "0.13.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/transient-0.13.0.tar";
-        sha256 = "0rwb7l823d4nkk7zmnyi5j7id7kswxrc0h9crqyd63n14w78bksi";
+        url = "https://elpa.gnu.org/packages/transient-0.13.4.tar";
+        sha256 = "02142xcxv50bycshbl6qj47q6s9gi6sbagrnyjqi5ma74509zq6h";
       };
       packageRequires = [
         compat
@@ -9699,6 +9792,27 @@
       packageRequires = [ compat ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/truename-cache.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  trust-manager = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "trust-manager";
+      ename = "trust-manager";
+      version = "0.4.1";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/trust-manager-0.4.1.tar";
+        sha256 = "1azp3kzkw76xbwsn6j94liy33d3swajc1v2h8ghczvxv8sw8khgj";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/trust-manager.html";
         license = lib.licenses.free;
       };
     }
@@ -10132,10 +10246,10 @@
     elpaBuild {
       pname = "verilog-mode";
       ename = "verilog-mode";
-      version = "2026.1.18.88738971";
+      version = "2026.4.14.10117132";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/verilog-mode-2026.1.18.88738971.tar";
-        sha256 = "1m215m38mia2wiq1zzyy85k268pch10yzf3p4i0nk5s7ijxl6ls4";
+        url = "https://elpa.gnu.org/packages/verilog-mode-2026.4.14.10117132.tar";
+        sha256 = "0n699kpqhh1b023wswm938f7kxc983faw0bv4x70kq12y7h3slj1";
       };
       packageRequires = [ ];
       meta = {
@@ -10154,10 +10268,10 @@
     elpaBuild {
       pname = "vertico";
       ename = "vertico";
-      version = "2.8";
+      version = "2.10";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/vertico-2.8.tar";
-        sha256 = "0v19z3sh4npjmvii03r5v9mbmg8g3bp1ay82ydalw864hlcwgb71";
+        url = "https://elpa.gnu.org/packages/vertico-2.10.tar";
+        sha256 = "1kwmlpfxjnjkv05hfqhxmxw5d1vlhqvdmyc3p34qhp3bj2xafwm0";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10306,10 +10420,10 @@
     elpaBuild {
       pname = "wcheck-mode";
       ename = "wcheck-mode";
-      version = "2026";
+      version = "2026.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/wcheck-mode-2026.tar";
-        sha256 = "019lsaihpl9w17qfhn8c5j8rp8nrvlmb16w6r8sb1iril31997sz";
+        url = "https://elpa.gnu.org/packages/wcheck-mode-2026.5.tar";
+        sha256 = "0yxg6s4s5103zfa8m82gaxc46d9gjpiknmvgm2lcb21dckdsay13";
       };
       packageRequires = [ ];
       meta = {
@@ -10761,10 +10875,10 @@
     elpaBuild {
       pname = "yaml";
       ename = "yaml";
-      version = "1.2.3";
+      version = "1.2.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/yaml-1.2.3.tar";
-        sha256 = "0wyvhh4ij22wdd3g5jkg2mnyglbk2k7mf2jv48jkpb5jc4kf6jvr";
+        url = "https://elpa.gnu.org/packages/yaml-1.2.4.tar";
+        sha256 = "12ji680hjm1isc5k3yapvnp2m7pk23syfxwhi95bizhka02n0qly";
       };
       packageRequires = [ ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -1536,6 +1536,8 @@ let
 
           org-change = ignoreCompilationError super.org-change; # elisp error
 
+          org-cite-overlay = ignoreCompilationError super.org-cite-overlay; # native-ice
+
           org-edit-latex = mkHome super.org-edit-latex;
 
           # https://github.com/GuiltyDolphin/org-evil/issues/24

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-generated.nix
@@ -9,10 +9,10 @@
     elpaBuild {
       pname = "adoc-mode";
       ename = "adoc-mode";
-      version = "0.8.0.0.20260221.220754";
+      version = "0.9.0.0.20260612.26";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/adoc-mode-0.8.0.0.20260221.220754.tar";
-        sha256 = "19cn5vm963pygzi42r7zw0n7g1adipa0k8f8chwlwibhzwmx3vyz";
+        url = "https://elpa.nongnu.org/nongnu-devel/adoc-mode-0.9.0.0.20260612.26.tar";
+        sha256 = "0ivn3j21cn5xqd4bwr2razaxg2sljg18d70vwksgrb74zyz3lkxy";
       };
       packageRequires = [ ];
       meta = {
@@ -75,10 +75,10 @@
     elpaBuild {
       pname = "aidermacs";
       ename = "aidermacs";
-      version = "1.6.0.20251203.181819";
+      version = "1.7.0.20260521.153004";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/aidermacs-1.6.0.20251203.181819.tar";
-        sha256 = "0kyy5fw8397hcahm4wlvl51ch2fbrlw2r8arvcxflssngy7cbbaa";
+        url = "https://elpa.nongnu.org/nongnu-devel/aidermacs-1.7.0.20260521.153004.tar";
+        sha256 = "11pw6absa9nj0ps8n17jzsqdnajk1cdz7rv6lnp2ibfyfg6vr03c";
       };
       packageRequires = [
         compat
@@ -121,10 +121,10 @@
     elpaBuild {
       pname = "ample-theme";
       ename = "ample-theme";
-      version = "0.3.0.0.20240426.84530";
+      version = "0.3.0.0.20260611.50";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/ample-theme-0.3.0.0.20240426.84530.tar";
-        sha256 = "00h1za3qdqjgaxr2c3qlmz374gl9fhrgg7r453wvkz1fy6n9vp5i";
+        url = "https://elpa.nongnu.org/nongnu-devel/ample-theme-0.3.0.0.20260611.50.tar";
+        sha256 = "1r0sw8iwrpxwvpr3ijxadh0ldkpljyd9j9wviga7j9c2q9248xkw";
       };
       packageRequires = [ ];
       meta = {
@@ -142,10 +142,10 @@
     elpaBuild {
       pname = "annotate";
       ename = "annotate";
-      version = "2.4.5.0.20251111.163545";
+      version = "2.5.0.0.20260514.132017";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/annotate-2.4.5.0.20251111.163545.tar";
-        sha256 = "09jghlf5bjiiah1qqvr1s3lkjqzywf9cxrfzpfq192ms1hzs1wmd";
+        url = "https://elpa.nongnu.org/nongnu-devel/annotate-2.5.0.0.20260514.132017.tar";
+        sha256 = "0rsgi0slvnjccv414f1229nm98yd9icla0py1nd11zqqi5n8a0c4";
       };
       packageRequires = [ ];
       meta = {
@@ -205,10 +205,10 @@
     elpaBuild {
       pname = "apache-mode";
       ename = "apache-mode";
-      version = "2.2.0.0.20251120.174624";
+      version = "2.2.0.0.20260618.15";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/apache-mode-2.2.0.0.20251120.174624.tar";
-        sha256 = "0f536bc064ykjajsgyxcbdjxch14wi2kkxhva9szi802l78zkdhh";
+        url = "https://elpa.nongnu.org/nongnu-devel/apache-mode-2.2.0.0.20260618.15.tar";
+        sha256 = "10n61089a40jh3n8ail15m7vy5k0lxgyw4jd31p4zihd45q4hhx1";
       };
       packageRequires = [ ];
       meta = {
@@ -291,10 +291,10 @@
     elpaBuild {
       pname = "autothemer";
       ename = "autothemer";
-      version = "0.2.18.0.20251114.41509";
+      version = "0.2.18.0.20260620.7";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/autothemer-0.2.18.0.20251114.41509.tar";
-        sha256 = "0ix8byl6fa2qpcjvcf93afbsk2f9frnsbq9mcnhxmx17l48fzl06";
+        url = "https://elpa.nongnu.org/nongnu-devel/autothemer-0.2.18.0.20260620.7.tar";
+        sha256 = "1awdmkxy2gdrk20j63k8fjclfsmnkx33hm55x636fmcrh2niqcg7";
       };
       packageRequires = [ dash ];
       meta = {
@@ -333,10 +333,10 @@
     elpaBuild {
       pname = "bash-completion";
       ename = "bash-completion";
-      version = "3.2.1snapshot0.20260325.162703";
+      version = "3.2.10.20260325.162703";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/bash-completion-3.2.1snapshot0.20260325.162703.tar";
-        sha256 = "1w2ymxz5pcpdfxw2jaqqg5c8i1dkj4cp23y15sk80q9mfcyfmkxj";
+        url = "https://elpa.nongnu.org/nongnu-devel/bash-completion-3.2.10.20260325.162703.tar";
+        sha256 = "0jfad1l564dz5w9n980d0yvf7ivbp570vapwx451h74f3g9xdcx1";
       };
       packageRequires = [ ];
       meta = {
@@ -354,10 +354,10 @@
     elpaBuild {
       pname = "beancount";
       ename = "beancount";
-      version = "0.9.0.0.20251027.80859";
+      version = "0.9.0.0.20260517.140330";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/beancount-0.9.0.0.20251027.80859.tar";
-        sha256 = "19lklnmqpxzxgwdjb3wzaarkklxqswnl9ff11pg854rr7kivlmwl";
+        url = "https://elpa.nongnu.org/nongnu-devel/beancount-0.9.0.0.20260517.140330.tar";
+        sha256 = "0rziax9ci1vi5z6v686j7nmbvx8cym7zpi8479md52gpsd58daqn";
       };
       packageRequires = [ ];
       meta = {
@@ -501,10 +501,10 @@
     elpaBuild {
       pname = "buttercup";
       ename = "buttercup";
-      version = "1.40.0.20260411.203013";
+      version = "1.40.0.20260512.214133";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/buttercup-1.40.0.20260411.203013.tar";
-        sha256 = "13s30dv7vhzbm80f4brza2mk7lpf3l7ffbzbjv4ln2s8rgsh6g64";
+        url = "https://elpa.nongnu.org/nongnu-devel/buttercup-1.40.0.20260512.214133.tar";
+        sha256 = "0fays43ygmxp14gsv75zgwmhg2iycl758684g3b3xvgiq8k6dlw8";
       };
       packageRequires = [ ];
       meta = {
@@ -543,10 +543,10 @@
     elpaBuild {
       pname = "caml";
       ename = "caml";
-      version = "4.10snapshot0.20250227.123439";
+      version = "4.100.20250227.123439";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/caml-4.10snapshot0.20250227.123439.tar";
-        sha256 = "1bg8vf7sh6f7s7jghfyqhb5da38kr8f3bbizzy7xfim2jy1i4ci7";
+        url = "https://elpa.nongnu.org/nongnu-devel/caml-4.100.20250227.123439.tar";
+        sha256 = "0niymrn7d4gh5bd7wgrpbfh8r7d8i455ihr0i4lgs2v7xrgzc5ci";
       };
       packageRequires = [ ];
       meta = {
@@ -566,10 +566,10 @@
     elpaBuild {
       pname = "casual";
       ename = "casual";
-      version = "2.16.0.0.20260415.182614";
+      version = "2.16.2.0.20260609.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/casual-2.16.0.0.20260415.182614.tar";
-        sha256 = "0a0ba4b506pbv4nff8qspqjfzlfng77i3nqs3vwg1ybz6rhj7cwj";
+        url = "https://elpa.nongnu.org/nongnu-devel/casual-2.16.2.0.20260609.0.tar";
+        sha256 = "1n3br77c56psicqs394kdgzlmsxbzzbm5w7bm0g3pkz5kq1jh5bh";
       };
       packageRequires = [
         csv-mode
@@ -619,10 +619,10 @@
     elpaBuild {
       pname = "cider";
       ename = "cider";
-      version = "1.22.0snapshot0.20260420.43551";
+      version = "1.23.0.20260624.34";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/cider-1.22.0snapshot0.20260420.43551.tar";
-        sha256 = "14vhww7sm3hzvrag671m8l4sbh4mi4iy395vnqhpyn6wxp0z9m91";
+        url = "https://elpa.nongnu.org/nongnu-devel/cider-1.23.0.20260624.34.tar";
+        sha256 = "0p56g5ni3w6rlajqp368zi6gw4jp0c0s5786fh04iv0kyqipw60p";
       };
       packageRequires = [
         clojure-mode
@@ -649,10 +649,10 @@
     elpaBuild {
       pname = "clojure-mode";
       ename = "clojure-mode";
-      version = "5.23.0.0.20260325.143544";
+      version = "5.23.0.0.20260615.3";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/clojure-mode-5.23.0.0.20260325.143544.tar";
-        sha256 = "0rapsgj8kxnf7c9zvpjn9adjw7gxb9q3bpxwv1r610l8gdz9haj5";
+        url = "https://elpa.nongnu.org/nongnu-devel/clojure-mode-5.23.0.0.20260615.3.tar";
+        sha256 = "03sfdnyp7m9mvz55mdvp62wkjklp5nr4xrmrac5z5gvjwviqhcva";
       };
       packageRequires = [ ];
       meta = {
@@ -670,10 +670,10 @@
     elpaBuild {
       pname = "clojure-ts-mode";
       ename = "clojure-ts-mode";
-      version = "0.6.0.0.20260325.210727";
+      version = "0.6.0.0.20260616.45";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/clojure-ts-mode-0.6.0.0.20260325.210727.tar";
-        sha256 = "06fi1l2dzd9gbkjafvnmhmhcc9i5iwlk5kgfbcavm8a9cvfrdv1q";
+        url = "https://elpa.nongnu.org/nongnu-devel/clojure-ts-mode-0.6.0.0.20260616.45.tar";
+        sha256 = "01vnjim6l8c6b6h6sgbznwssyqzr183j983i2p9s5gwpphcwi3qz";
       };
       packageRequires = [ ];
       meta = {
@@ -712,10 +712,10 @@
     elpaBuild {
       pname = "cond-let";
       ename = "cond-let";
-      version = "0.2.2.0.20260420.135245";
+      version = "1.1.2.0.20260601.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/cond-let-0.2.2.0.20260420.135245.tar";
-        sha256 = "1zm81zgmf5k6akh4pngjln1xp7p561h97hkcrsbc78v7nq48x8kb";
+        url = "https://elpa.nongnu.org/nongnu-devel/cond-let-1.1.2.0.20260601.0.tar";
+        sha256 = "0yqnwc5xv7aqazrr3g921lclrc6pnbaf1h3qv1qm8qxbvz7z76vd";
       };
       packageRequires = [ ];
       meta = {
@@ -735,10 +735,10 @@
     elpaBuild {
       pname = "consult-flycheck";
       ename = "consult-flycheck";
-      version = "1.1.0.20260330.61817";
+      version = "1.2.0.20260605.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/consult-flycheck-1.1.0.20260330.61817.tar";
-        sha256 = "0qibwl60kwyj3azpz7zph3frb8ia7ll7qr70mfj6brdng0wdc9b1";
+        url = "https://elpa.nongnu.org/nongnu-devel/consult-flycheck-1.2.0.20260605.0.tar";
+        sha256 = "0kyhr3wzcdzjacda9hf07h0lrgayzacv8ly3hpnrvxq0gyjk9sk8";
       };
       packageRequires = [
         consult
@@ -785,10 +785,10 @@
     elpaBuild {
       pname = "crux";
       ename = "crux";
-      version = "0.6.0snapshot0.20260315.62204";
+      version = "0.6.0.20260315.62204";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/crux-0.6.0snapshot0.20260315.62204.tar";
-        sha256 = "0pk55r3yr4nl43r61ay29rhx0kw77k0490w3j2gq60h89b605rjm";
+        url = "https://elpa.nongnu.org/nongnu-devel/crux-0.6.0.20260315.62204.tar";
+        sha256 = "0sbv5m22fgn5444ck8j0l9zvi8m8x7jv46z2zl06r6139s8m4l81";
       };
       packageRequires = [ ];
       meta = {
@@ -807,10 +807,10 @@
     elpaBuild {
       pname = "csv2ledger";
       ename = "csv2ledger";
-      version = "1.5.4.0.20250417.171625";
+      version = "1.5.5.0.20260621.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/csv2ledger-1.5.4.0.20250417.171625.tar";
-        sha256 = "1m72znfi5hd9pwavc99g8amxwc0jdyly7gsww2aq0fw4q971kiaf";
+        url = "https://elpa.nongnu.org/nongnu-devel/csv2ledger-1.5.5.0.20260621.0.tar";
+        sha256 = "0mvyzsr02allsf6a6ac4b8cb1cbzajcs4v082qnklf7dwmcya8dg";
       };
       packageRequires = [ csv-mode ];
       meta = {
@@ -850,10 +850,10 @@
     elpaBuild {
       pname = "cycle-at-point";
       ename = "cycle-at-point";
-      version = "0.2.0.20260111.124011";
+      version = "0.2.0.20260502.92709";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/cycle-at-point-0.2.0.20260111.124011.tar";
-        sha256 = "0jnd8r1xpyyklbpvy18mxz3slcl0jz6zi41vymzgmv9a6xig5cvs";
+        url = "https://elpa.nongnu.org/nongnu-devel/cycle-at-point-0.2.0.20260502.92709.tar";
+        sha256 = "0nyk8p55xjkfzxyrpgz7dy2k7scgdi3h4x9hiw1xcrbcfxnlaxks";
       };
       packageRequires = [ recomplete ];
       meta = {
@@ -892,10 +892,10 @@
     elpaBuild {
       pname = "dart-mode";
       ename = "dart-mode";
-      version = "1.0.7.0.20251203.195437";
+      version = "1.0.7.0.20260619.52";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/dart-mode-1.0.7.0.20251203.195437.tar";
-        sha256 = "1l4p4ybw69ni2vx016bi2nz3kjqziy6nk3vv1nr9gjbslpmkck5k";
+        url = "https://elpa.nongnu.org/nongnu-devel/dart-mode-1.0.7.0.20260619.52.tar";
+        sha256 = "114dh5k5b1b7gkbqn96k2ncgsav05hcgz6304br2czkdx0xcacid";
       };
       packageRequires = [ ];
       meta = {
@@ -914,10 +914,10 @@
     elpaBuild {
       pname = "datetime";
       ename = "datetime";
-      version = "0.10.3snapshot0.20250203.204701";
+      version = "0.10.30.20250203.204701";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/datetime-0.10.3snapshot0.20250203.204701.tar";
-        sha256 = "0l9z5bqbxbn456rin27x4zfa5pjvqjr2vhzxpgssrndm7bprm614";
+        url = "https://elpa.nongnu.org/nongnu-devel/datetime-0.10.30.20250203.204701.tar";
+        sha256 = "07c2wr4wdfp94hdiaxfzpcic80yckw32db9ay83gb21jy2rvys91";
       };
       packageRequires = [ extmap ];
       meta = {
@@ -978,10 +978,10 @@
     elpaBuild {
       pname = "devil";
       ename = "devil";
-      version = "0.7.0beta3.0.20240129.2809";
+      version = "0.7.3.0.20240129.2809";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/devil-0.7.0beta3.0.20240129.2809.tar";
-        sha256 = "1fhvp1kvvli5g9a3575bsa8zyfnf1q0p5wn15819zvncjp1912nl";
+        url = "https://elpa.nongnu.org/nongnu-devel/devil-0.7.3.0.20240129.2809.tar";
+        sha256 = "0gqmp1x6li3g7fvy3aydm1smlx587g59d9fwv5ci3z5ik8cb98h8";
       };
       packageRequires = [ ];
       meta = {
@@ -999,10 +999,10 @@
     elpaBuild {
       pname = "diff-ansi";
       ename = "diff-ansi";
-      version = "0.2.0.20260108.151229";
+      version = "0.2.0.20260524.93804";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/diff-ansi-0.2.0.20260108.151229.tar";
-        sha256 = "0b1i031fyjszinpngz804di4fng6i71pcmckq05z75p3gjjfyx2j";
+        url = "https://elpa.nongnu.org/nongnu-devel/diff-ansi-0.2.0.20260524.93804.tar";
+        sha256 = "1wjvyhs8lfq5fszxlmrjwpw3spa3qq9dn7wmh0m0ilavmnql492v";
       };
       packageRequires = [ ];
       meta = {
@@ -1084,10 +1084,10 @@
     elpaBuild {
       pname = "dracula-theme";
       ename = "dracula-theme";
-      version = "1.8.3.0.20260224.145537";
+      version = "1.8.3.0.20260519.113056";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/dracula-theme-1.8.3.0.20260224.145537.tar";
-        sha256 = "0g83cgcackysjh5x35j0vniqyysk1lgijk0mhmgnwnhm2fji1b74";
+        url = "https://elpa.nongnu.org/nongnu-devel/dracula-theme-1.8.3.0.20260519.113056.tar";
+        sha256 = "0jw288i092zgfkkazxsmx60va9fbklb2y7awcq2fwpbph7k14w4r";
       };
       packageRequires = [ ];
       meta = {
@@ -1256,10 +1256,10 @@
     elpaBuild {
       pname = "eldoc-mouse";
       ename = "eldoc-mouse";
-      version = "3.0.7.0.20260402.102509";
+      version = "3.0.8.0.20260612.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/eldoc-mouse-3.0.7.0.20260402.102509.tar";
-        sha256 = "1frp7dkqf1wzlfijlqra1himvl5qba0cj3s172kh8yyncpvjvnqj";
+        url = "https://elpa.nongnu.org/nongnu-devel/eldoc-mouse-3.0.8.0.20260612.0.tar";
+        sha256 = "0w0c30vxqbca8zgj6zql4lxqfj2nz1xh9lcllzz09k2pydki0f4n";
       };
       packageRequires = [
         eglot
@@ -1293,6 +1293,56 @@
       ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu-devel/eldoc-mouse-nov.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  elfeed = callPackage (
+    {
+      compat,
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "elfeed";
+      ename = "elfeed";
+      version = "4.0.1.0.20260623.15";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu-devel/elfeed-4.0.1.0.20260623.15.tar";
+        sha256 = "1l9zizafja49r9kmn85qv3sfwh4kpp44yvz33b6gfrj06gn1mppf";
+      };
+      packageRequires = [ compat ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu-devel/elfeed.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  elfeed-web = callPackage (
+    {
+      compat,
+      elfeed,
+      elpaBuild,
+      fetchurl,
+      lib,
+      simple-httpd,
+    }:
+    elpaBuild {
+      pname = "elfeed-web";
+      ename = "elfeed-web";
+      version = "4.0.0.0.20260623.3";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu-devel/elfeed-web-4.0.0.0.20260623.3.tar";
+        sha256 = "18sqr02xn2vzfajysbz8i0f2m6vqq39c2vhazs8bi638vjk4irc0";
+      };
+      packageRequires = [
+        compat
+        elfeed
+        simple-httpd
+      ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu-devel/elfeed-web.html";
         license = lib.licenses.free;
       };
     }
@@ -1348,10 +1398,10 @@
     elpaBuild {
       pname = "emacsql";
       ename = "emacsql";
-      version = "4.3.6.0.20260401.122028";
+      version = "4.4.1.0.20260601.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/emacsql-4.3.6.0.20260401.122028.tar";
-        sha256 = "0n9m33wlygpdj8id31sfxkj328j1dzf1gzkwkvr99ncvcn6qr0l6";
+        url = "https://elpa.nongnu.org/nongnu-devel/emacsql-4.4.1.0.20260601.0.tar";
+        sha256 = "0fnj6ysv7a0pwcklr9rdb1fybfpv0z6gw60r8jgjgb0y2j4204rz";
       };
       packageRequires = [ ];
       meta = {
@@ -1377,6 +1427,27 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu-devel/engine-mode.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  eprolog = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "eprolog";
+      ename = "eprolog";
+      version = "0.3.2.0.20260308.150317";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu-devel/eprolog-0.3.2.0.20260308.150317.tar";
+        sha256 = "0d5y5dz602npmfxpp9cbrg5dp6axb97v8v9nagindkmh3m7yymkz";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu-devel/eprolog.html";
         license = lib.licenses.free;
       };
     }
@@ -1415,10 +1486,10 @@
     elpaBuild {
       pname = "evil";
       ename = "evil";
-      version = "1.15.0.0.20251108.13841";
+      version = "1.15.0.0.20260603.296";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/evil-1.15.0.0.20251108.13841.tar";
-        sha256 = "0vh9pmwsapdg2pn1cnp03jv9y35ddi57niwacrikn12g7niwh8jn";
+        url = "https://elpa.nongnu.org/nongnu-devel/evil-1.15.0.0.20260603.296.tar";
+        sha256 = "08l0w089647g8h61wfpcjs0zwcrx3dxjp14shdw4k7p0g6ijrdxs";
       };
       packageRequires = [
         cl-lib
@@ -1685,10 +1756,10 @@
     elpaBuild {
       pname = "evil-nerd-commenter";
       ename = "evil-nerd-commenter";
-      version = "3.6.1.0.20240216.114656";
+      version = "3.6.1.0.20260507.41457";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/evil-nerd-commenter-3.6.1.0.20240216.114656.tar";
-        sha256 = "0wav3c5k2iz4xzrkwj7nj3xg5zp9nldynxag2gl7p3nkz4scg49r";
+        url = "https://elpa.nongnu.org/nongnu-devel/evil-nerd-commenter-3.6.1.0.20260507.41457.tar";
+        sha256 = "023gd3br1i6pvbnan83c9825jfc20q1w5xn472qsi0035lmi6wj2";
       };
       packageRequires = [ ];
       meta = {
@@ -1703,16 +1774,20 @@
       evil,
       fetchurl,
       lib,
+      shift-number,
     }:
     elpaBuild {
       pname = "evil-numbers";
       ename = "evil-numbers";
-      version = "0.7.0.20260102.82951";
+      version = "0.8.0.20260103.85055";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/evil-numbers-0.7.0.20260102.82951.tar";
-        sha256 = "03nxzdaxnlfmn6w3sgwixmqqv275rskxkjc93zwac55i9h3xn0kb";
+        url = "https://elpa.nongnu.org/nongnu-devel/evil-numbers-0.8.0.20260103.85055.tar";
+        sha256 = "1kr89paj83kiy27yd9rbq0xgda7xrifnxh5nyv3lik4sqd8ds7sm";
       };
-      packageRequires = [ evil ];
+      packageRequires = [
+        evil
+        shift-number
+      ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu-devel/evil-numbers.html";
         license = lib.licenses.free;
@@ -1729,10 +1804,10 @@
     elpaBuild {
       pname = "evil-surround";
       ename = "evil-surround";
-      version = "1.0.4.0.20240325.85222";
+      version = "1.0.4.0.20260607.25";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/evil-surround-1.0.4.0.20240325.85222.tar";
-        sha256 = "0ji4pp9dp0284km585a3iay60m9v0xzsn42g3fw431vadbs0y5ym";
+        url = "https://elpa.nongnu.org/nongnu-devel/evil-surround-1.0.4.0.20260607.25.tar";
+        sha256 = "0q14djyjciywxh7sb4ljgwfv09233nr2jprkk5h4pjn4a3ymsjv3";
       };
       packageRequires = [ evil ];
       meta = {
@@ -1798,10 +1873,10 @@
     elpaBuild {
       pname = "exec-path-from-shell";
       ename = "exec-path-from-shell";
-      version = "2.2.0.20260423.183347";
+      version = "2.2.0.20260619.14";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/exec-path-from-shell-2.2.0.20260423.183347.tar";
-        sha256 = "0s80hah6795p2k97qpnqj3baaw1cy9c54g38vbcczq4mn8faimk6";
+        url = "https://elpa.nongnu.org/nongnu-devel/exec-path-from-shell-2.2.0.20260619.14.tar";
+        sha256 = "197f0zlb9lkllssmzvc3zllsxn7i1glpvsm75aa54hylzyfiys1j";
       };
       packageRequires = [ ];
       meta = {
@@ -1819,10 +1894,10 @@
     elpaBuild {
       pname = "extmap";
       ename = "extmap";
-      version = "1.3.1snapshot0.20250203.193959";
+      version = "1.3.10.20250203.193959";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/extmap-1.3.1snapshot0.20250203.193959.tar";
-        sha256 = "16sfa2zv0g7dz1zflg848dh643c8vfrb93blqvnd1vmlmf3bsyqy";
+        url = "https://elpa.nongnu.org/nongnu-devel/extmap-1.3.10.20250203.193959.tar";
+        sha256 = "1xp7y64zi0pik02r78ks90zydddx583h3f4689n4ldif5zz3wd2k";
       };
       packageRequires = [ ];
       meta = {
@@ -1841,10 +1916,10 @@
     elpaBuild {
       pname = "fedi";
       ename = "fedi";
-      version = "0.3.0.20260223.132625";
+      version = "0.4.0.20260509.80113";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/fedi-0.3.0.20260223.132625.tar";
-        sha256 = "15cvwfyvixac3vvfjnmz0fvfzk5iq9sndnryzi3zlp3njjjds0wv";
+        url = "https://elpa.nongnu.org/nongnu-devel/fedi-0.4.0.20260509.80113.tar";
+        sha256 = "0c3zn9cb320zqy3p339npzlhp8z7jwd31l8p77hix6cnczx66z7y";
       };
       packageRequires = [ markdown-mode ];
       meta = {
@@ -1866,10 +1941,10 @@
     elpaBuild {
       pname = "fj";
       ename = "fj";
-      version = "0.34.0.20260327.90645";
+      version = "0.37.0.20260509.74153";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/fj-0.34.0.20260327.90645.tar";
-        sha256 = "0wigq0746npxkbqkqdarw4l89vk04ywd7cx01irc3v7ci9s192xk";
+        url = "https://elpa.nongnu.org/nongnu-devel/fj-0.37.0.20260509.74153.tar";
+        sha256 = "0fwklcgc11lynkfp00wwjrsbdkxsdhi5vis2qcmlcnh5l4lwmi7y";
       };
       packageRequires = [
         fedi
@@ -1879,6 +1954,27 @@
       ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu-devel/fj.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  flamegraph = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "flamegraph";
+      ename = "flamegraph";
+      version = "0.2.0.20260609.2";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu-devel/flamegraph-0.2.0.20260609.2.tar";
+        sha256 = "09akb8akgvrh8gigchalkb29ipfa90b7r8li9vxdh7d7ginq5mw6";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu-devel/flamegraph.html";
         license = lib.licenses.free;
       };
     }
@@ -1941,10 +2037,10 @@
     elpaBuild {
       pname = "flycheck";
       ename = "flycheck";
-      version = "36.0.0.20260320.171504";
+      version = "36.0.0.20260604.57";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/flycheck-36.0.0.20260320.171504.tar";
-        sha256 = "1pzwhry986dfkvibfdqwb6nllmmn2yc3kpzgd046jnyq25xikgig";
+        url = "https://elpa.nongnu.org/nongnu-devel/flycheck-36.0.0.20260604.57.tar";
+        sha256 = "1rkpzjy998x346sc7ka2nvhavlam0d9klpgccsandacywdps1imq";
       };
       packageRequires = [ seq ];
       meta = {
@@ -2142,10 +2238,10 @@
     elpaBuild {
       pname = "geiser";
       ename = "geiser";
-      version = "0.32.0.20251220.230156";
+      version = "0.33.1.0.20260523.150214";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/geiser-0.32.0.20251220.230156.tar";
-        sha256 = "1a6l6b659h9mf0dqc6yvq2pc75x3rw3ysn6k9ap5pyrsdz7286f5";
+        url = "https://elpa.nongnu.org/nongnu-devel/geiser-0.33.1.0.20260523.150214.tar";
+        sha256 = "1k0x34c6w0bnrbbkc01frn5h2kbn9pr02i80clr9vfixjv7zar9b";
       };
       packageRequires = [ project ];
       meta = {
@@ -2275,10 +2371,10 @@
     elpaBuild {
       pname = "geiser-guile";
       ename = "geiser-guile";
-      version = "0.28.3.0.20240920.3540";
+      version = "0.28.5.0.20260516.1909";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/geiser-guile-0.28.3.0.20240920.3540.tar";
-        sha256 = "1ijrhz86nva194qsdch2zm9v4bzdppcg3vslnh03ss4f6qkcrfzz";
+        url = "https://elpa.nongnu.org/nongnu-devel/geiser-guile-0.28.5.0.20260516.1909.tar";
+        sha256 = "1pvpji1py4ghxkpvxf08fpdg8j37qcn2lc8dc9i47b7b9w5x9bpg";
       };
       packageRequires = [
         geiser
@@ -2418,10 +2514,10 @@
     elpaBuild {
       pname = "git-modes";
       ename = "git-modes";
-      version = "1.4.8.0.20260101.183425";
+      version = "1.5.0.0.20260601.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/git-modes-1.4.8.0.20260101.183425.tar";
-        sha256 = "1lw8cwrg66gw4pxbf6kwzglddc9jszz55nw1z0hpaiaz24yi17lg";
+        url = "https://elpa.nongnu.org/nongnu-devel/git-modes-1.5.0.0.20260601.0.tar";
+        sha256 = "1wwqr0w7vdspv0lkznh6srb0mil0ydirr7mb6wy1yacpz5mlzvwz";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2512,10 +2608,10 @@
     elpaBuild {
       pname = "gnuplot";
       ename = "gnuplot";
-      version = "0.11.0.20260330.71827";
+      version = "0.12.0.20260623.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/gnuplot-0.11.0.20260330.71827.tar";
-        sha256 = "16m7jnsd9rv7f7fnbcm8sbphb21sl63igpzcbki27rcvhp3r5y4i";
+        url = "https://elpa.nongnu.org/nongnu-devel/gnuplot-0.12.0.20260623.2.tar";
+        sha256 = "0w38z2cmrrnc0bh6pdsqyrhsipz59lknfrkcyahybpbi80x0cgl8";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2533,10 +2629,10 @@
     elpaBuild {
       pname = "go-mode";
       ename = "go-mode";
-      version = "1.6.0.0.20250311.20239";
+      version = "1.6.0.0.20260529.24";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/go-mode-1.6.0.0.20250311.20239.tar";
-        sha256 = "1viwxqbp6jdhbmapjgcgrjyrzn4m2r68b5vb0814y3w4gi55rzgq";
+        url = "https://elpa.nongnu.org/nongnu-devel/go-mode-1.6.0.0.20260529.24.tar";
+        sha256 = "0m69khwj17fp6fhl6xgqsmxqc3729x679rpxph7gv5hgdpqks7ha";
       };
       packageRequires = [ ];
       meta = {
@@ -2619,10 +2715,10 @@
     elpaBuild {
       pname = "gptel";
       ename = "gptel";
-      version = "0.9.9.4.0.20260422.5643";
+      version = "0.9.9.5.0.20260620.44";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/gptel-0.9.9.4.0.20260422.5643.tar";
-        sha256 = "07drqy9aksqsvfgg7a6r7bp430qccs6bngrs367dp0vr46mx6kw0";
+        url = "https://elpa.nongnu.org/nongnu-devel/gptel-0.9.9.5.0.20260620.44.tar";
+        sha256 = "1j9ij8z4hyd4rbz96gk99myrw39x8fd907imnvarqq9xl42m9hrj";
       };
       packageRequires = [
         compat
@@ -2643,10 +2739,10 @@
     elpaBuild {
       pname = "graphql-mode";
       ename = "graphql-mode";
-      version = "1.0.0.0.20260330.140853";
+      version = "1.0.0.0.20260524.82344";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/graphql-mode-1.0.0.0.20260330.140853.tar";
-        sha256 = "07rwy23fglwq5h8x16syvgl9nb0lg5gqfx4d1qqls0c6gha7pal1";
+        url = "https://elpa.nongnu.org/nongnu-devel/graphql-mode-1.0.0.0.20260524.82344.tar";
+        sha256 = "0zr62g3jhf47d7cjjcx3a8m1kqp4h14k4k7jdqqiivg6hc1k43qv";
       };
       packageRequires = [ ];
       meta = {
@@ -2750,10 +2846,10 @@
     elpaBuild {
       pname = "haskell-mode";
       ename = "haskell-mode";
-      version = "17.5.0.20260206.105045";
+      version = "17.5.0.20260619.67";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/haskell-mode-17.5.0.20260206.105045.tar";
-        sha256 = "012w356crya0ik9p16xlkykk1xv9yk4w3k029xrmjhjw1jqvkybd";
+        url = "https://elpa.nongnu.org/nongnu-devel/haskell-mode-17.5.0.20260619.67.tar";
+        sha256 = "1v4ksswhi8d17did2fz3j3yqm30jd0yqj83h2093dqnhyphha9dl";
       };
       packageRequires = [ ];
       meta = {
@@ -2816,10 +2912,10 @@
     elpaBuild {
       pname = "helm";
       ename = "helm";
-      version = "4.0.6.0.20260424.61638";
+      version = "4.0.7.0.20260624.21";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/helm-4.0.6.0.20260424.61638.tar";
-        sha256 = "1h45ffmj2myiv1yg0gy1kfxwky41xfzdzy4vhzc67w1a6g6kh9jq";
+        url = "https://elpa.nongnu.org/nongnu-devel/helm-4.0.7.0.20260624.21.tar";
+        sha256 = "13kprv1v1snk018m4ccjiyj8ndmc9jf7f5saw896kq16rdiwq72p";
       };
       packageRequires = [
         helm-core
@@ -2841,10 +2937,10 @@
     elpaBuild {
       pname = "helm-core";
       ename = "helm-core";
-      version = "4.0.6.0.20260424.61638";
+      version = "4.0.7.0.20260624.21";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/helm-core-4.0.6.0.20260424.61638.tar";
-        sha256 = "1484qsigbybnxlcb0jrx8v62fa7dqv7szia7p1lghp3q76cjlfv7";
+        url = "https://elpa.nongnu.org/nongnu-devel/helm-core-4.0.7.0.20260624.21.tar";
+        sha256 = "1w3xdawc6br7i0300544rc6c35yrbck2rkd0d667fv4c79nhvix3";
       };
       packageRequires = [ async ];
       meta = {
@@ -2974,10 +3070,10 @@
     elpaBuild {
       pname = "hyperdrive";
       ename = "hyperdrive";
-      version = "0.6pre0.20251120.145618";
+      version = "0.60.20251120.145618";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/hyperdrive-0.6pre0.20251120.145618.tar";
-        sha256 = "1s57c6m6fh593b9ax5skc5v1k3l0w983iq6mp3vx2a6g276qa44l";
+        url = "https://elpa.nongnu.org/nongnu-devel/hyperdrive-0.60.20251120.145618.tar";
+        sha256 = "0m4ns20mfcbxqy68qdlbyy9ywvwvhrlrz34dr7g35cz836740a2v";
       };
       packageRequires = [
         compat
@@ -3052,10 +3148,10 @@
     elpaBuild {
       pname = "idris-mode";
       ename = "idris-mode";
-      version = "1.1.0.0.20260209.110723";
+      version = "1.1.0.0.20260506.203306";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/idris-mode-1.1.0.0.20260209.110723.tar";
-        sha256 = "19rw6k40qkn4b11vhr95w71rdfqdmrr27ga8vdj7imb812wcdqyy";
+        url = "https://elpa.nongnu.org/nongnu-devel/idris-mode-1.1.0.0.20260506.203306.tar";
+        sha256 = "11mcszs9l8cw90v1kp4dnsjw3y86dspbjbb87fz7za8yrizki0id";
       };
       packageRequires = [
         cl-lib
@@ -3098,10 +3194,10 @@
     elpaBuild {
       pname = "inf-clojure";
       ename = "inf-clojure";
-      version = "3.4.0.0.20260227.65854";
+      version = "3.4.0.0.20260507.60144";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/inf-clojure-3.4.0.0.20260227.65854.tar";
-        sha256 = "1115nzzddmwz8rxvln6lgn0halnxjdlf6cgjprfnjm60ajfa861h";
+        url = "https://elpa.nongnu.org/nongnu-devel/inf-clojure-3.4.0.0.20260507.60144.tar";
+        sha256 = "031kf4yqnvggrk9flxcfwgz3ps2wpl6sxsvdkwxymdaahywv5yp2";
       };
       packageRequires = [ clojure-mode ];
       meta = {
@@ -3161,10 +3257,10 @@
     elpaBuild {
       pname = "isl";
       ename = "isl";
-      version = "1.6.0.20260414.62054";
+      version = "1.7.0.20260524.35203";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/isl-1.6.0.20260414.62054.tar";
-        sha256 = "149fcgwl3r5wiw8zwb1cgy4g96nv90a8wpjk8qh0dgcdz1vgsiqq";
+        url = "https://elpa.nongnu.org/nongnu-devel/isl-1.7.0.20260524.35203.tar";
+        sha256 = "1hr6nngd0z266vwz2h76xzvjx5zgy8ljjf04q6338kmzb16m24wr";
       };
       packageRequires = [ ];
       meta = {
@@ -3231,10 +3327,10 @@
     elpaBuild {
       pname = "jabber";
       ename = "jabber";
-      version = "0.11.0.0.20260614.0";
+      version = "0.11.0.0.20260619.11";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/jabber-0.11.0.0.20260614.0.tar";
-        sha256 = "19h0w85m6vzwwpsgg6ifcyx2j082cgj6dpd7s5yd7pr438jazkn3";
+        url = "https://elpa.nongnu.org/nongnu-devel/jabber-0.11.0.0.20260619.11.tar";
+        sha256 = "0gjjbl93l0x9sqlmxabrpirkkw5c514pbja74znmdh3j89b7x5zs";
       };
       packageRequires = [
         fsm
@@ -3318,10 +3414,10 @@
     elpaBuild {
       pname = "julia-mode";
       ename = "julia-mode";
-      version = "1.1.0.0.20260226.104209";
+      version = "1.1.0.0.20260529.7";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/julia-mode-1.1.0.0.20260226.104209.tar";
-        sha256 = "0ks6a1h9mfcc5fjjs6dwg0gv4w5l56kifxl59gpxfn3ahca3y2z0";
+        url = "https://elpa.nongnu.org/nongnu-devel/julia-mode-1.1.0.0.20260529.7.tar";
+        sha256 = "0h0aahyw658zqkzk7h39lsc5vmab4b9jzkqrmwn3q5zgnqy5nfcr";
       };
       packageRequires = [ ];
       meta = {
@@ -3333,6 +3429,7 @@
   keycast = callPackage (
     {
       compat,
+      cond-let,
       elpaBuild,
       fetchurl,
       lib,
@@ -3340,12 +3437,15 @@
     elpaBuild {
       pname = "keycast";
       ename = "keycast";
-      version = "1.4.7.0.20260101.183551";
+      version = "1.4.8.0.20260601.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/keycast-1.4.7.0.20260101.183551.tar";
-        sha256 = "1p0kzw0ciygp5xgyv2c7z9byn7x1x8zdrd7x3mlizjh3mpmwyl3k";
+        url = "https://elpa.nongnu.org/nongnu-devel/keycast-1.4.8.0.20260601.0.tar";
+        sha256 = "1b27wp1y2c0sh29f7chpks3zmdxksg8v8xyy9r62r7mdy2aylm2z";
       };
-      packageRequires = [ compat ];
+      packageRequires = [
+        compat
+        cond-let
+      ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu-devel/keycast.html";
         license = lib.licenses.free;
@@ -3384,10 +3484,10 @@
     elpaBuild {
       pname = "lem";
       ename = "lem";
-      version = "0.24.0.20250806.92416";
+      version = "0.25.0.20260509.75856";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/lem-0.24.0.20250806.92416.tar";
-        sha256 = "0hamh1xvwir0dhf91vn0fch39hxs7k443q4x9anfv44006fsgd3f";
+        url = "https://elpa.nongnu.org/nongnu-devel/lem-0.25.0.20260509.75856.tar";
+        sha256 = "0l6kg0y6y268hgyifxbkwjx1wk1d5d6wq86kykfq9fngwy8d5359";
       };
       packageRequires = [
         fedi
@@ -3409,10 +3509,10 @@
     elpaBuild {
       pname = "llama";
       ename = "llama";
-      version = "1.0.4.0.20260301.125328";
+      version = "1.0.5.0.20260601.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/llama-1.0.4.0.20260301.125328.tar";
-        sha256 = "04g5qakdxc4dfarkiv4d4jmfw609hbfxad1582aykfrzqngma2sd";
+        url = "https://elpa.nongnu.org/nongnu-devel/llama-1.0.5.0.20260601.0.tar";
+        sha256 = "0fv7agjcfj59wbis1sw175j6v36zdg0qp84dkv1l3ql6fixcwqh1";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3433,10 +3533,10 @@
     elpaBuild {
       pname = "logview";
       ename = "logview";
-      version = "0.19.4snapshot0.20260218.201306";
+      version = "0.19.40.20260218.201306";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/logview-0.19.4snapshot0.20260218.201306.tar";
-        sha256 = "1f49zs4w4wmn7famsc3ay8n7834c8zk2z3xmw74sk3744ygrc8d3";
+        url = "https://elpa.nongnu.org/nongnu-devel/logview-0.19.40.20260218.201306.tar";
+        sha256 = "0nzhy8g714gy2w7dd9wyiwx9my2asbl9d1ps7k6m9g44xbvb2y0s";
       };
       packageRequires = [
         compat
@@ -3462,10 +3562,10 @@
     elpaBuild {
       pname = "loopy";
       ename = "loopy";
-      version = "0.15.0.0.20260312.10626";
+      version = "0.16.0.0.20260622.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/loopy-0.15.0.0.20260312.10626.tar";
-        sha256 = "1s16v7g2lszhq3qxp9fyfqk0f8l1x4599zgvbnplnamll0jsi7z3";
+        url = "https://elpa.nongnu.org/nongnu-devel/loopy-0.16.0.0.20260622.0.tar";
+        sha256 = "1s534lm9ysk8q0z4ndlb4zxns1mzpffy1p11zf4qy54qsh0brj9x";
       };
       packageRequires = [
         compat
@@ -3589,10 +3689,10 @@
     elpaBuild {
       pname = "magit";
       ename = "magit";
-      version = "4.5.0.0.20260422.220622";
+      version = "4.5.0.0.20260622.306";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/magit-4.5.0.0.20260422.220622.tar";
-        sha256 = "1sm2ixy8hnamzvapy4i2j58ydharg47xb3s1981yr2d948dl2kxd";
+        url = "https://elpa.nongnu.org/nongnu-devel/magit-4.5.0.0.20260622.306.tar";
+        sha256 = "07r0zjz7n6vy7fywmqf577vh7mx801104ph7302m4icawqbrk1gd";
       };
       packageRequires = [
         compat
@@ -3622,10 +3722,10 @@
     elpaBuild {
       pname = "magit-section";
       ename = "magit-section";
-      version = "4.5.0.0.20260422.220622";
+      version = "4.5.0.0.20260622.306";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/magit-section-4.5.0.0.20260422.220622.tar";
-        sha256 = "13hzbc26wi6llab43gy8m6jpnm5faji7bqk5xlaxwinfqhzjfb2a";
+        url = "https://elpa.nongnu.org/nongnu-devel/magit-section-4.5.0.0.20260622.306.tar";
+        sha256 = "017345kx3wpfipy6pas53cyrhg4qx9pjl8ja7kram2g1hra3hm3z";
       };
       packageRequires = [
         compat
@@ -3648,10 +3748,10 @@
     elpaBuild {
       pname = "markdown-mode";
       ename = "markdown-mode";
-      version = "2.9alpha0.20260423.150805";
+      version = "2.90.20260425.95459";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/markdown-mode-2.9alpha0.20260423.150805.tar";
-        sha256 = "1ap384fyxbny1pn59grjj6x8y29hcfl1vlhim4r177j2killr4sh";
+        url = "https://elpa.nongnu.org/nongnu-devel/markdown-mode-2.90.20260425.95459.tar";
+        sha256 = "1xdszi0kjn3dg9nrn004hcb7ib7adh3vf6a8aznkaz4zhhqs420m";
       };
       packageRequires = [ ];
       meta = {
@@ -3671,10 +3771,10 @@
     elpaBuild {
       pname = "mastodon";
       ename = "mastodon";
-      version = "2.0.16.0.20260406.85635";
+      version = "2.0.17.0.20260509.74935";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/mastodon-2.0.16.0.20260406.85635.tar";
-        sha256 = "0wlb1pd08m0bhn5fjxynhq285z7c210k5i8g08wj7b5gsjxmqqkx";
+        url = "https://elpa.nongnu.org/nongnu-devel/mastodon-2.0.17.0.20260509.74935.tar";
+        sha256 = "1i656xma6mw8fis91fwvzz9c1fpihxcgpwx78vm10k939j1ghhpg";
       };
       packageRequires = [
         persist
@@ -3746,10 +3846,10 @@
     elpaBuild {
       pname = "meow";
       ename = "meow";
-      version = "1.5.0.0.20250914.165407";
+      version = "1.5.0.0.20260619.66";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/meow-1.5.0.0.20250914.165407.tar";
-        sha256 = "02wq0az10vqa7m55mga89aipjfqdwbw83rrf0xdyzc1f1r8841bm";
+        url = "https://elpa.nongnu.org/nongnu-devel/meow-1.5.0.0.20260619.66.tar";
+        sha256 = "1m4ymrg1q8d87zxg72na8a272852qhw443na1g2lf0i01sqijsr8";
       };
       packageRequires = [ ];
       meta = {
@@ -3788,10 +3888,10 @@
     elpaBuild {
       pname = "moe-theme";
       ename = "moe-theme";
-      version = "1.1.0.0.20260304.151933";
+      version = "1.1.0.0.20260515.84137";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/moe-theme-1.1.0.0.20260304.151933.tar";
-        sha256 = "1chfka5hgda9bclgvlkvs76zn6w7ra4rqnsrhmn8bn6s9s1k8chj";
+        url = "https://elpa.nongnu.org/nongnu-devel/moe-theme-1.1.0.0.20260515.84137.tar";
+        sha256 = "0q8sdm7sd82xgas83z0i5rrjq26b9crvakr5iqdcms9pnckqkfl8";
       };
       packageRequires = [ ];
       meta = {
@@ -3873,10 +3973,10 @@
     elpaBuild {
       pname = "nasm-mode";
       ename = "nasm-mode";
-      version = "1.1.1.0.20250320.164627";
+      version = "1.1.1.0.20260509.95321";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/nasm-mode-1.1.1.0.20250320.164627.tar";
-        sha256 = "0dm1zg15q18v9y4mx2p8hdqvql4dikw8chkj3i3jb1jp9d0v2rf3";
+        url = "https://elpa.nongnu.org/nongnu-devel/nasm-mode-1.1.1.0.20260509.95321.tar";
+        sha256 = "0gp5mn9p9k647042nizvnzx0ns0fhlg9h266vzbkzpimhn8a7pp2";
       };
       packageRequires = [ ];
       meta = {
@@ -3984,10 +4084,10 @@
     elpaBuild {
       pname = "opam-switch-mode";
       ename = "opam-switch-mode";
-      version = "1.8snapshot0.20230802.91729";
+      version = "1.80.20230802.91729";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/opam-switch-mode-1.8snapshot0.20230802.91729.tar";
-        sha256 = "01ccpzlanc42na9hdm8f8ys4b1lsxqx5f2ks3ya3f5yr580amy1w";
+        url = "https://elpa.nongnu.org/nongnu-devel/opam-switch-mode-1.80.20230802.91729.tar";
+        sha256 = "1wp7h0p0mfa5gpwbn9sh43a7zy2yaslb9db9k54ylapqn8d8zapx";
       };
       packageRequires = [ ];
       meta = {
@@ -4028,10 +4128,10 @@
     elpaBuild {
       pname = "org-contrib";
       ename = "org-contrib";
-      version = "0.8.0.20260221.192041";
+      version = "0.8.0.20260505.72437";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/org-contrib-0.8.0.20260221.192041.tar";
-        sha256 = "15mrdfmj4nxqh7ayyc2nyhxak5ymfsa9ym8dl8gwjsc8xym9jidd";
+        url = "https://elpa.nongnu.org/nongnu-devel/org-contrib-0.8.0.20260505.72437.tar";
+        sha256 = "1qx4vnbqczn313pjx1fky78d83ixyr39807hr88sd81h98ggq61f";
       };
       packageRequires = [ org ];
       meta = {
@@ -4166,10 +4266,10 @@
     elpaBuild {
       pname = "org-transclusion-http";
       ename = "org-transclusion-http";
-      version = "0.5pre0.20240630.140904";
+      version = "0.50.20240630.140904";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/org-transclusion-http-0.5pre0.20240630.140904.tar";
-        sha256 = "1gkh5flmbj0gah8vbw6ghqagak220ljym8rsgpwmpxmqzwjhp5kp";
+        url = "https://elpa.nongnu.org/nongnu-devel/org-transclusion-http-0.50.20240630.140904.tar";
+        sha256 = "0kgq58mr7r9jlsc68nm6z6fm3wb0y1kjayj0qp7pbipqj9dx6b9z";
       };
       packageRequires = [
         org-transclusion
@@ -4209,20 +4309,22 @@
       elpaBuild,
       fetchurl,
       lib,
+      llama,
       magit,
       org,
     }:
     elpaBuild {
       pname = "orgit";
       ename = "orgit";
-      version = "2.1.2.0.20260301.125552";
+      version = "2.1.3.0.20260623.18";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/orgit-2.1.2.0.20260301.125552.tar";
-        sha256 = "1yy549phcdkm6sn70bb92lm1yrfc1k1d716kcblmrl6p2vd450l7";
+        url = "https://elpa.nongnu.org/nongnu-devel/orgit-2.1.3.0.20260623.18.tar";
+        sha256 = "0cpi9xzs79jbysj127z72611x82wpbzhfgz603ww454x9qiyb9fa";
       };
       packageRequires = [
         compat
         cond-let
+        llama
         magit
         org
       ];
@@ -4263,10 +4365,10 @@
     elpaBuild {
       pname = "package-lint";
       ename = "package-lint";
-      version = "0.26.0.20251205.172019";
+      version = "0.26.0.20260619.23";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/package-lint-0.26.0.20251205.172019.tar";
-        sha256 = "1b8pdsy3ym66vcf7f98prlr9hia710zxksyjsnf6r9mnddk2hry4";
+        url = "https://elpa.nongnu.org/nongnu-devel/package-lint-0.26.0.20260619.23.tar";
+        sha256 = "1a1lbk0ypicqwx6afavwfqwibp0pvyry84372s441bmd89xp072k";
       };
       packageRequires = [ let-alist ];
       meta = {
@@ -4306,10 +4408,10 @@
     elpaBuild {
       pname = "page-break-lines";
       ename = "page-break-lines";
-      version = "0.15.0.20251121.212752";
+      version = "0.15.0.20260619.18";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/page-break-lines-0.15.0.20251121.212752.tar";
-        sha256 = "0jzga42sd4p4nibbypi0f6427pfibdmpdjrcxnygvj8rc3wk1qv6";
+        url = "https://elpa.nongnu.org/nongnu-devel/page-break-lines-0.15.0.20260619.18.tar";
+        sha256 = "0x9b97wgxjvm42k9910fyfyd6ddwkh3fiwc5g7ix7izzxvsx511g";
       };
       packageRequires = [ ];
       meta = {
@@ -4327,10 +4429,10 @@
     elpaBuild {
       pname = "paredit";
       ename = "paredit";
-      version = "27beta0.20241103.213959";
+      version = "270.20241103.213959";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/paredit-27beta0.20241103.213959.tar";
-        sha256 = "00xb4lzkbfsz7f7pnsjfzbhigp4r2piimj7cplq7fxjl80j39lka";
+        url = "https://elpa.nongnu.org/nongnu-devel/paredit-270.20241103.213959.tar";
+        sha256 = "11fbgw18934ddrba1z5fz6c42m2b7jdmrg2lnzlracxfgk9gfp8p";
       };
       packageRequires = [ ];
       meta = {
@@ -4348,10 +4450,10 @@
     elpaBuild {
       pname = "parseclj";
       ename = "parseclj";
-      version = "1.1.1.0.20231203.190509";
+      version = "1.1.1.0.20260526.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/parseclj-1.1.1.0.20231203.190509.tar";
-        sha256 = "1h0lfy17613s7ls55ca77nqmc87v3kdwz1cvymzf2jp4xckgcsvw";
+        url = "https://elpa.nongnu.org/nongnu-devel/parseclj-1.1.1.0.20260526.2.tar";
+        sha256 = "0w6d1bvjdl1sg17iz77bf6n7j1k8j7x2jp7iki1r1lipi0ygfrmv";
       };
       packageRequires = [ ];
       meta = {
@@ -4371,10 +4473,10 @@
     elpaBuild {
       pname = "parseedn";
       ename = "parseedn";
-      version = "1.2.1.0.20231203.190947";
+      version = "1.2.1.0.20260601.4";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/parseedn-1.2.1.0.20231203.190947.tar";
-        sha256 = "0l8w1qr2nqngpcdcw1052dpx8q69xyz20mr2vvqayr5jmsgbvaad";
+        url = "https://elpa.nongnu.org/nongnu-devel/parseedn-1.2.1.0.20260601.4.tar";
+        sha256 = "0im6p06rh0vzqc5rdz5ydgqlys69dfcibkl4lz7isd3yndalwqwy";
       };
       packageRequires = [
         map
@@ -4464,10 +4566,10 @@
     elpaBuild {
       pname = "pg";
       ename = "pg";
-      version = "0.65.0.20260421.212130";
+      version = "0.67.0.20260610.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/pg-0.65.0.20260421.212130.tar";
-        sha256 = "13a88q1hx7mkc58a3ry5ym56kn5ppqr32j18n2ms69a5if301nhs";
+        url = "https://elpa.nongnu.org/nongnu-devel/pg-0.67.0.20260610.2.tar";
+        sha256 = "16014aqcz3pj31pbwgyaw9qsqz5rfmmscdah6qvppg2dg17lwfhg";
       };
       packageRequires = [ peg ];
       meta = {
@@ -4527,10 +4629,10 @@
     elpaBuild {
       pname = "popup";
       ename = "popup";
-      version = "0.5.9.0.20251231.162233";
+      version = "0.5.9.0.20260619.57";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/popup-0.5.9.0.20251231.162233.tar";
-        sha256 = "0w6f04gx4k3das0p8hdx178ldvwwx8jbzns1n1kwwgc1i5x8fl51";
+        url = "https://elpa.nongnu.org/nongnu-devel/popup-0.5.9.0.20260619.57.tar";
+        sha256 = "01pjvxcsrvcp8j8xrh096x6c4fd94wwihvzphqcxmbrdkhvsgbhh";
       };
       packageRequires = [ ];
       meta = {
@@ -4570,10 +4672,10 @@
     elpaBuild {
       pname = "projectile";
       ename = "projectile";
-      version = "2.10.0snapshot0.20260310.85858";
+      version = "2.10.0.20260620.133";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/projectile-2.10.0snapshot0.20260310.85858.tar";
-        sha256 = "081aljvri52f6l4jj9w16lv67gzihmw1afymzpr6c8ak5q02c5vd";
+        url = "https://elpa.nongnu.org/nongnu-devel/projectile-2.10.0.20260620.133.tar";
+        sha256 = "1l2m7v59jx8myiaswyrwrm2z60hkk8vqnfl7bnzzvjcs10jafl82";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4591,10 +4693,10 @@
     elpaBuild {
       pname = "proof-general";
       ename = "proof-general";
-      version = "4.6snapshot0.20260124.135141";
+      version = "4.60.20260622.265";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/proof-general-4.6snapshot0.20260124.135141.tar";
-        sha256 = "0wjjip6pph8s8j613md5j6f5ba40cl88v44i88s6s11ixrmd73sl";
+        url = "https://elpa.nongnu.org/nongnu-devel/proof-general-4.60.20260622.265.tar";
+        sha256 = "1b9qv3dv173aqx5k0drkysk017g1ycrzy25kzdhkxg8280kz3v5k";
       };
       packageRequires = [ ];
       meta = {
@@ -4715,16 +4817,17 @@
       elpaBuild,
       fetchurl,
       lib,
+      with-command-redo,
     }:
     elpaBuild {
       pname = "recomplete";
       ename = "recomplete";
-      version = "0.2.0.20260403.113038";
+      version = "0.2.0.20260504.120143";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/recomplete-0.2.0.20260403.113038.tar";
-        sha256 = "1mnd8d2hyfcjribvgq955sn0vm1265xs0jqc55rylwpkr4cff779";
+        url = "https://elpa.nongnu.org/nongnu-devel/recomplete-0.2.0.20260504.120143.tar";
+        sha256 = "0za4w629nwd1yra59qrn9j8ll9w8bl10skx9xk16lcli7g479j2s";
       };
-      packageRequires = [ ];
+      packageRequires = [ with-command-redo ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu-devel/recomplete.html";
         license = lib.licenses.free;
@@ -4740,10 +4843,10 @@
     elpaBuild {
       pname = "reformatter";
       ename = "reformatter";
-      version = "0.8.0.20251121.93526";
+      version = "0.8.0.20260619.30";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/reformatter-0.8.0.20251121.93526.tar";
-        sha256 = "11s23mply7aaa68y6miwzn6bld5m1rynk19l5jj2i1mwjk2plrlk";
+        url = "https://elpa.nongnu.org/nongnu-devel/reformatter-0.8.0.20260619.30.tar";
+        sha256 = "0lqigd7kr1xyzz3asy376ng5r9flda4l8njxpflgaly137ifzil3";
       };
       packageRequires = [ ];
       meta = {
@@ -4782,10 +4885,10 @@
     elpaBuild {
       pname = "rfc-mode";
       ename = "rfc-mode";
-      version = "1.4.2.0.20260127.180740";
+      version = "1.4.2.0.20260617.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/rfc-mode-1.4.2.0.20260127.180740.tar";
-        sha256 = "1i01x9k208zasil586q1jz28hdl5hpx964a6bgb6wwgf9ya79xlx";
+        url = "https://elpa.nongnu.org/nongnu-devel/rfc-mode-1.4.2.0.20260617.2.tar";
+        sha256 = "1kk70niw36vb2ldrclk34r6hy4555hcqkcbss2dn1mfbp9sf54d6";
       };
       packageRequires = [ ];
       meta = {
@@ -4804,10 +4907,10 @@
     elpaBuild {
       pname = "rpm-spec-mode";
       ename = "rpm-spec-mode";
-      version = "0.16.0.20260423.74352";
+      version = "0.16.0.20260616.59";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/rpm-spec-mode-0.16.0.20260423.74352.tar";
-        sha256 = "0pqq31x60g3ig7fmd4jh7kjz051m020kqs3pfpbiznwhjh8v63ad";
+        url = "https://elpa.nongnu.org/nongnu-devel/rpm-spec-mode-0.16.0.20260616.59.tar";
+        sha256 = "1yn9ihrbviyzyadh2yc6c85sjh94pdbp9h7jzlmmims6xhkmjk24";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4825,10 +4928,10 @@
     elpaBuild {
       pname = "rubocop";
       ename = "rubocop";
-      version = "0.7.0snapshot0.20210309.124149";
+      version = "0.7.0.20210309.124149";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/rubocop-0.7.0snapshot0.20210309.124149.tar";
-        sha256 = "110rfww9kl2f8mj45nf1irwmwj4bfgla6glc52dhqi2ibvpik1h5";
+        url = "https://elpa.nongnu.org/nongnu-devel/rubocop-0.7.0.20210309.124149.tar";
+        sha256 = "0akmidx76zrrfcax7397cs1plwnr3dm83npakbpkssihf08b13aq";
       };
       packageRequires = [ ];
       meta = {
@@ -4846,10 +4949,10 @@
     elpaBuild {
       pname = "rust-mode";
       ename = "rust-mode";
-      version = "1.0.6.0.20260416.50503";
+      version = "1.0.6.0.20260618.49";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/rust-mode-1.0.6.0.20260416.50503.tar";
-        sha256 = "12bcjfi7s7gisx31rwncvcs7j7m57kcs7rs5jfhmmpfsm8n24yba";
+        url = "https://elpa.nongnu.org/nongnu-devel/rust-mode-1.0.6.0.20260618.49.tar";
+        sha256 = "1ldkx6plsvaijibb4szyjs2b3hcl6svmbd8fn0j4015558shif4q";
       };
       packageRequires = [ ];
       meta = {
@@ -4894,10 +4997,10 @@
     elpaBuild {
       pname = "scad-mode";
       ename = "scad-mode";
-      version = "98.0.0.20260330.71707";
+      version = "99.0.0.20260519.103934";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/scad-mode-98.0.0.20260330.71707.tar";
-        sha256 = "05fcw1wc6n0k9acjm6hmmidfp7pp0zgshwd63ijpz5d8l0plim29";
+        url = "https://elpa.nongnu.org/nongnu-devel/scad-mode-99.0.0.20260519.103934.tar";
+        sha256 = "1rh44ifrfihh1jiy1g8fj5gln6ycdimpszilfhzy9fawxwlqhrqk";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4999,10 +5102,10 @@
     elpaBuild {
       pname = "sesman";
       ename = "sesman";
-      version = "0.3.3snapshot0.20240417.172323";
+      version = "0.3.30.20260616.21";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/sesman-0.3.3snapshot0.20240417.172323.tar";
-        sha256 = "1d4c3ymxas4xsjbkg7yj80x6lgly5rch7fvyvi495yvk3mzd9yzk";
+        url = "https://elpa.nongnu.org/nongnu-devel/sesman-0.3.30.20260616.21.tar";
+        sha256 = "0px5lb4xqv8j1n4qran31ra5cq7l1adgfsghm63hwd2sqb999337";
       };
       packageRequires = [ ];
       meta = {
@@ -5032,6 +5135,28 @@
       };
     }
   ) { };
+  simple-httpd = callPackage (
+    {
+      compat,
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "simple-httpd";
+      ename = "simple-httpd";
+      version = "1.6.0.20260623.1";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu-devel/simple-httpd-1.6.0.20260623.1.tar";
+        sha256 = "1npss5lv7r2nzvbhzh5jr7w53n2hx6w9pws554srh25hw68v3zd4";
+      };
+      packageRequires = [ compat ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu-devel/simple-httpd.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   slime = callPackage (
     {
       elpaBuild,
@@ -5042,10 +5167,10 @@
     elpaBuild {
       pname = "slime";
       ename = "slime";
-      version = "2.32snapshot0.20260421.225639";
+      version = "2.320.20260612.49";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/slime-2.32snapshot0.20260421.225639.tar";
-        sha256 = "0gqj2nd82wljvfrqwah3qczkjq8q4i1k3cprypydxzlfh45k13jf";
+        url = "https://elpa.nongnu.org/nongnu-devel/slime-2.320.20260612.49.tar";
+        sha256 = "196g2sc1v84013nk3c8my3w2r3aqvg9sjix2ca64vvrarfamb0ck";
       };
       packageRequires = [ macrostep ];
       meta = {
@@ -5106,10 +5231,10 @@
     elpaBuild {
       pname = "solarized-theme";
       ename = "solarized-theme";
-      version = "2.1.0.0.20260329.155902";
+      version = "2.1.0.0.20260610.7";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/solarized-theme-2.1.0.0.20260329.155902.tar";
-        sha256 = "19bj5hfz6ydhxd6qcrkw1lgpfbhjm5iwq96i6i4z56yffm7ijl9k";
+        url = "https://elpa.nongnu.org/nongnu-devel/solarized-theme-2.1.0.0.20260610.7.tar";
+        sha256 = "1phh2qqjf68ap6giid63zpnggx41y1zvn9q2c60igx01fv7xnykd";
       };
       packageRequires = [ ];
       meta = {
@@ -5127,10 +5252,10 @@
     elpaBuild {
       pname = "spacemacs-theme";
       ename = "spacemacs-theme";
-      version = "0.2.0.20260414.205200";
+      version = "0.2.0.20260523.125627";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/spacemacs-theme-0.2.0.20260414.205200.tar";
-        sha256 = "076nbpp16wy6j9ic3bhj9cj58bmah6ivhh842lkh7y7lgp6f7q7j";
+        url = "https://elpa.nongnu.org/nongnu-devel/spacemacs-theme-0.2.0.20260523.125627.tar";
+        sha256 = "0rxvvfcssxvgfi8djd3y5ncd5hhhbqclprp3529zw390m8qlcicd";
       };
       packageRequires = [ ];
       meta = {
@@ -5148,10 +5273,10 @@
     elpaBuild {
       pname = "spell-fu";
       ename = "spell-fu";
-      version = "0.3.0.20260108.133641";
+      version = "0.3.0.20260524.63613";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/spell-fu-0.3.0.20260108.133641.tar";
-        sha256 = "1yrv1a3k6nk92bhs4gsqpb1gc7x55gpp365ykpx6zj0hiapfhq80";
+        url = "https://elpa.nongnu.org/nongnu-devel/spell-fu-0.3.0.20260524.63613.tar";
+        sha256 = "1s2x3ymj1zb5iczwsrq00s0ynx1n6s3ls7y2nxrhxf04x93swqbf";
       };
       packageRequires = [ ];
       meta = {
@@ -5253,10 +5378,10 @@
     elpaBuild {
       pname = "subed";
       ename = "subed";
-      version = "1.4.2.0.20260418.123100";
+      version = "1.5.1.0.20260618.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/subed-1.4.2.0.20260418.123100.tar";
-        sha256 = "1xdz1vglwza0lik5zqx6f8x8w3a7yq8x7wkd7zr5k932pjmhqbnd";
+        url = "https://elpa.nongnu.org/nongnu-devel/subed-1.5.1.0.20260618.1.tar";
+        sha256 = "1b74rndjdjawxl6fbksw7816135hyyk9sffijcrfyfd5c9k0c5zn";
       };
       packageRequires = [ ];
       meta = {
@@ -5275,10 +5400,10 @@
     elpaBuild {
       pname = "sweeprolog";
       ename = "sweeprolog";
-      version = "0.27.6.0.20250624.64526";
+      version = "0.27.6.0.20260510.162905";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/sweeprolog-0.27.6.0.20250624.64526.tar";
-        sha256 = "1ywcwm4r7hd21bayilvmw530axa2gc8f689fr5swxfyig49qjqz5";
+        url = "https://elpa.nongnu.org/nongnu-devel/sweeprolog-0.27.6.0.20260510.162905.tar";
+        sha256 = "1x38q2hrrapfzb8ky7bzfw58pi00yyj4qnwrpsqcc1hhaxq6h1dr";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5296,10 +5421,10 @@
     elpaBuild {
       pname = "swift-mode";
       ename = "swift-mode";
-      version = "9.4.0.0.20251122.85713";
+      version = "10.0.0.0.20260608.3";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/swift-mode-9.4.0.0.20251122.85713.tar";
-        sha256 = "1sn7lm6srrlnbxfdjpqdr503plkml61bz79ivwgz9rs9fqkbrvgg";
+        url = "https://elpa.nongnu.org/nongnu-devel/swift-mode-10.0.0.0.20260608.3.tar";
+        sha256 = "0xla80pyl6x1jmni7n4n7kxshhn7yb5zsmbck5dxmc1jh6cfvjp6";
       };
       packageRequires = [ ];
       meta = {
@@ -5493,10 +5618,10 @@
     elpaBuild {
       pname = "toc-org";
       ename = "toc-org";
-      version = "1.1.0.20230831.75249";
+      version = "1.1.0.20260514.144504";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/toc-org-1.1.0.20230831.75249.tar";
-        sha256 = "1kscz2s87l8a8w0d4s3g8ilspd63p0ij2vgncvzvb8hjld4pdcfh";
+        url = "https://elpa.nongnu.org/nongnu-devel/toc-org-1.1.0.20260514.144504.tar";
+        sha256 = "0rjzk0lzxppj5xvkh80nkaipf1m1d7wascx09hljrsk4fg583idb";
       };
       packageRequires = [ ];
       meta = {
@@ -5537,10 +5662,10 @@
     elpaBuild {
       pname = "tp";
       ename = "tp";
-      version = "0.8.0.20260219.143500";
+      version = "0.9.0.20260509.80242";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/tp-0.8.0.20260219.143500.tar";
-        sha256 = "15szb0li4ibsaja39699rc85nvk2s466g303dp0si62h9ipha68w";
+        url = "https://elpa.nongnu.org/nongnu-devel/tp-0.9.0.20260509.80242.tar";
+        sha256 = "15yw87gayvm79i2ah5qkvgvcsma3l6iwa34732bs3r0yqcgwfw9q";
       };
       packageRequires = [ transient ];
       meta = {
@@ -5558,10 +5683,10 @@
     elpaBuild {
       pname = "treepy";
       ename = "treepy";
-      version = "0.1.3.0.20260313.91605";
+      version = "0.1.3.0.20260531.3";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/treepy-0.1.3.0.20260313.91605.tar";
-        sha256 = "0bxp1xf2ckq4pa7bm5sc5i8y1nlyy36zyfavjndc2fihskr7d6pm";
+        url = "https://elpa.nongnu.org/nongnu-devel/treepy-0.1.3.0.20260531.3.tar";
+        sha256 = "0zzz43pdxirljmjn0zwf2rdnd2gm14nk5gzafsshbw9mzys1r2vq";
       };
       packageRequires = [ ];
       meta = {
@@ -5579,10 +5704,10 @@
     elpaBuild {
       pname = "treesit-fold";
       ename = "treesit-fold";
-      version = "0.2.1.0.20260417.100827";
+      version = "0.2.1.0.20260619.51";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/treesit-fold-0.2.1.0.20260417.100827.tar";
-        sha256 = "04v6yqj6a4aahff2kbpmj3k8jzqxa6idfgpfsd6l98yb3kqldil7";
+        url = "https://elpa.nongnu.org/nongnu-devel/treesit-fold-0.2.1.0.20260619.51.tar";
+        sha256 = "0zjkpa07dd3lk9clf10gb3l5s626yg2qyzwxczmymy4lla8njjnr";
       };
       packageRequires = [ ];
       meta = {
@@ -5622,10 +5747,10 @@
     elpaBuild {
       pname = "tuareg";
       ename = "tuareg";
-      version = "3.0.2snapshot0.20250910.140516";
+      version = "3.0.20.20260617.40";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/tuareg-3.0.2snapshot0.20250910.140516.tar";
-        sha256 = "0m9xid4s6qqdw8vlpgzsf2lc877shf7dvfxk8b9bhiva56dhrqfw";
+        url = "https://elpa.nongnu.org/nongnu-devel/tuareg-3.0.20.20260617.40.tar";
+        sha256 = "0xmfvmxnk50pymajgmymwzmhjs8x5ac9dg1r7mx4iwsv15x13m4f";
       };
       packageRequires = [ caml ];
       meta = {
@@ -5812,10 +5937,10 @@
     elpaBuild {
       pname = "vm";
       ename = "vm";
-      version = "8.3.3snapshot0.20260420.63204";
+      version = "8.3.30.20260610.33";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/vm-8.3.3snapshot0.20260420.63204.tar";
-        sha256 = "03804kmfwp994szv5gdgsg1sxmmdhzam8aq17r402chj6lhpla1x";
+        url = "https://elpa.nongnu.org/nongnu-devel/vm-8.3.30.20260610.33.tar";
+        sha256 = "0194px4dg5q2rgddvqwylcywymjx39s3ih16kh6d8whvlk1xcm6p";
       };
       packageRequires = [ vcard ];
       meta = {
@@ -5833,10 +5958,10 @@
     elpaBuild {
       pname = "web-mode";
       ename = "web-mode";
-      version = "17.3.23.0.20260331.144101";
+      version = "17.3.24.0.20260623.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/web-mode-17.3.23.0.20260331.144101.tar";
-        sha256 = "1yk7dcsgry69dz3scx32p4zqp1ay6354rr017ygqffkl0fcqhgdg";
+        url = "https://elpa.nongnu.org/nongnu-devel/web-mode-17.3.24.0.20260623.0.tar";
+        sha256 = "0k6p06qbcclc2hywplpk09iz266k80zhlw4031whrrrmij9700j6";
       };
       packageRequires = [ ];
       meta = {
@@ -5937,19 +6062,25 @@
   with-editor = callPackage (
     {
       compat,
+      cond-let,
       elpaBuild,
       fetchurl,
       lib,
+      llama,
     }:
     elpaBuild {
       pname = "with-editor";
       ename = "with-editor";
-      version = "3.4.9.0.20260422.182143";
+      version = "3.5.1.0.20260623.3";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/with-editor-3.4.9.0.20260422.182143.tar";
-        sha256 = "10zb39gwdbamb11msxkayzspi09fpagip93xm90lc39w850xmbbm";
+        url = "https://elpa.nongnu.org/nongnu-devel/with-editor-3.5.1.0.20260623.3.tar";
+        sha256 = "16mfh41zkdylbk92cizm4ia69lwirq58mb8rms9v448s41w2wvka";
       };
-      packageRequires = [ compat ];
+      packageRequires = [
+        compat
+        cond-let
+        llama
+      ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu-devel/with-editor.html";
         license = lib.licenses.free;
@@ -6097,10 +6228,10 @@
     elpaBuild {
       pname = "xml-rpc";
       ename = "xml-rpc";
-      version = "1.6.17.0.20251122.185743";
+      version = "1.6.17.0.20260619.13";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/xml-rpc-1.6.17.0.20251122.185743.tar";
-        sha256 = "1sshmzg6v27v8l0q3lq2apfvpbkkg71dyn7mk99a56qab4ajm6zs";
+        url = "https://elpa.nongnu.org/nongnu-devel/xml-rpc-1.6.17.0.20260619.13.tar";
+        sha256 = "0h0l1xlifl12n2bhjr9yx8nffl0wbhi1mnlj0f1w7f9b3vdgcn1a";
       };
       packageRequires = [ ];
       meta = {
@@ -6161,10 +6292,10 @@
     elpaBuild {
       pname = "zenburn-theme";
       ename = "zenburn-theme";
-      version = "2.9.0.0.20260329.183806";
+      version = "2.10.0.0.20260601.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/zenburn-theme-2.9.0.0.20260329.183806.tar";
-        sha256 = "16ma8gishgdbaalk1slqci7dciyjjnbifvn15iyby4ccqy3dc8gz";
+        url = "https://elpa.nongnu.org/nongnu-devel/zenburn-theme-2.10.0.0.20260601.0.tar";
+        sha256 = "0li865y8wp8gsim2xiscxhmpfnwd394ag9x9kpff082yg2q4j2ww";
       };
       packageRequires = [ ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
@@ -9,10 +9,10 @@
     elpaBuild {
       pname = "adoc-mode";
       ename = "adoc-mode";
-      version = "0.8.0";
+      version = "0.9.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/adoc-mode-0.8.0.tar";
-        sha256 = "16459ial82gybqjm8ib0cxry6daipak4baxiz2wnldgy5vpgjnrd";
+        url = "https://elpa.nongnu.org/nongnu/adoc-mode-0.9.0.tar";
+        sha256 = "11anl5b9ka9aww2w2jv0clrvq98f2vsa9ri3n1xxdll5z77rvw56";
       };
       packageRequires = [ ];
       meta = {
@@ -75,10 +75,10 @@
     elpaBuild {
       pname = "aidermacs";
       ename = "aidermacs";
-      version = "1.6";
+      version = "1.7";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/aidermacs-1.6.tar";
-        sha256 = "07ql2kv7naza7jigmsw9x1k3md0hz2c302qrc0cy1a1h07567nli";
+        url = "https://elpa.nongnu.org/nongnu/aidermacs-1.7.tar";
+        sha256 = "17l7dlg218j63zwzi51wdczamvxlv54l0ivkip3h3kll386lkcm6";
       };
       packageRequires = [
         compat
@@ -142,10 +142,10 @@
     elpaBuild {
       pname = "annotate";
       ename = "annotate";
-      version = "2.4.5";
+      version = "2.5.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/annotate-2.4.5.tar";
-        sha256 = "0pdhwlz792sf5zipv8s449bah7xm9klbpicx9203fhsc0ad82d0j";
+        url = "https://elpa.nongnu.org/nongnu/annotate-2.5.0.tar";
+        sha256 = "0nydnnjx1p4fkiix70zg0apxxd0sprlzxk111lvgnamp3c4hxf93";
       };
       packageRequires = [ ];
       meta = {
@@ -566,10 +566,10 @@
     elpaBuild {
       pname = "casual";
       ename = "casual";
-      version = "2.16.0";
+      version = "2.16.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/casual-2.16.0.tar";
-        sha256 = "1s0d5c3aacyh1n5qy7ka4xwnmdbx3qrh0z0z41bc958zmay6mgpa";
+        url = "https://elpa.nongnu.org/nongnu/casual-2.16.2.tar";
+        sha256 = "0aqkxxds4paicn1r4hy13f71cl4qllf9dfijpl4mp5zizyx8a8a2";
       };
       packageRequires = [
         csv-mode
@@ -605,6 +605,7 @@
   cider = callPackage (
     {
       clojure-mode,
+      compat,
       elpaBuild,
       fetchurl,
       lib,
@@ -618,13 +619,14 @@
     elpaBuild {
       pname = "cider";
       ename = "cider";
-      version = "1.21.0";
+      version = "1.22.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/cider-1.21.0.tar";
-        sha256 = "0rfjq6fqvam9v7mcx1459p377ryzi9wf7p2dn68nd51f324hx0gj";
+        url = "https://elpa.nongnu.org/nongnu/cider-1.22.2.tar";
+        sha256 = "0a7mcg1lazn1xyl3sxy0qpwd4qipf0ix56891ydjcv7i9yhggnpc";
       };
       packageRequires = [
         clojure-mode
+        compat
         parseedn
         queue
         seq
@@ -733,10 +735,10 @@
     elpaBuild {
       pname = "cond-let";
       ename = "cond-let";
-      version = "0.2.2";
+      version = "1.1.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/cond-let-0.2.2.tar";
-        sha256 = "0ip5k8jhdgq1zkc6cj4ax8rv4236cxla2dapj83y526ra321gkzy";
+        url = "https://elpa.nongnu.org/nongnu/cond-let-1.1.2.tar";
+        sha256 = "04p2jf8nm1q00439r26vvg9549hld4spcabghwsgmf89gqjiv8mm";
       };
       packageRequires = [ ];
       meta = {
@@ -756,10 +758,10 @@
     elpaBuild {
       pname = "consult-flycheck";
       ename = "consult-flycheck";
-      version = "1.1";
+      version = "1.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/consult-flycheck-1.1.tar";
-        sha256 = "0nanxx0fbj6w9sxzz4ys8nxpv63al3m4lliy30y4ydiaig2a0abc";
+        url = "https://elpa.nongnu.org/nongnu/consult-flycheck-1.2.tar";
+        sha256 = "0g5lb3p4g91ax0c4zkkyvi2l4hkq5b9r2bciddgg1h4bsmrs6vhx";
       };
       packageRequires = [
         consult
@@ -828,10 +830,10 @@
     elpaBuild {
       pname = "csv2ledger";
       ename = "csv2ledger";
-      version = "1.5.4";
+      version = "1.5.5";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/csv2ledger-1.5.4.tar";
-        sha256 = "1h935g97fjrs1q0yz0q071zp91bhsb3yg13zqpp8il5gif20qqls";
+        url = "https://elpa.nongnu.org/nongnu/csv2ledger-1.5.5.tar";
+        sha256 = "09k7q33jxwrcf52csgf25kd9wqcs9bicl8azmkbrmm8d9jqgg3md";
       };
       packageRequires = [ csv-mode ];
       meta = {
@@ -1278,10 +1280,10 @@
     elpaBuild {
       pname = "eldoc-mouse";
       ename = "eldoc-mouse";
-      version = "3.0.7";
+      version = "3.0.8";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/eldoc-mouse-3.0.7.tar";
-        sha256 = "17s3iqkdswjfcdiyaa732v27pcpmxa96i17mwpzi34vw53a1r3wl";
+        url = "https://elpa.nongnu.org/nongnu/eldoc-mouse-3.0.8.tar";
+        sha256 = "1snacbxjqp8ykic5z1nzhg0fnd5fnafsgwxmfd9vy4rsm0ag9mrl";
       };
       packageRequires = [
         eglot
@@ -1315,6 +1317,56 @@
       ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu/eldoc-mouse-nov.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  elfeed = callPackage (
+    {
+      compat,
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "elfeed";
+      ename = "elfeed";
+      version = "4.0.1";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu/elfeed-4.0.1.tar";
+        sha256 = "1az6lj58j1kkxzpa7ik8irl3z2b9f7yxsm92pfqlcwplsnm2q8q2";
+      };
+      packageRequires = [ compat ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu/elfeed.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  elfeed-web = callPackage (
+    {
+      compat,
+      elfeed,
+      elpaBuild,
+      fetchurl,
+      lib,
+      simple-httpd,
+    }:
+    elpaBuild {
+      pname = "elfeed-web";
+      ename = "elfeed-web";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu/elfeed-web-4.0.0.tar";
+        sha256 = "0ah6zjcihxfra34zglqrj6pnxqnakgc58dlkgjzgrxdamx4dxfwg";
+      };
+      packageRequires = [
+        compat
+        elfeed
+        simple-httpd
+      ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu/elfeed-web.html";
         license = lib.licenses.free;
       };
     }
@@ -1370,10 +1422,10 @@
     elpaBuild {
       pname = "emacsql";
       ename = "emacsql";
-      version = "4.3.6";
+      version = "4.4.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/emacsql-4.3.6.tar";
-        sha256 = "1zj04kqq3c5915n9pj5qx63rw8hnnpag2y5qca4d4y9h1lqnj2pp";
+        url = "https://elpa.nongnu.org/nongnu/emacsql-4.4.1.tar";
+        sha256 = "1gja15jyalzrlcs85ng98p6g7b0id4rayj4shwf7x1ic30sv12p3";
       };
       packageRequires = [ ];
       meta = {
@@ -1400,6 +1452,27 @@
       packageRequires = [ cl-lib ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu/engine-mode.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  eprolog = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "eprolog";
+      ename = "eprolog";
+      version = "0.3.2";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu/eprolog-0.3.2.tar";
+        sha256 = "1vbnbdpmxvqgay5m01bcm1wlsyz16nn4fydv7ipd8kzr4lw59qyg";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu/eprolog.html";
         license = lib.licenses.free;
       };
     }
@@ -1719,16 +1792,20 @@
       evil,
       fetchurl,
       lib,
+      shift-number,
     }:
     elpaBuild {
       pname = "evil-numbers";
       ename = "evil-numbers";
-      version = "0.7";
+      version = "0.8";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/evil-numbers-0.7.tar";
-        sha256 = "1k5vrh8bj9kldqq8kxn1qi3k82i7k4v4h6nkk9hng8p90zhac02i";
+        url = "https://elpa.nongnu.org/nongnu/evil-numbers-0.8.tar";
+        sha256 = "0l1ik0fz1bzpxnz9rnn0817j8ghpwhf3qv3lidzb3vpbynkas5a1";
       };
-      packageRequires = [ evil ];
+      packageRequires = [
+        evil
+        shift-number
+      ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu/evil-numbers.html";
         license = lib.licenses.free;
@@ -1857,10 +1934,10 @@
     elpaBuild {
       pname = "fedi";
       ename = "fedi";
-      version = "0.3";
+      version = "0.4";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/fedi-0.3.tar";
-        sha256 = "1s1dn7n860b18cwyahc20lbl1bhv4y5h8jijs4iqbbgbk8w7hsjg";
+        url = "https://elpa.nongnu.org/nongnu/fedi-0.4.tar";
+        sha256 = "0zh2rkkj1wyj7csg72gg54mxlrd5kav54z3qhk6lp6j8h3zxkdvd";
       };
       packageRequires = [ markdown-mode ];
       meta = {
@@ -1882,10 +1959,10 @@
     elpaBuild {
       pname = "fj";
       ename = "fj";
-      version = "0.34";
+      version = "0.37";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/fj-0.34.tar";
-        sha256 = "0aqfipcpbsxp2pm05p44fdybhldpbvii2x2m0az9s3gkm7dvwg87";
+        url = "https://elpa.nongnu.org/nongnu/fj-0.37.tar";
+        sha256 = "1kya5xif5ffiqv9fk4mxwx6x6gqshkpji21z0q84q438hfbxpwl9";
       };
       packageRequires = [
         fedi
@@ -1895,6 +1972,27 @@
       ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu/fj.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  flamegraph = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "flamegraph";
+      ename = "flamegraph";
+      version = "0.2";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu/flamegraph-0.2.tar";
+        sha256 = "0zlji7iq7zrxix4mzw6z25rqgrmlnxnrc7skflkj0nv90z5w3fsh";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu/flamegraph.html";
         license = lib.licenses.free;
       };
     }
@@ -2158,10 +2256,10 @@
     elpaBuild {
       pname = "geiser";
       ename = "geiser";
-      version = "0.32";
+      version = "0.33.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/geiser-0.32.tar";
-        sha256 = "1mija2lp2fqhzi9bifl0ipkjhj3gx89qz41mk0phb5y5cws6nar1";
+        url = "https://elpa.nongnu.org/nongnu/geiser-0.33.1.tar";
+        sha256 = "0mh701hp587ahiqf0znnc4jm46i49z85nwac4bxn7sxxjid3xffl";
       };
       packageRequires = [ project ];
       meta = {
@@ -2291,10 +2389,10 @@
     elpaBuild {
       pname = "geiser-guile";
       ename = "geiser-guile";
-      version = "0.28.3";
+      version = "0.28.5";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/geiser-guile-0.28.3.tar";
-        sha256 = "163p8ll68qdgpz6l1ixwcmffcsv1kas095davgwgq001hfx9db5x";
+        url = "https://elpa.nongnu.org/nongnu/geiser-guile-0.28.5.tar";
+        sha256 = "078hmmqg6m428bg2sf640bwylrh4y64qanbz00prvjhgkrp1awnn";
       };
       packageRequires = [
         geiser
@@ -2434,10 +2532,10 @@
     elpaBuild {
       pname = "git-modes";
       ename = "git-modes";
-      version = "1.4.8";
+      version = "1.5.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/git-modes-1.4.8.tar";
-        sha256 = "08bgjpns90c36cdb6qbc24d41z1jg94mwsc91irpsmsvivxw1ksr";
+        url = "https://elpa.nongnu.org/nongnu/git-modes-1.5.0.tar";
+        sha256 = "0fxvv451pf8izn5q16ly21dxjax43l2p7qav11hi7qmygrrhxsc6";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2528,10 +2626,10 @@
     elpaBuild {
       pname = "gnuplot";
       ename = "gnuplot";
-      version = "0.11";
+      version = "0.12";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/gnuplot-0.11.tar";
-        sha256 = "10zjkf0ba7jaqx41csa815apx58s0b87svvmzzld3i3xf91sash7";
+        url = "https://elpa.nongnu.org/nongnu/gnuplot-0.12.tar";
+        sha256 = "13pbnlwg9z7yc8s1hr1fq031cl9swld2jgxdd74jra49vvh6a3ar";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2635,10 +2733,10 @@
     elpaBuild {
       pname = "gptel";
       ename = "gptel";
-      version = "0.9.9.4";
+      version = "0.9.9.5";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/gptel-0.9.9.4.tar";
-        sha256 = "0j410b0bynq91dxwakrrzp92m3p2lznzvmyq41viscjm0gjng4kn";
+        url = "https://elpa.nongnu.org/nongnu/gptel-0.9.9.5.tar";
+        sha256 = "1x1sd8g5fbgidj40ri9xg0rvyxdyjpxxnr45i0dj8d333nvssdq0";
       };
       packageRequires = [
         compat
@@ -2831,10 +2929,10 @@
     elpaBuild {
       pname = "helm";
       ename = "helm";
-      version = "4.0.6";
+      version = "4.0.7";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/helm-4.0.6.tar";
-        sha256 = "1nnkhffns1yj24slfln5rywqdw514jfklys3g5kmrl90i9apd5cp";
+        url = "https://elpa.nongnu.org/nongnu/helm-4.0.7.tar";
+        sha256 = "1x1wg3z6y5rb4r17ifwvz79pa3m6w9kkvxlfivznqh4ajgafrnn5";
       };
       packageRequires = [
         helm-core
@@ -2856,10 +2954,10 @@
     elpaBuild {
       pname = "helm-core";
       ename = "helm-core";
-      version = "4.0.6";
+      version = "4.0.7";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/helm-core-4.0.6.tar";
-        sha256 = "0b39k4wwl3sjw5c19g36a0lsxiascrqw23cf3hgksrpzp3amipbz";
+        url = "https://elpa.nongnu.org/nongnu/helm-core-4.0.7.tar";
+        sha256 = "1d7a61rbc7rlr144v9qm6c89dnchn7xwcv05gl6kdapb7gir9l8f";
       };
       packageRequires = [ async ];
       meta = {
@@ -3176,10 +3274,10 @@
     elpaBuild {
       pname = "isl";
       ename = "isl";
-      version = "1.6";
+      version = "1.7";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/isl-1.6.tar";
-        sha256 = "1bsqq3i7flpbihvcmvcwb1s3gabq6wslwpamcqhcf15j30znwhb1";
+        url = "https://elpa.nongnu.org/nongnu/isl-1.7.tar";
+        sha256 = "1nksczxv2bq6l8wg855a0ahzp1w3dhai4vwni8hyrp5fk2z0gcan";
       };
       packageRequires = [ ];
       meta = {
@@ -3348,6 +3446,7 @@
   keycast = callPackage (
     {
       compat,
+      cond-let,
       elpaBuild,
       fetchurl,
       lib,
@@ -3355,12 +3454,15 @@
     elpaBuild {
       pname = "keycast";
       ename = "keycast";
-      version = "1.4.7";
+      version = "1.4.8";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/keycast-1.4.7.tar";
-        sha256 = "0ipjn0b9jr6m7a88f76mz6j5na20hix94h8c5ghv705izjlqla0w";
+        url = "https://elpa.nongnu.org/nongnu/keycast-1.4.8.tar";
+        sha256 = "0rgaqc2d7n8a498n8jb14890gp6z49nqnpzk1h0xw03hnh8smz90";
       };
-      packageRequires = [ compat ];
+      packageRequires = [
+        compat
+        cond-let
+      ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu/keycast.html";
         license = lib.licenses.free;
@@ -3399,10 +3501,10 @@
     elpaBuild {
       pname = "lem";
       ename = "lem";
-      version = "0.24";
+      version = "0.25";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/lem-0.24.tar";
-        sha256 = "1ykyahpd7y43lf3vk3a0w9rjim4lsm35mlw1qqljbixci2izk797";
+        url = "https://elpa.nongnu.org/nongnu/lem-0.25.tar";
+        sha256 = "1hrnq46bmz10a3w89flhw85rqs58wpnywslx3p8g16196ln348sd";
       };
       packageRequires = [
         fedi
@@ -3424,10 +3526,10 @@
     elpaBuild {
       pname = "llama";
       ename = "llama";
-      version = "1.0.4";
+      version = "1.0.5";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/llama-1.0.4.tar";
-        sha256 = "0kxrbsck78f4r4npssywai2paf9mlyx59zpnfvmkgv50gphrwx7h";
+        url = "https://elpa.nongnu.org/nongnu/llama-1.0.5.tar";
+        sha256 = "10ysi2a7aifp9ixrhygfcas7zn9dfqy1zpiycwz3gamlzkvjzw2l";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3477,10 +3579,10 @@
     elpaBuild {
       pname = "loopy";
       ename = "loopy";
-      version = "0.15.0";
+      version = "0.16.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/loopy-0.15.0.tar";
-        sha256 = "18l1bml8xiji0mgmm6fb669iwyidg7pay231kv14kbv1agiwfkbp";
+        url = "https://elpa.nongnu.org/nongnu/loopy-0.16.0.tar";
+        sha256 = "0bav318gimpv42y0ww9c0gm90pkma3ri0xp9mfimz9yriw2bjzyv";
       };
       packageRequires = [
         compat
@@ -3686,10 +3788,10 @@
     elpaBuild {
       pname = "mastodon";
       ename = "mastodon";
-      version = "2.0.16";
+      version = "2.0.17";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/mastodon-2.0.16.tar";
-        sha256 = "0zyqqfxg7b22pj8y181x30rhy81ijbm21ai70l7cq79dr2a3yr96";
+        url = "https://elpa.nongnu.org/nongnu/mastodon-2.0.17.tar";
+        sha256 = "1yg1fylz1dp7my8zfnscnvd1sdhjhi45xw10sqn3rmqmmrwd87d9";
       };
       packageRequires = [
         persist
@@ -4237,10 +4339,10 @@
     elpaBuild {
       pname = "orgit";
       ename = "orgit";
-      version = "2.1.2";
+      version = "2.1.3";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/orgit-2.1.2.tar";
-        sha256 = "10cc70538mq89ypwcb22x4797qa38z60mw0h67xdf2zisdiw5c6z";
+        url = "https://elpa.nongnu.org/nongnu/orgit-2.1.3.tar";
+        sha256 = "1brwy6jx7jxb8jlkr8jq8hsdzmizqs41hkb3p14rmqqd0m5ddapl";
       };
       packageRequires = [
         compat
@@ -4486,10 +4588,10 @@
     elpaBuild {
       pname = "pg";
       ename = "pg";
-      version = "0.65";
+      version = "0.67";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/pg-0.65.tar";
-        sha256 = "1gf93xsldhx105r5m03hiq3lzlzb3r5pjd3j99jl0gs3z8pmn8ic";
+        url = "https://elpa.nongnu.org/nongnu/pg-0.67.tar";
+        sha256 = "01q06yk011pn9pg9srilwy0k9nn8x5pl32k1mn9i54mbikf7ac5b";
       };
       packageRequires = [ peg ];
       meta = {
@@ -4910,10 +5012,10 @@
     elpaBuild {
       pname = "scad-mode";
       ename = "scad-mode";
-      version = "98.0";
+      version = "99.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/scad-mode-98.0.tar";
-        sha256 = "0ksiz8rxxykm2lnc2lil1qndpl0lxcw8fa9nlh420xva9m3s9sda";
+        url = "https://elpa.nongnu.org/nongnu/scad-mode-99.0.tar";
+        sha256 = "1wdb7ri2716r4m22asj370c3mnjchcsnxjwbw3m13rgvkj2ax6j4";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5044,6 +5146,28 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu/shellcop.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  simple-httpd = callPackage (
+    {
+      compat,
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "simple-httpd";
+      ename = "simple-httpd";
+      version = "1.6";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu/simple-httpd-1.6.tar";
+        sha256 = "08rkqid2c11dl0sm8795jzkiilj02kbq6xy56b3bh83pc09wfmay";
+      };
+      packageRequires = [ compat ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu/simple-httpd.html";
         license = lib.licenses.free;
       };
     }
@@ -5269,10 +5393,10 @@
     elpaBuild {
       pname = "subed";
       ename = "subed";
-      version = "1.4.2";
+      version = "1.5.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/subed-1.4.2.tar";
-        sha256 = "0crpgxqk164z602iajhx7b0zxdjs5f9g8hv0q6n1vjrsby87pl1x";
+        url = "https://elpa.nongnu.org/nongnu/subed-1.5.1.tar";
+        sha256 = "0gk9r2dvmrxpz4gpypnnzjgph6xasn5f9i51cx1hnd9r5zim2qy3";
       };
       packageRequires = [ ];
       meta = {
@@ -5308,17 +5432,16 @@
       elpaBuild,
       fetchurl,
       lib,
-      seq,
     }:
     elpaBuild {
       pname = "swift-mode";
       ename = "swift-mode";
-      version = "9.4.0";
+      version = "10.0.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/swift-mode-9.4.0.tar";
-        sha256 = "0zfwzz5n98svv1if9wwj37hraiw2in06ks7n3mnk1jjik54kmpxd";
+        url = "https://elpa.nongnu.org/nongnu/swift-mode-10.0.0.tar";
+        sha256 = "07wydsy8ihfmr1i4hya270f9v5dy9mfn6kzbmyj3kf9kx5grhybl";
       };
-      packageRequires = [ seq ];
+      packageRequires = [ ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu/swift-mode.html";
         license = lib.licenses.free;
@@ -5576,10 +5699,10 @@
     elpaBuild {
       pname = "tp";
       ename = "tp";
-      version = "0.8";
+      version = "0.9";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/tp-0.8.tar";
-        sha256 = "1psa4sdia1vx3l2v1lklc8wy8nqbq6g83fyj46xii20rfm4db9hk";
+        url = "https://elpa.nongnu.org/nongnu/tp-0.9.tar";
+        sha256 = "0xaqynvw65l5dm3hxba6v8jrh2pvn6b2q0npsf9sdwryjg2zlk41";
       };
       packageRequires = [ transient ];
       meta = {
@@ -5872,10 +5995,10 @@
     elpaBuild {
       pname = "web-mode";
       ename = "web-mode";
-      version = "17.3.23";
+      version = "17.3.24";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/web-mode-17.3.23.tar";
-        sha256 = "17l0lda5p8nf239b0x43w8fx9a87rmk9rk282983nqi4f57iyzb2";
+        url = "https://elpa.nongnu.org/nongnu/web-mode-17.3.24.tar";
+        sha256 = "129hz6h2ygmqhn3bbjxx2gpdnvh0gifc4xaipsjz0716rj1s0k81";
       };
       packageRequires = [ ];
       meta = {
@@ -5976,6 +6099,7 @@
   with-editor = callPackage (
     {
       compat,
+      cond-let,
       elpaBuild,
       fetchurl,
       lib,
@@ -5983,12 +6107,15 @@
     elpaBuild {
       pname = "with-editor";
       ename = "with-editor";
-      version = "3.4.9";
+      version = "3.5.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/with-editor-3.4.9.tar";
-        sha256 = "0bzwxy67x8yvs1qv2m5mzkcssk9r3dm1zvq2map6kpscqgc15gq8";
+        url = "https://elpa.nongnu.org/nongnu/with-editor-3.5.1.tar";
+        sha256 = "0p19n8kx9gkj87pr8rlac8b9vlrb57w7k5b62fx9dwx2m54dixh9";
       };
-      packageRequires = [ compat ];
+      packageRequires = [
+        compat
+        cond-let
+      ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu/with-editor.html";
         license = lib.licenses.free;
@@ -6200,10 +6327,10 @@
     elpaBuild {
       pname = "zenburn-theme";
       ename = "zenburn-theme";
-      version = "2.9.0";
+      version = "2.10.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/zenburn-theme-2.9.0.tar";
-        sha256 = "0nldp5id0lkajnqpzw8agmpdjm0jfb70ma2wip06nh5zqcrrpg6s";
+        url = "https://elpa.nongnu.org/nongnu/zenburn-theme-2.10.0.tar";
+        sha256 = "0h1qd1xay2ci51y3vdq480afbx6hq40ywplsh76m85mr199pf751";
       };
       packageRequires = [ ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -19702,8 +19702,8 @@
   "repo": "armindarvish/consult-gh",
   "unstable": {
    "version": [
-    20260623,
-    1820
+    20260625,
+    257
    ],
    "deps": [
     "consult",
@@ -19711,8 +19711,8 @@
     "ox-gfm",
     "yaml"
    ],
-   "commit": "7b0fba0dc81a446c95cd39fa2a6adcd39501df9d",
-   "sha256": "18bmk52z2fx23mnbg8c8cv78fp68l958j2zkhk7wxcip7zzjnr7q"
+   "commit": "7042619362cd47314d3d0f706fa9cac5bf07950c",
+   "sha256": "0xa7z2zhz44i2fhgiag3a96jkhz71z294qfnphqjxw96cqcq3mb7"
   },
   "stable": {
    "version": [

--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -1599,20 +1599,20 @@
   "repo": "xenodium/acp.el",
   "unstable": {
    "version": [
-    20260325,
-    1158
+    20260527,
+    2132
    ],
-   "commit": "c32fbf8df34ed0095853a8cf55dc783e68b67d90",
-   "sha256": "0hr1176sy8xrx6wkqadmvwdjm1sv7aq8ddrw8h3ha6sn74glx8ws"
+   "commit": "3ddfa907eb7f17949a4a8e731ea5c5241e6cbcb4",
+   "sha256": "0c9bsj9qz0v788m18bqr71a13jmby61d18dvmnzgl14a8gb5rpl4"
   },
   "stable": {
    "version": [
     0,
-    11,
-    3
+    12,
+    2
    ],
-   "commit": "c32fbf8df34ed0095853a8cf55dc783e68b67d90",
-   "sha256": "0hr1176sy8xrx6wkqadmvwdjm1sv7aq8ddrw8h3ha6sn74glx8ws"
+   "commit": "c8ee1d7f70105fba8efa964ca63f38ca94a1e759",
+   "sha256": "1zxns3y4wgfq7mndyvia3yhmc1qzlk9f7rw3khlyl1sxr0rnim42"
   }
  },
  {
@@ -1728,11 +1728,11 @@
   "repo": "brownts/ada-ts-mode",
   "unstable": {
    "version": [
-    20251125,
-    2018
+    20260603,
+    1308
    ],
-   "commit": "52e0fd11604ab1d51a34c89e05692446d9dc5ecb",
-   "sha256": "064lbyywnlcgjfz86bwhk13waqsc651jrnpf9liqc55r8i97igxi"
+   "commit": "95f64aec514891039d04d0158df798bec152894a",
+   "sha256": "1dj1sdlhg5wyp6q01w7n6qkj9fkcnxmpgb18hch6b9myyjdgxvgk"
   },
   "stable": {
    "version": [
@@ -1883,20 +1883,20 @@
   "repo": "bbatsov/adoc-mode",
   "unstable": {
    "version": [
-    20260221,
-    2207
+    20260612,
+    638
    ],
-   "commit": "50b601dd92f99dd9534ff44de5f411480ca32b09",
-   "sha256": "1sgmhsvr0kbkv86zgp82r5bs3wpn4sn7mm15fdn7mv3dsjkngssv"
+   "commit": "5c1484b8982845845ccd0be02629e21f1d5bed81",
+   "sha256": "174930vgjf35ix2q3ra40zb9n2r1x7ynnb2h8p7dp37x31v38lhv"
   },
   "stable": {
    "version": [
     0,
-    8,
+    9,
     0
    ],
-   "commit": "6fc5ebc9478de17b1971222485e7729f04fbcf57",
-   "sha256": "0hjhjg9kdx849qbdhzryfv8c21h2xq02991hixykmxf1b2xv1y69"
+   "commit": "ba362d87d5970fa2c3287d46950063b2b686179c",
+   "sha256": "1d0r3nffpxzvshg72xp951fk4g8dyy7ynp6xvz65fbnsnw1sm7g7"
   }
  },
  {
@@ -1969,25 +1969,25 @@
   "repo": "minad/affe",
   "unstable": {
    "version": [
-    20260322,
-    19
+    20260519,
+    1026
    ],
    "deps": [
     "consult"
    ],
-   "commit": "6e06b8efcd5b57160ba267e42cbf3b982a4b89a1",
-   "sha256": "1bm3fcmr8kspd09qzvxfklblapm1p3z7p9div651450pbwn0ccnx"
+   "commit": "ccc6e4dc3dc7c87bdd4733d174274f4710f9e99e",
+   "sha256": "07f3z5cp98nlmxbii8fnsq9p87v4j29pydadzic2kzckzp5rcymw"
   },
   "stable": {
    "version": [
     0,
-    9
+    10
    ],
    "deps": [
     "consult"
    ],
-   "commit": "a1607fbc66789408128e12c9224b6a6c51d12bcb",
-   "sha256": "166v7d120hbk6vczj1iam85xivk6wwpvga8m0vxgcii19issh5b3"
+   "commit": "ccc6e4dc3dc7c87bdd4733d174274f4710f9e99e",
+   "sha256": "07f3z5cp98nlmxbii8fnsq9p87v4j29pydadzic2kzckzp5rcymw"
   }
  },
  {
@@ -2152,14 +2152,14 @@
   "repo": "Marx-A00/agent-recall",
   "unstable": {
    "version": [
-    20260420,
-    1713
+    20260515,
+    1821
    ],
    "deps": [
     "agent-shell"
    ],
-   "commit": "a90c86c53e65f95fd19c67587ba7d904b939db3d",
-   "sha256": "15p23fvf6mc461j5rl4jzhhq2lkznfllhrcd9pagzzqwp0mjy8l1"
+   "commit": "89436ed83a7a77a424627479ff486ca97a009f4a",
+   "sha256": "06v7rd7m0pszjs9g23djbxv679vnijy367ja3mhcaz8013504jir"
   }
  },
  {
@@ -2170,28 +2170,28 @@
   "repo": "xenodium/agent-shell",
   "unstable": {
    "version": [
-    20260423,
-    2254
+    20260621,
+    1300
    ],
    "deps": [
     "acp",
     "shell-maker"
    ],
-   "commit": "21a8c8b4e735cf3f35ac857b4857817971432265",
-   "sha256": "0f8ds25x4fl1195jm4jn13wx791zn76my26f9xnxfslmiam6f36a"
+   "commit": "131b9bec01588488c353de1f2510dc1bd68fa850",
+   "sha256": "15mp9r4yx4amanzrbbqblkxg7wriqg4kkb09w0x8a43ssi401fc0"
   },
   "stable": {
    "version": [
     0,
-    50,
+    56,
     1
    ],
    "deps": [
     "acp",
     "shell-maker"
    ],
-   "commit": "68b8c394a4838fb54f7dbfc70cee38e7310f03a3",
-   "sha256": "0njajpz51pbz4hqaq7lcvwaypilq1c9sdxsk6sdxgk1xpivqlxfb"
+   "commit": "6b3799cac0e3a224fc7486970bfbc46b78fde8b7",
+   "sha256": "15pw3hsz8abxgbzmg0r7nycmzx4fxx771alw4cyzx0zr0hfk7r53"
   }
  },
  {
@@ -2244,16 +2244,16 @@
   "repo": "halvin/agitjo",
   "unstable": {
    "version": [
-    20260415,
-    1451
+    20260523,
+    2048
    ],
    "deps": [
     "magit",
     "markdown-mode",
     "transient"
    ],
-   "commit": "47f20e04ed09724b0859cade3cb52eae31274c13",
-   "sha256": "046fcrhm0fhnq2fygbswbcyl21davbjirjl9mq7cdx5cl5x4kg5q"
+   "commit": "fa9737479f44c62f76e2dc6561ffb340d8eead3e",
+   "sha256": "07hf538qbj2anb3007i7vafmbb87szs5n4cimpmh2g97j2vzxwah"
   },
   "stable": {
    "version": [
@@ -2365,33 +2365,33 @@
  },
  {
   "ename": "ai-code",
-  "commit": "3751d27902c40d37f780bc8304d9a54fb23cc929",
-  "sha256": "1ans15163afvmh3l6mn1j8h5sbkivxqmf9v9wcbgs33xrnl6xc85",
+  "commit": "091b5d894f5a30a31790d1d834f14e2405955a3c",
+  "sha256": "039bx5s9pwjrf6cfbaiq10vx7jrgg8z05xyvv8i5p7pqmc3c06vn",
   "fetcher": "github",
   "repo": "tninja/ai-code-interface.el",
   "unstable": {
    "version": [
-    20260423,
-    1511
+    20260624,
+    320
    ],
    "deps": [
     "magit",
     "transient"
    ],
-   "commit": "bb725e376479d0c6ac50f47fd89b7f8972db2465",
-   "sha256": "0lzxd2v7v5fysna2ywh8zks5s51kf2naqw9mp3mcmbx482n5sv86"
+   "commit": "911a0631a1bc0a56080780715b749f0423ac8a08",
+   "sha256": "0zg3ilabsxmhgqpms9cq40yml5fmdq5ghabvrcls4inzv47991y2"
   },
   "stable": {
    "version": [
     1,
-    74
+    86
    ],
    "deps": [
     "magit",
     "transient"
    ],
-   "commit": "e44a49ef51ab795538cb39238c9290c0ac2783c9",
-   "sha256": "1ra6r227d5b7g0rynb8a3ngb9cpa3zjjjrbvb778bkc3h1fr6mz6"
+   "commit": "8f4ac59dfc33f9907335b5b223739662a376ddf9",
+   "sha256": "0amq0b6fv80kbjv2pcisjzm17g458ivy25w0r3iii0pijr9qbnaf"
   }
  },
  {
@@ -2438,29 +2438,29 @@
   "repo": "MatthewZMD/aidermacs",
   "unstable": {
    "version": [
-    20251203,
-    2318
+    20260521,
+    1930
    ],
    "deps": [
     "compat",
     "markdown-mode",
     "transient"
    ],
-   "commit": "6d0c41d1cfd24821fb32933edf8c0c2a9bb8c847",
-   "sha256": "0mwh2ikw3kkbphm2f8grgygmib51azwisp5s7nljb17aq7ncdk3h"
+   "commit": "9772db3e1969eec1df6a53b7d3e5597d07e3337f",
+   "sha256": "0q1ya7952cl8i2xr54idp9s76zlz6n9xmdklsfymd611l3pvchfj"
   },
   "stable": {
    "version": [
     1,
-    6
+    7
    ],
    "deps": [
     "compat",
     "markdown-mode",
     "transient"
    ],
-   "commit": "9cd6796833b7f830b55d2e3dcc6ef05693bed61b",
-   "sha256": "0fbhigzba5mj9303bvwn999dain916zqc59hvl2gk7v2i5gr1wmb"
+   "commit": "9772db3e1969eec1df6a53b7d3e5597d07e3337f",
+   "sha256": "0q1ya7952cl8i2xr54idp9s76zlz6n9xmdklsfymd611l3pvchfj"
   }
  },
  {
@@ -2609,15 +2609,15 @@
   "repo": "alan-platform/AlanForEmacs",
   "unstable": {
    "version": [
-    20260209,
-    1113
+    20260523,
+    1330
    ],
    "deps": [
     "flycheck",
     "s"
    ],
-   "commit": "87eed317ea7eac483a33680fd230ffc9f0eb3297",
-   "sha256": "1ky2znrnmsjl9vahlbkcrmab6cbjf5j7ja3iixb2wir3d712fifv"
+   "commit": "10d7a0a51451e9b023ac3dc0b24fdba9d81ecb2c",
+   "sha256": "11413241wr0sa913nvilkn5b0x70b22xhpr0gwn6c6f4qhzpw49c"
   },
   "stable": {
    "version": [
@@ -2748,14 +2748,14 @@
   "repo": "cpitclaudel/alectryon",
   "unstable": {
    "version": [
-    20260406,
-    2342
+    20260525,
+    2000
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "86bac4eae28c2d6f27859a4ca8821a374e8b1c4f",
-   "sha256": "1gfsrr9w2xj0synd9i0xzrrva7k6ngdf53j4aidh66wg75iihws1"
+   "commit": "bf99e72c54579460769984ba668e46c235ad18d8",
+   "sha256": "0nnzxhp3y98ay9sykig8v5fh468ysdn98dka3mb3wj4l3kwwf7qj"
   },
   "stable": {
    "version": [
@@ -3091,15 +3091,15 @@
   "repo": "mohkale/all-the-icons-nerd-fonts",
   "unstable": {
    "version": [
-    20240210,
-    1127
+    20260614,
+    1246
    ],
    "deps": [
     "all-the-icons",
     "nerd-icons"
    ],
-   "commit": "67a9cc9de2d2d4516cbfb752879b1355234cb42a",
-   "sha256": "00klvdalj8051axxg50dq4wdbzzrfr7ayzq8a6zzpnbhzlq7j2f6"
+   "commit": "4583cf5e8cce73c35e8ec3195915ce693d703bb1",
+   "sha256": "0lc770zw5v3k97mi39ppkgag3p9i49wwxrmycw1n9264xpjvqcjk"
   }
  },
  {
@@ -3283,11 +3283,11 @@
   "repo": "jordonbiondo/ample-theme",
   "unstable": {
    "version": [
-    20240426,
-    1545
+    20260611,
+    1532
    ],
-   "commit": "39ac29cf9a1229bb076964335fbd71cfb52e498b",
-   "sha256": "1s2k1r3wwvwa3rkfsyg5y9386fl0v4qzlqriwldblpq5glyg40qq"
+   "commit": "6952b29a588c854084ca1360bed16c9bc2d48e37",
+   "sha256": "1jxlfqbgjwc4s5y8b7v3qhpqgx5klq5hfkxlqn9gygg2plc726xy"
   }
  },
  {
@@ -3596,28 +3596,28 @@
   "repo": "kickingvegas/anju",
   "unstable": {
    "version": [
-    20260424,
-    156
+    20260624,
+    510
    ],
    "deps": [
     "casual",
     "markdown-mode"
    ],
-   "commit": "7a700608e9143f8e29a533bdeee9a6f175df6d06",
-   "sha256": "1gfwd0j1bwnggj0sjw1kcwx462qcvxjg1px2vfzmsh41zbxlv02x"
+   "commit": "eb3889778f212a69fbe40acbc4d208c0e0c9ee2c",
+   "sha256": "0l6xw9i1cis2wxp6ncj8w2v685cqqs3p0mpdplwvfar1q9gl63hn"
   },
   "stable": {
    "version": [
     1,
-    2,
+    7,
     0
    ],
    "deps": [
     "casual",
     "markdown-mode"
    ],
-   "commit": "7a700608e9143f8e29a533bdeee9a6f175df6d06",
-   "sha256": "1gfwd0j1bwnggj0sjw1kcwx462qcvxjg1px2vfzmsh41zbxlv02x"
+   "commit": "eb3889778f212a69fbe40acbc4d208c0e0c9ee2c",
+   "sha256": "0l6xw9i1cis2wxp6ncj8w2v685cqqs3p0mpdplwvfar1q9gl63hn"
   }
  },
  {
@@ -3643,11 +3643,11 @@
   "repo": "anki-editor/anki-editor",
   "unstable": {
    "version": [
-    20260317,
-    715
+    20260605,
+    551
    ],
-   "commit": "982a9d141fe87b1378f6695c3804e30446cbeac2",
-   "sha256": "14bcsx9f0lcbmw709qgjb20yrqdc0dfkbv7dgq7qva0j86z0gkih"
+   "commit": "7089c15f3151e0318e3d7d801f6b87eeeb25d226",
+   "sha256": "0mmnk8dnliad97jw25ck2h61v8065qjgxl3sm1k0l60x5knwl6n3"
   }
  },
  {
@@ -3728,14 +3728,14 @@
   "repo": "noctuid/annalist.el",
   "unstable": {
    "version": [
-    20240501,
-    1201
+    20260531,
+    1558
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "e1ef5dad75fa502d761f70d9ddf1aeb1c423f41d",
-   "sha256": "1di8wknirx3ql9bqp940yy5p07n2x82wgqyvfmdxblagh7pcp8a8"
+   "commit": "0d958732b710a8e9edc4c70b2318570e1c7d4923",
+   "sha256": "062rxrs0hcd9zgjpb7bnyrlkvmsh66mp7lixfjal8v71fbvd8j77"
   },
   "stable": {
    "version": [
@@ -3758,11 +3758,11 @@
   "repo": "bastibe/annotate.el",
   "unstable": {
    "version": [
-    20251111,
-    1635
+    20260514,
+    1320
    ],
-   "commit": "9c80b465297dce20901abaf0389a48951b6e030f",
-   "sha256": "04d8737kjqavg8j062wf6z1fd7k8l25bcc7h82fgg9w485c953qk"
+   "commit": "347525024f319ab50735ef324e8900aecda3724c",
+   "sha256": "0b6mzkfk4wabhrriwya8gzly5sp5nvc80p491fw0ib8p3cg39504"
   },
   "stable": {
    "version": [
@@ -3879,28 +3879,28 @@
   "repo": "emacs-ansible/emacs-ansible",
   "unstable": {
    "version": [
-    20250613,
-    2354
+    20260607,
+    1852
    ],
    "deps": [
     "f",
     "s"
    ],
-   "commit": "7385222a4f209eca6d72d412c03da99097e2755f",
-   "sha256": "0b5rrkxygxhnixbwhv5gsz3d216l2j6ljbvipdyysmvzv4fxmgwj"
+   "commit": "0d7bc93ad963677880d99c846a30ea6e6ed9eec5",
+   "sha256": "04zr6vswxnh3jqf180lv32s4f6bap8913fym2d2gnmjv7nb6wb3i"
   },
   "stable": {
    "version": [
     0,
     4,
-    2
+    3
    ],
    "deps": [
     "f",
     "s"
    ],
-   "commit": "7385222a4f209eca6d72d412c03da99097e2755f",
-   "sha256": "0b5rrkxygxhnixbwhv5gsz3d216l2j6ljbvipdyysmvzv4fxmgwj"
+   "commit": "0d7bc93ad963677880d99c846a30ea6e6ed9eec5",
+   "sha256": "04zr6vswxnh3jqf180lv32s4f6bap8913fym2d2gnmjv7nb6wb3i"
   }
  },
  {
@@ -4176,20 +4176,20 @@
   "repo": "radian-software/apheleia",
   "unstable": {
    "version": [
-    20260422,
-    253
+    20260619,
+    1935
    ],
-   "commit": "1720200b1271a9e70ebfc86c0f942ff02aefcdd1",
-   "sha256": "19wwb71v7jpwhrk3y1pn39sb0knizfg1vrgscflgvcgk3qc8l3kr"
+   "commit": "14a0bb4454fb2cc3b5b377619288b742ce117da5",
+   "sha256": "0yp74vmwiav15igwcmgjngzylixw11ayrhyj3wg97w07sqxivlcr"
   },
   "stable": {
    "version": [
     4,
-    4,
-    3
+    5,
+    0
    ],
-   "commit": "2bc2bb4cc2caad111e6f2f1b9daf20ec388101ff",
-   "sha256": "1vs532hjkwj19laigqvvk11r0gwhv5vd8v6wh5598dzmfw3yh4bm"
+   "commit": "b5d120a419816f9d6b3d0e45f0951dd3d6a10b77",
+   "sha256": "181whpb774gv3k2xxswxkjhd3075r2dpgvdfmpsjqyl2s1jpn5fj"
   }
  },
  {
@@ -4267,11 +4267,26 @@
   "repo": "apparmor/apparmor-mode",
   "unstable": {
    "version": [
-    20260311,
-    140
+    20260515,
+    454
    ],
-   "commit": "fd9c6f142602bf5ed730305419b2b7cad2269e57",
-   "sha256": "1xw2v51m7x68xx36z41qqxy1vwd3aszfz4qkx8bhdic7n7xqv9xy"
+   "commit": "b0e4bbcd30aafd71f484c74164351af40ef885bf",
+   "sha256": "04kz786xwmsv8w879c9nwspgv0dgfkqmrg2frplhvyizdi0cfinl"
+  }
+ },
+ {
+  "ename": "apple-container-tramp",
+  "commit": "497d8e93d2e3faaa2bf6c63548bf43c5f6862f5b",
+  "sha256": "0kzx8dvrv36nppvw3l5zqfzri1clql2wr0x7513cp43k9971f70f",
+  "fetcher": "github",
+  "repo": "major1201/apple-container-tramp.el",
+  "unstable": {
+   "version": [
+    20260504,
+    1350
+   ],
+   "commit": "f47d58d029c594f4c9e9b1cfff79630de68a9cb5",
+   "sha256": "0545qhdnwdm3cqxa25mkll8qkr818za1wmp8vmnqbs0q9qckyf61"
   }
  },
  {
@@ -4680,20 +4695,20 @@
   "repo": "bbatsov/asciidoc-mode",
   "unstable": {
    "version": [
-    20260222,
-    1804
+    20260612,
+    645
    ],
-   "commit": "4b5e89bedc0453e63147e08cdd759cbf2e31be26",
-   "sha256": "0gn8lcx2j6yrgh0wggnb6hjs5x1hwhvbc6g2f7vk42hsgz5skng4"
+   "commit": "8914fad451f9c7f9c2286cf18db5edaa51a92cd7",
+   "sha256": "07mmc2xg0dyrxsas5xqvfa3bmscww240707l5kf0l1k18dbxa06f"
   },
   "stable": {
    "version": [
     0,
-    1,
+    4,
     0
    ],
-   "commit": "4b5e89bedc0453e63147e08cdd759cbf2e31be26",
-   "sha256": "0gn8lcx2j6yrgh0wggnb6hjs5x1hwhvbc6g2f7vk42hsgz5skng4"
+   "commit": "aa836bb0aa25427914ef3a938ed218aedd9123d9",
+   "sha256": "07imzld1j3jkr2p327ha1h1qikzw8jn3hxqzin9rs4m8av5fn38g"
   }
  },
  {
@@ -4835,20 +4850,20 @@
   "repo": "SunskyXH/ast-grep.el",
   "unstable": {
    "version": [
-    20250703,
-    723
+    20260615,
+    1001
    ],
-   "commit": "3682f0cab0147e85d3f8ffc6b68b1dc30ffba5cd",
-   "sha256": "01hcdqd4wccpynhfjgbvcm7rn343qkbfh61p2bkmsll29ias3lcs"
+   "commit": "8fabb5064131a1c822580e47bf35871466d469ff",
+   "sha256": "1r0i49vjrr9x86kn656l0dbbj40snvgq5k91w249cnq8xh2khh5m"
   },
   "stable": {
    "version": [
     0,
-    1,
-    2
+    4,
+    1
    ],
-   "commit": "cb9e9c453abaf7852dda84707152e52ad7f9e910",
-   "sha256": "08akfj0g27qy7a2l6p5rssinh5l2rgambzx95ggpdzg1rbzxw8yd"
+   "commit": "8fabb5064131a1c822580e47bf35871466d469ff",
+   "sha256": "1r0i49vjrr9x86kn656l0dbbj40snvgq5k91w249cnq8xh2khh5m"
   }
  },
  {
@@ -5403,27 +5418,25 @@
   "repo": "alezost/aurel",
   "unstable": {
    "version": [
-    20170114,
-    937
+    20260429,
+    458
    ],
    "deps": [
-    "bui",
-    "dash"
+    "bui"
    ],
-   "commit": "fc7ad208f43f8525f84a18941c9b55f956df8961",
-   "sha256": "0mcbw8p4wrnnr39wzkfz9kc899w0k1jb00q1926mchf202cmnz94"
+   "commit": "c571cc44ea3b9aa96399056bff22919efffbbb06",
+   "sha256": "1h2x0424s9ia6wb4yd3rsq9xn90fzbydhqlqikgrf4mk1ab7pnl3"
   },
   "stable": {
    "version": [
     0,
-    9
+    10
    ],
    "deps": [
-    "bui",
-    "dash"
+    "bui"
    ],
-   "commit": "fc7ad208f43f8525f84a18941c9b55f956df8961",
-   "sha256": "0mcbw8p4wrnnr39wzkfz9kc899w0k1jb00q1926mchf202cmnz94"
+   "commit": "c571cc44ea3b9aa96399056bff22919efffbbb06",
+   "sha256": "1h2x0424s9ia6wb4yd3rsq9xn90fzbydhqlqikgrf4mk1ab7pnl3"
   }
  },
  {
@@ -5619,26 +5632,26 @@
  },
  {
   "ename": "auto-compile",
-  "commit": "57a2fb9524df3fdfdc54c403112e12bd70888b23",
-  "sha256": "08k9wqk4yysps8n5n50v7lpadwsnm553pv9p7m242fwbgbsgz6nf",
+  "commit": "aec4a76eaea31408bd27d76a0b8cea5268663cc1",
+  "sha256": "0d7l6vc1vp0kg1rlh7nl6bf9w08sw67wci1q16br0g584bwh8cjz",
   "fetcher": "github",
   "repo": "emacscollective/auto-compile",
   "unstable": {
    "version": [
-    20260301,
-    1252
+    20260601,
+    1449
    ],
-   "commit": "cc51aea86617cab6cb1ef76672a343f2bf3206c1",
-   "sha256": "0pccv3jgl6grfl1rh0yspdcg2kfap0sn24gj5ps5vz6mqli85221"
+   "commit": "4db3a0e497feecc8b3dbeeefacdf363ae60a6392",
+   "sha256": "1kcmr2jb79qg6jx8pfw2yxgsiwx3hwgwglbjwamr8hv9swj5jdl1"
   },
   "stable": {
    "version": [
     2,
     1,
-    3
+    4
    ],
-   "commit": "cc51aea86617cab6cb1ef76672a343f2bf3206c1",
-   "sha256": "0pccv3jgl6grfl1rh0yspdcg2kfap0sn24gj5ps5vz6mqli85221"
+   "commit": "4db3a0e497feecc8b3dbeeefacdf363ae60a6392",
+   "sha256": "1kcmr2jb79qg6jx8pfw2yxgsiwx3hwgwglbjwamr8hv9swj5jdl1"
   }
  },
  {
@@ -6091,14 +6104,14 @@
   "repo": "rranelli/auto-package-update.el",
   "unstable": {
    "version": [
-    20211108,
-    2025
+    20260601,
+    1804
    ],
    "deps": [
     "dash"
    ],
-   "commit": "ad95435fefe2bb501d1d787b08272f9c1b7df488",
-   "sha256": "00456kxd1zb5lcwkm211mhdgkl0b01pp4fbkl1ryvdnhddn83ipv"
+   "commit": "e966c6c95de1742d867250dc15b1c6bd570b6ea5",
+   "sha256": "06ndbwk6agzzymdw1zk1j12xa2cc8q2118bv482sjhvlm8asv7bj"
   },
   "stable": {
    "version": [
@@ -6136,14 +6149,14 @@
   "repo": "zonuexe/auto-read-only.el",
   "unstable": {
    "version": [
-    20200827,
-    1754
+    20260521,
+    1659
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "db209bf5b7f76f4c3dc4d0892fc6a24430779f29",
-   "sha256": "0zb8n97x5ji9clyls7k5pj7pq3yms82b6wgkww6djcabb26b5xb4"
+   "commit": "206d4559762fe6ef9e91de8f9dc43e1e41c0f42c",
+   "sha256": "1vgi84yvpbvmsaydwhpzc5vwcj62lwijw91wpw4182gqfzbva9pf"
   }
  },
  {
@@ -6540,14 +6553,14 @@
   "repo": "jasonm23/autothemer",
   "unstable": {
    "version": [
-    20251114,
-    415
+    20260530,
+    2349
    ],
    "deps": [
     "dash"
    ],
-   "commit": "e62bf83414abd8b1cefafb7480612faa30ed7878",
-   "sha256": "0w7qrfl38qc64a6bansrmvzxcdrlfpkd4l41scgr242dgy4dnq45"
+   "commit": "99fd9b45ef6cc931fcf030b1a6c050ca3c17ce04",
+   "sha256": "1cw9j6vfkppzrcaxacb9hjnxwcds6nx1xwgyvhb9wv79pnigr7z6"
   },
   "stable": {
    "version": [
@@ -6839,15 +6852,14 @@
   "repo": "zkry/awqat",
   "unstable": {
    "version": [
-    20250727,
-    1902
+    20260613,
+    2054
    ],
    "deps": [
-    "alert",
-    "s"
+    "alert"
    ],
-   "commit": "52754b230c5796eb9c8aaeda87083855c4235f32",
-   "sha256": "1r2q2amn3qry6k7z1wyyfmabb6kq5ggr8068apwpb1vc4jgc5prn"
+   "commit": "0ef8501dc31774cbc6b17f8b899609a45c1fe0c7",
+   "sha256": "03jm1hpl9mymbb1kfnf8a7kqd4j5zp18p35jff3642zh4bgwycy9"
   }
  },
  {
@@ -7069,28 +7081,28 @@
   "repo": "tarsius/backline",
   "unstable": {
    "version": [
-    20260101,
-    1825
+    20260601,
+    1450
    ],
    "deps": [
     "compat",
     "outline-minor-faces"
    ],
-   "commit": "ba263f5ea3dc1818c7a61b50acec52fe2cce02ca",
-   "sha256": "02wk8qhy1ns1dfbgid7z77hjiywmx5ngv3bvli5h5js1zkj9fcr9"
+   "commit": "cc6e54e40bdbb725cdaf0cc95cef8cd48dce413f",
+   "sha256": "1jnxp817jc5b38xmfp67n17fyzib06fg5waly6zalnmcrsqdm2cq"
   },
   "stable": {
    "version": [
     1,
     2,
-    2
+    3
    ],
    "deps": [
     "compat",
     "outline-minor-faces"
    ],
-   "commit": "ba263f5ea3dc1818c7a61b50acec52fe2cce02ca",
-   "sha256": "02wk8qhy1ns1dfbgid7z77hjiywmx5ngv3bvli5h5js1zkj9fcr9"
+   "commit": "cc6e54e40bdbb725cdaf0cc95cef8cd48dce413f",
+   "sha256": "1jnxp817jc5b38xmfp67n17fyzib06fg5waly6zalnmcrsqdm2cq"
   }
  },
  {
@@ -7334,11 +7346,11 @@
   "repo": "tinted-theming/base16-emacs",
   "unstable": {
    "version": [
-    20260419,
-    235
+    20260621,
+    406
    ],
-   "commit": "8461432c62353f302b79bf0b2db2f99b83183dbe",
-   "sha256": "1n36k7fax231x07n82licps5kvm682nz1adr93ly7np5434m0926"
+   "commit": "93b118e5ae7477361d1120db32508cb9756eb145",
+   "sha256": "1lmzfm2yscq1f4xrf47vabaf6r8svc6hrwdn2166zfj42sf3zx2h"
   },
   "stable": {
    "version": [
@@ -7505,11 +7517,11 @@
   "repo": "bbatsov/batppuccin-emacs",
   "unstable": {
    "version": [
-    20260421,
-    1706
+    20260520,
+    1150
    ],
-   "commit": "4e9c240c332e745d58cf47ad900fdeefb01f707a",
-   "sha256": "0xlhiybbnxgjgiqh88h9fp8q5gdkgwrjir2pm3afqmrhhzr3d933"
+   "commit": "16a6f902cd2d9e25019b4c17a7ee41025f99b93d",
+   "sha256": "1raxr8rnfq1f1z936bl20y2yjcf7r6hh003br8y9g986gwgs0rz1"
   },
   "stable": {
    "version": [
@@ -7992,15 +8004,28 @@
   "repo": "pastor/ben.el",
   "unstable": {
    "version": [
-    20260424,
-    826
+    20260617,
+    1102
    ],
    "deps": [
     "inheritenv",
     "seq"
    ],
-   "commit": "139dcfef116e376138abddc7cc179cbe68f457fd",
-   "sha256": "0mscx327acxv74c54lnb0xzsqnkbzrkrwngw6qkrkbqsllbyagwc"
+   "commit": "259f76f83efb03220e60bd799fb17fc49bddcda0",
+   "sha256": "12qliyhk9ni10ks2hrwv74dhwakqb0jkvhip44qcfcrnhjvyacka"
+  },
+  "stable": {
+   "version": [
+    0,
+    12,
+    12
+   ],
+   "deps": [
+    "inheritenv",
+    "seq"
+   ],
+   "commit": "c91cce703deb0cafb9f344cbc66d63791665fcb2",
+   "sha256": "05ls9sdydwnz2sifakk1jww68dkv0pinj25mpqw4j11kh48s7cm7"
   }
  },
  {
@@ -8133,11 +8158,11 @@
   "repo": "technomancy/better-defaults",
   "unstable": {
    "version": [
-    20251012,
-    2227
+    20260621,
+    1647
    ],
-   "commit": "b4e566ddd368609c7df711c4f0d9cc345455aa0f",
-   "sha256": "1jn2cp2hj62yl3ari0q7jdjw0cmnwzidd9xd1d2w3xwc998j8har"
+   "commit": "faf5c664472d01d978442b5e567470a51f9566c2",
+   "sha256": "02shdak3cy53qswbzyq6zzm1s26fwrwjf9mdzjmkfq5ddmdim1qz"
   }
  },
  {
@@ -8274,20 +8299,20 @@
   "repo": "kristjoc/bible-gateway",
   "unstable": {
    "version": [
-    20260404,
-    2018
+    20260601,
+    825
    ],
-   "commit": "dcae05a4a3bae4d07cb6d7144f54d14651c56f61",
-   "sha256": "1lnrl70qzx5c9j08gisyd1mzxm86wz6s2vimsk0c08z7kn58yhdb"
+   "commit": "2df8d0500aa842fbb60109e863a70c705dfe998d",
+   "sha256": "1d8wxk169gpv5h24fwav2532njl6hgl39pxk14rvljkw72bi6h9p"
   },
   "stable": {
    "version": [
     1,
     6,
-    4
+    7
    ],
-   "commit": "fdca45e4f84c7743b4a57c3318114fa987fafb95",
-   "sha256": "1lbfig3sz9n5lhw29p1q3c2rl4b1y9q47lgf3wpwca4hmdlz0zgk"
+   "commit": "2df8d0500aa842fbb60109e863a70c705dfe998d",
+   "sha256": "1d8wxk169gpv5h24fwav2532njl6hgl39pxk14rvljkw72bi6h9p"
   }
  },
  {
@@ -8449,9 +8474,9 @@
  },
  {
   "ename": "bibtex-capf",
-  "commit": "a400d5b255b8aba48aa32fe0a503df476053e4eb",
-  "sha256": "1014wj9wa8jv3vp9ddwqj205s37br7msfklv33ppwi14salqq9y5",
-  "fetcher": "github",
+  "commit": "bbf2574e8c8be0f19149e4971ae6f1f2e7bd2b54",
+  "sha256": "07s0hnvyb4pc0awf9v78clgl9hhbvn8r2pn44nrllh5y6vxsr5s1",
+  "fetcher": "codeberg",
   "repo": "mclear-tools/bibtex-capf",
   "unstable": {
    "version": [
@@ -8528,26 +8553,26 @@
   "repo": "tarsius/bicycle",
   "unstable": {
    "version": [
-    20260101,
-    1825
+    20260601,
+    1451
    ],
    "deps": [
     "compat"
    ],
-   "commit": "9da65dcb0e8ea6a9fe2b02d3be3cd4f2f4e29977",
-   "sha256": "113aj4mc3dz199826sy69nja9qys3637947alq3mv185gbaz4gdd"
+   "commit": "b8919e56e7f20e4164002e9b4dba0268779b5645",
+   "sha256": "1mw1826lfvqibg0gxwa39mbas4d3m83xix3pgmscvpphidpnl61h"
   },
   "stable": {
    "version": [
     1,
     1,
-    2
+    3
    ],
    "deps": [
     "compat"
    ],
-   "commit": "9da65dcb0e8ea6a9fe2b02d3be3cd4f2f4e29977",
-   "sha256": "113aj4mc3dz199826sy69nja9qys3637947alq3mv185gbaz4gdd"
+   "commit": "b8919e56e7f20e4164002e9b4dba0268779b5645",
+   "sha256": "1mw1826lfvqibg0gxwa39mbas4d3m83xix3pgmscvpphidpnl61h"
   }
  },
  {
@@ -8809,8 +8834,8 @@
   "repo": "SqrtMinusOne/biome",
   "unstable": {
    "version": [
-    20250623,
-    1954
+    20260607,
+    1500
    ],
    "deps": [
     "compat",
@@ -8818,8 +8843,8 @@
     "request",
     "transient"
    ],
-   "commit": "b26c0a6ec533ba5c3524721af224708de9362979",
-   "sha256": "0fsh21fgrqw0mlh1kwn7idk0sdah5yxlwwcz8f847pj0w1n4rvxg"
+   "commit": "77a94f3c5210b80b63d5002c4780e542cd98a65f",
+   "sha256": "1n2am7gf28nlz7pxb02x5nvy0911x0z61az9vasl9i47ff9yzch4"
   }
  },
  {
@@ -8895,22 +8920,22 @@
  },
  {
   "ename": "bitbake",
-  "commit": "da099b66180ed537f8962ab4ca727d2441f9691d",
-  "sha256": "1k2n1i8g0jc78sp1icm64rlhi1q0vqar2a889nldp134a1l7bfah",
+  "commit": "a5308691e59a7803320af6792a92546d004317af",
+  "sha256": "0xqpgg5b5ahqilvfc71sva0can04cbr5l9h3mgg1l44csmvgz4wb",
   "fetcher": "github",
-  "repo": "canatella/bitbake-el",
+  "repo": "danielcmccarthy/bitbake-el",
   "unstable": {
    "version": [
-    20251230,
-    1237
+    20260620,
+    217
    ],
    "deps": [
     "dash",
     "mmm-mode",
     "s"
    ],
-   "commit": "44513a330d3bb2bceb1bfd99b4eb63b37f681369",
-   "sha256": "0zbbxgi87594aikvc89fq66sky9xp1kfmif74jbdkyfjjkydkzz0"
+   "commit": "683f6e9fa1d15447eeef0415b88bd116180463d3",
+   "sha256": "0dpjsknphrwjc6hqrdfgdv18nz7dcbx6vksiibdc0jmxr0bzk558"
   }
  },
  {
@@ -9312,14 +9337,48 @@
   "repo": "lapislazuli/blue.el",
   "unstable": {
    "version": [
-    20260422,
-    644
+    20260620,
+    951
    ],
    "deps": [
     "magit-section"
    ],
-   "commit": "16c7092e7483cf7b29511374bbc8c80a1359b6b9",
-   "sha256": "1f0glcg6y081wqgidakn56bdy6cx87fxw4zhdxc4l0vcsr98rc7m"
+   "commit": "ca78d0ee1f7ff9e08b46ec2e90b69a8fbd05a9ab",
+   "sha256": "1sn54gijg5x9vwjn8y0vl9d7f8ig6rink6s2fibcv11har2gazps"
+  }
+ },
+ {
+  "ename": "bluesky",
+  "commit": "100e7d9b24c01f98456197ad904983c6758219ff",
+  "sha256": "07mhiqyv7mxv7hplsykmfnqpblgyhr63g6crrgl5fn7sl9fd3ysn",
+  "fetcher": "github",
+  "repo": "ahyatt/emacs-bluesky",
+  "unstable": {
+   "version": [
+    20260618,
+    147
+   ],
+   "deps": [
+    "futur",
+    "plz",
+    "vui"
+   ],
+   "commit": "b4b7957a3af0533918535486f44afcb808d38d24",
+   "sha256": "1vrbspbn58b90fx6vvwnndlvzp05znvsr0gyz3akk7p9s8a0svvn"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    3
+   ],
+   "deps": [
+    "futur",
+    "plz",
+    "vui"
+   ],
+   "commit": "f88486f57bde983f24d1cad04525039ca5d37344",
+   "sha256": "1frmgg7zy1a2mc620v2rr0hr3m2m88521if40v2imysf9lp429ny"
   }
  },
  {
@@ -9330,11 +9389,11 @@
   "repo": "rwv/bluesound-el",
   "unstable": {
    "version": [
-    20251022,
-    1406
+    20260616,
+    831
    ],
-   "commit": "60d7f422483bd7f3cf23983160e28ecff9c14b38",
-   "sha256": "1bg2y0ny4yszs03hj7aiq8mm57zbind5i0pk17bms12sl2ahkm82"
+   "commit": "3a99edc4232d41a9cd13b846c7a4f27036256d29",
+   "sha256": "0jrch7sbry41r630yxwvcqzzi1w6nszr615xmx4v2dly70w3khj0"
   },
   "stable": {
    "version": [
@@ -9722,28 +9781,28 @@
   "repo": "emacscollective/borg",
   "unstable": {
    "version": [
-    20260422,
-    1711
+    20260602,
+    2342
    ],
    "deps": [
     "epkg",
     "magit"
    ],
-   "commit": "5aa950cf07c3f16528232a81dcedd792f74c0471",
-   "sha256": "1ygv5hvbr9ygkdab4mqc94f6z7h10yfbllxv8v48wfx902ys4wjs"
+   "commit": "04fc19ef58fc23965d582721cf22691e1bd91cfd",
+   "sha256": "0c98shqd1ns0ggjzkd19rgbxnzssl5iw7w1hfx28a7pzdm96rkjj"
   },
   "stable": {
    "version": [
     4,
-    4,
-    3
+    5,
+    1
    ],
    "deps": [
     "epkg",
     "magit"
    ],
-   "commit": "8d0e26e6c16c1e503785b3e6b62a9a6d55b4e472",
-   "sha256": "094ykn4niknciqy71v74ry70imj6xri6wrm477yavwanzdr4b2rc"
+   "commit": "8269db64810cc2ff574d27311648ce3da35181f2",
+   "sha256": "0m4kzyd5vwgypykliq64530qrqq6acap0igh1dgi2q0cf35vmf33"
   }
  },
  {
@@ -9754,11 +9813,11 @@
   "repo": "fourier/borland-blue-theme",
   "unstable": {
    "version": [
-    20160117,
-    1321
+    20260620,
+    1425
    ],
-   "commit": "db74eefebbc89d3c62575f8f50b319e87b4a3470",
-   "sha256": "0yzfxxv2bw4x320268bixfc7yf97851804bz3829vbdhnr4kp6y5"
+   "commit": "c24ef5aa16fed6727696b0ea71bf154889e4ee0a",
+   "sha256": "1hwyyv20xkb4ygqfk0nyp2z59bmxxiycnca6yi9iifq7cwwiq7yi"
   }
  },
  {
@@ -9890,17 +9949,26 @@
  },
  {
   "ename": "bracket-face",
-  "commit": "890e94376ea0b6ada2c49a0a3e11b2a59aab7caa",
-  "sha256": "1j9iczccp494yqviqawphhndzyz6hsd21fqvsj7cd20balgz2g3g",
+  "commit": "fefa3d4feab1be45b0169c31781a1e995d0963ae",
+  "sha256": "1wj0mmn8wz7srm2rzh1hj2wd3szhnbrrj7xj77n94r3cmzffaaq7",
   "fetcher": "github",
   "repo": "tarsius/paren-face",
   "unstable": {
    "version": [
-    20260101,
-    1846
+    20260601,
+    1519
    ],
-   "commit": "2c279a236404b2eebacb435aa92d5e9c97939c03",
-   "sha256": "06ypi3hgrr9rigcb9gy5j4l9f3z7lnz1rssv1pqda55srkvcp39x"
+   "commit": "57307b5ea75e07d2dc0c64c7e3eeadee3369a7aa",
+   "sha256": "11g3wg79kvg4nkm2knabpzsf0lcpnak94kkdb5cscp3w3fg3x5a7"
+  },
+  "stable": {
+   "version": [
+    1,
+    2,
+    4
+   ],
+   "commit": "57307b5ea75e07d2dc0c64c7e3eeadee3369a7aa",
+   "sha256": "11g3wg79kvg4nkm2knabpzsf0lcpnak94kkdb5cscp3w3fg3x5a7"
   }
  },
  {
@@ -10115,20 +10183,20 @@
   "repo": "browse-kill-ring/browse-kill-ring",
   "unstable": {
    "version": [
-    20251208,
-    1041
+    20260503,
+    1620
    ],
-   "commit": "26ea5759c996e782abadc61b85c5f9324d1d1dae",
-   "sha256": "1wr0adcbb6l9ma5lnjq37w0f7m7w7vw77f7jvm53x3vw0cpz3mmv"
+   "commit": "39d65a830b93530c9bd68a7dc14353cbffd1d01f",
+   "sha256": "01v64b8p0nzqczv3sjd6qacdh6lm635w5hndqk76ydxz5nga89n5"
   },
   "stable": {
    "version": [
     2,
-    0,
+    1,
     0
    ],
-   "commit": "2a7acf98c348c4f405a6b2ab216224ca14915be8",
-   "sha256": "0y9m6cv70pzcm0v2v8nwmyh1xx40831chx72m85h5ic5db03gy7b"
+   "commit": "1fa2c611f80ccdadfe766e3e7f4272b0f5d1dd28",
+   "sha256": "0xm857gs7xj5z9l8zfkdh87j3r6kszj1jwzzx4w0wafr69dnyjwc"
   }
  },
  {
@@ -10169,11 +10237,11 @@
   "repo": "agzam/browser-hist.el",
   "unstable": {
    "version": [
-    20250501,
-    1450
+    20260425,
+    1930
    ],
-   "commit": "1cd80081feaab99fef9e8eadd55d68b3cef90144",
-   "sha256": "12jarw5sca6r171lzba727xbii6xjlv432j8frgkph4r0k0946id"
+   "commit": "aab0a364077bfbf5559085086545d30bbaf7ac5e",
+   "sha256": "04xmn00pvnzralw4y8j3ilf7lprv5h01kmasyxnnr99ndphs8q62"
   }
  },
  {
@@ -10318,14 +10386,14 @@
   "repo": "astoff/buffer-env",
   "unstable": {
    "version": [
-    20250516,
-    1223
+    20260604,
+    645
    ],
    "deps": [
     "compat"
    ],
-   "commit": "fc5cab4db55f0b95c4b97fbe3104e394da34b91a",
-   "sha256": "0a30li0s06qviz44cdnbw1mh0kxlap9zzwa2cfdd79xj8aj5r3z4"
+   "commit": "81968582b2dbfd5171b57206b44a4bb8fc31cc69",
+   "sha256": "1bfc9yxirwm2z5q58w3v9lr6sb4v4yivirmmpk56qw6zxk9c7jbj"
   }
  },
  {
@@ -10362,20 +10430,20 @@
   "repo": "jamescherti/buffer-guardian.el",
   "unstable": {
    "version": [
-    20260316,
-    1912
+    20260604,
+    226
    ],
-   "commit": "0bffb2bf0ab5b54e1dd61b773cb453f8dff33636",
-   "sha256": "1xp8hhys1x278dskwzfrc5f92jzzjhq2csnndjhy1n3fxqi3gabi"
+   "commit": "44a692448659e529a9b6d5a1b36b40a66601376f",
+   "sha256": "16lb8f38qgf8rnh9k9ik00g6qrilv1dx91qpsia94kld85ympwqn"
   },
   "stable": {
    "version": [
     1,
     0,
-    0
+    1
    ],
-   "commit": "0bffb2bf0ab5b54e1dd61b773cb453f8dff33636",
-   "sha256": "1xp8hhys1x278dskwzfrc5f92jzzjhq2csnndjhy1n3fxqi3gabi"
+   "commit": "44a692448659e529a9b6d5a1b36b40a66601376f",
+   "sha256": "16lb8f38qgf8rnh9k9ik00g6qrilv1dx91qpsia94kld85ympwqn"
   }
  },
  {
@@ -10386,15 +10454,15 @@
   "repo": "plandes/buffer-manage",
   "unstable": {
    "version": [
-    20241019,
-    1748
+    20260615,
+    1909
    ],
    "deps": [
     "choice-program",
     "dash"
    ],
-   "commit": "3d338b1e64f256ccb70adf81de4c04bcda7eb8d8",
-   "sha256": "122nwyakicv72jxwrrjcg5j2arlhqqzlislfsy48920jjz47ngk0"
+   "commit": "3063b6efb9eb9e5efa27098ddb25bc12205c362f",
+   "sha256": "0hiy2smidfjhm7kibjaaz73k6pdjfysszpd94j2p79d20h8h5wjf"
   },
   "stable": {
    "version": [
@@ -10518,20 +10586,20 @@
   "repo": "jamescherti/buffer-terminator.el",
   "unstable": {
    "version": [
-    20260404,
-    1551
+    20260607,
+    157
    ],
-   "commit": "19ff0cc0096ceed961e2a4ea95124cd3a38ce966",
-   "sha256": "1y9398p87sl2gxkg1qyk0vam7s9rja2vx3zgzrliipc26s4rvx75"
+   "commit": "0f31cbbb1a8368f08b486525f419dc3d059f05df",
+   "sha256": "0m7l6a6dmjaxq76g2kxnx2g9ayp3h2r8v9liz8djskdllaxkxvyd"
   },
   "stable": {
    "version": [
     1,
     2,
-    4
+    5
    ],
-   "commit": "f4f3733863e90dcf90e2d6b3cdbdf67d036f37ad",
-   "sha256": "08cyrvz9bnf3s1b99zamyi77jvlcy7fq8wkj962bk19ykwqf3dbn"
+   "commit": "0f31cbbb1a8368f08b486525f419dc3d059f05df",
+   "sha256": "0m7l6a6dmjaxq76g2kxnx2g9ayp3h2r8v9liz8djskdllaxkxvyd"
   }
  },
  {
@@ -10635,20 +10703,20 @@
   "repo": "jamescherti/bufferfile.el",
   "unstable": {
    "version": [
-    20260401,
-    233
+    20260619,
+    1542
    ],
-   "commit": "05b893762ede97f59923684868a4ba26e82c4f75",
-   "sha256": "1py13x9bdmxjs1j1awplqpvvq6gd7c7b8vxxvm1n0lvpggb2sgqh"
+   "commit": "11e610d799ba4ec4355630fb0651d3cf8de9ee31",
+   "sha256": "0bfz1lp661785hl36z6vk6137rw9l52l9l3sibhh3yrzs9ykf48f"
   },
   "stable": {
    "version": [
     1,
     0,
-    6
+    7
    ],
-   "commit": "5a78bf05443d60d651aaadcb8855d84b39bab182",
-   "sha256": "157hs1wigczs7l674j3aml7hlng806kafdryix939v9xrv58z8lx"
+   "commit": "55dbc57268c18e8965a020c6bbdad3be6c7e019c",
+   "sha256": "0xwbigjn1i01qsn49kpvp01hf4k9bhgy3fv9mmqs2n1pxf42d2l3"
   }
  },
  {
@@ -10745,26 +10813,19 @@
   "repo": "alezost/bui.el",
   "unstable": {
    "version": [
-    20210108,
-    1141
+    20260502,
+    730
    ],
-   "deps": [
-    "dash"
-   ],
-   "commit": "ab62fcefc3c7ddf5e5d64c18045148a3c297592d",
-   "sha256": "1vcfrm776y108kibkiabdzq0rbgqx0wwx6hqm2r87bbsfqxhbbrz"
+   "commit": "4319e1bf3ff94ff0568eed280ac1f980a4b68679",
+   "sha256": "1645v8h2szhmy2ahzf6f2izc834k00gpik5qmmpdysw50p90d3n3"
   },
   "stable": {
    "version": [
     1,
-    2,
-    1
+    3
    ],
-   "deps": [
-    "dash"
-   ],
-   "commit": "9162c24b75799857d54838d961c60776ffcd657e",
-   "sha256": "0sszdl4kvqbihdh8d7mybpp0d8yw2p3gyiipjcxz9xhvvmw3ww4x"
+   "commit": "5be69e47d5fa4e48a6c8f75d6b85f4c32a31398c",
+   "sha256": "1dwmx7fmfg6jcwplk2pds56vvcy425plhfzajm52i5ysi2qka6p1"
   }
  },
  {
@@ -10975,11 +11036,11 @@
   "repo": "jorgenschaefer/emacs-buttercup",
   "unstable": {
    "version": [
-    20260411,
-    2019
+    20260512,
+    2141
    ],
-   "commit": "57d03004cc730678bcdefb91ad294824975cfea4",
-   "sha256": "1b55cfh4wr40max2c42crvaa6wid7a83g28yximsin98i32q5f5r"
+   "commit": "39c8e762408a166a5afa03b8e79dd8d1a0de5caa",
+   "sha256": "1k5x12mn8xp4wyalxwjc86zl96ai3f62ia06mfavkkzm7s90smlg"
   },
   "stable": {
    "version": [
@@ -11214,11 +11275,11 @@
   "repo": "Michael-Garibaldi/cacao-theme",
   "unstable": {
    "version": [
-    20251104,
-    2135
+    20260519,
+    1959
    ],
-   "commit": "72c1cff056fcfbada298d32811b14988dff1cf6d",
-   "sha256": "1xx5zqppl91bj9flrphr215i62z7zw3lcq2iar0l452q5jqxyygd"
+   "commit": "73d8f81b7c9d2957cf7201d89a7a81bb673af03f",
+   "sha256": "0k6kgx2lxikirp5isqc5jk9fmkdlphsdmvrsww5r4gnp45wjcd85"
   }
  },
  {
@@ -11552,14 +11613,14 @@
   "repo": "kiwanami/emacs-calfw",
   "unstable": {
    "version": [
-    20251030,
-    845
+    20260426,
+    925
    ],
    "deps": [
     "calfw"
    ],
-   "commit": "57be107b20625c13ed010cb0f70a603a61d47629",
-   "sha256": "0hr55mwqk8h2hx2lwdlwrwq2hjwrxvjjbnwzzv4rr0ywqpxf6g5r"
+   "commit": "24fa167af96a6e677aea7c6b9385f669b550ee2f",
+   "sha256": "1i4ww2r26xr1f8nh1fssh679h0j08h3r3mqkynxaxvjc3bz794s6"
   },
   "stable": {
    "version": [
@@ -11686,20 +11747,20 @@
   "repo": "kickingvegas/calle24",
   "unstable": {
    "version": [
-    20260326,
-    1749
+    20260506,
+    2210
    ],
-   "commit": "1ebc385496a600ee492df4abd55cbf7b899145d5",
-   "sha256": "06cbdpysya1kkh3g0cjih5k88al30xc8jcr2arslmdn4zn50ifcm"
+   "commit": "24d6240209b46c5005121d14cba3fae0e0ff257f",
+   "sha256": "18scb447smgg9lmpvk3mymh85k9yb230kc30a4c0ksbr692ppfx8"
   },
   "stable": {
    "version": [
     1,
     1,
-    3
+    4
    ],
-   "commit": "1ebc385496a600ee492df4abd55cbf7b899145d5",
-   "sha256": "06cbdpysya1kkh3g0cjih5k88al30xc8jcr2arslmdn4zn50ifcm"
+   "commit": "24d6240209b46c5005121d14cba3fae0e0ff257f",
+   "sha256": "18scb447smgg9lmpvk3mymh85k9yb230kc30a4c0ksbr692ppfx8"
   }
  },
  {
@@ -11813,25 +11874,25 @@
   "repo": "minad/cape",
   "unstable": {
    "version": [
-    20260419,
-    1847
+    20260519,
+    1021
    ],
    "deps": [
     "compat"
    ],
-   "commit": "2e15e1909754752f66096dde1b8d639d6eb25f35",
-   "sha256": "0lhjavwiyp5vd9i6xcr1g4mcb53fxmqyq0yx5f5sp00mcp6y3kg5"
+   "commit": "c99911b08831c26179145686b4beffa96f1f8a68",
+   "sha256": "1qnqn27jay3gffqj5vm1bfsd8qaqx7jixja2y2i9f0r7hlh399ny"
   },
   "stable": {
    "version": [
     2,
-    6
+    7
    ],
    "deps": [
     "compat"
    ],
-   "commit": "2b2a5c5bef16eddcce507d9b5804e5a0cc9481ae",
-   "sha256": "18pdm8dlvzjry7xxx3yyka7rmrx94cvwkhwiagxcfprk6yinx21z"
+   "commit": "c99911b08831c26179145686b4beffa96f1f8a68",
+   "sha256": "1qnqn27jay3gffqj5vm1bfsd8qaqx7jixja2y2i9f0r7hlh399ny"
   }
  },
  {
@@ -12141,28 +12202,28 @@
   "repo": "kickingvegas/casual",
   "unstable": {
    "version": [
-    20260416,
-    126
+    20260609,
+    1642
    ],
    "deps": [
     "csv-mode",
     "transient"
    ],
-   "commit": "6a3fbb40d3369614f36d9a37035942fa57572c5b",
-   "sha256": "06i7zv7x8cs87qjpvsjqg2bi68pyw2j0z9pnzbsjj81pafmm2xdy"
+   "commit": "f2977bc97e0e80f5b6ea817f016e739e4f64b6e1",
+   "sha256": "0fi15hgqjxjz1z6jxsm9lwssl97zaa1ds1hhsnsihhij0hs95vny"
   },
   "stable": {
    "version": [
     2,
     16,
-    0
+    2
    ],
    "deps": [
     "csv-mode",
     "transient"
    ],
-   "commit": "6a3fbb40d3369614f36d9a37035942fa57572c5b",
-   "sha256": "06i7zv7x8cs87qjpvsjqg2bi68pyw2j0z9pnzbsjj81pafmm2xdy"
+   "commit": "f2977bc97e0e80f5b6ea817f016e739e4f64b6e1",
+   "sha256": "0fi15hgqjxjz1z6jxsm9lwssl97zaa1ds1hhsnsihhij0hs95vny"
   }
  },
  {
@@ -12408,15 +12469,15 @@
   "repo": "emacs-lsp/emacs-ccls",
   "unstable": {
    "version": [
-    20250825,
-    531
+    20260507,
+    1746
    ],
    "deps": [
     "dash",
     "lsp-mode"
    ],
-   "commit": "80981d751198b59a7960a5437cb42a4d9974f254",
-   "sha256": "02crd43hxk2b8pdwnihp3lchb1wbba0whj3jwhg4yzxn32zlgw1y"
+   "commit": "f728c92e33844f1da54cb47ecb4e44160f2042a8",
+   "sha256": "1mmz7dxj577lr8viyqpcjdqxla1jabm96fhdxvxw13qvfm0c2v2s"
   }
  },
  {
@@ -12784,7 +12845,7 @@
   "repo": "worr/cfn-mode",
   "unstable": {
    "version": [
-    20260419,
+    20260621,
     807
    ],
    "deps": [
@@ -12792,8 +12853,8 @@
     "s",
     "yaml-mode"
    ],
-   "commit": "2813707d1f2c98562fa873624abc79ce49db969c",
-   "sha256": "0kc3mb0q86wc9ajmdvb26wpd0fg4gllgg8s3pfb49w8qgz7z02ba"
+   "commit": "fb0b04fe6c6c46ad59f8691668339f53c6d9da57",
+   "sha256": "16czlly566h70x4dcv441ckj71rlgqky6chhxj55x6cmk3sdypf0"
   },
   "stable": {
    "version": [
@@ -13745,8 +13806,8 @@
   "repo": "clojure-emacs/cider",
   "unstable": {
    "version": [
-    20260417,
-    1318
+    20260624,
+    952
    ],
    "deps": [
     "clojure-mode",
@@ -13758,17 +13819,18 @@
     "spinner",
     "transient"
    ],
-   "commit": "b9e8a26197f5a2a6a8d1dfb21ef5eae6fe17e0b6",
-   "sha256": "11v3d5gl4p2iqfym9nxcdwyvyyzal9dkri6wwfd74w0cgkgrlw46"
+   "commit": "696334fdaedea14722ee95fc916018d62d10b7bc",
+   "sha256": "0myga7bg8yix1dy81yx5p5mf8gy2lc69d06jz7lw9y0bmavdg8w6"
   },
   "stable": {
    "version": [
     1,
-    21,
-    0
+    22,
+    2
    ],
    "deps": [
     "clojure-mode",
+    "compat",
     "parseedn",
     "queue",
     "seq",
@@ -13776,8 +13838,8 @@
     "spinner",
     "transient"
    ],
-   "commit": "c71bc65af7709667b0cc77306f4e3d5befe86d27",
-   "sha256": "19wx9mc488qipm08s7hc0zrfmiylw577lmf3jpvqcjq7amx14jgc"
+   "commit": "7bba70a194fa6687274a85d17b6201201f732223",
+   "sha256": "0lfkh1q4nw3kzj3885ipkmzlnppv6nc1badzqw3p6i9cgaqjfq55"
   }
  },
  {
@@ -13980,14 +14042,14 @@
   "repo": "emacs-circe/circe",
   "unstable": {
    "version": [
-    20260315,
-    1435
+    20260525,
+    1114
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "f717332348e4b59499dbf60c56155d9f03cd9303",
-   "sha256": "01z41abbhp2plsa9qq28rx16mzflzr1vmy4b2h1fmw4qiqafs9r4"
+   "commit": "4bd1e964066fe8985d8112ed9172db3a1ecf58c8",
+   "sha256": "0gs270kpbr8a574y58bdh3jwz3ma4n2fz5r2zp2z2pflhf9vk9kg"
   },
   "stable": {
    "version": [
@@ -14371,11 +14433,11 @@
   "repo": "universal-ctags/citre",
   "unstable": {
    "version": [
-    20260220,
-    1324
+    20260530,
+    602
    ],
-   "commit": "72375aac87cb245b4f49a4737456f626091a0a42",
-   "sha256": "0gslc3xqdbwjyb0rci1877ihinp8zlvjgf7maxbbmdgjgqpdlmwh"
+   "commit": "be0d9c6dc9b1ac67d76fc7ed315f2369d5c3bde8",
+   "sha256": "1zgkbx9slm2kgcxjarvjxq01j00v6xggiixvsvxnacy7pqm23s66"
   },
   "stable": {
    "version": [
@@ -14510,6 +14572,30 @@
   }
  },
  {
+  "ename": "clatter",
+  "commit": "94c60de3a59fb002f2c1e8bbf7996079feba2d38",
+  "sha256": "1l99xvnbm6swrjid4rrv48g1skxa2an67sirnih4ijjfrxh82pg9",
+  "fetcher": "github",
+  "repo": "parenworks/clatter.el",
+  "unstable": {
+   "version": [
+    20260622,
+    343
+   ],
+   "commit": "8b1ae9949717da2491d4a0d869592a2c4d6ba2bf",
+   "sha256": "07c4izlp9xw1p3i8z0q367yr19rmn7jamcwpy32bjqb32r6g1apz"
+  },
+  "stable": {
+   "version": [
+    0,
+    4,
+    3
+   ],
+   "commit": "bf967054e9c81d9a1fe8bf00e53e4762e3141d93",
+   "sha256": "09azczifqhhxhh87s836mnjihjv59y71y0mwbal4r7dsjilai47k"
+  }
+ },
+ {
   "ename": "claude-code",
   "commit": "ad463328e858a1df77d95da55cfde40ccae31cc9",
   "sha256": "1q7q64ydp38kmg8sxj7rsgn528fw2jz0m1m5yzfvvvc9sbjzy4m1",
@@ -14517,8 +14603,8 @@
   "repo": "yuya373/claude-code-emacs",
   "unstable": {
    "version": [
-    20260227,
-    1055
+    20260526,
+    1329
    ],
    "deps": [
     "markdown-mode",
@@ -14526,13 +14612,13 @@
     "transient",
     "vterm"
    ],
-   "commit": "0c3019819ce870619d4425cebf7286e03e531c66",
-   "sha256": "08l8pg2v7gi25nvijbxfazqw9syqkkjbrqld3hz5h7w1nyiwp35q"
+   "commit": "4d460e2fa56e6919a9fc4f9b985592a983f9f724",
+   "sha256": "076xb0193bjav8g03l6sjlb4pgwhnkbvri69lj3lcn8mqj2swxcz"
   },
   "stable": {
    "version": [
     0,
-    8,
+    9,
     1
    ],
    "deps": [
@@ -14541,8 +14627,23 @@
     "transient",
     "vterm"
    ],
-   "commit": "0c3019819ce870619d4425cebf7286e03e531c66",
-   "sha256": "08l8pg2v7gi25nvijbxfazqw9syqkkjbrqld3hz5h7w1nyiwp35q"
+   "commit": "4d460e2fa56e6919a9fc4f9b985592a983f9f724",
+   "sha256": "076xb0193bjav8g03l6sjlb4pgwhnkbvri69lj3lcn8mqj2swxcz"
+  }
+ },
+ {
+  "ename": "claude-code-context",
+  "commit": "6082e33dbf835c4a86d13d15c8f17df0c392a19f",
+  "sha256": "0h8al6ifiag66pgcw51y0bq1f7favg00idx32pkwykkvhgj9dl4l",
+  "fetcher": "github",
+  "repo": "lukehoersten/claude-code-context",
+  "unstable": {
+   "version": [
+    20260503,
+    2210
+   ],
+   "commit": "1e9062b0bc5e0d4f3f9f98a349b6ed9c775360ca",
+   "sha256": "01m86vy5dv2i9phzhir9rm23gqpn9zymn5l2g4r3qpi2bkajwqfc"
   }
  },
  {
@@ -15032,24 +15133,6 @@
   }
  },
  {
-  "ename": "cljstyle-format",
-  "commit": "dbc850fd5711658cd4f04a5c796ec5062fb71469",
-  "sha256": "145p63r2arn3cpn3i6d7d5mvsj4030fpqn6aj9dyqyx5minmd0zq",
-  "fetcher": "github",
-  "repo": "dpassen/cljstyle-format",
-  "unstable": {
-   "version": [
-    20220706,
-    309
-   ],
-   "deps": [
-    "reformatter"
-   ],
-   "commit": "31a43dfbeea12bbd4639dcec4fbb043cc0ff86d3",
-   "sha256": "0gjyxbwmidl1g4ld88rfg2rgc3fjzanw189xj9v1psv0dpbgv4yx"
-  }
- },
- {
   "ename": "clmemo",
   "commit": "890ec47013f1638d3b12f2d08118bf64c104be2b",
   "sha256": "1gg2ny2jdz58qkpp2idvh727crrvwk3007zr9mxl4b9kz1xfxbnn",
@@ -15254,11 +15337,11 @@
   "repo": "clojure-emacs/clojure-mode",
   "unstable": {
    "version": [
-    20260325,
-    811
+    20260615,
+    1407
    ],
-   "commit": "9146525680b29a0c6b72a1126d075b54f8066710",
-   "sha256": "1nl51qmm50n2l4wmwbm35lhpjy3k56nji2ncb9iz67hlivncvb5h"
+   "commit": "762674d956a4e861f46711a00921b159f96792c0",
+   "sha256": "0h43a80w222409nsp1bvrl8jgcb3rghjp8f0z2gpn4yaq4k7qzdf"
   },
   "stable": {
    "version": [
@@ -15371,11 +15454,11 @@
   "repo": "clojure-emacs/clojure-ts-mode",
   "unstable": {
    "version": [
-    20260325,
-    2107
+    20260616,
+    1927
    ],
-   "commit": "ba6de87b0acb5aa5483f6012611b30f6bf0414f3",
-   "sha256": "0bqcw4ljvnks5ngbv6rr01c4v2chxr5g7f7h0y34cyklcrv50yyp"
+   "commit": "af00860cd85a46d7b95af1e4f966d3ddccdab9b4",
+   "sha256": "0fxl153gszq8clnqmhzp7lnki34zzfa788x3jh6wiw2nd0hidsvl"
   },
   "stable": {
    "version": [
@@ -15430,30 +15513,32 @@
   "repo": "magit/closql",
   "unstable": {
    "version": [
-    20260101,
-    1828
+    20260601,
+    1540
    ],
    "deps": [
     "compat",
     "cond-let",
-    "emacsql"
+    "emacsql",
+    "llama"
    ],
-   "commit": "947426d0c93e5ad5374c464b2f121c36cdaf2132",
-   "sha256": "08zxrzwpsixcc9ma7zps21krm0fn7l97aawhhacn2yf1mjja0p5s"
+   "commit": "d382e7427f5d375ffc872851b049e9f9c4a43dfc",
+   "sha256": "0jh5qkcxxmdql7jfizqfkiix6ikwli8qgk5z5k9sxn4kpniisvjk"
   },
   "stable": {
    "version": [
     2,
     4,
-    0
+    1
    ],
    "deps": [
     "compat",
     "cond-let",
-    "emacsql"
+    "emacsql",
+    "llama"
    ],
-   "commit": "947426d0c93e5ad5374c464b2f121c36cdaf2132",
-   "sha256": "08zxrzwpsixcc9ma7zps21krm0fn7l97aawhhacn2yf1mjja0p5s"
+   "commit": "d382e7427f5d375ffc872851b049e9f9c4a43dfc",
+   "sha256": "0jh5qkcxxmdql7jfizqfkiix6ikwli8qgk5z5k9sxn4kpniisvjk"
   }
  },
  {
@@ -15526,6 +15611,26 @@
   }
  },
  {
+  "ename": "clutch",
+  "commit": "08801af1c2c10c1cc6f456392680d05bc57398a7",
+  "sha256": "1637jb2ggxlaabla0w9yfbxvlda21yy5vayhvivhx7mwsnp02yik",
+  "fetcher": "github",
+  "repo": "LuciusChen/clutch",
+  "unstable": {
+   "version": [
+    20260611,
+    1401
+   ],
+   "deps": [
+    "mysql",
+    "pg",
+    "transient"
+   ],
+   "commit": "40a6f93e14a6742dbad59e383236e3be6ec0e9e5",
+   "sha256": "06sp1wlzkagvw949rg38pg40864fqkgxss02dxwxd0xymb25f4bl"
+  }
+ },
+ {
   "ename": "cm-mode",
   "commit": "42dda804ec0c7338c39c57eec6ba479609a38555",
   "sha256": "1rgfpxbnp8wiq9j8aywm2n07rxzkhqljigwynrkyvrnsgxlq2a9x",
@@ -15533,25 +15638,25 @@
   "repo": "joostkremers/criticmarkup-emacs",
   "unstable": {
    "version": [
-    20251229,
-    930
+    20260518,
+    1920
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "5c9fadbae23d5ba51b65a4620354621ee8c1907d",
-   "sha256": "1lg22rj7axrpay8r5gdpiffm9lz27pmkv86nmh72am2bb4094c1p"
+   "commit": "a5816175548a821bf62d374b40d6974e4956c44b",
+   "sha256": "1nxfjfwfmzf68rfhbmb3qk26g0z5pdgn5jwzzcqv43s6iz55dxgm"
   },
   "stable": {
    "version": [
     1,
-    9
+    10
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "5c2decacdd1a48c9e4ed2ce2289622aa5915ea24",
-   "sha256": "1lblkdp0xim22xc71xxgiwlvqrs500rirqz1in546d10ij445ygq"
+   "commit": "a5816175548a821bf62d374b40d6974e4956c44b",
+   "sha256": "1nxfjfwfmzf68rfhbmb3qk26g0z5pdgn5jwzzcqv43s6iz55dxgm"
   }
  },
  {
@@ -15626,20 +15731,20 @@
   "url": "https://gitlab.kitware.com/cmake/cmake.git",
   "unstable": {
    "version": [
-    20260421,
-    1337
+    20260617,
+    1353
    ],
-   "commit": "8d3c68cc0f36108f7ebb23ba7a6bc08b9b1d81e4",
-   "sha256": "15q1qgjsgqzirq6f59q6y402bhcw6q3pvmpdh8zs5va70a37p7j5"
+   "commit": "c2fd48014f39786ba5c5e51b983d1cdcf05aa269",
+   "sha256": "0hrx31ljc89ij1chrn47cgsc2n9jc6szf89ycafhq7pli765ak6x"
   },
   "stable": {
    "version": [
     4,
     3,
-    2
+    4
    ],
-   "commit": "8d3c68cc0f36108f7ebb23ba7a6bc08b9b1d81e4",
-   "sha256": "15q1qgjsgqzirq6f59q6y402bhcw6q3pvmpdh8zs5va70a37p7j5"
+   "commit": "c2fd48014f39786ba5c5e51b983d1cdcf05aa269",
+   "sha256": "0hrx31ljc89ij1chrn47cgsc2n9jc6szf89ycafhq7pli765ak6x"
   }
  },
  {
@@ -15755,10 +15860,10 @@
  },
  {
   "ename": "coc-dc",
-  "commit": "df9255e363e96363a7d976abd3276a3cb08dd601",
-  "sha256": "1zfd2pzgmisksq7jprwhrpx7x92fhjfk4camrjqhlkwmanlbql67",
+  "commit": "bb59486eac3592dde53412b52bdd49e7589887f9",
+  "sha256": "1d41ws61xlpbly5p0m9sxd2iqc8a56vjlx8m5p2vhhacyycgnawv",
   "fetcher": "github",
-  "repo": "S0mbr3/coc-damage-calculator",
+  "repo": "lejicore/coc-damage-calculator",
   "unstable": {
    "version": [
     20241104,
@@ -15827,8 +15932,8 @@
   "repo": "ag91/code-compass",
   "unstable": {
    "version": [
-    20250227,
-    1124
+    20260520,
+    1418
    ],
    "deps": [
     "async",
@@ -15836,8 +15941,8 @@
     "s",
     "simple-httpd"
    ],
-   "commit": "6b741978c83f0359c7e555ab78708eed6ced8486",
-   "sha256": "0g8bw01jpp488y95m14nbizq0acx9grqhk34g37lwn8imshl9hi6"
+   "commit": "f5b96ab2f0866ab3dcae170a9953d7eb0ef52dbf",
+   "sha256": "1fxg7hkgv9lmjjbakg2i7wfi4xdj7bm1wnnb8aav16zwx45vighw"
   }
  },
  {
@@ -16308,11 +16413,11 @@
   "repo": "purcell/color-theme-sanityinc-tomorrow",
   "unstable": {
    "version": [
-    20260211,
-    1131
+    20260619,
+    1157
    ],
-   "commit": "7aec77ed89402bebf0ed879848329ac336f44188",
-   "sha256": "04a0mvff2k9dg3flx953w1yfnwp345za7k8220zcwxmpi5rcnzz5"
+   "commit": "9ce4bc783acc4ebebed1b13427873cdffc1b7960",
+   "sha256": "1hmh25ib4lrc8ipp440c269w036rz4qvb30p1gs1d8zvlb4npbfm"
   },
   "stable": {
    "version": [
@@ -16495,14 +16600,14 @@
   "repo": "NicholasBHubbard/comint-histories",
   "unstable": {
    "version": [
-    20260330,
-    1650
+    20260608,
+    1833
    ],
    "deps": [
     "f"
    ],
-   "commit": "da9dddafa825a40cd1e25261bb088701c08a80d8",
-   "sha256": "0j64ia11p7jlxvkyvjn3bls03qpin2j5amg7liy7fzc17hpjx5iy"
+   "commit": "e13c5ac7f812bc6f7da57c4640600b97356bd02b",
+   "sha256": "0axi8nkywysvbw311b9gbjpk0zr0mwqb93rd485mzpq93di537kp"
   }
  },
  {
@@ -16810,11 +16915,14 @@
   "repo": "company-mode/company-mode",
   "unstable": {
    "version": [
-    20260331,
-    245
+    20260618,
+    1349
    ],
-   "commit": "59626254bbac187fc2b8d7a189aca90976ab36a8",
-   "sha256": "13dd87hcad91y5ay6gxrzkn98d5h90ib4k7nsfkzf955rdpxqvrr"
+   "deps": [
+    "posframe"
+   ],
+   "commit": "04fa1b9bfe150b1f8c76cea47c3a4af3f0e1b22e",
+   "sha256": "156vlp2a67dcn9cp3w8pgkjjmq51aw1w3w929wrhhvkq1kg0v20r"
   },
   "stable": {
    "version": [
@@ -16985,14 +17093,14 @@
   "repo": "randomphrase/company-c-headers",
   "unstable": {
    "version": [
-    20190825,
-    1631
+    20260511,
+    1117
    ],
    "deps": [
     "company"
    ],
-   "commit": "5e676ab0c2f287c868b1e3931afd4c78895910cd",
-   "sha256": "18zyzhjnlbwblgqgr876ynrc7k736lg5s6bgxmxph7gymdz4fb4h"
+   "commit": "986cef8c7aae821ae65b193ea15e7f4a7097821c",
+   "sha256": "1imsk4c5dpggi92pljzmv035i55pvmhs3a0xnjk6519g6j54yzzr"
   }
  },
  {
@@ -18732,20 +18840,20 @@
   "repo": "jamescherti/compile-angel.el",
   "unstable": {
    "version": [
-    20260421,
-    1222
+    20260604,
+    227
    ],
-   "commit": "e17764996ec7a0f74f0ad4399cfdd7e44e11d8ae",
-   "sha256": "054546x4d11mrva52kg8ja3ik13v6yii34pnv56ml5wkscpsq2v9"
+   "commit": "a75f4fe69abc0e8b15c739e3d07bc237a974e052",
+   "sha256": "1vzs2j9xwgxd54gm6j73dpxs5si77l3ywkf3g4af5hmrqpshb6c0"
   },
   "stable": {
    "version": [
     1,
     2,
-    0
+    1
    ],
-   "commit": "520e516fb794336ddaef4a4e7b02e3e9d60eda04",
-   "sha256": "18bhhsw8qfj4rx6fmvr3cp419pw5yn5lfvdwdi8dcczi8bf1f7dh"
+   "commit": "a75f4fe69abc0e8b15c739e3d07bc237a974e052",
+   "sha256": "1vzs2j9xwgxd54gm6j73dpxs5si77l3ywkf3g4af5hmrqpshb6c0"
   }
  },
  {
@@ -18779,14 +18887,14 @@
   "repo": "mohkale/compile-multi",
   "unstable": {
    "version": [
-    20250101,
-    2156
+    20251004,
+    2121
    ],
    "deps": [
     "all-the-icons-completion"
    ],
-   "commit": "19d16d8871b5f19f5625e1a66c1dc46a7c3f6a3a",
-   "sha256": "0zs7s8k5vf0wl3jh374p62vaak0l6p5xy525ys2nv7mghgbv5a53"
+   "commit": "2976058c416b19f9761d5b8cf596210803afd2d7",
+   "sha256": "01jhkygrddsrw0m3y6aa10vy4qjgigsszyl5z50hl8xglfc3pijm"
   },
   "stable": {
    "version": [
@@ -18839,14 +18947,14 @@
   "repo": "mohkale/compile-multi",
   "unstable": {
    "version": [
-    20250101,
-    2156
+    20251004,
+    2121
    ],
    "deps": [
     "nerd-icons-completion"
    ],
-   "commit": "19d16d8871b5f19f5625e1a66c1dc46a7c3f6a3a",
-   "sha256": "0zs7s8k5vf0wl3jh374p62vaak0l6p5xy525ys2nv7mghgbv5a53"
+   "commit": "2976058c416b19f9761d5b8cf596210803afd2d7",
+   "sha256": "01jhkygrddsrw0m3y6aa10vy4qjgigsszyl5z50hl8xglfc3pijm"
   },
   "stable": {
    "version": [
@@ -19029,20 +19137,20 @@
   "repo": "tarsius/cond-let",
   "unstable": {
    "version": [
-    20260201,
-    1500
+    20260601,
+    1457
    ],
-   "commit": "8bf87d45e169ebc091103b2aae325aece3aa804d",
-   "sha256": "08ay78mbypfs1nl31dsv4b7bixnsl5kp1xkg0jkk7fvbsfv22679"
+   "commit": "21b9e9835756ff5cd1acb971cf9eb56fff671c8b",
+   "sha256": "18507g86bz50as93cajx754nmg5y26djhmrj50ba88rm2rl8szlf"
   },
   "stable": {
    "version": [
-    0,
-    2,
+    1,
+    1,
     2
    ],
-   "commit": "8bf87d45e169ebc091103b2aae325aece3aa804d",
-   "sha256": "08ay78mbypfs1nl31dsv4b7bixnsl5kp1xkg0jkk7fvbsfv22679"
+   "commit": "21b9e9835756ff5cd1acb971cf9eb56fff671c8b",
+   "sha256": "18507g86bz50as93cajx754nmg5y26djhmrj50ba88rm2rl8szlf"
   }
  },
  {
@@ -19291,25 +19399,25 @@
   "repo": "minad/consult",
   "unstable": {
    "version": [
-    20260421,
-    1105
+    20260605,
+    1907
    ],
    "deps": [
     "compat"
    ],
-   "commit": "14131ab6247e1b4b0f28134fba5e92a4707dbc1d",
-   "sha256": "01bjr30ka1xljwk93yzfqvb210fyc6ln9jik9gi9cinp27hmaap7"
+   "commit": "9bb68cf3941eb618fff18bd7626164951c70eb8a",
+   "sha256": "02ain9sqvivhhy1fbxv7ayl6mshaiz484y2gcifvml1wjrnygwr2"
   },
   "stable": {
    "version": [
     3,
-    4
+    6
    ],
    "deps": [
     "compat"
    ],
-   "commit": "f8c2ef57e83af3d45e345e5c14089f2f9973682b",
-   "sha256": "0la70jnf14aqaa23ym5phamjay4l4fy3vmizplljli63q8jf89qk"
+   "commit": "9bb68cf3941eb618fff18bd7626164951c70eb8a",
+   "sha256": "02ain9sqvivhhy1fbxv7ayl6mshaiz484y2gcifvml1wjrnygwr2"
   }
  },
  {
@@ -19479,16 +19587,16 @@
   "repo": "mohkale/consult-eglot",
   "unstable": {
    "version": [
-    20250831,
-    924
+    20260613,
+    1443
    ],
    "deps": [
     "consult",
     "eglot",
     "project"
    ],
-   "commit": "d7296fef3f9c4280229df51f32fc0b5db2392c22",
-   "sha256": "1x5v82zrjqlckshy4sjpkwkj6mqqk6njiz00z68n1a8383f1jlik"
+   "commit": "3e4d9a40911b897c0a2c5d20199d0f7c30bfc1c2",
+   "sha256": "0rbsh5v836jdfwiy9p92f4wra33p4v6x4d77jmsys2sl92d57qx0"
   },
   "stable": {
    "version": [
@@ -19545,27 +19653,27 @@
   "repo": "minad/consult-flycheck",
   "unstable": {
    "version": [
-    20260322,
-    16
+    20260605,
+    1858
    ],
    "deps": [
     "consult",
     "flycheck"
    ],
-   "commit": "21c74a96e787606f8572453b17f6912c3755be42",
-   "sha256": "1sxkyxqkgxcysqyapjsylwanas419wz8y59q9prdld0sm57npjsa"
+   "commit": "9dd95361669f87e14230376f4f93c6b9a222c497",
+   "sha256": "1n8n9wd4rn3x8kqyrlimb1hhm3nwgh7vawg7hjy63mfmvcfgrlqk"
   },
   "stable": {
    "version": [
     1,
-    1
+    2
    ],
    "deps": [
     "consult",
     "flycheck"
    ],
-   "commit": "9fe96c4b75c8566170ad41a04c3849d2e2606104",
-   "sha256": "0ga6mqskgmq979nj6ri89x85chcfw0pxhx2vz1xgssz10hwpbla9"
+   "commit": "9dd95361669f87e14230376f4f93c6b9a222c497",
+   "sha256": "1n8n9wd4rn3x8kqyrlimb1hhm3nwgh7vawg7hjy63mfmvcfgrlqk"
   }
  },
  {
@@ -19594,8 +19702,8 @@
   "repo": "armindarvish/consult-gh",
   "unstable": {
    "version": [
-    20250915,
-    2043
+    20260623,
+    1820
    ],
    "deps": [
     "consult",
@@ -19603,8 +19711,8 @@
     "ox-gfm",
     "yaml"
    ],
-   "commit": "699af6c2b179c6a7888352e78413b7e3f76ae6ba",
-   "sha256": "1brv97np4l3cfby88izwdqc4k1h6ikbx5h08i01j858bkpzkwbnz"
+   "commit": "7b0fba0dc81a446c95cd39fa2a6adcd39501df9d",
+   "sha256": "18bmk52z2fx23mnbg8c8cv78fp68l958j2zkhk7wxcip7zzjnr7q"
   },
   "stable": {
    "version": [
@@ -19629,8 +19737,8 @@
   "repo": "armindarvish/consult-gh",
   "unstable": {
    "version": [
-    20250906,
-    1805
+    20260623,
+    1820
    ],
    "deps": [
     "consult",
@@ -19638,8 +19746,8 @@
     "embark-consult",
     "which-key"
    ],
-   "commit": "2b625a0331c9a92c67fef8ea2e694b28d5006421",
-   "sha256": "1p9lcjrzwxgscxpy0x992g8sxy6h3mcin1vffxf6nx28akwz13in"
+   "commit": "7b0fba0dc81a446c95cd39fa2a6adcd39501df9d",
+   "sha256": "18bmk52z2fx23mnbg8c8cv78fp68l958j2zkhk7wxcip7zzjnr7q"
   },
   "stable": {
    "version": [
@@ -19728,16 +19836,16 @@
   "repo": "armindarvish/consult-gh",
   "unstable": {
    "version": [
-    20250906,
-    1805
+    20260623,
+    1742
    ],
    "deps": [
     "consult",
     "consult-gh",
     "pr-review"
    ],
-   "commit": "2b625a0331c9a92c67fef8ea2e694b28d5006421",
-   "sha256": "1p9lcjrzwxgscxpy0x992g8sxy6h3mcin1vffxf6nx28akwz13in"
+   "commit": "a9e9144fd9d0a689d26818eeb8eb108cd4696718",
+   "sha256": "1jd2ky32l51vd89lxgk95dl9q8yh4mghdyfx7y11pzmjrw9nbljp"
   },
   "stable": {
    "version": [
@@ -19896,16 +20004,16 @@
   "repo": "gagbo/consult-lsp",
   "unstable": {
    "version": [
-    20251025,
-    719
+    20260619,
+    643
    ],
    "deps": [
     "consult",
     "f",
     "lsp-mode"
    ],
-   "commit": "d11102c9db33c4ca7817296a2edafc3e26a61117",
-   "sha256": "1lswbg18f1f3xg25hlgbn4rrlm4h4p5y27msx2g2gm49bk6ybfdi"
+   "commit": "f41a3946987a3880068f95f3725bbb7b0d4b0b22",
+   "sha256": "1az6p9m1vf78a2p11apvh0105vys5ibbifvzbljilifjs5mfb07w"
   },
   "stable": {
    "version": [
@@ -19923,9 +20031,9 @@
  },
  {
   "ename": "consult-notes",
-  "commit": "bd01544509dfe92d007d1edd47cfff0686a057f5",
-  "sha256": "0s13l1xdbihyp48k9nkflfw257q008imhv2zpfa86g9j04n4h0rz",
-  "fetcher": "github",
+  "commit": "e5b575433d962e6c281731daf227f82a57f2ce7d",
+  "sha256": "0v2vij3hdn47343xps5xm7mk4vig98y8mv39bw5h273ndc73yad2",
+  "fetcher": "codeberg",
   "repo": "mclear-tools/consult-notes",
   "unstable": {
    "version": [
@@ -20000,15 +20108,15 @@
   "repo": "Qkessler/consult-project-extra",
   "unstable": {
    "version": [
-    20260117,
-    813
+    20260428,
+    2007
    ],
    "deps": [
     "consult",
     "project"
    ],
-   "commit": "2b3fa36fd3a14deacf594f4acd54d220d6890c55",
-   "sha256": "1k1z8rsqqri4dpvc7vnrgc2s53h538vyllvc700wci1zk5pa9khj"
+   "commit": "52c453b7f85dea90cc53ff8fba750795606415df",
+   "sha256": "0j14ama1n79w7h3kdmknx3hrjp6a2vfcmmwaa1y5df2ymhnc2bkq"
   },
   "stable": {
    "version": [
@@ -20098,14 +20206,14 @@
   "repo": "guibor/consult-spotlight",
   "unstable": {
    "version": [
-    20260202,
-    2318
+    20260612,
+    1527
    ],
    "deps": [
     "consult"
    ],
-   "commit": "b60fef973c19e22225cae395217ff01bd32a0ef5",
-   "sha256": "0dsd12kj7blnd6mhs3kgww5x4bz7xl8qbj2xg3xra8jgdic03njk"
+   "commit": "0a8a60e26fcbf15414c0f56f4c8b4a504c5c9c11",
+   "sha256": "13729iapksanf2p53a802yj8m3jkspixq5z648ysgdkjpa1kk4iw"
   }
  },
  {
@@ -20257,15 +20365,15 @@
   "repo": "mohkale/consult-yasnippet",
   "unstable": {
    "version": [
-    20250411,
-    1922
+    20260613,
+    1436
    ],
    "deps": [
     "consult",
     "yasnippet"
    ],
-   "commit": "a3482dfbdcbe487ba5ff934a1bb6047066ff2194",
-   "sha256": "0cyzyxmdrk7dcpsw51pv1vz1f6px5yjmbmsa6r74vmshfdmljm3j"
+   "commit": "89e39887c87e25d18861216a4d72e5d174f13751",
+   "sha256": "1x72lgk79j215l5gn0mzqakf20h06fbhjg7afkwcywm5gpqhnind"
   }
  },
  {
@@ -20428,8 +20536,8 @@
   "repo": "copilot-emacs/copilot.el",
   "unstable": {
    "version": [
-    20260331,
-    713
+    20260622,
+    2038
    ],
    "deps": [
     "compat",
@@ -20437,13 +20545,13 @@
     "jsonrpc",
     "track-changes"
    ],
-   "commit": "ab5c58bc969f52f6d75e972658f2c3381c70b4fa",
-   "sha256": "1glqr4x7r2f0wgcn0mbcvphdidirpnq1b771ig5ly4s3zaxnqxl5"
+   "commit": "2882a50182a6e2ca3b1ccfded22645831a85a59a",
+   "sha256": "1gyhg2lix2k2xc3g30455li3kqjgllwyhb6z8jakvnivd7gd314p"
   },
   "stable": {
    "version": [
     0,
-    5,
+    6,
     0
    ],
    "deps": [
@@ -20452,16 +20560,16 @@
     "jsonrpc",
     "track-changes"
    ],
-   "commit": "c8c06efaa508569e13d7191882ae33435bb14543",
-   "sha256": "1xvhfwgddms0cxhi9pn75vb6qsd6gqfv8s59xjk9ilh57nvwzqfn"
+   "commit": "2882a50182a6e2ca3b1ccfded22645831a85a59a",
+   "sha256": "1gyhg2lix2k2xc3g30455li3kqjgllwyhb6z8jakvnivd7gd314p"
   }
  },
  {
   "ename": "copilot-chat",
-  "commit": "6e3852d02866ef577717fae04a56c876efa4217d",
-  "sha256": "1xzaa9rn8bnbjlcvlir2nnvidnmyhhcjqi7yi7xadv5i0rw66zxz",
+  "commit": "b5b0b336a5c9cbe201c26449eca9d7a854d4ac0a",
+  "sha256": "1cwixa30d6k9915wbv31wzzllb75i8rp27ssrs30vdxiz3a46z0h",
   "fetcher": "github",
-  "repo": "chep/copilot-chat.el",
+  "repo": "chep/gh-copilot-chat.el",
   "unstable": {
    "version": [
     20260401,
@@ -20649,25 +20757,25 @@
   "repo": "minad/corfu",
   "unstable": {
    "version": [
-    20260419,
-    1808
+    20260519,
+    1053
    ],
    "deps": [
     "compat"
    ],
-   "commit": "1466f6f7effc0a783c8acda66471be0db11f789a",
-   "sha256": "1qsq3cay6khphq008nyfybg4iafsmszk9j4dr35sr1bzfdq0wml2"
+   "commit": "4a9c67da16eb64cadaa4bfcc16713188145c83da",
+   "sha256": "1qw0xzlxr6fh9iiszqnl4hfjm2h0rd08warhanq99q34nz4iviny"
   },
   "stable": {
    "version": [
     2,
-    9
+    10
    ],
    "deps": [
     "compat"
    ],
-   "commit": "d2a995c5c732d0fc439efe09440870a9de779a74",
-   "sha256": "0hb9ycq6v28nkx0qbczfks4hz26g1d1bdb48ylxb9pd26irxb9pm"
+   "commit": "4a9c67da16eb64cadaa4bfcc16713188145c83da",
+   "sha256": "1qw0xzlxr6fh9iiszqnl4hfjm2h0rd08warhanq99q34nz4iviny"
   }
  },
  {
@@ -20794,14 +20902,14 @@
   "repo": "rob137/Corsair",
   "unstable": {
    "version": [
-    20241018,
-    1015
+    20260505,
+    1402
    ],
    "deps": [
     "gptel"
    ],
-   "commit": "f750a435d6be68f0d75dc5a90f8aa3cb58e8c16a",
-   "sha256": "0xwkfv63klpyqkgx1ihwqh1aqyk8yi3z3appygp28q60rybsyiyl"
+   "commit": "412285e1feeba9c6e0e3a103d64396cef1e73d51",
+   "sha256": "04azlj15jhg02sxjihnc15k4sgcar1vxhd8rxz82y446y00hg235"
   }
  },
  {
@@ -20812,15 +20920,15 @@
   "repo": "conao3/cort.el",
   "unstable": {
    "version": [
-    20241019,
-    936
+    20260516,
+    827
    ],
    "deps": [
     "ansi",
     "cl-lib"
    ],
-   "commit": "262966c9bc7fd3aa7bcf2dc3b9edc286c7f19e58",
-   "sha256": "01n7rcvdw98q0dvc51pk6nyrjwcf76cfs7r7c93xnjv5pmpjczfr"
+   "commit": "851a8669f14a1cfc3b0f9d6bf046139cb5bb7470",
+   "sha256": "170dbh6cywyvzc0asayql4vmwa4dyk9k102q0ndkh7m7s33dlsjr"
   },
   "stable": {
    "version": [
@@ -21096,26 +21204,26 @@
   "repo": "redguardtoo/counsel-etags",
   "unstable": {
    "version": [
-    20260320,
-    524
+    20260513,
+    1048
    ],
    "deps": [
     "counsel"
    ],
-   "commit": "292fe179ccfc4a194e1a362d2929280bdf6e76b1",
-   "sha256": "1jd7hxf0np94fxzp0p9nrm2ql8j85zq6a0ivsq3xg4j6wm8bbjbh"
+   "commit": "d9ed92310da368d8d037e151b8dcbb7ada55d42c",
+   "sha256": "063anpspqamza51ndbg6q0j3m29w6w9jklryq5kbwgmp4h3qz71b"
   },
   "stable": {
    "version": [
-    1,
-    11,
-    0
+    2,
+    0,
+    5
    ],
    "deps": [
     "counsel"
    ],
-   "commit": "292fe179ccfc4a194e1a362d2929280bdf6e76b1",
-   "sha256": "1jd7hxf0np94fxzp0p9nrm2ql8j85zq6a0ivsq3xg4j6wm8bbjbh"
+   "commit": "385eb738d09ce47f905982532e2b03cfb8381f17",
+   "sha256": "1g9pbk4xdwz0qr49wgzg5hkk1rjc8ayv9zyckn0b46jcg7cqg14i"
   }
  },
  {
@@ -21499,6 +21607,30 @@
    ],
    "commit": "139dea91fc818d65944aca5f16c9626abbdfbf04",
    "sha256": "0khwqwwsp2zhz7x2w7qcsdh5vmk3ybshj9isa6zr2ygag8aag13h"
+  }
+ },
+ {
+  "ename": "countdown-modeline",
+  "commit": "f5d525e6591a6e7aa4a8b28f096adbae03851856",
+  "sha256": "1p3k558189lb3h93znpm2prrl3jc1z7wpk94qsn59bszjlfjqzcg",
+  "fetcher": "github",
+  "repo": "jholland82/countdown-modeline",
+  "unstable": {
+   "version": [
+    20260615,
+    1455
+   ],
+   "commit": "7485863972bd941a786bc595d566e02a490bb352",
+   "sha256": "03nq1l4m2cc5r0mhgq1bc4zjfxak6rsnq2hm1lgyazrwsgk6kyi1"
+  },
+  "stable": {
+   "version": [
+    1,
+    3,
+    2
+   ],
+   "commit": "7485863972bd941a786bc595d566e02a490bb352",
+   "sha256": "03nq1l4m2cc5r0mhgq1bc4zjfxak6rsnq2hm1lgyazrwsgk6kyi1"
   }
  },
  {
@@ -22081,11 +22213,11 @@
   "repo": "crystal-lang-tools/emacs-crystal-mode",
   "unstable": {
    "version": [
-    20260111,
-    2220
+    20260607,
+    2043
    ],
-   "commit": "559e1d8ff9bb87a4e937978001386bfb58b113a0",
-   "sha256": "0mf2cl99y187c1v0cw192jchdwivm5c1m1154hnl6kyks2wkh7l2"
+   "commit": "f3b01df0bbe58852d0d7242bf5c0495931bb6fa6",
+   "sha256": "1823q4clg1hr085pbxpwdqy9gy86grvwfj224wnx5x2w7xi1mqsc"
   },
   "stable": {
    "version": [
@@ -22177,8 +22309,8 @@
   "repo": "hlolli/csound-mode",
   "unstable": {
    "version": [
-    20250310,
-    1026
+    20260502,
+    1425
    ],
    "deps": [
     "dash",
@@ -22186,8 +22318,8 @@
     "multi",
     "shut-up"
    ],
-   "commit": "4a6aa20ad919f088d65b903814453bd56266cf77",
-   "sha256": "18q4jpj6fnry67m6z3y5kk70hhk8db5l7wjwylhwmh362c3hzp30"
+   "commit": "fb8152be0cfccd498c3d9f6bf4f550cfa96c416a",
+   "sha256": "1nj5drdpwpn34581x6sbgfv4zkwzgh36q6nmwqgfgnqiwv9c27az"
   },
   "stable": {
    "version": [
@@ -22658,6 +22790,30 @@
   }
  },
  {
+  "ename": "cui",
+  "commit": "4e8c83c93df26fdbec89d3bd1152ae7daaeb35f5",
+  "sha256": "0gkaqg6m58smi4fhylz139aznr33xq50nrdz5jwcm5313skd7hkb",
+  "fetcher": "github",
+  "repo": "Anoncheg1/emacs-cui",
+  "unstable": {
+   "version": [
+    20260623,
+    919
+   ],
+   "commit": "25ad76bd01d6e94b1eada4c19d52a6245a87bbba",
+   "sha256": "111bba10y98n0hcamnqm5s5za7gavzmxpnjmnycgvx4mm7bqh1wk"
+  },
+  "stable": {
+   "version": [
+    0,
+    3,
+    2
+   ],
+   "commit": "d4ea6f0667f12a7b6022107e84de76fd5739a041",
+   "sha256": "0n4jf27yxwnwa28xk14r7gj46r0k2a1rp4pqd5s2n72hmm6a1g4l"
+  }
+ },
+ {
   "ename": "curl-to-elisp",
   "commit": "11453864d71c7853bc743341db7ca071126ca160",
   "sha256": "16qyw6yx5vlm32ikmgxhf162jjl1nq7lmrcn6g43fkk93id0374n",
@@ -22930,14 +23086,14 @@
   "repo": "ideasman42/emacs-cycle-at-point",
   "unstable": {
    "version": [
-    20260111,
-    1240
+    20260502,
+    927
    ],
    "deps": [
     "recomplete"
    ],
-   "commit": "0af1fa35f49d320960870b9dbcb4d03440139fdf",
-   "sha256": "154sh14iqdwf02qdl8h8jsrr8rw60479bh6n1p1mx2xvx2yjpad1"
+   "commit": "0be4e5813250139697773275784a9a8d144f47b1",
+   "sha256": "1x1ml0sxm37f737j4cpfwxr5d704pfcywxaz49hshrvc53i3s55x"
   }
  },
  {
@@ -23371,8 +23527,8 @@
   "repo": "emacs-lsp/dap-mode",
   "unstable": {
    "version": [
-    20260208,
-    1403
+    20260616,
+    1526
    ],
    "deps": [
     "bui",
@@ -23385,8 +23541,8 @@
     "posframe",
     "s"
    ],
-   "commit": "b77d9bdb15d89e354b8a20906bebe7789e19fc9b",
-   "sha256": "1092xys5dx9k0rq3vgkrrgx6bfkpvq8lbhng8p8cvhspi2fi766s"
+   "commit": "c73a587d613788003986a11ffe393b46affe8322",
+   "sha256": "1556sxkgm1n0m70js4qspzq613j490z18395c33zm8i1smj21ybl"
   },
   "stable": {
    "version": [
@@ -23431,11 +23587,11 @@
   "repo": "fommil/darcula-theme.el",
   "unstable": {
    "version": [
-    20171227,
-    1845
+    20260617,
+    1603
    ],
-   "commit": "d9b82b58ded9014985be6658f4ab17e26ed9e93e",
-   "sha256": "1y8rsc63nl4n43pvn283f1vcpqyjnv6xl60fwyscwrqaz19bsnl1"
+   "commit": "89e81a156f375306aa0aa639b3d0161543ce514f",
+   "sha256": "0i8x4a9kds8v0j3rdlrs3rl2k4vkksp1w4ik61r5zk79ip8lnpy0"
   },
   "stable": {
    "version": [
@@ -23583,11 +23739,11 @@
   "repo": "emacsorphanage/dart-mode",
   "unstable": {
    "version": [
-    20251105,
-    543
+    20260529,
+    1840
    ],
-   "commit": "22288d0bb374f6880ffc211ce87c302acb3421e7",
-   "sha256": "0z1j0v5h5472r04bl9c7hwr0l9mjhp48kcyqgdrb3rx7z0id7052"
+   "commit": "793d7bcc18a2636ebafe06450356c08ea6d638ca",
+   "sha256": "0x7nmrwjsac0bpln5w38na8bx14q2q76a4r9dgcyyq3qckcq2qqa"
   },
   "stable": {
    "version": [
@@ -23643,11 +23799,11 @@
   "repo": "nameiwillforget/d-emacs",
   "unstable": {
    "version": [
-    20260421,
-    833
+    20260620,
+    1902
    ],
-   "commit": "8e23c3b0eda55ba9bcdaffa5ab7f179c23012163",
-   "sha256": "0v7zkxdpcr5wgccvz8yiwahb6j2pl89hsjxhzs7ishakxw41asxa"
+   "commit": "c07ed16da91c66162d3b3dcf06ed076440445a1a",
+   "sha256": "0r3fzl7sqdi6ca71acvr73s51sa7hrzyb8arq229cq8ma2j30iyc"
   }
  },
  {
@@ -23785,15 +23941,15 @@
   "repo": "hyakt/emacs-dashboard-hackernews",
   "unstable": {
    "version": [
-    20240918,
-    1301
+    20260521,
+    1635
    ],
    "deps": [
     "dashboard",
     "request"
    ],
-   "commit": "ea49fd79d12c26a2c3f9bcdffd0d70dcfee7cd74",
-   "sha256": "1s5rs8snd82fcq5ic7vy1612462958h02n23bpvl2mss6m7w33w0"
+   "commit": "ecc8c1eeca10408ac1fab2ad0e80fccf9c6bc0b2",
+   "sha256": "0psxjlr2fhvyjnz4hk1khbyl1frc2nzqjsc4xzzbkbayd7bp5bci"
   }
  },
  {
@@ -24200,15 +24356,15 @@
   "repo": "conao3/ddskk-posframe.el",
   "unstable": {
    "version": [
-    20200812,
-    917
+    20260516,
+    827
    ],
    "deps": [
     "ddskk",
     "posframe"
    ],
-   "commit": "299493dd951e5a0b43b8213321e3dc0bac10f762",
-   "sha256": "1rsy0wjncxzjhis8jrxpxjh9l9pw0bngg1sb4dj5qvhsgszhawpn"
+   "commit": "1b5c8f85cafb1e763e214f4310113c75e28cce0d",
+   "sha256": "12d8nnq2czk2qjkgz3csh37943v0jgccdw8gng1lqsfcxywsil6g"
   },
   "stable": {
    "version": [
@@ -24462,11 +24618,11 @@
   "repo": "ideasman42/emacs-default-font-presets",
   "unstable": {
    "version": [
-    20251214,
-    1133
+    20260505,
+    1159
    ],
-   "commit": "6d69a989409ba3498032d9218abe92f58148562f",
-   "sha256": "00v94ckw5klljdv0pm4xjpcm9qhq6i5r76kzn7fkkjm1jvgp6cmj"
+   "commit": "43e778da6ef468e187743f009e14270875bc312e",
+   "sha256": "0p81fhmcp7m7z52i34j6hcz85pmx0xmgz9w3x9pk0rzkb9096c80"
   }
  },
  {
@@ -24893,16 +25049,17 @@
   "repo": "pprevos/denote-explore",
   "unstable": {
    "version": [
-    20251027,
-    911
+    20260525,
+    2035
    ],
    "deps": [
     "dash",
     "denote",
-    "denote-regexp"
+    "denote-regexp",
+    "denote-sequence"
    ],
-   "commit": "3adc8b4d342bbc411d667f93dbc1f1468a245e04",
-   "sha256": "12b0bxvz01za3bxs66n63l6fyffnhq1br5fz0nf28839gvi80npg"
+   "commit": "5a6d005fbc9e2131197c20acdffca239f9cd4961",
+   "sha256": "12h94rikibs4h3qx173v5l3ljk2iylnnj1jk1p521zk1yxznv9ih"
   },
   "stable": {
    "version": [
@@ -24943,14 +25100,14 @@
   "repo": "swflint/denote-project-notes",
   "unstable": {
    "version": [
-    20250610,
-    1516
+    20260622,
+    1947
    ],
    "deps": [
     "denote"
    ],
-   "commit": "697420c089d313bf65e7963248c1909a8fdb348d",
-   "sha256": "1yh8idry374lxngv63rclaci5h8cpxc3b2fk8q15v70ivsc04gvj"
+   "commit": "e109c84071b3aa8da49e5b0fc56e96f8d1cf5e95",
+   "sha256": "06qc0qi93s6cw81bnyxxlv9b6ynapg7bj8m8vyxc591hmrw109nj"
   }
  },
  {
@@ -24988,6 +25145,24 @@
    ],
    "commit": "dde6836a4663cb3fc23cdce8ea25834720711c8a",
    "sha256": "0rrnr3my8w76zv99wlhhym0j5c3amlgjlamv8q3raglhbk683q3g"
+  }
+ },
+ {
+  "ename": "denote-wordcloud",
+  "commit": "eaae76cbd2071cb7841baa01f30a80681cbe7289",
+  "sha256": "1b3plav8vrfbwvlh9qz48jm18kybfj1qvargg1ygkk6hm1k0zkg7",
+  "fetcher": "codeberg",
+  "repo": "treflip/denote-wordcloud",
+  "unstable": {
+   "version": [
+    20260506,
+    1238
+   ],
+   "deps": [
+    "denote"
+   ],
+   "commit": "01a74f13bd1fa4f1645851cc64f2701ff2654e64",
+   "sha256": "0y371cq7gkqw8xg5pr3p8vprf9mkfkm9v0wv8izvq0d7xf1syksz"
   }
  },
  {
@@ -25060,6 +25235,21 @@
    ],
    "commit": "40618345a37831804b29589849a785ef5aa5ac24",
    "sha256": "13fasbhdjwc4jh3cy25gm5sbbg56hq8la271098qpx6dhqm2wycq"
+  }
+ },
+ {
+  "ename": "desert-theme",
+  "commit": "fa2e546d32f6d70d57daf387fe49fc3c9e1d6034",
+  "sha256": "1nlp9v23ias4bc5bplk8c05d0shgrz6ijdx441g43vr1kv53f85p",
+  "fetcher": "github",
+  "repo": "bkc39/desert-theme",
+  "unstable": {
+   "version": [
+    20260606,
+    1836
+   ],
+   "commit": "a334abfe4d624cb37bb4a2dc309f8623f42b74d1",
+   "sha256": "1yglxj03k9ffh0ywp5285q9pczzkcnpkl6w7rjb959d5n5arcfmk"
   }
  },
  {
@@ -25316,11 +25506,11 @@
   "repo": "mew/dialog-mode",
   "unstable": {
    "version": [
-    20260406,
-    1841
+    20260619,
+    1559
    ],
-   "commit": "7a14cb400ec46a4f0d9df5270866592d3529986d",
-   "sha256": "0sh59a1i19lqws8mn1j1pi1hyyhskysx7xwvi0xqwcf1h2iwf72x"
+   "commit": "e092fe2c3915e28ae9151f856d340c2ba17ecb68",
+   "sha256": "12qfbyk9f8s77y8q09xg674xbc9b23a32672v7z9f92bl64x0nd2"
   }
  },
  {
@@ -25398,25 +25588,25 @@
   "repo": "minad/dicom",
   "unstable": {
    "version": [
-    20260117,
-    1648
+    20260605,
+    1901
    ],
    "deps": [
     "compat"
    ],
-   "commit": "03a12498905ef80d67ff53d138d415d828ceb12f",
-   "sha256": "0k4gq0bznkq8i017xpycmyii5x48xqcq8x04p3r5a7qg9ljlwvfk"
+   "commit": "026a12a27939b29935ea343bab9162ed27bd732e",
+   "sha256": "1bi9mrwvyw4gkxix66gf9xhars830kbfinzrai3biixfd3gkdgs2"
   },
   "stable": {
    "version": [
     1,
-    3
+    5
    ],
    "deps": [
     "compat"
    ],
-   "commit": "03a12498905ef80d67ff53d138d415d828ceb12f",
-   "sha256": "0k4gq0bznkq8i017xpycmyii5x48xqcq8x04p3r5a7qg9ljlwvfk"
+   "commit": "026a12a27939b29935ea343bab9162ed27bd732e",
+   "sha256": "1bi9mrwvyw4gkxix66gf9xhars830kbfinzrai3biixfd3gkdgs2"
   }
  },
  {
@@ -25513,11 +25703,11 @@
   "repo": "ideasman42/emacs-diff-ansi",
   "unstable": {
    "version": [
-    20260108,
-    1512
+    20260524,
+    938
    ],
-   "commit": "98f1837840e9afedbff48969b2bd8468af7ceef3",
-   "sha256": "1hrhg1zly19c7fplswb2jcspsf0rcjwkh28pjrgrinw9n7dvwzqm"
+   "commit": "2edacc2c6bda60b1be7bf5dfdde006a9a7018af5",
+   "sha256": "11lk7dj0r5xdra0vg4csck6d6jd4mjjp13gjp75sl2i7vs4mf2d1"
   }
  },
  {
@@ -25543,14 +25733,14 @@
   "repo": "dgutov/diff-hl",
   "unstable": {
    "version": [
-    20260328,
-    1925
+    20260624,
+    444
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "b965e19e6e7f9933199e421849a49229207c1c9f",
-   "sha256": "07mmfc44wn0gsg4h4c4fnz0w8jzsj403nxkjbbn20pr3rfln42rq"
+   "commit": "23302acc331738652f6295eae9c8feb856cb021e",
+   "sha256": "1fkhdqa6apz6wvy9w29iagj3q0571ggskgf1snnfj002gydmd5n2"
   },
   "stable": {
    "version": [
@@ -25582,22 +25772,22 @@
  },
  {
   "ename": "difflib",
-  "commit": "df1924ddff6fd1b5fa32481d3b3d6fbe89a127d3",
-  "sha256": "07bm5hib3ihrrx0lhfsl6km9gfckl73qd4cb37h93zw0hc9xwhy6",
-  "fetcher": "github",
+  "commit": "1d888e12b1c4002896723b3c993a72bf920ef37b",
+  "sha256": "0z3rvzp63bbnxp7i22w9qd475k53xk75501d2gz25wv01xs030vk",
+  "fetcher": "sourcehut",
   "repo": "dieggsy/difflib.el",
   "unstable": {
    "version": [
-    20210224,
-    2242
+    20260530,
+    536
    ],
    "deps": [
     "cl-generic",
     "ht",
     "s"
    ],
-   "commit": "646fc4388274fe765bbf4661e17a24e4d081250c",
-   "sha256": "1qagl3ffg01zjqrgpq32h4ya869066n8ll9yq8lk40argjm523fa"
+   "commit": "9efb87bcf430600e8beb1a821dc78c1088a081e7",
+   "sha256": "0ky754i5czqi5rfw9k69hdccjg0ky5rfnnvhs3xvkc5d4kswr1w5"
   },
   "stable": {
    "version": [
@@ -25850,32 +26040,32 @@
  },
  {
   "ename": "dim-autoload",
-  "commit": "66b1a81dfd09a2859ae996d5d8e3d704857a340f",
-  "sha256": "0lhzzjrgfvbqnzwhjywrk3skdb7x10xdq7d21q6kdk3h5r0np9f9",
+  "commit": "aec4a76eaea31408bd27d76a0b8cea5268663cc1",
+  "sha256": "0v6dyij2fvj6wp1jlg9q3ii39ylabjh3vlmlb1f4ff9jw99ngf5k",
   "fetcher": "github",
   "repo": "tarsius/dim-autoload",
   "unstable": {
    "version": [
-    20260101,
-    1826
+    20260601,
+    1459
    ],
    "deps": [
     "compat"
    ],
-   "commit": "503eee682c2fcc24e05a765ac28e847be950bad9",
-   "sha256": "1f0nwz85dhnf0via74yw21f30mg3afkfng5w6ssrny906jzg3pnp"
+   "commit": "a9024464f0f0573338eaa490cfca998e66bf47f7",
+   "sha256": "15654pgqcm2lngkiznq3xf29m8c0an9rs6nzvpdrlmar8h98dqg3"
   },
   "stable": {
    "version": [
     2,
     1,
-    2
+    3
    ],
    "deps": [
     "compat"
    ],
-   "commit": "503eee682c2fcc24e05a765ac28e847be950bad9",
-   "sha256": "1f0nwz85dhnf0via74yw21f30mg3afkfng5w6ssrny906jzg3pnp"
+   "commit": "a9024464f0f0573338eaa490cfca998e66bf47f7",
+   "sha256": "15654pgqcm2lngkiznq3xf29m8c0an9rs6nzvpdrlmar8h98dqg3"
   }
  },
  {
@@ -25963,20 +26153,20 @@
   "repo": "gonewest818/dimmer.el",
   "unstable": {
    "version": [
-    20220817,
-    122
+    20260618,
+    1559
    ],
-   "commit": "a5b697580e5aed6168b571ae3d925753428284f8",
-   "sha256": "1lj7pgsyzmd547yq33k4r75vfz3pdqafvnrxcv110hmb7mj3dvr4"
+   "commit": "bbab62f01d45086b9098f6a0ab765282d9c7bc45",
+   "sha256": "1azpm377q2qvwfgfpc01fgma66s52xy829r2kjadqsw0px0gjkq4"
   },
   "stable": {
    "version": [
     0,
     4,
-    2
+    3
    ],
-   "commit": "e45bf2d064a8ecdea2b4caf646ece2d0adc1d84e",
-   "sha256": "0dw0qh5hm1x76s5cqxvylvmjgy0jwy11xm258g6kmx6w1k6r1d2l"
+   "commit": "a5b697580e5aed6168b571ae3d925753428284f8",
+   "sha256": "1lj7pgsyzmd547yq33k4r75vfz3pdqafvnrxcv110hmb7mj3dvr4"
   }
  },
  {
@@ -26881,15 +27071,15 @@
   "repo": "jojojames/dired-sidebar",
   "unstable": {
    "version": [
-    20260415,
-    638
+    20260619,
+    56
    ],
    "deps": [
     "compat",
     "dired-subtree"
    ],
-   "commit": "19cdf0b9ed634efb7ae7047861fbcbd9dc0ee2e9",
-   "sha256": "1jsyrj6mam68klb5ygjks98a4npx85d1xx5viwss2c11zk52699r"
+   "commit": "1852a0b17bf2619607f6b4dfc437e279ba04e93c",
+   "sha256": "0br2a2nccbbmp5mgj4b0q28k0gaq10w1mrsyabfk9va9dqb8iscn"
   },
   "stable": {
    "version": [
@@ -27034,14 +27224,14 @@
   "repo": "Boruch-Baum/emacs-diredc",
   "unstable": {
    "version": [
-    20260414,
-    1238
+    20260616,
+    1507
    ],
    "deps": [
     "key-assist"
    ],
-   "commit": "7bbc7bfa60c2b3c7f39f75e1600b13260315271e",
-   "sha256": "0knsbywpmdb6jbb3frgnl9p6mi6ac2brhajb2rlqxqvr8fx9xz4b"
+   "commit": "0b826202e12d6c66ae902d71ab770693cf89c33e",
+   "sha256": "0zsgvznmqgbywfar8pxl56ig3zqqd3gaqxg1y6xvwnz27s0ngkhx"
   },
   "stable": {
    "version": [
@@ -28028,8 +28218,8 @@
   "repo": "Silex/docker.el",
   "unstable": {
    "version": [
-    20260126,
-    1212
+    20260623,
+    746
    ],
    "deps": [
     "aio",
@@ -28038,8 +28228,8 @@
     "tablist",
     "transient"
    ],
-   "commit": "916686b86e83a3bd2281fbc5e6f98962aa747429",
-   "sha256": "0yql0k5bw1vsqh44g5aq6ip6dn3c36k8gpljvbghsj01fcqdlvj6"
+   "commit": "2128c0d432f4cc0feef21d1e1c11398a3ee2432b",
+   "sha256": "0nacf9zxjllkpqgvjvmj08acppm3qifvjgnrqnwxm9nc1w7brjgx"
   },
   "stable": {
    "version": [
@@ -28296,11 +28486,11 @@
   "repo": "ag91/doctest",
   "unstable": {
    "version": [
-    20240421,
-    1517
+    20260620,
+    2225
    ],
-   "commit": "0620ab6283a4e4302761ac415354b0b2b889dcda",
-   "sha256": "1g759f1ypw00vqbbcxa8yxf51bdmlrfdxybgjf4fmzzhvfbcpc4d"
+   "commit": "cdf41b5185dcd502f92722297f4361eab4ef1d13",
+   "sha256": "1mli87r0nlrfalh5mbnlg52cfhz9pgccnqlfzjj7k3fj0cl7rnvw"
   }
  },
  {
@@ -28459,16 +28649,16 @@
   "repo": "seagle0128/doom-modeline",
   "unstable": {
    "version": [
-    20260411,
-    1454
+    20260612,
+    740
    ],
    "deps": [
     "compat",
     "nerd-icons",
     "shrink-path"
    ],
-   "commit": "870b4b215fda881d29278d81bbab7f934a9bd8b3",
-   "sha256": "15m4c6bafc742cm3mwq9x889c3s96minp6957ipbxyd6qaxzfjly"
+   "commit": "a9900c89409984572b514f0fcb4f336c9d5bba4b",
+   "sha256": "1sbq1hk1m3djzp78xzzbx5ggc04dkpsnb5gc9pb6kqavq4m9644w"
   },
   "stable": {
    "version": [
@@ -28493,14 +28683,14 @@
   "repo": "elken/doom-modeline-now-playing",
   "unstable": {
    "version": [
-    20250906,
-    630
+    20260501,
+    743
    ],
    "deps": [
     "doom-modeline"
    ],
-   "commit": "aff9417faaf5f1945b9ad95f27fa777bbcf269f7",
-   "sha256": "0z7xsrm30dmi359hzairy94md0jmas0q9n939zy4yv708xykbxpj"
+   "commit": "11e060f9e30c2ae3e95e71a18f3d0d91b7a54d97",
+   "sha256": "1fqmbxchy8i9qb4lsqpb8lj9ly5sq3xxhzh9pn0jc5j5g37wak0x"
   },
   "stable": {
    "version": [
@@ -28831,14 +29021,14 @@
   "url": "https://salsa.debian.org/emacsen-team/dpkg-dev-el.git",
   "unstable": {
    "version": [
-    20260326,
-    2334
+    20260502,
+    631
    ],
    "deps": [
     "debian-el"
    ],
-   "commit": "f65f60feb19357196594a09ce9fe23da9291cef0",
-   "sha256": "1vqibm6iwnbdxgq2mmly1xqdgbs80qqi20xzwcrb571yvw42nqh3"
+   "commit": "1392d194b3ef00e58901163081df47ba06afba24",
+   "sha256": "0js3pf8c5qsaxphxiakjfaj23xc724k87gv3j9si1lcpbmb5cz0w"
   },
   "stable": {
    "version": [
@@ -29201,19 +29391,19 @@
   "repo": "jscheid/dtrt-indent",
   "unstable": {
    "version": [
-    20251102,
-    857
+    20260608,
+    1055
    ],
-   "commit": "7c372bec8d84c247e4bd0d5599024d66ee300429",
-   "sha256": "04p6avj8d15i6qswdfpgvdil5c13rcfmc4n2jili485zgpw14j81"
+   "commit": "4b71bf995b12966bbc350a32796b9a5f11d67fa6",
+   "sha256": "1xl2m790nq4yingv0fzkh223gp10l36ahrbvarlgkix0y7xq99mj"
   },
   "stable": {
    "version": [
     1,
-    26
+    27
    ],
-   "commit": "7c372bec8d84c247e4bd0d5599024d66ee300429",
-   "sha256": "04p6avj8d15i6qswdfpgvdil5c13rcfmc4n2jili485zgpw14j81"
+   "commit": "4b71bf995b12966bbc350a32796b9a5f11d67fa6",
+   "sha256": "1xl2m790nq4yingv0fzkh223gp10l36ahrbvarlgkix0y7xq99mj"
   }
  },
  {
@@ -29304,11 +29494,11 @@
   "repo": "jacktasia/dumb-jump",
   "unstable": {
    "version": [
-    20260406,
-    1824
+    20260603,
+    1700
    ],
-   "commit": "9ce4598e9c485821a6e639fa48854d8e05acd970",
-   "sha256": "00p4wmymvc0rspg3kddv5y8r1hxwb1j907bpgscjwjfpshm5swaq"
+   "commit": "cf06b4ccdce6a39346c32f05139f9ee8b77ee229",
+   "sha256": "1i3zykfg5dc562naqd9f7fybx9y624783av1w1ikw51p0f2wr139"
   },
   "stable": {
    "version": [
@@ -29365,20 +29555,20 @@
   "repo": "ocaml/dune",
   "unstable": {
    "version": [
-    20260410,
-    1721
+    20260120,
+    2128
    ],
-   "commit": "df26745e52be99ecdb2ff994feab1eacd858b226",
-   "sha256": "0gnv5926xmvsna0bvgymj1rr9awkrc9krij6zbjnx90mcf091bsv"
+   "commit": "ccdb380ab5714b81f1ba71f7f8acfd792e6200bf",
+   "sha256": "0b6xndnh8c27v84vbv0bl8x3062y9fvbrh92p2hm065qsaj8gr7s"
   },
   "stable": {
    "version": [
     3,
-    22,
-    2
+    24,
+    0
    ],
-   "commit": "df26745e52be99ecdb2ff994feab1eacd858b226",
-   "sha256": "0gnv5926xmvsna0bvgymj1rr9awkrc9krij6zbjnx90mcf091bsv"
+   "commit": "47f64de764078db6edb2698958b5270a17bffb05",
+   "sha256": "1j0nqvr4njj8z8fcfhxq7c2fid4hc4c46vcx2077sj6iqd8kd02f"
   }
  },
  {
@@ -30021,20 +30211,20 @@
   "repo": "redguardtoo/eacl",
   "unstable": {
    "version": [
-    20260412,
-    237
+    20260427,
+    655
    ],
-   "commit": "5a304e4655a28cc817b9a633304bd64a5d5ddf53",
-   "sha256": "145z8qv1xmx0y3g00n2jivhzi8h6zc5ai3wfijmijdam0yg377p5"
+   "commit": "19f0170f3548eb49f5bd92653f321c3b1742b492",
+   "sha256": "08fdsnh0jxpnihqmv9vbrv8hxiw2dd4y66h67w6lw6yxlglw9p0d"
   },
   "stable": {
    "version": [
     2,
     2,
-    2
+    3
    ],
-   "commit": "5a304e4655a28cc817b9a633304bd64a5d5ddf53",
-   "sha256": "145z8qv1xmx0y3g00n2jivhzi8h6zc5ai3wfijmijdam0yg377p5"
+   "commit": "19f0170f3548eb49f5bd92653f321c3b1742b492",
+   "sha256": "08fdsnh0jxpnihqmv9vbrv8hxiw2dd4y66h67w6lw6yxlglw9p0d"
   }
  },
  {
@@ -30384,20 +30574,20 @@
   "repo": "jamescherti/easysession.el",
   "unstable": {
    "version": [
-    20260421,
-    1132
+    20260614,
+    1745
    ],
-   "commit": "77a55e7ed2ad0ea5b741193a4e5a91c91021387f",
-   "sha256": "0bzc1078r485177nnfsxxjjjxd502cm850jysg57zbwp1yydmzk4"
+   "commit": "e5264f31d1d2ca7ffe6fb836d6ab1a6a14eabc30",
+   "sha256": "02n821lh0nf418w98mnq5nmvp0dpinksf3sav892kkglj1j5qd68"
   },
   "stable": {
    "version": [
     1,
     2,
-    1
+    3
    ],
-   "commit": "962cf2c6465acc7ef2d7d260240058a98ec2342d",
-   "sha256": "02z5w31sv091yvzhgri2aaparh6m4nhvrhglqia73ly9p7n6jr6s"
+   "commit": "07c24d08b02c7433d99a63d9260eb8c632e3533d",
+   "sha256": "1s1nf2hswg9pvydxj16sxky2rx85xdis46sqbcscbkv3cdpvy6l8"
   }
  },
  {
@@ -30473,15 +30663,15 @@
   "repo": "joostkremers/ebib",
   "unstable": {
    "version": [
-    20250909,
-    1036
+    20260621,
+    1413
    ],
    "deps": [
     "compat",
     "parsebib"
    ],
-   "commit": "72686b4d045dcbdb794e56c8ba60a77eed52ee83",
-   "sha256": "07sl4myxvqqdyj6fgybiz93dw9yba1wkhy3f99mz3fv8hyr06jjr"
+   "commit": "32c6ab8ce418af10b54f497a404b9b33a67d48fc",
+   "sha256": "1nf7lhzgiwhxslaa65a5i3iw7mwzj0jdh3ishrdwybaxyirili4v"
   },
   "stable": {
    "version": [
@@ -30571,8 +30761,8 @@
   "repo": "editor-code-assistant/eca-emacs",
   "unstable": {
    "version": [
-    20260423,
-    1754
+    20260622,
+    1430
    ],
    "deps": [
     "compat",
@@ -30581,14 +30771,14 @@
     "markdown-mode",
     "s"
    ],
-   "commit": "bd5a72aef67eca944a7ad0d9916eb0d0f0f11f9d",
-   "sha256": "0ngap75h8344csabhmf12y4wdii6rxb94yxvdx8aj31kggxaqn6l"
+   "commit": "f91296cd8ddd1477700cc81c3edda0a45b1a6cd1",
+   "sha256": "0xrizvv94vrckirpdc2mwl4s5iqm2m23v020vhycryz0vcami9z7"
   },
   "stable": {
    "version": [
     0,
     9,
-    0
+    1
    ],
    "deps": [
     "compat",
@@ -30597,8 +30787,8 @@
     "markdown-mode",
     "s"
    ],
-   "commit": "4e867e883cdb7733809a9c5b76c0ca9af022db98",
-   "sha256": "1kdf2vb2905zz80hnzwclfdqb3zk3v5qdchajfwr8snwlsdca80r"
+   "commit": "0e1c7b4e924d7d7d99720342e60483b6dda187a3",
+   "sha256": "053qqrwlrnaa306kq8fz9s2dlaavgd71frxikkyq7ph6gnj2p6wf"
   }
  },
  {
@@ -30609,11 +30799,11 @@
   "repo": "ecb-org/ecb",
   "unstable": {
    "version": [
-    20251014,
-    1427
+    20260518,
+    524
    ],
-   "commit": "2f9028aa1d8791720e809954016dbc84fe8fc864",
-   "sha256": "1gvqayfp8a5fjd6clibj4fn4algy921ck0ifa61g3gykhkmj1jhi"
+   "commit": "ac7c585be4de7ba085ec91ef580361711a7f8c54",
+   "sha256": "0mk5dd386z52cidpkjf6igwcbg75i5cs85q8j2rkjnzsl3qrli25"
   },
   "stable": {
    "version": [
@@ -31409,26 +31599,26 @@
  },
  {
   "ename": "egison-mode",
-  "commit": "3416586d4d782cdd61a56159c5f80a0ca9b3ddf4",
-  "sha256": "0bch4863l9wxrss63fj46gy3nx3hp635709xr4c2arw0j7n82lzd",
+  "commit": "9fdde45d92600e1327dec06b78e8bfea1a58c601",
+  "sha256": "0kx0gf98zzyvvqxi8mips2bgfx3cf34gc0mhz3rx9gw8bsb94sil",
   "fetcher": "github",
   "repo": "egison/egison",
   "unstable": {
    "version": [
-    20260104,
-    1519
+    20260217,
+    1013
    ],
-   "commit": "4e796ee52785e052f3b10c6493fa484461bb4482",
-   "sha256": "0m4sp7ncf6d9maf1sm4p4rg4z140bdfvbxgd05fmly4pk1yz0yv8"
+   "commit": "448dc7ee9db1e2778261f295715fcb64496ba19e",
+   "sha256": "1jgv77v6wkbc8ixmifvwlc6izn9rkr8nnca7g9cbzzp4npys2d5n"
   },
   "stable": {
    "version": [
-    4,
-    1,
-    3
+    5,
+    0,
+    0
    ],
-   "commit": "dbb395b41a4e4eb69f3f045cbfbe95a1575ac45b",
-   "sha256": "14g0dpn8j7kh3iiq7qlhaa1wdk6xvl60hkl3j87ncjwkh6h4imcg"
+   "commit": "3a5b520c6b5bc4a78523573d06e3be887e02d1dd",
+   "sha256": "04rk39z345wm8byrg0kk02d5l2i6vvjnmaa3h817kns1d3gsdk9s"
   }
  },
  {
@@ -31567,26 +31757,26 @@
   "repo": "mwolson/eglot-python-preset",
   "unstable": {
    "version": [
-    20260424,
-    334
+    20260617,
+    148
    ],
    "deps": [
     "eglot"
    ],
-   "commit": "8219aa2b3d595af42108881b4d26750ec20105b7",
-   "sha256": "1w4vvhdjdv8ny3wg6nlvwjv7mgz0bkdi9pkvi2krzarsk6wlhiv3"
+   "commit": "719b3aa8fd47aec6c1c3094e2468f41b9d588b09",
+   "sha256": "08y0y1bsbyrlp704ajjkyd0ki8bfpcm9ncb7796fc61ajmz26ak2"
   },
   "stable": {
    "version": [
+    1,
     0,
-    6,
     0
    ],
    "deps": [
     "eglot"
    ],
-   "commit": "8219aa2b3d595af42108881b4d26750ec20105b7",
-   "sha256": "1w4vvhdjdv8ny3wg6nlvwjv7mgz0bkdi9pkvi2krzarsk6wlhiv3"
+   "commit": "719b3aa8fd47aec6c1c3094e2468f41b9d588b09",
+   "sha256": "08y0y1bsbyrlp704ajjkyd0ki8bfpcm9ncb7796fc61ajmz26ak2"
   }
  },
  {
@@ -31665,26 +31855,26 @@
   "repo": "mwolson/eglot-typescript-preset",
   "unstable": {
    "version": [
-    20260417,
-    1841
+    20260617,
+    128
    ],
    "deps": [
     "eglot"
    ],
-   "commit": "f789a45d98eb4d5cc8129a34893a91bd36abd09c",
-   "sha256": "1jy3hp621p7lh3zrxs7rgq7kajmxb5wvqjfd4flna4vmxrjg4r3q"
+   "commit": "cc780650223cf08f2268bca3de16509c61ef885d",
+   "sha256": "18vsmjfsa6fm5lsdpfh05gckllppj5b048da04wmvnb2l4xbmsis"
   },
   "stable": {
    "version": [
+    1,
     0,
-    5,
-    2
+    0
    ],
    "deps": [
     "eglot"
    ],
-   "commit": "97c673f6408fa35fe859330f6014c35f9dce15a8",
-   "sha256": "0k12kszfg68q343mww7ivacpkw177ca23878v13b8p00xac86app"
+   "commit": "cc780650223cf08f2268bca3de16509c61ef885d",
+   "sha256": "18vsmjfsa6fm5lsdpfh05gckllppj5b048da04wmvnb2l4xbmsis"
   }
  },
  {
@@ -31854,16 +32044,16 @@
   "repo": "ahyatt/ekg",
   "unstable": {
    "version": [
-    20260415,
-    39
+    20260624,
+    333
    ],
    "deps": [
     "llm",
     "triples",
     "vui"
    ],
-   "commit": "be6cc349a5054154470173af6521e569cb21bcb1",
-   "sha256": "12jkrzxk541i4d1b427zhg7klg304kqidksypikbq18dppsvdh5l"
+   "commit": "2330740b43cd68063499a8e71b9b07e66dc74082",
+   "sha256": "1lirapvam5l08fql67g25478j1fiimx7ic38y8qa6cib3fmyp6ik"
   },
   "stable": {
    "version": [
@@ -31888,15 +32078,15 @@
   "repo": "ahyatt/ekg",
   "unstable": {
    "version": [
-    20260415,
-    39
+    20260624,
+    333
    ],
    "deps": [
     "ekg",
     "futur"
    ],
-   "commit": "be6cc349a5054154470173af6521e569cb21bcb1",
-   "sha256": "12jkrzxk541i4d1b427zhg7klg304kqidksypikbq18dppsvdh5l"
+   "commit": "2330740b43cd68063499a8e71b9b07e66dc74082",
+   "sha256": "1lirapvam5l08fql67g25478j1fiimx7ic38y8qa6cib3fmyp6ik"
   },
   "stable": {
    "version": [
@@ -32014,19 +32204,19 @@
   "repo": "dimitri/el-get",
   "unstable": {
    "version": [
-    20260215,
-    1117
+    20260615,
+    2354
    ],
-   "commit": "911c252afe763a5cd1cbd188c476d44353cd5271",
-   "sha256": "094xlvqaj2crd405jhfk7raxdylw43k9f42wzc15miix6c98ldsz"
+   "commit": "447b7efc9fca29a087f4ec29c5d8ccb580cd1c78",
+   "sha256": "1qxxrvjw5fi75q6sgpkb83r4jg77prjgzf6lgvjb2vqzqyl046ir"
   },
   "stable": {
    "version": [
     5,
-    1
+    2
    ],
-   "commit": "bfffd553f4c72b818e9ee94f05458eae7a16056b",
-   "sha256": "1awyh9ffd6a4cia239s89asb88ddqlnrv757d76vcb701pq412bz"
+   "commit": "ec3b0a052bf2f90f30c51042ddb06471b35c7ab6",
+   "sha256": "1qmgrkwyv8irfsagz0n960z7ihw0q995d2s2cazyxcxzhw6817vx"
   }
  },
  {
@@ -32486,11 +32676,11 @@
   "repo": "Mstrodl/elcord",
   "unstable": {
    "version": [
-    20260121,
-    1637
+    20260506,
+    2048
    ],
-   "commit": "827dccbbdae038330f47e16ca189fd3e4ef25964",
-   "sha256": "15vfrb6vl1ycx2as051p8nqmfbcxhzcf2pqc52a5nq1lsdq1ybk0"
+   "commit": "033be3dc076fdb3de335d3b12bac5f783ebec820",
+   "sha256": "0x17jrv7pblrd8r2kgky1ndwi8fnz8p88hd6hmghdrwbl7ffpdlw"
   }
  },
  {
@@ -32580,20 +32770,20 @@
   "repo": "emacs-eldev/eldev",
   "unstable": {
    "version": [
-    20250314,
-    2105
+    20260612,
+    1624
    ],
-   "commit": "87373ddace0c4b2267d8f45ebd20e4b0eb27f821",
-   "sha256": "19lapjhhq39ffimgh20l148c456811xrgdxnycjlc6iy6zrbdbda"
+   "commit": "7ce62b0a71f75c8568e391e45eafe0687f610076",
+   "sha256": "0hch4cp47a4hrc1604cryq0yq8a9518a0wjkaz9s0a9ajlvx13y6"
   },
   "stable": {
    "version": [
     1,
     11,
-    1
+    2
    ],
-   "commit": "ff1e8269fca7e2ee2e50774ade3ce88b79e78cfc",
-   "sha256": "0sf8xyzblc0fs2d65jgcycavnzmrp1wg0sfr29gjkq1kvzyl7phb"
+   "commit": "92a46b48793e561b00189a06014df0d7bbeed3be",
+   "sha256": "1khqapvgm1y3svzb3pr6s1a3b6mzxdwy1cybbnssaxlvfjvgyvaz"
   }
  },
  {
@@ -32604,11 +32794,11 @@
   "repo": "casouri/eldoc-box",
   "unstable": {
    "version": [
-    20260415,
-    226
+    20260620,
+    158
    ],
-   "commit": "2680a08ff2438ff8c2ea6f8d57f22095f857900c",
-   "sha256": "1iqha79lpydaz2i5dah11zsj060bs1livl3fpi76kh3j5ak6v5id"
+   "commit": "e458cefba4013785ef6099c6245463689a50dd7d",
+   "sha256": "0bza0jgzlrz25xb1dy3l17gbmd4nnqi5x8bsvqa586i8jgd06hqw"
   },
   "stable": {
    "version": [
@@ -32696,28 +32886,28 @@
   "repo": "huangfeiyu/eldoc-mouse",
   "unstable": {
    "version": [
-    20260402,
-    1025
+    20260612,
+    945
    ],
    "deps": [
     "eglot",
     "posframe"
    ],
-   "commit": "67bb73e54533e276e35d2548aa30e299c3a5ee18",
-   "sha256": "1ysdf36dva7kzhxm63fp229fqp1ii2i5swf1qwgj03i4j755pfnz"
+   "commit": "6b7bddc4b16c0b3d6f4203e03e659b5211cab516",
+   "sha256": "1y4lfk2k3qhpjav0b3vhlfhvl1zy74lg64cbmhs6kmiajrn578rv"
   },
   "stable": {
    "version": [
     3,
     0,
-    6
+    8
    ],
    "deps": [
     "eglot",
     "posframe"
    ],
-   "commit": "79e47a4099cd4f9144a1636d8353a07b614c0c0a",
-   "sha256": "028gyngnlq6x0g8cd3m0a33v9skn94lavykls65lqxh91gr39lb3"
+   "commit": "6b7bddc4b16c0b3d6f4203e03e659b5211cab516",
+   "sha256": "1y4lfk2k3qhpjav0b3vhlfhvl1zy74lg64cbmhs6kmiajrn578rv"
   }
  },
  {
@@ -32988,26 +33178,32 @@
  },
  {
   "ename": "elfeed",
-  "commit": "25cd87f2f80a7228ae65ec26dc6c87f50fd2f9d0",
-  "sha256": "16f6y81n1kh9fhyl9950pfm0z3knv1ygam2cs41ydz6drnrvh119",
+  "commit": "d006f2f4284c73e83028d951632d4b7a61e87607",
+  "sha256": "1qi1q9lbf5x4zwa3nr5h7srr8ckyys0jdxwbc57nhch65dbs7l4y",
   "fetcher": "github",
-  "repo": "skeeto/elfeed",
+  "repo": "emacs-elfeed/elfeed",
   "unstable": {
    "version": [
-    20260218,
-    1306
+    20260623,
+    1113
    ],
-   "commit": "bbb3cac27b0412d80b327b5cfaab83683c96a2a1",
-   "sha256": "1z1ig5h2mhy7zdz8vh003536mmpkrjr7jm84ih3wsx8krvhgc1lb"
+   "deps": [
+    "compat"
+   ],
+   "commit": "2c4f03158a3bf410d95c57851de284a1f88537ca",
+   "sha256": "0q3mff27id2jasz217im8xdxryl55jf7b6k746pjs99rsqlw3vvj"
   },
   "stable": {
    "version": [
-    3,
     4,
-    2
+    0,
+    1
    ],
-   "commit": "904b6d4feca78e7e5336d7dbb7b8ba53b8c4dac1",
-   "sha256": "0yq93abyadzrmcd40pi06wcr4jg9ddhlz2phg0wjypprqvv4q49z"
+   "deps": [
+    "compat"
+   ],
+   "commit": "90470c3ff7cf215771f31e8c5e4b08fe6ad8f65b",
+   "sha256": "0sldxrvqcdf7is4x8g2dj4apix78bqq0q5pq1pzdawl6hfwdy1xw"
   }
  },
  {
@@ -33177,28 +33373,28 @@
   "repo": "fasheng/elfeed-protocol",
   "unstable": {
    "version": [
-    20240822,
-    805
+    20260523,
+    1339
    ],
    "deps": [
     "cl-lib",
     "elfeed"
    ],
-   "commit": "4f5e77a28c501db686ac06a2ea250a7b37d5420c",
-   "sha256": "04dvg0haz5b2gl4iz7aqiryys24fwjrp6h23fcga3gjipwwwxzmb"
+   "commit": "58936590459ccc2dfd6132f69983011d15d9404a",
+   "sha256": "014b4986w860mf8zvbfmchbc3sjmndcwy3wrx5fncmndkd750j2b"
   },
   "stable": {
    "version": [
+    1,
     0,
-    9,
-    1
+    0
    ],
    "deps": [
     "cl-lib",
     "elfeed"
    ],
-   "commit": "bcefb85a1d4075f36e73a94bda569e71f28a52c2",
-   "sha256": "1n5bns7181j6n603a626jsv26v06s3wm86ml7vixlp234p0frypp"
+   "commit": "58936590459ccc2dfd6132f69983011d15d9404a",
+   "sha256": "014b4986w860mf8zvbfmchbc3sjmndcwy3wrx5fncmndkd750j2b"
   }
  },
  {
@@ -33239,15 +33435,15 @@
   "repo": "fritzgrabo/elfeed-summarize",
   "unstable": {
    "version": [
-    20260217,
-    1534
+    20260522,
+    2046
    ],
    "deps": [
     "elfeed",
     "llm"
    ],
-   "commit": "b4d9f8a7bb72d9fd0db804eff535c42859d94cf8",
-   "sha256": "09f0v2mxrq01fjkpz6zk34c74hqy8y2z9qawv5lmm55sc91z2ajv"
+   "commit": "9b2fbc469d31e1f965ff1953e483adabbdf4495d",
+   "sha256": "116znd3s2alzr59zv0yarili4nk2sgbymkj7mkr9plfnzshr80ka"
   }
  },
  {
@@ -33258,15 +33454,15 @@
   "repo": "SqrtMinusOne/elfeed-summary",
   "unstable": {
    "version": [
-    20240929,
-    2043
+    20260607,
+    1418
    ],
    "deps": [
     "elfeed",
     "magit-section"
    ],
-   "commit": "76b4b93838b0420a114f934bbf8c09f25bf6ad16",
-   "sha256": "0ic2nzs88ck4f5vkk8m7sln2hawglnj4b2vzfl80vlip13dj3l3a"
+   "commit": "d8f237530c05c8be3093af295d3f5d530c2d3130",
+   "sha256": "1b2kfjjk8kk4hl6mswjh74hklmx494ra4m3lzrkx2yrmj3mmgw0w"
   },
   "stable": {
    "version": [
@@ -33290,15 +33486,15 @@
   "repo": "karthink/elfeed-tube",
   "unstable": {
    "version": [
-    20260404,
-    1841
+    20260522,
+    916
    ],
    "deps": [
     "aio",
     "elfeed"
    ],
-   "commit": "8e1334cfc8114ddd71b4de99760429e4e8a81f7b",
-   "sha256": "0c3lxk5r1v04rbsv4ivhwpvd0g8dzlq1lqzc35xy862ckaj41ci7"
+   "commit": "ae763194ad36942ccdbd9d59a40926a33bffd89b",
+   "sha256": "1s5df4z559jb805nb6b23hdhs0a72bqlyr12wvmn7858zn9p09bx"
   },
   "stable": {
    "version": [
@@ -33342,6 +33538,40 @@
    ],
    "commit": "7e1409e41628d61d8197ca248d910182ae4fc520",
    "sha256": "1vsrsnvz0ysd36a99zk7n2giv0gxznlnls8zq6lcc0hwqw78i5cq"
+  }
+ },
+ {
+  "ename": "elfeed-web",
+  "commit": "4b3677dd24b0167dcd342a5367640c6ed54d1142",
+  "sha256": "1miajgc19swv2wl1pfa5xn2c80pcbwmwhq023msb3bzxadhhw9y6",
+  "fetcher": "github",
+  "repo": "emacs-elfeed/elfeed-web",
+  "unstable": {
+   "version": [
+    20260623,
+    1111
+   ],
+   "deps": [
+    "compat",
+    "elfeed",
+    "simple-httpd"
+   ],
+   "commit": "9074428d7a5159e647ebdd07f53c9720b908aaf6",
+   "sha256": "0awlazj1cpb1idsw8pflc3r1xdc65n7fwyjf3csa6aph0awzrnq3"
+  },
+  "stable": {
+   "version": [
+    4,
+    0,
+    0
+   ],
+   "deps": [
+    "compat",
+    "elfeed",
+    "simple-httpd"
+   ],
+   "commit": "e947501a29457a55dfb0828aa791185c6b41bc37",
+   "sha256": "1gz10229bksz96l06czk2n6as65zb8kyib9mwln08ysrpdjs2k18"
   }
  },
  {
@@ -33571,14 +33801,14 @@
   "repo": "laurynas-biveinis/elisp-dev-mcp",
   "unstable": {
    "version": [
-    20260210,
-    434
+    20260602,
+    1123
    ],
    "deps": [
     "mcp-server-lib"
    ],
-   "commit": "acce467f667df06e8dd391d64c5a553997dabed5",
-   "sha256": "019b0yg1k1dknmw47wz9s8f9k6rzj7535g5alxrf4nw9j165n0i2"
+   "commit": "6120460212e03daf2f9502c3a5cebab958faa419",
+   "sha256": "02lcr7diwbrj3ij6c8wxvymr3mf9hf1bv385wyc4r3cfakjcw4gj"
   },
   "stable": {
    "version": [
@@ -33872,8 +34102,8 @@
   "repo": "s-kostyaev/ellama",
   "unstable": {
    "version": [
-    20260410,
-    54
+    20260605,
+    1826
    ],
    "deps": [
     "compat",
@@ -33882,14 +34112,14 @@
     "transient",
     "yaml"
    ],
-   "commit": "de68b25318a1eef629f4aad677dc7dd6fe446c2e",
-   "sha256": "0nk7c47qqm2w00c6cmlw6fv23qsfhg7fqb303fv5a9avdl47mnvh"
+   "commit": "b122f2e043313d470fa68c0c1e042e3dec536cbf",
+   "sha256": "1pv85p94w8yr81bll30mwlwyb30rsw3sx81lwznghg5jvi8bb875"
   },
   "stable": {
    "version": [
     1,
-    13,
-    0
+    27,
+    2
    ],
    "deps": [
     "compat",
@@ -33898,8 +34128,8 @@
     "transient",
     "yaml"
    ],
-   "commit": "de68b25318a1eef629f4aad677dc7dd6fe446c2e",
-   "sha256": "0nk7c47qqm2w00c6cmlw6fv23qsfhg7fqb303fv5a9avdl47mnvh"
+   "commit": "b122f2e043313d470fa68c0c1e042e3dec536cbf",
+   "sha256": "1pv85p94w8yr81bll30mwlwyb30rsw3sx81lwznghg5jvi8bb875"
   }
  },
  {
@@ -34056,20 +34286,20 @@
   "repo": "sp1ff/elmpd",
   "unstable": {
    "version": [
-    20250910,
-    327
+    20260619,
+    2114
    ],
-   "commit": "a68563fa3e3b09fcdaf4b9f070542f8cfa257067",
-   "sha256": "0kyw7j2zi2ji07hmpiyrpnyfmdrficinyjnvp7cnrphai925gj92"
+   "commit": "40a666c153da0c45262230bed3c7594e3362ca09",
+   "sha256": "0qip0rj6zj1p2a8a45dvlnkayjc2pj4ywc80mq0qg7yf6cnxw7jp"
   },
   "stable": {
    "version": [
     1,
     0,
-    1
+    2
    ],
-   "commit": "89d8b514ed940d7a9452a804158fe6604ec6016f",
-   "sha256": "16fg699zgy14yl3ymqq2cqbpplb9prsqvi550rx69zbq7sq24bp0"
+   "commit": "40a666c153da0c45262230bed3c7594e3362ca09",
+   "sha256": "0qip0rj6zj1p2a8a45dvlnkayjc2pj4ywc80mq0qg7yf6cnxw7jp"
   }
  },
  {
@@ -34142,6 +34372,30 @@
    ],
    "commit": "f2f19d7ab6b77b8fec55cb67524df629fe967891",
    "sha256": "0fwl14xqnxq5d4a9wk0p1xvfkmff5inwmz2v1s8n7w1sy29zslrn"
+  }
+ },
+ {
+  "ename": "elot",
+  "commit": "523f6f9edbf3af4a4bbfe0bdbdc15cfd0376c4c7",
+  "sha256": "1z1jrp3g8jsdsiq2p0abns0zmj4h09d2aq78bcm4kg8m9173s1mm",
+  "fetcher": "github",
+  "repo": "johanwk/elot",
+  "unstable": {
+   "version": [
+    20260603,
+    1452
+   ],
+   "commit": "aa2e0b60307ab1d06622281a9c69411b55a442b3",
+   "sha256": "093xianvfgcqd6yyk3f9nc0ccdmcny825aah3icn72phb5ws566h"
+  },
+  "stable": {
+   "version": [
+    2,
+    1,
+    0
+   ],
+   "commit": "62e4ce56610caf2336a19f23418bea819c1e36b7",
+   "sha256": "07syg6kih7z2hzwxvx8h9pd8wrpyak7m0z343yggzncl5iyp9zq1"
   }
  },
  {
@@ -34295,8 +34549,8 @@
   "repo": "jorgenschaefer/elpy",
   "unstable": {
    "version": [
-    20260413,
-    2143
+    20260517,
+    631
    ],
    "deps": [
     "company",
@@ -34305,8 +34559,8 @@
     "s",
     "yasnippet"
    ],
-   "commit": "777f5a5f951ee4b717856007c337e9f37fd4ea5d",
-   "sha256": "03rkjfi08j5lz0jl0aw66sqc2rbrx55kj6yanxmd6drv63ryd1zj"
+   "commit": "261774a6d024503a8198c020999ed54a163f85ad",
+   "sha256": "1k2rgimv0wf62jy82wgjkbakr3xz6xmayxx8sgnhgb79fl1sigf3"
   },
   "stable": {
    "version": [
@@ -34656,34 +34910,36 @@
  },
  {
   "ename": "elx",
-  "commit": "57a2fb9524df3fdfdc54c403112e12bd70888b23",
-  "sha256": "008nwa2gn3d2ayr8023pxyvph52gh9m56f77h41hp8hcw6hbdwrz",
+  "commit": "aec4a76eaea31408bd27d76a0b8cea5268663cc1",
+  "sha256": "1rn1cxcw8gqagiap4k0zrl680x8jr7x2fcbli9kc5s16gibazdzw",
   "fetcher": "github",
   "repo": "emacscollective/elx",
   "unstable": {
    "version": [
-    20260101,
-    1832
+    20260601,
+    1500
    ],
    "deps": [
     "compat",
+    "cond-let",
     "llama"
    ],
-   "commit": "5c700de6d3b4163b0a3ed3060f491c22b4bfaa85",
-   "sha256": "1naspqq3d93l8d2iba00gkhhvwxrj8nj5h459msd6in0s1lqc682"
+   "commit": "99ea4bde756a3ae4a0cae96e9fffe6b13421d25f",
+   "sha256": "0ni8agxcf64cgpmy4jhqsss2d90bd0hfg48187idfq7clhnxl07i"
   },
   "stable": {
    "version": [
     2,
     3,
-    2
+    3
    ],
    "deps": [
     "compat",
+    "cond-let",
     "llama"
    ],
-   "commit": "5c700de6d3b4163b0a3ed3060f491c22b4bfaa85",
-   "sha256": "1naspqq3d93l8d2iba00gkhhvwxrj8nj5h459msd6in0s1lqc682"
+   "commit": "99ea4bde756a3ae4a0cae96e9fffe6b13421d25f",
+   "sha256": "0ni8agxcf64cgpmy4jhqsss2d90bd0hfg48187idfq7clhnxl07i"
   }
  },
  {
@@ -34778,20 +35034,20 @@
   "repo": "magit/emacsql",
   "unstable": {
    "version": [
-    20260401,
-    1220
+    20260601,
+    1722
    ],
-   "commit": "2fe6d4562b32a170a750d5e80514fbb6b6694803",
-   "sha256": "1hm6g2ad8bsfrl7gqcb5psphcgvak8608b6vw1rc5rrsr7j6rdsl"
+   "commit": "d811bbefcb5e27841af55cae53aa939ba720de77",
+   "sha256": "0spinavna6k6b43lcj92w1sc0jlffzqyj9byxyayg4g6md995dhi"
   },
   "stable": {
    "version": [
     4,
-    3,
-    6
+    4,
+    1
    ],
-   "commit": "2fe6d4562b32a170a750d5e80514fbb6b6694803",
-   "sha256": "1hm6g2ad8bsfrl7gqcb5psphcgvak8608b6vw1rc5rrsr7j6rdsl"
+   "commit": "d811bbefcb5e27841af55cae53aa939ba720de77",
+   "sha256": "0spinavna6k6b43lcj92w1sc0jlffzqyj9byxyayg4g6md995dhi"
   }
  },
  {
@@ -34898,14 +35154,14 @@
   "repo": "oantolin/embark",
   "unstable": {
    "version": [
-    20260404,
-    2302
+    20260610,
+    302
    ],
    "deps": [
     "compat"
    ],
-   "commit": "27de48004242e98586b9c9661fdb6912f26fe70f",
-   "sha256": "1y97kibzz36wrzcjv997qp5pliikda0dhsm9461pin3q5gv8y6kq"
+   "commit": "350ca86924c5027e80875943fba7b912a71e5791",
+   "sha256": "0s2q46qbf9aa0hs53m4qp4pwjh9zhsfiagragwy0iffh4rw5jn73"
   },
   "stable": {
    "version": [
@@ -34927,16 +35183,16 @@
   "repo": "oantolin/embark",
   "unstable": {
    "version": [
-    20260404,
-    2302
+    20260503,
+    118
    ],
    "deps": [
     "compat",
     "consult",
     "embark"
    ],
-   "commit": "27de48004242e98586b9c9661fdb6912f26fe70f",
-   "sha256": "1y97kibzz36wrzcjv997qp5pliikda0dhsm9461pin3q5gv8y6kq"
+   "commit": "ec5dd1475595277ef908567d0a18d32f1c40bc91",
+   "sha256": "04kbfad7qjcraihf3238xxadw10g96ndl08449d53avwwclr679d"
   },
   "stable": {
    "version": [
@@ -35102,6 +35358,26 @@
    ],
    "commit": "f788e164056801059b5821a64909d49472d0e77e",
    "sha256": "0hc61haiyhrzfm44b17ndqdbyq5vgy4g2v4da87scvkaxnsj8vbq"
+  }
+ },
+ {
+  "ename": "emcp",
+  "commit": "49fc1d7aaed297404c3d40d083395ae108aef4eb",
+  "sha256": "06d5l76qdd48130w2zyqq80m682das82l2w7mc7n5039zqfz8fvs",
+  "fetcher": "codeberg",
+  "repo": "martenlienen/emcp",
+  "unstable": {
+   "version": [
+    20260612,
+    1547
+   ],
+   "deps": [
+    "elisp-refs",
+    "http-server",
+    "magit-section"
+   ],
+   "commit": "19523208ee78d6548a8f8ad6aa2e296a6836d4db",
+   "sha256": "1np8g6dk1d75xa6pfa2mh6jqmr2dl665h6bnjn3f2p7llm5bw2w5"
   }
  },
  {
@@ -35769,28 +36045,28 @@
   "repo": "jamescherti/enhanced-evil-paredit.el",
   "unstable": {
    "version": [
-    20260314,
-    1908
+    20260604,
+    223
    ],
    "deps": [
     "evil",
     "paredit"
    ],
-   "commit": "11521019d4800f4de2a2ac460a48eba013ad89b6",
-   "sha256": "0px209sgx7lzlybbaw28l71zcgbynb95gwyb7xnis37mb4m6w589"
+   "commit": "2209fceae2acab381facb1865ac41b28c2938f10",
+   "sha256": "1xyld0nfgnzrz36djv7c1q722gva9a93gxrsxxnx6s4pknrghlza"
   },
   "stable": {
    "version": [
     1,
     0,
-    4
+    5
    ],
    "deps": [
     "evil",
     "paredit"
    ],
-   "commit": "7ca82138881a5efacacf0494b898fb1201311fc8",
-   "sha256": "0kkfnnqd2pzzm92pi13ngh63frp33z2mfb1prkqaw62nq4yrw6d8"
+   "commit": "2209fceae2acab381facb1865ac41b28c2938f10",
+   "sha256": "1xyld0nfgnzrz36djv7c1q722gva9a93gxrsxxnx6s4pknrghlza"
   }
  },
  {
@@ -35946,15 +36222,15 @@
   "repo": "purcell/envrc",
   "unstable": {
    "version": [
-    20260325,
-    1609
+    20260622,
+    1004
    ],
    "deps": [
     "inheritenv",
     "seq"
    ],
-   "commit": "60820285aeed4f87969d663a1c14a905c7bb763a",
-   "sha256": "0a8ymkzjvykjjpnd6m1ysmbq1pqyvbijx6awwwwqwgzq0q5q2l8z"
+   "commit": "77e9dec1563bc204cc9e086cd8a7d3622196224c",
+   "sha256": "11ksm8049332a9j5p1xmrwwvmmn74kxwc7v4gaza131kx271jr19"
   },
   "stable": {
    "version": [
@@ -36090,32 +36366,34 @@
   "repo": "emacscollective/epkg",
   "unstable": {
    "version": [
-    20260416,
-    1107
+    20260617,
+    1602
    ],
    "deps": [
     "closql",
     "compat",
+    "cond-let",
     "emacsql",
     "llama"
    ],
-   "commit": "f3f8d26401a7a9c49d4b670dbf463dd010c26fae",
-   "sha256": "0n6agpskxxqm5618ajp9wk8i6g047yjf889lw4qp5cb2kdqslfp8"
+   "commit": "636490387d8fef3dc4d54b0b7cdc7ffe947663a1",
+   "sha256": "0xgjp20gr3qjkf2bry9r91cl3b49jsc7zdkzvi0zqcbwvi0gpdjh"
   },
   "stable": {
    "version": [
     4,
-    1,
-    4
+    2,
+    1
    ],
    "deps": [
     "closql",
     "compat",
+    "cond-let",
     "emacsql",
     "llama"
    ],
-   "commit": "fc3cba38a416ec4e26a7d8eb7bc5ee910e67aa73",
-   "sha256": "1im5di9rgvirzlnkfns6sv6wrn2sfb7k98f4i4b29kh7jwrrwzax"
+   "commit": "849ce2359fcd51467e7ef00faaf6130e1017e6ce",
+   "sha256": "0cb2bqhbh60lk1s9w0aan4qkq4v9pvsqqiiijmi3kgvyhfnkcwhn"
   }
  },
  {
@@ -36126,30 +36404,32 @@
   "repo": "emacscollective/epkg-marginalia",
   "unstable": {
    "version": [
-    20260301,
-    1306
+    20260601,
+    1622
    ],
    "deps": [
     "compat",
+    "cond-let",
     "epkg",
     "marginalia"
    ],
-   "commit": "d6ccf20529c39652968d1b017fae78404ac191fb",
-   "sha256": "1qchlg0aimljbxsa641lgscyqlbyjch6p1lyaa9gffmc1jgslzn2"
+   "commit": "e789ebff7af97f193e38cc3d5636dd55022973b8",
+   "sha256": "1pkjlyh5n714q604savi4yg05xlqza9q6a85p1gdpxgv5gxa3dfd"
   },
   "stable": {
    "version": [
     1,
     1,
-    4
+    5
    ],
    "deps": [
     "compat",
+    "cond-let",
     "epkg",
     "marginalia"
    ],
-   "commit": "d6ccf20529c39652968d1b017fae78404ac191fb",
-   "sha256": "1qchlg0aimljbxsa641lgscyqlbyjch6p1lyaa9gffmc1jgslzn2"
+   "commit": "e789ebff7af97f193e38cc3d5636dd55022973b8",
+   "sha256": "1pkjlyh5n714q604savi4yg05xlqza9q6a85p1gdpxgv5gxa3dfd"
   }
  },
  {
@@ -36842,19 +37122,20 @@
   "repo": "erlang/otp",
   "unstable": {
    "version": [
-    20260420,
-    1445
+    20260609,
+    1424
    ],
-   "commit": "a42e46bab47432b988ee60e4c9d915c858bcf32d",
-   "sha256": "0vfzzxs7dv3wadrlgb97fjc7vr8hvwghjz9hynqjvzf2i2ranl4f"
+   "commit": "36b336d7675edfb976768465c5067bc8bc16ee9a",
+   "sha256": "0xzhcwmll71048is39kqli15fx8cgi91zk7391v5a2wf63x5xnpa"
   },
   "stable": {
    "version": [
-    28,
-    5
+    29,
+    0,
+    2
    ],
-   "commit": "f4506ee46d68694a1d23ca81c314092fd83e8f85",
-   "sha256": "15vjxb10840jvxhnnrgsd2s4j1sclwn5nkfwyd8zdbdcyn6hi203"
+   "commit": "36b336d7675edfb976768465c5067bc8bc16ee9a",
+   "sha256": "0xzhcwmll71048is39kqli15fx8cgi91zk7391v5a2wf63x5xnpa"
   }
  },
  {
@@ -36877,13 +37158,13 @@
   "stable": {
    "version": [
     0,
-    3
+    4
    ],
    "deps": [
     "erlang"
    ],
-   "commit": "bf5adaa17a55a8a0d21c30de949d6074731711a0",
-   "sha256": "01sl1162w9qx10yl1c8k5a5gskflpd47ky7qsh5zln9qyrqpr5bw"
+   "commit": "4e9095be49630dc279c70033245a7e1051614f92",
+   "sha256": "149brvyawf38q0d1i43abnzqijnwj2sqnvwic68kz1cn3c3vdzch"
   }
  },
  {
@@ -37281,32 +37562,32 @@
  },
  {
   "ename": "esh-autosuggest",
-  "commit": "dc3776068d6928fc1661a27cccaeb8fb85577099",
-  "sha256": "1rcng1dhy4yw95qg909ck33svpdxhv9v5k7226d29gp4y54dwyrx",
-  "fetcher": "github",
+  "commit": "1d888e12b1c4002896723b3c993a72bf920ef37b",
+  "sha256": "1adsjqm1h8pj2p6n49l7y02ccqwxfw40crkpd1r60xizmdj19gcn",
+  "fetcher": "sourcehut",
   "repo": "dieggsy/esh-autosuggest",
   "unstable": {
    "version": [
-    20241002,
-    1820
+    20260530,
+    527
    ],
    "deps": [
     "company"
    ],
-   "commit": "b3ae8eb2d6f8da1dc59f61a589003d741514d6f6",
-   "sha256": "1n4zswxs49qn2jngr82w9kk7qdhdwysknsm95iq3ija2azyvqgcr"
+   "commit": "40774022105ed16287fcf26553a16c4cdda5e1ab",
+   "sha256": "08x015gvdp804gpfhvxz72m7iw4zg4lrrzyd8gg191j4mrskjbzk"
   },
   "stable": {
    "version": [
     2,
-    0,
-    1
+    1,
+    0
    ],
    "deps": [
     "company"
    ],
-   "commit": "a6d5eb3337d010bd2a2d677ff304cd53adc291a0",
-   "sha256": "0l2nnlr3b6df1xn0qjf5d5ryy1wcs1jczyfy795vsasd5gm3g0xh"
+   "commit": "1017a4992c086d6d0924572561879af1ac1d8c03",
+   "sha256": "01d40x7zibd8gdxlvnkn9hhj6bgdxn6g4mz4h7pvgryyvgbljy0g"
   }
  },
  {
@@ -37971,11 +38252,11 @@
   "repo": "emacs-ess/ESS",
   "unstable": {
    "version": [
-    20260423,
-    1426
+    20260526,
+    1432
    ],
-   "commit": "5a09992aa6276fc8626a41d01d58b1d85959edaf",
-   "sha256": "1f238ajfm1qjg5qqkaknw1flvrdxrzhqmsb5mswv00irbagb6bb2"
+   "commit": "da7d7dc1d2cf95760f56cb1763eb543c4dadaa0c",
+   "sha256": "0rma9cz44ajiwnbndmc8hqfn61gc6asj38fzd06nhyf2l39gqrcs"
   },
   "stable": {
    "version": [
@@ -38317,21 +38598,21 @@
  },
  {
   "ename": "eterm-256color",
-  "commit": "e556383f7e18c0215111aa720d4653465e91eff6",
-  "sha256": "1mxc2hqjcj67jq5k4621a7f089qahcqw7f0dzqpaxn7if11w333b",
-  "fetcher": "github",
+  "commit": "1d888e12b1c4002896723b3c993a72bf920ef37b",
+  "sha256": "153g793mfgwrf9b7jkdlk18z493jgx3igbg1mz5n6g6s8vps92dc",
+  "fetcher": "sourcehut",
   "repo": "dieggsy/eterm-256color",
   "unstable": {
    "version": [
-    20210224,
-    2241
+    20260530,
+    531
    ],
    "deps": [
     "f",
     "xterm-color"
    ],
-   "commit": "05fdbd336a888a0f4068578a6d385d8bf812a4e8",
-   "sha256": "0ln1agcgr607n5akm0ax659g11kfbik7cq8ssnqpr3z7riiv95dm"
+   "commit": "868eeaa958de1deab690fe8ac8f5477452ccdb6a",
+   "sha256": "0w9khzgkg17dsyd623p3gbqyd372ld3mrniwsidj2awk6y5k0y2r"
   },
   "stable": {
    "version": [
@@ -38645,16 +38926,16 @@
   "repo": "emacs-evil/evil",
   "unstable": {
    "version": [
-    20251108,
-    138
+    20260603,
+    654
    ],
    "deps": [
     "cl-lib",
     "goto-chg",
     "nadvice"
    ],
-   "commit": "729d9a58b387704011a115c9200614e32da3cefc",
-   "sha256": "0scdws40fg4k9lqyznjghnn8svn7l0c6mq7h2aq5pzkm6hanzqn3"
+   "commit": "3b678a221ee99cc6a95b01d7a3129ce5efc4c3da",
+   "sha256": "18hqjh4vz2pq40bvnrmshg1w5msq1b17l20vv5j6a76a2a7iqy8x"
   },
   "stable": {
    "version": [
@@ -38797,28 +39078,28 @@
   "repo": "wbolster/emacs-evil-colemak-basics",
   "unstable": {
    "version": [
-    20241004,
-    1613
+    20260619,
+    1649
    ],
    "deps": [
     "evil",
     "evil-snipe"
    ],
-   "commit": "9465c8da35fe7dd0f66184e671e357ec91faa3fe",
-   "sha256": "1w1d239c7ivqdz46vnqhaz2fkx8xzzc2209ldf9w4f68nd6awqj3"
+   "commit": "70a08ff4c8148c38e0cdc2b89b0316fd504501f6",
+   "sha256": "1dg7kymvq3v5dblzja6qvm7nx44ly15715279vhpkq3xnig6ag3d"
   },
   "stable": {
    "version": [
-    2,
-    2,
-    1
+    3,
+    0,
+    0
    ],
    "deps": [
     "evil",
     "evil-snipe"
    ],
-   "commit": "05c023740f3d95805533081894bfd87f06401af5",
-   "sha256": "1fnzrwr53h18wp4wkb834j39xg8bv7yqcmilb41bc81npfmi2mn1"
+   "commit": "70a08ff4c8148c38e0cdc2b89b0316fd504501f6",
+   "sha256": "1dg7kymvq3v5dblzja6qvm7nx44ly15715279vhpkq3xnig6ag3d"
   }
  },
  {
@@ -38847,28 +39128,26 @@
   "repo": "emacs-evil/evil-collection",
   "unstable": {
    "version": [
-    20260423,
-    438
+    20260624,
+    327
    ],
    "deps": [
-    "annalist",
     "evil"
    ],
-   "commit": "2df40737c6cc9ccd8b69462a6f2f6a045c2d7684",
-   "sha256": "1skwz01sjhgha848gk0vw9cbxzkip1nz4hkn629z8jzw25npdna3"
+   "commit": "23fa1e6eaf32d5eb8ab83861c176f866e8d8cff2",
+   "sha256": "1hl343rpxaizmal75fnmfwpp2vvjbl9bd30smlzh2j3bqvzy2mp2"
   },
   "stable": {
    "version": [
+    1,
     0,
-    0,
-    10
+    0
    ],
    "deps": [
-    "annalist",
     "evil"
    ],
-   "commit": "d0518fc1626f09a341d4b5a98c857087abfb1b0c",
-   "sha256": "09hnxb8nh3g0hi93fz9f1y164gv9iyh5994wfn6fsq2v1xdz8phm"
+   "commit": "4ab182ddf139f0df2b5da2e745ad0aad195fb23f",
+   "sha256": "1lq0yh7isplr8glh9f7fb1fds7dq7k3jcxzz8zrhvyj5yhl4sj3c"
   }
  },
  {
@@ -38927,15 +39206,16 @@
   "repo": "PythonNut/evil-easymotion",
   "unstable": {
    "version": [
-    20200424,
-    135
+    20260602,
+    2314
    ],
    "deps": [
     "avy",
-    "cl-lib"
+    "cl-lib",
+    "evil"
    ],
-   "commit": "f96c2ed38ddc07908db7c3c11bcd6285a3e8c2e9",
-   "sha256": "0xsva9bnlfwfmccm38qh3yvn4jr9za5rxqn4pwxbmhnx4rk47cch"
+   "commit": "629c894af63336028a61cc93d6465d10837eb82b",
+   "sha256": "0mlaqlfq99s3l6azrx2lbhxb4d7lc45z6jrj3y5cs8j606qd9x6h"
   }
  },
  {
@@ -39133,6 +39413,38 @@
   }
  },
  {
+  "ename": "evil-ghostel",
+  "commit": "32c111d2c381b618d3ca556c09b15bc3a0d91287",
+  "sha256": "0dq9lcwxil6qayxhhcy6csfbfk8jx8pi3r9gyx9l0jn2rsm9b6d6",
+  "fetcher": "github",
+  "repo": "dakra/ghostel",
+  "unstable": {
+   "version": [
+    20260623,
+    1940
+   ],
+   "deps": [
+    "evil",
+    "ghostel"
+   ],
+   "commit": "b6d7b37353572bf92d04c8de5abced3ef68a0304",
+   "sha256": "1yv31zvyk80k2yl67hx67l1xwizm9p9257fwwz5hfav6lx0z6vm2"
+  },
+  "stable": {
+   "version": [
+    0,
+    38,
+    0
+   ],
+   "deps": [
+    "evil",
+    "ghostel"
+   ],
+   "commit": "b6d7b37353572bf92d04c8de5abced3ef68a0304",
+   "sha256": "1yv31zvyk80k2yl67hx67l1xwizm9p9257fwwz5hfav6lx0z6vm2"
+  }
+ },
+ {
   "ename": "evil-god-state",
   "commit": "46b8586e9a821efb67539155f783a32867084bfa",
   "sha256": "1g547d58zf11qw0zz3fk5kmrzmfx1rhawyh5d2h8bll8hwygnrxf",
@@ -39159,28 +39471,28 @@
   "repo": "jam1015/evil-god-toggle",
   "unstable": {
    "version": [
-    20251031,
-    2050
+    20260522,
+    2049
    ],
    "deps": [
     "evil",
     "god-mode"
    ],
-   "commit": "5f61e718133c86db3ddc0532cc0e1d4f80b967cb",
-   "sha256": "1l7mj3lndk4lzn8min1cncqs7kdyzjd750i5m6dk9q1llnfnbn3d"
+   "commit": "d6f8d098b9f9e0046df5afd35ced5bc5ed5a0ea0",
+   "sha256": "0zrl2rzp8pb03ji90r9nr2kjfw39iw5kifkiyv01wh7jrdyjsxy3"
   },
   "stable": {
    "version": [
     1,
-    0,
+    3,
     0
    ],
    "deps": [
     "evil",
     "god-mode"
    ],
-   "commit": "a2e240e8ffdfff16ffa2be2517a7c60d3cc3ced9",
-   "sha256": "19j9ip27va0m6sjm67mffyzz00fy1bxj09jlsvhxisd3c30300gk"
+   "commit": "d6f8d098b9f9e0046df5afd35ced5bc5ed5a0ea0",
+   "sha256": "0zrl2rzp8pb03ji90r9nr2kjfw39iw5kifkiyv01wh7jrdyjsxy3"
   }
  },
  {
@@ -39290,13 +39602,13 @@
    "version": [
     0,
     5,
-    5
+    4
    ],
    "deps": [
     "evil"
    ],
-   "commit": "a43914e3d483685dc11d616f9fcd268779dd0258",
-   "sha256": "1ahnh30qimcfydwmdwblg3h1gmjlq5iibcr7h0r1s720fsb73fn7"
+   "commit": "d584ed3ea2a49ed7f93fe176800e7a2f95dff6aa",
+   "sha256": "1fjrq54vfacxmmk1w1f35w9mdbrlld462nnqfappj6v4d14cq3fs"
   }
  },
  {
@@ -39675,11 +39987,11 @@
   "repo": "redguardtoo/evil-nerd-commenter",
   "unstable": {
    "version": [
-    20230625,
-    254
+    20260507,
+    414
    ],
-   "commit": "3b197a2b559b06a7cf39978704b196f53dac802a",
-   "sha256": "1xi4sd75pzhgcd9lzhx18hlzbrwh5q9gbscb1971qn94mzxwd60r"
+   "commit": "db5ee61a6e75db074b7d20e9dcb68e0b94b4edc7",
+   "sha256": "0x7h3b44jdsdvz1991bmhblmc82s59rq9wnd4qvl3m783cxa9jdi"
   },
   "stable": {
    "version": [
@@ -40280,11 +40592,11 @@
   "repo": "7696122/evil-terminal-cursor-changer",
   "unstable": {
    "version": [
-    20260405,
-    711
+    20260523,
+    1907
    ],
-   "commit": "06adce5174cf97d500d250fa6053722a326c18db",
-   "sha256": "0a2v0wryg7y4y0chq08045wppm0bms0z99vv0bbzmc90cmpgsm6x"
+   "commit": "fb824f657fb4325c1124f3e1b61f0de7ed062adf",
+   "sha256": "1qywpk9z893q4a12n0zqgwsychhfqjv2py20z0fsg4j78aszdpnv"
   },
   "stable": {
    "version": [
@@ -40530,11 +40842,11 @@
   "repo": "meain/evil-textobj-tree-sitter",
   "unstable": {
    "version": [
-    20260310,
-    405
+    20260616,
+    730
    ],
-   "commit": "7f58008a82c70eb1c6c5761db499f0be0db9d6cb",
-   "sha256": "0nfaz4vdghyaf0k8b35ssqif4fdisylqs55v1v0a8ss114r96b26"
+   "commit": "fecc0e11615df31a6651ce11b012388e53cad4e9",
+   "sha256": "074kadi1z43ixxvlfwd917czpiw4qg1ysybwxwdd7kb4x8siqpas"
   },
   "stable": {
    "version": [
@@ -41139,10 +41451,10 @@
  },
  {
   "ename": "exotica-theme",
-  "commit": "ca71d6b596e2595f356f7848e202b2450d395f49",
-  "sha256": "0bzibc1s7a2qxh03573q43dw4pk1svrvh17n6nzxznag8abnndqn",
+  "commit": "f5dc52f2853b75497df431a4d35663f3574c8286",
+  "sha256": "0yyn8fsj0x6cfp68skr72zy4ipndyi2f4s37fkns81ykgpmdrkas",
   "fetcher": "github",
-  "repo": "sacredyak/exotica-theme",
+  "repo": "rokrdev/exotica-theme",
   "unstable": {
    "version": [
     20180212,
@@ -41734,6 +42046,30 @@
   }
  },
  {
+  "ename": "f90-ts-mode",
+  "commit": "15ade73fdc7b379649b5cead652f8ad3a2c1e624",
+  "sha256": "1rwgvjks9bp37zgb81d7h0q8dw2rj2v3bxf5z678bkcx8bs8gfih",
+  "fetcher": "github",
+  "repo": "mscfd/emacs-f90-ts-mode",
+  "unstable": {
+   "version": [
+    20260620,
+    1316
+   ],
+   "commit": "2df0e82c35e3690553231370884e340a925ba158",
+   "sha256": "1572qxrxb5riqw4psjvms4k2qd1kgskjhci4wnc0xvi95xjiqh6q"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    2
+   ],
+   "commit": "6c3e40cad1fc459b5c4084ce21e748a0a4145612",
+   "sha256": "0r9xmshsxq9ypsfn3wnx1sc2avrlnwmpql083blpawphs6pzxm01"
+  }
+ },
+ {
   "ename": "fabric",
   "commit": "83939d2a4d5874244a4916eee9ae6b327af18b5d",
   "sha256": "1mkblsakdhvi10b67bv3j0jsf7hr8lf9sibmprvx8smqsih7l88m",
@@ -41831,25 +42167,26 @@
   "repo": "WJCFerguson/emacs-faff-theme",
   "unstable": {
    "version": [
-    20260413,
-    2137
+    20260507,
+    114
    ],
    "deps": [
     "modus-themes"
    ],
-   "commit": "1a6ee167627a4c623f157f3afb5ec12d368889af",
-   "sha256": "13vb0c5v5hd8jzy8cp6r2fv8wixcj5gfl9060d7w0qdf1h6kx6rv"
+   "commit": "468d7d4fafc8f8fe8515ac0454561121619e1129",
+   "sha256": "0j1b5irhj9ijs504i0sa4i4jvd9n08cr8r2qr1l0l3mj5qlppy8k"
   },
   "stable": {
    "version": [
     4,
-    0
+    0,
+    4
    ],
    "deps": [
     "modus-themes"
    ],
-   "commit": "8f976f810e6f23d2afaaa13f53e11d73e941cbcf",
-   "sha256": "1083ias5bk17vcvpa4xrnpps6r1v46xnzy2b2x0azin0vj9pvc65"
+   "commit": "468d7d4fafc8f8fe8515ac0454561121619e1129",
+   "sha256": "0j1b5irhj9ijs504i0sa4i4jvd9n08cr8r2qr1l0l3mj5qlppy8k"
   }
  },
  {
@@ -41936,11 +42273,11 @@
   "repo": "ideasman42/emacs-fancy-fill-paragraph",
   "unstable": {
    "version": [
-    20260421,
-    124
+    20260615,
+    716
    ],
-   "commit": "3f3e8fddc4f69c7c0ff933af58e8c3a71292a7cb",
-   "sha256": "1475h2i8b8b7xawkvawb76yr62y8p603id4lbhrrrrw9wvr7dnj2"
+   "commit": "a3a2b880db857e8e55a4d20a87680c35d0325439",
+   "sha256": "0ky203nmvdz4nfl8acs7g3fzklcm1pynjz2z3kiqgyhhxn85f4p4"
   }
  },
  {
@@ -42355,25 +42692,25 @@
   "repo": "martianh/fedi.el",
   "unstable": {
    "version": [
-    20260223,
-    1326
+    20260509,
+    801
    ],
    "deps": [
     "markdown-mode"
    ],
-   "commit": "74fab520f1d008f5a389a673616a617c03c74600",
-   "sha256": "0ldag8659nqphc2isw1n3xv8dqf468ppwf1q10zn03sdj4dc1i11"
+   "commit": "91f28ee199a499b8d6e1b9c7a0f1c15f8a382198",
+   "sha256": "0xlsh4a42mymi4jrb32ak4srbm28hq67jwijnpbyfzfkchjsqimj"
   },
   "stable": {
    "version": [
     0,
-    3
+    4
    ],
    "deps": [
     "markdown-mode"
    ],
-   "commit": "74fab520f1d008f5a389a673616a617c03c74600",
-   "sha256": "0ldag8659nqphc2isw1n3xv8dqf468ppwf1q10zn03sdj4dc1i11"
+   "commit": "91f28ee199a499b8d6e1b9c7a0f1c15f8a382198",
+   "sha256": "0xlsh4a42mymi4jrb32ak4srbm28hq67jwijnpbyfzfkchjsqimj"
   }
  },
  {
@@ -42452,11 +42789,11 @@
   "repo": "technomancy/fennel-mode",
   "unstable": {
    "version": [
-    20260408,
-    1529
+    20260507,
+    757
    ],
-   "commit": "c963b4701e4668717df083c8a4591c93e6b1dc8d",
-   "sha256": "0mdhcqns89fm2yc7j3pbaniqg3mx9gffgfj3fbnnpfwj7mf9gadc"
+   "commit": "1ef8ae0cff094cfba750e72b897e03eaeebbc117",
+   "sha256": "1q31ym8gy1m9xyn9w633br8kz0wxkzk4cri6373y0d5a4ic9r53c"
   },
   "stable": {
    "version": [
@@ -42587,15 +42924,15 @@
   "repo": "Artawower/file-info.el",
   "unstable": {
    "version": [
-    20251107,
-    1738
+    20260509,
+    754
    ],
    "deps": [
     "browse-at-remote",
     "hydra"
    ],
-   "commit": "5d8c5158a57e0077410bcdb802c344f5e8da4aca",
-   "sha256": "1ap8ms7vrv0hnra0mcxpkf364j3ql5s9j40fmqqi84djr6w0abn6"
+   "commit": "c20ab17ee23e7e1b07975cce9a3c2d5e3dff14f6",
+   "sha256": "19msd6iaadnxg8rdvlj12vdwpq3jk81q23hz68pdz1yp9spndbc5"
   },
   "stable": {
    "version": [
@@ -43363,8 +43700,8 @@
   "repo": "martianh/fj.el",
   "unstable": {
    "version": [
-    20260327,
-    906
+    20260509,
+    741
    ],
    "deps": [
     "fedi",
@@ -43372,13 +43709,13 @@
     "tp",
     "transient"
    ],
-   "commit": "3697ac2847180bd307e70ff0fb9ef086f59dec24",
-   "sha256": "1y3k82q5iii7ddm6yj7397x2jscbcnvapd04zc5wjkqdr50cay3l"
+   "commit": "4832dcfcd167d1975bb44a024881c75fef64182e",
+   "sha256": "09ff20am16ysjpbqx7b92qgmvyar9b6blm32flkvzqxccqqinxya"
   },
   "stable": {
    "version": [
     0,
-    34
+    37
    ],
    "deps": [
     "fedi",
@@ -43386,8 +43723,8 @@
     "tp",
     "transient"
    ],
-   "commit": "3697ac2847180bd307e70ff0fb9ef086f59dec24",
-   "sha256": "1y3k82q5iii7ddm6yj7397x2jscbcnvapd04zc5wjkqdr50cay3l"
+   "commit": "4832dcfcd167d1975bb44a024881c75fef64182e",
+   "sha256": "09ff20am16ysjpbqx7b92qgmvyar9b6blm32flkvzqxccqqinxya"
   }
  },
  {
@@ -43610,15 +43947,15 @@
   "repo": "plandes/flex-compile",
   "unstable": {
    "version": [
-    20251218,
-    243
+    20260615,
+    2248
    ],
    "deps": [
     "buffer-manage",
     "dash"
    ],
-   "commit": "f15d23afabd03c39583b1a87dd847a91cb7bfe34",
-   "sha256": "0k1q4fmh43jwcl81v4qxr4s0azbikh6cnfa0ngs8g83ahrwdag76"
+   "commit": "2d9d805ad6d1db8d7eeedf67460e4e13c9b06528",
+   "sha256": "0qvfvxc9jb9fwfbj209srzq122z056nwfywhvv0z9pnijv6k11wx"
   },
   "stable": {
    "version": [
@@ -43657,11 +43994,11 @@
   "repo": "crmsnbleyd/flexoki-emacs-theme",
   "unstable": {
    "version": [
-    20250228,
-    1934
+    20260516,
+    1228
    ],
-   "commit": "4ca5d80bc4f33b5ace8950f0c00069539835fab4",
-   "sha256": "0yka5ry44cfdwgfbl2bwix3pfnrvziyq9bza64j21f5f3kjwdmw2"
+   "commit": "3d6074282ff6e181e98f16000f3355fb977e2b56",
+   "sha256": "19x1rr6bzc9l2j4srz1f51z3cjf6s1b7m4k98mbkbfghw5nl23mn"
   }
  },
  {
@@ -43973,14 +44310,14 @@
   "repo": "flycheck/flycheck",
   "unstable": {
    "version": [
-    20260320,
-    1715
+    20260604,
+    2002
    ],
    "deps": [
     "seq"
    ],
-   "commit": "0e5eb8300d32fd562724216c19eaf199ee1451ab",
-   "sha256": "0jzzx3hhvb4rmqvavzkw3gnf3csczng1imgfk019pd30pj2wrxbd"
+   "commit": "96f1852c7e352c969393e6e66176178177e933be",
+   "sha256": "0qar882187wm4yqpabrzc8vkcgh0ybvim1dxxskc2x97zvvqf3mp"
   },
   "stable": {
    "version": [
@@ -44352,14 +44689,14 @@
   "repo": "borkdude/flycheck-clj-kondo",
   "unstable": {
    "version": [
-    20240218,
-    2215
+    20260615,
+    1926
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "e38c67ba9db1ea1cbe1b61ab39b506c05efdcdbf",
-   "sha256": "1pxlb8axgmc8cw4id40z576kd041qb1irq8rkjn6xbda585ix58f"
+   "commit": "414a3ead1faefb234d658fd8a8ba121c95b71de2",
+   "sha256": "08llz442nxk2ijpfshfcb5mh2h9rk76h93rax90rg5xmbbsx3f26"
   },
   "stable": {
    "version": [
@@ -45108,14 +45445,14 @@
   "url": "https://git.umaneti.net/flycheck-grammalecte/",
   "unstable": {
    "version": [
-    20251001,
-    2010
+    20260615,
+    1837
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "4b50d794a88d31c43023bed78f1815673f0c8890",
-   "sha256": "1bv6g3y39ifcyxynmwk619hkfl643s3pa4qrmy7m440dndfqjzxf"
+   "commit": "f822e96ef54cc8d0d9ca64ad489b915bc36f6ac0",
+   "sha256": "1vbvgh9qkvvylskk292hcgl347ygb744w2jwx8cw41fk30i2v7qc"
   },
   "stable": {
    "version": [
@@ -45317,15 +45654,15 @@
   "repo": "conao3/indent-lint.el",
   "unstable": {
    "version": [
-    20200129,
-    2046
+    20260516,
+    852
    ],
    "deps": [
     "flycheck",
     "indent-lint"
    ],
-   "commit": "23ef4bab5509e2e7fb1f4a194895a9510fa7c797",
-   "sha256": "00ipp87hjiymraiv6xy0lqzhn9h3wcrw7z4dkzb2934d7bd08j29"
+   "commit": "3660b10520d78dd545fd0c52d7e7a36dc602492d",
+   "sha256": "1r15nwxkb5d3zx7m1i5z8jmql551dcnq37czhk57v5madr6hggw6"
   },
   "stable": {
    "version": [
@@ -46207,14 +46544,14 @@
   "repo": "msherry/flycheck-pycheckers",
   "unstable": {
    "version": [
-    20240817,
-    2
+    20260624,
+    439
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "1bd9b7a7d4009a81ebd34515a72a3a94c313ad76",
-   "sha256": "1m33yrx2nbwawh38fsibv97fb8gnr461bbrh5yqcnjyw635n7199"
+   "commit": "de546e52ceb3147da9688c428f7243e6d98af507",
+   "sha256": "1hfbsb0rrlsdvay34jl1cw0dsv6vbgc0l3wsqr7d3cxx1va3j5k2"
   },
   "stable": {
    "version": [
@@ -46811,20 +47148,20 @@
   "repo": "jamescherti/flymake-ansible-lint.el",
   "unstable": {
    "version": [
-    20260320,
-    13
+    20260602,
+    1355
    ],
-   "commit": "359a11d3e1a9f1cd131aa85edd1c5feb3fcee38b",
-   "sha256": "1jlnnxdxq94ndcbi62xgy6g2nijzqllg40ijxby1kn7slp5bn91x"
+   "commit": "8e300cc49b234a03aca90f497a69de2de8deab96",
+   "sha256": "1i0isj0ra6g330cq676lflfqks198lz589rrf0s2nnj3mvnwsvzd"
   },
   "stable": {
    "version": [
     1,
     0,
-    5
+    6
    ],
-   "commit": "c5375aea83586e1ae97e6c2fa74ea61cf44d98f4",
-   "sha256": "1w34h714q7gvhpazbqfh0b6vgm0sy7h5xkhsksdqy144agj7jja3"
+   "commit": "8e300cc49b234a03aca90f497a69de2de8deab96",
+   "sha256": "1i0isj0ra6g330cq676lflfqks198lz589rrf0s2nnj3mvnwsvzd"
   }
  },
  {
@@ -46850,26 +47187,26 @@
   "repo": "jamescherti/flymake-bashate.el",
   "unstable": {
    "version": [
-    20260314,
-    1906
+    20260605,
+    1304
    ],
    "deps": [
     "flymake-quickdef"
    ],
-   "commit": "f60c17c8f4b8c9059f615e0895656de65ffb21dd",
-   "sha256": "1xqi111ilcqk3lj3xhkvlzj11vc58as0gia8pli9p5cidmyl8djk"
+   "commit": "e36eab741444112bcc1a0cd95b7eb878b82e31da",
+   "sha256": "1nbh6m8c121ql78ziw86ydvf66b4277hw66i7m5zh6g638davy6v"
   },
   "stable": {
    "version": [
     1,
     0,
-    4
+    5
    ],
    "deps": [
     "flymake-quickdef"
    ],
-   "commit": "c599d3c15c6f174a54c1f3d0081311758e682089",
-   "sha256": "1xwngb8i39siw2wb0m4pvgwnd1ax5rl5xq9ny3s40bcxs262grm7"
+   "commit": "4893738819306517736e3f8ea8aeebadb4df4bf9",
+   "sha256": "1g4vh6kcgla3mdwrbjzfmcljxfd8bmb67w64n7j73xgg3sm867dd"
   }
  },
  {
@@ -46939,15 +47276,15 @@
   "repo": "mohkale/flymake-collection",
   "unstable": {
    "version": [
-    20250831,
-    1353
+    20260613,
+    1434
    ],
    "deps": [
     "flymake",
     "let-alist"
    ],
-   "commit": "909d98d9ec70c2baa5467634ec37181a058f2548",
-   "sha256": "0082l6ia1p08y86qr1vz6i76gmcpliba7lzm9akr6nlzr5s2d8g0"
+   "commit": "1c771edc125ae44d9574489f3989397027b17654",
+   "sha256": "18bb38h9gc69h1shbqdzfrq939jpvb49v98cdgq8d8zcw72nfn8m"
   },
   "stable": {
    "version": [
@@ -48083,14 +48420,14 @@
   "repo": "erickgnavar/flymake-ruff",
   "unstable": {
    "version": [
-    20251221,
-    2344
+    20260616,
+    427
    ],
    "deps": [
     "project"
    ],
-   "commit": "8f1602fa4ddf0abd3dfb8051cbd0259fc351d015",
-   "sha256": "1mm7lq4qrq8m56cwygi2darm1kakwprm4fm1x3h12slgk4fayww5"
+   "commit": "ef4a6caed72bce77a27bda54ffb30e3fdb0e7d76",
+   "sha256": "0frlx7fhfppisldk05jqj2ifhyfkq6015kp1cwmazczb4zsvz45i"
   }
  },
  {
@@ -48577,11 +48914,11 @@
   "repo": "awdeorio/flywrite",
   "unstable": {
    "version": [
-    20260404,
-    33
+    20260526,
+    1418
    ],
-   "commit": "174d72ed77a72e0b5751062caa4cae1a853f9974",
-   "sha256": "1l7ijm6kqw687akm8qlh75skrfpp9wbkwyqh92y4wb9zwhfd2jsz"
+   "commit": "e9d11b17fdb4a2d986354a5b942952dea9876a6b",
+   "sha256": "1fk7nz73s9xhkfq2f4kdabq18ij5vjpbcm312zx1zkvkb055ccsf"
   }
  },
  {
@@ -48803,6 +49140,24 @@
    ],
    "commit": "443b826c76a4938fc0961298ff0e6c924c723ed7",
    "sha256": "05z1xg474mar77wax2lxlf35461w2wk0bwkg79c671wcsgjixvdw"
+  }
+ },
+ {
+  "ename": "folgezett",
+  "commit": "06df34c7f3def8eadf72c97650aa1ae28746d79c",
+  "sha256": "0an09035lkj4nb98d6ixval8iq4vck9mj4b32h7v2j5zcsmg08dd",
+  "fetcher": "github",
+  "repo": "landerwells/folgezett.el",
+  "unstable": {
+   "version": [
+    20260517,
+    422
+   ],
+   "deps": [
+    "org-roam"
+   ],
+   "commit": "8b60ab378fd83a4fc9abc15c82bdcd3cdb2c507d",
+   "sha256": "1985nyxd7rpca440brzns9kvd5k6pqjgh3r6hyihmwqypx92ac7i"
   }
  },
  {
@@ -49086,8 +49441,8 @@
   "repo": "magit/forge",
   "unstable": {
    "version": [
-    20260423,
-    1757
+    20260623,
+    1325
    ],
    "deps": [
     "closql",
@@ -49098,18 +49453,17 @@
     "llama",
     "magit",
     "markdown-mode",
-    "seq",
     "transient",
     "yaml"
    ],
-   "commit": "3eff1dab171602db9d1b7cfb0e6e7014eac73665",
-   "sha256": "0115af0vg9bsmmizfny3k4k9hlkgclpgq6wd05fv3ibhbhc95n5a"
+   "commit": "0c9407833bd688f83ad496b37ea71381e758d65b",
+   "sha256": "070mfivrbxgbyzhskzq1dqwwkhazgj0nk2np45sfw9irfp2mn0ig"
   },
   "stable": {
    "version": [
     0,
     6,
-    4
+    6
    ],
    "deps": [
     "closql",
@@ -49124,8 +49478,8 @@
     "transient",
     "yaml"
    ],
-   "commit": "69801d0da19d62b4b68b1f1756900e47ce7e8769",
-   "sha256": "10ym872n05nlkd9q1r3dl7vkbniacxm8g9159v56f9z9r6nznwyh"
+   "commit": "a8af709bc15e973804af776bba66b4205540bd73",
+   "sha256": "001q4nk7dval6g6gd7cw69jldkal5k0mnimzl2vxlrhck88jqkjf"
   }
  },
  {
@@ -49194,15 +49548,15 @@
   "repo": "lassik/emacs-format-all-the-code",
   "unstable": {
    "version": [
-    20260312,
-    1136
+    20260620,
+    1824
    ],
    "deps": [
     "inheritenv",
     "language-id"
    ],
-   "commit": "d44bf536fdae83ad7a798565e21f59c02e461c47",
-   "sha256": "14wjms8q2pjbwain5gimfcalvxp6vfa1wwv2cb6wr11qdb64n9rd"
+   "commit": "0dbe9c70eaf8b92dca1a42552761eaa13c3139cf",
+   "sha256": "16rdqcprb09fgsgbw0fl5zm1d6fg01sr6infg1z1q1r0s7c4z3za"
   },
   "stable": {
    "version": [
@@ -49522,26 +49876,26 @@
   "repo": "tarsius/frameshot",
   "unstable": {
    "version": [
-    20260101,
-    1833
+    20260601,
+    1501
    ],
    "deps": [
     "compat"
    ],
-   "commit": "975450f325f0e29a73214deff011ad524f02bc74",
-   "sha256": "0ax9jkchlb1fc6fxw09zps6qhaazbpgm7b66hbsblkdy2apczcnm"
+   "commit": "6e1f45af13ebaf6ff6f13207c74ed4c5fb8e10c9",
+   "sha256": "0fqkq3wj4h6qfdd69gz18g7jl4vxy392hp64c6bnk8h38basfs2h"
   },
   "stable": {
    "version": [
     1,
     2,
-    1
+    2
    ],
    "deps": [
     "compat"
    ],
-   "commit": "975450f325f0e29a73214deff011ad524f02bc74",
-   "sha256": "0ax9jkchlb1fc6fxw09zps6qhaazbpgm7b66hbsblkdy2apczcnm"
+   "commit": "6e1f45af13ebaf6ff6f13207c74ed4c5fb8e10c9",
+   "sha256": "0fqkq3wj4h6qfdd69gz18g7jl4vxy392hp64c6bnk8h38basfs2h"
   }
  },
  {
@@ -49998,11 +50352,11 @@
   "repo": "bbatsov/fsharp-ts-mode",
   "unstable": {
    "version": [
-    20260424,
-    617
+    20260624,
+    924
    ],
-   "commit": "415dcaf2cb83d98af86ae072a11eae2558047c6c",
-   "sha256": "0z20v2wnqqd672y7mwjgx88nh3pwq7mdvzck1sjpmqq53gb2lgj4"
+   "commit": "a7a4f0612456e992c5e3420b3296ed2c1d3c472c",
+   "sha256": "1zqw57r4gg2rwg8z2p3i2j73rybg3zmm5554s2xs6jf72zvn7mb5"
   },
   "stable": {
    "version": [
@@ -50233,27 +50587,27 @@
   "repo": "jojojames/fussy",
   "unstable": {
    "version": [
-    20260424,
-    408
+    20260613,
+    1231
    ],
    "deps": [
     "compat",
     "flx"
    ],
-   "commit": "6366161a0e03c6c12aeba872fed3dfdc135bff9c",
-   "sha256": "1hwk15hlq82khx38xriqpd1syfr3zn4m90n65s8ijfjmaysfcg9j"
+   "commit": "78730ceefb23ee6314803f54eaf73cb044055f47",
+   "sha256": "0bq6mpq0h65l2nc9wv3vhfqfvsid989brxswli5bbv6n13yrji72"
   },
   "stable": {
    "version": [
     2,
-    2
+    3
    ],
    "deps": [
     "compat",
     "flx"
    ],
-   "commit": "92fb91c034707af77be9869500a5ae1ea0079b7d",
-   "sha256": "1vwxqil4mmll7zdnc1yn8g54kk7p39fyf7y62lxpakij7vxncf43"
+   "commit": "029d726c3309f148cff162758f60d0e6dbe18f76",
+   "sha256": "0cnb3a471hwq9pyz69f705a4pyvhjhgm9n358xr2bl8qd802wxw1"
   }
  },
  {
@@ -50387,32 +50741,32 @@
  },
  {
   "ename": "fwb-cmds",
-  "commit": "fe40cdeb5e19628937820181479897acdad40200",
-  "sha256": "0wnjvi0v0l2h1mhwlsk2d8ggwh3nk7pks48l55gp18nmj00jxycx",
+  "commit": "aec4a76eaea31408bd27d76a0b8cea5268663cc1",
+  "sha256": "0lci0xrkqwdlgw31grl16ljxnmw0jsji5p13gbg8sid72z11w0sz",
   "fetcher": "github",
   "repo": "tarsius/fwb-cmds",
   "unstable": {
    "version": [
-    20260101,
-    1833
+    20260601,
+    1507
    ],
    "deps": [
     "compat"
    ],
-   "commit": "d230b9e42f992d9a4c4b155ba7f1920e8577caca",
-   "sha256": "07h0h2jsb4imkc6n4wxc255f3glgq5kcl2xq85h0769qa28qy5w4"
+   "commit": "bb62a32dbd3febdd2e644af25a22e56259ed060d",
+   "sha256": "1a3vmd64zijcxp1fvg7yp8lmc3lfxlfjpblqlwn2y5c03852bc37"
   },
   "stable": {
    "version": [
     2,
     0,
-    5
+    6
    ],
    "deps": [
     "compat"
    ],
-   "commit": "d230b9e42f992d9a4c4b155ba7f1920e8577caca",
-   "sha256": "07h0h2jsb4imkc6n4wxc255f3glgq5kcl2xq85h0769qa28qy5w4"
+   "commit": "bb62a32dbd3febdd2e644af25a22e56259ed060d",
+   "sha256": "1a3vmd64zijcxp1fvg7yp8lmc3lfxlfjpblqlwn2y5c03852bc37"
   }
  },
  {
@@ -50467,11 +50821,11 @@
   "repo": "bling/fzf.el",
   "unstable": {
    "version": [
-    20260121,
-    1418
+    20260505,
+    1105
    ],
-   "commit": "0f6a2fd644bedfbcc061f995c8c270d084da1cba",
-   "sha256": "1q6hs3kksr7lxj6w42gp6q16m86zmkc4r1mr8j5s3n0y8mw9gy2y"
+   "commit": "75060d81f4eea3f8088ac2a4a3a253c686b44d44",
+   "sha256": "0a6k9s5c92qg078xgyhfhz7pf3g677rfp0my7zln10nxh628pc3k"
   },
   "stable": {
    "version": [
@@ -50480,6 +50834,29 @@
    ],
    "commit": "383a050920e9b99d37c21d041deb7f38b202485c",
    "sha256": "14drm6b6rxbcdilcms1jlqyrqbipcqbdil6q06ni9pgafi7xp8hz"
+  }
+ },
+ {
+  "ename": "fzf-native",
+  "commit": "7869ef9df545789bebfc73caf7a55cbf649324be",
+  "sha256": "01hbi1jgqdbjliybfc3aw5b8xy6xk5ckpdwh743xanbn994xjvzv",
+  "fetcher": "github",
+  "repo": "dangduc/fzf-native",
+  "unstable": {
+   "version": [
+    20260614,
+    1331
+   ],
+   "commit": "ae9c747e93ca48443792a59f4f59a4cda96949f2",
+   "sha256": "1b11javzwlnb1jhvbf0bg8ayfd3wlk3a15gla5dblrj3hdc002hd"
+  },
+  "stable": {
+   "version": [
+    2,
+    1
+   ],
+   "commit": "ae9c747e93ca48443792a59f4f59a4cda96949f2",
+   "sha256": "1b11javzwlnb1jhvbf0bg8ayfd3wlk3a15gla5dblrj3hdc002hd"
   }
  },
  {
@@ -50655,11 +51032,11 @@
   "repo": "godotengine/emacs-gdscript-mode",
   "unstable": {
    "version": [
-    20260417,
-    1926
+    20260615,
+    928
    ],
-   "commit": "f6ee6891e15b4aaf4e159ecf3ab8482da6fe0ea7",
-   "sha256": "1hqrc20cgqgcrbc5wqwldq7f0xxfvm3y6cnxzy4brdvg61hdg82b"
+   "commit": "6bfea8c477cda3f300b84248b5f56c9d241e8029",
+   "sha256": "0wfcyan4qasqfhf70ilcq82f9zb05vhrk61nrb8pq9cmj7kr6xwf"
   },
   "stable": {
    "version": [
@@ -50768,39 +51145,40 @@
  },
  {
   "ename": "geiser",
-  "commit": "4f305d3a7823c69455aad9088789afef73477c7a",
-  "sha256": "0k0jv5a3qlad5qp72m80yi5xws3gdf38pj06azvdg4kzvhgrxpgz",
-  "fetcher": "gitlab",
-  "repo": "emacs-geiser/geiser",
+  "commit": "008e3547b0de78eb6e89edb936b9e40d4b0eb7e0",
+  "sha256": "0pp2yndrjkhsyym46sn5ww0332kdzwiicq3a2fk2vpkhj98bj1sk",
+  "fetcher": "codeberg",
+  "repo": "geiser/geiser",
   "unstable": {
    "version": [
-    20251220,
-    2301
+    20260523,
+    1502
    ],
    "deps": [
     "project"
    ],
-   "commit": "8842104d1521a00c182ce78e9d50d394e9ba86f5",
-   "sha256": "05sfrads398vh8wghlwhqw809s91j6n5v3k1lfi25dqlp2zvif7m"
+   "commit": "84c25e9683a18d00387b6c16b0cee66269536c3c",
+   "sha256": "0gyr7fky3jppk3vy44mq3lfwz0n7r0k6cxim7bdfp9qy8jqw1pr8"
   },
   "stable": {
    "version": [
     0,
-    32
+    33,
+    1
    ],
    "deps": [
     "project"
    ],
-   "commit": "9e76f336b91151315642de9bcbed0ffe83b69db7",
-   "sha256": "09dqwxa2h471xcyk5zncxzaz19gf8d5r83yhi425blf2r1ir7b34"
+   "commit": "84c25e9683a18d00387b6c16b0cee66269536c3c",
+   "sha256": "0gyr7fky3jppk3vy44mq3lfwz0n7r0k6cxim7bdfp9qy8jqw1pr8"
   }
  },
  {
   "ename": "geiser-chez",
-  "commit": "6c2ee4d4fbde853481aa66925763845daadd5439",
-  "sha256": "1csx76zgg26wqbq6q10v4yqj5hadsww0jw17dbz718521906a4ql",
-  "fetcher": "gitlab",
-  "repo": "emacs-geiser/chez",
+  "commit": "8baa86e8c2c05343785242c791347152df6da8b7",
+  "sha256": "1wikn3n73jx58xnzrcrwh0kn58l1hlx9lgbkhr8nj1qw0iw6hr0h",
+  "fetcher": "codeberg",
+  "repo": "geiser/chez",
   "unstable": {
    "version": [
     20230707,
@@ -50826,10 +51204,10 @@
  },
  {
   "ename": "geiser-chibi",
-  "commit": "29aa9f96fa0826e8e26e2e1219b78c73f9af66fb",
-  "sha256": "17zkic298ckq8mdmlc25ycafcx2yy11xfdlfjnyy20p7nqqw8njj",
-  "fetcher": "gitlab",
-  "repo": "emacs-geiser/chibi",
+  "commit": "eff5e148c77386a7451ebb194645866c0a5fbce9",
+  "sha256": "0ka6yf8pm7brvj719sk4qmz5pg4v2bk8gwrwwqwbvhqlhg7777xf",
+  "fetcher": "codeberg",
+  "repo": "geiser/chibi",
   "unstable": {
    "version": [
     20240521,
@@ -50855,10 +51233,10 @@
  },
  {
   "ename": "geiser-chicken",
-  "commit": "a2ad985f3b2b3e9192b6a8525483f43f52df9a10",
-  "sha256": "1hq3qk8vbspycvm9fv5s9d07gn0m55gwcvgv4ycvyf8gmi2j3xdy",
-  "fetcher": "gitlab",
-  "repo": "emacs-geiser/chicken",
+  "commit": "9fff1d932215fdc55a768d1c6c5e714d83b1b7bd",
+  "sha256": "0valajqf5x9s09jzzr15z3nl5r0s0y69psd4mg61ach2lb9x0ggk",
+  "fetcher": "codeberg",
+  "repo": "geiser/chicken",
   "unstable": {
    "version": [
     20250803,
@@ -50884,10 +51262,10 @@
  },
  {
   "ename": "geiser-gambit",
-  "commit": "3b4af6c41cf776dff3bcb09ae08f6f3acc880b33",
-  "sha256": "0vjq5b1warybr57kc855lbmda109vv4kbysn4s4zfi0mz45y0lbx",
-  "fetcher": "gitlab",
-  "repo": "emacs-geiser/gambit",
+  "commit": "bdd0a29ce7b3a725f9216562a942ed990de30295",
+  "sha256": "03a8z9r8bzb7yw0v1rj2vyxzj9adw6qa10vm5xs3lfi5vkiv7fi6",
+  "fetcher": "codeberg",
+  "repo": "geiser/gambit",
   "unstable": {
    "version": [
     20220208,
@@ -50940,34 +51318,34 @@
  },
  {
   "ename": "geiser-guile",
-  "commit": "779ebb6fa2f9ee7a86425c4364ae8141f66a0f4f",
-  "sha256": "18w8spn3ys3ggnqic4isy6ggzdjjsvsc1rbpq346mmb1xdy5bjna",
-  "fetcher": "gitlab",
-  "repo": "emacs-geiser/guile",
+  "commit": "d66972d8569c062b7cd9492bf27e6a37f1b8d09e",
+  "sha256": "0ciz7dbhgkn4dj760s5gx9zldl05qysmjcyx3bf829rfjschnpzw",
+  "fetcher": "codeberg",
+  "repo": "geiser/guile",
   "unstable": {
    "version": [
-    20240920,
-    35
+    20260516,
+    19
    ],
    "deps": [
     "geiser",
     "transient"
    ],
-   "commit": "a0f111f8dedd31c593c4ed12c0b99745f3c1340f",
-   "sha256": "0i6drqz7cnx97bs5kprvb0hsg2h4bwkfdi61ajv43dqgb368jbff"
+   "commit": "cbab81bd2dcb4c787bcda4ae18062db3087e6887",
+   "sha256": "0hvjc1s74ansn3c5pmizs9q234wz2h52y0070qg008i1vmqvymzp"
   },
   "stable": {
    "version": [
     0,
     28,
-    3
+    5
    ],
    "deps": [
     "geiser",
     "transient"
    ],
-   "commit": "a0f111f8dedd31c593c4ed12c0b99745f3c1340f",
-   "sha256": "0i6drqz7cnx97bs5kprvb0hsg2h4bwkfdi61ajv43dqgb368jbff"
+   "commit": "cbab81bd2dcb4c787bcda4ae18062db3087e6887",
+   "sha256": "0hvjc1s74ansn3c5pmizs9q234wz2h52y0070qg008i1vmqvymzp"
   }
  },
  {
@@ -51001,10 +51379,10 @@
  },
  {
   "ename": "geiser-mit",
-  "commit": "a327661f80b577f53ae8874ce9ab499d95c442c8",
-  "sha256": "1zbisdf8mw183qxx7khlfni31lp6airza8q8vvcp5frz277kk9cg",
-  "fetcher": "gitlab",
-  "repo": "emacs-geiser/mit",
+  "commit": "243e7a585f04deb209b6ba4d043b39560e0abc2a",
+  "sha256": "1vj8jvhllpbq70pb3vaxlajmw3sdvfng7vqhn8qhnvnszdbf0sr1",
+  "fetcher": "codeberg",
+  "repo": "geiser/mit",
   "unstable": {
    "version": [
     20240909,
@@ -51060,10 +51438,10 @@
  },
  {
   "ename": "geiser-racket",
-  "commit": "eddf5704aa4c2373dbe7b7b89934f6db3737a769",
-  "sha256": "13m7xkimn7qn03cxdp8h1b5g1cnkn5pviq48zlw394xlaz67vn3m",
-  "fetcher": "gitlab",
-  "repo": "emacs-geiser/racket",
+  "commit": "b7b544af40010e336548b5c7ef50ab3323a6cfc4",
+  "sha256": "09nqp0sy133mnj13g1pgbf9kc0inrl1xkv026cz266z4dggd52sr",
+  "fetcher": "codeberg",
+  "repo": "geiser/racket",
   "unstable": {
    "version": [
     20210421,
@@ -51077,14 +51455,14 @@
   },
   "stable": {
    "version": [
-    1,
-    0
+    0,
+    16
    ],
    "deps": [
     "geiser"
    ],
-   "commit": "42376b74ae0ad84d02c26560dfd9181493dcccd7",
-   "sha256": "04gwd9qa0785zfr6m9a5443ilgvyz05l06cb1waicf83sgp8xl32"
+   "commit": "22e56ce80389544d3872cf4beb4008fb514b2218",
+   "sha256": "1aqsvmk1hi7kc3j4h8xlza7c6rwm71v98fv5wpw8kmyj9vsp49wx"
   }
  },
  {
@@ -51133,10 +51511,10 @@
  },
  {
   "ename": "gemini-write",
-  "commit": "e97c45cafc44a4b2f08e577325e375c6312f6557",
-  "sha256": "039rdjsyx9lw7lh21ps84agm1rpinbylzlks6iv1h5pn341s67nd",
+  "commit": "fd2082f1d5170d65f46116a012d2d1abedf62dba",
+  "sha256": "0x2qbiy1s15xpfhqgvajp59fjrzkpc6crwglmh93h7l25bzyivz5",
   "fetcher": "git",
-  "url": "https://alexschroeder.ch/cgit/gemini-write",
+  "url": "https://src.alexschroeder.ch/gemini-write.git",
   "unstable": {
    "version": [
     20211114,
@@ -51328,16 +51706,16 @@
   "repo": "twmr/gerrit.el",
   "unstable": {
    "version": [
-    20260208,
-    922
+    20260512,
+    617
    ],
    "deps": [
     "dash",
     "magit",
     "s"
    ],
-   "commit": "317599943495da561a508b31e83ae55c800e5a52",
-   "sha256": "185q22afq281k6whhjrmikgr711xd7blv6ixir8pinv7d4m5psmd"
+   "commit": "ccbc70a482305c8f0c88da3a9daead6a16c63ae5",
+   "sha256": "1g3l0igmrll7a39bw1068yjfdyhvwysn94pk8z0yyh5jclh3hhr8"
   }
  },
  {
@@ -51580,26 +51958,32 @@
  },
  {
   "ename": "ghostel",
-  "commit": "f092656c1fc300c4d69c762a1e6c72dd3eb657d9",
-  "sha256": "191p8jh0ck96645skbijybrrsvckr98p54ls2d1n474yxdnbywpf",
+  "commit": "32c111d2c381b618d3ca556c09b15bc3a0d91287",
+  "sha256": "1k6yvnsd13lqxw31kmdszsfikabc8js4d4xrcsf4m50gzvk3bf4f",
   "fetcher": "github",
   "repo": "dakra/ghostel",
   "unstable": {
    "version": [
-    20260423,
-    1706
+    20260624,
+    710
    ],
-   "commit": "63e008f32e4896ecd18e24ccfc08a3775561722c",
-   "sha256": "13pk32b32p9hw0lw957gha89dinqs8g53v73nqhzq9axrp7m9qp0"
+   "deps": [
+    "compat"
+   ],
+   "commit": "162cb0fa0fa24df2c92e4287e1307a0a6d570b8f",
+   "sha256": "06yns5qyjkb11iyxpac6lgnli78d6r5ap5x8zssrbjcqzzfk2917"
   },
   "stable": {
    "version": [
     0,
-    17,
+    38,
     0
    ],
-   "commit": "6117978d2089d807dd457f9cf2d9382a4a4558c6",
-   "sha256": "0mmvwms7r4l1ypvxa10s164a6shqwc7bqvrr1wgqkp5z4wqd9dsk"
+   "deps": [
+    "compat"
+   ],
+   "commit": "b6d7b37353572bf92d04c8de5abced3ef68a0304",
+   "sha256": "1yv31zvyk80k2yl67hx67l1xwizm9p9257fwwz5hfav6lx0z6vm2"
   }
  },
  {
@@ -51642,8 +52026,8 @@
   "repo": "magit/ghub",
   "unstable": {
    "version": [
-    20260423,
-    1634
+    20260603,
+    1818
    ],
    "deps": [
     "compat",
@@ -51651,14 +52035,14 @@
     "llama",
     "treepy"
    ],
-   "commit": "2b6df7c3f958e64c47151d7d6ef45de38e614936",
-   "sha256": "1mm60zga2flbh2gnv5554if8d6jiwvzw3px8h87zi7y8dx8rkwmw"
+   "commit": "89cd6c5d2770fad2c4d635136e3e36643d8bbde4",
+   "sha256": "14qrds6w62ss2cca3ryr9x09f6d71maxfvd3p1jv0zn00fca120i"
   },
   "stable": {
    "version": [
     5,
-    1,
-    0
+    2,
+    1
    ],
    "deps": [
     "compat",
@@ -51666,8 +52050,8 @@
     "llama",
     "treepy"
    ],
-   "commit": "1fb0fba075cb8b80f9819c874be584dffce50b51",
-   "sha256": "0d49qkkza9my2xz1vdyq7l3vmmjbamhsqm9xy7xikisyhsngvj73"
+   "commit": "62d3582f1e395de1cf410af1f125dae56fe1dc4d",
+   "sha256": "0s27qknrsx5b36lnamns59ijgyy2rpdf6g5i6gz7slz4iccrczh8"
   }
  },
  {
@@ -52330,20 +52714,20 @@
   "repo": "sshaw/git-link",
   "unstable": {
    "version": [
-    20260411,
-    1730
+    20260612,
+    337
    ],
-   "commit": "b651de43236276cdb18ec7727f645cbf6743a499",
-   "sha256": "1zpws6z5v54g94jnsw78k42apxpffg54dlkm5i8gclsaxhn6xpdg"
+   "commit": "3870ae57408dc72ae2215b0056d6661e2c198e75",
+   "sha256": "0qlmmb1h4clg2967ia9mbrpawhmgj6lbzp6hcb5ihwr10msw7s04"
   },
   "stable": {
    "version": [
     0,
-    10,
+    11,
     0
    ],
-   "commit": "67b02cf0df4e789771f2344b4dd77c85334a0f9f",
-   "sha256": "1cq456q908nmbz2br578fhi8vq2jh11nf0axxa7913gd7dhmqklg"
+   "commit": "ca1a170343448c6d5d265ec12f934d865f7e0aee",
+   "sha256": "03dgjnjgyz8km7y0mfd4snk8s8r1w7ybmai6wgvjm5hzwmsqrq3l"
   }
  },
  {
@@ -52377,32 +52761,32 @@
  },
  {
   "ename": "git-modes",
-  "commit": "cc3a0ce6c8a4a67b8a8d4b8b2c090694535e6848",
-  "sha256": "0rpl890n76aqdpx6flgc5kvgg7sic1i85ps8c5j8mbz0pbz06ajv",
+  "commit": "aec4a76eaea31408bd27d76a0b8cea5268663cc1",
+  "sha256": "16960l5zpy78k5lcfh7gihw569w12qal644j4x3dpz7db5wn14cd",
   "fetcher": "github",
   "repo": "magit/git-modes",
   "unstable": {
    "version": [
-    20260101,
-    1834
+    20260601,
+    1550
    ],
    "deps": [
     "compat"
    ],
-   "commit": "c3faeeea1982786f78d8c38397dec0f078eaec84",
-   "sha256": "12r2n3w3yigszh2cszfca1rmrifj2lib5aswcjrx4rd9pzziavzk"
+   "commit": "f291a4cc4a8b02a25d5cf93b4ab6af29e6f060d9",
+   "sha256": "16j4slgl1mlqz8bd6g4izkc9dskv80c2dvvqclkabq6mldmib1n6"
   },
   "stable": {
    "version": [
     1,
-    4,
-    8
+    5,
+    0
    ],
    "deps": [
     "compat"
    ],
-   "commit": "c3faeeea1982786f78d8c38397dec0f078eaec84",
-   "sha256": "12r2n3w3yigszh2cszfca1rmrifj2lib5aswcjrx4rd9pzziavzk"
+   "commit": "f291a4cc4a8b02a25d5cf93b4ab6af29e6f060d9",
+   "sha256": "16j4slgl1mlqz8bd6g4izkc9dskv80c2dvvqclkabq6mldmib1n6"
   }
  },
  {
@@ -53315,11 +53699,11 @@
   "repo": "gleam-lang/gleam-mode",
   "unstable": {
    "version": [
-    20251106,
-    221
+    20260604,
+    1354
    ],
-   "commit": "91cf073c5fb889c091b1797f44cc52419b7c9ae2",
-   "sha256": "0dd7qylvhrqlxnbvvkb3f03gz14v0sjg9fhiymfhw7p571bq8nqi"
+   "commit": "ae8aecda23e9dca755d80e86cdb7c336011c2321",
+   "sha256": "1sg9349ris49gfbx69fawiqfgj2xilqz5w514p3dhbc8qw6brhdb"
   },
   "stable": {
    "version": [
@@ -53372,11 +53756,11 @@
   "repo": "jimhourihan/glsl-mode",
   "unstable": {
    "version": [
-    20250324,
-    1304
+    20260603,
+    1348
    ],
-   "commit": "86e6bb6cf28d1053366039683a4498401bab9c47",
-   "sha256": "03ajf9q2ijgfmmqvk7kmmxba6bsyrb2q49li93fmdj5dwdyjkgqv"
+   "commit": "515a2ba4dab3ec89c83a962902a123ddf81e3cfe",
+   "sha256": "1lf2ydjw5vlvn50l0lag0n31zmy3m6wlhih54q05brzaf2m8rrni"
   }
  },
  {
@@ -53582,26 +53966,28 @@
   "url": "https://git.thanosapollo.org/gnosis",
   "unstable": {
    "version": [
-    20260406,
-    150
+    20260507,
+    2347
    ],
    "deps": [
-    "compat"
+    "compat",
+    "keymap-popup"
    ],
-   "commit": "62193075aa38cd64fc812b6208e6fffb2a207e5f",
-   "sha256": "02cirrzwzsjhrng2p3rb09790p7yc1v598miwdkjbz30linlgjvn"
+   "commit": "07de9c67536fe3e8c5fef1daf61527f3bcfa46a7",
+   "sha256": "1cjm8hj62zm9k89pnsh5hbgjqqnh53byw4mijl76a7cn8args4gy"
   },
   "stable": {
    "version": [
     0,
     10,
-    3
+    6
    ],
    "deps": [
-    "compat"
+    "compat",
+    "keymap-popup"
    ],
-   "commit": "e830171c4bcbcbc0b1d466ffdbec179e32e9688e",
-   "sha256": "0kpzc2jw51sklz15v0d0vzm5ck05n3d90l02la4nxn8r85jb1f53"
+   "commit": "07de9c67536fe3e8c5fef1daf61527f3bcfa46a7",
+   "sha256": "1cjm8hj62zm9k89pnsh5hbgjqqnh53byw4mijl76a7cn8args4gy"
   }
  },
  {
@@ -53665,25 +54051,25 @@
   "repo": "emacs-gnuplot/gnuplot",
   "unstable": {
    "version": [
-    20260322,
-    20
+    20260623,
+    1111
    ],
    "deps": [
     "compat"
    ],
-   "commit": "39ba1dec5e8e227ba093a30ca07b20d8eb038f29",
-   "sha256": "1laysqvkn1nvjhx9mjh2m0qc72gky9zja858l557imvhvihllr1c"
+   "commit": "81e3cb30297f0d12df41b865d2a76c8ba179089c",
+   "sha256": "1yhs7jxa9z6c1girzpch0db40kvbfzyfzl3iiyh3wjh05i9r31jm"
   },
   "stable": {
    "version": [
     0,
-    11
+    12
    ],
    "deps": [
     "compat"
    ],
-   "commit": "f10d42221856e86c57dd5cc7400c078c021ba710",
-   "sha256": "17kh2mpbm5rir4bfrl2hmf8hic6v09z13y6svbf22fm0nkfvic1p"
+   "commit": "2da2ef68d4861e2e5a5b1a81340b8d92b276a3a5",
+   "sha256": "1hv7pyvwad67p2ii0lnww0vkk1jrj5pdkph5fxpavyln84wxxnmq"
   }
  },
  {
@@ -53714,6 +54100,21 @@
    ],
    "commit": "cd7e3f92a12fe7948e2658d26bd0c53ca4a483bd",
    "sha256": "15fpvwz2mxgn6jb6gvgfnp9snjiwxhw783lfkj8qxn12hcwz6c7m"
+  }
+ },
+ {
+  "ename": "gnus-browse-url-in-article",
+  "commit": "a9c676b593e91b7ddc18353c7d0db13e2f4ea7e2",
+  "sha256": "1fis9jgrdy8gi4bjg3kx72xr3n2f7f3p609sph7ks8p4fxma3dnl",
+  "fetcher": "github",
+  "repo": "jmibanez/gnus-browse-url-in-article",
+  "unstable": {
+   "version": [
+    20260514,
+    2045
+   ],
+   "commit": "45d1cbc7bcb55d25d215d4ae39bf6dedf357853a",
+   "sha256": "0dgcb6lcbhv10drxh1mzmgz1jax5xbgf6ja5iry5hm6drz4fd1pg"
   }
  },
  {
@@ -54171,15 +54572,15 @@
   "repo": "dominikh/go-mode.el",
   "unstable": {
    "version": [
-    20240210,
-    10
+    20260529,
+    1355
    ],
    "deps": [
     "cl-lib",
     "go-mode"
    ],
-   "commit": "6f4ff9ef874d151ed8d297a80f1bf27db5d9dbf0",
-   "sha256": "1pbnpj8qqdk4871m1nj39jilcqnz0l5sn9w34s9y2j526rz5l83z"
+   "commit": "3a71d28ab47df685e54ca6046a7a3dd3e28b682c",
+   "sha256": "0hm3917kxqgx23ig7617vv5nk8wc17qd26rlxbj141ag0ifwqs32"
   },
   "stable": {
    "version": [
@@ -54271,11 +54672,11 @@
   "repo": "dominikh/go-mode.el",
   "unstable": {
    "version": [
-    20250311,
-    156
+    20260510,
+    1707
    ],
-   "commit": "58b0c3dfc87f5ae4137ea498dc0e03adc9eeb751",
-   "sha256": "01db618lfkqwf7ps9hi9k2s1v6p7vgj901p04kn5vdcrs3b7cxny"
+   "commit": "8aaaa9d2574d7862ecbbe1ff369e88fe3796c8be",
+   "sha256": "1svycl0zai9zkhpmq72063szwzww6g270qik46d79mg3j0jhaf46"
   },
   "stable": {
    "version": [
@@ -54366,11 +54767,11 @@
   "repo": "snyssfx/go-prettify-mode.el",
   "unstable": {
    "version": [
-    20260422,
-    732
+    20260429,
+    1651
    ],
-   "commit": "6aafd440383931b368901de66bf974bbd37a45f9",
-   "sha256": "1rrfcnyfqry6ihlkz2w05sgsvcjb8yx74f3dinzpafxa8c2lh9x4"
+   "commit": "446907afa83d749dbd0a610d1d6fea6bbb822335",
+   "sha256": "0cang6yam22c7mhakj90pjg5jb72f7p89pmdq5dih1vjxm51lbkb"
   }
  },
  {
@@ -54404,14 +54805,14 @@
   "repo": "dominikh/go-mode.el",
   "unstable": {
    "version": [
-    20220114,
-    2239
+    20260510,
+    1707
    ],
    "deps": [
     "go-mode"
    ],
-   "commit": "3273fcece5d9ab7edd4f15b2d6bce61f4e5a0666",
-   "sha256": "00qzn136d8cl3szbi44xf3iiv75r6n1m7wwgldmzn4i5mpz8dbq7"
+   "commit": "144dc7d312d260f8dad7dfa6168537ae57f8e436",
+   "sha256": "154yhmkcdfwdhkgy4bi20wfz0mhgarm3wq5rz2zs2n0xx84437pj"
   },
   "stable": {
    "version": [
@@ -54590,11 +54991,11 @@
   "repo": "emacsorphanage/god-mode",
   "unstable": {
    "version": [
-    20250820,
-    259
+    20260428,
+    56
    ],
-   "commit": "e6eef24dbf739d819a6651e854ec732ac3f386e6",
-   "sha256": "1b39lq1l7xa2i4l5ciry3pjaxgzs0xawadb5kbcfhqhd4xlgb04g"
+   "commit": "4deb47444dd21c67521908cef8b11ab377bfbd6f",
+   "sha256": "0djj04spg2m40a0c6cgb18pfdcxr3xr3qwhzqpb78ml2p9yxd2za"
   },
   "stable": {
    "version": [
@@ -54662,19 +55063,25 @@
   "repo": "minad/goggles",
   "unstable": {
    "version": [
-    20260322,
-    18
+    20260519,
+    1038
    ],
-   "commit": "73040c4dc8fe946d3657accb5dc4ed4065abd348",
-   "sha256": "0dbvzyg9cmiis1aj0xb57gdr32p238hwfw731n10gxik9yzhhd2w"
+   "deps": [
+    "compat"
+   ],
+   "commit": "e473909708aa0df2134b7bb7f6654d0fb5f23e23",
+   "sha256": "0247jq97l30ykn02wmkpq401is453yqix7y28pf2milj3mic9blw"
   },
   "stable": {
    "version": [
     0,
-    4
+    5
    ],
-   "commit": "41d3669d7ae7b73bd39d298e5373ece48b656ce3",
-   "sha256": "1fczxygg1blfmlwswck49rllww77rc7qn91wqw1kvjwfz31sk8z4"
+   "deps": [
+    "compat"
+   ],
+   "commit": "e473909708aa0df2134b7bb7f6654d0fb5f23e23",
+   "sha256": "0247jq97l30ykn02wmkpq401is453yqix7y28pf2milj3mic9blw"
   }
  },
  {
@@ -55041,24 +55448,6 @@
   }
  },
  {
-  "ename": "gotest-ts",
-  "commit": "86837556b6cdc831bb4bb387a0840fe6186ebedc",
-  "sha256": "1fl8cyykfq9myrs8p5240mp2jh3lb1p5f0fgvrq0bw7cj4rp9306",
-  "fetcher": "github",
-  "repo": "chmouel/gotest-ts.el",
-  "unstable": {
-   "version": [
-    20260127,
-    1547
-   ],
-   "deps": [
-    "gotest"
-   ],
-   "commit": "b12e08d925bab705792f14b29acdca9af550d9a8",
-   "sha256": "053q4h0wd8rbrcdmn85v1530cvbx4ygwlr0yp8v5pji7wrgbbpd7"
-  }
- },
- {
   "ename": "gotham-theme",
   "commit": "20b2cc78b41a26e434b984943681fea774fd3c50",
   "sha256": "17nkg3ac8ckk5sa722nqinzhln8nb96yppjyp0567cc8p9a3bp59",
@@ -55216,7 +55605,7 @@
   "stable": {
    "version": [
     0,
-    53,
+    54,
     1
    ],
    "deps": [
@@ -55225,8 +55614,8 @@
     "magit-popup",
     "s"
    ],
-   "commit": "21f582334c38f866ac587f1489d637440d1428aa",
-   "sha256": "19bwm2sn8g3a85y6kgs3fh40z2xv53k1ipddfb3qdiml1z69f33s"
+   "commit": "e6cfff79a15f1c7e7a59187985132ee1685b8233",
+   "sha256": "1xyrl4f4rcpm66c7b7kcghy1zhsfznq3jxrya1h3mzlzfpi7b33y"
   }
  },
  {
@@ -55389,29 +55778,29 @@
   "repo": "karthink/gptel",
   "unstable": {
    "version": [
-    20260422,
-    756
+    20260620,
+    734
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "593786fce27b54248d4c0ae19b120cbbcf51aea9",
-   "sha256": "1g436n57r6czk7vrzq8brzvsadrc16p37wicars750i5qhph7f48"
+   "commit": "5b2b95fee4a632be5a5845eaff33438f96b37312",
+   "sha256": "1glqcfsxaqp30aknqlz9lvycq237dp3xhd1qkbwmgqpsvhr1im2z"
   },
   "stable": {
    "version": [
     0,
     9,
     9,
-    4
+    5
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "d221329ee3aa0198ad51c003a8d94b2af3a72dce",
-   "sha256": "1ffh2mwy9znjd0v9mh065lv122xg4nlnkbxwjfrsaqn1j1q2xc0c"
+   "commit": "f5ad4eb812920fba3fcfbe32042ef89f979a7e17",
+   "sha256": "1bf7xynmrm859471nxc56sv028i039qnqhhmkhzkhf76mwac6cx8"
   }
  },
  {
@@ -55422,8 +55811,8 @@
   "repo": "karthink/gptel-agent",
   "unstable": {
    "version": [
-    20260415,
-    611
+    20260605,
+    732
    ],
    "deps": [
     "compat",
@@ -55431,8 +55820,8 @@
     "orderless",
     "yaml"
    ],
-   "commit": "e2ef97d6b566b2ad751c8a0a87b8272710c95808",
-   "sha256": "0k88fav640ckjjv269zx6zlhjghr551bcamx7argvs8i5ca7r9jx"
+   "commit": "2853a579154cb4528082a372db79ecdec1eb17ad",
+   "sha256": "0bg8r1zg4cy5yzakvbyca0nclbi8flyflqy2pwxp60j9pwnnhk4x"
   }
  },
  {
@@ -55461,14 +55850,14 @@
   "repo": "lakkiy/gptel-commit",
   "unstable": {
    "version": [
-    20250726,
-    1448
+    20260520,
+    342
    ],
    "deps": [
     "gptel"
    ],
-   "commit": "2b1063a01ab894ae5661bfffeb97331ad0cf2e3b",
-   "sha256": "1lc459dhjhhhh2dzvfmvnjdjmn0z1998wn6n6927llways61wvz5"
+   "commit": "c354320fc6a2f3df4594d524d78a7effa765636e",
+   "sha256": "1j0fg9qp9nyd62qis2gvjf7cy9i0pfhj2ar82m587r2hy4lyf75s"
   },
   "stable": {
    "version": [
@@ -55540,16 +55929,16 @@
   "repo": "ArthurHeymans/gptel-forge-prs",
   "unstable": {
    "version": [
-    20260318,
-    1114
+    20260624,
+    821
    ],
    "deps": [
     "forge",
     "gptel",
     "magit"
    ],
-   "commit": "aed2bbd21a359770a7739f18f34837ec8d0add24",
-   "sha256": "01p9n7515xn1blssv04lfb1yqm9g2zvjf9npqm3szmqrnxr88c0g"
+   "commit": "0a23a7f3f339bb0110a446a7b358aa68867c7898",
+   "sha256": "06wzpw5z9vgwz7yls5z52wpw8wd17kz01krf13qi8781m1v64b6h"
   }
  },
  {
@@ -56042,28 +56431,28 @@
   "repo": "michelangelo-rodriguez/greader",
   "unstable": {
    "version": [
-    20260409,
-    2330
+    20260608,
+    1822
    ],
    "deps": [
     "compat",
     "seq"
    ],
-   "commit": "4b0deb0b0ef4a73ea8fe9e2b62b45321dd76a609",
-   "sha256": "1f6mz0815v862ppnf67gs13p4mfjykp2iap8iysl8yy999a23bac"
+   "commit": "24914f0d679c6adaa7aaa0de46fefb7a11cb1094",
+   "sha256": "0wyn9z6bhp0vyv8gybw14dvaj19nz4c7k8m1j1v24naczv2dhbhc"
   },
   "stable": {
    "version": [
     0,
     19,
-    0
+    4
    ],
    "deps": [
     "compat",
     "seq"
    ],
-   "commit": "e3f930f6ad3f5296252409d3015d6ecce0a5e91b",
-   "sha256": "08c4i5qbr0ndbbps6y5kpp0lzfmxnwifrxssqkd9qdzj068k69k3"
+   "commit": "24914f0d679c6adaa7aaa0de46fefb7a11cb1094",
+   "sha256": "0wyn9z6bhp0vyv8gybw14dvaj19nz4c7k8m1j1v24naczv2dhbhc"
   }
  },
  {
@@ -56227,11 +56616,11 @@
   "repo": "seagle0128/grip-mode",
   "unstable": {
    "version": [
-    20260324,
-    1109
+    20260610,
+    628
    ],
-   "commit": "d2d27240d0150c00f0b9a5d7d840357e84d4728d",
-   "sha256": "1x0r8zcblbzzjx9w192mygndga6qp4baq4xkyvsny121vifdb9za"
+   "commit": "6ed3f9739e4a3320ab063f923c00215f7ee5b5cc",
+   "sha256": "0vgi7ji64xvy45qn84h2dysyhfngc331swkqc69216sl50d24vh8"
   },
   "stable": {
    "version": [
@@ -56331,6 +56720,21 @@
    ],
    "commit": "99eaf70720e4a6337fbd5acb68ae45cc1779bdc4",
    "sha256": "1jpfyqnqd8nj0g8xbiw4ar2qzxx3pvhwibr6hdzhyy9mmc4yzdgk"
+  }
+ },
+ {
+  "ename": "grove",
+  "commit": "ad2ba82bb65b2d3e140887299dffada73955cad6",
+  "sha256": "19ffibm27ibqz0xrhj8rpxw5fyw7qs971jrf2zzilbq7jrbqa9cq",
+  "fetcher": "github",
+  "repo": "jonathanchu/grove",
+  "unstable": {
+   "version": [
+    20260509,
+    358
+   ],
+   "commit": "8cb33df4e39c51265b8021ecf858ab4bde27f41e",
+   "sha256": "0g2s3hyc8nhxc0ga33snvh2ybccapc9fc62giw496mzw2x75d3hp"
   }
  },
  {
@@ -56663,20 +57067,20 @@
   "repo": "bormoge/guava-themes",
   "unstable": {
    "version": [
-    20260421,
-    2012
+    20260621,
+    1947
    ],
-   "commit": "de9bbe98c5186ab56cb460c59644bb9da6c6437c",
-   "sha256": "04xf7k1x7l13hzsyi56dzph1nhc6rmanqvdbqv7ngb8kqd810msv"
+   "commit": "550247dca3bf268d68a703affd25e1aaa72665f5",
+   "sha256": "1nggijiwazdx72ans74awrl6kha08pzykhfn5j4wbi4yb2lqamg8"
   },
   "stable": {
    "version": [
     0,
-    15,
+    18,
     0
    ],
-   "commit": "50881883b9ca7fbceb9bfedb04d2a16ea01125bb",
-   "sha256": "0pkng9vra4ymjnwys4d3b6ly8marpc6zl6yl02k731lhx3a1kll7"
+   "commit": "92ed6ba6c117ce52137fae975e6c73aa1ff3ed62",
+   "sha256": "11ii5l7kvsf9vm0wlixsysbcqsagrbz3qncj7phriwrwxqsf1nmh"
   }
  },
  {
@@ -56687,14 +57091,14 @@
   "repo": "tmalsburg/guess-language.el",
   "unstable": {
    "version": [
-    20240528,
-    1319
+    20260529,
+    1228
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "a17203d26135b970e4d7c5d101955d41303a758f",
-   "sha256": "1v9wwpfjl7a37jx0s2w5g48mv58vw8b3d0552v5ksxw21mbkya8s"
+   "commit": "78508e91d60064de398e118d452c8f61180fc17f",
+   "sha256": "0n3zxny07q79802xicazsywgwqcl62b8l291nb71d73lc27g6493"
   }
  },
  {
@@ -57001,17 +57405,17 @@
  },
  {
   "ename": "hacker-typer",
-  "commit": "3416586d4d782cdd61a56159c5f80a0ca9b3ddf4",
-  "sha256": "0vf18hylhszvplam6c4yynr53zc3n816p9k36gywm6awwblfpyfb",
-  "fetcher": "github",
+  "commit": "1d888e12b1c4002896723b3c993a72bf920ef37b",
+  "sha256": "1a60cx65nn50xlrrcbyh47drnkh2an0wfsyjbxzqzgacbjf1v5g7",
+  "fetcher": "sourcehut",
   "repo": "dieggsy/emacs-hacker-typer",
   "unstable": {
    "version": [
-    20170206,
-    1520
+    20260530,
+    526
    ],
-   "commit": "d5a23714a4ccc5071580622f278597d5973f40bd",
-   "sha256": "13wp7cg9d9ij44inxxyk1knczglxrbfaq50wyhc4x5zfhz5yw7wx"
+   "commit": "3f15d0cfe7636d5b32cbc882f23d5a7b61a86ae7",
+   "sha256": "0mvavn0xvih5bnag5g94przsxhmmc6bf1xh4s1268ng3j3if8d1j"
   },
   "stable": {
    "version": [
@@ -57377,6 +57781,21 @@
    ],
    "commit": "eafb1144751493c33dc005a317236ec3e84aeb07",
    "sha256": "17xsyvi8myrcyxrv07ckb6dr3mpkihva7y3daw13a3jnm2kzjsp4"
+  }
+ },
+ {
+  "ename": "har-viewer",
+  "commit": "a5c3eb103915ee1fb71f39125567e938c0ced7cc",
+  "sha256": "1c8agd7lgaz31nss6plz7hqf3jd7183v3w94ixm5d223hg9ax4az",
+  "fetcher": "github",
+  "repo": "bozoslivehere/har-viewer.el",
+  "unstable": {
+   "version": [
+    20260523,
+    2035
+   ],
+   "commit": "0b36dd0ef6743e0267e603127a4509737f8b1f0b",
+   "sha256": "1cdlc41vxv3z8n5l9q1dixznjdm6vx1kna44hrmcgqc366phs5k3"
   }
  },
  {
@@ -57969,11 +58388,11 @@
   "repo": "mgmarlow/helix-mode",
   "unstable": {
    "version": [
-    20260313,
-    2319
+    20260604,
+    125
    ],
-   "commit": "682049dbc0616f5f9737db3aad2aa1caacf71727",
-   "sha256": "1i41z8jqy7sm4cn1wm54xnkvfng8nkc499clk66vqppzjjrq8gnw"
+   "commit": "6b191a4fcf0e99a3a53902d6226f9963212140dc",
+   "sha256": "1yask43jhi4hxp60wg6hxsw58s4sirdl08nsxx0hw2rqivyqq144"
   },
   "stable": {
    "version": [
@@ -58008,28 +58427,28 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20260424,
-    553
+    20260624,
+    409
    ],
    "deps": [
     "helm-core",
     "wfnames"
    ],
-   "commit": "c316c0b50317f83d0448d1e49714733215eae133",
-   "sha256": "1zyr0ra1kd4lqphz1f079wf6w0p8mmyn9rm008y61i77p8w3mgfk"
+   "commit": "ad104b941015294faca3fa26146bd97127df883c",
+   "sha256": "19xh761bji11kaskvfiq7jqycx099jw7qpw4ip259skfkfr4kmvx"
   },
   "stable": {
    "version": [
     4,
     0,
-    6
+    7
    ],
    "deps": [
     "helm-core",
     "wfnames"
    ],
-   "commit": "f12e7dd3132724cc294e79b55291a2c967a8fe5c",
-   "sha256": "0bcwy60wqfhxvxkhc0rl7bkasf0y1pm5kwg90qh9y23ri69z08zx"
+   "commit": "3cd5097285dc10ac0898cf6f30c9699c3399e421",
+   "sha256": "1yihrb2gsl4p24xwwpdapgmnv64sd0pmbfzgpcp8nypyvs5g7kb3"
   }
  },
  {
@@ -58819,26 +59238,26 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20260412,
-    600
+    20260618,
+    1908
    ],
    "deps": [
     "async"
    ],
-   "commit": "8e1be2fdba8d99aab20c31f1bd08535773549fa4",
-   "sha256": "0f6q8wimad16wqarhkzkqyc47maad77r7s9mjlfpfmm3mbbi9ixa"
+   "commit": "558427bf221a61014e25d1be3a29dbebad277973",
+   "sha256": "1brd3q69yfhw5dr0bwmlsjsjh9m32wdkr3llv6y7rx35bh4rhdf5"
   },
   "stable": {
    "version": [
     4,
     0,
-    6
+    7
    ],
    "deps": [
     "async"
    ],
-   "commit": "f12e7dd3132724cc294e79b55291a2c967a8fe5c",
-   "sha256": "0bcwy60wqfhxvxkhc0rl7bkasf0y1pm5kwg90qh9y23ri69z08zx"
+   "commit": "3cd5097285dc10ac0898cf6f30c9699c3399e421",
+   "sha256": "1yihrb2gsl4p24xwwpdapgmnv64sd0pmbfzgpcp8nypyvs5g7kb3"
   }
  },
  {
@@ -59002,14 +59421,14 @@
   "repo": "emacs-helm/helm-dictionary",
   "unstable": {
    "version": [
-    20250227,
-    1635
+    20260611,
+    719
    ],
    "deps": [
     "helm"
    ],
-   "commit": "725cc0df42ad57a7902c330065d9e8ee1216791c",
-   "sha256": "1ipia68s5x1ny6w99g56hfcnhphlz7zh7bhmrrjyv3aflr7d3170"
+   "commit": "79eb9b8b33cb3fd8228efde146e23866b4a02652",
+   "sha256": "0hc31rn0ri6l3nv5z4l2gqc03zmi6p08q80dbdddjk6npv8nf9ba"
   }
  },
  {
@@ -60295,16 +60714,16 @@
   "repo": "emacs-lsp/helm-lsp",
   "unstable": {
    "version": [
-    20250812,
-    1134
+    20260507,
+    1749
    ],
    "deps": [
     "dash",
     "helm",
     "lsp-mode"
    ],
-   "commit": "d9d1a60f5020196b71fa89e5db3dcd12d00b7d02",
-   "sha256": "1g212mkzfm3pb1ynn3m141sz7w0ih9ssdz36a97l3wk4g14p9ric"
+   "commit": "056bb16b5f69137218613b7558b477f6b21f22be",
+   "sha256": "0m0lbw7n8lfyahpwg9lpqa9wf7bn90416va3wn2lik8gapxwwgwa"
   },
   "stable": {
    "version": [
@@ -62599,19 +63018,19 @@
   "repo": "Anoncheg1/emacs-hidepass",
   "unstable": {
    "version": [
-    20260415,
-    1941
+    20260512,
+    1112
    ],
-   "commit": "0cdc0d7910501d91d5d75ae53a42726d3fca0302",
-   "sha256": "1fv98diy9nj8n8y6ndb3n6vddvbqi539b1q87vsfzfna2gwnrpn6"
+   "commit": "6094bc0e37f5ac4abfe3fe8ed0ce8eef1a928ef9",
+   "sha256": "1ji625asb8xrb7ajm2vdk2iq2n6dv8y4558pi9ywq0ihdfddxvwd"
   },
   "stable": {
    "version": [
     0,
-    1
+    2
    ],
-   "commit": "da33a03407f1fd8e23959abbc37ba50ec1317a39",
-   "sha256": "1xjl1z7nxdkc7s18jl4bbvaf3cayki865xm3w3f0py276j7gl1gw"
+   "commit": "6094bc0e37f5ac4abfe3fe8ed0ce8eef1a928ef9",
+   "sha256": "1ji625asb8xrb7ajm2vdk2iq2n6dv8y4558pi9ywq0ihdfddxvwd"
   }
  },
  {
@@ -63369,11 +63788,11 @@
   "repo": "ideasman42/emacs-hl-indent-scope",
   "unstable": {
    "version": [
-    20251231,
-    706
+    20260502,
+    926
    ],
-   "commit": "38c8775dc575ecf6a35fa88946be3dfb5b489018",
-   "sha256": "0qmab8g6mwacvgyjjwdblzx9j5wgyzkwz7b54vj9r1v2as79idhb"
+   "commit": "538ddc0295727b11e20a9615a18d0f280bc0212a",
+   "sha256": "16v0cp3z655siniqz8x27xxyifs7jmpkb60gbjvs1yx36jg1k6zp"
   }
  },
  {
@@ -63402,11 +63821,11 @@
   "repo": "ideasman42/emacs-hl-prog-extra",
   "unstable": {
    "version": [
-    20251224,
-    230
+    20260502,
+    900
    ],
-   "commit": "1cfce465f59700820932ec71c019d821c6cea126",
-   "sha256": "0fl94alqmj1530l632wwv2s84jgvppbxsk3w5r6faddf03c8zpcm"
+   "commit": "2eac9eb5a428b23f87cfa1373f5f8fd634a72e48",
+   "sha256": "0raxwlqbp6587c5f68dd3xq12yxaq3g5cw9r3526vnmkzajxix1s"
   }
  },
  {
@@ -63433,32 +63852,34 @@
  },
  {
   "ename": "hl-todo",
-  "commit": "7c262f6a1a10e8b3cc30151cad2e34ceb66c6ed7",
-  "sha256": "1iyh68xwldj1r02blar5zi01wnb90dkbmi67vd6h78ksghl3z9j4",
+  "commit": "aec4a76eaea31408bd27d76a0b8cea5268663cc1",
+  "sha256": "14h09cxwi3hh63xdnc2a9pvaf51gws7crhs2ivci7h9377yqqcir",
   "fetcher": "github",
   "repo": "tarsius/hl-todo",
   "unstable": {
    "version": [
-    20260101,
-    1834
+    20260601,
+    1508
    ],
    "deps": [
-    "compat"
+    "compat",
+    "cond-let"
    ],
-   "commit": "9540fc414014822dde00f0188b74e17ac99e916d",
-   "sha256": "01rfyp1iqiyp8k7fg16ji8p2dp74ffdhl4bdikfxb2sz4jbz8x80"
+   "commit": "527d545b8c2f36243194cbe4a8d0e6ac9d50e6a7",
+   "sha256": "0zn5mk2m9gk7dyx04hmn8jfq0b4ai6l0nd9xss4gdzcdxh74779s"
   },
   "stable": {
    "version": [
     3,
     9,
-    3
+    4
    ],
    "deps": [
-    "compat"
+    "compat",
+    "cond-let"
    ],
-   "commit": "9540fc414014822dde00f0188b74e17ac99e916d",
-   "sha256": "01rfyp1iqiyp8k7fg16ji8p2dp74ffdhl4bdikfxb2sz4jbz8x80"
+   "commit": "527d545b8c2f36243194cbe4a8d0e6ac9d50e6a7",
+   "sha256": "0zn5mk2m9gk7dyx04hmn8jfq0b4ai6l0nd9xss4gdzcdxh74779s"
   }
  },
  {
@@ -64107,17 +64528,17 @@
  },
  {
   "ename": "http-server",
-  "commit": "038be2fbd45ee801be37c42f8cd2ddedd0138f05",
-  "sha256": "0cy94j82qfd7x0riz7mhas52xdbr3nhi0ch0x3whbnpjklhkq6c0",
-  "fetcher": "git",
-  "url": "https://codeberg.org/martenlienen/http-server.el.git",
+  "commit": "555731d091158b9d7d16fe0c6904b66c7e0e502f",
+  "sha256": "025z8pk4064rmgpjx7g6vh8am8q2sa6yinj162y84a74a1af06ah",
+  "fetcher": "codeberg",
+  "repo": "martenlienen/http-server.el",
   "unstable": {
    "version": [
-    20260419,
-    1924
+    20260609,
+    1136
    ],
-   "commit": "973c87b418e59404dcdfe823254e5094adf290f7",
-   "sha256": "1hmkm0wp5g6ac2hdg306sl42v12x3znsz363v75k6fd1qydhkk1v"
+   "commit": "4285bd3e4b67983cb783f46afc736032f895882d",
+   "sha256": "0wwv7k4avxgrscmvqnxada38ry03ijncracwvgkpgfky1cj3r0l8"
   }
  },
  {
@@ -64498,11 +64919,11 @@
   "url": "https://git.savannah.gnu.org/git/hyperbole.git",
   "unstable": {
    "version": [
-    20260422,
-    744
+    20260622,
+    756
    ],
-   "commit": "d16aa9cf3e496aa9a6c20d73f4494e16feb4d092",
-   "sha256": "0iv3sy2zympi1r04aqmlrz64zjf9xy51v6yf329nqybm12mkqgsx"
+   "commit": "510d713b6ebef63e7c4f41fc8039e3be4da0c28d",
+   "sha256": "1yic3m59pxp9bdkfz5k9q67bsjq7zj8cqxgxi34f94bywry78l5n"
   },
   "stable": {
    "version": [
@@ -64946,11 +65367,20 @@
   "repo": "jojojames/ibuffer-sidebar",
   "unstable": {
    "version": [
-    20210508,
-    836
+    20260612,
+    632
    ],
-   "commit": "fb685e1e43db979e25713081d8ae4073453bbd5e",
-   "sha256": "04x87gngmvyj4nfq1dm3h9jr6b0kvikxsg1533kdkz9k72khs3n3"
+   "commit": "1330b0f156e2275acd1a9256fc13a1d22e5e3a9e",
+   "sha256": "00nc690aqywxn4rrp2fnd7jq7vik8722ds2c1prq10bwwn6n653h"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    1
+   ],
+   "commit": "39299532ad8a040197b18ed2bce928524182c7b7",
+   "sha256": "0gxn5j4i5jjkzjkyzv42j3a3y6158b4ynj4vj6aznj4dzin8hm8s"
   }
  },
  {
@@ -65029,14 +65459,14 @@
   "repo": "conao3/iceberg-theme.el",
   "unstable": {
    "version": [
-    20220622,
-    1
+    20260516,
+    827
    ],
    "deps": [
     "solarized-theme"
    ],
-   "commit": "c9fdf9a8f5ff417c206730a84731f64a95483935",
-   "sha256": "03a7mmaykwvmm9yc8ii5k5wgihl88kyq0amp2byjddl7f4mq7zak"
+   "commit": "78b6cb1fce4d7456d928c32a7799809103fbbc10",
+   "sha256": "08zlw6krpfd5116w4dawp07gp2636gfv6lizd5virm4qvg3s2cg1"
   },
   "stable": {
    "version": [
@@ -65624,15 +66054,15 @@
   "repo": "idris-hackers/idris-mode",
   "unstable": {
    "version": [
-    20260209,
-    1107
+    20260506,
+    2033
    ],
    "deps": [
     "cl-lib",
     "prop-menu"
    ],
-   "commit": "d32b2396a8ad17820e308cd267f1b464a5235abc",
-   "sha256": "1vldwsmyaazrkcmff6qv5hlprsj37dvj7p01lphg6x20pv63c6av"
+   "commit": "22cc1bf237428b24de5f4f228db747e93a4ae619",
+   "sha256": "1rjk1xmx75r32giazj88jq392lakwvpa03a8xdwmifrw5kryrl5h"
   },
   "stable": {
    "version": [
@@ -65734,28 +66164,28 @@
   "repo": "KarimAziev/igist",
   "unstable": {
    "version": [
-    20251023,
-    848
+    20260508,
+    1037
    ],
    "deps": [
     "ghub",
     "transient"
    ],
-   "commit": "badbc1302e6f83cfebd304c6332b321ca3313f21",
-   "sha256": "0s96wv35dax1j4qa0c72l658317r34xbgmhvvl3lz6khac64k8s5"
+   "commit": "0735363f6b24910655e42e086e3a82ca5267dfc0",
+   "sha256": "1319nprmnrqwlqslrrm8wdzbjpyyj5gndrxnn7akkbg7x3lpsrp9"
   },
   "stable": {
    "version": [
     1,
     8,
-    0
+    2
    ],
    "deps": [
     "ghub",
     "transient"
    ],
-   "commit": "badbc1302e6f83cfebd304c6332b321ca3313f21",
-   "sha256": "0s96wv35dax1j4qa0c72l658317r34xbgmhvvl3lz6khac64k8s5"
+   "commit": "0735363f6b24910655e42e086e3a82ca5267dfc0",
+   "sha256": "1319nprmnrqwlqslrrm8wdzbjpyyj5gndrxnn7akkbg7x3lpsrp9"
   }
  },
  {
@@ -65910,26 +66340,26 @@
   "repo": "tarsius/imake",
   "unstable": {
    "version": [
-    20260101,
-    1835
+    20260601,
+    1510
    ],
    "deps": [
     "compat"
    ],
-   "commit": "c3d7fcc0d40676f47450891dc034511185566a0e",
-   "sha256": "1ch8ckb9gd89wr8v6150k0rnia54cbna9hxiivx3jnnr4lwn63lj"
+   "commit": "19447819b9e27421fff8381873489938978d220e",
+   "sha256": "01pp1n278hkgy7p6waq1gvm2l154fc1xzsbdyi2aw0bf69l53j3r"
   },
   "stable": {
    "version": [
     1,
     2,
-    6
+    7
    ],
    "deps": [
     "compat"
    ],
-   "commit": "c3d7fcc0d40676f47450891dc034511185566a0e",
-   "sha256": "1ch8ckb9gd89wr8v6150k0rnia54cbna9hxiivx3jnnr4lwn63lj"
+   "commit": "19447819b9e27421fff8381873489938978d220e",
+   "sha256": "01pp1n278hkgy7p6waq1gvm2l154fc1xzsbdyi2aw0bf69l53j3r"
   }
  },
  {
@@ -65940,11 +66370,11 @@
   "repo": "QiangF/imbot",
   "unstable": {
    "version": [
-    20260422,
-    1521
+    20260606,
+    428
    ],
-   "commit": "d228085198669c559f670d48251bfc5399e72a63",
-   "sha256": "1jnyxyahzs8hm8bcnafzwxa08gvvqry3xgqaxd627wv5zddkyrbl"
+   "commit": "69d1551bbca9c991a4cfe3ccb133d862854ee1c7",
+   "sha256": "08jrx67m0zlvmbkh7l82z3xhysv3hna309w909gb1yb4g2c278qm"
   }
  },
  {
@@ -66166,15 +66596,15 @@
   "repo": "skeeto/impatient-mode",
   "unstable": {
    "version": [
-    20230511,
-    1746
+    20260426,
+    1323
    ],
    "deps": [
     "htmlize",
     "simple-httpd"
    ],
-   "commit": "a4e4e12852840996b027cb8e9fb2b809c37a0ee3",
-   "sha256": "1cwascc08pzmvgjf0z5fh3w3jf85rgk13haz085qbdkhxsbivav2"
+   "commit": "4bb8009c6c6a6339a8fd7b4dea4a165af3721812",
+   "sha256": "1mic0g45g93r53zh8y1gdl0lkwpvdhi05jffz1jr8qq41jpp1886"
   },
   "stable": {
    "version": [
@@ -66389,11 +66819,11 @@
   "repo": "zk-phi/indent-guide",
   "unstable": {
    "version": [
-    20260211,
-    1005
+    20260515,
+    1152
    ],
-   "commit": "f3455c6c798b568a6ea1013b7eea1153d2e092be",
-   "sha256": "18bmf426xbqlrz448i9aphw69zh8nki1zy1s59l9drz1h5h15n7r"
+   "commit": "ab71cac290505caf6c374cb8594b0b78d5109af1",
+   "sha256": "1b0g1hw1l2r6zmij90w7a78gxxncnnpjk6zmn4mafxgnkrg8x1q8"
   },
   "stable": {
    "version": [
@@ -66435,16 +66865,16 @@
   "repo": "conao3/indent-lint.el",
   "unstable": {
    "version": [
-    20230822,
-    46
+    20260516,
+    852
    ],
    "deps": [
     "async",
     "async-await",
     "promise"
    ],
-   "commit": "aee76faf54a55e0bcb5dc07a667d7f5999299c9b",
-   "sha256": "19yixxsrwdm4wqch5011mk4gimsyh9rqzvrxkg7l7baa7am8v902"
+   "commit": "3660b10520d78dd545fd0c52d7e7a36dc602492d",
+   "sha256": "1r15nwxkb5d3zx7m1i5z8jmql551dcnq37czhk57v5madr6hggw6"
   },
   "stable": {
    "version": [
@@ -66536,6 +66966,30 @@
    ],
    "commit": "9b80c4545fc5c50332b2748c30d492517ae583b5",
    "sha256": "1dx93qlzsl5zsinslgybd1lca6962dinzy91ndqijj7sicv9nd0r"
+  }
+ },
+ {
+  "ename": "indigo",
+  "commit": "8dc4f277cf9a064587a614ef685774a4ef398534",
+  "sha256": "1vznkl2mh9zyr004gy0xnwkvwna2hxikpbxhvggmzqz4wg24n14a",
+  "fetcher": "github",
+  "repo": "gicrisf/emacs-indigo",
+  "unstable": {
+   "version": [
+    20260506,
+    1617
+   ],
+   "commit": "86433c884f5ef591ff8250b3322e5e9abd8a502d",
+   "sha256": "1aa6pgxqv37x26cm2fdxls5lyqr20v62zyghfm14w7lb1w0j6h6r"
+  },
+  "stable": {
+   "version": [
+    0,
+    11,
+    1
+   ],
+   "commit": "f9305632ca14dd27bef538007ff73ec941bbbd31",
+   "sha256": "083kkhc4hfxihib7b2kzkf1mh17wzv4l8hbf6nwalwp3rm92dzrn"
   }
  },
  {
@@ -67001,20 +67455,20 @@
   "repo": "jamescherti/inhibit-mouse.el",
   "unstable": {
    "version": [
-    20260314,
-    1908
+    20260603,
+    1158
    ],
-   "commit": "93d7e3f3dc2a869f025f743e9fc0bedf1aaa82f0",
-   "sha256": "1s958as7d46ha1pa7v1fik5pqvqxajry3v476pa6sf5l9glx3a2c"
+   "commit": "86cae75bbb771ea6be6269b925c39761be12b065",
+   "sha256": "1046g96qvvsz66qnhnk6x1d4a535cgk7qbhx6bqhr44vwzg0h1h8"
   },
   "stable": {
    "version": [
     1,
     0,
-    2
+    4
    ],
-   "commit": "89e009898dca46e07fed5fb313eb7bcdeb9d9714",
-   "sha256": "01jcgrqlwwihvdv0bm1lddlm933czgdnas7rbxhr5zvdys9gfimz"
+   "commit": "86cae75bbb771ea6be6269b925c39761be12b065",
+   "sha256": "1046g96qvvsz66qnhnk6x1d4a535cgk7qbhx6bqhr44vwzg0h1h8"
   }
  },
  {
@@ -67984,29 +68438,6 @@
    ],
    "commit": "ea855f63be7febc15bd08aec6229fab9407734fb",
    "sha256": "0avxwa6d19i5fns27vwpl95f5iawm710jlnrihi5i21ndfm4mcyw"
-  }
- },
- {
-  "ename": "isgd",
-  "commit": "d5ff75b269fd57c5822277b9ed850c69b626f1a5",
-  "sha256": "0yc9mkjzj3w64f48flnjvd193mk9gndrrqbxz3cvmvq3vgahhzyi",
-  "fetcher": "github",
-  "repo": "chmouel/isgd.el",
-  "unstable": {
-   "version": [
-    20241230,
-    1331
-   ],
-   "commit": "2dd030ab451cb9e704d173ee1b2388d92362db3b",
-   "sha256": "0wn6nx94pl7nc94bygm4vi1apzp2qlhfc3m2cg7myj9d2n5aa4xd"
-  },
-  "stable": {
-   "version": [
-    1,
-    1
-   ],
-   "commit": "764306dadd5a9213799081a48aba22f7c75cca9a",
-   "sha256": "09hx28lmldm7z3x22a0qx34id09fdp3z61pdr61flgny213q1ach"
   }
  },
  {
@@ -70023,25 +70454,25 @@
   "repo": "minad/jinx",
   "unstable": {
    "version": [
-    20260325,
-    1326
+    20260519,
+    1041
    ],
    "deps": [
     "compat"
    ],
-   "commit": "70d7a0680edcb0db74b0c9c89a5b5bf4de3eeb20",
-   "sha256": "113zjfa98qgvs9i96sdmbn82gyi1vsfnkmivim3q4ga7a8h1d4xk"
+   "commit": "987b9f90eb10df53c34c0f4972469875c1e93203",
+   "sha256": "0vb7vdv168wpn7pxcnkj2lqkc2y50ig7inr5l7z2mbx5xasgkb7y"
   },
   "stable": {
    "version": [
     2,
-    7
+    8
    ],
    "deps": [
     "compat"
    ],
-   "commit": "61bed3f77d37ae02100e8a2ec1cfb849d649fa5d",
-   "sha256": "116kah9l2bw3a6a8hgvqb9bqb388m63j5603vlybgafkra46gjwl"
+   "commit": "987b9f90eb10df53c34c0f4972469875c1e93203",
+   "sha256": "0vb7vdv168wpn7pxcnkj2lqkc2y50ig7inr5l7z2mbx5xasgkb7y"
   }
  },
  {
@@ -70794,15 +71225,15 @@
   "stable": {
    "version": [
     0,
-    4,
+    3,
     0
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "5b514ad23834b7a584b184125ba4a66bc3c26cff",
-   "sha256": "0j99rax3n905ya0ya42093pl8q7kcb8xx2qz6b918f7d8q0mr44n"
+   "commit": "623994bb50d845de487c100f5cd393ce1d792460",
+   "sha256": "1aza1p747i6bz2xg2vz63isbnh8agkdffsd7mdxb9xdfnn9cik6f"
   }
  },
  {
@@ -71056,11 +71487,11 @@
   "repo": "iwahbe/jsonian",
   "unstable": {
    "version": [
-    20250507,
-    1231
+    20260612,
+    2214
    ],
-   "commit": "513219ebb3ccdefc915715e4bf2dd6e718fabccd",
-   "sha256": "0liyv5lgx8lp7gkkljr7crich03w6w07i0jx1qifpxpq4rxmwpi0"
+   "commit": "2709fb0140c92eb183c849fdc530fd59f4e4fd3d",
+   "sha256": "1alqaynlrwqnakq2x03xh66jbh7365rsbdnip39xwxwfjnkblj0g"
   },
   "stable": {
    "version": [
@@ -71246,11 +71677,11 @@
   "repo": "JuliaEditorSupport/julia-emacs",
   "unstable": {
    "version": [
-    20260204,
-    807
+    20260529,
+    1424
    ],
-   "commit": "aadf29523a120c666939cd7adac4b7dece5bd6ef",
-   "sha256": "0kw79pz3l40d533hhrrw21hskayr38nffnp0cnwjq0zv9fvxwin1"
+   "commit": "1b5a4c2f5b7c3f842785985bf8778b8805cc6766",
+   "sha256": "00by1x900gzg42lwzd59awhsl5z73pna4cmzjpp2dflwvddy7vn6"
   },
   "stable": {
    "version": [
@@ -71317,8 +71748,8 @@
   "repo": "gcv/julia-snail",
   "unstable": {
    "version": [
-    20260403,
-    453
+    20260516,
+    750
    ],
    "deps": [
     "dash",
@@ -71327,8 +71758,8 @@
     "s",
     "spinner"
    ],
-   "commit": "3c0beddcd21464d52e95e65ee8b3d7b3a148d83d",
-   "sha256": "1p00j4lh9nhkim0lg1f0swvv5lsn54w9qk1g2pjxldrfsad7bqwg"
+   "commit": "90e2278921ff4155577f97b937f375375c32a34f",
+   "sha256": "046la1mh70syq96sla8v92mk8fg5dl05w75bs0plppxkhbnjv2ky"
   },
   "stable": {
    "version": [
@@ -71355,14 +71786,14 @@
   "repo": "JuliaEditorSupport/julia-ts-mode",
   "unstable": {
    "version": [
-    20250115,
-    1449
+    20260616,
+    1624
    ],
    "deps": [
     "julia-mode"
    ],
-   "commit": "d693c6b35d3aed986b2700a3b5f910de12d6c53c",
-   "sha256": "0jg59d6q4lab2p5d2f8yp95xpbqkc614ayl137mv14l5apgayvbc"
+   "commit": "d53fb5b2c7e83223dcd8c7ae6bd5e1abf18665f6",
+   "sha256": "16iss4q0arlggwdgqjjwj8flywk6h53ylzf5m1ig1jxkl8vqpiby"
   },
   "stable": {
    "version": [
@@ -71629,8 +72060,8 @@
   "repo": "psibi/justl.el",
   "unstable": {
    "version": [
-    20260228,
-    1147
+    20260513,
+    850
    ],
    "deps": [
     "f",
@@ -71638,8 +72069,8 @@
     "s",
     "transient"
    ],
-   "commit": "4a149c0ad91f60c4d4338e7aa0676ad792a52eca",
-   "sha256": "01wg76330lcff8bd83ym65yhbbwp48yrr2crafn2bdlncgd4whqy"
+   "commit": "2b6e5f8d2d16e7c535553dcb9c496f8bd1bb827e",
+   "sha256": "01fqxpkyv1l1hqmsjc50g65cdq5fd3wx9id3qgzng9f7vc2dmfh9"
   },
   "stable": {
    "version": [
@@ -71694,11 +72125,11 @@
   "repo": "joshbax189/jwt-el",
   "unstable": {
    "version": [
-    20251022,
-    2118
+    20260514,
+    2219
    ],
-   "commit": "d6754f8fab6ff4041a7bece1963495e99ad9fe68",
-   "sha256": "0crqy2r2bx03f2z7pg1h2qm7csx3ncxqbya4bz976ssq0p7mljnv"
+   "commit": "83bcef37c311645a07c0263007c5b962ca3dab15",
+   "sha256": "0kawf3f59cizq730dyh7avkb774lw773vb7wvqjnygjqky8kqirj"
   },
   "stable": {
    "version": [
@@ -71998,11 +72429,11 @@
   "repo": "Fabiokleis/kanagawa-emacs",
   "unstable": {
    "version": [
-    20260413,
-    1643
+    20260522,
+    325
    ],
-   "commit": "c0ec6694a6574ad2d54ca671de2093c81b54888a",
-   "sha256": "1bk7x77a11nlnfl0z40bvyi0c86vyfncjrk1dggs79qw9bnx04i2"
+   "commit": "399dff7bc7abf5726ef85f880aa70d10b433afb4",
+   "sha256": "16ya2f28z5c68pf7i0zy555nv9ly8ggsr50g2mrfycwpg5na2zim"
   }
  },
  {
@@ -72077,28 +72508,28 @@
   "repo": "ogdenwebb/emacs-kaolin-themes",
   "unstable": {
    "version": [
-    20260114,
-    2021
+    20260619,
+    2211
    ],
    "deps": [
     "autothemer",
     "cl-lib"
    ],
-   "commit": "fc0337582f36167b74cbdc86a48471092c8f3262",
-   "sha256": "1lbqvs2jqvs6x8gj7bali24mw2fl6gk184zln6avy6wmam7n8dqi"
+   "commit": "432c6672b16e867ec40eaf312d2fbbeb38673fa9",
+   "sha256": "0jsxmi4l2kjpfgfbacixcbxdr1sz45qj5y2hz447fca8y9875p9y"
   },
   "stable": {
    "version": [
     1,
     7,
-    4
+    7
    ],
    "deps": [
     "autothemer",
     "cl-lib"
    ],
-   "commit": "fc0337582f36167b74cbdc86a48471092c8f3262",
-   "sha256": "1lbqvs2jqvs6x8gj7bali24mw2fl6gk184zln6avy6wmam7n8dqi"
+   "commit": "8dc98bd1a63aa35e44ff8b3fd1be6d6afd4e2301",
+   "sha256": "1133gw5fnfj5plg4ny2lkhzsqsd6624fbnfh822p9dqxfmfckb1z"
   }
  },
  {
@@ -72109,11 +72540,11 @@
   "repo": "gicrisf/kaomel",
   "unstable": {
    "version": [
-    20250923,
-    1958
+    20260615,
+    1304
    ],
-   "commit": "9476f16a72e61f08f403cb4dbe860e39f1856c7a",
-   "sha256": "04k36fjd165isbbb5vz0nl945k0b73z62hs271ivp74z6f8nfafg"
+   "commit": "652b31cc8437d87b65e618af9428229182ea595c",
+   "sha256": "1na4jn2w147sl3qq4jxnfz98qv5cfydrhvdny7pd3z4mlj9w5f3f"
   },
   "stable": {
    "version": [
@@ -72300,11 +72731,11 @@
   "repo": "conao3/keg.el",
   "unstable": {
    "version": [
-    20240713,
-    1007
+    20260527,
+    831
    ],
-   "commit": "e1726f89dab1811a110eebb3f3e4b673742faf05",
-   "sha256": "02wwr40jxny9w0xnjwi4n40hn5jmdkkzng4rml846hw4ih1vxc0k"
+   "commit": "91030f36115ce50c4f812b95b169aeaffdd0e042",
+   "sha256": "1jlwd71ba6ahcbl1dydhx63c5wxsh4kdml1jjs9zc75sd18j69k4"
   }
  },
  {
@@ -72532,26 +72963,28 @@
   "repo": "tarsius/keycast",
   "unstable": {
    "version": [
-    20260101,
-    1835
+    20260601,
+    1510
    ],
    "deps": [
-    "compat"
+    "compat",
+    "cond-let"
    ],
-   "commit": "b831e380c4deb1d51ce5db0a965b96427aec52e4",
-   "sha256": "1bn30n0b0wsvzhpa4qsghh5acb82r07sw82xjwjqq26kckfisvkx"
+   "commit": "a6518e1b48b08ba883e9b1a2db0872d5bf3d85f4",
+   "sha256": "1q4mfxy0022hw07nh2rqii1wkmk5za5hx5jdaqmb7xkj5z12cxj3"
   },
   "stable": {
    "version": [
     1,
     4,
-    7
+    8
    ],
    "deps": [
-    "compat"
+    "compat",
+    "cond-let"
    ],
-   "commit": "b831e380c4deb1d51ce5db0a965b96427aec52e4",
-   "sha256": "1bn30n0b0wsvzhpa4qsghh5acb82r07sw82xjwjqq26kckfisvkx"
+   "commit": "a6518e1b48b08ba883e9b1a2db0872d5bf3d85f4",
+   "sha256": "1q4mfxy0022hw07nh2rqii1wkmk5za5hx5jdaqmb7xkj5z12cxj3"
   }
  },
  {
@@ -72629,32 +73062,34 @@
  },
  {
   "ename": "keymap-utils",
-  "commit": "c03acebf1462dea36c81d4b9ab41e2e5739be3c3",
-  "sha256": "0nbcwz4nls0pva79lbx91bpzkl38g98yavwkvg2rxbhn9vjbhzs9",
+  "commit": "aec4a76eaea31408bd27d76a0b8cea5268663cc1",
+  "sha256": "00xjczwi1f2wzjp556p94kn7b5gkvb9gmblfqx0rpk4y6akn8afw",
   "fetcher": "github",
   "repo": "tarsius/keymap-utils",
   "unstable": {
    "version": [
-    20260401,
-    1221
+    20260601,
+    1550
    ],
    "deps": [
-    "compat"
+    "compat",
+    "llama"
    ],
-   "commit": "46e4aeb2801740a69f4ab5411579cc9cb2f0e786",
-   "sha256": "0bgx2v23z8iq04f8d3zyga9729l7arqyv6id0qc7br9yacj5x4jc"
+   "commit": "3064e5ffe98458500c75bf7c854c45d3e60e8e90",
+   "sha256": "1a0n5k19ra3k0chsc8j74b6rcnaf3jdk0hi28f3g600h3ivccfxl"
   },
   "stable": {
    "version": [
     4,
     1,
-    3
+    4
    ],
    "deps": [
-    "compat"
+    "compat",
+    "llama"
    ],
-   "commit": "46e4aeb2801740a69f4ab5411579cc9cb2f0e786",
-   "sha256": "0bgx2v23z8iq04f8d3zyga9729l7arqyv6id0qc7br9yacj5x4jc"
+   "commit": "3064e5ffe98458500c75bf7c854c45d3e60e8e90",
+   "sha256": "1a0n5k19ra3k0chsc8j74b6rcnaf3jdk0hi28f3g600h3ivccfxl"
   }
  },
  {
@@ -73032,20 +73467,20 @@
   "repo": "jamescherti/kirigami.el",
   "unstable": {
    "version": [
-    20260416,
-    1901
+    20260613,
+    1820
    ],
-   "commit": "5236f011f420465c2abd853e7f16727c0c8eab7d",
-   "sha256": "1awvliza7fva0a74lf6xqx7gzfbby5kr7z4ki818yd98z4x1rqxf"
+   "commit": "948cccf6499415005a43112e5daadc6ecc57fa1c",
+   "sha256": "0203slgl1wal7x6hygwc2hkkm92i95cq6n0abgc0x8bnkkm7n0v5"
   },
   "stable": {
    "version": [
     1,
-    0,
+    1,
     5
    ],
-   "commit": "7038a9dcfa7e2d8848817508777d8ad878756cfb",
-   "sha256": "1j6l2nm5jv96636sz9w9yf32vcmkc5n9zylh6k1vf5gidgwlgxni"
+   "commit": "77e967baf830aa411404ed695826f0b589bdc28a",
+   "sha256": "03ql2x4npkw60mjvfn83gnp6dbshf6ikhj7558mwdk8qi695q2fc"
   }
  },
  {
@@ -73166,14 +73601,14 @@
   "repo": "benotn/kkp",
   "unstable": {
    "version": [
-    20260306,
-    1633
+    20260617,
+    1005
    ],
    "deps": [
     "compat"
    ],
-   "commit": "73957230ffdd3dedf16f4436f61471bd1365abf6",
-   "sha256": "1j5igiys8asjg0v18flc7p71xjynqi7v8s06qgkac8djvjamd4lh"
+   "commit": "0b77ce2fb9eefbb07ffa906f8fe2df14450a9cfc",
+   "sha256": "08whip7ghmihrc345135kwsda7wjqm85p3hfrfhclkxd1yrpv8y7"
   }
  },
  {
@@ -73184,11 +73619,11 @@
   "repo": "tomenzgg/emacs-klere-theme",
   "unstable": {
    "version": [
-    20250517,
-    452
+    20260526,
+    323
    ],
-   "commit": "377cc33617184e23acde6707beaf8938915fe093",
-   "sha256": "15rgq1a6k64ws0fh864awnw22qzpb58z5s2gj2cp1svw4yakr84w"
+   "commit": "332d93b22f0359150c8dd8de710ffed09c34664f",
+   "sha256": "1x3z1j33w3pj6mhj07lgclzmf9cwgx505mn4gvlpshwlxwp6ms0w"
   }
  },
  {
@@ -73392,11 +73827,11 @@
   "repo": "bricka/emacs-kotlin-ts-mode",
   "unstable": {
    "version": [
-    20260326,
-    930
+    20260512,
+    1409
    ],
-   "commit": "136d8d1fd3158fc5558aff866041c1935b574588",
-   "sha256": "15iqvbv8i3n27yssfr47fh75ir89a6jxicp7vi8jk51a45symhnf"
+   "commit": "39e30e4cf803910c2f6716efd7a5cd408a9d996b",
+   "sha256": "1zabj07ffmi9g0vv74xkrwim7dwx3hsirr9abaxh6acwykp2ma6d"
   }
  },
  {
@@ -73552,8 +73987,8 @@
   "repo": "abrochard/kubel",
   "unstable": {
    "version": [
-    20260423,
-    1353
+    20260508,
+    2043
    ],
    "deps": [
     "dash",
@@ -73561,8 +73996,8 @@
     "transient",
     "yaml-mode"
    ],
-   "commit": "b6581c657830c21a58aba5df5239cf7ece44f1c9",
-   "sha256": "03qrdr0gf5a560ywwjj1xwq9xh19v1rliwjjdklhcq6qacaxvq0k"
+   "commit": "f2d64227c6d2ce0a3a9023345b230b5b2b30d147",
+   "sha256": "0sij8hi8h92ryp6vphs4hpqvw5r19k5q7cr0r6aifqfk4di61j7q"
   },
   "stable": {
    "version": [
@@ -73843,8 +74278,8 @@
   "repo": "isamert/lab.el",
   "unstable": {
    "version": [
-    20260419,
-    1535
+    20260620,
+    1757
    ],
    "deps": [
     "async-await",
@@ -73854,13 +74289,13 @@
     "request",
     "s"
    ],
-   "commit": "b91086760688328e032af454c1ca3ae5061356dc",
-   "sha256": "003pm093zrx6qv2sa959sws74a4h0w8g2mcyjyqsvm0xxjshzifw"
+   "commit": "2be6e50e75b4372337b77d0ae5563cb8cd671352",
+   "sha256": "1d0q7ssm9ynhd1da34by6a5zwbyzq20x8bqky9hf0fk28m9xpjjh"
   },
   "stable": {
    "version": [
     3,
-    7,
+    8,
     0
    ],
    "deps": [
@@ -73871,8 +74306,8 @@
     "request",
     "s"
    ],
-   "commit": "aa3af6f8e2eb16edac2b680ecddf4823f94287de",
-   "sha256": "12xb18ssn5zf9gy2px2x6mnbjh9bny1rf7kldlvv84s86iiqzxpl"
+   "commit": "2be6e50e75b4372337b77d0ae5563cb8cd671352",
+   "sha256": "1d0q7ssm9ynhd1da34by6a5zwbyzq20x8bqky9hf0fk28m9xpjjh"
   }
  },
  {
@@ -73961,16 +74396,16 @@
   "repo": "Deducteam/lambdapi",
   "unstable": {
    "version": [
-    20260423,
-    1057
+    20260624,
+    735
    ],
    "deps": [
     "eglot",
     "highlight",
     "math-symbol-lists"
    ],
-   "commit": "fbbe050639dfe7c1c1f2be2e6807dd31e3108e5e",
-   "sha256": "11jpn7w0iy4vp555hsc425ipjzsv0ajhph1ih5ajqkn2lxd46b8v"
+   "commit": "e2e0e4a1fc921205e56dd4d78dc22d364644813d",
+   "sha256": "01jih46346wv236hvb698vmicz0m8x7lcrgqsw0nc8sq6pb73yc9"
   },
   "stable": {
    "version": [
@@ -74379,28 +74814,28 @@
   "repo": "enricoflor/latex-table-wizard",
   "unstable": {
    "version": [
-    20260212,
-    2229
+    20260504,
+    128
    ],
    "deps": [
     "auctex",
     "transient"
    ],
-   "commit": "681c03010e38e8cb4089171be72d73e6d28cd472",
-   "sha256": "1v5dwidr9gvlqdspalr1iqw7gdcyl6lyji4cl8dddj9rmyf3x8rw"
+   "commit": "0ccd242ba521ed3b323d1dc84f49febe80b2eec7",
+   "sha256": "0mf7r22n51wyrdbsb5jm1jfhcivifz6d5l029wv3p5p88mylx2ks"
   },
   "stable": {
    "version": [
     1,
-    5,
+    6,
     0
    ],
    "deps": [
     "auctex",
     "transient"
    ],
-   "commit": "b41aac096b96aeb446346c3cbd6537cc0eb1f70d",
-   "sha256": "03sj7kq9xwak5mzllvgjq5ysarph55rxknn09dgdn8fs74hlifcb"
+   "commit": "0ccd242ba521ed3b323d1dc84f49febe80b2eec7",
+   "sha256": "0mf7r22n51wyrdbsb5jm1jfhcivifz6d5l029wv3p5p88mylx2ks"
   }
  },
  {
@@ -74705,6 +75140,30 @@
   }
  },
  {
+  "ename": "leadkey",
+  "commit": "20a81a260cec3d49dd1ebde86bf99b9bf3f3cd8e",
+  "sha256": "1s03n14nzqmp1p7shz9ym0n7p8plhc9wzlfw20krmg7xcqy91dmz",
+  "fetcher": "github",
+  "repo": "jixiuf/emacs-leadkey",
+  "unstable": {
+   "version": [
+    20260624,
+    731
+   ],
+   "commit": "3a0befd5a8937f8effe07da001cf8d3c765fc2ce",
+   "sha256": "1xx8flk34f99kh54x9k5872g4961x35jgrx4ia2f54qswjgdn499"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    0
+   ],
+   "commit": "61042efbbde72e096e74833eeebdcdf9599cab7c",
+   "sha256": "1z43875hnqv4xz383ahs035v41n39ycnm9r10s7qamy6sv5rvj99"
+  }
+ },
+ {
   "ename": "leaf",
   "commit": "24afe5b39979e2f17e104ae97d840645d2a5c2f1",
   "sha256": "0h4v3fswbwa40hws8l29mmnka5wl9kyj6f01dnvadc725a34az38",
@@ -74736,16 +75195,16 @@
   "repo": "conao3/leaf-convert.el",
   "unstable": {
    "version": [
-    20210816,
-    1103
+    20260516,
+    853
    ],
    "deps": [
     "leaf",
     "leaf-keywords",
     "ppp"
    ],
-   "commit": "da86654f1021445cc42c1a5a9195f15097352209",
-   "sha256": "14pvdkknbng44frlf8accpqd1bc9j99x7xjymgrdbyczbq2srv4n"
+   "commit": "37967565c023596d863d9cd45527a024c5922553",
+   "sha256": "0vfj01b37im8wqzn4rnbl9wqxgsb8pcandzmnk9d3bhb1scg3lx0"
   }
  },
  {
@@ -74756,15 +75215,15 @@
   "repo": "conao3/leaf-defaults.el",
   "unstable": {
    "version": [
-    20210301,
-    118
+    20260516,
+    827
    ],
    "deps": [
     "leaf",
     "leaf-keywords"
    ],
-   "commit": "96ce39d4f16736f1e654e24eac16a2603976c724",
-   "sha256": "1z56x3wnyakilgxak2yyf6rf35072996szxfz712lmdwqs6xfqv4"
+   "commit": "238282d31d20c9b5077d7274ba9448eaaf0d44cc",
+   "sha256": "0wxzs107fp8hsbm9r2nb4chw9qvwkf72nn49ki1wwd8za205d8vj"
   }
  },
  {
@@ -74775,14 +75234,14 @@
   "repo": "conao3/leaf-keywords.el",
   "unstable": {
    "version": [
-    20240808,
-    2302
+    20260516,
+    827
    ],
    "deps": [
     "leaf"
    ],
-   "commit": "82ec27e3441900daedeaaebca509181f964da81f",
-   "sha256": "0nsa01d35z3dvvb6dnc43ii461c15pp35ji92k15x8z9nyr25wrd"
+   "commit": "36efb8c94071c0fd98b6534866297f2238b78630",
+   "sha256": "0sfrjiwrzyphmwyh2yxzgw46js7jiwrnm10hhaqkzrqalvh4i68h"
   },
   "stable": {
    "version": [
@@ -74836,14 +75295,14 @@
   "repo": "conao3/leaf-tree.el",
   "unstable": {
    "version": [
-    20211105,
-    19
+    20260516,
+    827
    ],
    "deps": [
     "imenu-list"
    ],
-   "commit": "89c3b8842df067bba67663d309f43aa311acdccd",
-   "sha256": "0him39wsl65nmml9as8gfrix707xjxwvjkwmrgxc9qfjwcxvbvsj"
+   "commit": "6c85ef64bb21ddbd64e70625dbd59b0539fac534",
+   "sha256": "1n3h5mk7j295br17nx9vfn8v6sx1683wdnyd5j8scwqc7qwgf9ds"
   },
   "stable": {
    "version": [
@@ -74948,11 +75407,11 @@
   "repo": "ledger/ledger-mode",
   "unstable": {
    "version": [
-    20251219,
-    2350
+    20260609,
+    609
    ],
-   "commit": "40e6a167530e21968e3ce7b8cb74e7595cb6009a",
-   "sha256": "020sm0ljnbx389cspn1blz1d19w6sx4j68cp39b8hb9h9xdd4n55"
+   "commit": "b0ee99feb2dcae5e304ad735d82d488f2191a51c",
+   "sha256": "193m7nbpbp33i79y25g09ippxskpxsb8ixiyn6v1a1il0qjhf8rf"
   },
   "stable": {
    "version": [
@@ -75036,27 +75495,27 @@
   "repo": "martianh/lem.el",
   "unstable": {
    "version": [
-    20250806,
-    924
+    20260509,
+    758
    ],
    "deps": [
     "fedi",
     "markdown-mode"
    ],
-   "commit": "a0f4fa89fe73dfe7412f5d25d6e0619abf8cff14",
-   "sha256": "181cibmv6da4rjr6p3nqpza6i7v4scc4qndznhyjb9nhbf3gsil4"
+   "commit": "3abd1604c3ab9451dcbc087099c499e6dc8882d7",
+   "sha256": "1h28bwy0nd08lxvpqdxqcbg0n2j09ilb7rf3nj6csflz64nhg40x"
   },
   "stable": {
    "version": [
     0,
-    24
+    25
    ],
    "deps": [
     "fedi",
     "markdown-mode"
    ],
-   "commit": "a0f4fa89fe73dfe7412f5d25d6e0619abf8cff14",
-   "sha256": "181cibmv6da4rjr6p3nqpza6i7v4scc4qndznhyjb9nhbf3gsil4"
+   "commit": "3abd1604c3ab9451dcbc087099c499e6dc8882d7",
+   "sha256": "1h28bwy0nd08lxvpqdxqcbg0n2j09ilb7rf3nj6csflz64nhg40x"
   }
  },
  {
@@ -75322,15 +75781,15 @@
   "repo": "alhassy/lf",
   "unstable": {
    "version": [
-    20210808,
-    1921
+    20260502,
+    1103
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "35db92ca765a0544721fdeea036d77b7d192d083",
-   "sha256": "0c22347dfrjdrn0cn4bqqsw8gd1663hkgycxkfivpyg0d734g5nq"
+   "commit": "dbe5a7c66c51d1a3036eb33d13c0a0a399349dda",
+   "sha256": "0ljr174ni05mbp2b169d96qkik2kzpqr4rqp5px9v0rs22v0g50g"
   }
  },
  {
@@ -75434,26 +75893,26 @@
  },
  {
   "ename": "liberime",
-  "commit": "0ccac33c02762314d997156df4627c0c4a0279c6",
-  "sha256": "0i95vjn4rw7n4f83nrxjkmilzalgmjlmyhsvwfm4n1rqfqdwkl5h",
+  "commit": "41d8e39c6f7bdade9b13c27ee1290dad21b4877f",
+  "sha256": "0vwmfr0lk7fmxfg7bdi6kcsaaz5hvv4rvfzdkv7klpvp89dvjvzz",
   "fetcher": "github",
-  "repo": "merrickluo/liberime",
+  "repo": "emacs-rime/liberime",
   "unstable": {
    "version": [
-    20260427,
-    303
+    20260622,
+    955
    ],
-   "commit": "2130baba8e5e15922650bc01de95a1d6c6a1c1f7",
-   "sha256": "0zr0hk11xani4pn0yv2xlpfwargv33q610w0yw6ac1r91bn9r9z9"
+   "commit": "8e52f3128e553a9b0cf270ead5c8cca4de2dd0d8",
+   "sha256": "0mq106yppl9kkqfyvbxma4d9k88bqpvwk6b6lcyr8kmkd2bd6n8f"
   },
   "stable": {
    "version": [
     0,
     0,
-    9
+    10
    ],
-   "commit": "2130baba8e5e15922650bc01de95a1d6c6a1c1f7",
-   "sha256": "0zr0hk11xani4pn0yv2xlpfwargv33q610w0yw6ac1r91bn9r9z9"
+   "commit": "482b7854b04169b348f3c943891f0895bd38bc4f",
+   "sha256": "0bmp4ajczw4nvgshbkycnvr0m0pjlji14qgkk8k58qxy38zxvli2"
   }
  },
  {
@@ -75887,11 +76346,11 @@
   "repo": "Judafa/linkin-org",
   "unstable": {
    "version": [
-    20260313,
-    2013
+    20260617,
+    2114
    ],
-   "commit": "daab39c4e3dc5d77c55630e26f8b0339ae218dd1",
-   "sha256": "0iy6vipdf74ggz14brnj3hljq75kj2dfg49vlv0p85x0a5aacv1y"
+   "commit": "51d7c2c2689c0cfd48f91986d36ffdabea57369f",
+   "sha256": "02ym261g4y8k98b4f78fbjb9alk844h8p3snck4q4n7f6371w6sl"
   }
  },
  {
@@ -75902,11 +76361,11 @@
   "repo": "erickgnavar/linkode.el",
   "unstable": {
    "version": [
-    20240604,
-    53
+    20260605,
+    352
    ],
-   "commit": "5152aa3ba7a4360133efd5892f0891837af30440",
-   "sha256": "0c9ly7lf1ydn3zjqn265vkjq4n4qn3xvr4lhs66gh2krk8qrm9cm"
+   "commit": "8bfb80ca046bc0c942a14effef354722ad8a8a6c",
+   "sha256": "151115q9c1l87c4kv60nv4py0h121wrxr5xs2asibh9p3773zx3m"
   }
  },
  {
@@ -76071,26 +76530,26 @@
   "repo": "ryukinix/lisp-chat",
   "unstable": {
    "version": [
-    20260323,
-    206
+    20260425,
+    1217
    ],
    "deps": [
     "websocket"
    ],
-   "commit": "cff980c915db1e47d3090c212050b7598d15daca",
-   "sha256": "02fiyky63z4zr6x4xyf72d457f4x8fqraax3lk13zwjlxv1nn2xd"
+   "commit": "066f2a5d4ca2ff50f6a0a1413182e08f17040e3a",
+   "sha256": "0qqnn5pb7qghn3ryrixjzgb9vabgm96n10l189j9izr5zfzg194f"
   },
   "stable": {
    "version": [
     0,
     9,
-    0
+    1
    ],
    "deps": [
     "websocket"
    ],
-   "commit": "cff980c915db1e47d3090c212050b7598d15daca",
-   "sha256": "02fiyky63z4zr6x4xyf72d457f4x8fqraax3lk13zwjlxv1nn2xd"
+   "commit": "066f2a5d4ca2ff50f6a0a1413182e08f17040e3a",
+   "sha256": "0qqnn5pb7qghn3ryrixjzgb9vabgm96n10l189j9izr5zfzg194f"
   }
  },
  {
@@ -76368,14 +76827,14 @@
   "repo": "zzkt/metabrainz",
   "unstable": {
    "version": [
-    20230530,
-    741
+    20260603,
+    1009
    ],
    "deps": [
     "request"
    ],
-   "commit": "2386189ec8a19a74d7b8a46e08a9fa6d974a6305",
-   "sha256": "0lkqgjzp5lwjv1j6jjal4nsps3cxdg1nc2rr83v5a3gylsy0x69w"
+   "commit": "abd37d9f1c25a021b32eac54e6deff6080a66bca",
+   "sha256": "1kri05wx2r88pbh7pvwkcz4csi8g5qn1bjb31nbda6vs39db8l6m"
   }
  },
  {
@@ -76578,11 +77037,11 @@
   "repo": "jingtaozf/literate-elisp",
   "unstable": {
    "version": [
-    20250103,
-    132
+    20260621,
+    1253
    ],
-   "commit": "c559eff46dd7fe0ffc4ad7bf6dd65ee5be516368",
-   "sha256": "1h8j16hqhncbfa6nf046qfzhplzqql9i2jjwx1kmqnyxfcvv1zs6"
+   "commit": "6cbe22aab87886cf61c4866653e24ebdb88b1523",
+   "sha256": "0xaz583wvk6510027kp73p7swkdi8z7929k8p0jmpav2x5n1207d"
   },
   "stable": {
    "version": [
@@ -76828,26 +77287,26 @@
   "repo": "tarsius/llama",
   "unstable": {
    "version": [
-    20260301,
-    1253
+    20260601,
+    1455
    ],
    "deps": [
     "compat"
    ],
-   "commit": "d430d48e0b5afd2a34b5531f103dcb110c3539c4",
-   "sha256": "07rjfjk01gd4jqk38wc0a2vrsk15p8sx0varqbhjdyns7w2xs1d7"
+   "commit": "4d4024048053b898a01521046e0f063ee47615b0",
+   "sha256": "1qya4drpfnr25lgpagxzi22llrvs9ysqgfhs3093ly2k4pi28nvk"
   },
   "stable": {
    "version": [
     1,
     0,
-    4
+    5
    ],
    "deps": [
     "compat"
    ],
-   "commit": "d430d48e0b5afd2a34b5531f103dcb110c3539c4",
-   "sha256": "07rjfjk01gd4jqk38wc0a2vrsk15p8sx0varqbhjdyns7w2xs1d7"
+   "commit": "4d4024048053b898a01521046e0f063ee47615b0",
+   "sha256": "1qya4drpfnr25lgpagxzi22llrvs9ysqgfhs3093ly2k4pi28nvk"
   }
  },
  {
@@ -77006,15 +77465,15 @@
   "repo": "tanrax/lobsters.el",
   "unstable": {
    "version": [
-    20251217,
-    1458
+    20260623,
+    735
    ],
    "deps": [
     "request",
     "visual-fill-column"
    ],
-   "commit": "58f91e5adc9660a54a3f6eb1cd49fbbeb2229b74",
-   "sha256": "19nik1vaazf0w43fvksshx2c1fbby0fyafn2859jbdmvxwb5imw7"
+   "commit": "41ca67e5827793e91834bf03cdefab581783c3d5",
+   "sha256": "01pxdzk0xaqqkc17zp3x2d4s8sm212z217kvzlwj697afh1vndy4"
   },
   "stable": {
    "version": [
@@ -77530,8 +77989,8 @@
   "repo": "okamsn/loopy",
   "unstable": {
    "version": [
-    20260309,
-    304
+    20260622,
+    2352
    ],
    "deps": [
     "compat",
@@ -77539,13 +77998,13 @@
     "seq",
     "stream"
    ],
-   "commit": "b78b88173df00cf95cda401a6d3b0872dce8aa08",
-   "sha256": "156r43kpfk2kdkgj7m6pk4pql4y9vsj5igwni00dzr437y74sb2p"
+   "commit": "09fecad848c8671902ceae7d74afecdd29a84ac5",
+   "sha256": "1bg0icla79jjjplh5ibjbcimnkxiziiw6r3s13prg2fr6mngbs1f"
   },
   "stable": {
    "version": [
     0,
-    15,
+    16,
     0
    ],
    "deps": [
@@ -77554,8 +78013,8 @@
     "seq",
     "stream"
    ],
-   "commit": "1849c6c774332c6451288debd4c353449ee79a92",
-   "sha256": "0qpzg7p8qiggscddbbf85av7zp7b38jjib49jrzl9skliwc0klcr"
+   "commit": "09fecad848c8671902ceae7d74afecdd29a84ac5",
+   "sha256": "1bg0icla79jjjplh5ibjbcimnkxiziiw6r3s13prg2fr6mngbs1f"
   }
  },
  {
@@ -77688,8 +78147,8 @@
   "repo": "emacs-lsp/lsp-dart",
   "unstable": {
    "version": [
-    20260214,
-    2354
+    20260507,
+    1741
    ],
    "deps": [
     "dap-mode",
@@ -77701,8 +78160,8 @@
     "lsp-mode",
     "lsp-treemacs"
    ],
-   "commit": "166e4f2ba12403da5691d352b587c88d24ddb574",
-   "sha256": "177l32r1ns8rxq5z8qa5k5nv3v4l29zps9xn4ps196298phd253a"
+   "commit": "a0649b4dbf3eb1f1fac4be172ba282df43b16b73",
+   "sha256": "1khpnm3m90ijbrcaz2isgq7z9zs5hfh9kqn7g14wqzbzrvvijz37"
   },
   "stable": {
    "version": [
@@ -77732,8 +78191,8 @@
   "repo": "emacs-lsp/lsp-docker",
   "unstable": {
    "version": [
-    20250228,
-    2210
+    20260507,
+    1750
    ],
    "deps": [
     "dash",
@@ -77743,8 +78202,8 @@
     "s",
     "yaml"
    ],
-   "commit": "3960c73349e5658220f0f48587894ac098e62b97",
-   "sha256": "05sblmvj1vhk4rgfqahr0i0dnaczcixcddd88w3rsdyh72wpxdg6"
+   "commit": "f666fba72b496c7750bb3f349771b07aa51714f0",
+   "sha256": "02ihnn5rnk6l9x5wvgj0mrglyss80x47phhks6r3is1frh935xxq"
   },
   "stable": {
    "version": [
@@ -77772,15 +78231,15 @@
   "repo": "emacs-lsp/lsp-focus",
   "unstable": {
    "version": [
-    20250825,
-    539
+    20260507,
+    1747
    ],
    "deps": [
     "focus",
     "lsp-mode"
    ],
-   "commit": "4621d310e780e384cbe93d5680fa9ec5d03e2c73",
-   "sha256": "09yzcfv9gpifsy5ckvmacj7fg0fz1pnnjdzghj4i28x738g7ixxb"
+   "commit": "675a20610c63577bb5363c2ed9b253705bbfee4f",
+   "sha256": "0kcy73chsrilb7clmwdmjlcdmfi6zdg6q758lnb20dicixlpjayi"
   },
   "stable": {
    "version": [
@@ -77804,8 +78263,8 @@
   "repo": "emacs-grammarly/lsp-grammarly",
   "unstable": {
    "version": [
-    20251231,
-    1727
+    20260503,
+    1232
    ],
    "deps": [
     "grammarly",
@@ -77814,8 +78273,8 @@
     "request",
     "s"
    ],
-   "commit": "4c3aa9e757ff9082a4d7ff104dd5ff0f28f0b811",
-   "sha256": "16ysivfk6lv8ndifxrhxya3hk3w3rv8p3bwy3ssz7g7q388n1k3v"
+   "commit": "237a8322bee1982e926610c7d228fd0bc1e3bc50",
+   "sha256": "1z8gwldm9gqkw9mwlnv6hlsqk603c3zngsf56pq5r1d89wm7j34b"
   },
   "stable": {
    "version": [
@@ -77842,14 +78301,14 @@
   "repo": "emacs-lsp/lsp-haskell",
   "unstable": {
    "version": [
-    20251121,
-    1710
+    20260507,
+    1745
    ],
    "deps": [
     "lsp-mode"
    ],
-   "commit": "871a0ef2e98b3a749d0b69d958698000ca5640d3",
-   "sha256": "0chk1nxagbf0n1xxl8namxj7z5bqhidgyp0nqynqbi8799v62aa7"
+   "commit": "4c3001aeb116fb489223269ea353359b90e2a5e1",
+   "sha256": "17wgagx29piqgss8qkfizh4ikss7dm6m9jglh9x04dyk4264c197"
   }
  },
  {
@@ -77878,16 +78337,16 @@
   "repo": "emacs-lsp/lsp-ivy",
   "unstable": {
    "version": [
-    20250825,
-    512
+    20260507,
+    1752
    ],
    "deps": [
     "dash",
     "ivy",
     "lsp-mode"
    ],
-   "commit": "2927cbc776477e23d4a1062568d55793eed33c51",
-   "sha256": "12l160q4wi9wc17n1r4pdmp42hwyqrmzc3xcfki6pivmqdaark45"
+   "commit": "c0930544948dfdb7bf497fc9e58aa6b4b857e237",
+   "sha256": "11mknb893ry3m99gd44ywjwjp21a02j0yg2xibc9zf2jbb16rppb"
   },
   "stable": {
    "version": [
@@ -77911,8 +78370,8 @@
   "repo": "emacs-lsp/lsp-java",
   "unstable": {
    "version": [
-    20260312,
-    1356
+    20260510,
+    647
    ],
    "deps": [
     "dap-mode",
@@ -77924,18 +78383,17 @@
     "request",
     "treemacs"
    ],
-   "commit": "0a9f4d0b3ddf300bc9ca7546f5bed288bdfc8377",
-   "sha256": "1rc9fy27kzgs6hdp7j9ybzmzxmcdj63jzwzsxfzlm8pqp1y8xkcb"
+   "commit": "5294db2ac033a289e4878fa8386629b75cb3ccb6",
+   "sha256": "134fw9kxwfi2glkxb7r32la3wip9y2jz8hkv0c3si1jv5p4g22zp"
   },
   "stable": {
    "version": [
-    3,
-    1
+    4,
+    0
    ],
    "deps": [
     "dap-mode",
     "dash",
-    "dash-functional",
     "f",
     "ht",
     "lsp-mode",
@@ -77943,8 +78401,8 @@
     "request",
     "treemacs"
    ],
-   "commit": "260016236fa0520b5b6ec7f51ca2086288524cba",
-   "sha256": "1h0hqgjpk5mbylma1fkva0vx45achf0k7ab2c5y8a2449niww90h"
+   "commit": "5294db2ac033a289e4878fa8386629b75cb3ccb6",
+   "sha256": "134fw9kxwfi2glkxb7r32la3wip9y2jz8hkv0c3si1jv5p4g22zp"
   }
  },
  {
@@ -78068,14 +78526,14 @@
   "repo": "emacs-languagetool/lsp-ltex",
   "unstable": {
    "version": [
-    20260101,
-    535
+    20260503,
+    1233
    ],
    "deps": [
     "lsp-mode"
    ],
-   "commit": "6adc2b4d32a907943a6ce06e2267090241e7af6a",
-   "sha256": "1rll8wa07inh39nnk7j0g8v9z4h4wfnqcff3dqq1kcnp5r5p4vpk"
+   "commit": "a7014677b10ddc1127f9e6ed4ffaf9c5ab18922c",
+   "sha256": "0k1wsik3bnrpkpyqbmbgwjmkq9wzycwn6ql13zrlspb2rjz5njvg"
   },
   "stable": {
    "version": [
@@ -78093,6 +78551,36 @@
   }
  },
  {
+  "ename": "lsp-ltex-plus",
+  "commit": "adbdf03557a845c56935b40a4cd7f9e1dbcf92ab",
+  "sha256": "1gcbaw9nwpz98a75v2i6jykwnay4chk65kq8cynf55xbfpzavhwp",
+  "fetcher": "github",
+  "repo": "ltex-plus/emacs-ltex-plus",
+  "unstable": {
+   "version": [
+    20260614,
+    1645
+   ],
+   "deps": [
+    "lsp-mode"
+   ],
+   "commit": "2dded9da2dbced4624ecad4ab51ee2ee62aa2cad",
+   "sha256": "1fwihxqhb4x94z36qvh45rrjg95sswwx4y952skxy2fvm0dl5fa0"
+  },
+  "stable": {
+   "version": [
+    0,
+    4,
+    0
+   ],
+   "deps": [
+    "lsp-mode"
+   ],
+   "commit": "2dded9da2dbced4624ecad4ab51ee2ee62aa2cad",
+   "sha256": "1fwihxqhb4x94z36qvh45rrjg95sswwx4y952skxy2fvm0dl5fa0"
+  }
+ },
+ {
   "ename": "lsp-metals",
   "commit": "ee055cc258692a92f727633306adf7df31267479",
   "sha256": "1nl9ay741y7qxvgdr6vywavr3aayh6z3a3bvmc4q5g5vsh3inwya",
@@ -78100,8 +78588,8 @@
   "repo": "emacs-lsp/lsp-metals",
   "unstable": {
    "version": [
-    20250228,
-    2145
+    20260529,
+    1928
    ],
    "deps": [
     "dap-mode",
@@ -78113,8 +78601,8 @@
     "scala-mode",
     "treemacs"
    ],
-   "commit": "345b4fa80e31c58fd14e4c0cf9b88eb2aededcb0",
-   "sha256": "0y1pkzc7symdzgh0vk5plcn2r23ai2gbnjps1cr5kjjbwqq1yz4q"
+   "commit": "afeacc7a528b80b9a9f2747428e5608c264201ec",
+   "sha256": "023yydw9lbk621pka6iavdqdm515cxi9fmbqh7flkfgq09lvj00a"
   },
   "stable": {
    "version": [
@@ -78144,8 +78632,8 @@
   "repo": "emacs-lsp/lsp-mode",
   "unstable": {
    "version": [
-    20260423,
-    1033
+    20260616,
+    510
    ],
    "deps": [
     "dash",
@@ -78156,8 +78644,8 @@
     "markdown-mode",
     "spinner"
    ],
-   "commit": "74270b286a9c8f1fc56f97dc118ff010880ed3ff",
-   "sha256": "13avmvbldb27pwm8a4s190601jwgzfhpzx86h2yjd6g0vjvx3lkv"
+   "commit": "2a6ab7cd41e31e4a74b1a6ea670ac4e4356f4be9",
+   "sha256": "1sf9bicrsm59fw8jkcrvk91n4d7hk62kcjw89rmpl55gybz1b3v3"
   },
   "stable": {
    "version": [
@@ -78186,8 +78674,8 @@
   "repo": "emacs-lsp/lsp-mssql",
   "unstable": {
    "version": [
-    20251117,
-    1444
+    20260507,
+    1743
    ],
    "deps": [
     "dash",
@@ -78196,8 +78684,8 @@
     "lsp-mode",
     "lsp-treemacs"
    ],
-   "commit": "810d632bd4abc4f105681a674ebea5d09407a04e",
-   "sha256": "0v3csv4qgpkh3g7vwd4fxd35adjsz5g425m8972zixinshy2csk6"
+   "commit": "02e50306c92af1c98473840169a477b22f72af2d",
+   "sha256": "1w6diyzsyf7p2kipl6yf3rjjinz3pfggf66ybhji8zc4jmdwxkgf"
   }
  },
  {
@@ -78208,15 +78696,15 @@
   "repo": "emacs-lsp/lsp-origami",
   "unstable": {
    "version": [
-    20250825,
-    521
+    20260507,
+    1743
    ],
    "deps": [
     "lsp-mode",
     "origami"
    ],
-   "commit": "b52f42b7932dd968b398e7cfd2ca29051b1a50b4",
-   "sha256": "0gpvdhipwz70p6pmrsy6z1f8zbpfazmrvp5anymywm9g8gq212pr"
+   "commit": "dd398afcf8e9077231dc26ea189916e6ea64c6ab",
+   "sha256": "0grk1b9xg53qz3lmmqyj3vy5zp7wq9ifx3yjyyqcyw4fbn0j87wl"
   },
   "stable": {
    "version": [
@@ -78276,16 +78764,16 @@
   "repo": "emacs-lsp/lsp-pyright",
   "unstable": {
    "version": [
-    20250905,
-    136
+    20260507,
+    1742
    ],
    "deps": [
     "dash",
     "ht",
     "lsp-mode"
    ],
-   "commit": "3756ff971797ae04fc43ca29c66ba4d854eff038",
-   "sha256": "0pd9g8asags5sqj8h77r9k6yn0xj8da4604zva0vqj5plzq81ral"
+   "commit": "187e08caee4e1630a9975f492274c739f325392f",
+   "sha256": "0n2nx5xms6jpngkrvjsbamhd5fid5i6yqaravw3s5bl5km6ljddy"
   },
   "stable": {
    "version": [
@@ -78391,14 +78879,14 @@
   "repo": "shader-ls/lsp-shader",
   "unstable": {
    "version": [
-    20251231,
-    1653
+    20260503,
+    1236
    ],
    "deps": [
     "lsp-mode"
    ],
-   "commit": "f8772e749d212adf95b901c3c94c9c96f9da3707",
-   "sha256": "09j7i051qp6qi28sn52wzxqcl5sg7433a1q7f1qm3lsgdyq8zw7c"
+   "commit": "85430cd7d20019aa39e624990fd814650af9b3a2",
+   "sha256": "07kvykysqpkq7n5zqy7s3l52a9scyf4nfrfm16f686mgvv0amj5d"
   },
   "stable": {
    "version": [
@@ -78421,16 +78909,16 @@
   "repo": "emacs-lsp/lsp-sonarlint",
   "unstable": {
    "version": [
-    20250301,
-    131
+    20260507,
+    1751
    ],
    "deps": [
     "dash",
     "ht",
     "lsp-mode"
    ],
-   "commit": "f9c61eafce62edf15f05d7262290ea87f2beb60d",
-   "sha256": "0v8jvgy5y0s0nyiga4p2xmfdjzkhl29y6kl12kw6zfz82r3y4smv"
+   "commit": "91794c7663fc24afd8d93a74e775793de8f2f811",
+   "sha256": "0rbb9gfkz4lizwq81xwfvdq8pfv1d0536c73zff9ik1c14ahqa6n"
   },
   "stable": {
    "version": [
@@ -78455,44 +78943,14 @@
   "repo": "emacs-lsp/lsp-sourcekit",
   "unstable": {
    "version": [
-    20250825,
-    538
+    20260507,
+    1745
    ],
    "deps": [
     "lsp-mode"
    ],
-   "commit": "30918cd1aeeda5cfbc0fd615f97cf1bf388d8f2d",
-   "sha256": "1d5iq4rhcpa0crwi67ibzmahg6zzlwpm48dkvgbckqa8si589g88"
-  }
- },
- {
-  "ename": "lsp-tailwindcss",
-  "commit": "c837c3b97d7e833d22a1605dcf3c2ebc35c19e0c",
-  "sha256": "0cnkj1ahp48i8zx1qh0fbxf40cnv6d1i9c579kmkfmfbnvxpp080",
-  "fetcher": "github",
-  "repo": "merrickluo/lsp-tailwindcss",
-  "unstable": {
-   "version": [
-    20251009,
-    810
-   ],
-   "deps": [
-    "f",
-    "lsp-mode"
-   ],
-   "commit": "cdd0325a6a571e51f6c7d1cbc198c7a7ea4a194a",
-   "sha256": "1a159pbq5x2w3id815ln103prdvyg8kbcmzr2r2cag8aa24hvs91"
-  },
-  "stable": {
-   "version": [
-    0,
-    2
-   ],
-   "deps": [
-    "lsp-mode"
-   ],
-   "commit": "5250c4305f2334796d65779c7b61442e17d7c69b",
-   "sha256": "10xlb3gqlsx9k716mmrvpwlsdn086vr0jiqakcj2f5vixpxj1sxy"
+   "commit": "252decc7ae53170eb1c67f97ff3e7f576dd13734",
+   "sha256": "1fphyd85qjv3zx1ggrbz973s8dmsb14nqzvgg2ad5jqvp0ijgmwv"
   }
  },
  {
@@ -78503,8 +78961,8 @@
   "repo": "emacs-lsp/lsp-treemacs",
   "unstable": {
    "version": [
-    20251217,
-    1621
+    20260515,
+    746
    ],
    "deps": [
     "dash",
@@ -78513,8 +78971,8 @@
     "lsp-mode",
     "treemacs"
    ],
-   "commit": "49df7292c521b4bac058985ceeaf006607b497dd",
-   "sha256": "17jp3xfi1xxqn8amqx279pns3r25xhx789bjlqmj2apm338wm6z2"
+   "commit": "3519ac907ea391e18d9599375b116aeeb6f8a38a",
+   "sha256": "0bwdbzc9h4zypmspvw14fksbzkr6z87x42rnmynv28hrwy7r5ayd"
   },
   "stable": {
    "version": [
@@ -78540,16 +78998,16 @@
   "repo": "emacs-lsp/lsp-ui",
   "unstable": {
    "version": [
-    20260104,
-    1525
+    20260512,
+    1516
    ],
    "deps": [
     "dash",
     "lsp-mode",
     "markdown-mode"
    ],
-   "commit": "ff349658ed69086bd18c336c8a071ba15f7fd574",
-   "sha256": "1gkqd9lqb1f6xxl6zf00lc8a14khsqjkjm4mx3253fagd6m242li"
+   "commit": "8d888a3ab1ba9e46bd4711398c57d39d0b709a45",
+   "sha256": "0hqjp55049bmjzxwv3bxks5rr8j91372aj11dsfmmi9r0y5l9wwl"
   },
   "stable": {
    "version": [
@@ -78893,6 +79351,30 @@
   }
  },
  {
+  "ename": "mac-ime",
+  "commit": "3bf8f44390c988a00ec38963aca6cf3d87fc4132",
+  "sha256": "05l2s58h16z7spyxqkkpn5n8hasks5g0cxxv12wms490nxmwmg2z",
+  "fetcher": "github",
+  "repo": "ma0001/mac-ime",
+  "unstable": {
+   "version": [
+    20260605,
+    1210
+   ],
+   "commit": "0a8f40c6ad8d02f9b99e3eaa5a68e625b87e7f30",
+   "sha256": "0db1sg51z7n7skigsz329fzrb5q2jh4lgslb98b5kk9y8p0lkirs"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    2
+   ],
+   "commit": "0a8f40c6ad8d02f9b99e3eaa5a68e625b87e7f30",
+   "sha256": "0db1sg51z7n7skigsz329fzrb5q2jh4lgslb98b5kk9y8p0lkirs"
+  }
+ },
+ {
   "ename": "mac-pseudo-daemon",
   "commit": "6104efc035bcf469d133ab9a2caf42c9d4482334",
   "sha256": "12fwrcnwzsfms42rzv4wif5yzx3gnsz8yzdcgkpl37kkx85iy8v0",
@@ -78967,14 +79449,14 @@
   "repo": "kmontag/macher",
   "unstable": {
    "version": [
-    20260420,
-    107
+    20260621,
+    121
    ],
    "deps": [
     "gptel"
    ],
-   "commit": "2a4d2ce81076134c7521bfd3a345c5440c440c2f",
-   "sha256": "130i2qzqb9p1k6qznciab2n8m1911pm5yqv13x0fdhfd8nyj4hkj"
+   "commit": "67972625ae052a5a07929043324fbd3b6b2fc08a",
+   "sha256": "0i5nhxjz5dni2x7wq45wifq47a4cx15pgzppc76plnz1y43rlx1y"
   },
   "stable": {
    "version": [
@@ -79204,40 +79686,40 @@
   "repo": "roadrunner1776/magik",
   "unstable": {
    "version": [
-    20260328,
-    1014
+    20260608,
+    1331
    ],
    "deps": [
     "compat",
     "yasnippet"
    ],
-   "commit": "caeb52d21d5cdb2b1e3550cd95d68568479d0dbb",
-   "sha256": "0f3wdjzr7g2ym5m8dpd6srg1ggwffssm5f6rbdpdkdf4424f3jmf"
+   "commit": "ba05cca022a2cc27ee655acd1f25779b245ff380",
+   "sha256": "19biw69a6zpdb930v8innsnddh2ikx9fl6g5a9mw0ayczqv5kx87"
   },
   "stable": {
    "version": [
     0,
-    5,
-    5
+    6,
+    0
    ],
    "deps": [
     "compat",
     "yasnippet"
    ],
-   "commit": "0ccfffef530802698447ce4f549477e724ab8710",
-   "sha256": "0vfjbf4vm4r2cc0bd3yc5rw6mn8c5169nirw0ixrzp6w70h0b903"
+   "commit": "ba05cca022a2cc27ee655acd1f25779b245ff380",
+   "sha256": "19biw69a6zpdb930v8innsnddh2ikx9fl6g5a9mw0ayczqv5kx87"
   }
  },
  {
   "ename": "magit",
-  "commit": "ad502b9c75d8b2cc09f5fe64dcc5b36e434129b4",
-  "sha256": "1h3zqmc1jz9l8g5mfc2miihib29w69nsyg8anyfqbij1v0rdg3ln",
+  "commit": "5c4845003f7a970416c0db190987ba99369e8cb9",
+  "sha256": "1mfm8xs3acjikl66d1ra0n20v0ava72wvlwxjsh5r8813s2kjfa0",
   "fetcher": "github",
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20260422,
-    2206
+    20260621,
+    1253
    ],
    "deps": [
     "compat",
@@ -79248,8 +79730,8 @@
     "transient",
     "with-editor"
    ],
-   "commit": "569b9656d6a2c792b07d3980796c76b121c9737e",
-   "sha256": "1y8q8d3lw4yq04kngnskw0yx6x96yzd09052cjx9anyqwcyhbhk8"
+   "commit": "20058311576bd47751681bdc2ae239da76dec2dc",
+   "sha256": "1k8nmx2lp48wcd6zrj12ry7p6bg2rwsshsrrmaxblbd1c8qfn499"
   },
   "stable": {
    "version": [
@@ -79326,14 +79808,14 @@
   "repo": "ideasman42/emacs-magit-commit-mark",
   "unstable": {
    "version": [
-    20260105,
-    203
+    20260511,
+    839
    ],
    "deps": [
     "magit"
    ],
-   "commit": "ba986f350466a68d9937d0487e9b8f75303bc465",
-   "sha256": "0rhinmvpcyv17klix5bivw0ksfz4kzlwa9q6n8wkwikxpsh1m6ks"
+   "commit": "9712db3fd09fe493d2ac5644b40e9cd451877180",
+   "sha256": "09bx5l7d4ilsxx3gqrj5j3c2ivbrx5gbxaa0x8pfgg46x7zbbx1m"
   }
  },
  {
@@ -79445,14 +79927,14 @@
   "unstable": {
    "version": [
     20250825,
-    722
+    811
    ],
    "deps": [
     "magit",
     "transient"
    ],
-   "commit": "37a4774c3cc401f849d57aaa2c105ca401f9983c",
-   "sha256": "0pbh0w49jhvmgz6liravkn0ajdgzdapb13gpd8j6r4i6mw3n0v2a"
+   "commit": "d95d6d3febf7f9c04a4abefa3640610aae626683",
+   "sha256": "0kl05z07jjlm58fl6dpnijyl5gnx54b75cl0gbvflyv8z60y8mmz"
   },
   "stable": {
    "version": [
@@ -79615,16 +80097,16 @@
   "repo": "douo/magit-gptcommit",
   "unstable": {
    "version": [
-    20251206,
-    1143
+    20260530,
+    2339
    ],
    "deps": [
     "dash",
     "llm",
     "magit"
    ],
-   "commit": "4a60438fd2a349610e571f10596f6642dfab119d",
-   "sha256": "0li82bf6cmwmh7mb2bfz4m9dy6w01sn89lvsx1ywwi96vax36688"
+   "commit": "b3ac0bfad8b06b6930dc4e35e3adefb4b6646193",
+   "sha256": "1mr3xhkwwwhdcsakmhz670cn69igmgqvqfs9wkpb9918dcsw5vqj"
   }
  },
  {
@@ -79808,10 +80290,10 @@
  },
  {
   "ename": "magit-popup",
-  "commit": "0263ca6aea7bf6eae26a637454affbda6bd106df",
-  "sha256": "1pv5slspcfmi10bnnw6acpijn7vkn2h9iqww3w641v41d3p37jmv",
+  "commit": "5c4189d36ff03a8a2425d5db65e5a7eaefa09761",
+  "sha256": "0x4c21f7ir8aaxp9jra80djrj52w0c144gfhwyhdwnxq4rzwyq4b",
   "fetcher": "github",
-  "repo": "magit/magit-popup",
+  "repo": "emacsattic/magit-popup",
   "unstable": {
    "version": [
     20200719,
@@ -79932,8 +80414,8 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20260422,
-    2206
+    20260514,
+    937
    ],
    "deps": [
     "compat",
@@ -79941,8 +80423,8 @@
     "llama",
     "seq"
    ],
-   "commit": "569b9656d6a2c792b07d3980796c76b121c9737e",
-   "sha256": "1y8q8d3lw4yq04kngnskw0yx6x96yzd09052cjx9anyqwcyhbhk8"
+   "commit": "be5a3b0e9f7a64bcb222ba546a18e6b09922e0a9",
+   "sha256": "1cnl0558vjmbw5900g2mg1ph30301hg1zvjpi23v7rf4qkkq6xl0"
   },
   "stable": {
    "version": [
@@ -80213,15 +80695,15 @@
   "repo": "hrishikeshs/magnus",
   "unstable": {
    "version": [
-    20260421,
-    201
+    20260618,
+    36
    ],
    "deps": [
     "transient",
     "vterm"
    ],
-   "commit": "ef87ed770acf3113f060afdd6949ac24ce46dee8",
-   "sha256": "1qlf4vc0r73jh4nxx86dw0f4g6qk4c5ypkwkj591p02x3w7l5a3s"
+   "commit": "58c6673d4740d98dcd1445c01c6930208341bc2c",
+   "sha256": "0450dlh4vxfm3y6dhpplc61b5spzxbqvgw85vd6nxfjhhn0pz7m2"
   }
  },
  {
@@ -80582,11 +81064,11 @@
   "repo": "choppsv1/emacs-mandm-theme",
   "unstable": {
    "version": [
-    20260328,
-    1745
+    20260513,
+    247
    ],
-   "commit": "bccf228e07e785f6534faaf50edc2e1b212c9d54",
-   "sha256": "15fzbs3ygzj8x4g3js2gjyvzilmvfr482z8a6hnvs4316yzp1vjd"
+   "commit": "c9ebcbe0518798cab3667762637062f0255bbad2",
+   "sha256": "166i2iic1n848099x1khrxl1phcmn4d7sgkjknd3b40ns6mf4a48"
   }
  },
  {
@@ -80704,25 +81186,25 @@
   "repo": "minad/marginalia",
   "unstable": {
    "version": [
-    20260309,
-    1545
+    20260519,
+    1044
    ],
    "deps": [
     "compat"
    ],
-   "commit": "d28a5e5c1a2e5f3e6669b0197f38da84e08f94a0",
-   "sha256": "12gz095kmlj5xvx6709jl388x16724hivnncan9s52yf8rfjnlbm"
+   "commit": "feb66c02bbd88dba867cdd92b94fe24279ed578a",
+   "sha256": "11w1avjwqbv1pbsvhlw3vrc7ka41nmgaqa90zjvfgf69z46ycgsx"
   },
   "stable": {
    "version": [
     2,
-    10
+    11
    ],
    "deps": [
     "compat"
    ],
-   "commit": "d28a5e5c1a2e5f3e6669b0197f38da84e08f94a0",
-   "sha256": "12gz095kmlj5xvx6709jl388x16724hivnncan9s52yf8rfjnlbm"
+   "commit": "feb66c02bbd88dba867cdd92b94fe24279ed578a",
+   "sha256": "11w1avjwqbv1pbsvhlw3vrc7ka41nmgaqa90zjvfgf69z46ycgsx"
   }
  },
  {
@@ -80894,11 +81376,11 @@
   "repo": "jrblevin/markdown-mode",
   "unstable": {
    "version": [
-    20260423,
-    1508
+    20260425,
+    954
    ],
-   "commit": "51ccd3df38d85d0abc9d43d25fc7ea9b9131db45",
-   "sha256": "1a0ah4r2shbjb9gwa5yr534fq2rb6nyf0qbhsqsf0pvwx5lskfr4"
+   "commit": "1f72cefa6a4b759f90e335e4908725a721b17ad9",
+   "sha256": "100dwx61v5n07i04r9gh9s9c29v1d59lqrqnk88x0v9z9jjpvgnq"
   },
   "stable": {
    "version": [
@@ -81060,11 +81542,11 @@
   "repo": "LionyxML/markdown-ts-mode",
   "unstable": {
    "version": [
-    20240422,
-    2329
+    20260505,
+    1217
    ],
-   "commit": "2f1ee8b94cdf53cebc31ae08ecfbba846193d5e1",
-   "sha256": "1fhvsfa4q46xa092dkpgki8qhfs71x414yrqlxnf2vfs9bd6w7pn"
+   "commit": "e7e78ec55213909d2b70e3dd943b776f622cc991",
+   "sha256": "1gkb0xf1qwf808k7ihwkixffmpb31b3zq23qwavhj8h9q6y4p5c5"
   }
  },
  {
@@ -81278,14 +81760,14 @@
   "repo": "mason-org/mason.el",
   "unstable": {
    "version": [
-    20260409,
+    20260517,
     1744
    ],
    "deps": [
     "s"
    ],
-   "commit": "3ac674a7880dd6432f83e249bfd6fea8cf6fc974",
-   "sha256": "0mslpkdxlkvzvn0av5vdjgi4w39jp07nr7ki1ni7pialrf3qdfg9"
+   "commit": "8dc604d12bea314dba3db89ea29d84b0d1438eeb",
+   "sha256": "0pwxx0wb345cn408ssg9h8bsfjclfv43zzxcwz8z6fy9yilhkbyh"
   }
  },
  {
@@ -81296,28 +81778,28 @@
   "repo": "martianh/mastodon.el",
   "unstable": {
    "version": [
-    20260406,
-    856
+    20260509,
+    749
    ],
    "deps": [
     "persist",
     "tp"
    ],
-   "commit": "5bba23045efda9f63c36ac431bec8f318a55e76a",
-   "sha256": "1z8qwnc01d9hx5m1xj3acpdzllfh4rxmypzcr3jl4ipp6dybzbx6"
+   "commit": "4b30b2d96625e23325ff3727daa30969b6fe2eed",
+   "sha256": "1pz0ac5r6g34x0nlwwh55c369swiv8h3dr6ndkkm7k2ql7f75xdv"
   },
   "stable": {
    "version": [
     2,
     0,
-    16
+    17
    ],
    "deps": [
     "persist",
     "tp"
    ],
-   "commit": "5bba23045efda9f63c36ac431bec8f318a55e76a",
-   "sha256": "1z8qwnc01d9hx5m1xj3acpdzllfh4rxmypzcr3jl4ipp6dybzbx6"
+   "commit": "4b30b2d96625e23325ff3727daa30969b6fe2eed",
+   "sha256": "1pz0ac5r6g34x0nlwwh55c369swiv8h3dr6ndkkm7k2ql7f75xdv"
   }
  },
  {
@@ -81470,11 +81952,11 @@
   "repo": "mathworks/Emacs-MATLAB-Mode",
   "unstable": {
    "version": [
-    20260419,
-    1224
+    20260428,
+    1740
    ],
-   "commit": "a42d34dfc498b8754ac89512b399b77481791406",
-   "sha256": "020ay6d8hm6z8n6p70yi4hpa0kzbc0dd2kwik3d2jgwdc9s8sb8i"
+   "commit": "83ea45983975bc6d17a908bf4acddfc47d51763a",
+   "sha256": "1r9ky4rdjp4vzbzkzi0xjr5arjwmih22bq1qsnch3gq83x3yxxnj"
   },
   "stable": {
    "version": [
@@ -81725,14 +82207,14 @@
   "repo": "lizqwerscott/mcp.el",
   "unstable": {
    "version": [
-    20260222,
-    1058
+    20260615,
+    940
    ],
    "deps": [
     "jsonrpc"
    ],
-   "commit": "5c105a8db470eb9777fdbd26251548dec42c03f0",
-   "sha256": "03npn50zfc3f0w30d47qqwxzky7ambd03arf94w025ilcfbc4dmm"
+   "commit": "2d172809cbdb2a40d86b28ad73bd65547cefe0e1",
+   "sha256": "03zvdvjh724kpb2p7j208fm0z73g21vij0jms8azdxbazyw6yj77"
   }
  },
  {
@@ -81743,20 +82225,20 @@
   "repo": "laurynas-biveinis/mcp-server-lib.el",
   "unstable": {
    "version": [
-    20260415,
-    1038
+    20260613,
+    600
    ],
-   "commit": "942d0d2da3a6b61be4d4b12e8158f8b0189963a8",
-   "sha256": "0brfaqm0f670zkgqf4k1dww1ji26rmgwpc2xxa3s23cp0csv136h"
+   "commit": "6a33350e768af0029af224a14b526ab6246d29b4",
+   "sha256": "13qgf4v2zsn6b1435x6qa54pfrzyhj2q55p3475c7bwc5d7bhdlv"
   },
   "stable": {
    "version": [
     0,
-    2,
+    3,
     0
    ],
-   "commit": "cfa2f2f3367b32429a06d2c401a2b791a896bba6",
-   "sha256": "0qn38iqf75xzz0vkgac2ngv49qv52rbbfpziczb052r5fnl0pzp0"
+   "commit": "e643b25af647e7bb5d3958262c9c728a3bb9676f",
+   "sha256": "0c8wk2mhyn10ri4qjk3zy1811k7pzg3i3mm9lzn00v6wdccrm59a"
   }
  },
  {
@@ -81782,11 +82264,11 @@
   "repo": "dnouri/md-ts-mode",
   "unstable": {
    "version": [
-    20260309,
-    11
+    20260530,
+    1627
    ],
-   "commit": "209f7b89383169ad759ba6bec8642d3fc15ce212",
-   "sha256": "0fiblwqn66xp38n50mca9zcmrxassmxqiyfmn86gwp4zcfbifx9i"
+   "commit": "95ae25162da092cb1d55d2be0c2c95e0591086c2",
+   "sha256": "1ssparkbli7zrrkdvlr5nav460rq3xr38dnmvdbcalkhyzswzfbg"
   },
   "stable": {
    "version": [
@@ -81912,20 +82394,20 @@
   "repo": "hexmode/mediawiki-el",
   "unstable": {
    "version": [
-    20260303,
-    2008
+    20260619,
+    737
    ],
-   "commit": "e7b229450ac5383c4cde2639836cb0dc99220127",
-   "sha256": "1ygiq0xvxm5jgx9l50wicviq4j6b02ss2fydzkaz47zsffr8mhk2"
+   "commit": "8002f2fea253b5c2f601325c5b4968e568a3aa2a",
+   "sha256": "0kjy0vkwnrxblwcdqs7brnc82n3dljj4d1syb3ayf8kk40rfr217"
   },
   "stable": {
    "version": [
-    2,
     4,
-    10
+    0,
+    1
    ],
-   "commit": "cf091148fd8fcf17d81bc5ad556ae18c839f6507",
-   "sha256": "199vkks9adkw7rvac960sz2625n0pa7zr2bixrb552dvh29c1lxc"
+   "commit": "bcee6701b474bb805d558e58e7d0e29d999dc873",
+   "sha256": "021gxmx8492gz9zi9535s09z1rhwgh6fprxw6q231nx5cdrfbi1a"
   }
  },
  {
@@ -81936,11 +82418,11 @@
   "repo": "ideasman42/emacs-meep",
   "unstable": {
    "version": [
-    20260423,
-    152
+    20260624,
+    344
    ],
-   "commit": "98a8b2bd6384237005e258a647f3d16a90bc0b97",
-   "sha256": "16q48yh2nzrf07x5j7kkb9s0ykdnvkw2glzk2ds3wf6zhq10agjl"
+   "commit": "cc2761444e652722a65e5d31db663315abc4df2f",
+   "sha256": "13ag4qfsf82a87ybf6lzv5qb0ivyv00qd06p25f4m8y4rckfkmlw"
   }
  },
  {
@@ -82146,11 +82628,11 @@
   "repo": "meow-edit/meow",
   "unstable": {
    "version": [
-    20250904,
-    1606
+    20260619,
+    1030
    ],
-   "commit": "ff5315b3b2ebc9a37414cbd2f2a3378162f9953a",
-   "sha256": "1l6m3vbbqg11nyr51zl3yqz5d61rl60ccrr43p00pagrpql9sacn"
+   "commit": "96648fa6398222e1376422d01f5249afa2a25680",
+   "sha256": "15mp09k5iy4dmmkzsg0ss7k2l5wdh5z1ncnfi5w06apg8x1nkr0a"
   },
   "stable": {
    "version": [
@@ -82200,11 +82682,11 @@
   "repo": "ocaml/merlin",
   "unstable": {
    "version": [
-    20240925,
-    900
+    20260602,
+    1457
    ],
-   "commit": "80e919cf32a62acdaee95a5dab9b4bc18a8b4034",
-   "sha256": "1lwh4pv7an9rfalk9nz2ds2ia09dm69bhsfx28795v7hal46rq80"
+   "commit": "653fdaaf2b1be998e3edc6645a2ddee9a3e1bf52",
+   "sha256": "0pjybqp404j42qzmbk47rmg72jg94nc0hg9b22xq2cmg61aa9kaz"
   },
   "stable": {
    "version": [
@@ -82363,11 +82845,11 @@
   "repo": "abrochard/mermaid-mode",
   "unstable": {
    "version": [
-    20260306,
-    2210
+    20260607,
+    15
    ],
-   "commit": "127fad71666faacf4e962a1498f3fe08910cc6c4",
-   "sha256": "0nr89nnk3gwwm8ij9n49afmc384s3lrxzfmip47q4i03z40dkh38"
+   "commit": "804dbcb1452e7496ae0c48e20362da6351227246",
+   "sha256": "1f1dzabb5647la40siwifv90678xpig2bsn5dl1p1s88q5xs9yk9"
   }
  },
  {
@@ -82393,11 +82875,26 @@
   "url": "https://git.andros.dev/andros/meshmonitor-chat.el.git",
   "unstable": {
    "version": [
-    20260409,
-    802
+    20260609,
+    557
    ],
-   "commit": "862d8fed090dde4db19105afcc29199b3aa38cf0",
-   "sha256": "1rncjj6l31v6q4dhpngsarm31ifmnd6gsrdkaqpkp4y7qrspy0vd"
+   "commit": "cb89039bb723301d2a69326f98ca1f141d6a0112",
+   "sha256": "0bgfkbxxb650r7nd6xgwcdydz7kwfa0c99kv713r15lkmmlndj8z"
+  }
+ },
+ {
+  "ename": "meshtastic",
+  "commit": "141f731232697e997efe49295531f92589d36c3b",
+  "sha256": "0pv628gsjck99s6qqjysm5drwrqsmyzyrf5ydxn5n048nmyl2b71",
+  "fetcher": "git",
+  "url": "https://git.andros.dev/andros/meshtastic.el",
+  "unstable": {
+   "version": [
+    20260527,
+    1500
+   ],
+   "commit": "5ad027669b3e652f704857e3d7e373095d1c09d1",
+   "sha256": "16h9vif9i82gk3bpy6d3x1ifbc3bag3hg3dl19hfbqs054xkjccq"
   }
  },
  {
@@ -82676,19 +83173,19 @@
   "repo": "kazu-yamamoto/Mew",
   "unstable": {
    "version": [
-    20260424,
-    551
+    20260511,
+    310
    ],
-   "commit": "b53e86e1a9bd7db8634387ee54e5af62e35925ad",
-   "sha256": "0is3lvaxgsv1qvh3m0qa9s91m7wffsqjnwzyv5csd85xs6rypv16"
+   "commit": "b905786ae1da9da4c015d69b9417a55985f07668",
+   "sha256": "1xbdix7hn6i224gglpab43qqi5mkv356zf7gs9359vnwslfm5x6n"
   },
   "stable": {
    "version": [
     6,
-    10
+    11
    ],
-   "commit": "2392ee9b869029a9900587011fe541abe08a2fd5",
-   "sha256": "13ajr51yk2hcfiq532cayb0kvpdb3psf877cxl6qwx0pgaf1qm57"
+   "commit": "b905786ae1da9da4c015d69b9417a55985f07668",
+   "sha256": "1xbdix7hn6i224gglpab43qqi5mkv356zf7gs9359vnwslfm5x6n"
   }
  },
  {
@@ -82714,8 +83211,8 @@
   "repo": "danielsz/meyvn-el",
   "unstable": {
    "version": [
-    20250815,
-    2140
+    20260611,
+    354
    ],
    "deps": [
     "cider",
@@ -82723,16 +83220,15 @@
     "geiser",
     "parseclj",
     "parseedn",
-    "projectile",
     "s"
    ],
-   "commit": "5380626e327b7a48531c4a652bab4896ba179312",
-   "sha256": "0gnjal5ikz2g5ac7h1lx8hwkix0j18l6sg26ydn6wdhix2yjdfmq"
+   "commit": "48c12b8d7d79c1b35d54d195d1ce4c7113ef5215",
+   "sha256": "0qm7qz3w9pm1820xk8h2kga5g1c31fxc7jr1bzcl79mqvjhw351x"
   },
   "stable": {
    "version": [
     1,
-    4
+    8
    ],
    "deps": [
     "cider",
@@ -82740,11 +83236,10 @@
     "geiser",
     "parseclj",
     "parseedn",
-    "projectile",
     "s"
    ],
-   "commit": "62802ab42ee021f89f980bd3de3e1336ad760944",
-   "sha256": "0821sk0mq1602mk3hp7igcafp8fpfg586nk41iz9syc06xbh0if7"
+   "commit": "48c12b8d7d79c1b35d54d195d1ce4c7113ef5215",
+   "sha256": "0qm7qz3w9pm1820xk8h2kga5g1c31fxc7jr1bzcl79mqvjhw351x"
   }
  },
  {
@@ -82755,20 +83250,20 @@
   "repo": "purpleidea/mgmt",
   "unstable": {
    "version": [
-    20260222,
-    1339
+    20260623,
+    203
    ],
-   "commit": "2a08fa18cd3d0ba4a6433bdd9c4c0f3e85ed7528",
-   "sha256": "0576pmm5cya802p4kw0d1g0fv95ng8jzzgaiw6x9xb86p3vkifcw"
+   "commit": "0f7ad93cd17e5251c6ec112fa6ff4272499b430a",
+   "sha256": "0csy7rkx3wdknk2j1b0b0zy2ml3rm5zr3mhcmk9zf3mdbib4hlcd"
   },
   "stable": {
    "version": [
     1,
-    0,
-    2
+    1,
+    0
    ],
-   "commit": "2a08fa18cd3d0ba4a6433bdd9c4c0f3e85ed7528",
-   "sha256": "0576pmm5cya802p4kw0d1g0fv95ng8jzzgaiw6x9xb86p3vkifcw"
+   "commit": "0f7ad93cd17e5251c6ec112fa6ff4272499b430a",
+   "sha256": "0csy7rkx3wdknk2j1b0b0zy2ml3rm5zr3mhcmk9zf3mdbib4hlcd"
   }
  },
  {
@@ -82973,11 +83468,11 @@
   "repo": "countvajhula/mindstream",
   "unstable": {
    "version": [
-    20260218,
-    312
+    20260614,
+    1629
    ],
-   "commit": "6b51036a069379d18538a7cca5274c21666a5979",
-   "sha256": "0j82dm2mj49fs2q6qklhfimv1gvy6q3l6bqaj1azxyh1hbg4d0vi"
+   "commit": "0b7a2889e8de419d90a3eaa137c82febe014fda6",
+   "sha256": "1w00k2l021l2g4amxdfsyfxs252kfskd2pflhcki8fzbdghaxa0a"
   },
   "stable": {
    "version": [
@@ -83060,11 +83555,11 @@
   "repo": "muffinmad/emacs-mini-frame",
   "unstable": {
    "version": [
-    20220627,
-    2041
+    20260619,
+    549
    ],
-   "commit": "60838f3cab438dcbda8eaa15ab3e5d1af88910e9",
-   "sha256": "0q01iymz657bg3mcmq7vcl8r0ypsa1pqj1p6gxs7ywx1d33lan4d"
+   "commit": "066af90bb2c9a52ff0bfbcdb25539e1b92b68586",
+   "sha256": "07a0l53ihkqan5n1kg07vy80m46y6ri6ijjf1frzd6ciha37ad4b"
   }
  },
  {
@@ -83274,26 +83769,28 @@
   "repo": "tarsius/minions",
   "unstable": {
    "version": [
-    20260101,
-    1837
+    20260601,
+    1513
    ],
    "deps": [
-    "compat"
+    "compat",
+    "seq"
    ],
-   "commit": "5b73cd443c28a6e9c8e5ddd60ada38afdf40dfb9",
-   "sha256": "0kl269rq1abjcpnxffd8xgcdw3bwgcq31bzfvmp8wvdnkdpfi3ci"
+   "commit": "7ec2810c9b3019f8e379022b0ca7ce61e9e7c810",
+   "sha256": "11y569lmrm7fj42janr9n4fggvi3jh5zzxs33n9q49kg50hclh4s"
   },
   "stable": {
    "version": [
     1,
     2,
-    0
+    1
    ],
    "deps": [
-    "compat"
+    "compat",
+    "seq"
    ],
-   "commit": "5b73cd443c28a6e9c8e5ddd60ada38afdf40dfb9",
-   "sha256": "0kl269rq1abjcpnxffd8xgcdw3bwgcq31bzfvmp8wvdnkdpfi3ci"
+   "commit": "7ec2810c9b3019f8e379022b0ca7ce61e9e7c810",
+   "sha256": "11y569lmrm7fj42janr9n4fggvi3jh5zzxs33n9q49kg50hclh4s"
   }
  },
  {
@@ -83304,14 +83801,14 @@
   "repo": "shoshin/minitest-emacs",
   "unstable": {
    "version": [
-    20250803,
-    49
+    20260622,
+    2214
    ],
    "deps": [
     "dash"
    ],
-   "commit": "d278e94fb1874c584699e1d6fa1b34224c1f8550",
-   "sha256": "1snkk3fqhaaaxbhlshfvmpq1bs2bcbgmamm7fncgaz5kkv3d0x0n"
+   "commit": "596cc885d3f4898d85c78d1686b22c379fe2acae",
+   "sha256": "0ysdaysqm82zb01dwy5yxk3g41fy0phskd4imcwzkngazwdq2k2l"
   },
   "stable": {
    "version": [
@@ -83379,11 +83876,11 @@
   "repo": "loj/minsk-theme",
   "unstable": {
    "version": [
-    20250706,
-    1827
+    20260612,
+    845
    ],
-   "commit": "c9caae876ef184053fef0bd3fee6243632702487",
-   "sha256": "0lmf5wdwffgi9l0y8wpis45gg7wzhvvflzfnxly681byginaqjrc"
+   "commit": "7d1259165a1b7eaecc97d76fc288fa56f8736bef",
+   "sha256": "1r4hkw4qpx9xq25w0hzzw1kxzvl2rk050a39hd96s15a3jsfix38"
   }
  },
  {
@@ -83418,28 +83915,28 @@
   "repo": "milanglacier/minuet-ai.el",
   "unstable": {
    "version": [
-    20260424,
-    430
+    20260519,
+    111
    ],
    "deps": [
     "dash",
     "plz"
    ],
-   "commit": "36049820ca987c79c87cc4d9f21d16ca23ff8ebb",
-   "sha256": "15165fn161c6fvqcrpfffy7l5abs7zscarzhhvzbwppqk3r9wrq8"
+   "commit": "13fb314a795951b9190c53c59ef281abf7a2cb4f",
+   "sha256": "13maiy40n4sgmwwp83xc4pwgmdv0jd1j7ca75cna9swqq28dmfgi"
   },
   "stable": {
    "version": [
     0,
-    7,
-    1
+    8,
+    0
    ],
    "deps": [
     "dash",
     "plz"
    ],
-   "commit": "7b34bf0f0334478dab15ce185eacc794a6c7415f",
-   "sha256": "085iclc2766sv6mxim7ppxdcss769zax2gk92wpj5130zpayngzq"
+   "commit": "13fb314a795951b9190c53c59ef281abf7a2cb4f",
+   "sha256": "13maiy40n4sgmwwp83xc4pwgmdv0jd1j7ca75cna9swqq28dmfgi"
   }
  },
  {
@@ -83993,32 +84490,32 @@
  },
  {
   "ename": "mode-line-debug",
-  "commit": "b0080ab9ef1eca5dd19b3fd9af536d8aa17773a2",
-  "sha256": "0ppj14bm3rx3xgg4mfxa5zcm2r129jgmsx817wq3h7akjngcbfkd",
+  "commit": "aec4a76eaea31408bd27d76a0b8cea5268663cc1",
+  "sha256": "02zr339lbgzqn881jbfs0yhg7d9kaa89szd90q30kbhd8ykly4yz",
   "fetcher": "github",
   "repo": "tarsius/mode-line-debug",
   "unstable": {
    "version": [
-    20260101,
-    1838
+    20260601,
+    1514
    ],
    "deps": [
     "compat"
    ],
-   "commit": "a6c26f9d8b574edd3001b8abc6c4801048428385",
-   "sha256": "0nggr6pwl34qhdjh7dxh88fa35i4d3nhan9w1xwa2fvmjycbayvg"
+   "commit": "3e1b50bc666beaf6441f652608bf7f48b74e80df",
+   "sha256": "0n0a5k4vp971nxmpvx0ywynv7si67h0a3ajr10sk51j4v3gffynr"
   },
   "stable": {
    "version": [
     1,
     5,
-    2
+    3
    ],
    "deps": [
     "compat"
    ],
-   "commit": "a6c26f9d8b574edd3001b8abc6c4801048428385",
-   "sha256": "0nggr6pwl34qhdjh7dxh88fa35i4d3nhan9w1xwa2fvmjycbayvg"
+   "commit": "3e1b50bc666beaf6441f652608bf7f48b74e80df",
+   "sha256": "0n0a5k4vp971nxmpvx0ywynv7si67h0a3ajr10sk51j4v3gffynr"
   }
  },
  {
@@ -84197,15 +84694,15 @@
   "repo": "deadendpl/modus-ewal-theme",
   "unstable": {
    "version": [
-    20260413,
-    1551
+    20260609,
+    1423
    ],
    "deps": [
     "ewal",
     "modus-themes"
    ],
-   "commit": "4e52d98c95fb506daa2eec35c6141171f686649d",
-   "sha256": "0ph4vshvl8knbqhxbklca73zkh0pgihar85lfliyahcr32zfpiax"
+   "commit": "2856520a2474b3d5fddae64001817d6cecf3da51",
+   "sha256": "069wcl2l194rnkkf3gf9lp4ikc2s1zx963b2nj94zz0yw8z51lxl"
   }
  },
  {
@@ -84216,20 +84713,20 @@
   "repo": "protesilaos/modus-themes",
   "unstable": {
    "version": [
-    20260418,
-    1313
+    20260621,
+    1325
    ],
-   "commit": "7c2ce1ff0dc25215061d05a9d796d6193f93c84e",
-   "sha256": "0ymzjwqbmszjsy30057m91vwvbqyvprsjd7r0cxigqspk2qabfiy"
+   "commit": "2d044ac89f3bca7011fa2bfda003cf80ce115f70",
+   "sha256": "1xbwvw3fg1c18gs6w10vp843mzjqxrv24ks7ll2zj8y4mcig3fbm"
   },
   "stable": {
    "version": [
     5,
-    2,
+    3,
     0
    ],
-   "commit": "d1037f1322487e5686fff655dcd88aa644b2ad51",
-   "sha256": "1iqbi71h9xajsw4330157dfs10npfi1z2ads99vr7n5pll7060rc"
+   "commit": "2d044ac89f3bca7011fa2bfda003cf80ce115f70",
+   "sha256": "1xbwvw3fg1c18gs6w10vp843mzjqxrv24ks7ll2zj8y4mcig3fbm"
   }
  },
  {
@@ -84240,11 +84737,11 @@
   "repo": "kuanyui/moe-theme.el",
   "unstable": {
    "version": [
-    20260304,
-    1519
+    20260515,
+    841
    ],
-   "commit": "075f91acc2a7ad722bdda0ab945a7fb0f7c4565f",
-   "sha256": "1z3whsgjj404dxylgz430l0n8j9kbjab87phy6g8q2pqciailbd8"
+   "commit": "c7d711e940a6c4e7a2270830aeaf52c1ce789455",
+   "sha256": "141jzhfpcah0lw17lwgsd31jp93qr02371rjm2k92vawhx90hir6"
   },
   "stable": {
    "version": [
@@ -84407,11 +84904,11 @@
   "repo": "ideasman42/emacs-mono-complete",
   "unstable": {
    "version": [
-    20260105,
-    209
+    20260522,
+    348
    ],
-   "commit": "12eb3f326f49212787be6e34a69e830652c8a9be",
-   "sha256": "1p9bac7196cjfxqsxigcpjxxswvhrpy8cxpxhyd5n8mw8yp7nl5w"
+   "commit": "7d3d5656269f290a8ebec772d877d95cc815939b",
+   "sha256": "0m2qma32a23amc3s3h66j9df55gm4airw888ibd3nmsfx6n46iki"
   }
  },
  {
@@ -84578,26 +85075,26 @@
   "repo": "tarsius/moody",
   "unstable": {
    "version": [
-    20260101,
-    1838
+    20260601,
+    1514
    ],
    "deps": [
     "compat"
    ],
-   "commit": "82f65014dcdfc7178464c282b5c9ec5f7016c945",
-   "sha256": "1ash61h0w26yzjgxzi8ga4baki35724h75nf3ivp8hlgpcnnb8rj"
+   "commit": "48556e65f37c040a430f123494f517f961ae000c",
+   "sha256": "04y4nlrfrk35pw55pfss2kwxg851dpb9lbmzi3hzc1xm3wmk63mb"
   },
   "stable": {
    "version": [
     1,
     2,
-    2
+    3
    ],
    "deps": [
     "compat"
    ],
-   "commit": "82f65014dcdfc7178464c282b5c9ec5f7016c945",
-   "sha256": "1ash61h0w26yzjgxzi8ga4baki35724h75nf3ivp8hlgpcnnb8rj"
+   "commit": "48556e65f37c040a430f123494f517f961ae000c",
+   "sha256": "04y4nlrfrk35pw55pfss2kwxg851dpb9lbmzi3hzc1xm3wmk63mb"
   }
  },
  {
@@ -84699,26 +85196,26 @@
  },
  {
   "ename": "morlock",
-  "commit": "b6ef53bbc80edda12a90a8a9705fe14415972833",
-  "sha256": "0693jr1k8mzd7hwp52azkl62c1g1p5yinarjcmdksfyqblqq5jna",
+  "commit": "aec4a76eaea31408bd27d76a0b8cea5268663cc1",
+  "sha256": "1cg5p37w83z5jrryp574qmnqgp4rpzgd0ghm2arwd18lmryddi66",
   "fetcher": "github",
   "repo": "tarsius/morlock",
   "unstable": {
    "version": [
-    20260101,
-    1839
+    20260601,
+    1518
    ],
-   "commit": "4ec0253ffbac4764b90457bb3b887b0a07badb20",
-   "sha256": "03n4vrlik3mid9jvvn36q856a48dghpcjcdhkjfshxdialywfdza"
+   "commit": "1fd3cc79b1fa1f69386d6b2fa058e2477d35a4e7",
+   "sha256": "0xwm8dzb9jaflra3r60iq56wgfwhydh7y66ycgfk3fja48mzppxk"
   },
   "stable": {
    "version": [
     2,
     1,
-    3
+    4
    ],
-   "commit": "4ec0253ffbac4764b90457bb3b887b0a07badb20",
-   "sha256": "03n4vrlik3mid9jvvn36q856a48dghpcjcdhkjfshxdialywfdza"
+   "commit": "1fd3cc79b1fa1f69386d6b2fa058e2477d35a4e7",
+   "sha256": "0xwm8dzb9jaflra3r60iq56wgfwhydh7y66ycgfk3fja48mzppxk"
   }
  },
  {
@@ -84937,11 +85434,11 @@
   "repo": "emacsfodder/move-text",
   "unstable": {
    "version": [
-    20231204,
-    1514
+    20260508,
+    508
    ],
-   "commit": "90ef0b078dbcb2dee47a15b0c6c6f417101e0c43",
-   "sha256": "16x8p9brj5nrjk2rmhwf6hb8sj0rjr4j2827z0g679zyns3cbyrb"
+   "commit": "142890cfb46d9c374113b4b49021a4202033147b",
+   "sha256": "0zhzfiwcslkgbjqgiyrp7yr3n41cys26i1qdq7p29bwmsm61iqc9"
   },
   "stable": {
    "version": [
@@ -84985,20 +85482,20 @@
   "repo": "mekeor/mowie",
   "unstable": {
    "version": [
-    20250113,
-    122
+    20260610,
+    846
    ],
-   "commit": "26f605cf632579af897a85a3922bf17fac616519",
-   "sha256": "091ylr2mk1767h076g6wcx99rv2v78bmfw2b6hjmc9260m7mvr8y"
+   "commit": "30eb09b9c671b61b081b1d7096f4650641ee3ea0",
+   "sha256": "0aq078i75x742b15cr7crn7bfb8nqw9kldax8g2ixbyp3h374l9l"
   },
   "stable": {
    "version": [
     0,
     1,
-    1
+    2
    ],
-   "commit": "7b826c751014a294b493a6bfebe1cda6a1832ab0",
-   "sha256": "19k89z6ji2j99q72b3dc28w2d9pqhcfwnzfll1yqd8sc1dkkd03k"
+   "commit": "30eb09b9c671b61b081b1d7096f4650641ee3ea0",
+   "sha256": "0aq078i75x742b15cr7crn7bfb8nqw9kldax8g2ixbyp3h374l9l"
   }
  },
  {
@@ -85009,11 +85506,11 @@
   "repo": "google/mozc",
   "unstable": {
    "version": [
-    20260327,
-    323
+    20260519,
+    247
    ],
-   "commit": "891e32473ece7f77f0b69c73bc5a53a352a27ad0",
-   "sha256": "0izy16hdjqrlh5516y868fvgmrfmncxpxbfjsiwlwg9xf006vh41"
+   "commit": "324a09a905c238e15ed37b828b4a70ef2eaad2a2",
+   "sha256": "055dxly08fxmyhsa9sjimbhvhc5wqfq7cppi777spfhwfyc7d33r"
   },
   "stable": {
    "version": [
@@ -85061,6 +85558,36 @@
    ],
    "commit": "df614a1076c28a11551fb3e822868bae47e855a5",
    "sha256": "0cpcldizgyr125j7lzkl8l6jw1hc3fb12cwgkpjrl6pjpr80vb15"
+  }
+ },
+ {
+  "ename": "mozc-modeless",
+  "commit": "021a4e6c04f634474e15acb8685c5e2adc286e2d",
+  "sha256": "0ncjci8a2szdimb7zmyxla57jgljmz6kc5dgc12rg1ggqbndp76g",
+  "fetcher": "github",
+  "repo": "kiyoka/mozc-modeless-emacs",
+  "unstable": {
+   "version": [
+    20260621,
+    520
+   ],
+   "deps": [
+    "mozc"
+   ],
+   "commit": "95adeb91fbafb569d7ac06a3ab7df9679349a7be",
+   "sha256": "1bn673i194w77k84lnj2m5lmdhnxw5xpw5byr74496075axlnrnh"
+  },
+  "stable": {
+   "version": [
+    0,
+    10,
+    0
+   ],
+   "deps": [
+    "mozc"
+   ],
+   "commit": "95adeb91fbafb569d7ac06a3ab7df9679349a7be",
+   "sha256": "1bn673i194w77k84lnj2m5lmdhnxw5xpw5byr74496075axlnrnh"
   }
  },
  {
@@ -85610,11 +86137,11 @@
   "repo": "mkcms/mu4e-overview",
   "unstable": {
    "version": [
-    20250406,
-    1225
+    20260515,
+    1818
    ],
-   "commit": "527c3d3a4618c6ba7e6dec679ec2eff8854775d2",
-   "sha256": "1fxxbfn8hgx07rr9rrfr8bmhay576shc1s14smnjakrg51a69sl9"
+   "commit": "b6dfe3ecc569aa6313ef093c0c49df8a507f19c4",
+   "sha256": "0xkaqnqxj2f1f9ssnrgv4aqdwb6aq148pnhzrl52z1lj3p8k7q31"
   },
   "stable": {
    "version": [
@@ -85859,11 +86386,11 @@
   "repo": "ellisvelo/multi-project",
   "unstable": {
    "version": [
-    20240115,
-    1635
+    20260513,
+    1126
    ],
-   "commit": "3bc67ba8adf10a0844fa2f9cce9d78f130307645",
-   "sha256": "0f4p3ndp2qlphad46qhyfmjcd0kmazkz6yr7278ca4zminchfrvc"
+   "commit": "1ddfd60410dd146c59e9950ef88c5f0084807012",
+   "sha256": "17zjbfjz96j5bjjdwxb7qaybd4s1f8xgnldnd0qjqrcc5w2aazis"
   },
   "stable": {
    "version": [
@@ -86468,6 +86995,21 @@
   }
  },
  {
+  "ename": "mysql",
+  "commit": "81dfb7ffcdeaca544f659556c1dd9f020f3429df",
+  "sha256": "0kfdchh7nhywdq3yw0ac9clxaihxib9rysbrybzyk9ksxkpdvqgj",
+  "fetcher": "github",
+  "repo": "LuciusChen/mysql.el",
+  "unstable": {
+   "version": [
+    20260617,
+    643
+   ],
+   "commit": "a3a3b151687197906586464b8f9e812261673897",
+   "sha256": "1y9ggpnwxiphmlslv5mvw9wnq86raiy7ylp4jrcykvrcvg4agld8"
+  }
+ },
+ {
   "ename": "mysql-to-org",
   "commit": "855ea20024b606314f8590129259747cac0bcc97",
   "sha256": "0jjdv6ywdn1618l36bw3xa3mdgg3rc8r0rdv9xdqx8mmg648a7gj",
@@ -86958,20 +87500,20 @@
   "repo": "skeeto/nasm-mode",
   "unstable": {
    "version": [
-    20250320,
-    1646
+    20260509,
+    953
    ],
-   "commit": "4e670f6dededab858251670aa5459c950f78d867",
-   "sha256": "12ynvw6l1a9n8x1q4fpm0fz15zf2vp3jibsq5z8si1czgkz0cw97"
+   "commit": "fab76d8e092419c341b6240fcc7123975db177e1",
+   "sha256": "11qjcbvac2aqba136zyvgqhcfcrx6znc9s4cym8mcvfms05sphsm"
   },
   "stable": {
    "version": [
     1,
-    1,
-    1
+    2,
+    0
    ],
-   "commit": "d990ed94d902b74a5c834fb567e03307607cee45",
-   "sha256": "1dyc50a1zskx9fqxl2iy2x74f3bkb2ccz908v0aj13rqfqqnns9j"
+   "commit": "fab76d8e092419c341b6240fcc7123975db177e1",
+   "sha256": "11qjcbvac2aqba136zyvgqhcfcrx6znc9s4cym8mcvfms05sphsm"
   }
  },
  {
@@ -87176,20 +87718,20 @@
   "repo": "babashka/neil",
   "unstable": {
    "version": [
-    20251217,
-    857
+    20260524,
+    1246
    ],
-   "commit": "196e8f7933289902965fdc6da2d0227b80e06936",
-   "sha256": "1rn5ykaccwmgx7s68nksfv6v5s9qz7saq3ayhafzfpv3smj02p0m"
+   "commit": "2cdd7c66843ba3f1a2adb08208f2312b72b31900",
+   "sha256": "0x93zp21744df5i7aqqgxbgdi1xwmx2yr6x96c0r8g9rzyp5krby"
   },
   "stable": {
    "version": [
     0,
     3,
-    69
+    70
    ],
-   "commit": "fa793214d7820e6763108c942e9cf16e1cd2db96",
-   "sha256": "0lk0ppykxp4nci6989bz0rh5jb4a4pl0pdzqim87kxv1ji2rc6rm"
+   "commit": "2cdd7c66843ba3f1a2adb08208f2312b72b31900",
+   "sha256": "0x93zp21744df5i7aqqgxbgdi1xwmx2yr6x96c0r8g9rzyp5krby"
   }
  },
  {
@@ -87223,20 +87765,20 @@
   "repo": "bbatsov/neocaml",
   "unstable": {
    "version": [
-    20260416,
-    647
+    20260624,
+    440
    ],
-   "commit": "06794d8d9ae1180a37b71b02ed8eadd464129b73",
-   "sha256": "1wzjsk8252clak794yhk89s2qwgcl95a8mgdyd6wvn4a4bg0ksaw"
+   "commit": "6acca5831d723105af361b742049cbf53d05bdf7",
+   "sha256": "0alk1dsipnb3njc08crjqcw10ljnrgbb6ciiiysmfsml7bl67ywc"
   },
   "stable": {
    "version": [
     0,
-    8,
+    9,
     0
    ],
-   "commit": "deb95d8b87641cf31d64487f627d8a51e48ff2e7",
-   "sha256": "0prsi5g8wamh6v4l6jqsws78q63i07gfxkgbvns139fckdssgr2b"
+   "commit": "6acca5831d723105af361b742049cbf53d05bdf7",
+   "sha256": "0alk1dsipnb3njc08crjqcw10ljnrgbb6ciiiysmfsml7bl67ywc"
   }
  },
  {
@@ -87301,11 +87843,11 @@
   "repo": "rainstormstudio/nerd-icons.el",
   "unstable": {
    "version": [
-    20260325,
-    346
+    20260619,
+    455
    ],
-   "commit": "1db0b0b9203cf293b38ac278273efcfc3581a05f",
-   "sha256": "0v7wm8p432h3v2q4sll254hl3n9vdb5irfp6yw9kl1sc9j5x4iif"
+   "commit": "a9a9177e135dd407d508609ac4d9915eb8608b4f",
+   "sha256": "0jp0pql4sns74dm6xnh21v3icb8q9411gbaryv0wh0klfrllw2id"
   },
   "stable": {
    "version": [
@@ -87532,11 +88074,11 @@
   "repo": "Feyorsh/nethack-el",
   "unstable": {
    "version": [
-    20260417,
-    234
+    20260503,
+    532
    ],
-   "commit": "4c6e483966eee5a210b99ea8de34d20146e21237",
-   "sha256": "1x5z3ncla9726pihvfw8qzdbahqii0gfh9wcfh3v03f1ggjim7hh"
+   "commit": "a666c5917a44458a103e99587239fa7db67b9072",
+   "sha256": "1h2akkw5hg7d2ffra94gam2zm5al4lxxhd2indkap8ppnjiidl32"
   }
  },
  {
@@ -87632,11 +88174,11 @@
   "repo": "vekatze/neut-mode",
   "unstable": {
    "version": [
-    20250608,
-    958
+    20260425,
+    747
    ],
-   "commit": "8cfea9d387dd252de40c941c52b08699d45e1f04",
-   "sha256": "01pifaj9dsilxh020v2qqhw070r8hhy4s3n73bfs6ka957wrjja9"
+   "commit": "536ba9641011ea31c019beb6399ffca9945fc34e",
+   "sha256": "1va03vy072cd4n0pvi0swvnx9bxirfsaiwk29j55w91f14jcqh0p"
   }
  },
  {
@@ -88442,26 +88984,26 @@
   "repo": "emacscollective/no-littering",
   "unstable": {
    "version": [
-    20260415,
-    2031
+    20260605,
+    1120
    ],
    "deps": [
     "compat"
    ],
-   "commit": "3c40e8a1dd7b20c6db90874b7b3088089a48acdc",
-   "sha256": "19pbbhdad38h87mwqrhrzzbi66ml9l94rjyfh6h14xqvhy11z0y4"
+   "commit": "8e8e427f332a501b0a35b5de518d474c87c178d9",
+   "sha256": "188vcm99izdbh11vws84vpmm496ldv7kbgj3lic5jpc4a5400n17"
   },
   "stable": {
    "version": [
     1,
     8,
-    6
+    8
    ],
    "deps": [
     "compat"
    ],
-   "commit": "db60be0939f31eae0cfc537918503a13b028fa56",
-   "sha256": "1iaszl8q6chaj8cx0gmzg3pkmm9kl9pdr9nxlqydnzbxfc041zi9"
+   "commit": "a279e2606f749e35e9af3d9f349484ee379eda84",
+   "sha256": "1b40aphl084wwi6pi0dvxihkysl67z2gvhjhi1yadd4qn3hbxy73"
   }
  },
  {
@@ -88961,28 +89503,28 @@
   "repo": "tarsius/notmuch-addr",
   "unstable": {
    "version": [
-    20260101,
-    1842
+    20260601,
+    1530
    ],
    "deps": [
     "compat",
     "notmuch"
    ],
-   "commit": "f4cb7f273b44faa4c0c5c85b2d740086ca709c56",
-   "sha256": "17nbzpq69drksjbi2ckwnp837kjapsg0s0y8xd1m3p706cvsnd6i"
+   "commit": "0cb6f9e0dc0e27b31b4849630f7e74bafaa78758",
+   "sha256": "07030f81pskm3v3fwqwrrjl3jmk9sw21hypmzv764zvifd4mq5z4"
   },
   "stable": {
    "version": [
     1,
     1,
-    3
+    4
    ],
    "deps": [
     "compat",
     "notmuch"
    ],
-   "commit": "f4cb7f273b44faa4c0c5c85b2d740086ca709c56",
-   "sha256": "17nbzpq69drksjbi2ckwnp837kjapsg0s0y8xd1m3p706cvsnd6i"
+   "commit": "0cb6f9e0dc0e27b31b4849630f7e74bafaa78758",
+   "sha256": "07030f81pskm3v3fwqwrrjl3jmk9sw21hypmzv764zvifd4mq5z4"
   }
  },
  {
@@ -89053,28 +89595,58 @@
   "repo": "tarsius/notmuch-maildir",
   "unstable": {
    "version": [
-    20260101,
-    1843
+    20260601,
+    1530
    ],
    "deps": [
     "compat",
     "notmuch"
    ],
-   "commit": "ef3952c785cc4bc41366d798bff5edad1a945553",
-   "sha256": "0an2y57q45dmwm0jp884m6bfnl2x6r1fxb41ckznylcmvwbn3km2"
+   "commit": "1ed7738468da9910a9bd32f3c44201ab1e9db242",
+   "sha256": "09zm428867fkmn5dbmn4l5d1lh8w5d6iwa09skakqmkq2ms4m334"
   },
   "stable": {
    "version": [
     1,
     3,
-    2
+    3
    ],
    "deps": [
     "compat",
     "notmuch"
    ],
-   "commit": "ef3952c785cc4bc41366d798bff5edad1a945553",
-   "sha256": "0an2y57q45dmwm0jp884m6bfnl2x6r1fxb41ckznylcmvwbn3km2"
+   "commit": "1ed7738468da9910a9bd32f3c44201ab1e9db242",
+   "sha256": "09zm428867fkmn5dbmn4l5d1lh8w5d6iwa09skakqmkq2ms4m334"
+  }
+ },
+ {
+  "ename": "notmuch-multi",
+  "commit": "2eb9727941d4815bd04d47495df109a0320e6198",
+  "sha256": "0qd4kwgsr7f5gvylajlaq7p5lh222p70f6fynfbf96j063k1n0i6",
+  "fetcher": "github",
+  "repo": "pivaldi/notmuch-multi",
+  "unstable": {
+   "version": [
+    20260616,
+    722
+   ],
+   "deps": [
+    "notmuch"
+   ],
+   "commit": "baf954b1d510b0e298823ac9c4b1174d953a24c0",
+   "sha256": "1q47pj6i6rhxwwfi6kjz6g1k62z0lgwpmjl1g2kpngwci79s3mg9"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    3
+   ],
+   "deps": [
+    "notmuch"
+   ],
+   "commit": "baf954b1d510b0e298823ac9c4b1174d953a24c0",
+   "sha256": "1q47pj6i6rhxwwfi6kjz6g1k62z0lgwpmjl1g2kpngwci79s3mg9"
   }
  },
  {
@@ -89085,30 +89657,30 @@
   "repo": "tarsius/notmuch-transient",
   "unstable": {
    "version": [
-    20260401,
-    1226
+    20260601,
+    1531
    ],
    "deps": [
     "compat",
     "notmuch",
     "transient"
    ],
-   "commit": "582ebaab67d3c59ec002ae23e0072e4ac9a2f13a",
-   "sha256": "1k3fk086ijixaqcl2xj4izdncn2q42ldz72bh0rdpng7zn4bfb97"
+   "commit": "41090076ad90b579ec48058d3edd135a1b9d05b5",
+   "sha256": "0m5h7nkd52n64vyp1nhq9vbv0cknm77yxnnk85qj8cqwd9awlmra"
   },
   "stable": {
    "version": [
     1,
     2,
-    0
+    1
    ],
    "deps": [
     "compat",
     "notmuch",
     "transient"
    ],
-   "commit": "582ebaab67d3c59ec002ae23e0072e4ac9a2f13a",
-   "sha256": "1k3fk086ijixaqcl2xj4izdncn2q42ldz72bh0rdpng7zn4bfb97"
+   "commit": "41090076ad90b579ec48058d3edd135a1b9d05b5",
+   "sha256": "0m5h7nkd52n64vyp1nhq9vbv0cknm77yxnnk85qj8cqwd9awlmra"
   }
  },
  {
@@ -89149,11 +89721,11 @@
   "repo": "muirdm/emacs-nova-theme",
   "unstable": {
    "version": [
-    20260202,
-    501
+    20260508,
+    2135
    ],
-   "commit": "6daa91ff091653cae7a94345ca579084f954effc",
-   "sha256": "1m2hrg9nxc179v9zv4asr38wq4h1w5gk0ih1yfm0fhp8gknkjhw6"
+   "commit": "84915bcaf5b5ac3accd39853a17b59483e38a8ac",
+   "sha256": "16z33vg8jf0114l7g3h0ix8kjnb3ziqircpdwa1w21ykk3sczhq9"
   }
  },
  {
@@ -89390,6 +89962,30 @@
    ],
    "commit": "84aa965f0cb4bde293237e4cc586643d1f662f83",
    "sha256": "0i1x0sd61c8k4q9ijgxyz21gvj1gah273990qfjzj9a25r4hzvlj"
+  }
+ },
+ {
+  "ename": "nucleo-completion",
+  "commit": "8f1634e697286e8cf318d112f698dd01b53f72e9",
+  "sha256": "08lhzg7wprax9maggk4vhlf8j9yna4q1qawbrva90lfm4a0yzhaw",
+  "fetcher": "github",
+  "repo": "kn66/nucleo-completion.el",
+  "unstable": {
+   "version": [
+    20260530,
+    1008
+   ],
+   "commit": "0f07a5bcd384716a3b79ab9e82005bb54f721122",
+   "sha256": "0lbif4isxnawj266cgxvh82fz8238g6vchfishqk9h8b025b6vc4"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    15
+   ],
+   "commit": "0f07a5bcd384716a3b79ab9e82005bb54f721122",
+   "sha256": "0lbif4isxnawj266cgxvh82fz8238g6vchfishqk9h8b025b6vc4"
   }
  },
  {
@@ -89658,29 +90254,6 @@
   }
  },
  {
-  "ename": "oai",
-  "commit": "c726b8b2a8db2f008123086f72ec31c99f91c7ea",
-  "sha256": "1kg3hkka9hp4w2jqg6b7170d2afdgvmlyx51sl05pdqynb3i3zzv",
-  "fetcher": "github",
-  "repo": "Anoncheg1/emacs-oai",
-  "unstable": {
-   "version": [
-    20260422,
-    858
-   ],
-   "commit": "fd2fea7b49a51a1e9d6690d35b1e2f14bf389692",
-   "sha256": "00kfr18vscizfpf80a9n0yjkbrxlq9wkmrxsr0x18n458cck4fr5"
-  },
-  "stable": {
-   "version": [
-    0,
-    2
-   ],
-   "commit": "48831f36bf7262d33cec19fa6bcafad6b7edfb59",
-   "sha256": "1b4jp14zvxr3gi4qf3fvcimx24mh96x2nb4hpdjrbdl37wl2wcap"
-  }
- },
- {
   "ename": "oauth",
   "commit": "32bb970e1577ea36895cf45edec93c9b0878685e",
   "sha256": "0xn1ci4f5hkz8biqq1q0qxygn8vif68iq67lbvw56mcxw0jxs7jc",
@@ -89723,15 +90296,15 @@
   "repo": "conao3/oauth2-request.el",
   "unstable": {
    "version": [
-    20210215,
-    657
+    20260516,
+    830
    ],
    "deps": [
     "oauth2",
     "request"
    ],
-   "commit": "86ff048635e002b00e23d6bed2ec6f36c17bca8e",
-   "sha256": "0z9vkssdxkikwjcb3vrby5dfcixy4lw9r2jp7g9nls6w88l184jf"
+   "commit": "f6b7ba42ecdfd4cc3588bd57bbb345bdae9b9cd6",
+   "sha256": "0hclg17qskz2hpxy056x9wgj0lg45z0vrp2h8aswxz7f9dk42x86"
   }
  },
  {
@@ -91540,11 +92113,11 @@
   "repo": "gynamics/oboe.el",
   "unstable": {
    "version": [
-    20260311,
-    1431
+    20260611,
+    1508
    ],
-   "commit": "8205f2c6ea747179382423ec5317b70126faaeb2",
-   "sha256": "0fbh6511s07b4rbx53h7yhfjp8hy57wpgq0ws872ic1r6wf5p1kp"
+   "commit": "07bd775c04b7c6cf552e34fb7ff5f7df9bb2f81c",
+   "sha256": "0yn3xhjyqqha61bs9shf9qxpkiij0yf0az2181ii8z1avysh501p"
   }
  },
  {
@@ -91612,11 +92185,11 @@
   "repo": "tarides/ocaml-eglot",
   "unstable": {
    "version": [
-    20260331,
-    1306
+    20260526,
+    2031
    ],
-   "commit": "b3ab5f049838d96444d8dcaa83e0b9cb2e9ee4cc",
-   "sha256": "06nsaxyzvgdjp3wy4hrjcyi904dwqk4wdvyfiprvgd93bqg18f46"
+   "commit": "1edc88567f45dba18f220fc705acd93e652e12ff",
+   "sha256": "0w8ca8d8hyyl6mglxyqwbgzbpd1hsjx6h0k602k1m38jc8l7zbbi"
   },
   "stable": {
    "version": [
@@ -91975,30 +92548,30 @@
   "repo": "tarsius/ol-notmuch",
   "unstable": {
    "version": [
-    20260101,
-    1844
+    20260601,
+    1532
    ],
    "deps": [
     "compat",
     "notmuch",
     "org"
    ],
-   "commit": "8f717329388935538fe433b9a15f1599edd9fcd5",
-   "sha256": "0vlb6wgp314n6ilzfhz3j3lkzdpv4y0mngp6l2q04np9cqffkvf3"
+   "commit": "fba0b5790a4c9aafeab69fd329776d0b4afa9aac",
+   "sha256": "1d5dfr5ndl9lr045fy0wwf1fkxyx4v1viln4pv3gg771x0wxx3sk"
   },
   "stable": {
    "version": [
     2,
     1,
-    3
+    4
    ],
    "deps": [
     "compat",
     "notmuch",
     "org"
    ],
-   "commit": "8f717329388935538fe433b9a15f1599edd9fcd5",
-   "sha256": "0vlb6wgp314n6ilzfhz3j3lkzdpv4y0mngp6l2q04np9cqffkvf3"
+   "commit": "fba0b5790a4c9aafeab69fd329776d0b4afa9aac",
+   "sha256": "1d5dfr5ndl9lr045fy0wwf1fkxyx4v1viln4pv3gg771x0wxx3sk"
   }
  },
  {
@@ -92081,11 +92654,11 @@
   "repo": "rnkn/olivetti",
   "unstable": {
    "version": [
-    20260419,
-    703
+    20260524,
+    213
    ],
-   "commit": "d1bdd439421865c20e907d9abe65840c57411bc9",
-   "sha256": "1x88ncrv2mvj5lxwj79pix33mmlarh073vkx8ghdfhlk8qm05w5a"
+   "commit": "d2ccae56b442d9c5b06dd2481057abbd7eb82551",
+   "sha256": "1kxzyg453wwn3kr8216zh36z9sn17y4s69fqka1ax33q05074h5s"
   },
   "stable": {
    "version": [
@@ -92105,11 +92678,14 @@
   "repo": "captainflasmr/ollama-buddy",
   "unstable": {
    "version": [
-    20260421,
-    1616
+    20260622,
+    1737
    ],
-   "commit": "62451e54c6f523d839d46a779ebd5c03e10c38c1",
-   "sha256": "0n29n43jwscplyr8ybpb4fvsg9wcws7cslahwi9vsq0b6rg0ja2b"
+   "deps": [
+    "transient"
+   ],
+   "commit": "c87a8fd73f1fb49859da37d6ef440ae456f2c6e1",
+   "sha256": "06a1zyyyyaag5gm8mfaqhi4lgfdd0gsfp6n5na7lnh2j3phc8gam"
   },
   "stable": {
    "version": [
@@ -92870,25 +93446,25 @@
   "repo": "oantolin/orderless",
   "unstable": {
    "version": [
-    20260124,
-    1000
+    20260519,
+    1029
    ],
    "deps": [
     "compat"
    ],
-   "commit": "6e3a09d6026fe7d7d5a3caf9a3d777cc9841fe80",
-   "sha256": "1r6sbyz8f3nkq5pr7iq3mm0q2dq3nq28xycf0x6xys7nsq2nink5"
+   "commit": "cebe19e3cf0f30604d1ed1bfaa74fff21a4e89a5",
+   "sha256": "0qw3lcn5iqmfa7lmkhrlzpwxm80k1bxb11h0w8akp6910iiq12b8"
   },
   "stable": {
    "version": [
     1,
-    6
+    7
    ],
    "deps": [
     "compat"
    ],
-   "commit": "6e3a09d6026fe7d7d5a3caf9a3d777cc9841fe80",
-   "sha256": "1r6sbyz8f3nkq5pr7iq3mm0q2dq3nq28xycf0x6xys7nsq2nink5"
+   "commit": "cebe19e3cf0f30604d1ed1bfaa74fff21a4e89a5",
+   "sha256": "0qw3lcn5iqmfa7lmkhrlzpwxm80k1bxb11h0w8akp6910iiq12b8"
   }
  },
  {
@@ -93137,30 +93713,30 @@
   "repo": "eyeinsky/org-anki",
   "unstable": {
    "version": [
-    20260423,
-    741
+    20260427,
+    1354
    ],
    "deps": [
     "dash",
     "promise",
     "request"
    ],
-   "commit": "2f44330aa2cd0a1f58259c9d83bb697fb0f7b0cc",
-   "sha256": "0x33724pw8xk6vwksswn7wky1q3n0cxgy0s5s25hxjwzgfg8j4n1"
+   "commit": "fa5e66fc96a25477780b13cec1fca391260da81e",
+   "sha256": "1dxij5lm1vk58w87j9ckn38ax5kawcx5v4r2d6rmdvsphnzaxi81"
   },
   "stable": {
    "version": [
     4,
     0,
-    4
+    5
    ],
    "deps": [
     "dash",
     "promise",
     "request"
    ],
-   "commit": "2f44330aa2cd0a1f58259c9d83bb697fb0f7b0cc",
-   "sha256": "0x33724pw8xk6vwksswn7wky1q3n0cxgy0s5s25hxjwzgfg8j4n1"
+   "commit": "fa5e66fc96a25477780b13cec1fca391260da81e",
+   "sha256": "1dxij5lm1vk58w87j9ckn38ax5kawcx5v4r2d6rmdvsphnzaxi81"
   }
  },
  {
@@ -93598,8 +94174,8 @@
   "repo": "lepisma/org-books",
   "unstable": {
    "version": [
-    20251022,
-    1020
+    20260528,
+    819
    ],
    "deps": [
     "dash",
@@ -93609,14 +94185,14 @@
     "org",
     "s"
    ],
-   "commit": "3f769e5a5a85a5eb6a2249ba971a3d77dc6e7d94",
-   "sha256": "0nf5d5nc9x7sjg35hcjk19xspr6k722g60lmfrb855m4vxliril7"
+   "commit": "74b82acd56c7ddaec5b03135a4cbbd5330a9b020",
+   "sha256": "1j2yw6mpki3k5ak5ll93129y389gpbnl86y4c651gash3pd6k088"
   },
   "stable": {
    "version": [
     0,
     3,
-    1
+    2
    ],
    "deps": [
     "dash",
@@ -93626,8 +94202,8 @@
     "org",
     "s"
    ],
-   "commit": "3f769e5a5a85a5eb6a2249ba971a3d77dc6e7d94",
-   "sha256": "0nf5d5nc9x7sjg35hcjk19xspr6k722g60lmfrb855m4vxliril7"
+   "commit": "74b82acd56c7ddaec5b03135a4cbbd5330a9b020",
+   "sha256": "1j2yw6mpki3k5ak5ll93129y389gpbnl86y4c651gash3pd6k088"
   }
  },
  {
@@ -93703,14 +94279,14 @@
   "repo": "dengste/org-caldav",
   "unstable": {
    "version": [
-    20260222,
-    437
+    20260501,
+    8
    ],
    "deps": [
     "org"
    ],
-   "commit": "2afbeca982d6b0987b1566eba5a4efa871546955",
-   "sha256": "0f6pi583zb0i2323m5xdsh8w3f78a0f46nf3315mhdyrv74i7isv"
+   "commit": "14f541814df597395fddb44b6e4bdb7c20f72cbe",
+   "sha256": "09gc1q2zs4b66lnjmhbil5c0z84cl44si4qrjh30f6i21gbbbsnq"
   },
   "stable": {
    "version": [
@@ -93825,14 +94401,14 @@
   "repo": "swflint/org-cite-overlay",
   "unstable": {
    "version": [
-    20251130,
-    328
+    20260619,
+    1531
    ],
    "deps": [
     "citeproc"
    ],
-   "commit": "b30e7fa63779ea6adf626227bc84c0b114e66c50",
-   "sha256": "1hbk2zkj0sjm0qlv9lzaacnkp90ajfrahh1wmxcd3qc1r2dcchkd"
+   "commit": "ec716f4e84d0796f652f789e4108617df4d233de",
+   "sha256": "1i9nvfwgzslyga9nakg90bf030vxhwc1y4fsrsg9xnxd67vwkfq7"
   },
   "stable": {
    "version": [
@@ -94440,10 +95016,10 @@
  },
  {
   "ename": "org-elisp-help",
-  "commit": "b0a9bf5046a4c3be8a83004d506bd258a6f7ff15",
-  "sha256": "0a4wvz52hkcw5nrml3h1yp8w97vg5jw22wnpfbb827zh7iwb259h",
+  "commit": "b8bb0d76e4f23f7255a45360f2a89c5563fd7ed2",
+  "sha256": "1r0v1ppvdkxc6c1glysc78gq7cx5n8ig4kgrxvdbcydyy5xlss4n",
   "fetcher": "github",
-  "repo": "tarsius/org-elisp-help",
+  "repo": "emacsorphanage/org-elisp-help",
   "unstable": {
    "version": [
     20161122,
@@ -94620,10 +95196,11 @@
   "stable": {
    "version": [
     0,
-    21
+    2,
+    1
    ],
-   "commit": "ba81ff4866326dae63b5eecf2643abb444de32a3",
-   "sha256": "1596r4ix0yas2qwrf38kj14dxdrns0m5622kxvapg7kin67kbifk"
+   "commit": "5ca3994f2e13b342e0b9d353b66b892e34c7b784",
+   "sha256": "1sn90262rcrqmmwy45dz8vdd10sv7d5m2dmzz79f5lj6kh90h5zw"
   }
  },
  {
@@ -94688,8 +95265,8 @@
   "repo": "kidd/org-gcal.el",
   "unstable": {
    "version": [
-    20260225,
-    409
+    20260612,
+    1823
    ],
    "deps": [
     "aio",
@@ -94700,8 +95277,8 @@
     "request",
     "request-deferred"
    ],
-   "commit": "0f46c08f60355729526e970e370defe624e84956",
-   "sha256": "0cdscldk9fi9vvk8qc4qqhi61qm8n1y35d44jw52dxl4i6wfiggi"
+   "commit": "7304b592c283944db54ac83201d7be6f13a1f447",
+   "sha256": "1b701j2m4cn17bh8n3xmxh5d4bwg5i4spc1v9i9rcq96kpj4mkbj"
   },
   "stable": {
    "version": [
@@ -94730,15 +95307,15 @@
   "repo": "conao3/org-generate.el",
   "unstable": {
    "version": [
-    20240713,
-    159
+    20260516,
+    826
    ],
    "deps": [
     "mustache",
     "org"
    ],
-   "commit": "39dbf8b5c3d225438f7d65e0dc7e9766d61d4c81",
-   "sha256": "03xd0cm0splhiznd8sdaipjvifc8pvsyj82s7mj5f3nzpqvv1m9m"
+   "commit": "e77b9cc063fdc035110ac2feea0799316e7e5339",
+   "sha256": "041q7mn1kw4wj4kr5gbmqc7nwibqxx9rhzswhwcqh0gvk65pz38a"
   },
   "stable": {
    "version": [
@@ -94849,8 +95426,8 @@
   "repo": "Trevoke/org-gtd.el",
   "unstable": {
    "version": [
-    20260303,
-    1359
+    20260605,
+    2210
    ],
    "deps": [
     "compat",
@@ -94860,8 +95437,8 @@
     "org-edna",
     "transient"
    ],
-   "commit": "1b93028024f587b3da133b4bcae473f92bb60bb6",
-   "sha256": "0y4rjjxbwgczv3g2mpakx36hp5zbvwkmh9s4594r2vi5mlfllmh5"
+   "commit": "01a12298033304b751628f41c088e9467d80532c",
+   "sha256": "1rppn7x9aamag0y7jwpfvbg7gga6bdxh7armrdinpsh1bdrfz2ff"
   },
   "stable": {
    "version": [
@@ -95188,14 +95765,14 @@
   "repo": "a-manumohan/org-invox",
   "unstable": {
    "version": [
-    20260408,
-    1633
+    20260624,
+    405
    ],
    "deps": [
     "org"
    ],
-   "commit": "6725996a43a1f223caf202eed9d81efd08adf5a7",
-   "sha256": "0yd5gadhb0s2y8r2n8p2l98k7lygfcr58llb4mw3arri88gc1a6q"
+   "commit": "0373529a0c922fcca62c7cb604099323bc869f76",
+   "sha256": "13q23lliqcn1jb7jshl25krgw3lrfcllgq570hgjd7bzf50cs2lr"
   }
  },
  {
@@ -95433,6 +96010,21 @@
   }
  },
  {
+  "ename": "org-lark",
+  "commit": "6f590a3e7e130a87efa3bcb4e166682849dbe103",
+  "sha256": "1ydwk0vb5xvb6hdhpqys2568lz8dnm2l26kqbs0k4wncpxmyphm9",
+  "fetcher": "github",
+  "repo": "bbw9n/org-lark",
+  "unstable": {
+   "version": [
+    20260614,
+    319
+   ],
+   "commit": "ebbe9ed102be2bf00b698f1280a305d8f3b0d38d",
+   "sha256": "1a4njnhr9cih9v4mnrf9fpdqbfv5x3rywrs7pk3nhggl81890j40"
+  }
+ },
+ {
   "ename": "org-latex-impatient",
   "commit": "5c49e1970a12617b00c79ec2d7112da8c9d8f4f7",
   "sha256": "0c16h2n6wx21cp1a5rhmvqhf8pryik3blkq5j0aiyxnxxqiikbly",
@@ -95461,18 +96053,16 @@
   "repo": "seokbeomKim/org-linenote",
   "unstable": {
    "version": [
-    20241231,
-    616
+    20260518,
+    1058
    ],
    "deps": [
     "eldoc",
     "fringe-helper",
-    "lsp-mode",
-    "projectile",
     "vertico"
    ],
-   "commit": "407d2ac834d1de82dd1e37f4642f74a81cf03350",
-   "sha256": "12scyxmiirc50qqwxql976560ccipyjrlnxsifwhc7p6xr0jylii"
+   "commit": "35a7940c1c81a1faf8f4b58a633cdcdd89c99509",
+   "sha256": "0za47d07qkg1h4baa0jhwd8sgpd56dxkznqjw46524dhzgl9b9mk"
   }
  },
  {
@@ -95483,15 +96073,15 @@
   "url": "https://repo.or.cz/org-link-beautify.git",
   "unstable": {
    "version": [
-    20260417,
-    705
+    20260426,
+    557
    ],
    "deps": [
     "nerd-icons",
     "qrencode"
    ],
-   "commit": "273e5b250fa2cc9b2dbbb63d9a7225536116fbd7",
-   "sha256": "1zhwq9mlx6bpfvqqgzmk210na7s8z9dc2cgs031by9b983rjh0bs"
+   "commit": "7ef11d4fe9874324985006875b9c96f227c6c10b",
+   "sha256": "1blyiszcrddyr9qjp39fmbz81zbv273d8d2iyxqfpl69nwmvixwq"
   },
   "stable": {
    "version": [
@@ -95576,11 +96166,11 @@
   "repo": "Anoncheg1/emacs-org-links",
   "unstable": {
    "version": [
-    20260423,
-    1949
+    20260605,
+    743
    ],
-   "commit": "cd2e9c074576e44469d84b5827933a035cf493c5",
-   "sha256": "01z3pph23cciv92l007s0z9rlhfgyj2ihy264s3l02csssnijma7"
+   "commit": "c168b06e408adc4b3ac03163e96e3dcbaac884bc",
+   "sha256": "1nfjb6cav830d6x055hciffg7q7g1bv82r8a8mz8435fv8cjff90"
   },
   "stable": {
    "version": [
@@ -95675,14 +96265,14 @@
   "repo": "laurynas-biveinis/org-mcp",
   "unstable": {
    "version": [
-    20251111,
-    1319
+    20260620,
+    1427
    ],
    "deps": [
     "mcp-server-lib"
    ],
-   "commit": "70fef64ee096c13eb33389c4803c5825e146c60e",
-   "sha256": "0r76wcyxmg4glhgj7576jbb0ax7zxbzl7rkg3fx13yfaaxqyw90f"
+   "commit": "eea4942d82858297d6f31d5872bce3e3ebe8bb50",
+   "sha256": "1hkvp98jc8la6akq0lvxldnjd7xnl1pn4g6dh8727yyba8y1q08m"
   },
   "stable": {
    "version": [
@@ -95833,58 +96423,27 @@
   "repo": "minad/org-modern",
   "unstable": {
    "version": [
-    20260325,
-    721
+    20260519,
+    1046
    ],
    "deps": [
     "compat",
     "org"
    ],
-   "commit": "0e385ab42887b8589292527735ccd4d2345fa904",
-   "sha256": "1kdbaxx11gc8q52szfs9hp3is17v04z0jr147d06sxmky5rigphx"
+   "commit": "4855ade77ab17de7587c37bde12a0afeab342783",
+   "sha256": "18yg3bg0mnhk4hkx5402rb5d6lyy5qn9pp5m2cigwjaa3316prk9"
   },
   "stable": {
    "version": [
     1,
-    13
+    14
    ],
    "deps": [
     "compat",
     "org"
    ],
-   "commit": "f514a2570da0f7a8ff0d72641458dbcf96ccf702",
-   "sha256": "16i1nwdilhpjlphpbwi8vjfwfb721gm0mm37hjx570wx4sskvg30"
-  }
- },
- {
-  "ename": "org-movies",
-  "commit": "ea06dc48003ba3c4f8e70fef4738cdb306362198",
-  "sha256": "1l4vd091vqhcs7qgws762x4cdnalj1hiq31d6l740miskc8nb8hr",
-  "fetcher": "github",
-  "repo": "teeann/org-movies",
-  "unstable": {
-   "version": [
-    20210920,
-    101
-   ],
-   "deps": [
-    "org",
-    "request"
-   ],
-   "commit": "e96fecaffa2924de64a507aa31d2934e667ee1ea",
-   "sha256": "1h514knqys20nv9qknxdl5y6rgmyymyr42i07dar8hln9vj0ywqm"
-  },
-  "stable": {
-   "version": [
-    0,
-    1
-   ],
-   "deps": [
-    "org",
-    "request"
-   ],
-   "commit": "e96fecaffa2924de64a507aa31d2934e667ee1ea",
-   "sha256": "1h514knqys20nv9qknxdl5y6rgmyymyr42i07dar8hln9vj0ywqm"
+   "commit": "4855ade77ab17de7587c37bde12a0afeab342783",
+   "sha256": "18yg3bg0mnhk4hkx5402rb5d6lyy5qn9pp5m2cigwjaa3316prk9"
   }
  },
  {
@@ -95934,14 +96493,14 @@
   "repo": "jeremy-compostella/org-msg",
   "unstable": {
    "version": [
-    20260211,
-    901
+    20260507,
+    725
    ],
    "deps": [
     "htmlize"
    ],
-   "commit": "aa608b399586fb771ad37045a837f8286a0b6124",
-   "sha256": "0n02g88jybzsx0lqqpzag7hkrlvy3gh6irphgm5wsx42w312k1jl"
+   "commit": "7b45df759340f3e388e84f497052b7cf3a41698c",
+   "sha256": "1h44pc7l4racn3rhc705rslwsnk7hmkad3508qdd2raadpj452ja"
   }
  },
  {
@@ -97026,20 +97585,20 @@
   "repo": "TomoeMami/org-repeat-by-cron.el",
   "unstable": {
    "version": [
-    20260303,
-    726
+    20260507,
+    721
    ],
-   "commit": "9a382e817dc63d5f8a6c74bd9d9233a14f1f3c96",
-   "sha256": "188ax1qyjgaz5qj5w1g67hnn7xg9m55j6ymqhd1gks52z0g67cyf"
+   "commit": "889944d9ee09fb4f09c3f7104c133a469dd242fd",
+   "sha256": "1j2hvsfzggm7kj7w41k953vfvi3v86qbxqmlf53kfmc5b3p7742i"
   },
   "stable": {
    "version": [
     1,
     1,
-    6
+    7
    ],
-   "commit": "9a382e817dc63d5f8a6c74bd9d9233a14f1f3c96",
-   "sha256": "188ax1qyjgaz5qj5w1g67hnn7xg9m55j6ymqhd1gks52z0g67cyf"
+   "commit": "a52d57016d350b10baca2229dc832311f77e6ebb",
+   "sha256": "195c8b1id0g65yajzmn880zlcsp42f69q96y0l4d0f4zp134pdm5"
   }
  },
  {
@@ -97145,8 +97704,8 @@
   "repo": "org-roam/org-roam",
   "unstable": {
    "version": [
-    20260423,
-    437
+    20260425,
+    1623
    ],
    "deps": [
     "compat",
@@ -97154,8 +97713,8 @@
     "magit-section",
     "org"
    ],
-   "commit": "d42da0e594b5737d25e3662e482d110f29a2668f",
-   "sha256": "0nvbzz6q4kvv8zqwnlwkk8m469vaf8b8zh0l3d8j2gsk4whn22y3"
+   "commit": "c54c523dec175695645399705606ea19056a3053",
+   "sha256": "18l0ka57l5j9js4dm50k174riyrb510yfaylyj8m0yqyrz6jbkn4"
   },
   "stable": {
    "version": [
@@ -97244,8 +97803,8 @@
   "repo": "ahmed-shariff/org-roam-ql",
   "unstable": {
    "version": [
-    20260322,
-    808
+    20260603,
+    2154
    ],
    "deps": [
     "dash",
@@ -97254,8 +97813,8 @@
     "s",
     "transient"
    ],
-   "commit": "b6b6a25029503c27c2d4e4e0ca17a0ab82611470",
-   "sha256": "1zqpr2hvxisk0lqf6j9ak79s338wwlf4xbvkqh752pm5idlia7fj"
+   "commit": "35900a7a97c459b6ded44d665d60c81ba2df6cc2",
+   "sha256": "0fcyk7m4wf8ibqvfplsysfqw5l7d4sl36bs4vjyx43rrdddl1gai"
   },
   "stable": {
    "version": [
@@ -97641,8 +98200,8 @@
   "repo": "tanrax/org-social.el",
   "unstable": {
    "version": [
-    20260418,
-    1402
+    20260525,
+    725
    ],
    "deps": [
     "async-http-queue",
@@ -97651,22 +98210,23 @@
     "request",
     "seq"
    ],
-   "commit": "613dcf8b65216a32afee1c42bb3273f6c4e1cd91",
-   "sha256": "14nnnfwp2wqhvv4pcwhasynrjgp6yyqkisfsqmsc87w0akfaziph"
+   "commit": "754f16c45585fb733fd521558b572f03bc964708",
+   "sha256": "0m5nrhp1d6ndj48fyh547fdk8gcldwxxczki8hklbpiv1w9s4jsb"
   },
   "stable": {
    "version": [
     2,
-    11
+    13
    ],
    "deps": [
+    "async-http-queue",
     "emojify",
     "org",
     "request",
     "seq"
    ],
-   "commit": "367ab5cf6ae12715bb9cade7a8eb45cf8d7f8723",
-   "sha256": "1aw0zfg898ggyn139n0x2fgaygayl14gv48mq59zw6b8ffkrff52"
+   "commit": "1dbc252a45881388f9f7cbbf51d5bfd5c0a80d80",
+   "sha256": "165c50rfzqjij3cm6cxw82gzh71zk5w6zswvzb3qp37rdwjynynf"
   }
  },
  {
@@ -98088,14 +98648,14 @@
   "url": "https://repo.or.cz/org-tag-beautify.git",
   "unstable": {
    "version": [
-    20260123,
-    235
+    20260606,
+    516
    ],
    "deps": [
     "nerd-icons"
    ],
-   "commit": "3b0e03b5a7929b2c0b107d90355e0a0f03490aef",
-   "sha256": "1y2lilr1yjfcrbb6vhc2h8vknh0pwrfrwajim1h8c0xcc6ilzl9g"
+   "commit": "af491d225771af377d65961e8a5f251b82a0a09a",
+   "sha256": "1q2bw2s0hs75babxs0wj7hylx0f98gnfv269bifymz6k7y2smwwx"
   }
  },
  {
@@ -98214,20 +98774,20 @@
   "repo": "rul/org-tempus",
   "unstable": {
    "version": [
-    20260222,
-    1840
+    20260601,
+    1225
    ],
-   "commit": "f3912ccd9032bea28ff0ee4b3d49a90e17097e26",
-   "sha256": "158gq02r7vcpbl93s2f1zdwbz4ccyn39i3m6w7bz2c6q3w3ymja6"
+   "commit": "b5562ca4e3344dde465b5cbd86275336aeac44df",
+   "sha256": "1gl4bcs7xq0bq4bs7mhmkr24a8n44v7iip2qfp423r4v1a3qk0ry"
   },
   "stable": {
    "version": [
     0,
     0,
-    1
+    2
    ],
-   "commit": "e07a05d66c084cf4796c2683f4320d9360af8b83",
-   "sha256": "1rsybp4827z7z3d66rzjp7kjyb84c12igzxqz26kfzhcd9dlqpav"
+   "commit": "2226ef0ae21022b9a343983847bce3e6bb07d63f",
+   "sha256": "0q3pc66naw399f13jgwmknyvsggxjaiyblxi9p77382rizqgkyb1"
   }
  },
  {
@@ -98898,14 +99458,14 @@
   "repo": "colonelpanic8/org-window-habit",
   "unstable": {
    "version": [
-    20260406,
-    1805
+    20260620,
+    108
    ],
    "deps": [
     "dash"
    ],
-   "commit": "dcf1d7b896bd2c0a706c00c0d0daab2fa9e49828",
-   "sha256": "1016w3zar3l5ry7fvvvidk4fb2hxbb54yizj1583ca57yf40qxid"
+   "commit": "19a6e070502e2b0d9aa85f12eda48debb44a479b",
+   "sha256": "16lhsvdi0niaab5cy3ga0h6y63lwqpjiav6ks95lhkf9fjrwa80z"
   },
   "stable": {
    "version": [
@@ -99280,23 +99840,24 @@
   "repo": "magit/orgit",
   "unstable": {
    "version": [
-    20260301,
-    1255
+    20260623,
+    2148
    ],
    "deps": [
     "compat",
     "cond-let",
+    "llama",
     "magit",
     "org"
    ],
-   "commit": "4fb91faff3bf32dac5f6f932654c280cd1f190f7",
-   "sha256": "1qa07q41383f79iv4r5ykxrb1fs2drk6h3qxkb3z7ymhjfbcifli"
+   "commit": "1aa3a27b1cb6aec913f7365caebdd6ffbe178443",
+   "sha256": "0rbj0b28dcgjcsa17wd01f1xw0psgxi4sak7c8wx55yaq8ym2i1s"
   },
   "stable": {
    "version": [
     2,
     1,
-    2
+    3
    ],
    "deps": [
     "compat",
@@ -99304,8 +99865,8 @@
     "magit",
     "org"
    ],
-   "commit": "4fb91faff3bf32dac5f6f932654c280cd1f190f7",
-   "sha256": "1qa07q41383f79iv4r5ykxrb1fs2drk6h3qxkb3z7ymhjfbcifli"
+   "commit": "4a4c03ee40b0e2509b49303e151ee217edaf0da4",
+   "sha256": "1gwl58mvanzbrh7lwkqbvfpmb32lz06k6dcnacan7kglvkm6mwgr"
   }
  },
  {
@@ -99352,8 +99913,8 @@
   "repo": "magit/orgit-forge",
   "unstable": {
    "version": [
-    20260401,
-    1227
+    20260623,
+    2150
    ],
    "deps": [
     "compat",
@@ -99363,8 +99924,8 @@
     "org",
     "orgit"
    ],
-   "commit": "8e4496d7f7f84fab3e36d10883386c02f43a67e7",
-   "sha256": "0fawwd2yys89kyp1q03xng9azgmbdai067m60x0agahrpvgdrysm"
+   "commit": "1e325a23ccc707373c13aee91c15a0bc0d1d6f41",
+   "sha256": "0c9lsjj5mpwyp4wc4kjazxdn23pldy2mbhbc88wcz7mzwbxpya8g"
   },
   "stable": {
    "version": [
@@ -99386,36 +99947,38 @@
  },
  {
   "ename": "orglink",
-  "commit": "be9b8e97cda6af91d54d402887f225e3a0caf055",
-  "sha256": "0ldrvvqs3hlazj0dch162gsbnbxcg6fgrxid8p7w9gj19vbcl52b",
+  "commit": "aec4a76eaea31408bd27d76a0b8cea5268663cc1",
+  "sha256": "1xnrj81fzzbczrh6cirgy9d4gsc6g6qydh1s0zzya1da1sgsd1sb",
   "fetcher": "github",
   "repo": "tarsius/orglink",
   "unstable": {
    "version": [
-    20260101,
-    1845
+    20260601,
+    1536
    ],
    "deps": [
     "compat",
+    "llama",
     "org",
     "seq"
    ],
-   "commit": "0de830edc6ffc0b07b95284f545ffe7d7c37dfb8",
-   "sha256": "11173ja0cga82fp7qxw900l8wg5fhygi7d5qn0vi5hrh1rwyg9da"
+   "commit": "e4805628e731021cf360ae7e61dcb40ae1e1992f",
+   "sha256": "17n6njdp824h0dkdpryw0hzkbaj344c5ya2a5ddiivxbx7i56x2y"
   },
   "stable": {
    "version": [
     1,
-    2,
-    9
+    3,
+    0
    ],
    "deps": [
     "compat",
+    "llama",
     "org",
     "seq"
    ],
-   "commit": "0de830edc6ffc0b07b95284f545ffe7d7c37dfb8",
-   "sha256": "11173ja0cga82fp7qxw900l8wg5fhygi7d5qn0vi5hrh1rwyg9da"
+   "commit": "e4805628e731021cf360ae7e61dcb40ae1e1992f",
+   "sha256": "17n6njdp824h0dkdpryw0hzkbaj344c5ya2a5ddiivxbx7i56x2y"
   }
  },
  {
@@ -99561,11 +100124,11 @@
   "repo": "tbanel/orgaggregate",
   "unstable": {
    "version": [
-    20260412,
-    811
+    20260624,
+    650
    ],
-   "commit": "348394cbd9d8a25b61bccd284196c97a065b7013",
-   "sha256": "1jriyc1ir4agljygsq4qc7qdr57231ba2gy1p64pccad01nkpbxl"
+   "commit": "84d7721b4bf8c07d121945d9a37890059d8fad1d",
+   "sha256": "0jcpk08vfr7xxz82sicxp5qxvzvps4xzqn80knzcbl82wxh75iqi"
   }
  },
  {
@@ -99606,11 +100169,11 @@
   "repo": "tbanel/orgtbljoin",
   "unstable": {
    "version": [
-    20260412,
-    844
+    20260624,
+    718
    ],
-   "commit": "37883c21e85e71797538d154226e24666bc73047",
-   "sha256": "0asvlwp7z350v7iphmvfrsgqmw8bfgqvi3bcgpxf2w7i6624hdks"
+   "commit": "1f00eeb9b95bd3075b67ebf5efc5e08dbdfc0361",
+   "sha256": "0im9r4gqf18k4bhbj66v6yfpb4l65nfsjfh7fhigljcid66sxz2l"
   }
  },
  {
@@ -99769,25 +100332,25 @@
   "repo": "minad/osm",
   "unstable": {
    "version": [
-    20260125,
-    1200
+    20260623,
+    1520
    ],
    "deps": [
     "compat"
    ],
-   "commit": "19c9c958dd530a1ba606fc1074a28523af40ec28",
-   "sha256": "1lwjnxafhy5f83ydlccd47r2ramgwdlgzlj15h82yxsl4l0sq380"
+   "commit": "b0fceb1f8488abb577e5110676f50753ea35ee24",
+   "sha256": "0w4y7cpnb371h8yf45p90gks3k601z5fkxf9ladk5kgyaz7i98an"
   },
   "stable": {
    "version": [
     2,
-    2
+    3
    ],
    "deps": [
     "compat"
    ],
-   "commit": "19c9c958dd530a1ba606fc1074a28523af40ec28",
-   "sha256": "1lwjnxafhy5f83ydlccd47r2ramgwdlgzlj15h82yxsl4l0sq380"
+   "commit": "a9e76ce08fb86e40a9f3efc42b38045c9b58fa95",
+   "sha256": "10237nlimmcm9n20fvwyicswm1x8kbmqck5f59y150qsns6am41p"
   }
  },
  {
@@ -99853,14 +100416,14 @@
   "repo": "xuchunyang/osx-dictionary.el",
   "unstable": {
    "version": [
-    20240330,
-    942
+    20260520,
+    1154
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "6abfd6908b0dc773020466225c908000870b383b",
-   "sha256": "16mvkrs82g6zhaa10r28v8br0cshv1bsbywyb1qkc8hdkj1hh37j"
+   "commit": "8e6897844c4d6ff6039b31569058273632afea16",
+   "sha256": "003rkv79rwaz2zy12vf5hb10sqs00b1ds8398swmj7k48d4la5p2"
   },
   "stable": {
    "version": [
@@ -100042,26 +100605,26 @@
   "repo": "abougouffa/one-tab-per-project",
   "unstable": {
    "version": [
-    20260211,
-    2247
+    20260606,
+    13
    ],
    "deps": [
     "compat"
    ],
-   "commit": "2c5bfb6ef06d27a9589394339dadb856580a5a84",
-   "sha256": "1qql95w8mdsb6scvi7xg0xc3c33pw385a1fvm1vilwbr1s7y32yd"
+   "commit": "ef1460cf7cd978554f894325303a46e629ea2633",
+   "sha256": "0qg4ysrcgw252flsr5hh0diy7f8wgplnib6r0rfdqswfprnhwlqm"
   },
   "stable": {
    "version": [
     3,
-    4,
-    1
+    5,
+    4
    ],
    "deps": [
     "compat"
    ],
-   "commit": "2c5bfb6ef06d27a9589394339dadb856580a5a84",
-   "sha256": "1qql95w8mdsb6scvi7xg0xc3c33pw385a1fvm1vilwbr1s7y32yd"
+   "commit": "ef1460cf7cd978554f894325303a46e629ea2633",
+   "sha256": "0qg4ysrcgw252flsr5hh0diy7f8wgplnib6r0rfdqswfprnhwlqm"
   }
  },
  {
@@ -100116,20 +100679,26 @@
   "repo": "jamescherti/outline-indent.el",
   "unstable": {
    "version": [
-    20260416,
-    1902
+    20260608,
+    1221
    ],
-   "commit": "b25886d0b6a6de1b6c3e881230e41b76ad8652e0",
-   "sha256": "1bmfi4bc0zjczivq7dc7zb1z016sswpz83czsfp0ggpm4xfjv79w"
+   "deps": [
+    "kirigami"
+   ],
+   "commit": "57b9f4bb9724a82f7e5e15e2a62e04373aee3d08",
+   "sha256": "0d9qm0a5vnnhfslpxvnsf5pcqv35wqqv4niqsq7m64fcn9z4lnlh"
   },
   "stable": {
    "version": [
     1,
-    1,
-    8
+    2,
+    0
    ],
-   "commit": "85d1f66e82454829fcda5aa40334bb47be10586c",
-   "sha256": "1r12xvlxr6mylz0jkc63hwdsapw73xcqvqry5xbyqc6d778m0zsz"
+   "deps": [
+    "kirigami"
+   ],
+   "commit": "57b9f4bb9724a82f7e5e15e2a62e04373aee3d08",
+   "sha256": "0d9qm0a5vnnhfslpxvnsf5pcqv35wqqv4niqsq7m64fcn9z4lnlh"
   }
  },
  {
@@ -100155,26 +100724,50 @@
   "repo": "tarsius/outline-minor-faces",
   "unstable": {
    "version": [
-    20260101,
-    1824
+    20260601,
+    1519
    ],
    "deps": [
     "compat"
    ],
-   "commit": "ad3ec4620b79ae5c3e840ed1f47f892c5f917d8c",
-   "sha256": "00l2pmvyglbl6440fkk0sm31a5l7gss4pmdnw1ar7vaqz4afwi4d"
+   "commit": "71705d0708459f765403968567a329a76c38cf62",
+   "sha256": "0xp8vk85kby4gvxb97hs4lpc1kd67m4jw185l87ssvc52v9yq9kv"
   },
   "stable": {
    "version": [
     1,
     2,
-    2
+    4
    ],
    "deps": [
     "compat"
    ],
-   "commit": "ad3ec4620b79ae5c3e840ed1f47f892c5f917d8c",
-   "sha256": "00l2pmvyglbl6440fkk0sm31a5l7gss4pmdnw1ar7vaqz4afwi4d"
+   "commit": "71705d0708459f765403968567a329a76c38cf62",
+   "sha256": "0xp8vk85kby4gvxb97hs4lpc1kd67m4jw185l87ssvc52v9yq9kv"
+  }
+ },
+ {
+  "ename": "outline-stars",
+  "commit": "cad99860ad193dbbc7ca8c3bfea6e36b3f140e90",
+  "sha256": "0f0342misllapvwa7qfmwxb78cmzzypb179bgnv1pwskqzd8ivfs",
+  "fetcher": "codeberg",
+  "repo": "phmcc/outline-stars",
+  "unstable": {
+   "version": [
+    20260427,
+    2355
+   ],
+   "commit": "a08f50d395a1a74406da97b22ab22d72ffc4df51",
+   "sha256": "0y7hivf5i9i0kazc5b7vs1i7jjgh1bc4raimq2ryh0f3fazv0r9s"
+  },
+  "stable": {
+   "version": [
+    0,
+    4,
+    3
+   ],
+   "commit": "a08f50d395a1a74406da97b22ab22d72ffc4df51",
+   "sha256": "0y7hivf5i9i0kazc5b7vs1i7jjgh1bc4raimq2ryh0f3fazv0r9s"
   }
  },
  {
@@ -100341,8 +100934,8 @@
   "repo": "vale981/overleaf.el",
   "unstable": {
    "version": [
-    20260417,
-    1854
+    20260604,
+    1734
    ],
    "deps": [
     "plz",
@@ -100350,8 +100943,8 @@
     "webdriver",
     "websocket"
    ],
-   "commit": "62c31c609d7d96ec6c592eec40fba41735e40875",
-   "sha256": "1bj7jq63v52gn8jaa7bsi22ac321j21cmsxd9vl5kvvagzrjqbiv"
+   "commit": "506fe07b79ceefce3e53196711e10700da344d49",
+   "sha256": "0hrn0dvk7pqhw63s015hfav7d8fcsfn9sx46dzjn59mfqy9qwm5c"
   },
   "stable": {
    "version": [
@@ -100884,16 +101477,16 @@
   "repo": "zzamboni/ox-leanpub",
   "unstable": {
    "version": [
-    20260419,
-    2104
+    20260506,
+    759
    ],
    "deps": [
     "org",
     "ox-gfm",
     "s"
    ],
-   "commit": "cfd521786c281ad7fa38212016226af80e163329",
-   "sha256": "1mf3s459b4s2ykj9af0j9afx3c77gndnyzlfb38ml2c17pl3jrsa"
+   "commit": "6197366b8b534484e9cba4a2dfaf82aa37432917",
+   "sha256": "1bi9g218w9wr98x26gaqs62148gar1cfxli4c1pzns7667qb3zb7"
   }
  },
  {
@@ -101032,15 +101625,15 @@
   "repo": "0x60df/ox-qmd",
   "unstable": {
    "version": [
-    20230325,
-    1315
+    20260514,
+    1442
    ],
    "deps": [
     "mimetypes",
     "request"
    ],
-   "commit": "0b5fa1e20aaa48d93600e1b8d09c3b6f55af3373",
-   "sha256": "1n0il25a5dwn0dh5a8q3190yfbmfgdi17k1b4vyj83gl7ga40v0d"
+   "commit": "7a1a4f2679a38e216130d749dfbb38e2d63b713f",
+   "sha256": "03svx2fc99kwlyvmsv9xm0j8hhnpvczl3l9x8366q5w1acg8pp53"
   }
  },
  {
@@ -101158,20 +101751,20 @@
  },
  {
   "ename": "ox-rss",
-  "commit": "0cc83cda4df36ceb9584d02c36392b6c1fcce4d0",
-  "sha256": "0ngc4v5gg7py623nxl56wm6qrijryvsrbasjgxpn74cx3lblw8m4",
+  "commit": "f04da02bca96384a837ba680b297b9f58b0a8db2",
+  "sha256": "097k7yc9gkvz0l6rrsgic1jwlsi6pv6wbd1hhxl90rx78vbm4r4k",
   "fetcher": "github",
-  "repo": "BenedictHW/ox-rss",
+  "repo": "bhw-foss/ox-rss",
   "unstable": {
    "version": [
-    20230408,
-    231
+    20260512,
+    2231
    ],
    "deps": [
     "org"
    ],
-   "commit": "ee7347fca8f10a4b53075a8d1e3cac3aff6e6dac",
-   "sha256": "19fz5vvad8j3p1sm39spmby1h3h9djw5hlvwsdssk6bdpmvlcjp0"
+   "commit": "c83db3dc521d0dd423b0f24e57b7eaa798ab5e40",
+   "sha256": "1dynf55r19iwci8b9dm20vi00r22z8949wzh12ya84ab4g29i9nq"
   }
  },
  {
@@ -101414,14 +102007,14 @@
   "repo": "jmpunkt/ox-typst",
   "unstable": {
    "version": [
-    20260419,
-    1805
+    20260502,
+    1009
    ],
    "deps": [
     "org"
    ],
-   "commit": "d05bdf1676c7564af6d87b438c669e93904c2b10",
-   "sha256": "10y15nhb3lkcykxd12wl8maf7ygvshif6r1nnk4hxjacsa8p6dkc"
+   "commit": "3e499609a201405a6064144792dab14e3cc19b93",
+   "sha256": "0aw2wz33s053vb1qxwshsblw6vd86qgdvjnrh73ala2fdfaqn0bs"
   }
  },
  {
@@ -101503,6 +102096,24 @@
    ],
    "commit": "b53bd82116c9f7dbb5b476d2cfcc8ed0f3bc9c78",
    "sha256": "1n57bzsp73g5iqdnhc4jhsylif93h4kkl7zgqi1i9b8bi90sqrl1"
+  }
+ },
+ {
+  "ename": "ox-zola",
+  "commit": "1e9831885355ff0d936446f45a848108093d8cb8",
+  "sha256": "1jjgnnl7l7qamjdbxbv7qmz5ghqn3wgm1mcdkdrx465f0pzva18i",
+  "fetcher": "github",
+  "repo": "gicrisf/ox-zola",
+  "unstable": {
+   "version": [
+    20260506,
+    1952
+   ],
+   "deps": [
+    "ox-hugo"
+   ],
+   "commit": "c6ab97d53b471ed53803e44169ac5d3766d72cbe",
+   "sha256": "09d7n0bc2axgkmj3yhl4smnjscsignlajrrhx8dj9hyvvp3pdkdv"
   }
  },
  {
@@ -101700,20 +102311,20 @@
  },
  {
   "ename": "package-build",
-  "commit": "948fb86b710aafe6bc71f95554655dfdfcab0cca",
-  "sha256": "0kr82j9rbvmapsph0jdxy24p0b8mcnj01sg1myywf428nf30cgbh",
+  "commit": "d328de2f2fed796535509e3a1b4e5d9194c5739d",
+  "sha256": "0aykmvx2rqk4zzgivl9hdzbnhk2p6alzyd2g5l1hx7sxigpwawhc",
   "fetcher": "github",
   "repo": "melpa/package-build",
   "unstable": {
    "version": [
-    20260421,
-    2136
+    20260608,
+    2212
    ],
    "deps": [
     "compat"
    ],
-   "commit": "2db42a9050923c2245bb525345a8b12bd6c0973a",
-   "sha256": "15iajmnrgm1lcl792km7c34nfw9r2dhy5hrzpvv4raijvcbhxkpq"
+   "commit": "47a50e7593498533e22a832160536a90acc837e5",
+   "sha256": "0kyjlj3vmkpl5bx9j6d3ila7kxpdjb8rfxlarjbaimcqz8jspmnp"
   },
   "stable": {
    "version": [
@@ -101748,14 +102359,14 @@
   "repo": "purcell/package-lint",
   "unstable": {
    "version": [
-    20251205,
-    1720
+    20260619,
+    1246
    ],
    "deps": [
     "let-alist"
    ],
-   "commit": "1c37329703a507fa357302cf6fc29d4f2fe631a8",
-   "sha256": "1c5icb7j8jc5d38svpfbxm4m4pdlb3xq4b9m2234wiwf2a128dkz"
+   "commit": "35996f478d81e51dae4fa30d051f741895d07399",
+   "sha256": "10yp7x36d0zj6pkr8asnyjfh9is40869vmyyx5k6vg0ar294x9l0"
   },
   "stable": {
    "version": [
@@ -102355,26 +102966,26 @@
   "repo": "tarsius/paren-face",
   "unstable": {
    "version": [
-    20260101,
-    1846
+    20260601,
+    1519
    ],
    "deps": [
     "compat"
    ],
-   "commit": "2c279a236404b2eebacb435aa92d5e9c97939c03",
-   "sha256": "06ypi3hgrr9rigcb9gy5j4l9f3z7lnz1rssv1pqda55srkvcp39x"
+   "commit": "57307b5ea75e07d2dc0c64c7e3eeadee3369a7aa",
+   "sha256": "11g3wg79kvg4nkm2knabpzsf0lcpnak94kkdb5cscp3w3fg3x5a7"
   },
   "stable": {
    "version": [
     1,
     2,
-    3
+    4
    ],
    "deps": [
     "compat"
    ],
-   "commit": "2c279a236404b2eebacb435aa92d5e9c97939c03",
-   "sha256": "06ypi3hgrr9rigcb9gy5j4l9f3z7lnz1rssv1pqda55srkvcp39x"
+   "commit": "57307b5ea75e07d2dc0c64c7e3eeadee3369a7aa",
+   "sha256": "11g3wg79kvg4nkm2knabpzsf0lcpnak94kkdb5cscp3w3fg3x5a7"
   }
  },
  {
@@ -102403,17 +103014,26 @@
  },
  {
   "ename": "parenthesis-face",
-  "commit": "890e94376ea0b6ada2c49a0a3e11b2a59aab7caa",
-  "sha256": "078c97yjxp6344i4d5v5k07yxpm9y0qbjcmgim89hmgmira8iqvx",
+  "commit": "fefa3d4feab1be45b0169c31781a1e995d0963ae",
+  "sha256": "1vwbwl0vyazrlc4d5dfa6301h4b33ix8bxjbmgh6d6facgj2rrxx",
   "fetcher": "github",
   "repo": "tarsius/paren-face",
   "unstable": {
    "version": [
-    20260101,
-    1846
+    20260601,
+    1519
    ],
-   "commit": "2c279a236404b2eebacb435aa92d5e9c97939c03",
-   "sha256": "06ypi3hgrr9rigcb9gy5j4l9f3z7lnz1rssv1pqda55srkvcp39x"
+   "commit": "57307b5ea75e07d2dc0c64c7e3eeadee3369a7aa",
+   "sha256": "11g3wg79kvg4nkm2knabpzsf0lcpnak94kkdb5cscp3w3fg3x5a7"
+  },
+  "stable": {
+   "version": [
+    1,
+    2,
+    4
+   ],
+   "commit": "57307b5ea75e07d2dc0c64c7e3eeadee3369a7aa",
+   "sha256": "11g3wg79kvg4nkm2knabpzsf0lcpnak94kkdb5cscp3w3fg3x5a7"
   }
  },
  {
@@ -102576,11 +103196,11 @@
   "repo": "clojure-emacs/parseclj",
   "unstable": {
    "version": [
-    20231203,
-    1905
+    20260526,
+    1843
    ],
-   "commit": "6af22372e0fe14df882dd300b22b12ba2d7e00b0",
-   "sha256": "1iz7qbsq4whmb3iqy777jlm47chjp62313hc6nfcp0lfqsanmcmv"
+   "commit": "ca828c202c026e45bd60503984cf510d904cae50",
+   "sha256": "1j992kbnl4f25cfb0bjjv2pcl6zxrlg4fvf2r3740a9vmigrl82q"
   },
   "stable": {
    "version": [
@@ -102600,15 +103220,15 @@
   "repo": "clojure-emacs/parseedn",
   "unstable": {
    "version": [
-    20231203,
-    1909
+    20260601,
+    1258
    ],
    "deps": [
     "map",
     "parseclj"
    ],
-   "commit": "3407e4530a367b6c2b857dae261cdbb67a440aaa",
-   "sha256": "0b2jralm5lm4z4lpkn8ygzfga67xsalaszc8gqqv36khmz2mrckc"
+   "commit": "1a28a88e2aabd99b41e02f491d6b8874ec128d7d",
+   "sha256": "1y25vvbknm5bsqhy7d6sjk6f3f2apmf3f84l1949pz3hcr7nh938"
   },
   "stable": {
    "version": [
@@ -103038,20 +103658,20 @@
   "repo": "jamescherti/pathaction.el",
   "unstable": {
    "version": [
-    20260328,
-    1613
+    20260604,
+    212
    ],
-   "commit": "f3010d3485d7939f252dee59e4b335cb28e5069c",
-   "sha256": "0k9b4a9psbz4zdbnfriayklbhgqglwlagcamk0srizjhs08xrqhy"
+   "commit": "19dc91a8da6574dc7f80b263cc3a909be1c300e4",
+   "sha256": "1f1bqaya4xbwqaljfqffvn3lahh4s9q3nflhj20ny86cd5zcgdaj"
   },
   "stable": {
    "version": [
     1,
     0,
-    1
+    2
    ],
-   "commit": "5082e3492a7f760cda3c2764f4b9a38b18bd44f3",
-   "sha256": "09ckg9l854kk203x08lacdmvhx70gngrv7z6x90lamc5qbc87ddc"
+   "commit": "19dc91a8da6574dc7f80b263cc3a909be1c300e4",
+   "sha256": "1f1bqaya4xbwqaljfqffvn3lahh4s9q3nflhj20ny86cd5zcgdaj"
   }
  },
  {
@@ -103392,10 +104012,11 @@
   "stable": {
    "version": [
     0,
-    23
+    2,
+    3
    ],
-   "commit": "8f7516510459477c2ff368a7fde4cc68cead2402",
-   "sha256": "0xx35811kxlrnsa2ydkgli60xvqjd9i7cx7j5z8zidzgzkywdnj5"
+   "commit": "15594c3348ed7febef31f99d709b128f267035eb",
+   "sha256": "0xap7i2x8mqpwr52xdqb8c6lhjmxm1d6car2533ynyr4k2fn4lw5"
   }
  },
  {
@@ -103505,14 +104126,14 @@
   "repo": "emacsomancer/pdffontetc",
   "unstable": {
    "version": [
-    20260325,
-    1408
+    20260615,
+    2141
    ],
    "deps": [
     "pdf-tools"
    ],
-   "commit": "b2db6c1377c080d9425836efa19690df3eb44516",
-   "sha256": "11kpb4k0xjnxxnf8dw1rvw2hnflag7w2k7a680gcvywpllp5zl6z"
+   "commit": "05c25591e807eaf79d25dbcfa20ca994f1ae78e3",
+   "sha256": "1faf6x7jckd0b408hija53074n9630srqk5hkn6wab6gz7rqn9g2"
   }
  },
  {
@@ -103770,20 +104391,20 @@
   "repo": "jamescherti/persist-text-scale.el",
   "unstable": {
    "version": [
-    20260326,
-    1609
+    20260609,
+    1528
    ],
-   "commit": "e835e76bad452b1e5a59eb9a0fef650e0680ab90",
-   "sha256": "0vvpd0vrzy2rk6xsqnfp65jbm1ls4z1v8syji6rlz2sfnkv94m73"
+   "commit": "27e43ba3becce78a9365ac8e5ecdfc30e08249d6",
+   "sha256": "0add2xw1s7lrakhpb5phdscy3x81vzy7p8wz017vly27l50q787q"
   },
   "stable": {
    "version": [
     1,
     0,
-    4
+    6
    ],
-   "commit": "8098af6ba9ff251d19f9e41b39c84f7b9b758f26",
-   "sha256": "006j8sdzp671wj07bs5lfr21lcfb81c2gn0kn13jphmki14s7i02"
+   "commit": "27e43ba3becce78a9365ac8e5ecdfc30e08249d6",
+   "sha256": "0add2xw1s7lrakhpb5phdscy3x81vzy7p8wz017vly27l50q787q"
   }
  },
  {
@@ -103995,25 +104616,25 @@
   "repo": "nex3/perspective-el",
   "unstable": {
    "version": [
-    20260403,
-    538
+    20260624,
+    732
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "230cabf4c1406569bac416cff9502ae23648e3f8",
-   "sha256": "0k7bfhjb71ippzrc65i0rbngj65wbhzl5rxygjshwf83rvfwimab"
+   "commit": "af96b2cdaa0e10953878b17d1eef4bcd382ed6f8",
+   "sha256": "1pwn2cz8p5d7n340da64lrp7fsl0lybw4ij8dsa6f23r970ii2n3"
   },
   "stable": {
    "version": [
     2,
-    21
+    22
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "64ef5eaaab9e7564e8b9788ce6d0e2359daf5dca",
-   "sha256": "1v22m3l7p89wsdy0ydv0w91v0h9wjl1v33gim756dz8zcx8m1p8y"
+   "commit": "451b0f0272c732f5e822b0c0c590d9dd0937915e",
+   "sha256": "1x1s2yji3w86mv0hfpma4axj70gqhavazmv0vj4kxwc24r8fj8xr"
   }
  },
  {
@@ -104184,25 +104805,25 @@
   "repo": "emarsden/pg-el",
   "unstable": {
    "version": [
-    20260418,
-    1149
+    20260607,
+    1014
    ],
    "deps": [
     "peg"
    ],
-   "commit": "e82be0a8a69042c102119b9c7d59619f3a2277a3",
-   "sha256": "164kfd0lc1qw3wnlxqyjmqd3yhmkkf81qmgdx0kydlrij8a7z594"
+   "commit": "7426269673da42ed6706db44d2b7d1696ede95f6",
+   "sha256": "1nfbzyidzlrhxvsk2z50l67lss9lgl4fswm23iyfkzbqqxiwm3w3"
   },
   "stable": {
    "version": [
     0,
-    65
+    67
    ],
    "deps": [
     "peg"
    ],
-   "commit": "e82be0a8a69042c102119b9c7d59619f3a2277a3",
-   "sha256": "164kfd0lc1qw3wnlxqyjmqd3yhmkkf81qmgdx0kydlrij8a7z594"
+   "commit": "7426269673da42ed6706db44d2b7d1696ede95f6",
+   "sha256": "1nfbzyidzlrhxvsk2z50l67lss9lgl4fswm23iyfkzbqqxiwm3w3"
   }
  },
  {
@@ -104443,6 +105064,36 @@
    ],
    "commit": "ddd98a45775be105984ec598384e68df3d3e8046",
    "sha256": "02fhna45wq3wja51yrwm0xysdvyck1r0a3dx41i5sh89504gl6a9"
+  }
+ },
+ {
+  "ename": "phony",
+  "commit": "763d5a953e1495c8abe8f86c873e4f78bef75050",
+  "sha256": "1dd4w968n5ni03i9m6dzf88b2bzadxdskhgs1xi8ah0b64ka8g4q",
+  "fetcher": "github",
+  "repo": "ErikPrantare/phony.el",
+  "unstable": {
+   "version": [
+    20260531,
+    2312
+   ],
+   "deps": [
+    "simulacrum"
+   ],
+   "commit": "1129dd32bb51cde770e62f56b7da50acd79790a4",
+   "sha256": "1zz2yq0fxigcwhnapx97r7i5m4s1zy8bcg40dm2qxndcj17wlgni"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "deps": [
+    "simulacrum"
+   ],
+   "commit": "1129dd32bb51cde770e62f56b7da50acd79790a4",
+   "sha256": "1zz2yq0fxigcwhnapx97r7i5m4s1zy8bcg40dm2qxndcj17wlgni"
   }
  },
  {
@@ -104776,21 +105427,21 @@
   "repo": "dnouri/pi-coding-agent",
   "unstable": {
    "version": [
-    20260418,
-    1713
+    20260622,
+    2213
    ],
    "deps": [
     "markdown-table-wrap",
     "md-ts-mode",
     "transient"
    ],
-   "commit": "a07e1d0a3a2dbbac6f1d2a92656d2239f0dcb2c7",
-   "sha256": "03cdqhsqml5sbpa2pm06hphavhnyq1b11nany1cpg7hshixz37wr"
+   "commit": "536e0f6e0ec12725874600734be3af41b02d08dd",
+   "sha256": "0i5kms8l5yda98220s3g5adz9561f30xchzvk53j0rwlz26mvqxb"
   },
   "stable": {
    "version": [
     2,
-    2,
+    5,
     1
    ],
    "deps": [
@@ -104798,8 +105449,8 @@
     "md-ts-mode",
     "transient"
    ],
-   "commit": "ca0d60474cede8198329a939a902f51081543612",
-   "sha256": "16vhk22gdcyl87l1fknkzqkr7nxyqrs2hlghr3vwlmcj9igr4cfa"
+   "commit": "255b5d560f2ebf0323803498f413fc79d0ae386e",
+   "sha256": "0bdkrrv1rawgikk69d9rwjvx0swdlipbkki2gr37fdba042933vc"
   }
  },
  {
@@ -104870,20 +105521,20 @@
   "repo": "oliverepper/pif",
   "unstable": {
    "version": [
-    20250207,
-    1624
+    20260504,
+    1621
    ],
-   "commit": "c993c1446ff3460a2f599b84ac81e9f00c4c7333",
-   "sha256": "02ywbxfg7s1hsiwi2zqvhlqd8wfhfzasb3n6gsj0rl5ix8c7gsmw"
+   "commit": "72978dddffa3d9c68c6510c3a0381ffcdb691188",
+   "sha256": "1pvvkg31w10am3fldkq7lgi7f0bjmzg5kwgfjiwfbnd24j7mi03x"
   },
   "stable": {
    "version": [
     0,
     0,
-    6
+    7
    ],
-   "commit": "c993c1446ff3460a2f599b84ac81e9f00c4c7333",
-   "sha256": "02ywbxfg7s1hsiwi2zqvhlqd8wfhfzasb3n6gsj0rl5ix8c7gsmw"
+   "commit": "85e55528967d5aee87ae84b306c1cd292a6705c9",
+   "sha256": "0628k53zcbid37dggn7jpsf2yqzi2hcrd3vr897xh0jcczb76m9s"
   }
  },
  {
@@ -105118,11 +105769,11 @@
   "repo": "Anoncheg1/pinyin-isearch",
   "unstable": {
    "version": [
-    20260323,
-    1922
+    20260620,
+    2130
    ],
-   "commit": "935e582668d6a9a55fd9dd262d46ed1f2bb98f35",
-   "sha256": "0zvx6xn8sl8gx3n4kk3i13vq55v5qjmhaxhk5k63cagjh0pzyy47"
+   "commit": "f15976e9989cfa9e7bd2bf59f2361e0cf62fed8e",
+   "sha256": "17nyik0xfjy17ln3pq5k69r3ad5cmjrqw3rbrygd6i0y5xqrq7iw"
   },
   "stable": {
    "version": [
@@ -105455,10 +106106,10 @@
  },
  {
   "ename": "plain-theme",
-  "commit": "0742da1d0fb37ebf2d66eba4533b914056399036",
-  "sha256": "0igncivhnzzirglmz451czx69cwshjkigqvqddj0a77b1cwszfw8",
+  "commit": "6f4c3e13ccb622527676b03dc23db47ff8152cb5",
+  "sha256": "1krlsb7sr1bl7rvplblkbsf41pbazp64l3d2vklxiqmdp95vv865",
   "fetcher": "github",
-  "repo": "yegortimoshenko/plain-theme",
+  "repo": "lukateras/plain-theme",
   "unstable": {
    "version": [
     20171124,
@@ -105524,28 +106175,28 @@
   "repo": "skuro/plantuml-mode",
   "unstable": {
    "version": [
-    20250705,
-    1148
+    20260514,
+    1745
    ],
    "deps": [
     "dash",
     "deflate"
    ],
-   "commit": "0a19d9988879c57b176dd4c03f59003644f9c9b0",
-   "sha256": "02nck5f8f7vlwi57kb33679d912dq2n2g9ipvkp0x9dsivz1fpi3"
+   "commit": "a4a63efa4a3980bfbd825bfb3a263c6664401e79",
+   "sha256": "18hibqf0yb8fdj3niy9l1i9j0diskg433f5jqnkg3fifm058fsf2"
   },
   "stable": {
    "version": [
     1,
-    8,
+    9,
     0
    ],
    "deps": [
     "dash",
     "deflate"
    ],
-   "commit": "0eaf340303cf65ddd20cfb65fee1137b52ea229f",
-   "sha256": "1h68bfczpvbzi29ggl3dciiz5187px14xi2sz5pywwl84sg5x2b5"
+   "commit": "7a93f7ce96cff5bd48ca4cde70d3bbf789839613",
+   "sha256": "125w8lz89wvr1micz470rvyfv1qq71xxjl0brimrbsb6ql5vrqam"
   }
  },
  {
@@ -106568,11 +107219,11 @@
   "repo": "polymode/polymode",
   "unstable": {
    "version": [
-    20260302,
-    1043
+    20260505,
+    1803
    ],
-   "commit": "4604f55cc020c75562526fb76b723e5e242c97c0",
-   "sha256": "1g36ss0ms12ah84dxdbdw0kim6wymrf2hmpsvd7lnszc19ip6zf9"
+   "commit": "8cb72fa5dcc0d98746c680043dc121edc7621e3a",
+   "sha256": "02vzq5v6kykw389lymgb5cri8h4p3rwjbwg67zkhbd1mrfa9525g"
   },
   "stable": {
    "version": [
@@ -106829,14 +107480,14 @@
   "repo": "CsBigDataHub/popterm.el",
   "unstable": {
    "version": [
-    20260423,
-    2106
+    20260621,
+    1534
    ],
    "deps": [
     "posframe"
    ],
-   "commit": "7efcca742ec9a23c2e6e627b2c1d42aa752dea5d",
-   "sha256": "0j0y4rgvrvj3kkr10qyl89nmdp7yzpqa9j1yy2bxaalsff6pbdpd"
+   "commit": "24b9f85226dde1e4fc18c5470ed2971a120d4f27",
+   "sha256": "1rxpb6mjpvra6pfby21c7222cpabi856r3n8mjkb41dvcfnas0vx"
   }
  },
  {
@@ -107126,20 +107777,20 @@
   "repo": "tumashu/posframe",
   "unstable": {
    "version": [
-    20260423,
-    213
+    20260527,
+    857
    ],
-   "commit": "fcf1757baee481f617fbf2dc39f8c561207df263",
-   "sha256": "0r6kr3b5kr34kbcic61qnjyhli9imz6n4arddf3v3c34abamgvdy"
+   "commit": "74c8c56131ed866db47ae4191364b72dd4852456",
+   "sha256": "10a6n3pgh36j3smizgh48p2bbi680dsdssz1563ijxj01cy2b0hv"
   },
   "stable": {
    "version": [
     1,
     5,
-    1
+    2
    ],
-   "commit": "4fc893c3c9ea3f6b5099ac1b369abb3c6da40b1e",
-   "sha256": "01x9kyfghx48gxh7mxfvkvvi0m64zv7w9pl4fnryzm9d5ql5lbw4"
+   "commit": "74c8c56131ed866db47ae4191364b72dd4852456",
+   "sha256": "10a6n3pgh36j3smizgh48p2bbi680dsdssz1563ijxj01cy2b0hv"
   }
  },
  {
@@ -107246,25 +107897,6 @@
    ],
    "commit": "d3dcfc57a36111d8e0b037d90c6ffce85ce071b2",
    "sha256": "1hp3xp18943n0rlggz55150020ivw8gvi1vyxkr4z8xhpwq4gaar"
-  }
- },
- {
-  "ename": "powerline-evil",
-  "commit": "c1a92c8b5b92269773d314aa6cec4f0057291a68",
-  "sha256": "1x5hvnjdrpn3c8z6m7xfk30qd5y58p3jcyqr48qx91d0109gk342",
-  "fetcher": "github",
-  "repo": "johnson-christopher/powerline-evil",
-  "unstable": {
-   "version": [
-    20190603,
-    340
-   ],
-   "deps": [
-    "evil",
-    "powerline"
-   ],
-   "commit": "b77e2cf571e9990734f2b30d826f3a362b559fd1",
-   "sha256": "1hs9jvl5lmfwr9k6qcnxjhd61zsmzq53ania1w5616gqa4qnjzhn"
   }
  },
  {
@@ -107393,8 +108025,8 @@
   "repo": "blahgeek/emacs-pr-review",
   "unstable": {
    "version": [
-    20260423,
-    953
+    20260509,
+    1433
    ],
    "deps": [
     "ghub",
@@ -107402,8 +108034,8 @@
     "magit-section",
     "markdown-mode"
    ],
-   "commit": "23dcb45979e58c971d1d9a94f0af819f5d04d583",
-   "sha256": "08gw1bb87f9rs812adfadqzccm63pm06mr7b4g0dnji1sclzfryv"
+   "commit": "938db766007f3444a2899b2457d9e2f4b4ffbebf",
+   "sha256": "0rc1phxl1hrfzj85b4fshir8lgmbzn1idwax37kkjvx42lgvw8v3"
   },
   "stable": {
    "version": [
@@ -108211,19 +108843,20 @@
   "repo": "lucius-martius/project-cmake",
   "unstable": {
    "version": [
-    20250830,
-    1304
+    20260529,
+    1744
    ],
-   "commit": "519ca5d7dd490a6b54435841c9fce3d5e3dcc140",
-   "sha256": "1dhs4irm6am24cx20bcrmnxspazm8iwv3kbb755lsx70040gx4b8"
+   "commit": "a1888d8ef6c32a8cf39e0056594179be1e9865ee",
+   "sha256": "1bs7pv2k0alh234haff7pg1j16j1jzcw53acrca99fxmvvhj33g9"
   },
   "stable": {
    "version": [
     0,
+    2,
     1
    ],
-   "commit": "4a261cef5b7ca406577d3b0eaeabfae88419edeb",
-   "sha256": "1m4pachj26gdbmwbv15d7wshay7qnmaxy6x5nzi9hnvcfhg5v7xs"
+   "commit": "e177dfff76c03fc8f589c8070c9b1a945b2f8851",
+   "sha256": "0vim9kik7pd9dml7lycdmc7q9l6i6hxgmympfk89ncqd68icmspr"
   }
  },
  {
@@ -108337,14 +108970,14 @@
   "repo": "harrybournis/project.el-rails",
   "unstable": {
    "version": [
-    20260415,
-    1855
+    20260425,
+    1314
    ],
    "deps": [
     "inflections"
    ],
-   "commit": "d066f984eb88c6d239d19adbf8025bcafe665d53",
-   "sha256": "175vsmf3zgl7qi8sa4pnhzjk0b3qr1a02pg16nlxa0ci4kx59x34"
+   "commit": "2c72764790f9f6f283f713bb72a9f4952ced690d",
+   "sha256": "0ipph4wfl74zmvpawhsqaq3x4bbwxxv1svqi9j1chf0rb0bzw99p"
   }
  },
  {
@@ -108403,26 +109036,26 @@
   "repo": "TxGVNN/project-tasks",
   "unstable": {
    "version": [
-    20241220,
-    1028
+    20260520,
+    133
    ],
    "deps": [
     "project"
    ],
-   "commit": "1faaa975c99e358165cfc3df160c21c2c611e1c3",
-   "sha256": "0wg1biic9sfsdhq1x1hkcbr396vkklhzz2f6an22amk2jc1pmfnn"
+   "commit": "a8736133dc3ee77b6002098592853ac56e5a5b40",
+   "sha256": "1rwi1y75migfg382nkahid9c4qh7f5jx8bkwmmmz5kfggjdf3cps"
   },
   "stable": {
    "version": [
     0,
     7,
-    1
+    2
    ],
    "deps": [
     "project"
    ],
-   "commit": "1faaa975c99e358165cfc3df160c21c2c611e1c3",
-   "sha256": "0wg1biic9sfsdhq1x1hkcbr396vkklhzz2f6an22amk2jc1pmfnn"
+   "commit": "a8736133dc3ee77b6002098592853ac56e5a5b40",
+   "sha256": "1rwi1y75migfg382nkahid9c4qh7f5jx8bkwmmmz5kfggjdf3cps"
   }
  },
  {
@@ -108451,14 +109084,14 @@
   "repo": "bbatsov/projectile",
   "unstable": {
    "version": [
-    20260310,
-    858
+    20260620,
+    902
    ],
    "deps": [
     "compat"
    ],
-   "commit": "f8be23b266aec7108fb4b80410623cd50ba8ded9",
-   "sha256": "1gg9mv6sz705x2lgwx4qz13wj20lcc6pv813k2h9ixdk4rxl1il4"
+   "commit": "1aebd4284f1cb83a4b434362c6356d06fa9d445b",
+   "sha256": "0bdclxazk6b0fzx4h6ildl846179j00ifqir61knd1gwyjsxzssc"
   },
   "stable": {
    "version": [
@@ -108719,8 +109352,8 @@
   "repo": "mohkale/projection",
   "unstable": {
    "version": [
-    20250927,
-    1605
+    20260614,
+    1822
    ],
    "deps": [
     "compat",
@@ -108728,8 +109361,8 @@
     "project",
     "s"
    ],
-   "commit": "482789397c5e11dbb95438c87ccd0cad3d37a33a",
-   "sha256": "0rlx9n1hmnzk46ml93g6lpv32ivmm7lfbb4mzicnapq7gly41132"
+   "commit": "870a60b26416e13a7cd37ecfd863ae730d6a13fa",
+   "sha256": "0xb46ispkmr8m46avhqx5sqbn9lcvsf7c43iigvn668xvivz4r2x"
   }
  },
  {
@@ -108759,15 +109392,15 @@
   "repo": "mohkale/projection",
   "unstable": {
    "version": [
-    20250921,
-    1037
+    20260614,
+    1822
    ],
    "deps": [
     "compile-multi",
     "projection"
    ],
-   "commit": "f4b108eeb55c79b201c140bd8fe7f1fcaffd3617",
-   "sha256": "0p9xpbc62rcf9qbcc0rf36hd0z7b6c7apnji4gxdmggmpfaxnhva"
+   "commit": "66dfa454cbd0ca356d0c5761f6ade248b612b204",
+   "sha256": "1xd9pdm0p0ips0xm11a3qswj2nbk3a1fnl186f3gkx4npfmz3x19"
   }
  },
  {
@@ -108985,11 +109618,11 @@
   "repo": "ProofGeneral/PG",
   "unstable": {
    "version": [
-    20260124,
-    1351
+    20260622,
+    1503
    ],
-   "commit": "75c13f91b6eb40b8855dfe8ac55f8f7dac876caa",
-   "sha256": "0zsvvq54q50q9zcmgxiqgks7hkzm9v740mrygvlxyb8yhrv7j4h9"
+   "commit": "38e3f59d4b650fbfb9649c84f24adbc9056ffa30",
+   "sha256": "1fgzfy6gfm4p8fafa58ismypac0lvna917dmfgwlb2bwb7n1k55v"
   },
   "stable": {
    "version": [
@@ -109097,11 +109730,11 @@
   },
   "stable": {
    "version": [
-    34,
+    35,
     1
    ],
-   "commit": "4b0c3aacf0657fbf38253b38918d3358dd4319ec",
-   "sha256": "07in860f2msc05ywh3di7d1fr6mszr2jxjh6lgm7m0kdqckib8ix"
+   "commit": "35cd01f9fe9afbeea38cc7b979a3b6bfcde82c03",
+   "sha256": "0n85mx3xq403yvavqa585lmahiac6dwlkvwvva8h9p3y6z3gs9wy"
   }
  },
  {
@@ -109621,11 +110254,11 @@
   "repo": "AmaiKinono/puni",
   "unstable": {
    "version": [
-    20260305,
-    1923
+    20260519,
+    1527
    ],
-   "commit": "fe132f803868f325cf6f162139e327b76df9e4c1",
-   "sha256": "0ffjpb0ilhcng1wwmnl1lx7h8v1z0bgsq6wb7x4x2rwsrvqjv9hm"
+   "commit": "04819e0bad5ed62af9e412ef9715b33bb1edc3ba",
+   "sha256": "0pydanhwji3jglqc4pq7ljc5ik93ycgg8c8nvzsmgw6q5anqs09g"
   }
  },
  {
@@ -109694,6 +110327,30 @@
    ],
    "commit": "f287c44f357604ec7fbf2f3ab0196dcd47056593",
    "sha256": "0lwx9j5p8ayg4px4jlfr57hv5cla1lmbxcqgagjpd73z3f8daahy"
+  }
+ },
+ {
+  "ename": "pure-light-theme",
+  "commit": "7a493d693870d0f73de1d39ae7ad22cc982b2a8c",
+  "sha256": "0rxcqj229pg4w9gf079qcgk6arp52myfd5hkig5wkd7iqdm687c6",
+  "fetcher": "github",
+  "repo": "nyrell/pure-light-eink-color",
+  "unstable": {
+   "version": [
+    20260613,
+    824
+   ],
+   "commit": "0cf41b8cb0ec95efd363889f8877d7f65514e4ad",
+   "sha256": "1cl806h6rgqnw410xqnnp7xg7cbgfdd40hh58kgxnx2b2hwh1p4v"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    1
+   ],
+   "commit": "0cf41b8cb0ec95efd363889f8877d7f65514e4ad",
+   "sha256": "1cl806h6rgqnw410xqnnp7xg7cbgfdd40hh58kgxnx2b2hwh1p4v"
   }
  },
  {
@@ -110171,8 +110828,8 @@
   "repo": "dwcoates/pygn-mode",
   "unstable": {
    "version": [
-    20241216,
-    1959
+    20260605,
+    1055
    ],
    "deps": [
     "ivy",
@@ -110181,8 +110838,8 @@
     "tree-sitter-langs",
     "uci-mode"
    ],
-   "commit": "3f1ce4efd1c34b9fc347c848eb4426bfcc851118",
-   "sha256": "0238s7dzrr0g19arah8b385bad5q1vz155f599pgwilj8cpqz7dz"
+   "commit": "6eed5ea66d37ae25c4db98ca21b164a98234b59e",
+   "sha256": "0pb7hqv7qkv2w0y3xqvcb86qb6l5fpi1927yx78xsl1gbs89z4hs"
   },
   "stable": {
    "version": [
@@ -110262,10 +110919,10 @@
  },
  {
   "ename": "pyim-cangjiedict",
-  "commit": "e5886262459d25a03839fd3a854510a7415bd241",
-  "sha256": "13lr9ms87s3b0hf97hx81lvag8kqk5pn99hnzi5nwwlj7nlf6xj4",
+  "commit": "46bd94ae4e098154d2c35a186277665c07575a30",
+  "sha256": "0cxszzyivp1g7hyyzlbcjv6h7flckv3bad3alg510va6l7nf87ym",
   "fetcher": "github",
-  "repo": "cor5corpii/pyim-cangjiedict",
+  "repo": "a5corpii/pyim-cangjiedict",
   "unstable": {
    "version": [
     20250924,
@@ -110280,10 +110937,10 @@
  },
  {
   "ename": "pyim-smzmdict",
-  "commit": "f42c59e7af89ec9a24363c1f942ef92e89d11a65",
-  "sha256": "1bl6b0zyv45wjz2fbb12a7vfb27439n2vgby6wxlya2d0pljfgk8",
+  "commit": "9c5fa988d59676fbb0cb7548d827d0425f6b3de5",
+  "sha256": "1bs7l86qngv2569881g6q88k9j2kcmn3g9nn408z28j3gaf8v4zs",
   "fetcher": "github",
-  "repo": "cor5corpii/pyim-smzmdict",
+  "repo": "a5corpii/pyim-smzmdict",
   "unstable": {
    "version": [
     20250621,
@@ -110752,11 +111409,11 @@
   "repo": "python-mode-devs/python-mode",
   "unstable": {
    "version": [
-    20260410,
-    1849
+    20260607,
+    1902
    ],
-   "commit": "c6f7bcd79d43b2a4915b75c481355601f95968a0",
-   "sha256": "09hhiwsk08c34h8v98q1s4g09byvj3r1dn18agl4x1v2528fiszk"
+   "commit": "4e2edae21655cf5d0559b1d7df23057ade20272c",
+   "sha256": "1ip3zy0jv8czygp0llclz3l7gx10q18a3gp8hhwl68l5ddv4vj5a"
   },
   "stable": {
    "version": [
@@ -110898,16 +111555,16 @@
   "repo": "wavexx/python-x.el",
   "unstable": {
    "version": [
-    20260309,
-    1727
+    20260619,
+    1406
    ],
    "deps": [
     "compat",
     "folding",
     "python"
    ],
-   "commit": "c7c1986753f112e3bf0e8f25bf74de1f422a5121",
-   "sha256": "0q9wg3brprlkkf512i8cbqpqd5bavj2cqyb3j4xgdab2amrc6w4v"
+   "commit": "548a95c42c110cd65b559416e497de20f5c21d92",
+   "sha256": "1d0mfl3z5954jm0v8fk2hkkajfzrv5j3v69ypyc21z66ysnz6qys"
   },
   "stable": {
    "version": [
@@ -111018,11 +111675,11 @@
   "repo": "psaris/q-mode",
   "unstable": {
    "version": [
-    20260418,
-    249
+    20260620,
+    531
    ],
-   "commit": "7690b9569892bf5e5f87cae290cb6a861cd1deeb",
-   "sha256": "0m9rxh51pny3cpiy4x24qqpgpfbaibdfv1yh5ckzy8hqcgkxq222"
+   "commit": "ca73cb94f8391ebfb2a60537f8c51b244cbad9d9",
+   "sha256": "06n6vf0xx61vzpmxdn1s7psanilmg30n1v8ach1za3996wmdx214"
   }
  },
  {
@@ -111371,20 +112028,20 @@
   "repo": "jamescherti/quick-sdcv.el",
   "unstable": {
    "version": [
-    20260326,
-    1610
+    20260601,
+    1608
    ],
-   "commit": "e28c59514500d61d825657fc735fbafce3599d32",
-   "sha256": "1bpgyry817zcbqilmbiiv3la11zszbvrhcy7826gif6rpyyq2wgi"
+   "commit": "f0583c0ca6a9c155ea0037c9c59e0665a884e33d",
+   "sha256": "0x0z124d4gp9d3dakxb9ghwssk3cwdh20r2xiwddgxxx77p4b5nw"
   },
   "stable": {
    "version": [
     1,
     0,
-    4
+    5
    ],
-   "commit": "43385cddb1e0cad978ac007079f33a788cc5457a",
-   "sha256": "1r881b5j207376zj73z9y54r8v0hjizh0lz8wckfsz2dhyqa00ri"
+   "commit": "f0583c0ca6a9c155ea0037c9c59e0665a884e33d",
+   "sha256": "0x0z124d4gp9d3dakxb9ghwssk3cwdh20r2xiwddgxxx77p4b5nw"
   }
  },
  {
@@ -111935,11 +112592,11 @@
   "repo": "punassuming/ranger.el",
   "unstable": {
    "version": [
-    20260201,
-    717
+    20260527,
+    2231
    ],
-   "commit": "61e7c840c52007dc17e64215fe8dbcb71139fa39",
-   "sha256": "1nyh2c6z9pp2gmcybpy5b2i1rg4d7v9v2ck8m7siagrjwfzdxqfk"
+   "commit": "cfcab21cd21eb48709fb4436ba84f3e2a048a432",
+   "sha256": "13z425h92ay1w3kkgz018ajig2ggd2lzgz76szws9vn3k57b9wzm"
   },
   "stable": {
    "version": [
@@ -111950,6 +112607,21 @@
    ],
    "commit": "584e4ae8cce1c54a44b40dd4c77fbb2f06d73ecb",
    "sha256": "01rphv92g1r0cw5bwkbrh02s0na7fjrddxx1dckk2y7qr97s7l8j"
+  }
+ },
+ {
+  "ename": "rare-words",
+  "commit": "bcedf998dbd7d11de06d4c6361863a8c594a4ae3",
+  "sha256": "1lh5q96nbrik69alj4agapmc0c8fjhxwi9dp5gvgqswgvhmxbil6",
+  "fetcher": "github",
+  "repo": "amolv06/rare-words",
+  "unstable": {
+   "version": [
+    20260401,
+    618
+   ],
+   "commit": "7e6b3e2083dd37e1a150422c648c28d3b703f185",
+   "sha256": "1982fnjpw6lqgnbkqn39q2dh52hyhakg35g2vgjn13f8a4csqdfs"
   }
  },
  {
@@ -112430,16 +113102,16 @@
   "repo": "realgud/realgud",
   "unstable": {
    "version": [
-    20260411,
-    2216
+    20260609,
+    1331
    ],
    "deps": [
     "load-relative",
     "loc-changes",
     "test-simple"
    ],
-   "commit": "34a9065d1695c3b4bfbae076440397ad24bc8faf",
-   "sha256": "1bwdmkj0imlarki09k5i1lrhk3c1rqa899zy6n8j76xpcc57jqwl"
+   "commit": "bc3fbafc190a1a38fd12459bf323ffe4dcb159af",
+   "sha256": "0y1kbmk4wyffbyzlhjn86bbvps5v4hapsmlfl35304kji24ydgia"
   },
   "stable": {
    "version": [
@@ -112906,11 +113578,14 @@
   "repo": "ideasman42/emacs-recomplete",
   "unstable": {
    "version": [
-    20260403,
-    1048
+    20260504,
+    1201
    ],
-   "commit": "c0b1a38cceb3cd65c8e6004f527eba293caafeef",
-   "sha256": "1sx0bnjnapnp9nym9hnhxc981ifg5waxiv1palgcsxm0jrazxkm7"
+   "deps": [
+    "with-command-redo"
+   ],
+   "commit": "d8e2b35a65910fee40cebee39153c1e6bc462cc1",
+   "sha256": "09kkh842ypi89l6r3qa5f1xx9985nvas22687fyv607ja4iyp9yz"
   }
  },
  {
@@ -113021,25 +113696,25 @@
   "repo": "minad/recursion-indicator",
   "unstable": {
    "version": [
-    20260322,
-    18
+    20260519,
+    1025
    ],
    "deps": [
     "compat"
    ],
-   "commit": "4805275937585102aba0047169f047032201c5b9",
-   "sha256": "0fs2xzpdj0prk8zc43biayk2yad4yyj07lq7qph1vfgv5dg308fv"
+   "commit": "eb33010866742808cabae694fa4e77b33737522e",
+   "sha256": "1i5rpzpmh50yg0vsy5049sf9xz5i5cglrpcm5fni1w1ja78qnxjd"
   },
   "stable": {
    "version": [
     1,
-    1
+    2
    ],
    "deps": [
     "compat"
    ],
-   "commit": "548838df2ef15fdd8e9d904d0a74182297e3383f",
-   "sha256": "1m9fxl405yprz0id18g7192h8sp51j07n8lc41lb3yn8vwl13g0l"
+   "commit": "eb33010866742808cabae694fa4e77b33737522e",
+   "sha256": "1i5rpzpmh50yg0vsy5049sf9xz5i5cglrpcm5fni1w1ja78qnxjd"
   }
  },
  {
@@ -113553,11 +114228,11 @@
   "repo": "ideasman42/emacs-repeat-fu",
   "unstable": {
    "version": [
-    20260403,
-    1127
+    20260617,
+    256
    ],
-   "commit": "ec9965832f4b94e635478fd6e67c29a523e2e36e",
-   "sha256": "0xymxdyj48q94zkk9igkcy8swmiad4l2rw2nwmsgrjkm0ccqmkfk"
+   "commit": "4d30d92a1fc3b5f0207866685de16cb78b83337c",
+   "sha256": "1dc3g7fagzll24ws39gwy5zl3bxmca1njky4gw5s5yb5gd40cypk"
   }
  },
  {
@@ -113988,11 +114663,11 @@
   "repo": "jjlee/rescript-mode",
   "unstable": {
    "version": [
-    20260419,
-    1929
+    20260505,
+    2042
    ],
-   "commit": "202cf1202f286b4440980e46c0a0c0a8003f7ec6",
-   "sha256": "0xfrqf61y70dl600p7pqg7fmykv5jwmis2m8r3dxgxajw84vl80j"
+   "commit": "d0ff73d8e6c9653f0baf7edbcd7e585a24dedf8d",
+   "sha256": "134ks3anl9p70f427pc0r90nrp5lxp28hqy1zcncdm1zjnxhlqwq"
   }
  },
  {
@@ -114437,11 +115112,11 @@
   "repo": "galdor/rfc-mode",
   "unstable": {
    "version": [
-    20260127,
-    1807
+    20260617,
+    1030
    ],
-   "commit": "2d3dcd649e291eeb93091560b504f96162371c32",
-   "sha256": "0hrh5b0ph39nbqxgvj69i3mcmiq2gfsxgfzydj539x3vcz8s4140"
+   "commit": "0ab3e0b5eca45e7baaea748063b8590d08b55789",
+   "sha256": "005006yz8yq7b0a0ds8k1p50in3yassds6p7jq45cwbblmchyv11"
   },
   "stable": {
    "version": [
@@ -114461,15 +115136,15 @@
   "repo": "dajva/rg.el",
   "unstable": {
    "version": [
-    20251022,
-    457
+    20260517,
+    1310
    ],
    "deps": [
     "transient",
     "wgrep"
    ],
-   "commit": "9ff6cb24bda58f481886ebaf16b524f4f9b3769c",
-   "sha256": "0yxs6szqhvkmg1ikmpykh5w2kk1jgyfvbymxp19i26pkjfrxfl52"
+   "commit": "e46a16b8bdba111c9c0036d0e209490dd7a3690f",
+   "sha256": "12niibbw7d1ncj8l6pm21wv61js9kmikphn9b7md1mpvbhz78bxy"
   },
   "stable": {
    "version": [
@@ -114749,20 +115424,20 @@
  },
  {
   "ename": "rimel",
-  "commit": "9071d1f195bcc22bbfb9c4486e5a8a5ec0d477c3",
-  "sha256": "197r8a0s0ixkkq8gh0ia23q42wgh9mxzq9pakma6wdxjljggqm5f",
+  "commit": "eb0134db6bc0f83b4b8984e354caa7efd55dda98",
+  "sha256": "0d2a780ml3c1js2521g5bcmfsrib6a88iai77y3gv41w8jzmwdnn",
   "fetcher": "github",
-  "repo": "jixiuf/rimel",
+  "repo": "emacs-rime/rimel",
   "unstable": {
    "version": [
-    20260420,
-    1036
+    20260601,
+    323
    ],
    "deps": [
     "liberime"
    ],
-   "commit": "1b7e6c7c626b36a7f80e8c388454bb4562da11e9",
-   "sha256": "00arwm2r3m80lq41ywdn0220a12ski8iwigxnr83wfh771kb2iw1"
+   "commit": "149d0094200f6781b4fffab52bec80ac6783cb8c",
+   "sha256": "11ydjchrvhblm5idn7r5ysxhaw7nxhp04vdmajnhkyfkgq57ywhd"
   },
   "stable": {
    "version": [
@@ -115231,11 +115906,11 @@
   "repo": "marcowahl/rope-read-mode",
   "unstable": {
    "version": [
-    20250428,
-    1236
+    20260610,
+    2004
    ],
-   "commit": "7cd80d6c8e4a7e24a5147c06f083d745aef91b55",
-   "sha256": "1f55x5cwc87jqhxpg7bwgr8mwv544awqf1sn6fnc7qzma8bm02pn"
+   "commit": "4270080eafa5fe5ce1d1a7ecc7ac4143a7d62a22",
+   "sha256": "123sdgbrgqsr0fdsviibhrmw5xp20g4ki2nvffd0h4p2fmrmdm89"
   },
   "stable": {
    "version": [
@@ -115328,11 +116003,11 @@
   "repo": "daichirata/emacs-rotate",
   "unstable": {
    "version": [
-    20210126,
-    637
+    20260521,
+    630
    ],
-   "commit": "4e9ac3ff800880bd9b705794ef0f7c99d72900a6",
-   "sha256": "1v4xaqfh3madrc8jcr16xzs40vvmk2ml1qwgsxkcm11l6pglmnnk"
+   "commit": "d61c7643b8dbe3fdd59f8ee40212f27bd14cfb61",
+   "sha256": "0v5jgmv78z7z5l92bfi39w36i8z29zni8cm4sbh39z97x059zljz"
   }
  },
  {
@@ -115417,15 +116092,15 @@
   "repo": "pezra/rspec-mode",
   "unstable": {
    "version": [
-    20230819,
-    154
+    20260618,
+    548
    ],
    "deps": [
     "cl-lib",
     "ruby-mode"
    ],
-   "commit": "29df3d081c6a1cbdf840cd13d45ea1c100c5bbaa",
-   "sha256": "0fyqlsj91j1fks16bx8zy0ly3mc6nk4fk2vbf0yjc2fa14hda41m"
+   "commit": "b5d48de9b56a0070d7a0d3e642b139992a1ce3f0",
+   "sha256": "067na709bbsazhpd8y22lxplh34lf0r4jf2akpqbyiai1izs9vdl"
   },
   "stable": {
    "version": [
@@ -115466,11 +116141,11 @@
   "repo": "Andersbakken/rtags",
   "unstable": {
    "version": [
-    20260303,
-    1816
+    20260504,
+    1903
    ],
-   "commit": "787fb682a13ca1c131c07ee28603cb1f2544595b",
-   "sha256": "0wcs0g588az1asdbkavac5543kglsvn0xlg8zh9jdj534q6a7n4b"
+   "commit": "2d9049adfef58961d0a710f93a8af387eb84dd01",
+   "sha256": "1a1k4rpjhp0k2255aa4myfymv3qailklgk200220yw3qn2wwcgs4"
   },
   "stable": {
    "version": [
@@ -116047,20 +116722,20 @@
   "repo": "Anoncheg/emacs-russian-calendar",
   "unstable": {
    "version": [
-    20251201,
-    1323
+    20260623,
+    1009
    ],
-   "commit": "4b250e6aeb37470a030ebddf92f9a65184f67f03",
-   "sha256": "0xcksm64fqg9bmkjp9h83rrvjnycbcyi1nqa6sk55zpyjq3gj7sb"
+   "commit": "23d222041dba8e5dad07542e0dc7dd3fc8419112",
+   "sha256": "0hwhs8qx0jp45d39zzbg7ab0nb96v6wyb86hymsahdxp32yhaing"
   },
   "stable": {
    "version": [
     0,
     1,
-    1
+    2
    ],
-   "commit": "23bc82093556a2bd045621c9964ba9162aac9937",
-   "sha256": "09609pffp0rr87xqldznjjx5f60h3l9dg266sgiciid34hl0f1m8"
+   "commit": "23d222041dba8e5dad07542e0dc7dd3fc8419112",
+   "sha256": "0hwhs8qx0jp45d39zzbg7ab0nb96v6wyb86hymsahdxp32yhaing"
   }
  },
  {
@@ -116133,11 +116808,11 @@
   "repo": "rust-lang/rust-mode",
   "unstable": {
    "version": [
-    20260416,
-    505
+    20260521,
+    745
    ],
-   "commit": "06cf08810018f54bf5246d8db155c90ab60d381f",
-   "sha256": "18khvsny09dbxbhfi3fl7dyy06n69p7xl5b84brfqcl9w8rgbcmr"
+   "commit": "ed401a65743359b8de11ee9ced0e1da39946cefd",
+   "sha256": "1srgvdg3mhgs9v4g5yan4p510gaw5mj56smy2i5lil1zzbrk0kd6"
   },
   "stable": {
    "version": [
@@ -116366,16 +117041,16 @@
   "repo": "sagemath/sage-shell-mode",
   "unstable": {
    "version": [
-    20240504,
-    726
+    20260523,
+    1504
    ],
    "deps": [
     "cl-lib",
     "deferred",
     "let-alist"
    ],
-   "commit": "4291700e981a2105d55fa56382ba25046d3d268d",
-   "sha256": "1dch7cwwslffgnzp1djlhz6a792ci42p4bvazxd9lqzhzal0rsbb"
+   "commit": "bb59cd559a9d7639d9ef16addbb0809ea4790392",
+   "sha256": "11daz4h30p74cc7rxyn12g53qgl01mfgd17d62sllip30iy1k035"
   },
   "stable": {
    "version": [
@@ -116784,25 +117459,25 @@
   "repo": "openscad/emacs-scad-mode",
   "unstable": {
    "version": [
-    20260330,
-    717
+    20260519,
+    1039
    ],
    "deps": [
     "compat"
    ],
-   "commit": "44481331536516e34940315f67fa58f99f62a589",
-   "sha256": "198m7xhyvjmqar9n7pmi7m36rvw47w2g218hkgzdkdlq55a17w32"
+   "commit": "8798dca7e919705bcbc35d4ab5639556827ccb6f",
+   "sha256": "0mqfvff8f7lqjviwz30j7vkb098xd0k8bdzznb77aw4q7gdsf8nm"
   },
   "stable": {
    "version": [
-    98,
+    99,
     0
    ],
    "deps": [
     "compat"
    ],
-   "commit": "546d1507cd131f55ca930de7ae1518884e8221f4",
-   "sha256": "19mn6z98c8s7mspa7j8xw7za33gmpsy4iw2r9xiggdv7yh6mh8h8"
+   "commit": "8798dca7e919705bcbc35d4ab5639556827ccb6f",
+   "sha256": "0mqfvff8f7lqjviwz30j7vkb098xd0k8bdzznb77aw4q7gdsf8nm"
   }
  },
  {
@@ -117521,10 +118196,10 @@
  },
  {
   "ename": "secretaria",
-  "commit": "3eeddbcf95315da40d021a6913ccf344849c4284",
-  "sha256": "04pcibzdljcfiha4yh10van8gsjrzn6bdkvkm2ahfcwrmscfn3hf",
-  "fetcher": "gitlab",
-  "repo": "shackra/secretaria",
+  "commit": "c2aa66942cf1712306f07bb15c8090ed10e50fd5",
+  "sha256": "0jlya40q1rflm75jzwr9cnlw94ggryhi1fc64dly8gjbp5zvkfvz",
+  "fetcher": "github",
+  "repo": "emacsattic/secretaria",
   "unstable": {
    "version": [
     20191128,
@@ -117690,11 +118365,11 @@
   "repo": "Kungsgeten/selected.el",
   "unstable": {
    "version": [
-    20230219,
-    1328
+    20260523,
+    1823
    ],
-   "commit": "1ca6e12f456caa1dc97c3d68597598662eb5de9a",
-   "sha256": "11xjv861mx15fhvv8g67ahri5p8mplnhq9sf30c825bk1f0h7xzy"
+   "commit": "9f5a6324e4911515972989841f143696472f2374",
+   "sha256": "00k3r89br7wqd30ka94igsbk7iqljf9ink60pbc2wkr6i5xl5hdi"
   }
  },
  {
@@ -117906,16 +118581,16 @@
   "repo": "conao3/seml-mode.el",
   "unstable": {
    "version": [
-    20230702,
-    1446
+    20260516,
+    826
    ],
    "deps": [
     "htmlize",
     "impatient-mode",
     "web-mode"
    ],
-   "commit": "23d684ac590fad6aa3c5ce3962c4683c1eb8fdb5",
-   "sha256": "1146ap0jl1n0qfn117r3iz98zm3qfwm5w0hj0gigq0cqy9c305lb"
+   "commit": "ec1efc3fb1a3d831a744bdaa0beb4ac5fcf59d2c",
+   "sha256": "0pmxglsyp2p0h1a3qmwbwnacqfrdbjfad2ja4gc49i4qz0jcp9x5"
   },
   "stable": {
    "version": [
@@ -118260,11 +118935,11 @@
   "repo": "vspinu/sesman",
   "unstable": {
    "version": [
-    20240417,
-    1723
+    20260616,
+    1239
    ],
-   "commit": "7bca68dbbab0af26a6a23be1ff5fa97f9a18e022",
-   "sha256": "1gl2dv7smyxkga4b5dflahqhasw9k15ppc4s0py29454p5k861yi"
+   "commit": "7eb733acb33e610a53979fa7fc13393eeda3cc53",
+   "sha256": "10c0djz3pqi84fynajaqkxls7j7r04xylxgfpysvlmj1jhd3f4lp"
   },
   "stable": {
    "version": [
@@ -118388,10 +119063,10 @@
  },
  {
   "ename": "sexy-theme",
-  "commit": "3c721d77616bda8bc4b7819a24698690c737c07e",
-  "sha256": "0pfnn880iyjzsr4fcrrpc65d0z5a9s4iy4bgrz7qrrjfygdni6fz",
+  "commit": "1e1e825c81265015938b1fca212b88b54982cbba",
+  "sha256": "1f2wh180smq8g6cny5yd2cnjkzam2xjykqlj7gy282rnj6bhs8gz",
   "fetcher": "github",
-  "repo": "thebigcicca/sexy-theme.el",
+  "repo": "xenodesire/sexy-theme.el",
   "unstable": {
    "version": [
     20250312,
@@ -118555,6 +119230,30 @@
   }
  },
  {
+  "ename": "shannon-max",
+  "commit": "73d14d4edcf1d456fc94b0edfa25334231eaa132",
+  "sha256": "0kyifilkk5xsimvyfwz894zwq2znycd3dwvi7qdnl3vhx7im9bck",
+  "fetcher": "github",
+  "repo": "sstraust/shannonmax",
+  "unstable": {
+   "version": [
+    20260505,
+    1426
+   ],
+   "commit": "539bd5f771b798973734696b3b0ae10f56d3966d",
+   "sha256": "0hg36vyn3lxl60jid04r61c9vwr7c3g1sniiwix86wv1ysmh6qi9"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    1
+   ],
+   "commit": "9ebeddb9e0fe4958a2347288d3860097a331a77c",
+   "sha256": "0pr14gywkpjmcsvjslqb0sxpk2r88s0sdiq67l7sxfkp9hrcszjx"
+  }
+ },
+ {
   "ename": "shanty-themes",
   "commit": "202aaca417d9e7a5a473fe4e448b13fa4ca3a444",
   "sha256": "004dgk5nqrv222jvln5mpv85asxr7khif0g1sgx2qbzq859am983",
@@ -118679,20 +119378,20 @@
   "repo": "xenodium/shell-maker",
   "unstable": {
    "version": [
-    20260330,
-    851
+    20260609,
+    1823
    ],
-   "commit": "6377cbdb49248d670170f1c8dbe045648063583e",
-   "sha256": "0v2iqvr2ywng5d22sw88k90i2jzl3cf2ybp9q6qpqirhvlsbgq19"
+   "commit": "43ee9e1862994cbaa89715d324edb7a424181f22",
+   "sha256": "0bdicj2bclx65n1lx1kwywfksbg1sd02yi03wrklbk56j82mk4ww"
   },
   "stable": {
    "version": [
     0,
-    90,
+    93,
     1
    ],
-   "commit": "38951e875c1203f1dd6d4a4a3bc57e6a7ffc066a",
-   "sha256": "06ibxnb765sjcxjv2w923cnjr9664qp2pf7w3wxdp8vrbxg1s670"
+   "commit": "43ee9e1862994cbaa89715d324edb7a424181f22",
+   "sha256": "0bdicj2bclx65n1lx1kwywfksbg1sd02yi03wrklbk56j82mk4ww"
   }
  },
  {
@@ -118703,22 +119402,19 @@
   "repo": "kyagi/shell-pop-el",
   "unstable": {
    "version": [
-    20241207,
-    1539
+    20260610,
+    2231
    ],
-   "commit": "657171f296fc930b1f335a96e6f67ae04b731b19",
-   "sha256": "1j8bwgrp4ydpd4s08px15sv5ri28zyb8zfpmfanh9k77m4hmx8cq"
+   "commit": "446b1691454e65be648dcb7e316639aa7dd73be2",
+   "sha256": "03j6kv0vhijjwb1d9rfb075d9qfbfi021prjwyx9a9jwp90z7pbr"
   },
   "stable": {
    "version": [
     0,
-    64
+    70
    ],
-   "deps": [
-    "cl-lib"
-   ],
-   "commit": "4a3a9d093ad1add792bba764c601aa28de302b34",
-   "sha256": "1ybvg048jvijcg9jjfrbllf59pswmp0fd5zwq5x6nwg5wmggplzd"
+   "commit": "29f279c36c002810b750c10326ccd7d63b3aded1",
+   "sha256": "1sdi7ckn3dcxy9kw7xz2b5z46fgjjn5mvwpqsmjh3qa6kqirlwmi"
   }
  },
  {
@@ -118934,6 +119630,33 @@
   }
  },
  {
+  "ename": "shexc-ts-mode",
+  "commit": "8d43ade341b5f0902f5e7748d325592e30178cc1",
+  "sha256": "03isnhya3hfc0l80p5m7xi6qdz83xb1zwam0yqgayc9zpal9yw0y",
+  "fetcher": "github",
+  "repo": "ericprud/shexc-mode-for-emacs",
+  "unstable": {
+   "version": [
+    20260622,
+    2327
+   ],
+   "deps": [
+    "compat",
+    "transient"
+   ],
+   "commit": "06cf27aedda3fdeb44d20b78d081a3f5d696dca6",
+   "sha256": "0kfn89sr2pv4b2c9vms5vzrp1h47afv0ndk5p5rrgv80wmfzd5fz"
+  },
+  "stable": {
+   "version": [
+    3,
+    0
+   ],
+   "commit": "485f3b3d215ad86ba36dcdca9cf9adfbeaba049b",
+   "sha256": "1jy3y3bqhg95451mhc3jkak745cnv6f4wgs8s7b2kl3lc2alga79"
+  }
+ },
+ {
   "ename": "shfmt",
   "commit": "a20dde08de1a7cd70739a791e1ae321e8f152685",
   "sha256": "1k4rr658473vd6xad2z40dl7f26sb1zv9nc1938cg61pqi10bjan",
@@ -118970,11 +119693,11 @@
   "repo": "ideasman42/emacs-shift-number",
   "unstable": {
    "version": [
-    20260103,
-    831
+    20260620,
+    1211
    ],
-   "commit": "a71f5c3c77affc27a3d0bf16886a8a3b03c05044",
-   "sha256": "03xv2y03xn08mb2hmqd5kljqa4jsfwg3l89micc6xvvkl1slimsj"
+   "commit": "d5e8bece6e6ab21ad5a93330d49b2554e9eb72a9",
+   "sha256": "139ilxbqjcf1x3x0dc9vw0jf986cr7qkc2x7fxggkcny90dwiqhi"
   },
   "stable": {
    "version": [
@@ -119142,11 +119865,11 @@
   "repo": "ideasman42/emacs-show-inactive-region",
   "unstable": {
    "version": [
-    20260410,
-    318
+    20260612,
+    949
    ],
-   "commit": "d2715aba9fb17e38651b434f0f71fa2234eb8576",
-   "sha256": "0q4qxazzvgjql6bcyv2awncgyb7f47yl738wi7ivr08hsf3k179k"
+   "commit": "c870fe641c56328458e16d92fd7aedf688844a3b",
+   "sha256": "15b6iynwxjxha86gsa1z1a8vfq346zprw39ngqv5pr834hyqyyrq"
   }
  },
  {
@@ -119496,11 +120219,11 @@
   "repo": "rain-64/sidebuf",
   "unstable": {
    "version": [
-    20260415,
-    2249
+    20260621,
+    1644
    ],
-   "commit": "89ca26d1859e89759f00065c07904d3ef5c80a4f",
-   "sha256": "19hfypy9ca0rnh66pfyzm2g93dn0q3iak4mgs8nx9vgnwsrc64sz"
+   "commit": "bac206ea46bdf8450317d29b98dfcd970aa6e85e",
+   "sha256": "0prya6sb1q35wq5ms0gq55n34ca47dwmx9735qacmfwcd0z61r9q"
   }
  },
  {
@@ -119621,16 +120344,16 @@
   "repo": "emacs-sideline/sideline-flycheck",
   "unstable": {
    "version": [
-    20260101,
-    541
+    20260514,
+    1443
    ],
    "deps": [
     "flycheck",
     "ht",
     "sideline"
    ],
-   "commit": "5a4d63210acf735829b08164897fef6a2abc8bab",
-   "sha256": "0mk7xbkhrknkc8wbkjbnsd2v12gzbrgpvwi7yzrj01dlmjqn9268"
+   "commit": "ceacbb060c382e31a47b7c7c09da0b42f4d091f5",
+   "sha256": "1z2ix4crmgxwjdrya2bzsw06jqpf1nhvnigrv5h3mz17fl6fb2lp"
   },
   "stable": {
    "version": [
@@ -119685,8 +120408,8 @@
   "repo": "emacs-sideline/sideline-lsp",
   "unstable": {
    "version": [
-    20260101,
-    542
+    20260503,
+    1235
    ],
    "deps": [
     "dash",
@@ -119695,8 +120418,8 @@
     "s",
     "sideline"
    ],
-   "commit": "dfa29a7b27e5ab64788c76544444f678ae4db18d",
-   "sha256": "027r0hfqw89pnknw1qmmgzmjixbg0dzk1vgsicnvdqgxr22lraym"
+   "commit": "393459a7a947a62eb3f1d587fe576937afefb63f",
+   "sha256": "1s4j1zmrrz6hzrksb3z334hn5xysvqqqappprpj6ywmyyfylpzqw"
   },
   "stable": {
    "version": [
@@ -119865,26 +120588,25 @@
   "repo": "skeeto/emacs-web-server",
   "unstable": {
    "version": [
-    20230821,
-    1458
+    20260623,
+    1110
    ],
    "deps": [
-    "cl-lib"
+    "compat"
    ],
-   "commit": "347c30494d3bcfc79de35e54538f92f4e4a46ecd",
-   "sha256": "1dj2w5yx2dzv6gv4iwahr3mx46dhjfaimw5yycdhb0iljr97a4lp"
+   "commit": "ceb208f96601be09397fc9e64fa96014ac1c8739",
+   "sha256": "0svqrd4a7xmxjnqdbj3sbx5glrg1b9gsr6rxy9rz5r1yz2nq1pzk"
   },
   "stable": {
    "version": [
     1,
-    5,
-    1
+    6
    ],
    "deps": [
-    "cl-lib"
+    "compat"
    ],
-   "commit": "a5eb49a6567e33586fba15dd649d63ca6e964314",
-   "sha256": "0dpn92rg813c4pq7a1vzj3znyxzp2lmvxqz6pzcqi0l2xn5r3wvb"
+   "commit": "5a9c69ae93ed5e2cdca98f51b41f6a6782091d74",
+   "sha256": "0cbidjfrrwwpj73248bw8mb1fbhh4md9awhq4x6wmjl6lkfwr8pj"
   }
  },
  {
@@ -120139,14 +120861,14 @@
   "repo": "captainflasmr/simply-annotate",
   "unstable": {
    "version": [
-    20260422,
-    1527
+    20260624,
+    534
    ],
    "deps": [
     "transient"
    ],
-   "commit": "fe7ed2ebcda0d1899f97f06191adbf260cc5b1eb",
-   "sha256": "0c3lwzcz6lcf1jdyxlln0npdlvnc3npz0743cjzkwy757wbdnlvs"
+   "commit": "ab87e4fb0c9cf7f86af7bf63103dd81988da907b",
+   "sha256": "0za13vdjrmi207zgpcwdway2faaynq99nf9f7yqymvvpgzkf8978"
   },
   "stable": {
    "version": [
@@ -120156,6 +120878,30 @@
    ],
    "commit": "0ace6e048d26e580ee02f614fde578c288c765fc",
    "sha256": "11irqfqk2rrsncaxm4dggxd639p4ljzcpvibv6g4qpvnzpdihjc8"
+  }
+ },
+ {
+  "ename": "simulacrum",
+  "commit": "c384223ee1dda500fa03fa314fdaf7b4a6da1e94",
+  "sha256": "0fxzkvm0rmjzzv4p9mavvrbr0yp6kzswzhyfh9sjah0ssxl3fgkh",
+  "fetcher": "github",
+  "repo": "ErikPrantare/simulacrum.el",
+  "unstable": {
+   "version": [
+    20260601,
+    35
+   ],
+   "commit": "ad01fcf054f9fc573b7023e2fc86566d27ae45b1",
+   "sha256": "1k06jm4v2xya267hlj516sad99swxi63i2cxdyq1kq46mx1ma40l"
+  },
+  "stable": {
+   "version": [
+    1,
+    1,
+    0
+   ],
+   "commit": "ad01fcf054f9fc573b7023e2fc86566d27ae45b1",
+   "sha256": "1k06jm4v2xya267hlj516sad99swxi63i2cxdyq1kq46mx1ma40l"
   }
  },
  {
@@ -120211,8 +120957,8 @@
   "repo": "magit/sisyphus",
   "unstable": {
    "version": [
-    20260101,
-    1900
+    20260601,
+    1544
    ],
    "deps": [
     "compat",
@@ -120221,14 +120967,14 @@
     "llama",
     "magit"
    ],
-   "commit": "7774ea7030fb7b2793eff41a8cae1e80c2ed955a",
-   "sha256": "0j8cz9gmb49x60hi0fq4swkr0nyyahda35nj7pqn9brpgiihaang"
+   "commit": "4c88989715f2c347714e9cad26b03789e2b68143",
+   "sha256": "0mpclwvygn28qk0xabz8fmjmiha4v8dk8k2z2vi5fgj8zrdmbm1k"
   },
   "stable": {
    "version": [
     0,
     4,
-    0
+    1
    ],
    "deps": [
     "compat",
@@ -120237,8 +120983,8 @@
     "llama",
     "magit"
    ],
-   "commit": "7774ea7030fb7b2793eff41a8cae1e80c2ed955a",
-   "sha256": "0j8cz9gmb49x60hi0fq4swkr0nyyahda35nj7pqn9brpgiihaang"
+   "commit": "4c88989715f2c347714e9cad26b03789e2b68143",
+   "sha256": "0mpclwvygn28qk0xabz8fmjmiha4v8dk8k2z2vi5fgj8zrdmbm1k"
   }
  },
  {
@@ -120329,9 +121075,9 @@
  },
  {
   "ename": "sketch-themes",
-  "commit": "d1b2026ff5fe7a2893dd4c71d9089e97c4fd48f1",
-  "sha256": "18n6blkrn72zyjj4ik3f6w2axmn0rwk8lpbcaynl3y7v7ij35m0r",
-  "fetcher": "github",
+  "commit": "1715bc37bd72251436041d0089c1472774c81379",
+  "sha256": "02ki700xrc87b46jpi0s2031c87dc42q9dp9yddrgv77wf0fa9xs",
+  "fetcher": "codeberg",
   "repo": "dawranliou/sketch-themes",
   "unstable": {
    "version": [
@@ -120481,8 +121227,8 @@
   "repo": "emacs-slack/emacs-slack",
   "unstable": {
    "version": [
-    20260417,
-    1053
+    20260611,
+    2247
    ],
    "deps": [
     "alert",
@@ -120494,8 +121240,32 @@
     "ts",
     "websocket"
    ],
-   "commit": "904741295a5df0e6a127cacaf60a567924bb27f3",
-   "sha256": "0n6z7p9b3n8mlwkwzv6b588lcla9d0izmrhf8p5ajlr1pf979i92"
+   "commit": "06a1fe9041e1aadf293692036ad522a6f808e2fc",
+   "sha256": "1zrwvk00mkx5xiy3an6j8mkpbikq7qiilh940k8y6304rrzc72dx"
+  }
+ },
+ {
+  "ename": "sleek-modeline",
+  "commit": "65dce69ca7a66141a74470c0c0345d7b3a960e28",
+  "sha256": "1hx3riadzdxspjshc8vasqv7dnf0hcpn5kw6l5xi6kjxix0iw6d7",
+  "fetcher": "github",
+  "repo": "abidanBrito/sleek-modeline",
+  "unstable": {
+   "version": [
+    20260622,
+    2257
+   ],
+   "commit": "882b440a816865d8db622f9722a6fb71d5ea1e27",
+   "sha256": "1v20k8gxlrzb4g4lc92mh4qjb6q66z8jjvgh44124nh0jkdags70"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "commit": "ac3335237397d01cddc4d9534e9da682e733d849",
+   "sha256": "1q3gb61h0xkdxvvpgjmf79z9raw4fwj4xd0973l03840ava4kanb"
   }
  },
  {
@@ -120553,14 +121323,14 @@
   "repo": "slime/slime",
   "unstable": {
    "version": [
-    20260421,
-    2256
+    20260612,
+    2309
    ],
    "deps": [
     "macrostep"
    ],
-   "commit": "b18fc71ab25ad8dd16e008ad6ed1ac1eb34be736",
-   "sha256": "0d27fqnbsl4ispi722b8q7bsd4n32rccm0p0hysq7q0b2ml2kg1g"
+   "commit": "b38be925a128dc3d6524121692988cb900fbcbf8",
+   "sha256": "0cby3xcpzgf07miwxpvxq0gnx3gfcyfxvjkqy1y1nl3xzizbl3yn"
   },
   "stable": {
    "version": [
@@ -120888,28 +121658,28 @@
   "repo": "mmgeorge/sly-asdf",
   "unstable": {
    "version": [
-    20221119,
-    2235
+    20260614,
+    2139
    ],
    "deps": [
     "popup",
     "sly"
    ],
-   "commit": "6f9d751469bb82530db1673c22e7437ca6c95f45",
-   "sha256": "0bxan0h12xqdsfr3bpk7n8zj7d5xvp4v3wg4fbcf2xw63j02m810"
+   "commit": "c1fa52dadb2f453243dc522203b7a883adef63fb",
+   "sha256": "090cam192hrk6xriwscbfnzkdbvrbmdncdrmxxqgv048bcnj93g0"
   },
   "stable": {
    "version": [
     0,
-    2,
+    3,
     0
    ],
    "deps": [
     "popup",
     "sly"
    ],
-   "commit": "3180921efdc19a2195960e1d601b2a6f31a6feea",
-   "sha256": "0gncp8xv33s4wx594bgd35vr1455bcggv1bg28qv75mhv41nzw97"
+   "commit": "c1fa52dadb2f453243dc522203b7a883adef63fb",
+   "sha256": "090cam192hrk6xriwscbfnzkdbvrbmdncdrmxxqgv048bcnj93g0"
   }
  },
  {
@@ -122294,11 +123064,11 @@
   "repo": "bbatsov/solarized-emacs",
   "unstable": {
    "version": [
-    20260329,
-    1559
+    20260610,
+    1943
    ],
-   "commit": "0972a0f1471ed67211b7c8918a3c049380050d7b",
-   "sha256": "17h3kncdkdnn2c64g0hlbl45yvv6vqvvy8akcgzn32iw7nlx7b9a"
+   "commit": "0d9d9efff196d8d8ee4ac606e70bf062a057136b",
+   "sha256": "12679vralilqxzdfkkylcxfj6qf74na0pakrbc4wqkqx8gak11vf"
   },
   "stable": {
    "version": [
@@ -122512,20 +123282,20 @@
   "repo": "djgoku/sops",
   "unstable": {
    "version": [
-    20251102,
-    57
+    20260518,
+    350
    ],
-   "commit": "7cce0d6800eff1e9c21ab43fffe1918bcc006e7d",
-   "sha256": "0vi7jw7zqj04ikajnssa68v6npd43bvaiw2afck25wxa9hnaja7f"
+   "commit": "95b2178a71dcbf3e69729c52cba2bc23171e059d",
+   "sha256": "01wd7qglz3z5ip9mviy92bhfvmnhfm3mwfirxrhjb9y4jxyq9da3"
   },
   "stable": {
    "version": [
     0,
-    1,
-    8
+    2,
+    0
    ],
-   "commit": "4c0eba238837b439ac23493e70255abb22653ac6",
-   "sha256": "0vi7jw7zqj04ikajnssa68v6npd43bvaiw2afck25wxa9hnaja7f"
+   "commit": "95b2178a71dcbf3e69729c52cba2bc23171e059d",
+   "sha256": "01wd7qglz3z5ip9mviy92bhfvmnhfm3mwfirxrhjb9y4jxyq9da3"
   }
  },
  {
@@ -122958,11 +123728,11 @@
   "repo": "nashamri/spacemacs-theme",
   "unstable": {
    "version": [
-    20260414,
-    2052
+    20260523,
+    1256
    ],
-   "commit": "789d20c55cd01f757929d0232dd1d5227c84ad7e",
-   "sha256": "0zxydjg954kaqsc5xi4yzr0b78nk4mxvbl5ch4yw6zv15h99n68i"
+   "commit": "cbd290dfde96f53a7b41730c7840850a8a7b8a02",
+   "sha256": "07a15mx6p1s3dpbqplv24p7blqvdcr8b92g9ds60za6p25yrfmgs"
   },
   "stable": {
    "version": [
@@ -123110,11 +123880,11 @@
   "repo": "ideasman42/emacs-spatial-navigate",
   "unstable": {
    "version": [
-    20260420,
-    428
+    20260614,
+    1125
    ],
-   "commit": "764cf2ea5ded501493bfd543c5a290b8cda847d5",
-   "sha256": "0dqa4lfw8kmnpnmf62s5p0z6y15k26c5y7vfqcv32apqzynqvkva"
+   "commit": "8b3e31be5a16657dc875d3ea248f907c75f8244f",
+   "sha256": "0mg7vllcyjwq3v34fdrfc902riap6aiphqpwa8dz2f1zhsvc55jf"
   }
  },
  {
@@ -123155,11 +123925,11 @@
   "repo": "condy0919/spdx.el",
   "unstable": {
    "version": [
-    20260424,
-    159
+    20260529,
+    230
    ],
-   "commit": "2cc92e11cc1b6007d8ffdd18c541e9ac126664ed",
-   "sha256": "01qk8zkm9kla42dabpjh04s2p8zmx7qfh27i7h5i5as0d4b3wgkh"
+   "commit": "f67824080cb48b4e54c3930319a3ed944f6a5c66",
+   "sha256": "113k0ljwmqdwcaqp3xq7qxy1m7dgjrxabycby8iz7ysdcymcfx9b"
   }
  },
  {
@@ -123220,14 +123990,14 @@
   "repo": "dakra/speed-type",
   "unstable": {
    "version": [
-    20260330,
-    1430
+    20260611,
+    1554
    ],
    "deps": [
     "compat"
    ],
-   "commit": "f349c000c4d9541cc0e9dcf072555c7f4c9f9a46",
-   "sha256": "0y2vi01agwwjgklxsfaf1hh9q1mnn82s2rnkkmqnqrycpa0p1wzk"
+   "commit": "f004cce95e0f5c5048d38f973b654587ed73abf6",
+   "sha256": "1a1fmnlkgrya86hw9alccfjhldg5lx1bbffvlhk5hqkgsm1dx627"
   },
   "stable": {
    "version": [
@@ -123294,11 +124064,11 @@
   "repo": "ideasman42/emacs-spell-fu",
   "unstable": {
    "version": [
-    20260108,
-    1336
+    20260524,
+    636
    ],
-   "commit": "94686051261a065574fc6535979f8ff08a37f0ee",
-   "sha256": "1gbyx1w0k1jwngp22qm7yl1wg82ciybnarcm3frqch7b472dpr7h"
+   "commit": "103c4aaf0d2ec452359e087bed50504e2bdf4661",
+   "sha256": "1hm396yhh62k95n8r0kw5jxnbfzx5i3d56sj51p7xb02ayccwv8l"
   }
  },
  {
@@ -123682,6 +124452,21 @@
   }
  },
  {
+  "ename": "sql-bigquery",
+  "commit": "c1d99b61ec22c5a86e5264c317cb39d845d45a67",
+  "sha256": "09gmia1vibh6k50wbh0w4hj8mrz4yzczgsyqjmd0rlqwlc6jsvp7",
+  "fetcher": "github",
+  "repo": "regadas/sql-bigquery",
+  "unstable": {
+   "version": [
+    20260502,
+    1517
+   ],
+   "commit": "1d068f7a7226d7af70d4ffceb86bc5e91826c29e",
+   "sha256": "0mjnv0llz818vq3j3rz7k4gya1jhmk0ppfdcf0v8i0lxp331awjs"
+  }
+ },
+ {
   "ename": "sql-clickhouse",
   "commit": "cdd1f8002636bf02c7a3d3d0a075758972eaf228",
   "sha256": "1sxh22dl0px81z85dj9r97nj8pnc6g9ah06q1bgf3bii7yl6qdy8",
@@ -123948,11 +124733,11 @@
   "repo": "srfi-explorations/emacs-srfi",
   "unstable": {
    "version": [
-    20260403,
-    411
+    20260623,
+    2303
    ],
-   "commit": "272df3cae401da0853dc50344500b522f96a9286",
-   "sha256": "1rbisgin3vs2yicyxs0acf6j59hzrr14vddv89vf223r40ipgwqp"
+   "commit": "cf83bdcfabfb06e0171f5f7a83d56d5fea72fd84",
+   "sha256": "0l9gk0i1p3cbrc6hi0w8cl9r5831qnqvr382ldqiyp8b7mdj3jv2"
   },
   "stable": {
    "version": [
@@ -124259,26 +125044,26 @@
   "repo": "draxil/starling-el",
   "unstable": {
    "version": [
-    20251029,
-    707
+    20260427,
+    1351
    ],
    "deps": [
     "plz"
    ],
-   "commit": "298186dc003052051cbcac08b270afb2b1f4f2b9",
-   "sha256": "01s7bkn8hr5j4ynk4lclc4269p1dr0l3zl5hlpc047ln32b2gfjb"
+   "commit": "9a5f3003d40a9c6bd64b5cf396973c4922006e4d",
+   "sha256": "0ns4f6nj80bygyizisabj6d25dpd3y98a1ni9flm0gk2q03hwh43"
   },
   "stable": {
    "version": [
     0,
     1,
-    4
+    5
    ],
    "deps": [
     "plz"
    ],
-   "commit": "e6fae24f889d886f3d02cafee0a6067d35576378",
-   "sha256": "1igmjvzjlbvv543laqajd5i08dzabd4dv3p9fvg7r3znk17fl2bq"
+   "commit": "9a5f3003d40a9c6bd64b5cf396973c4922006e4d",
+   "sha256": "0ns4f6nj80bygyizisabj6d25dpd3y98a1ni9flm0gk2q03hwh43"
   }
  },
  {
@@ -124448,20 +125233,20 @@
   "repo": "stacked-git/stgit",
   "unstable": {
    "version": [
-    20251110,
-    503
+    20260622,
+    407
    ],
-   "commit": "020140581698f62d846c995ee6e3bebe0c20ff14",
-   "sha256": "0r9canxbj30anga9mbhym87jdrxcd0xp4d7a3lfhrrbmig5z2pff"
+   "commit": "faa026a62a423762b9821d332aa0f13d59b339e0",
+   "sha256": "08hw37c1l4lrfkpch4vk1z6zcgvf89pkm7wsad51lhnkkaqrf7cr"
   },
   "stable": {
    "version": [
     2,
-    5,
-    5
+    6,
+    1
    ],
-   "commit": "020140581698f62d846c995ee6e3bebe0c20ff14",
-   "sha256": "0r9canxbj30anga9mbhym87jdrxcd0xp4d7a3lfhrrbmig5z2pff"
+   "commit": "faa026a62a423762b9821d332aa0f13d59b339e0",
+   "sha256": "08hw37c1l4lrfkpch4vk1z6zcgvf89pkm7wsad51lhnkkaqrf7cr"
   }
  },
  {
@@ -124829,20 +125614,20 @@
   "repo": "jamescherti/stripspace.el",
   "unstable": {
    "version": [
-    20260422,
-    1404
+    20260604,
+    232
    ],
-   "commit": "5dd864613dc2743d0970684de7c8c01a431f1ffa",
-   "sha256": "0l1rkgj5m0cka1y2qnxhisy8sx6qldw66k0bdrf1nib9dxfw3cyn"
+   "commit": "c8a53e2bce4347f5d6d8ae8d3050e3bbf3f96562",
+   "sha256": "1yfc0fwzpfi08p50ymmi3g8s947hdzdf42g0kic519rp4g9bd5cg"
   },
   "stable": {
    "version": [
     1,
     0,
-    4
+    5
    ],
-   "commit": "e77dadb7ad15e8eeff8c874118f8ce461b70dd44",
-   "sha256": "0vh45vhk873mqg2m9f6ym7n19r9d9wndd9zdr0g000qdbvmrmn9v"
+   "commit": "c8a53e2bce4347f5d6d8ae8d3050e3bbf3f96562",
+   "sha256": "1yfc0fwzpfi08p50ymmi3g8s947hdzdf42g0kic519rp4g9bd5cg"
   }
  },
  {
@@ -125238,8 +126023,8 @@
   "repo": "kiyoka/Sumibi",
   "unstable": {
    "version": [
-    20260417,
-    1157
+    20260612,
+    324
    ],
    "deps": [
     "deferred",
@@ -125247,13 +126032,13 @@
     "popup",
     "unicode-escape"
    ],
-   "commit": "366cf1a2a9f408cc34c1412a4b06dfe01f46d97f",
-   "sha256": "0z6g97975y2vchr2bkks4v18pk9zlcpgrffm53f4jvqjgp7pdxas"
+   "commit": "f5674b69135a49aa3d531d148609942e0b09913b",
+   "sha256": "0m2v9wj9yvrkifg953p1w7gm7hgdav4jrs4g6vsp8l3jxfac6grj"
   },
   "stable": {
    "version": [
     6,
-    0,
+    1,
     0
    ],
    "deps": [
@@ -125262,8 +126047,8 @@
     "popup",
     "unicode-escape"
    ],
-   "commit": "e52bd87416458bd8bb920b33fac9afdee27140d5",
-   "sha256": "0zbpycvymqhjx8jrfq9rszl9yyvjjk35a2fkd45ghg7kfcqhlsk3"
+   "commit": "de689010700597076adad241411a19255cfcdc6d",
+   "sha256": "1fjlx9rzzvjm7jj0m9mrryzsfhii5hbja392z3sgrbd697abaw9i"
   }
  },
  {
@@ -125358,21 +126143,6 @@
    ],
    "commit": "c7bcc9d9ce048995b9bb4216069e07209c13aa05",
    "sha256": "08mvmp87bx5blpc8l89dwxs7kcz9vql1mlzj7jr1hfh9ds1vd602"
-  }
- },
- {
-  "ename": "supergenpass",
-  "commit": "091dcc3775ec2137cb61d66df4e72aca4900897a",
-  "sha256": "0ldy6j6l6rf72w0hl195rdnrabml2a5k91200s186k0r5aja4b95",
-  "fetcher": "github",
-  "repo": "ober/sgpass",
-  "unstable": {
-   "version": [
-    20130329,
-    548
-   ],
-   "commit": "549072ef7b5b82913cadd4758e8a0a9926f0a04a",
-   "sha256": "0m02snzka243adhwwgriml133n4312lhdia3wdqjcq8y2mlp3331"
   }
  },
  {
@@ -125771,23 +126541,20 @@
   "repo": "swift-emacs/swift-mode",
   "unstable": {
    "version": [
-    20251122,
-    857
+    20260510,
+    616
    ],
-   "commit": "cfae3b85ad09bd293df941261afbc21e41bbb5f8",
-   "sha256": "11jwdk5h3mmsmfzllqfrh11v2p96fpiswf2aahg8hr80zqk4p6nb"
+   "commit": "a4c54629ba946cf009631e25a11618e886e7b25d",
+   "sha256": "1isw98pz3kar0zffjqhfgs8l850n05ikxpnmnm7xa1r0634hlbz7"
   },
   "stable": {
    "version": [
-    9,
-    4,
+    10,
+    0,
     0
    ],
-   "deps": [
-    "seq"
-   ],
-   "commit": "fc7df7bd906a2bb04aac6e0de47fc7acf33ceed3",
-   "sha256": "1z9ybkjwbdayk8yfclwp0irfy0mn15p6m1mfvv4vrn6ami2wvrsv"
+   "commit": "bf56866b98de2fd73029da2bca1035ca02f9e879",
+   "sha256": "01rn7g6xbalayx335jsvlb8kkab0p61g60fwn1h49pfi0kv2n9kx"
   }
  },
  {
@@ -126490,6 +127257,21 @@
   }
  },
  {
+  "ename": "sysml-mode",
+  "commit": "de274a2c8c5bfc0e22949c5c3e409ddf34f32cb0",
+  "sha256": "0vbkkdqcs2b5y5nmgqi99k6wjy6ax1r65qmz3a4wsm4916h4d1kx",
+  "fetcher": "github",
+  "repo": "DeciSym/sysml-mode",
+  "unstable": {
+   "version": [
+    20260528,
+    1759
+   ],
+   "commit": "e8ff9eea7f8f5d18e6a74a48411a1b8e39dd0916",
+   "sha256": "0j32ivr2lnwdpg1am4y84by844svns8cvixgjc7j4qgkrndvpmfy"
+  }
+ },
+ {
   "ename": "system-idle",
   "commit": "d3c041dafd99718beccfe4153b34b7ac8a6848ea",
   "sha256": "1ikqqzlv23rfd9v91ncafag2gmzdywn1x67csawx4ygdm6fyf8gr",
@@ -126611,11 +127393,11 @@
   "repo": "ajrosen/tab-bar-buffers",
   "unstable": {
    "version": [
-    20240227,
-    2037
+    20260511,
+    1927
    ],
-   "commit": "08a3f39c0b1673e3cad34e1f0e83fb56c903586c",
-   "sha256": "0rgxwyjkhlhzr4nbbjy08l4z26cic9dw4rhlkpkv9s51wxxnhaw8"
+   "commit": "12f52b896eedd7a871df4ef985430b53bcd6c08b",
+   "sha256": "0ygyn053gmlbqbmrg8900gk0xv35rydp1x0farw9vz7rzdh18ami"
   }
  },
  {
@@ -126780,8 +127562,8 @@
   "repo": "mattfidler/tabbar-ruler.el",
   "unstable": {
    "version": [
-    20260417,
-    2349
+    20260426,
+    1441
    ],
    "deps": [
     "cl-lib",
@@ -126789,8 +127571,8 @@
     "powerline",
     "tabbar"
    ],
-   "commit": "2b72193e4fa9665236ec5dd17c47d0cf91ccc977",
-   "sha256": "04y6yrgqvap4gkn0c1py8qx1vp9gpnhs5xaf82qb1ak903hwwms4"
+   "commit": "306fc4f8e450704c68fca23791cfa50f2f9f99db",
+   "sha256": "1akycy81cl2lxgz7fqcmiv7lj0rvz06ym72ck2r1gpwz7iydhy1a"
   },
   "stable": {
    "version": [
@@ -126875,19 +127657,19 @@
   "repo": "emacsorphanage/tablist",
   "unstable": {
    "version": [
-    20231019,
-    1126
+    20260623,
+    1855
    ],
-   "commit": "fcd37147121fabdf003a70279cf86fbe08cfac6f",
-   "sha256": "1n1isr98xsc66n8ax0lcld2p80rr3b9s0pnh0jllhvmbkkb88xzi"
+   "commit": "01f065e387ffe6b7a41f180f257cd12551c7a9c2",
+   "sha256": "0nc6dw9p420kf3c6wbi0fl31sm9q9357dnx3wyphj0r6162f3fvb"
   },
   "stable": {
    "version": [
     1,
-    1
+    3
    ],
-   "commit": "5f7b71a92bfb25418d7da86ad9c45f14b149496f",
-   "sha256": "11vmvrhmsxy97bfj7jndpc58bik7177i3wvc45mlyldxwyirs962"
+   "commit": "01f065e387ffe6b7a41f180f257cd12551c7a9c2",
+   "sha256": "0nc6dw9p420kf3c6wbi0fl31sm9q9357dnx3wyphj0r6162f3fvb"
   }
  },
  {
@@ -126930,20 +127712,20 @@
  },
  {
   "ename": "tabspaces",
-  "commit": "d0adcadc4cf81da6e1a7ec7c65ba510ff2f8f45c",
-  "sha256": "0aq9vqs5ixp78ppagzgw1jcjbvfafj6gz4a8jd438l7cd6ngsq6a",
-  "fetcher": "github",
+  "commit": "c333f3b3397a05eb38df3b631fbc1dc1ef87e622",
+  "sha256": "0lzbg0abxfa5cr7g76mq3ykxcq1an9wvrb2wjbx1brhk5ns69ix6",
+  "fetcher": "codeberg",
   "repo": "mclear-tools/tabspaces",
   "unstable": {
    "version": [
-    20260222,
-    1958
+    20260529,
+    1452
    ],
    "deps": [
     "project"
    ],
-   "commit": "06fe5ad149bc5852698cd0adda6dd6e320b4cf8f",
-   "sha256": "180gzqjmmin35b7lj93pgrakh0b5wq10q232y5zfhibsmsnxayhi"
+   "commit": "d3a74c0d39a0029d956dc37ddbf540802fb76973",
+   "sha256": "1hgsg01l17l61g3ky6r7c6579bm9j1hm93chdajfnlzcpaz4b9p1"
   }
  },
  {
@@ -127058,11 +127840,11 @@
   "repo": "tmalsburg/tango-plus-theme",
   "unstable": {
    "version": [
-    20250813,
-    1242
+    20260615,
+    1520
    ],
-   "commit": "6c57ae3745ab66c75d4ebb336d3403d90537206a",
-   "sha256": "1apvwc5v27dq4mjv0rk5yqs0pgxmd6ar3jgxdb2488lws2z08xdq"
+   "commit": "e9be23b05e39591e0740c1a837a9f093a0e14419",
+   "sha256": "0knxfnzirf2630hv8bcvqmp3cy8r41inf3m630bq4wzlvxnhp4sb"
   }
  },
  {
@@ -127151,20 +127933,20 @@
   "repo": "devrintalen/taskjuggler-mode.el",
   "unstable": {
    "version": [
-    20260423,
-    1854
+    20260506,
+    137
    ],
-   "commit": "49d3cdf2dbf4c27e037bb4c96bb0cc6d2e000fab",
-   "sha256": "1v5hln35qwy97qnc7nrql3mr53j8q2zkadnf49mw9zdw5psl383b"
+   "commit": "e68d9e6d50c848b1a20b75af3ac1ddda95c9fe3e",
+   "sha256": "04lbsqvc4sjh30q872srafq4x551vmi1z5ffzcb7fzvg884afz0i"
   },
   "stable": {
    "version": [
     0,
-    5,
-    2
+    6,
+    0
    ],
-   "commit": "9a43c9dcf36b52d302d41aeaf6ad62aa6776a966",
-   "sha256": "1qj57mk2qz9wwihj5jlgx4ngf4b33n581cpwvpmbidi6rj1dwb77"
+   "commit": "e68d9e6d50c848b1a20b75af3ac1ddda95c9fe3e",
+   "sha256": "04lbsqvc4sjh30q872srafq4x551vmi1z5ffzcb7fzvg884afz0i"
   }
  },
  {
@@ -127175,11 +127957,11 @@
   "repo": "saf-dmitry/taskpaper-mode",
   "unstable": {
    "version": [
-    20260414,
-    1851
+    20260517,
+    1410
    ],
-   "commit": "809c15fe893bb4ffa17bf515908a37c97e74afb9",
-   "sha256": "1gd3ip106zdwqhk39jsj2xhsn0c6wa65g6navkiy6z3gb95gs3ha"
+   "commit": "93a3c5fc3dde0c32f7a3b2ad313cb00d5660c5df",
+   "sha256": "0sq3mm4hf5sfmaqxnk37qd4w0d2bysm62nvi7fkkx13z0z8haai1"
   },
   "stable": {
    "version": [
@@ -127217,26 +127999,26 @@
   "repo": "phillord/tawny-owl",
   "unstable": {
    "version": [
-    20241104,
-    1432
+    20260508,
+    848
    ],
    "deps": [
     "cider"
    ],
-   "commit": "0baa9c3e9aea40bcf9c11c9a009f0e26efbc366f",
-   "sha256": "1rn0lmn0pcsyvh55kfv1afhwmgxyks8knlmncj95a53ydra0qriv"
+   "commit": "5366ed3d12e7272e7a404040d7199b0a560f25a8",
+   "sha256": "1kil0q6bc94551xs2x7z0wwk1yclqfdnf61hv1afrslm8p36z8q0"
   },
   "stable": {
    "version": [
-    2,
     3,
-    3
+    0,
+    0
    ],
    "deps": [
     "cider"
    ],
-   "commit": "b2708d693400a2010370df040d7571bc30fa4d75",
-   "sha256": "02p8gw7pzawzq2zzkgfx8wpp4l4zlz9zyw0f298yqrwp2zsrw5fx"
+   "commit": "5366ed3d12e7272e7a404040d7199b0a560f25a8",
+   "sha256": "1kil0q6bc94551xs2x7z0wwk1yclqfdnf61hv1afrslm8p36z8q0"
   }
  },
  {
@@ -127381,15 +128163,15 @@
   "repo": "zevlg/telega.el",
   "unstable": {
    "version": [
-    20260416,
-    546
+    20260624,
+    630
    ],
    "deps": [
     "transient",
     "visual-fill-column"
    ],
-   "commit": "5196e752b1dae4367d446a3fcc6169e6a7533093",
-   "sha256": "1l6lsbzha40nvbwiaqiva96vp5iyjjqls761ggzfl3bkrslk53vq"
+   "commit": "7cef62c2e7b9cca9467fe9da80544d0210d9c6e1",
+   "sha256": "108cgzqq7ccg8msydmbi30sy9w7ipp4lb189q7p7r1iwpf38nb15"
   },
   "stable": {
    "version": [
@@ -127520,25 +128302,25 @@
   "repo": "minad/tempel",
   "unstable": {
    "version": [
-    20260309,
-    1547
+    20260609,
+    1545
    ],
    "deps": [
     "compat"
    ],
-   "commit": "add72000e580aaf80e64195412747181fc95d231",
-   "sha256": "0183qyb9cvjkav0v7q3s64gza5yxjd806j9yn0scbxhr1d1pz0lw"
+   "commit": "0cfeac15a3c92373d41a743d00a5cb9368eaa006",
+   "sha256": "1kb873jr7664mb9i0k8y2x9akywnic3j2pk0sj9rxychzpb9f3p6"
   },
   "stable": {
    "version": [
     1,
-    12
+    13
    ],
    "deps": [
     "compat"
    ],
-   "commit": "add72000e580aaf80e64195412747181fc95d231",
-   "sha256": "0183qyb9cvjkav0v7q3s64gza5yxjd806j9yn0scbxhr1d1pz0lw"
+   "commit": "ab6d67c2e8abcb9bd20bfe56cba930a5ea093ae0",
+   "sha256": "0pn9a7rl8mqyyy63r284afjv26kqj8qk2v2sk7nkvcb3d98l8qr6"
   }
  },
  {
@@ -127549,14 +128331,14 @@
   "repo": "Crandel/tempel-collection",
   "unstable": {
    "version": [
-    20260227,
-    1133
+    20260516,
+    1317
    ],
    "deps": [
     "tempel"
    ],
-   "commit": "6292604c1d5ed0044ce0beb2d46c73697dc66ed3",
-   "sha256": "1nbffii5n07928kahc4cgkfb7f434rld9vm9l9n6h0xxb1vldzwj"
+   "commit": "4ea6f92ecb69dc38c666bfa6c4a253ff94699c80",
+   "sha256": "1gvw02sfnvsfi32fqw13hxb9kwkpag195kils9rlxyq3r23pp07c"
   }
  },
  {
@@ -127820,27 +128602,27 @@
   "repo": "calliecameron/term-cmd",
   "unstable": {
    "version": [
-    20260117,
-    1350
+    20260510,
+    1834
    ],
    "deps": [
     "dash",
     "f"
    ],
-   "commit": "0596a96b0e5a4e8a5f828951fb6e2c1af03914c8",
-   "sha256": "1fiwz43zvjx8wlzjs68lhgwjd6bywsk8pnnhc120rs7v88d6qygg"
+   "commit": "15f737427b21adc722a76a71c0aaeb2dcb95efbc",
+   "sha256": "1n1hj0xkr8ws78flcfmwn3qgvz0yvwg4705nwafysq3w29ddnlr4"
   },
   "stable": {
    "version": [
     1,
-    3
+    4
    ],
    "deps": [
     "dash",
     "f"
    ],
-   "commit": "0596a96b0e5a4e8a5f828951fb6e2c1af03914c8",
-   "sha256": "1fiwz43zvjx8wlzjs68lhgwjd6bywsk8pnnhc120rs7v88d6qygg"
+   "commit": "15f737427b21adc722a76a71c0aaeb2dcb95efbc",
+   "sha256": "1n1hj0xkr8ws78flcfmwn3qgvz0yvwg4705nwafysq3w29ddnlr4"
   }
  },
  {
@@ -128031,20 +128813,20 @@
   "repo": "milanglacier/termint.el",
   "unstable": {
    "version": [
-    20260412,
-    348
+    20260517,
+    2050
    ],
-   "commit": "689549245bb6dc0429d8af06c4830c92b09f4667",
-   "sha256": "1ggxqb9b7kv32rns9gagggmq0fsj9a8i3jkhqhfwz0c75fv05jlw"
+   "commit": "f51ab6c4ef50eb8781560d3596335a6f7f668c7c",
+   "sha256": "0wdyv7spafhj5d2y6xwdnm0dd5xv4bnaa9pc2wr6pz1q4x1r8qws"
   },
   "stable": {
    "version": [
     0,
     2,
-    2
+    3
    ],
-   "commit": "689549245bb6dc0429d8af06c4830c92b09f4667",
-   "sha256": "1ggxqb9b7kv32rns9gagggmq0fsj9a8i3jkhqhfwz0c75fv05jlw"
+   "commit": "f51ab6c4ef50eb8781560d3596335a6f7f668c7c",
+   "sha256": "0wdyv7spafhj5d2y6xwdnm0dd5xv4bnaa9pc2wr6pz1q4x1r8qws"
   }
  },
  {
@@ -128055,15 +128837,15 @@
   "repo": "ternjs/tern",
   "unstable": {
    "version": [
-    20191227,
-    950
+    20260514,
+    1348
    ],
    "deps": [
     "cl-lib",
     "json"
    ],
-   "commit": "0d19800db70a6348c627a69f444b91d21ad89629",
-   "sha256": "0ydrxxc3lgs8mpg577iw5sfxgyqfbdkrghwxmv8sxf6sawvhx8zv"
+   "commit": "fab80daebd798b233a9a40d5a8b99359ace63b5e",
+   "sha256": "10fh2hkiha7y0qviw7anfiw4qfv4aajqj342sp9l4q776v8gzdx8"
   },
   "stable": {
    "version": [
@@ -128614,11 +129396,11 @@
   "repo": "monkeyjunglejuice/matrix-emacs-theme",
   "unstable": {
    "version": [
-    20251103,
-    1021
+    20260615,
+    1213
    ],
-   "commit": "ff0d3ba077d7d48c46a00b724de8eb4ce163fab9",
-   "sha256": "0bnflam6hsayh2kcjd0bydsyj64d33gcjj7w7gj3y8x0h68n89hj"
+   "commit": "fe0b8776191744359767ecc4113dda1ade4a5adb",
+   "sha256": "0yyd4z2acz48h3d6j6d7kbb4kacqhy5b47vrbsw4xnvmzyjfsiik"
   }
  },
  {
@@ -128847,21 +129629,21 @@
   "repo": "facebook/fbthrift",
   "unstable": {
    "version": [
-    20260420,
-    1434
+    20260622,
+    1358
    ],
-   "commit": "075dc1f32336878453b628373e8e0b29775a60d3",
-   "sha256": "08l5hjwyfb4fm8zyp5im66r2mzbd72kz7z3ircsxzzf1zwaznn6f"
+   "commit": "72ab4f622ea110381e11f8a9981d863e5cbe5735",
+   "sha256": "1y3993xznrsmqwy3jsnjv4l2cmcwbk2n310y7h9pf6m9pwbwla1d"
   },
   "stable": {
    "version": [
     2026,
-    4,
-    20,
+    6,
+    22,
     0
    ],
-   "commit": "075dc1f32336878453b628373e8e0b29775a60d3",
-   "sha256": "08l5hjwyfb4fm8zyp5im66r2mzbd72kz7z3ircsxzzf1zwaznn6f"
+   "commit": "72ab4f622ea110381e11f8a9981d863e5cbe5735",
+   "sha256": "1y3993xznrsmqwy3jsnjv4l2cmcwbk2n310y7h9pf6m9pwbwla1d"
   }
  },
  {
@@ -128943,26 +129725,26 @@
   "repo": "uzu/tidal",
   "unstable": {
    "version": [
-    20260109,
-    1704
+    20260607,
+    1559
    ],
    "deps": [
     "haskell-mode"
    ],
-   "commit": "4e444a2d5118d67a0ef7a588a2b783b39d9b1357",
-   "sha256": "0yfv1pl8i256j7zy28af7x9yjgxk4bxmkbnh4j6s6bw3mfc2hx4w"
+   "commit": "864b8cc18efc2e999e65e676a5ec1670dbd186e9",
+   "sha256": "1jflb3jqq6jafnvdj810zi37iznihf38i29y2br3pxjfwwv5265s"
   },
   "stable": {
    "version": [
     1,
     10,
-    1
+    2
    ],
    "deps": [
     "haskell-mode"
    ],
-   "commit": "660ac746ec5c89da7ead100c0c46bf67e4037f41",
-   "sha256": "05xf1ifd24afqmxfs9kkhkc1m9sc2cs9q9xkyym6r3bywgi5zs4j"
+   "commit": "864b8cc18efc2e999e65e676a5ec1670dbd186e9",
+   "sha256": "1jflb3jqq6jafnvdj810zi37iznihf38i29y2br3pxjfwwv5265s"
   }
  },
  {
@@ -129074,11 +129856,19 @@
   "repo": "ctanas/tiles",
   "unstable": {
    "version": [
-    20260412,
-    1929
+    20260603,
+    1458
    ],
-   "commit": "149a5015b3d2a2ebdd15660cab9c736549af7532",
-   "sha256": "19fmzw46vyfz6kz4ksmm5w4c6vmkyjacsqznbf0d8d9qsmy1nyf8"
+   "commit": "754b11764f8204ff1fce6d3aa80eca2150a8a164",
+   "sha256": "0mmw3slsndfq2jrlmfl6aly018jz4ycyhg7rizc0igl0jpcg8acg"
+  },
+  "stable": {
+   "version": [
+    0,
+    5
+   ],
+   "commit": "15fa6fa0f2b44b0db0110862b609a42aabb8bb40",
+   "sha256": "1xjzbwddwlaf0dwf3ql4ljwr8sg3anrpgnlsz6zfi2bnhggl4v8z"
   }
  },
  {
@@ -129149,11 +129939,11 @@
   "repo": "xenodium/time-zones",
   "unstable": {
    "version": [
-    20260211,
-    2330
+    20260518,
+    1503
    ],
-   "commit": "9f1326ad9e62daa242a5174b193a27b28e209b36",
-   "sha256": "0wcbbxa6wsb08d76g4fyf4yblpx8rx8q96l2rhchk2jmrxl10rvz"
+   "commit": "4ec11f912d8af920d021c6189e59ab74fd404a2d",
+   "sha256": "0b12ql9l2xp2ab83d0s1bvidw8hmcrym3xdpjxi92lyslkg8gcaa"
   },
   "stable": {
    "version": [
@@ -129191,19 +129981,20 @@
   "repo": "karthink/timeout",
   "unstable": {
    "version": [
-    20251210,
-    758
+    20260504,
+    2312
    ],
-   "commit": "a5e661de4d3c1d5ac25c449011fe99059fc55920",
-   "sha256": "1lp57mfsvngx20sxvq0v0hmxqy705glya93yffk5q4r5vn946dx8"
+   "commit": "b1212984709c4b50c509ef6d3bd959951e5dcc91",
+   "sha256": "1h5z7gxl2q6dlcy9zj9f9iqlahqk30lqkw5ym3i89mm6m80h9731"
   },
   "stable": {
    "version": [
     2,
-    1
+    1,
+    7
    ],
-   "commit": "6d31046c5b1817271a52ab810e5bc635fe7ab3b4",
-   "sha256": "16hzgdm5pq5qwg7w64w1q8kkwv1r9967bpcashcnm7pcwgk7bavk"
+   "commit": "b1212984709c4b50c509ef6d3bd959951e5dcc91",
+   "sha256": "1h5z7gxl2q6dlcy9zj9f9iqlahqk30lqkw5ym3i89mm6m80h9731"
   }
  },
  {
@@ -129572,11 +130363,11 @@
   "repo": "acdw/titlecase.el",
   "unstable": {
    "version": [
-    20230714,
-    323
+    20260622,
+    446
    ],
-   "commit": "eb8d23925fb8ccbd3b2e3804fb0a312ee227610b",
-   "sha256": "1j696incblnqhz7yi8xmshiz2p5kp910288j513sj8rknlykpr4n"
+   "commit": "eb75d7539243832761e8e75782252fd7a489fb37",
+   "sha256": "04sdmawnpby5fhvch7fn83an24033zin3yxp1b0swjrdl8wbasjj"
   },
   "stable": {
    "version": [
@@ -129665,11 +130456,35 @@
   "repo": "vifon/tmsu.el",
   "unstable": {
    "version": [
-    20241230,
-    2209
+    20260610,
+    1429
    ],
-   "commit": "c75ae9bed8f3bb2229e873fcc85fe62701e47974",
-   "sha256": "0mxz9bmdcdxkj7f4ih405i4vpd35c72xgs1i8cbi0132dpnnblpz"
+   "commit": "625d01d87f2820f648816f78b0c5bc220f14488b",
+   "sha256": "1h043myzvk40c3lbykikvhy6zcx5ac8r3jhkrzzhak1ngb5lpa9g"
+  }
+ },
+ {
+  "ename": "tmux-csi-u",
+  "commit": "3e16dc8d7a262b450719b41ea64649a60146c8f1",
+  "sha256": "0gprwbcxi1rw1g3k3j6nqfrfbdqsg6yqhfppyvikr40xp9igzm4f",
+  "fetcher": "github",
+  "repo": "lajarre/tmux-csi-u.el",
+  "unstable": {
+   "version": [
+    20260428,
+    2220
+   ],
+   "commit": "38e95db84ad02ad440e4fc0b18896e1c621e5f5d",
+   "sha256": "1k8ys2x0hl8zhxba5fb9k1dbd2xmxmknai90z0j07f70zq8pkm34"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    0
+   ],
+   "commit": "38e95db84ad02ad440e4fc0b18896e1c621e5f5d",
+   "sha256": "1k8ys2x0hl8zhxba5fb9k1dbd2xmxmknai90z0j07f70zq8pkm34"
   }
  },
  {
@@ -129729,11 +130544,11 @@
   "repo": "snosov1/toc-org",
   "unstable": {
    "version": [
-    20220110,
-    1452
+    20260514,
+    1415
    ],
-   "commit": "bf2e4b358efbd860ecafe6e74776de0885d9d100",
-   "sha256": "1mck86704akw8jlczimb4wi9z7x5mxag9s7z2vxfgg8xfmbmj8jr"
+   "commit": "781376e9dc9a901116c0c39914aeb4d46e524e0a",
+   "sha256": "19vzfwcxvknbx0zdad6p8bfkj28mx2c5rm4zxq4yyqg56cpx224i"
   },
   "stable": {
    "version": [
@@ -129926,11 +130741,11 @@
   "repo": "bbatsov/tokyo-night-emacs",
   "unstable": {
    "version": [
-    20260421,
-    1234
+    20260528,
+    551
    ],
-   "commit": "8d30673c060ab791818e9ac3fd96ebeba93b926d",
-   "sha256": "1zgjhb9ngdll284h5gf0mdjikfgifrb1z55ydmd8vcm17b83sd48"
+   "commit": "92037072b6e9a48d5d736bf8a76731936ea94410",
+   "sha256": "13ya7p5ppd7p15q91g7a8yky85lzadii0ggchklxh8ipigsamrdh"
   },
   "stable": {
    "version": [
@@ -130047,11 +130862,11 @@
   "repo": "jamescherti/tomorrow-night-deepblue-theme.el",
   "unstable": {
    "version": [
-    20260314,
-    1909
+    20260614,
+    1718
    ],
-   "commit": "377fb120128c10929abc12f5d606a146b85372e0",
-   "sha256": "023q97lydjcqjaqw9flrmivvah8b24ahhm0c9q89h8zv99qzrfbd"
+   "commit": "ae24e3672e8832579052ce124d0c3b05ca835e16",
+   "sha256": "0jsd0p34ppl7wgyxcww0hk641h9c5jfiymqyqrhlpr4k2lv5yg46"
   },
   "stable": {
    "version": [
@@ -130314,30 +131129,6 @@
   }
  },
  {
-  "ename": "tox",
-  "commit": "08a7433e16f2a9a2c04168600a9c99bc21c68ddf",
-  "sha256": "1z81x8fs5q6r19hpqphsilk8wdwwnfr8w78x5x298x74s9mcsywl",
-  "fetcher": "github",
-  "repo": "chmouel/tox.el",
-  "unstable": {
-   "version": [
-    20250216,
-    1042
-   ],
-   "commit": "831521fdfdd0b903c50616c6d675e63279c8b4aa",
-   "sha256": "0kyg6bczgzjp79fiaqa2imq9xlmy40x3sbql3v1bdk6543r6dv2m"
-  },
-  "stable": {
-   "version": [
-    0,
-    4,
-    0
-   ],
-   "commit": "7655eb254038d5e34433e8a9d66b3ffc9c72e40c",
-   "sha256": "1212b7s00kw9hk5gc2jx88hqd825rvkz1ss7phnxkrz833l062ki"
-  }
- },
- {
   "ename": "toxi-theme",
   "commit": "2e57d7abe1e43101558b27b0995f54f74a620b33",
   "sha256": "1dyr8mp5p6j4c949dbzi4fqy86ay84yr3822ab8qx25hck1kdrhj",
@@ -130369,25 +131160,25 @@
   "repo": "martianh/tp.el",
   "unstable": {
    "version": [
-    20260219,
-    1435
+    20260509,
+    802
    ],
    "deps": [
     "transient"
    ],
-   "commit": "cef3fc2daefbbfc29ad02b7e1f39542b57c72fe8",
-   "sha256": "1zhvridy6p7dy9hpf088k166a1c918hqf6k3jmnm7raw8vflc7qq"
+   "commit": "a83cd422cca09bc863a7179f1c5b5a35435e0d32",
+   "sha256": "01g72x2lqmrdh3qgd3135hgijka975xg92ki36qyv71vi20rhmnm"
   },
   "stable": {
    "version": [
     0,
-    8
+    9
    ],
    "deps": [
     "transient"
    ],
-   "commit": "cef3fc2daefbbfc29ad02b7e1f39542b57c72fe8",
-   "sha256": "1zhvridy6p7dy9hpf088k166a1c918hqf6k3jmnm7raw8vflc7qq"
+   "commit": "a83cd422cca09bc863a7179f1c5b5a35435e0d32",
+   "sha256": "01g72x2lqmrdh3qgd3135hgijka975xg92ki36qyv71vi20rhmnm"
   }
  },
  {
@@ -130526,20 +131317,20 @@
   "repo": "saulotoledo/trailing-newline-indicator",
   "unstable": {
    "version": [
-    20260112,
-    1713
+    20260516,
+    2154
    ],
-   "commit": "f53d9e139f734d9ea35a907a6c44b70795d81737",
-   "sha256": "0zld6218jzmjq5afz4525mjc4whi9lix571wn35jpgvf8y1y8lgd"
+   "commit": "52af1d7d63499020b21d57147cd7d27bc1bb35d3",
+   "sha256": "16ggckn7g07jqnmldmdq9qwa5ldcdivi8im66dics5s0cf3g6xb2"
   },
   "stable": {
    "version": [
     0,
     3,
-    6
+    7
    ],
-   "commit": "f53d9e139f734d9ea35a907a6c44b70795d81737",
-   "sha256": "0zld6218jzmjq5afz4525mjc4whi9lix571wn35jpgvf8y1y8lgd"
+   "commit": "52af1d7d63499020b21d57147cd7d27bc1bb35d3",
+   "sha256": "16ggckn7g07jqnmldmdq9qwa5ldcdivi8im66dics5s0cf3g6xb2"
   }
  },
  {
@@ -130653,36 +131444,37 @@
  },
  {
   "ename": "transient",
-  "commit": "a74629656e9a23133219a0bd805982f1497b35d7",
-  "sha256": "0pjj4zj3sa6mhf7fwb5b33y9b506g3bcjyzy44h5n6s79shbak60",
+  "commit": "aec4a76eaea31408bd27d76a0b8cea5268663cc1",
+  "sha256": "11a2m4vdccn2yfn5aj2g5smiml69vidir9ss8c70pld17z1wzx07",
   "fetcher": "github",
   "repo": "magit/transient",
   "unstable": {
    "version": [
-    20260422,
-    1646
+    20260617,
+    1137
    ],
    "deps": [
     "compat",
     "cond-let",
+    "llama",
     "seq"
    ],
-   "commit": "cd97319a851db9b2ed3faecdb735c6d089edf4e1",
-   "sha256": "18pay3a7qbxw3ci2y11d3pvzbdkp8q1n4xyr4zhz1vg2n36vj56c"
+   "commit": "9d103f338fb9fd4506a0f1651c483209ab838f49",
+   "sha256": "1891ly16nc0fp46i4g79yz3p7is12ckcm8jbibm3ps3bbgkcqshj"
   },
   "stable": {
    "version": [
     0,
     13,
-    0
+    4
    ],
    "deps": [
     "compat",
     "cond-let",
     "seq"
    ],
-   "commit": "cd97319a851db9b2ed3faecdb735c6d089edf4e1",
-   "sha256": "18pay3a7qbxw3ci2y11d3pvzbdkp8q1n4xyr4zhz1vg2n36vj56c"
+   "commit": "1856230dc181f23dd15026b0ad21d8b299b034d1",
+   "sha256": "097fchxjs7wm0q2yngpnxk5lrscaxxbbnnkv1h19jbzysafpbgyc"
   }
  },
  {
@@ -130693,14 +131485,14 @@
   "repo": "conao3/transient-dwim.el",
   "unstable": {
    "version": [
-    20251006,
-    339
+    20260516,
+    853
    ],
    "deps": [
     "transient"
    ],
-   "commit": "65985faf00f5a0e5e725c4f3f9f4118d19b8ee5a",
-   "sha256": "16ygz5csgcx5ri3qpid3v3kk1wfshf9napli5ymn6g76spp07sam"
+   "commit": "f1973c1f75a9c4fd122ebba878aac7f1d0d54111",
+   "sha256": "0rzj1awr1d9lw2dkhnb9z7rwjsrhhr7icxqg9xir474n8x5yp7qr"
   }
  },
  {
@@ -130958,28 +131750,28 @@
   "repo": "tarsius/tray",
   "unstable": {
    "version": [
-    20260101,
-    1847
+    20260601,
+    1523
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "b77e046b173008a95f9ba37f4d34c088f5f0a8ab",
-   "sha256": "0y6mrqnc652jfcxhwh5xxphd5cfk3rbngv88i791f531lyninrih"
+   "commit": "2d3368d4dd70da4f9d7c5aec8468c97054dc8234",
+   "sha256": "100n2slsccmjxaz1dppzjg93a0qm6hbmw08crwjivja6f65arp29"
   },
   "stable": {
    "version": [
     0,
     1,
-    8
+    9
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "b77e046b173008a95f9ba37f4d34c088f5f0a8ab",
-   "sha256": "0y6mrqnc652jfcxhwh5xxphd5cfk3rbngv88i791f531lyninrih"
+   "commit": "2d3368d4dd70da4f9d7c5aec8468c97054dc8234",
+   "sha256": "100n2slsccmjxaz1dppzjg93a0qm6hbmw08crwjivja6f65arp29"
   }
  },
  {
@@ -131137,26 +131929,26 @@
   "repo": "emacs-tree-sitter/tree-sitter-langs",
   "unstable": {
    "version": [
-    20260420,
-    54
+    20260615,
+    1631
    ],
    "deps": [
     "tree-sitter"
    ],
-   "commit": "0c9390a5ec483a63c9cecd57be71520b20a858c5",
-   "sha256": "08jsvkjnqywgar2yv2a8vz85hwfiasa849dwixhrvavfqd2ss1d9"
+   "commit": "b344c86eb4fb3bbe1f30e7684fea130dbcbf32a8",
+   "sha256": "15vf7p4vd1axyk31hv5nhvjmvdd3b9069bli04ggazh0xqhkb0mw"
   },
   "stable": {
    "version": [
     0,
     13,
-    45
+    63
    ],
    "deps": [
     "tree-sitter"
    ],
-   "commit": "0c9390a5ec483a63c9cecd57be71520b20a858c5",
-   "sha256": "08jsvkjnqywgar2yv2a8vz85hwfiasa849dwixhrvavfqd2ss1d9"
+   "commit": "d7473e6c322b96de95d40401dbad7841f116bedf",
+   "sha256": "1xv3lhigdma8kslw7f2z6klj695r89z125f66zwdad3rk5xd9487"
   }
  },
  {
@@ -131167,14 +131959,11 @@
   "repo": "purplg/treebundel",
   "unstable": {
    "version": [
-    20260404,
-    2133
+    20260613,
+    317
    ],
-   "deps": [
-    "compat"
-   ],
-   "commit": "35e55a21914772e2f125fd1c4682f7e239f192d3",
-   "sha256": "1ipypcrc2xgyrvwv6hk3hvwrkamsf4rrpnm13xczz19bqp1svjqp"
+   "commit": "9b64c358338e90c02e9aedb4689a3c1a8be29abf",
+   "sha256": "0987rpd4zpc7wprva533gnl1l97pj10bkjkawlg7dqxhcipj2xig"
   },
   "stable": {
    "version": [
@@ -131560,11 +132349,11 @@
   "repo": "volrath/treepy.el",
   "unstable": {
    "version": [
-    20260313,
-    916
+    20260531,
+    1144
    ],
-   "commit": "28f0e2c2c75ea186e8beb570a4a70087926ff80b",
-   "sha256": "0z91vd12gikgb6207sz45fhcmhkl5hqbxjbzcaqpkznfgsq95f7j"
+   "commit": "806c000bd40153d17dfa5709c6d19546d507a416",
+   "sha256": "06i7r0v23j6d5q5w7p4cb7jidpnpy02a92fpjfqjlcd52cch02mc"
   },
   "stable": {
    "version": [
@@ -131714,20 +132503,20 @@
   "repo": "ianyepan/tron-legacy-emacs-theme",
   "unstable": {
    "version": [
-    20230506,
-    1037
+    20260610,
+    1908
    ],
-   "commit": "44996469041a9b7f54c2a42ad2a3c16ac9579d77",
-   "sha256": "09ak0pysizblq39ndzry6af2g6byzpwrdvfwb2d5kyc5z76cw36d"
+   "commit": "fab4946d6266f73d5ec25660f67bd186dc44d426",
+   "sha256": "07fpm6v9qk5z7l81c5ssm6612dprh330h4zsfql0s5hyyj273l0r"
   },
   "stable": {
    "version": [
     2,
-    6,
+    7,
     0
    ],
-   "commit": "74e0cf066392c6fa99327e42b24caf4ed2fc414f",
-   "sha256": "1vc50y7a248f0b4bk6mawb6f7n5dd6skrln8asall2m834bzzg37"
+   "commit": "fab4946d6266f73d5ec25660f67bd186dc44d426",
+   "sha256": "07fpm6v9qk5z7l81c5ssm6612dprh330h4zsfql0s5hyyj273l0r"
   }
  },
  {
@@ -131810,17 +132599,17 @@
  },
  {
   "ename": "trust-manager",
-  "commit": "420c42f0bf4fb2be86fd3103b0f35bfcb48184b4",
-  "sha256": "1nsm0xb6ls8vkc987ajs4qrbaclim5fc9m1i77mfwbz0znmwn32r",
-  "fetcher": "github",
-  "repo": "eshelyaron/trust-manager",
+  "commit": "bf967692af1501b21f0c07f026f1d8855cd7c6cb",
+  "sha256": "0r76fyd4f26ad3n9rgdwa143n0k5vv3hbfkgnnpnzfh535fxppf9",
+  "fetcher": "sourcehut",
+  "repo": "eshel/trust-manager",
   "unstable": {
    "version": [
-    20260422,
-    952
+    20260426,
+    1205
    ],
-   "commit": "3a702921eaa65ce8de552e88f6280786a645252d",
-   "sha256": "1c6v36fa8j9q0j8s5i1kdw4gkqmv6qldsswdccvyfcmbyl2wr3dw"
+   "commit": "530c559ffa01b99ced8073ba4c74f1b8152a0ef2",
+   "sha256": "0h6v3dcczh8644n09ny9mwx3zb5vy4ydify24zf09f6wlkkhzr5b"
   },
   "stable": {
    "version": [
@@ -132074,6 +132863,21 @@
   }
  },
  {
+  "ename": "ttx-mode",
+  "commit": "11181b36316b3e0658afb13bcb63a590173387d1",
+  "sha256": "06v42hidmncd6d6gli8fv11nrwz6n2prblac4dv9djkh5ja6zi79",
+  "fetcher": "github",
+  "repo": "wmedrano/ttx-mode",
+  "unstable": {
+   "version": [
+    20260504,
+    1858
+   ],
+   "commit": "11720c3623e38b054967653278d18ab480609213",
+   "sha256": "0yrs8x2mmlwva35g9ymj5fzlm2s318461fq2waj1a14c2vw4z7q1"
+  }
+ },
+ {
   "ename": "tuareg",
   "commit": "01fb6435a1dfeebdf4e7fa3f4f5928bc75526809",
   "sha256": "0wx723dmjlpm86xdabl9n8p22zbbxpapyfn6ifz0b0pvhh49ip7q",
@@ -132081,14 +132885,14 @@
   "repo": "ocaml/tuareg",
   "unstable": {
    "version": [
-    20250909,
-    1604
+    20260617,
+    1454
    ],
    "deps": [
     "caml"
    ],
-   "commit": "de9572f537b71c5e67b6ad676e1f7e42e8180878",
-   "sha256": "0c9cpwbqn1mpyz8gw09n7kffs3rm3v58q0wrzkihbig47cvzj998"
+   "commit": "7d4dd535e3f4bed2013bad545629302d07ba991e",
+   "sha256": "10x3zvjm81r5bk8fw8lbxq738j0p15g0yjfxgxjanms0mrbwj2bp"
   },
   "stable": {
    "version": [
@@ -132194,17 +132998,17 @@
  },
  {
   "ename": "turing-machine",
-  "commit": "6440f81aed1fcddcaf7afeedb74520e605211986",
-  "sha256": "0q9a31m5wnz9j9l4i8czdl7z12nrcdjw72w8sqvf94ri2g5dbpkq",
-  "fetcher": "github",
+  "commit": "1d888e12b1c4002896723b3c993a72bf920ef37b",
+  "sha256": "14xvh9p0jgkh8g3akrgbzcxyh0aa5jc66jc74731b3b10wmlpcrk",
+  "fetcher": "sourcehut",
   "repo": "dieggsy/turing-machine",
   "unstable": {
    "version": [
-    20180222,
-    438
+    20260530,
+    523
    ],
-   "commit": "ad1dccc9c445f9e4465e1c67cbbfea9583153047",
-   "sha256": "0qaz4r5ahg2fxsfyxilb8c9956i5ra9vg80l82slm8vrnsinzll6"
+   "commit": "165f868d5b47b93ca00bc73b0055cdcd7696449d",
+   "sha256": "0klq2d8q9vlqa80k9kxali6r5lv6lk8i5ry3ky4yii9jq7b0nwp3"
   },
   "stable": {
    "version": [
@@ -132224,11 +133028,11 @@
   "repo": "emres/turkish-mode",
   "unstable": {
    "version": [
-    20170910,
-    1511
+    20260614,
+    919
    ],
-   "commit": "9831a316c176bb21a1b91226323ea4133163e00c",
-   "sha256": "0nrxi845gd24d5vymbmxz696jwld4rn6nw2dz1gzmdaks7bbv87m"
+   "commit": "70196d4502759060bb2b0ac2f09f18ce1cbbcb20",
+   "sha256": "13axgawzw4838kwvabzn5g1c1bf8mnnn38yqmhl6mg306zlsqzxb"
   }
  },
  {
@@ -132581,15 +133385,15 @@
   "repo": "havarddj/typst-preview.el",
   "unstable": {
    "version": [
-    20260215,
-    2252
+    20260617,
+    2023
    ],
    "deps": [
     "compat",
     "websocket"
    ],
-   "commit": "7e89cf105e4fef5e79977a4a790d5b3b18d305f6",
-   "sha256": "0lsbr9i8kmzjbl9k86g8jnsbgz2vrlys7cii4fjrkg0dg9ijvk2w"
+   "commit": "f2903a1b98e13be7c927de835ae0d9159dd9fb9a",
+   "sha256": "0zd1hjqnjz9fhw7gbnawnx9cp0gbkd1730inl23q5rz0w80lksnl"
   },
   "stable": {
    "version": [
@@ -132779,14 +133583,14 @@
   "repo": "crmsnbleyd/uiua-mode",
   "unstable": {
    "version": [
-    20240930,
-    1206
+    20260618,
+    822
    ],
    "deps": [
     "reformatter"
    ],
-   "commit": "5627ac4450d5a5d2c657befc63c7594939c5ff4c",
-   "sha256": "1gnrjlp0p55n02vx0p1krjil2pxv4b7hg0krazs9b3nr2ar4cfqg"
+   "commit": "4194e877aef707f8475c3632390179b03571d091",
+   "sha256": "1ynhqz8g64zqry90g9s3c7wqzjy95vd348q1m0ff0cq3qjjqyws2"
   },
   "stable": {
    "version": [
@@ -132872,20 +133676,20 @@
   "repo": "jamescherti/ultisnips-mode.el",
   "unstable": {
    "version": [
-    20260324,
-    101
+    20260601,
+    1617
    ],
-   "commit": "1ccd9d4bfd12545de299974083da9d2fbeec194b",
-   "sha256": "074pwsps3ib7wnc8nqicqqpdg76688bwm4agfdjii6fh34w0w7wz"
+   "commit": "39df8b78d4a9450cec5acbd74eb82b7372e28b73",
+   "sha256": "0rynfikr47afa5nd0npk1b6q69fym7l0mqb7abivkipg2zz3ysn7"
   },
   "stable": {
    "version": [
     1,
     0,
-    3
+    4
    ],
-   "commit": "1ccd9d4bfd12545de299974083da9d2fbeec194b",
-   "sha256": "074pwsps3ib7wnc8nqicqqpdg76688bwm4agfdjii6fh34w0w7wz"
+   "commit": "39df8b78d4a9450cec5acbd74eb82b7372e28b73",
+   "sha256": "0rynfikr47afa5nd0npk1b6q69fym7l0mqb7abivkipg2zz3ysn7"
   }
  },
  {
@@ -132896,19 +133700,20 @@
   "repo": "jdtsmith/ultra-scroll",
   "unstable": {
    "version": [
-    20260325,
-    2311
+    20260616,
+    2126
    ],
-   "commit": "0a03e5f9f70f63a660623198179963c7c06a07c1",
-   "sha256": "0a3m1aapcrbf2b78712xh0lx4bblq3jx3n0bnhm9m9qs8889w7ir"
+   "commit": "5be267d2d92c230b4347e0769f584c71aec53589",
+   "sha256": "0lzycvg61lq0azc280bq4m0d1xrffrac966ax9qbnn5rxm78ikrp"
   },
   "stable": {
    "version": [
     0,
-    6
+    6,
+    2
    ],
-   "commit": "0a03e5f9f70f63a660623198179963c7c06a07c1",
-   "sha256": "0a3m1aapcrbf2b78712xh0lx4bblq3jx3n0bnhm9m9qs8889w7ir"
+   "commit": "f38653053b5c9bbe8dbcb6b2236ab8997fc2f9bb",
+   "sha256": "0ajynkiqiq7pvd7wqgf8wig8q288nsxixgl851bw0bjhivv32fmx"
   }
  },
  {
@@ -133298,17 +134103,17 @@
  },
  {
   "ename": "unicode-math-input",
-  "commit": "e0d39bc129500e55b99c11b3d27e042619777414",
-  "sha256": "1hra3vf6nzh99piagbxsmp0sizvki2jl7qkfmlwd5nwmicw0ykrq",
-  "fetcher": "github",
+  "commit": "94e6b48c731067a6f30a343f9ddbd5f365ae7043",
+  "sha256": "0czy5kp1f9xhakgd1g68z7sg3swwy3nc90cakpavja6bn6l1fbcz",
+  "fetcher": "codeberg",
   "repo": "astoff/unicode-math-input.el",
   "unstable": {
    "version": [
-    20251012,
-    953
+    20260601,
+    734
    ],
-   "commit": "d7ee1a963f140acd5650b86e808129077c6a7828",
-   "sha256": "0xsf0v2pnq1zaln8hcrd4np9d5clxykh9bhfvhrkp2zwi9xirr5s"
+   "commit": "f0ad9e4bf23df653bc68d578e610a2d0431b87df",
+   "sha256": "1cr7p5nysn28an9hkzanvifiv3c24j3y1p3b98lr1xcsm0q07dvm"
   }
  },
  {
@@ -133467,14 +134272,14 @@
   "repo": "tbanel/uniline",
   "unstable": {
    "version": [
-    20260411,
-    1423
+    20260619,
+    1103
    ],
    "deps": [
     "hydra"
    ],
-   "commit": "14a0949539679e89f706601a501ae8a8d090c71f",
-   "sha256": "1fcqr4q5dc9kfzqp6b9wfqma4qbb6dmjia639wfgdj3xqxa8ygl7"
+   "commit": "eaff70c71f17c85d3d26dd2c1dbf466b21c6c085",
+   "sha256": "1x8lw3pyp05fqsjrnyy0yd122m1dhnw089f9rmyka32g3kwk0hjs"
   }
  },
  {
@@ -133530,20 +134335,20 @@
   "repo": "fmguerreiro/unison-ts-mode",
   "unstable": {
    "version": [
-    20260126,
-    915
+    20260525,
+    909
    ],
-   "commit": "83fe7aadecc5438be19ccb50b089c1ba95803839",
-   "sha256": "04abri83yz3yr3ffvj780sjljbhlz468a579i2i8rh01pgdz4dqx"
+   "commit": "31bbb4fbcba02075cebcdedb05d29568420bac9f",
+   "sha256": "0bip87ld0dz2l48izbhmy88bwh1fsb1j1cwj6nkpcmy0nmji0pa7"
   },
   "stable": {
    "version": [
     0,
-    2,
+    3,
     0
    ],
-   "commit": "e31a211899e5c249a521b8b1e09f48bcc40383af",
-   "sha256": "00z4l8d1p80lb0n2h2sp1bbhyc6rym1y0wvcrcqwiq5k023kacyc"
+   "commit": "626e1575386f9ed996004ecce2e5672cc2583c18",
+   "sha256": "0jqkib3ibg3iyqpxibck1ax6lgprclrh7yhkhq8b7x8a9canb5xm"
   }
  },
  {
@@ -133825,19 +134630,19 @@
   "repo": "tee3/unobtrusive-magit-theme",
   "unstable": {
    "version": [
-    20200411,
-    1349
+    20260424,
+    1659
    ],
-   "commit": "aede357009655d19d4468320b2b61b0f26a47593",
-   "sha256": "1af8c7q3vxj23l2ah5waj9hn5pfp66834b4akm76jc5wqf0sr9j1"
+   "commit": "33d265d08a0a215aab558550d1596ac0e57c9d63",
+   "sha256": "07pdc6idc5zm1fjmi472lbc67y3sgli1pvksnphfp0gvd284fp7f"
   },
   "stable": {
    "version": [
     0,
-    4
+    5
    ],
-   "commit": "aede357009655d19d4468320b2b61b0f26a47593",
-   "sha256": "1af8c7q3vxj23l2ah5waj9hn5pfp66834b4akm76jc5wqf0sr9j1"
+   "commit": "33d265d08a0a215aab558550d1596ac0e57c9d63",
+   "sha256": "07pdc6idc5zm1fjmi472lbc67y3sgli1pvksnphfp0gvd284fp7f"
   }
  },
  {
@@ -133991,20 +134796,20 @@
   "repo": "ursalang/ursa-ts-mode",
   "unstable": {
    "version": [
-    20250407,
-    1303
+    20260503,
+    2249
    ],
-   "commit": "25dd8c309ad9433a5bb57b47b947447c420efb77",
-   "sha256": "02nkfaz8wwb3fywvig21br7m4rd6xk7gz04izv6vya9fsybphd2a"
+   "commit": "b76fb46721839ef210700ee6d00763f5646c30af",
+   "sha256": "05wshv3bv5xr8d6pdlcryfivv6f6dxyrdz1vxvawrjcw2h7m3cn1"
   },
   "stable": {
    "version": [
     1,
     3,
-    11
+    12
    ],
-   "commit": "84689fb37dfb6ddbd0a22cc1dcef25203f0689a8",
-   "sha256": "06fabv3b4ghljg2ybriswqc71avb4mzjpwc373k643l5gj47wfnf"
+   "commit": "b76fb46721839ef210700ee6d00763f5646c30af",
+   "sha256": "05wshv3bv5xr8d6pdlcryfivv6f6dxyrdz1vxvawrjcw2h7m3cn1"
   }
  },
  {
@@ -134124,6 +134929,38 @@
    ],
    "commit": "398ca0df10f2894b87c07073a446a53d943a6c18",
    "sha256": "0kpnac51ykmhkirz7shryasd7h2gvkfrhyysy55bpn8swdzknawm"
+  }
+ },
+ {
+  "ename": "use-package-x",
+  "commit": "28893a37e38074ffbadd6b1cf0109d4ba238e4dc",
+  "sha256": "004nr4fqdh131906j1pi8lk8bjm561vlqsj7ys9wwv777l80nxw0",
+  "fetcher": "github",
+  "repo": "DevelopmentCool2449/use-package-x",
+  "unstable": {
+   "version": [
+    20260525,
+    1628
+   ],
+   "deps": [
+    "compat",
+    "use-package"
+   ],
+   "commit": "45ed391f1d6816b1fff0a3104c6c0d94d9bebd64",
+   "sha256": "1cipdps4d2rxvqa8px26522sly55zchj6ag7n5g67i6xalw3nyf5"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    1
+   ],
+   "deps": [
+    "compat",
+    "use-package"
+   ],
+   "commit": "2f679f089956af769ddc8f7473f01afd9b6fe56a",
+   "sha256": "1cpj6ancx7ahpczn6bcig6jwcayz8cig466viq2p0qyrv7s8wj2a"
   }
  },
  {
@@ -134708,26 +135545,26 @@
  },
  {
   "ename": "vcomp",
-  "commit": "561442ea9f75ebe8444db1a0c40f7756fcbca482",
-  "sha256": "02cj2nlyxvgvl2rjfgacljvcsnfm9crmmkhcm2pznj9xw10y8pq0",
+  "commit": "aec4a76eaea31408bd27d76a0b8cea5268663cc1",
+  "sha256": "1i4jcbkcpqim8f1fdkfrznszn575zkhc61s030wxgdk1l19p5yib",
   "fetcher": "github",
   "repo": "tarsius/vcomp",
   "unstable": {
    "version": [
-    20260420,
-    1508
+    20260616,
+    2212
    ],
-   "commit": "213c3f6b085182d20065caa1c53b6a543ca42694",
-   "sha256": "1ajfpxnpbg92r2dvz9jfk2fxii079gif5sar8r6pvhqyh7868yrk"
+   "commit": "7b3f93d1202bd9353ee6401c47fbc3cc0d6d76e3",
+   "sha256": "116h3n0j5m0mi7c4qz1axjy4yvwh833bnj2s8crhcrzc2ppr20yz"
   },
   "stable": {
    "version": [
     1,
-    1,
+    2,
     0
    ],
-   "commit": "99831d234481a61488aca4b96b842b63a79c732a",
-   "sha256": "06qcmlr16dnvwln4136vz6m0zs5mp81awy40jv8pmvhwms9fprr7"
+   "commit": "2227de68c2fc4d7a029bd30d188422429bb18d28",
+   "sha256": "0w8z683sq1bq89vlypqbg5dzb5n1p6zhj0ci07flnr7gqcicg5fw"
   }
  },
  {
@@ -135030,20 +135867,88 @@
   "repo": "federicotdn/verb",
   "unstable": {
    "version": [
-    20260414,
-    1812
+    20260617,
+    1912
    ],
-   "commit": "ffe668c20120ba215f14d6d5720e327fbadbd10d",
-   "sha256": "0bvz5y05b6kvax4yak193ki8mja8v544ycg31i70863q6p356vhy"
+   "commit": "25a25456bb9ef5090d80105aaa8ad931f336a06e",
+   "sha256": "16s7va3d7wqbqipkh3nsqsw4vkpdy3bi9qq85a9w93wx113s0sqv"
   },
   "stable": {
    "version": [
     3,
-    1,
+    2,
     0
    ],
-   "commit": "2e778afd08b8a9872b8273528052f52d53c2bd45",
-   "sha256": "12y2shqhbl21xj18hldg17n03pq3qcycwmswxdwr0pnac8613pq6"
+   "commit": "81aa67dffb17b3d88b35f16787aa3292d5761abb",
+   "sha256": "0bz41lw1d4ps3hg07g2frdjx9d1w9fwdhsfc9k78d20ns3l07wrx"
+  }
+ },
+ {
+  "ename": "verdict",
+  "commit": "99def78eea057a9e772b7bea8baa08b45a6080a2",
+  "sha256": "1wjyramicz7p756r830r6jqvg3yybmyx20k4jvxncfdii921v7b9",
+  "fetcher": "github",
+  "repo": "tjarvstrand/verdict.el",
+  "unstable": {
+   "version": [
+    20260506,
+    914
+   ],
+   "deps": [
+    "dash",
+    "treemacs"
+   ],
+   "commit": "ff29a0681f7cca17c0e7b467229b2a8441559a2e",
+   "sha256": "0n9bh35l4sxrkq4c892fn0lhgna03hginabn0a3arb00yrrvxwar"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    4
+   ],
+   "deps": [
+    "dash",
+    "treemacs"
+   ],
+   "commit": "84fff362b8068a1a8112b772fa927b56a6786482",
+   "sha256": "1w79z03d1wq2g1d15b1zppnwh3hp3n74l2ciriq5fzybcwfk7kag"
+  }
+ },
+ {
+  "ename": "verdict-dart",
+  "commit": "d86b05b64bef357dd7c58b02ed58e45e6b6029e3",
+  "sha256": "0dg6vkdyw90641w3ilbqxg6gnzaxrx7abkxjys25q579c4lcv49h",
+  "fetcher": "github",
+  "repo": "tjarvstrand/verdict.el",
+  "unstable": {
+   "version": [
+    20260505,
+    1121
+   ],
+   "deps": [
+    "dash",
+    "f",
+    "verdict",
+    "yaml"
+   ],
+   "commit": "84fff362b8068a1a8112b772fa927b56a6786482",
+   "sha256": "1w79z03d1wq2g1d15b1zppnwh3hp3n74l2ciriq5fzybcwfk7kag"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    4
+   ],
+   "deps": [
+    "dash",
+    "f",
+    "verdict",
+    "yaml"
+   ],
+   "commit": "84fff362b8068a1a8112b772fa927b56a6786482",
+   "sha256": "1w79z03d1wq2g1d15b1zppnwh3hp3n74l2ciriq5fzybcwfk7kag"
   }
  },
  {
@@ -135091,8 +135996,8 @@
   "repo": "gmlarumbe/verilog-ext",
   "unstable": {
    "version": [
-    20260225,
-    1300
+    20260608,
+    1712
    ],
    "deps": [
     "ag",
@@ -135106,8 +136011,8 @@
     "verilog-ts-mode",
     "yasnippet"
    ],
-   "commit": "e2217561bc6ee84b4e925951ef3794957048bf73",
-   "sha256": "0h6q7105ccb64cid5h89j8m3a4s40ifnl6c9j8xak23k3q3l9jk4"
+   "commit": "000ed01eaeca1c3001874f1c8a6835a55d7b8b71",
+   "sha256": "125awjdw2dq7ywja2z07dzmlzw4552b7y6gg589nxklmpfmfjbsn"
   },
   "stable": {
    "version": [
@@ -135139,14 +136044,14 @@
   "repo": "gmlarumbe/verilog-ts-mode",
   "unstable": {
    "version": [
-    20260225,
-    1302
+    20260429,
+    1857
    ],
    "deps": [
     "verilog-mode"
    ],
-   "commit": "a804a3e8b744edeaf879705c85aae196f761cba8",
-   "sha256": "18ndf250z55dz8vic6xxyfxjlymy8inf4ga0swdf4swhfyfp5im3"
+   "commit": "b243ea4c78c37c8b01a06a269b1b3cd24996b00d",
+   "sha256": "1n5w8nzbkqk8c61hk9nbklp4j8saj5gba5p70q6lsigvwgci1ig7"
   },
   "stable": {
    "version": [
@@ -135262,25 +136167,25 @@
   "repo": "minad/vertico",
   "unstable": {
    "version": [
-    20260419,
-    1808
+    20260605,
+    1903
    ],
    "deps": [
     "compat"
    ],
-   "commit": "daa0dddeb5bc152e13ec4f166cc2f84150b7a2e8",
-   "sha256": "1vlhmvjsgcsfhpd2hcfq1zlz0r2pb6ww1rhra17kdf5cg0dnns2q"
+   "commit": "6028bd3d32c99c28e2b938e5e5393ec3508d2424",
+   "sha256": "0hzl3p7b62f3p2419c5d7340h7y6ry2xhwdds166wfcgwpwnm7m6"
   },
   "stable": {
    "version": [
     2,
-    8
+    10
    ],
    "deps": [
     "compat"
    ],
-   "commit": "0b96e8f169653cba6530da1ab0a1c28ffa44b180",
-   "sha256": "0kia499sijkmpj5l9r0r3pwc1kjyvbfxc15k85dyfq9dvc4z1drr"
+   "commit": "6028bd3d32c99c28e2b938e5e5393ec3508d2424",
+   "sha256": "0hzl3p7b62f3p2419c5d7340h7y6ry2xhwdds166wfcgwpwnm7m6"
   }
  },
  {
@@ -135525,20 +136430,20 @@
   "repo": "jamescherti/vim-tab-bar.el",
   "unstable": {
    "version": [
-    20260314,
-    1906
+    20260601,
+    1613
    ],
-   "commit": "3ab286ffc3ce5e4215d9d7f502a6982111e49207",
-   "sha256": "19n4nhm9gvz6z93prq3v413qcl4iknprnkjcmixlg4lkm59kl3bw"
+   "commit": "61290afd8c1fdef6b5b03b1588c5cf830e196ded",
+   "sha256": "1530p5qr9b53jljsv9bx7m54zri1i2jzglvcd58akrv5krs5wrp2"
   },
   "stable": {
    "version": [
     1,
     1,
-    4
+    5
    ],
-   "commit": "22d2d8a92b8d8cd0532c8382dcfe7df405f1563a",
-   "sha256": "00bajfkqcpn15d5vdr52nd56qny68r59xc7yshw7wxs9awfpxrzz"
+   "commit": "61290afd8c1fdef6b5b03b1588c5cf830e196ded",
+   "sha256": "1530p5qr9b53jljsv9bx7m54zri1i2jzglvcd58akrv5krs5wrp2"
   }
  },
  {
@@ -136082,11 +136987,11 @@
   "repo": "ianyepan/vscode-dark-plus-emacs-theme",
   "unstable": {
    "version": [
-    20260420,
-    8
+    20260606,
+    209
    ],
-   "commit": "082b012d203fed17d54b4a3b7437db545f15ddbb",
-   "sha256": "0mik95vf8nc61g33jfmb885jrrk64xghzx0ip443gigdr1pbs2yk"
+   "commit": "c401b44809bfbf5928582efddc19ddda4f271ed4",
+   "sha256": "1d9y5ghzpaflkd5dpqsf6cni47k1ib5sgh3fd58jh708cc0lhgsz"
   },
   "stable": {
    "version": [
@@ -136151,11 +137056,11 @@
   "repo": "akermu/emacs-libvterm",
   "unstable": {
    "version": [
-    20260406,
-    134
+    20260528,
+    1919
    ],
-   "commit": "54c29d14bca05bdd8ae60cda01715d727831e3f9",
-   "sha256": "1jwby4pyzqv4n7fi8d617j93bbgdr3hkcpkkv2cqqpz1lfy0cab5"
+   "commit": "d8157e74339e02b70fa5dcd9d572960dd5c8214a",
+   "sha256": "15n6qhqfd9k504w1vm4abdfagzxa50a387f1kjg9azj6v84hawnb"
   }
  },
  {
@@ -136202,14 +137107,14 @@
   "repo": "jixiuf/vterm-toggle",
   "unstable": {
    "version": [
-    20260420,
-    1244
+    20260601,
+    1632
    ],
    "deps": [
     "vterm"
    ],
-   "commit": "80989c6ca35416a5c85fa76277ef49a13c3eac11",
-   "sha256": "1941hls4lz4a4ww4jmns23zydzl3z948w72m7ji22y0f0hppf1af"
+   "commit": "a0051a8b8eaa85f8df54ddb032f5710c1f62779d",
+   "sha256": "14dpnvsjd1hz67japlp3vazydj4hljhhffywgq8r4mqgg0781cjw"
   }
  },
  {
@@ -136312,20 +137217,20 @@
   "repo": "d12frosted/vui.el",
   "unstable": {
    "version": [
-    20260130,
-    2113
+    20260624,
+    801
    ],
-   "commit": "7d904ddff91325d756ad7ffd4dfb0db855f3a120",
-   "sha256": "03p61v8ra4fy83amhgmzidhlh66vwpgcclw8h2wlwzsxg4sf3lr5"
+   "commit": "bc7add258504673a5c3e1bcd9f8341aaa104d522",
+   "sha256": "1x3viirn0c3ngmaqirnsgngkx45nxw88vcc63agnc0crj7wvfyaf"
   },
   "stable": {
    "version": [
     1,
-    0,
+    2,
     0
    ],
-   "commit": "67c508c0f2dd6773a590df47c355edb3911f0bcb",
-   "sha256": "05jny12ncjr7ybwab8lmshjjhcrsax67063xbfv7ri6j5kdk5r52"
+   "commit": "bc7add258504673a5c3e1bcd9f8341aaa104d522",
+   "sha256": "1x3viirn0c3ngmaqirnsgngkx45nxw88vcc63agnc0crj7wvfyaf"
   }
  },
  {
@@ -136374,8 +137279,8 @@
   "repo": "d12frosted/vulpea",
   "unstable": {
    "version": [
-    20260308,
-    1107
+    20260619,
+    803
    ],
    "deps": [
     "dash",
@@ -136383,13 +137288,13 @@
     "org",
     "s"
    ],
-   "commit": "4433949421f302edefb575896265f11a261275bf",
-   "sha256": "0f30icbk4z5l5b3bkww4y00rlb94cnpr3cc108p5rba4f9kffga0"
+   "commit": "0f55c96b6649872155d5486acb749710b3726e4a",
+   "sha256": "1lv0l2wq2zbvvbif5n49wa6khgx3mayi1is1igk6dv5lrxnc0h1c"
   },
   "stable": {
    "version": [
     2,
-    2,
+    4,
     0
    ],
    "deps": [
@@ -136398,8 +137303,8 @@
     "org",
     "s"
    ],
-   "commit": "e2330e8ff04590913570773ddcb87355427ffbb7",
-   "sha256": "01vq47y9sr62b1nb8dr5aq499kvgca8dswrxn3bpnzxfx5sfdq3b"
+   "commit": "0f55c96b6649872155d5486acb749710b3726e4a",
+   "sha256": "1lv0l2wq2zbvvbif5n49wa6khgx3mayi1is1igk6dv5lrxnc0h1c"
   }
  },
  {
@@ -136410,16 +137315,16 @@
   "repo": "d12frosted/vulpea-journal",
   "unstable": {
    "version": [
-    20260306,
-    921
+    20260619,
+    1002
    ],
    "deps": [
     "dash",
     "vulpea",
     "vulpea-ui"
    ],
-   "commit": "071533d534e69e302dac543053c59ea8d4d7af77",
-   "sha256": "0kaawf7jy4kd14spmi6pzhqjpf6gh0y18j8hn2a8nm4dfljr1hbd"
+   "commit": "eb503e67711284ef6ad95e40ad91bf723444d837",
+   "sha256": "123lr8f3b6db3pijrg1x33hbgh7hyh6w5qpab5n11hb90vdchimq"
   },
   "stable": {
    "version": [
@@ -136444,15 +137349,15 @@
   "repo": "d12frosted/vulpea-ui",
   "unstable": {
    "version": [
-    20260331,
-    601
+    20260619,
+    819
    ],
    "deps": [
     "vui",
     "vulpea"
    ],
-   "commit": "5bf32360d5107053a2b7ee9e75e647faa1f099c7",
-   "sha256": "04n5c3rl9y479cg98j37l5r4k13bc5jjnzl43yn9czyf9556b0vd"
+   "commit": "0d58924bea2ad034daa3bb3b315f5357ad65666d",
+   "sha256": "0rbipglig27waflrbql44sfsn9fhsbzgcj4mn9c7v0n5s8g3lwvp"
   },
   "stable": {
    "version": [
@@ -136570,15 +137475,14 @@
   "repo": "shosti/wacspace.el",
   "unstable": {
    "version": [
-    20180311,
-    2350
+    20260427,
+    2039
    ],
    "deps": [
-    "cl-lib",
     "dash"
    ],
-   "commit": "54d19aab6fd2bc5945b7ffc58104e695064927e2",
-   "sha256": "1nfx1qsl2gxjqbbc5xsr8f3xz2qyb4wnz3634k3hglb1jpa78j3n"
+   "commit": "28b1fb7a124febb8dbf47aaae8d7dd8c185eea7d",
+   "sha256": "102zabzygvf7aw879sdyyldgjsih0cpvmjfg4llwf4jp9wf0fzja"
   },
   "stable": {
    "version": [
@@ -136632,11 +137536,11 @@
   "repo": "wakatime/wakatime-mode",
   "unstable": {
    "version": [
-    20240623,
-    653
+    20260520,
+    234
    ],
-   "commit": "1c5b2254dd72f2ff504d6a6189a8c10be03a98d1",
-   "sha256": "00qv6b756qiaqrmfg1w03psnsdj0iaz3sp50ib4kmdm2g9vgxl1s"
+   "commit": "464ea0ea99696133553c565cdfc0966a496b1887",
+   "sha256": "0pyfjk7azfhxqklazvcc17n59dvin0csndkf6rm2cadr5n15r0wg"
   }
  },
  {
@@ -136719,16 +137623,16 @@
   "repo": "abrochard/walkman",
   "unstable": {
    "version": [
-    20241204,
-    2234
+    20260515,
+    1746
    ],
    "deps": [
     "json-mode",
     "org",
     "transient"
    ],
-   "commit": "b8260b6c1c6bdc8878c6f8cbeeea05040ac92b65",
-   "sha256": "1l3hg4spzgf4ymqp9ka7dys4hp1p227y1lf4cbni4ngz6ajynh26"
+   "commit": "0328a6b8ca98926a4fed88e722eba66ddbc5b0a8",
+   "sha256": "1n662r7q9vmbndswnhv77r1nngb65qwvnx5vii1nnd31p4vhvp0j"
   },
   "stable": {
    "version": [
@@ -137183,11 +138087,11 @@
   "repo": "fxbois/web-mode",
   "unstable": {
    "version": [
-    20260331,
-    1441
+    20260623,
+    932
    ],
-   "commit": "e93b3fb89fd6345a5ff59795bed712abd486200a",
-   "sha256": "02xn5wqmjv46nqrd73prddzx20c3r5idyg55rchbzvd4wwxjc9a6"
+   "commit": "aeee2d4c82a791ff69657c1413873bf9265544df",
+   "sha256": "0bpm6njk1pmqckvmk7zwcfms8csb9rzj3zylh3pl7xr2k25gaj1x"
   },
   "stable": {
    "version": [
@@ -138162,14 +139066,14 @@
   "repo": "agzam/wiktionary-bro.el",
   "unstable": {
    "version": [
-    20251218,
-    2021
+    20260615,
+    1744
    ],
    "deps": [
     "request"
    ],
-   "commit": "def5f3cb1486077cb090da48d77f790b858e7886",
-   "sha256": "1iijq66awixa8wr6rm44kxsgl55dggqvdgp3b41wm6j1w6vb1cic"
+   "commit": "bf53a1b3ce71ecf13d3b8a7aa0ba3a66bcf3f2a1",
+   "sha256": "1dyyp85jika15kq4cyjnm53zqfilsxbsljg38ib36r3hiic896x7"
   },
   "stable": {
    "version": [
@@ -138539,11 +139443,11 @@
   "repo": "xenodium/winpulse",
   "unstable": {
    "version": [
-    20260216,
-    2106
+    20260611,
+    341
    ],
-   "commit": "c58352bea2223fd6f0cc11deb4d33bca2ff0213c",
-   "sha256": "0fpnh45mm608i41mv7abkkm4m29bzwhgls9r2gcdvcbsaddcfk61"
+   "commit": "dcfccb28394d8eb09a8bbbca69e466b334af461d",
+   "sha256": "0zvfa5jkcaxxzcydx7w227hh08vgrgzij520620nbb0a5ran9vwz"
   }
  },
  {
@@ -138619,10 +139523,10 @@
    "version": [
     1,
     0,
-    12
+    13
    ],
-   "commit": "7c6239a779656cd55225ad24e15cc29bc896f834",
-   "sha256": "0m5ssl4ngk2jl1zk0fnsss0asyvwanjaa5rrcksldqnh2ikcr4bm"
+   "commit": "de5543e8e0b3bf05f3db552e71e0ed52169f0307",
+   "sha256": "0fb4l0ww4rnkrsh4x46301j5xrqniny9b7yh7i6lp4wprwx0a7fs"
   }
  },
  {
@@ -138656,33 +139560,51 @@
   }
  },
  {
+  "ename": "with-command-redo",
+  "commit": "fc803a9357d301d3f0b2b6396f1f85db36c27cbc",
+  "sha256": "0payls4280ng2lxqqjlhfc90xgxikk3kh6j7lhxfrykjag26k2m2",
+  "fetcher": "codeberg",
+  "repo": "ideasman42/emacs-with-command-redo",
+  "unstable": {
+   "version": [
+    20260504,
+    2116
+   ],
+   "commit": "d1c4be4bb3fb22dff8fcfb562912760be3a685e8",
+   "sha256": "1mlrmd4ncb4k1wbdpzrc6hja07pn0fzfcslpxkkigc4nz69r9y6l"
+  }
+ },
+ {
   "ename": "with-editor",
-  "commit": "a74629656e9a23133219a0bd805982f1497b35d7",
-  "sha256": "1pgw52pn0vam3p8hh5cyivsg0i8r6pigam6xvbk46siffk16g0wk",
+  "commit": "aec4a76eaea31408bd27d76a0b8cea5268663cc1",
+  "sha256": "1wsl1vwvywlc32r5pcc9jqd0pbzq1sn4fppxk3vwl0s5h40v8rnb",
   "fetcher": "github",
   "repo": "magit/with-editor",
   "unstable": {
    "version": [
-    20260417,
-    751
+    20260623,
+    1348
    ],
    "deps": [
-    "compat"
+    "compat",
+    "cond-let",
+    "llama"
    ],
-   "commit": "d0935036eb894680d8ca1a4d1ed8e8d5d90005e5",
-   "sha256": "15vvc6awlk8mzqqfqn7n3k349skzg0jk645sjgmzq1sfig4yfcsy"
+   "commit": "c319ef4d3a9dab479b4077cdc089d1ffac97d7db",
+   "sha256": "1h6r3rzif9c1jynm14z3ajlz0zb4mdbbzjclncn4ldwnsn7pxmia"
   },
   "stable": {
    "version": [
     3,
-    4,
-    9
+    5,
+    1
    ],
    "deps": [
-    "compat"
+    "compat",
+    "cond-let"
    ],
-   "commit": "64211dcb815f2533ac3d2a7e56ff36ae804d8338",
-   "sha256": "0gxmmzx7z84d4684q58ijms7d555ngasvzhfz2gna9awly5qig6z"
+   "commit": "cdf2ac2314042243fae385bb8c2821ec9c3888ae",
+   "sha256": "0cxmn7kgb5npvxdk1q5g0w9a1c1b8gvwkszd1b8bjrjwmli96as0"
   }
  },
  {
@@ -139057,11 +139979,11 @@
   "repo": "martianh/wordreference.el",
   "unstable": {
    "version": [
-    20241203,
-    1648
+    20260509,
+    754
    ],
-   "commit": "4f68d155ceb3328c3263faee86cfb82d50402f05",
-   "sha256": "0kv0b2nbaafjznclahymxcrp2mj06v71887jg5rlj2i09mb0igf1"
+   "commit": "6b1e321ec48ae6eadc06ed25f018c384e396644b",
+   "sha256": "1qsiwk6j73fvjhhwzf3qi5zhp59ix7h7fz3z6xp7vr7h6dyal2l9"
   }
  },
  {
@@ -139390,26 +140312,26 @@
   "repo": "cjennings/emacs-wttrin",
   "unstable": {
    "version": [
-    20260422,
-    507
+    20260624,
+    410
    ],
    "deps": [
     "xterm-color"
    ],
-   "commit": "9958ec4c4396ae8435f7e1818ff383c05df47a14",
-   "sha256": "1i4k7aj2w5mawfc9h8h7s5c3r886bmzxf4ai2q1caarhckb81wj3"
+   "commit": "efd3cdce5b3aebfdb3e02460d1ec0434cef85949",
+   "sha256": "0w204bk520jcm9qya02ag3bb9azbn3dwjar4mvap7hp86ck6bpki"
   },
   "stable": {
    "version": [
     0,
     3,
-    1
+    2
    ],
    "deps": [
     "xterm-color"
    ],
-   "commit": "a0f1b4f07c98ab3d4d4b50a330822d0991b733a7",
-   "sha256": "1b28z8zl53lf5cvybynsnkhs85jz346y7vvhd32l1ypwsr7s0p4d"
+   "commit": "fe653a231b186393b02a2723985e61ce97baba1c",
+   "sha256": "02wkqjyap6gxbi2mcrzpbdjz40igsmf1cbqqr7iw0mgp4ray7zxd"
   }
  },
  {
@@ -139511,14 +140433,14 @@
   "repo": "jobbflykt/x509-mode",
   "unstable": {
    "version": [
-    20260410,
-    723
+    20260602,
+    643
    ],
    "deps": [
     "compat"
    ],
-   "commit": "c5dc5a97469166b5a4e835b878ca3c0ed2df055a",
-   "sha256": "03k3lk2viplhivq01j5f088b6kv9dc5iz2zf6i0mlba45jm8vp5f"
+   "commit": "3d1a4b3973212b26774b43f7450ff320bec54afe",
+   "sha256": "1l349q7hdixp2gy8rzqk5n568zkry07ssb9q1drgi5jvcsjn2c6r"
   }
  },
  {
@@ -140042,11 +140964,11 @@
   "repo": "ideasman42/emacs-xref-rst",
   "unstable": {
    "version": [
-    20260108,
-    1306
+    20260528,
+    14
    ],
-   "commit": "2d1ed3f31b64a9e10a757dedf06f1b514894d67f",
-   "sha256": "157cfapjp8ip3maqlnbdndlk6j9sr0lrdcl67fvmcxnflabrssff"
+   "commit": "e54656eff9138d71c5d9ad7717675575b9f2b636",
+   "sha256": "08kw6ksgr9rjg56a377fvl5qb0x0c6zqcsv3v9zi4hqhqnycwri4"
   }
  },
  {
@@ -140081,11 +141003,11 @@
   "repo": "atomontage/xterm-color",
   "unstable": {
    "version": [
-    20251128,
-    1842
+    20260531,
+    1854
    ],
-   "commit": "ce82e87ea3d277c7e4fc48ce390d540fbd78f6d1",
-   "sha256": "0zkjfvma70lw0iv31g1n1naz40d2wpngiasnjy9gslm1nybxj76a"
+   "commit": "0b0d808f8bc5007037341dc5f63149cc32cf2c5b",
+   "sha256": "1jhflkq2jji1nv2hc94xkmfsw383nav2rppl1g4xf76ld1yinkfr"
   },
   "stable": {
    "version": [
@@ -140380,20 +141302,20 @@
   "repo": "zkry/yaml.el",
   "unstable": {
    "version": [
-    20260113,
-    653
+    20260605,
+    834
    ],
-   "commit": "f2369fb4985ed054be47ae111760ff2075dff72a",
-   "sha256": "1fb7hgb6r0pk30w2vdcci494rrn337ibjvq7xj1ihj2cv2xk8pdb"
+   "commit": "5546f36bde24a9a8c1934e0f6ce205cd41d72537",
+   "sha256": "06s7hl8gn80r7ydvgraml3i51iprmvllz15flfrv7y02ncz98jd5"
   },
   "stable": {
    "version": [
     1,
     2,
-    3
+    4
    ],
-   "commit": "f2369fb4985ed054be47ae111760ff2075dff72a",
-   "sha256": "1fb7hgb6r0pk30w2vdcci494rrn337ibjvq7xj1ihj2cv2xk8pdb"
+   "commit": "5546f36bde24a9a8c1934e0f6ce205cd41d72537",
+   "sha256": "06s7hl8gn80r7ydvgraml3i51iprmvllz15flfrv7y02ncz98jd5"
   }
  },
  {
@@ -140530,11 +141452,11 @@
   "repo": "Kungsgeten/yankpad",
   "unstable": {
    "version": [
-    20250609,
-    1121
+    20260506,
+    850
    ],
-   "commit": "55891dde4c9d83b86f94764e7a1990084e66ee53",
-   "sha256": "060vyy0l6y2mjyhk4xys28c85jhqrm8dilrzx4xdmlnd2x4nm1al"
+   "commit": "183b92a25a6fcc1496a8028d80397662e0bd5f19",
+   "sha256": "1s6kd0y1xk6k9xxlna8ayrz7ryd3jq05qcfmakxl4mi4jjf11q53"
   },
   "stable": {
    "version": [
@@ -140577,11 +141499,11 @@
   "repo": "binjo/yara-mode",
   "unstable": {
    "version": [
-    20220317,
-    935
+    20260624,
+    302
    ],
-   "commit": "4c959b300ce52665c92e04e524dda5ed051c34f3",
-   "sha256": "0kb2a4hcmaczn279hbgk0jv88hsjznv1kqpkgkadszd02q53n0cl"
+   "commit": "dc6eb93198c081c579300521d25199625e375530",
+   "sha256": "0j41lxn6krfffc6gv9a00rj2g20y4hhnslwp46gfm33vn52kcza7"
   }
  },
  {
@@ -140933,26 +141855,28 @@
   "url": "https://git.thanosapollo.org/yeetube",
   "unstable": {
    "version": [
-    20260302,
-    1931
+    20260609,
+    525
    ],
    "deps": [
-    "compat"
+    "compat",
+    "keymap-popup"
    ],
-   "commit": "77e816972a70db86ad06ef10db56e0d8cecede5c",
-   "sha256": "0zvbfwxq3dx14ynpafpvv1swg7hbg3k9avir9b7cymf4r5hrjnx3"
+   "commit": "f88374d100e9a1005d62a9822a4038ff6f2d91e7",
+   "sha256": "162gs3fdlx806s1riwjkky1s2qhh0vzxlhigj05j82ldn3s8kkf4"
   },
   "stable": {
    "version": [
     2,
-    1,
-    12
+    3,
+    0
    ],
    "deps": [
-    "compat"
+    "compat",
+    "keymap-popup"
    ],
-   "commit": "77e816972a70db86ad06ef10db56e0d8cecede5c",
-   "sha256": "0zvbfwxq3dx14ynpafpvv1swg7hbg3k9avir9b7cymf4r5hrjnx3"
+   "commit": "3a5ca54f63a1c8688ca580e77f06a1065283f0e7",
+   "sha256": "0phlcmf54f2wih7rksazf8k2jz4i31siqzd4gb7x3d6zddk2rs97"
   }
  },
  {
@@ -141258,11 +142182,11 @@
   "repo": "treflip/zathura.el",
   "unstable": {
    "version": [
-    20250728,
-    1208
+    20260603,
+    1620
    ],
-   "commit": "947b8332f25810105d35e350f604cdad4e32ee6f",
-   "sha256": "16hprzf15y7zwr28dimlmlylz5sxy54kfq2yniqwxsrm3r59j1bp"
+   "commit": "874dadbf07e22811b6b309200cad32b4ccca0e51",
+   "sha256": "1fjdwjygxxf6dfcff74r39z53mf3bkwgrfl8jcfdnkfdx9mpi8x9"
   }
  },
  {
@@ -141327,20 +142251,20 @@
   "repo": "bbatsov/zenburn-emacs",
   "unstable": {
    "version": [
-    20260329,
-    1838
+    20260601,
+    1829
    ],
-   "commit": "1022240b1061369ecb605d55fa074d20d5c84aae",
-   "sha256": "17rl292240j2c8db01irpp5khsqwwwwcjlzwa52adyirc5bdb74v"
+   "commit": "8697934a57151de119744ea79fde83120e05b88d",
+   "sha256": "0g54j3n2khc470i80diqqdxds0xiysvwdjss3jmgdf73argslj1q"
   },
   "stable": {
    "version": [
     2,
-    9,
+    10,
     0
    ],
-   "commit": "1022240b1061369ecb605d55fa074d20d5c84aae",
-   "sha256": "17rl292240j2c8db01irpp5khsqwwwwcjlzwa52adyirc5bdb74v"
+   "commit": "8697934a57151de119744ea79fde83120e05b88d",
+   "sha256": "0g54j3n2khc470i80diqqdxds0xiysvwdjss3jmgdf73argslj1q"
   }
  },
  {
@@ -141375,10 +142299,10 @@
  },
  {
   "ename": "zeno-theme",
-  "commit": "f6633f0376fd50b6cc45d96c67848dbf8f38e210",
-  "sha256": "0akc4llnam4p699v01szhf0xj7r6475y14kbpxli29n5612cwdax",
+  "commit": "469e38ed467ec98dd7fac2e2d3143f18dbd97197",
+  "sha256": "1pg7jkxg5ixqaj4c6igk6hkjv6fdn8b147i05jpl3pfh0dij6h5c",
   "fetcher": "github",
-  "repo": "sacredyak/zeno-theme",
+  "repo": "rokrdev/zeno-theme",
   "unstable": {
    "version": [
     20211205,
@@ -142256,11 +143180,11 @@
   "repo": "cyrus-and/zoom",
   "unstable": {
    "version": [
-    20250214,
-    1251
+    20260509,
+    908
    ],
-   "commit": "36f9db90941b10d34bac976aee35dfe25242cd03",
-   "sha256": "0y01yn0gaycyhqifg8gq0ilr20qr0xm51rh97vbp1vh1n74fca4q"
+   "commit": "5e524d98c7f2b4dd6ed41d95573b29b263632eb2",
+   "sha256": "1761ad33yppr3xb5244lpn68l4n3blk577f4l5mbvbkapnfly89q"
   },
   "stable": {
    "version": [
@@ -142512,24 +143436,6 @@
    ],
    "commit": "341d1a4a91a8acff5be6b81f95695e17c79c5309",
    "sha256": "02g65hri4k362lqk43vpzzdlxisdbjbknvb4riib5dcdar08qr34"
-  }
- },
- {
-  "ename": "zprint-format",
-  "commit": "54457e29def6ecfdf96f599e6a007f5ebee485b9",
-  "sha256": "1flb1i5byp6s8fj1vpgm5wc43f8hld7rg940m20a40ysr1x35szk",
-  "fetcher": "github",
-  "repo": "dpassen/zprint-format",
-  "unstable": {
-   "version": [
-    20210602,
-    146
-   ],
-   "deps": [
-    "reformatter"
-   ],
-   "commit": "fa575c17a40033189f2f23f1a5b27b88c399d200",
-   "sha256": "0xzq07xbk3pz1hhbwb7hakd1w6x20jm3q1flqjl3c8wxgbi7cmml"
   }
  },
  {


### PR DESCRIPTION
- emacs-overlay commit: 05d06425c4e17fdf1cbc5cdbf744e5d635993245
- build failures
  - [X] emacs-org-cite-overlay-20260619.1531.drv
  - [x] emacs-php-fill-1.1.1.drv: [upstream PR](https://github.com/arielenter/php-fill.el/pull/1)
  - [x] emacs-consult-gh-nerd-icons-20250915.2241.drv
  - [ ] emacs-phony-20260531.2312.drv: [upstream report](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=81299)
- previous bump: #513308
- [x] test new pkgs with my Emacs configuration
  ```console
  HOME=(mktemp -d) nix run github:jian-lin/wonima#emacs --override-input nixpkgs github:NixOS/nixpkgs?ref=refs/pull/535032/head
  ```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
