### PR TITLE
sing-box_unstable: init at 1.14.0-alpha.34

### DIFF
--- a/pkgs/by-name/si/sing-box_unstable/package.nix
+++ b/pkgs/by-name/si/sing-box_unstable/package.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  coreutils,
+  nix-update-script,
+  nixosTests,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "sing-box_unstable";
+  version = "1.14.0-alpha.34";
+
+  src = fetchFromGitHub {
+    owner = "SagerNet";
+    repo = "sing-box";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-QwG46iZtc5jqWar/28/K9STZHWnLUwofHBlR2mE5lYs=";
+  };
+
+  vendorHash = "sha256-c99as3LIzPR/IZel76rEOJ/kHmxE0fwJV84eSPG98Ls=";
+
+  __structuredAttrs = true;
+
+  tags = [
+    "with_gvisor"
+    "with_quic"
+    "with_dhcp"
+    "with_wireguard"
+    "with_utls"
+    "with_acme"
+    "with_clash_api"
+    "with_tailscale"
+    "with_ccm"
+    "with_ocm"
+    "with_cloudflared"
+    "badlinkname"
+    "tfogo_checklinkname0"
+  ];
+
+  subPackages = [
+    "cmd/sing-box"
+  ];
+
+  env.CGO_ENABLED = 0;
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  ldflags = [
+    "-X=github.com/sagernet/sing-box/constant.Version=${finalAttrs.version}"
+    "-X=internal/godebug.defaultGODEBUG=multipathtcp=0"
+    "-checklinkname=0"
+  ];
+
+  postInstall = ''
+    installShellCompletion release/completions/sing-box.{bash,fish,zsh}
+
+    substituteInPlace release/config/sing-box{,@}.service \
+      --replace-fail "/usr/bin/sing-box" "$out/bin/sing-box" \
+      --replace-fail "/bin/kill" "${coreutils}/bin/kill"
+    install -Dm444 -t "$out/lib/systemd/system/" release/config/sing-box{,@}.service
+
+    install -Dm444 release/config/sing-box.rules $out/share/polkit-1/rules.d/sing-box.rules
+    install -Dm444 release/config/sing-box-split-dns.xml $out/share/dbus-1/system.d/sing-box-split-dns.conf
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version=unstable" ]; };
+    tests = { inherit (nixosTests) sing-box_unstable; };
+  };
+
+  meta = {
+    homepage = "https://sing-box.sagernet.org";
+    description = "Universal proxy platform";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      nix-julia
+    ];
+    mainProgram = "sing-box";
+  };
+})


### PR DESCRIPTION
Since firewall updates require rapid updates of tools like sing-box, it may be better to provide an unstable version alongside (or even instead of) a stable version. I’m not sure whether my approach to creating a new package is correct—@Prince213, could you please share your thoughts?
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
