### PR TITLE
 python3Packages.tree-sitter-grammars: implement checkTreeSitterJson escape hatch

### DIFF
--- a/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
+++ b/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
@@ -3191,10 +3191,12 @@
   };
 
   yuck = {
-    version = "0.0.2-unstable-2024-05-05";
-    url = "github:Philipp-M/tree-sitter-yuck";
-    rev = "e877f6ade4b77d5ef8787075141053631ba12318";
-    hash = "sha256-l8c1/7q8S78jGyl+VAVVgs8wq58PrrjycyJfWXsCgAI=";
+    version = "0.0.2-unstable-2026-04-03";
+    url = "github:tree-sitter-grammars/tree-sitter-yuck";
+    rev = "6c60112b3b3e739fb1ca4a8ea4bea2b6ffe11318";
+    hash = "sha256-ZbUN9lv2nGgpQ0rU+H38gSCdCSav//47ESHXDMuQX7c=";
+    # Fails strict schema validation due to empty string properties
+    checkTreeSitterJson = false;
     meta = {
       license = lib.licenses.mit;
       maintainers = with lib.maintainers; [

--- a/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
+++ b/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
@@ -3094,10 +3094,11 @@
   };
 
   wit = {
-    version = "0-unstable-2022-10-31";
-    url = "github:hh9527/tree-sitter-wit";
-    rev = "c917790ab9aec50c5fd664cbfad8dd45110cfff3";
-    hash = "sha256-5+cw9vWPizK7YlEhiNJheYVYOgtheEifd4g1KF5ldyE=";
+    version = "1.3.0";
+    url = "github:bytecodealliance/tree-sitter-wit";
+    hash = "sha256-FG73R38Bw60+aT5YB/xpENCnQwoGMVjXRLjP1GdJEn4=";
+    # Fails strict schema validation due to Neovim ecosystem extensions
+    checkTreeSitterJson = false;
     meta = {
       license = lib.licenses.mit;
       maintainers = with lib.maintainers; [

--- a/pkgs/development/python-modules/tree-sitter-grammars/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-grammars/default.nix
@@ -201,6 +201,10 @@ buildPythonPackage {
     pytestCheckHook
   ];
 
+  disabledTests = lib.optionals (!(grammarDrv.checkTreeSitterJson or true)) [
+    "test_config"
+  ];
+
   pythonImportsCheck = [ snakeCaseName ];
 
   meta = {


### PR DESCRIPTION
As mentioned when tree-sitter-config was introduced, grammars whose tree-sitter.json deviates from the strict upstream schema (e.g., adding Neovim ecosystem keys like folds or using empty strings for URLs) fail the test_config python test.

This formally implements the checkTreeSitterJson = false override on the grammar derivation to disable test_config for those specific non-compliant grammars while keeping strict validation by default for all others.



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
