### PR TITLE
rns,lxmf: simplfify

### DIFF
--- a/pkgs/by-name/lx/lxmf/package.nix
+++ b/pkgs/by-name/lx/lxmf/package.nix
@@ -2,13 +2,4 @@
   python3Packages,
 }:
 
-let
-  pythonPackages = python3Packages.overrideScope (
-    self: super: {
-      lxmf = super.lxmf.override {
-        propagateRns = true;
-      };
-    }
-  );
-in
-pythonPackages.toPythonApplication pythonPackages.lxmf
+python3Packages.toPythonApplication python3Packages.lxmf

--- a/pkgs/by-name/rn/rns/package.nix
+++ b/pkgs/by-name/rn/rns/package.nix
@@ -2,19 +2,4 @@
   python3Packages,
 }:
 
-let
-  pythonPackages = python3Packages.overrideScope (
-    self: super: {
-      lxmf = super.lxmf.override {
-        propagateRns = false;
-      };
-    }
-  );
-in
-pythonPackages.toPythonApplication (
-  pythonPackages.rns.overridePythonAttrs (old: {
-    dependencies = old.dependencies ++ [
-      pythonPackages.lxmf
-    ];
-  })
-)
+python3Packages.toPythonApplication python3Packages.rns.withLxmf

--- a/pkgs/development/python-modules/lxmf/default.nix
+++ b/pkgs/development/python-modules/lxmf/default.nix
@@ -2,9 +2,8 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  # rns optionally depends on lxmf but we can't have two versions of rns in a closure
-  propagateRns ? false,
   qrcode,
+  lxmf,
   rns,
   setuptools,
   versionCheckHook,
@@ -25,22 +24,20 @@ buildPythonPackage (finalAttrs: {
 
   build-system = [ setuptools ];
 
-  buildInputs = lib.optionals (!propagateRns) [
-    rns
-  ];
+  buildInputs = [ rns ];
 
   dependencies = [
     qrcode
-  ]
-  ++ lib.optionals propagateRns [
     rns
   ];
 
   pythonImportsCheck = [ "LXMF" ];
+  nativeCheckInputs = [ versionCheckHook ];
 
-  nativeCheckInputs = lib.optionals propagateRns [
-    versionCheckHook
-  ];
+  passthru.withoutRns = lxmf.overridePythonAttrs (old: {
+    dependencies = builtins.filter (dep: dep != rns) (old.dependencies or [ ]);
+    nativeCheckInputs = [];
+  });
 
   meta = {
     description = "Lightweight Extensible Message Format for Reticulum";

--- a/pkgs/development/python-modules/rns/default.nix
+++ b/pkgs/development/python-modules/rns/default.nix
@@ -10,6 +10,8 @@
   replaceVars,
   setuptools,
   versionCheckHook,
+  rns,
+  lxmf,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -44,6 +46,10 @@ buildPythonPackage (finalAttrs: {
   nativeCheckInputs = [ versionCheckHook ];
 
   versionCheckProgram = "${placeholder "out"}/bin/rncp";
+
+  passthru.withLxmf = rns.overridePythonAttrs (old: {
+    dependencies = (old.dependencies or [ ]) ++ [ lxmf.withoutRns ];
+  });
 
   meta = {
     description = "Cryptography-based networking stack for wide-area networks";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
