### PR TITLE
guile-hoot: partially under LGPL v3 or later

### DIFF
--- a/pkgs/by-name/gu/guile-hoot/package.nix
+++ b/pkgs/by-name/gu/guile-hoot/package.nix
@@ -62,7 +62,10 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Scheme to WebAssembly compiler backend for GNU Guile and a general purpose WASM toolchain";
     homepage = "https://codeberg.org/spritely/hoot";
-    license = lib.licenses.asl20;
+    license = with lib.licenses; [
+      asl20
+      lgpl3Plus
+    ];
     maintainers = with lib.maintainers; [ jinser ];
     platforms = lib.platforms.unix;
     mainProgram = "hoot";


### PR DESCRIPTION
Several files of the Hoot source code are licensed under the GNU Lesser General Public License version 3 or later. This was the case since [commit `bcec3960`](https://codeberg.org/spritely/hoot/commit/bcec3960f86d5d2ec368b3ae5299496a1fc6e505) preceding even v0.1.0, but has been marked clearly in the README since [commit `efdb6a59`](https://codeberg.org/spritely/hoot/commit/efdb6a590799798083d6cc540cbb23e55a352ded) / PR [#792](https://codeberg.org/spritely/hoot/pulls/792), which made it into v0.8.0.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
