### PR TITLE
python3Packages.torch: fix inductor on darwin

### DIFF
--- a/pkgs/development/python-modules/accelerate/default.nix
+++ b/pkgs/development/python-modules/accelerate/default.nix
@@ -44,8 +44,6 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-IfKePiU38fUd5HefaS7J1s8Mb6hVmldINemxAJY+83o=";
   };
 
-  buildInputs = [ llvmPackages.openmp ];
-
   build-system = [ setuptools ];
 
   dependencies = [

--- a/pkgs/development/python-modules/compressed-tensors/default.nix
+++ b/pkgs/development/python-modules/compressed-tensors/default.nix
@@ -7,7 +7,6 @@
   # build-system
   setuptools,
   setuptools-scm,
-  llvmPackages,
 
   # dependencies
   frozendict,
@@ -45,10 +44,6 @@ buildPythonPackage (finalAttrs: {
   build-system = [
     setuptools
     setuptools-scm
-  ];
-
-  buildInputs = lib.optionals stdenv.cc.isClang [
-    llvmPackages.openmp
   ];
 
   dependencies = [

--- a/pkgs/development/python-modules/compressed-tensors/default.nix
+++ b/pkgs/development/python-modules/compressed-tensors/default.nix
@@ -93,6 +93,9 @@ buildPythonPackage (finalAttrs: {
     "test_mxfp8_scales_e2e"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # AssertionError: Numerical precision error
+    "test_quantization_enabled_disabled"
+
     # torch._inductor.exc.InductorError: ImportError: dlopen(/nix/var/nix/builds/nix-25002-542173852/torchinductor__nixbld1/xo/cxovsevcfanmw7lgoddbnyhoxes3nzlu7ecugxedaq2zr4f6b2qh.main.so, 0x0002):
     # symbol not found in flat namespace '___kmpc_barrier'
     "test_compress_decompress_module"

--- a/pkgs/development/python-modules/e3nn/default.nix
+++ b/pkgs/development/python-modules/e3nn/default.nix
@@ -62,12 +62,6 @@ buildPythonPackage (finalAttrs: {
     "test_variance"
   ];
 
-  propagatedBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
-    # Otherwise, torch will fail to include `omp.h`:
-    # torch._inductor.exc.InductorError: CppCompileError: C++ compile error OpenMP support not found
-    llvmPackages.openmp
-  ];
-
   meta = {
     description = "Modular framework for neural networks with Euclidean symmetry";
     homepage = "https://github.com/e3nn/e3nn";

--- a/pkgs/development/python-modules/hoptorch/default.nix
+++ b/pkgs/development/python-modules/hoptorch/default.nix
@@ -40,12 +40,6 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "hoptorch" ];
 
-  checkInputs = lib.optionals stdenv.hostPlatform.isDarwin [
-    # torch._inductor.exc.InductorError: CppCompileError: C++ compile error
-    # fatal error: 'omp.h' file not found
-    llvmPackages.openmp
-  ];
-
   nativeCheckInputs = [
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/lerobot/default.nix
+++ b/pkgs/development/python-modules/lerobot/default.nix
@@ -59,11 +59,6 @@ buildPythonPackage (finalAttrs: {
   ];
   dontUseCmakeConfigure = true;
 
-  checkInputs = lib.optionals stdenv.cc.isClang [
-    # test_async_iterator_* hangs after failing to find OMP headers
-    llvmPackages.openmp
-  ];
-
   pythonRelaxDeps = [
     "av"
     "diffusers"

--- a/pkgs/development/python-modules/skorch/default.nix
+++ b/pkgs/development/python-modules/skorch/default.nix
@@ -1,35 +1,40 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
   numpy,
+  pandas,
   scikit-learn,
   scipy,
-  setuptools,
   tabulate,
   torch,
   tqdm,
+
+  # tests
   flaky,
-  llvmPackages,
   openssl,
-  pandas,
   pytest-cov-stub,
   pytestCheckHook,
   safetensors,
   transformers,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "skorch";
   version = "1.4.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "skorch-dev";
     repo = "skorch";
-    tag = "v${version}";
-    sha256 = "sha256-il3S5cfW47tKvMQGr/BfbEjMEMVzBF4gSrQhR1uKxks=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-il3S5cfW47tKvMQGr/BfbEjMEMVzBF4gSrQhR1uKxks=";
   };
 
   build-system = [ setuptools ];
@@ -75,6 +80,7 @@ buildPythonPackage rec {
     "skorch/tests/test_dataset.py"
     "skorch/tests/test_hf.py"
     "skorch/tests/llm/test_llm_classifier.py"
+
     # These tests fail when running in parallel for all platforms with:
     # "RuntimeError: The server socket has failed to listen on any local
     # network address because they use the same hardcoded port."
@@ -91,4 +97,4 @@ buildPythonPackage rec {
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ bcdarwin ];
   };
-}
+})

--- a/pkgs/development/python-modules/skorch/default.nix
+++ b/pkgs/development/python-modules/skorch/default.nix
@@ -53,8 +53,6 @@ buildPythonPackage rec {
     transformers
   ];
 
-  checkInputs = lib.optionals stdenv.cc.isClang [ llvmPackages.openmp ];
-
   disabledTests = [
     # on CPU, these expect artifacts from previous GPU run
     "test_load_cuda_params_to_cpu"

--- a/pkgs/development/python-modules/skorch/default.nix
+++ b/pkgs/development/python-modules/skorch/default.nix
@@ -90,10 +90,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/skorch-dev/skorch/blob/master/CHANGES.md";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ bcdarwin ];
-    badPlatforms = [
-      # Most tests fail with:
-      # Fatal Python error: Segmentation fault
-      lib.systems.inspect.patterns.isDarwin
-    ];
   };
 }

--- a/pkgs/development/python-modules/torch/source/default.nix
+++ b/pkgs/development/python-modules/torch/source/default.nix
@@ -389,7 +389,7 @@ buildPythonPackage.override { inherit stdenv; } (finalAttrs: {
   # Otherwise, torch compile will fail at runtime if openmp is not available
   #   torch._inductor.exc.InductorError: CppCompileError: C++ compile error
   #   fatal error: 'omp.h' file not found
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+  + lib.optionalString stdenv.cc.isClang ''
     substituteInPlace torch/csrc/inductor/cpp_prefix.h \
       --replace-fail \
         "#include <omp.h>" \

--- a/pkgs/development/python-modules/torch/source/default.nix
+++ b/pkgs/development/python-modules/torch/source/default.nix
@@ -385,6 +385,15 @@ buildPythonPackage.override { inherit stdenv; } (finalAttrs: {
   # until https://github.com/pytorch/pytorch/issues/76082 is addressed
   + lib.optionalString cudaSupport ''
     rm cmake/Modules/FindCUDAToolkit.cmake
+  ''
+  # Otherwise, torch compile will fail at runtime if openmp is not available
+  #   torch._inductor.exc.InductorError: CppCompileError: C++ compile error
+  #   fatal error: 'omp.h' file not found
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace torch/csrc/inductor/cpp_prefix.h \
+      --replace-fail \
+        "#include <omp.h>" \
+        '#include "${lib.getInclude llvmPackages.openmp}/include/omp.h"'
   '';
 
   # NOTE(@connorbaker): Though we do not disable Gloo or MPI when building with CUDA support, caution should be taken

--- a/pkgs/development/python-modules/torchao/default.nix
+++ b/pkgs/development/python-modules/torchao/default.nix
@@ -77,13 +77,6 @@ buildPythonPackage (finalAttrs: {
     cpuinfo
   ];
 
-  propagatedBuildInputs = lib.optionals isDarwin [
-    # Otherwise, torch will fail to include `omp.h`:
-    # torch._inductor.exc.InductorError: CppCompileError: C++ compile error
-    # OpenMP support not found.
-    llvmPackages.openmp
-  ];
-
   dependencies = [
     torch
   ];

--- a/pkgs/development/python-modules/torchaudio/default.nix
+++ b/pkgs/development/python-modules/torchaudio/default.nix
@@ -4,9 +4,6 @@
   buildPythonPackage,
   fetchFromGitHub,
 
-  # buildInputs
-  llvmPackages,
-
   # build-system
   setuptools,
 
@@ -89,13 +86,9 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
     cudaPackages.cuda_nvcc
   ];
 
-  buildInputs =
-    lib.optionals cudaSupport [
-      cudaPackages.cuda_cudart
-    ]
-    ++ lib.optionals torch.stdenv.cc.isClang [
-      llvmPackages.openmp
-    ];
+  buildInputs = lib.optionals cudaSupport [
+    cudaPackages.cuda_cudart
+  ];
 
   dependencies = [
     torch

--- a/pkgs/development/python-modules/torchaudio/default.nix
+++ b/pkgs/development/python-modules/torchaudio/default.nix
@@ -14,12 +14,17 @@
   # tests
   expecttest,
   inflect,
+  librosa,
   parameterized,
   pytestCheckHook,
   pytorch-lightning,
+  requests,
   scipy,
   sentencepiece,
+  soundfile,
   unidecode,
+  # linux-only:
+  fairseq,
 
   # passthru
   torchaudio,
@@ -106,11 +111,21 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
     scipy
     sentencepiece
     unidecode
+    librosa
+    requests
+    soundfile
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    fairseq
   ];
 
   disabledTestPaths = [
     # Require internet access
     "test/integration_tests"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # Passes, but hangs the build after Pytest completes
+    "test/torchaudio_unittest/models/models_test.py::TestConvTasNet"
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/torchmd-net/default.nix
+++ b/pkgs/development/python-modules/torchmd-net/default.nix
@@ -42,6 +42,13 @@ buildPythonPackage (finalAttrs: {
     setuptools-scm
   ];
 
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    # NotImplementedError: The operator 'torchmdnet::warp_neighbor_brute_fwd' is not currently implemented for the MPS device.
+    # As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` to use the CPU as a fallback for this op.
+    # WARNING: this will be slower than running natively on MPS.
+    PYTORCH_ENABLE_MPS_FALLBACK = true;
+  };
+
   pythonRemoveDeps = [
     # Not a runtime dependency
     "setuptools"

--- a/pkgs/development/python-modules/torchmd-net/default.nix
+++ b/pkgs/development/python-modules/torchmd-net/default.nix
@@ -22,7 +22,6 @@
   pytest-xdist,
   pytestCheckHook,
   writableTmpDirAsHomeHook,
-  llvmPackages,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -64,12 +63,6 @@ buildPythonPackage (finalAttrs: {
     pytest-xdist
     pytestCheckHook
     writableTmpDirAsHomeHook
-  ];
-
-  checkInputs = lib.optionals stdenv.cc.isClang [
-    # torch._inductor.exc.InductorError: CppCompileError: C++ compile error
-    # fatal error: 'omp.h' file not found
-    llvmPackages.openmp
   ];
 
   disabledTests = [


### PR DESCRIPTION
## Things done

- **python3Packages.torch: fix inductor on darwin**
- **python3Packages: remove unnecessary llvmPackages.openmp inclusions**
- **python3Packages.skorch: re-enable on darwin**
- **python3Packages.skorch: cleanup**
- **python3Packages.torchaudio: add missing test dependencies**
- **python3Packages.compressed-tensors: skip failing test on darwin**
- **python3Packages.torchmd-net: allow test to run without MPS support on darwin**

---

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
