### PR TITLE
[Backport release-26.05] home-assistant: backport pyjwt 2.13.0 support

### DIFF
--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -333,6 +333,9 @@ python3Packages.buildPythonApplication rec {
       url = "https://github.com/home-assistant/core/commit/e796d9c46744097585bfada483108a55ae16344a.patch";
       hash = "sha256-T0Nb6LcL/21WdUm8RmczhHaVX92n5O/rpMdpqDVQ2VU=";
     })
+
+    # https://github.com/home-assistant/core/pull/172893
+    ./patches/pyjwt-2.13-compat.patch
   ];
 
   postPatch = ''

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -316,6 +316,9 @@ python3Packages.buildPythonApplication rec {
     # No scaring our users about not running in a docker or a venv
     ./patches/pythonpath-is-a-venv.patch
 
+    # No scaring our users about our install method
+    ./patches/nixos-was-never-supported.patch
+
     # Patch path to ffmpeg binary
     (replaceVars ./patches/ffmpeg-path.patch {
       ffmpeg = "${lib.getExe ffmpeg-headless}";

--- a/pkgs/servers/home-assistant/patches/nixos-was-never-supported.patch
+++ b/pkgs/servers/home-assistant/patches/nixos-was-never-supported.patch
@@ -1,0 +1,13 @@
+diff --git a/homeassistant/components/homeassistant/__init__.py b/homeassistant/components/homeassistant/__init__.py
+index 54c6454167b..026fda54578 100644
+--- a/homeassistant/components/homeassistant/__init__.py
++++ b/homeassistant/components/homeassistant/__init__.py
+@@ -420,7 +420,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
+ 
+         installation_type = info["installation_type"][15:]
+         if installation_type in {"Core", "Container"}:
+-            deprecated_method = installation_type == "Core"
++            deprecated_method = False
+             bit32 = _is_32_bit()
+             arch = info["arch"]
+             if bit32 and installation_type == "Container":

--- a/pkgs/servers/home-assistant/patches/pyjwt-2.13-compat.patch
+++ b/pkgs/servers/home-assistant/patches/pyjwt-2.13-compat.patch
@@ -1,0 +1,48 @@
+diff --git a/homeassistant/auth/__init__.py b/homeassistant/auth/__init__.py
+index e16c29ceaa8..8224aca0e43 100644
+--- a/homeassistant/auth/__init__.py
++++ b/homeassistant/auth/__init__.py
+@@ -656,6 +656,8 @@ class AuthManager:
+         try:
+             unverif_claims = jwt_wrapper.unverified_hs256_token_decode(token)
+         except jwt.InvalidTokenError:
++            # PyJWT 2.13 raises InvalidKeyError (not an InvalidTokenError) when
++            # the refresh token's key has been removed and is therefore empty.
+             return None
+ 
+         refresh_token = self.async_get_refresh_token(
+@@ -673,7 +675,7 @@ class AuthManager:
+             jwt_wrapper.verify_and_decode(
+                 token, jwt_key, leeway=10, issuer=issuer, algorithms=["HS256"]
+             )
+-        except jwt.InvalidTokenError:
++        except jwt.InvalidTokenError, jwt.InvalidKeyError:
+             return None
+ 
+         if refresh_token is None or not refresh_token.user.is_active:
+diff --git a/homeassistant/components/html5/notify.py b/homeassistant/components/html5/notify.py
+index c3ea03d01b9..98878696139 100644
+--- a/homeassistant/components/html5/notify.py
++++ b/homeassistant/components/html5/notify.py
+@@ -327,7 +327,7 @@ class HTML5PushCallbackView(HomeAssistantView):
+         if target_check.get(ATTR_TARGET) in self.registrations:
+             possible_target = self.registrations[target_check[ATTR_TARGET]]
+             key = possible_target["subscription"]["keys"]["auth"]
+-            with suppress(jwt.exceptions.DecodeError):
++            with suppress(jwt.exceptions.DecodeError, jwt.exceptions.InvalidKeyError):
+                 return jwt.decode(token, key, algorithms=["ES256", "HS256"])
+ 
+         return self.json_message(
+diff --git a/tests/components/elmax/conftest.py b/tests/components/elmax/conftest.py
+index 02f01036996..c9c3f13e9e3 100644
+--- a/tests/components/elmax/conftest.py
++++ b/tests/components/elmax/conftest.py
+@@ -82,7 +82,7 @@ def httpx_mock_direct_fixture(base_uri: str) -> Generator[respx.MockRouter]:
+         expiration = datetime.now() + timedelta(hours=1)
+         decoded_jwt["payload"]["exp"] = int(expiration.timestamp())
+         jws_string = jwt.encode(
+-            payload=decoded_jwt["payload"], algorithm="HS256", key=""
++            payload=decoded_jwt["payload"], algorithm="HS256", key="test"
+         )
+         login_json["token"] = f"JWT {jws_string}"
+         login_route.return_value = Response(200, json=login_json)

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -134,6 +134,10 @@ let
       # 2026.5.0: after reload device is in loaded state instead of retry state
       "test_usb_device_reactivity"
     ];
+    homeassistant = [
+      # disabled via nixos-was-never-supported.patch
+      "test_deprecated_installation_issue_core"
+    ];
     homeassistant_connect_zbt2 = [
       # 2026.5.0: after reload device is in loaded state instead of retry state
       "test_usb_device_reactivity"


### PR DESCRIPTION
Fixes a regression from staging-next-26.05 and backports a patch to ignore a deprecation warning shown to endusers.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
