### PR TITLE
icann-rdap: init at 0.0.29

### DIFF
--- a/pkgs/by-name/ic/icann-rdap/package.nix
+++ b/pkgs/by-name/ic/icann-rdap/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  writableTmpDirAsHomeHook,
+  pkg-config,
+  openssl,
+  sqlite,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "icann-rdap";
+  version = "0.0.29";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "icann";
+    repo = "icann-rdap";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-HVD3hXiUfVXPC/9aqU+3QclJ9PLb5o6FNg7D4l5WP7k=";
+  };
+
+  # Tests clear $HOME, on Darwin this makes `ProjectDirs` fail in the sandbox
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace icann-rdap-cli/tests/integration/test_jig.rs \
+      --replace-fail '.create("cache", FileType::Dir)' '.create("home", FileType::Dir).create("cache", FileType::Dir)' \
+      --replace-fail '.timeout(Duration::from_secs(2))' '.timeout(Duration::from_secs(2)).env("HOME", self.test_dir.path("home"))'
+  '';
+
+  cargoHash = "sha256-Oew4RUbAs+IM2ipH680WemJ2jMjP5GnMw+pS4WEwg/k=";
+
+  nativeBuildInputs = [
+    writableTmpDirAsHomeHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+    sqlite
+  ];
+
+  __darwinAllowLocalNetworking = true;
+  env = {
+    OPENSSL_NO_VENDOR = true;
+  };
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  versionCheckKeepEnvironment = lib.optional stdenv.hostPlatform.isDarwin "HOME";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "ICANN implementation of the Registry Data Access Protocol (RDAP)";
+    homepage = "https://github.com/icann/icann-rdap";
+    changelog = "https://github.com/icann/icann-rdap/releases/tag/${
+      finalAttrs.src.tag or "v${finalAttrs.version}"
+    }";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    maintainers = with lib.maintainers; [ moraxyc ];
+    mainProgram = "rdap";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
