### PR TITLE
palemoon: init at 34.3.1

### DIFF
--- a/pkgs/by-name/pa/palemoon/mozconfig
+++ b/pkgs/by-name/pa/palemoon/mozconfig
@@ -1,0 +1,54 @@
+# -*- mode: sh; coding: utf-8-unix; fill-column: 80 -*-
+
+# Mozconfig template file for nixpkgs
+
+# Keep this similar to the official .mozconfig file, only minor changes for
+# portability are permitted with branding.
+# https://developer.palemoon.org/build/linux/
+
+_BUILD_64=@build64@
+
+# Set GTK Version
+_GTK_VERSION=@gtkversion@
+
+# Standard build options for Pale Moon
+ac_add_options --enable-application=palemoon
+ac_add_options --enable-optimize="-O2 -w"
+ac_add_options --enable-default-toolkit=cairo-gtk$_GTK_VERSION
+ac_add_options --enable-jemalloc
+ac_add_options --enable-strip
+ac_add_options --enable-devtools
+ac_add_options --enable-av1
+
+ac_add_options --disable-webrtc
+ac_add_options --disable-gamepad
+ac_add_options --disable-tests
+ac_add_options --disable-debug
+ac_add_options --disable-necko-wifi
+ac_add_options --disable-updater
+
+ac_add_options --with-pthreads
+
+# Please see https://www.palemoon.org/redist.shtml for restrictions when using the official branding.
+ac_add_options --enable-official-branding
+export MOZILLA_OFFICIAL=1
+
+ac_add_options --x-libraries=@xlibs@
+
+# MOZ_PKG_SPECIAL is only relevant for upstream's packaging
+
+#
+# NixOS-specific additions
+#
+
+ac_add_options --prefix=@prefix@
+
+mk_add_options MOZ_MAKE_FLAGS=@mozmakeflags@
+mk_add_options AUTOCONF=@autoconf@
+
+# https://forum.palemoon.org/viewtopic.php?f=5&t=33559#p276135
+# "It's not actually used in official releases, and is known to be temperamental."
+ac_add_options --disable-precompiled-startupcache
+
+# GTK2 is actively getting dropped in Nixpkgs, and many NPAPI plugins sadly depend on it
+ac_add_options --disable-npapi

--- a/pkgs/by-name/pa/palemoon/package.nix
+++ b/pkgs/by-name/pa/palemoon/package.nix
@@ -1,0 +1,246 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitea,
+  testers,
+  writeShellApplication,
+  alsa-lib,
+  autoconf,
+  cairo,
+  common-updater-scripts,
+  curl,
+  dbus,
+  dbus-glib,
+  desktop-file-utils,
+  ffmpeg,
+  fontconfig,
+  freetype,
+  gnum4,
+  gtk3,
+  libGL,
+  libGLU,
+  libevent,
+  libnotify,
+  libpulseaudio,
+  libstartup_notification,
+  libx11,
+  libxext,
+  libxft,
+  libxi,
+  libxml2,
+  libxrender,
+  libxscrnsaver,
+  libxt,
+  nasm,
+  pango,
+  perl,
+  pixman,
+  pkg-config,
+  python3,
+  unzip,
+  which,
+  wrapGAppsHook3,
+  xorgproto,
+  yasm,
+  zip,
+  zlib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "palemoon";
+  version = "34.3.1";
+
+  src = fetchFromGitea {
+    domain = "repo.palemoon.org";
+    owner = "MoonchildProductions";
+    repo = "Pale-Moon";
+    rev = "${finalAttrs.version}_Release";
+    fetchSubmodules = true;
+    hash = "sha256-0RvY1iw5pL4KlEUEe2omaF7TVkcn/D5sw4OjciT7Jys=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoconf
+    desktop-file-utils
+    gnum4
+    nasm
+    perl
+    pkg-config
+    python3
+    unzip
+    which
+    wrapGAppsHook3
+    yasm
+    zip
+  ];
+
+  buildInputs = [
+    alsa-lib
+    cairo
+    dbus
+    dbus-glib
+    ffmpeg
+    fontconfig
+    freetype
+    gtk3
+    libGL
+    libGLU
+    libevent
+    libnotify
+    libpulseaudio
+    libstartup_notification
+    libx11
+    libxext
+    libxft
+    libxi
+    libxrender
+    libxscrnsaver
+    libxt
+    pango
+    pixman
+    xorgproto
+    zlib
+  ];
+
+  # Manual
+  dontWrapGApps = true;
+
+  postPatch = ''
+    patchShebangs ./mach
+  '';
+
+  configurePhase = ''
+    runHook preConfigure
+
+    # Too many cores can lead to build flakiness
+    # https://forum.palemoon.org/viewtopic.php?f=5&t=28480
+    export jobs=$(($NIX_BUILD_CORES<=16 ? $NIX_BUILD_CORES : 16))
+    if [ -z "$enableParallelBuilding" ]; then
+      jobs=1
+    fi
+
+    export MOZCONFIG=$PWD/mozconfig
+    export MOZ_NOSPAM=1
+
+    export build64=${lib.optionalString stdenv.hostPlatform.is64bit "1"}
+    export gtkversion="3"
+    export xlibs=${lib.makeLibraryPath [ libx11 ]}
+    export prefix=$out
+    export mozmakeflags="-j$jobs"
+    export autoconf=${autoconf}/bin/autoconf
+
+    substituteAll ${./mozconfig} $MOZCONFIG
+
+    runHook postConfigure
+  '';
+
+  enableParallelBuilding = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    ./mach build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    ./mach install
+
+    # Install official branding stuff
+    desktop-file-install --dir=$out/share/applications \
+      ./palemoon/branding/official/palemoon.desktop
+    for iconname in default{16,22,24,32,48,256} mozicon128; do
+      n=''${iconname//[^0-9]/}
+      size=$n"x"$n
+      install -Dm644 ./palemoon/branding/official/$iconname.png $out/share/icons/hicolor/$size/apps/palemoon.png
+    done
+
+    # Remove unneeded SDK data from installation
+    # https://forum.palemoon.org/viewtopic.php?f=37&t=26796&p=214676#p214729
+    rm -r $out/{include,share/idl,lib/palemoon-devel-${finalAttrs.version}}
+
+    runHook postInstall
+  '';
+
+  preFixup =
+    let
+      libPath = lib.makeLibraryPath [
+        ffmpeg
+        libGL
+        libpulseaudio
+      ];
+    in
+    ''
+      gappsWrapperArgs+=(
+        --prefix LD_LIBRARY_PATH : "${libPath}"
+      )
+      wrapGApp $out/lib/palemoon-${finalAttrs.version}/palemoon
+    '';
+
+  passthru = {
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+    };
+    updateScript = lib.getExe (writeShellApplication {
+      name = "update-palemoon";
+      runtimeInputs = [
+        common-updater-scripts
+        curl
+        libxml2
+      ];
+      text = ''
+        # Only release note announcement == finalized release
+        version="$(
+          curl -s 'http://www.palemoon.org/releasenotes.shtml' |
+          xmllint --html --xpath 'html/body/table/tbody/tr/td/h3/text()' - 2>/dev/null | head -n1 |
+          sed 's/v\(\S*\).*/\1/'
+        )"
+        update-source-version ${finalAttrs.pname} "$version"
+      '';
+    });
+  };
+
+  meta = {
+    homepage = "https://www.palemoon.org/";
+    description = "An Open Source, Goanna-based web browser focusing on efficiency and customization";
+    longDescription = ''
+      Pale Moon is an Open Source, Goanna-based web browser focusing on
+      efficiency and customization.
+
+      Pale Moon offers you a browsing experience in a browser completely built
+      from its own, independently developed source that has been forked off from
+      Firefox/Mozilla code a number of years ago, with carefully selected
+      features and optimizations to improve the browser's stability and user
+      experience, while offering full customization and a growing collection of
+      extensions and themes to make the browser truly your own.
+
+      Package notes:
+
+      - NPAPI plugin support has been disabled because it depends on GTK2, which is being dropped from Nixpkgs
+    '';
+    changelog = "https://repo.palemoon.org/MoonchildProductions/Pale-Moon/releases/tag/${finalAttrs.version}_Release";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [
+      OPNA2608
+    ];
+    platforms = [
+      "i686-linux"
+      "x86_64-linux"
+    ];
+    # Only specific GCC versions are supported with branding
+    # https://developer.palemoon.org/build/linux/
+    # assert breaks PR eval on GitHub CI :(
+    broken =
+      !(
+        stdenv.cc.isGNU
+        && lib.strings.versionAtLeast stdenv.cc.version "9"
+        && lib.strings.versionOlder stdenv.cc.version "16"
+      );
+  };
+})


### PR DESCRIPTION
Was previously dropped in #232571 due to the build system requiring Python 2. Build system has recently been upgraded to Python 3.

NPAPI plugin support is disabled because it relies on GTK2, which we're working on getting rid of (#410814). Since that removes a piece of functionality that the browser is at least very well known for, this might require us to drop the official branding and come up with our own…

<img width="756" height="322" alt="image" src="https://github.com/user-attachments/assets/a6634cfd-a626-4a58-b9fe-c2fb83a7bb09" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
