### PR TITLE
neovim-remote: fix nvr --version by replacing pkg_resources with importlib.metadata

### DIFF
--- a/pkgs/by-name/ne/neovim-remote/package.nix
+++ b/pkgs/by-name/ne/neovim-remote/package.nix
@@ -25,6 +25,10 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
       url = "https://github.com/mhinz/neovim-remote/commit/56d2a4097f4b639a16902390d9bdd8d1350f948c.patch";
       hash = "sha256-/PjE+9yfHtOUEp3xBaobzRM8Eo2wqOhnF1Es7SIdxvM=";
     })
+    # Fix nvr --version: replace deprecated pkg_resources with importlib.metadata
+    # (stdlib since Python 3.8). setuptools was correctly kept in build-system
+    # only; this avoids adding it as a spurious runtime dependency.
+    ./use-importlib-metadata.patch
   ];
 
   build-system = with python3.pkgs; [ setuptools ];

--- a/pkgs/by-name/ne/neovim-remote/use-importlib-metadata.patch
+++ b/pkgs/by-name/ne/neovim-remote/use-importlib-metadata.patch
@@ -1,0 +1,20 @@
+Use importlib.metadata instead of pkg_resources for version queries.
+
+pkg_resources is a legacy setuptools API. importlib.metadata (stdlib since
+Python 3.8) is the correct replacement and requires no extra runtime dependency.
+
+--- a/nvr/nvr.py
++++ b/nvr/nvr.py
+@@ -360,10 +360,10 @@
+
+
+ def print_versions():
+-    import pkg_resources
+-    print('nvr ' + pkg_resources.require("neovim-remote")[0].version)
+-    print('pynvim ' + pkg_resources.require('pynvim')[0].version)
+-    print('psutil ' + pkg_resources.require('psutil')[0].version)
++    from importlib.metadata import version
++    print('nvr ' + version("neovim-remote"))
++    print('pynvim ' + version('pynvim'))
++    print('psutil ' + version('psutil'))
+     print('Python ' + sys.version.split('\n')[0])


### PR DESCRIPTION
## Problem

`nvr --version` crashes with:

```
ModuleNotFoundError: No module named 'pkg_resources'
```

`pkg_resources` (from `setuptools`) is imported only in `print_versions()`. Since `setuptools` is correctly listed under `build-system` and not `dependencies`, it is absent from the runtime closure.

The prior fix for this (#80044, merged 2020) was lost when the package was later refactored to `pyproject = true` with the `build-system` / `dependencies` split.

## Fix

Replace the three `pkg_resources.require(pkg)[0].version` calls with `importlib.metadata.version(pkg)`. `importlib.metadata` is in the stdlib since Python 3.8 and is the PyPA-recommended replacement for this use of `pkg_resources`. No new runtime dependency is introduced.

A local patch is used because `mhinz/neovim-remote` has had no upstream activity since May 2022.

## Testing

```
$ nvr --version
nvr 2.5.1
pynvim 0.6.0
psutil 6.1.1
Python 3.13.x ...
```