### PR TITLE
provide client packages for all mysql-ish database flavours

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -155,6 +155,8 @@
 
 - `buildFHSEnv`, `appimageTools.wrapAppImage`, and `appimageTools.wrapType2` now support the `finalAttrs` pattern. When using `wrapAppImage`, it is now recommended to pass the extracted AppImage to the `contents` attribute (instead of `src`), to avoid shadowing `src`. Passing the extracted contents to `src` is now deprecated and will be removed in a future release.
 
+- All databases of the MySQL family – `mysql`, `mariadb` and `percona` – now provide a client-only package `client` sub-attribute. Use the `<dbname>.client` package if the server components are not needed. The main package continues to ship the client binaries as well.
+
 - Package-URL (PURL, https://github.com/package-url/purl-spec) metadata identifier has been added for `fetchgit`, `fetchpypi` and `fetchFromGithub` fetchers.
   `mkDerivation` has been adjusted to reuse this information.
   Package-URLs allow reliably identifying and locating software packages.

--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -213,7 +213,7 @@ in
       initialScript = lib.mkOption {
         type = lib.types.nullOr lib.types.path;
         default = null;
-        description = "A file containing SQL statements to be executed on the first startup. Can be used for granting certain permissions on the database.";
+        description = "A file containing SQL statements to be executed on the first startup. Can be used for granting certain permissions on the database. Run as superuser.";
       };
 
       ensureDatabases = lib.mkOption {

--- a/nixos/tests/mysql/common.nix
+++ b/nixos/tests/mysql/common.nix
@@ -10,5 +10,8 @@
     inherit (pkgs) percona-server_8_4;
   };
   mkTestName =
-    pkg: "mariadb_${builtins.replaceStrings [ "." ] [ "" ] (lib.versions.majorMinor pkg.version)}";
+    pkg:
+    "${builtins.replaceStrings [ "-" ] [ "_" ] pkg.pname}_${
+      builtins.replaceStrings [ "." ] [ "" ] (lib.versions.majorMinor pkg.version)
+    }";
 }

--- a/nixos/tests/mysql/mysql.nix
+++ b/nixos/tests/mysql/mysql.nix
@@ -104,61 +104,66 @@ let
           };
       };
 
-      testScript = ''
-        start_all()
+      testScript =
+        { nodes, ... }:
+        let
+          mysqlClient = lib.getExe nodes.${name}.services.mysql.package.client;
+        in
+        ''
+          start_all()
 
-        machine = ${name}
-        machine.wait_for_unit("mysql")
-        machine.succeed(
-            "echo 'use testdb; create table tests (test_id INT, PRIMARY KEY (test_id));' | sudo -u testuser mysql -u testuser"
-        )
-        machine.succeed(
-            "echo 'use testdb; insert into tests values (42);' | sudo -u testuser mysql -u testuser"
-        )
-        # Ensure testuser2 is not able to insert into testdb as mysql testuser2
-        machine.fail(
-            "echo 'use testdb; insert into tests values (23);' | sudo -u testuser2 mysql -u testuser2"
-        )
-        # Ensure testuser2 is not able to authenticate as mysql testuser
-        machine.fail(
-            "echo 'use testdb; insert into tests values (23);' | sudo -u testuser2 mysql -u testuser"
-        )
-        machine.succeed(
-            "echo 'use testdb; select test_id from tests;' | sudo -u testuser mysql -u testuser -N | grep 42"
-        )
+          machine = ${name}
+          machine.wait_for_unit("mysql")
+          machine.succeed(
+              "echo 'use testdb; create table tests (test_id INT, PRIMARY KEY (test_id));' | sudo -u testuser ${mysqlClient} -u testuser"
+          )
+          machine.succeed(
+              "echo 'use testdb; insert into tests values (42);' | sudo -u testuser ${mysqlClient} -u testuser"
+          )
+          # Ensure testuser2 is not able to insert into testdb as mysql testuser2
+          machine.fail(
+              "echo 'use testdb; insert into tests values (23);' | sudo -u testuser2 ${mysqlClient} -u testuser2"
+          )
+          # Ensure testuser2 is not able to authenticate as mysql testuser
+          machine.fail(
+              "echo 'use testdb; insert into tests values (23);' | sudo -u testuser2 ${mysqlClient} -u testuser"
+          )
+          machine.succeed(
+              "echo 'use testdb; select test_id from tests;' | sudo -u testuser ${mysqlClient} -u testuser -N | grep 42"
+          )
 
-        ${lib.optionalString hasMroonga ''
-          # Check if Mroonga plugin works
-          machine.succeed(
-              "echo 'use testdb; create table mroongadb (test_id INT, PRIMARY KEY (test_id)) ENGINE = Mroonga;' | sudo -u testuser mysql -u testuser"
-          )
-          machine.succeed(
-              "echo 'use testdb; insert into mroongadb values (25);' | sudo -u testuser mysql -u testuser"
-          )
-          machine.succeed(
-              "echo 'use testdb; select test_id from mroongadb;' | sudo -u testuser mysql -u testuser -N | grep 25"
-          )
-          machine.succeed(
-              "echo 'use testdb; drop table mroongadb;' | sudo -u testuser mysql -u testuser"
-          )
-        ''}
+          ${lib.optionalString hasMroonga ''
+            # Check if Mroonga plugin works
+            machine.succeed(
+                "echo 'use testdb; create table mroongadb (test_id INT, PRIMARY KEY (test_id)) ENGINE = Mroonga;' | sudo -u testuser ${mysqlClient} -u testuser"
+            )
+            machine.succeed(
+                "echo 'use testdb; insert into mroongadb values (25);' | sudo -u testuser ${mysqlClient} -u testuser"
+            )
+            machine.succeed(
+                "echo 'use testdb; select test_id from mroongadb;' | sudo -u testuser ${mysqlClient} -u testuser -N | grep 25"
+            )
+            machine.succeed(
+                "echo 'use testdb; drop table mroongadb;' | sudo -u testuser ${mysqlClient} -u testuser"
+            )
+          ''}
 
-        ${lib.optionalString hasRocksDB ''
-          # Check if RocksDB plugin works
-          machine.succeed(
-              "echo 'use testdb; create table rocksdb (test_id INT, PRIMARY KEY (test_id)) ENGINE = RocksDB;' | sudo -u testuser mysql -u testuser"
-          )
-          machine.succeed(
-              "echo 'use testdb; insert into rocksdb values (28);' | sudo -u testuser mysql -u testuser"
-          )
-          machine.succeed(
-              "echo 'use testdb; select test_id from rocksdb;' | sudo -u testuser mysql -u testuser -N | grep 28"
-          )
-          machine.succeed(
-              "echo 'use testdb; drop table rocksdb;' | sudo -u testuser mysql -u testuser"
-          )
-        ''}
-      '';
+          ${lib.optionalString hasRocksDB ''
+            # Check if RocksDB plugin works
+            machine.succeed(
+                "echo 'use testdb; create table rocksdb (test_id INT, PRIMARY KEY (test_id)) ENGINE = RocksDB;' | sudo -u testuser ${mysqlClient} -u testuser"
+            )
+            machine.succeed(
+                "echo 'use testdb; insert into rocksdb values (28);' | sudo -u testuser ${mysqlClient} -u testuser"
+            )
+            machine.succeed(
+                "echo 'use testdb; select test_id from rocksdb;' | sudo -u testuser ${mysqlClient} -u testuser -N | grep 28"
+            )
+            machine.succeed(
+                "echo 'use testdb; drop table rocksdb;' | sudo -u testuser ${mysqlClient} -u testuser"
+            )
+          ''}
+        '';
     };
 in
 lib.mapAttrs (

--- a/nixos/tests/mysql/mysql.nix
+++ b/nixos/tests/mysql/mysql.nix
@@ -33,7 +33,7 @@ let
 
       nodes = {
         ${name} =
-          { pkgs, ... }:
+          { pkgs, config, ... }:
           {
 
             users = {
@@ -61,17 +61,17 @@ let
               # note that using pkgs.writeText here is generally not a good idea,
               # as it will store the password in world-readable /nix/store ;)
               initialScript = pkgs.writeText "mysql-init.sql" (
-                if (!useSocketAuth) then
-                  ''
-                    CREATE USER 'testuser3'@'localhost' IDENTIFIED BY 'secure';
-                    GRANT ALL PRIVILEGES ON testdb3.* TO 'testuser3'@'localhost';
-                  ''
-                else
+                if config.services.mysql.package.pname == "mariadb" then
                   ''
                     ALTER USER root@localhost IDENTIFIED WITH unix_socket;
                     DELETE FROM mysql.user WHERE password = ''' AND plugin = ''';
                     DELETE FROM mysql.user WHERE user = ''';
                     FLUSH PRIVILEGES;
+                  ''
+                else
+                  # just some smoketest initial script sql statement
+                  ''
+                    SELECT * FROM mysql.user;
                   ''
               );
 
@@ -185,7 +185,6 @@ lib.mapAttrs (
   _: package:
   makeMySQLTest {
     inherit package;
-    name = builtins.replaceStrings [ "-" ] [ "_" ] package.pname;
     hasMroonga = false;
     useSocketAuth = false;
   }

--- a/pkgs/by-name/gd/gdal/package.nix
+++ b/pkgs/by-name/gd/gdal/package.nix
@@ -113,7 +113,9 @@ stdenv.mkDerivation (finalAttrs: {
     "-DGEOTIFF_LIBRARY_RELEASE=${lib.getLib libgeotiff}/lib/libgeotiff${stdenv.hostPlatform.extensions.sharedLibrary}"
     "-DMYSQL_INCLUDE_DIR=${lib.getDev libmysqlclient}/include/mysql"
     "-DMYSQL_LIBRARY=${lib.getLib libmysqlclient}/lib/${
-      lib.optionalString (libmysqlclient.pname != "mysql") "mysql/"
+      # mysql puts libraries into top-level `lib` (but has pkgconfig),
+      # mariadb puts them into a subdirectory (but has no pkgconfig)
+      lib.optionalString (libmysqlclient.pname != "mysql-client") "mysql/"
     }libmysqlclient${stdenv.hostPlatform.extensions.sharedLibrary}"
   ]
   ++ lib.optionals finalAttrs.doInstallCheck [

--- a/pkgs/by-name/li/libmysqlconnectorcpp/package.nix
+++ b/pkgs/by-name/li/libmysqlconnectorcpp/package.nix
@@ -26,13 +26,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
-    mysql84
+    mysql84.connector-c
   ];
 
   buildInputs = [
     boost
     openssl
-    mysql84
+    mysql84.connector-c
   ];
 
   strictDeps = true;

--- a/pkgs/by-name/my/mysql-workbench/package.nix
+++ b/pkgs/by-name/my/mysql-workbench/package.nix
@@ -41,7 +41,7 @@
 }:
 
 let
-  mysql = mysql84;
+  mysql = mysql84.client;
   gdal' = gdal.override { libmysqlclient = mysql; };
   antlr = antlr4_13;
 

--- a/pkgs/by-name/my/mysql84/package.nix
+++ b/pkgs/by-name/my/mysql84/package.nix
@@ -26,108 +26,144 @@
   nixosTests,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
-  pname = "mysql";
-  version = "8.4.11";
+let
+  common = finalAttrs: {
 
-  src = fetchurl {
-    url = "https://dev.mysql.com/get/Downloads/MySQL-${lib.versions.majorMinor finalAttrs.version}/mysql-${finalAttrs.version}.tar.gz";
-    hash = "sha256-6zBRFk1iXdNGqCA/duDV1dmuxR2+nVF4jjnsaz8TlMI=";
-  };
+    version = "8.4.11";
 
-  nativeBuildInputs = [
-    bison
-    cmake
-    pkg-config
-  ]
-  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [ rpcsvc-proto ];
+    src = fetchurl {
+      url = "https://dev.mysql.com/get/Downloads/MySQL-${lib.versions.majorMinor finalAttrs.version}/mysql-${finalAttrs.version}.tar.gz";
+      hash = "sha256-6zBRFk1iXdNGqCA/duDV1dmuxR2+nVF4jjnsaz8TlMI=";
+    };
 
-  patches = [
-    ./no-force-outline-atomics.patch # Do not force compilers to turn on -moutline-atomics switch
-  ];
+    patches = [
+      ./no-force-outline-atomics.patch # Do not force compilers to turn on -moutline-atomics switch
+    ];
 
-  ## NOTE: MySQL upstream frequently twiddles the invocations of libtool. When updating, you might proactively grep for libtool references.
-  postPatch = ''
-    substituteInPlace cmake/libutils.cmake --replace /usr/bin/libtool libtool
-    substituteInPlace cmake/os/Darwin.cmake --replace /usr/bin/libtool libtool
-  '';
+    ## NOTE: MySQL upstream frequently twiddles the invocations of libtool. When updating, you might proactively grep for libtool references.
+    postPatch = ''
+      substituteInPlace cmake/libutils.cmake --replace /usr/bin/libtool libtool
+      substituteInPlace cmake/os/Darwin.cmake --replace /usr/bin/libtool libtool
+    '';
+    nativeBuildInputs = [
+      bison
+      cmake
+      pkg-config
+    ]
+    ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [ rpcsvc-proto ];
 
-  buildInputs = [
-    (curl.override { inherit openssl; })
-    icu
-    libedit
-    libevent
-    lz4
-    ncurses
-    openssl
-    protobuf_21
-    re2
-    readline
-    zlib
-    zstd
-    libfido2
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
-    numactl
-    libtirpc
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    cctools
-    darwin.developer_cmds
-    darwin.DarwinTools
-  ];
+    buildInputs = [
+      (curl.override { inherit openssl; })
+      icu
+      libedit
+      libevent
+      lz4
+      ncurses
+      openssl
+      protobuf_21
+      re2
+      readline
+      zlib
+      zstd
+      libfido2
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      numactl
+      libtirpc
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      cctools
+      darwin.developer_cmds
+      darwin.DarwinTools
+    ];
 
-  outputs = [
-    "out"
-    "static"
-  ];
+    outputs = [
+      "out"
+      "static"
+      "man"
+    ];
 
-  cmakeFlags = [
-    "-DFORCE_UNSUPPORTED_COMPILER=1" # To configure on Darwin.
-    "-DWITH_ROUTER=OFF" # It may be packaged separately.
-    "-DWITH_SYSTEM_LIBS=ON"
-    "-DWITH_UNIT_TESTS=OFF"
-    "-DMYSQL_UNIX_ADDR=/run/mysqld/mysqld.sock"
-    "-DMYSQL_DATADIR=/var/lib/mysql"
-    "-DINSTALL_INFODIR=share/mysql/docs"
-    "-DINSTALL_MANDIR=share/man"
-    "-DINSTALL_PLUGINDIR=lib/mysql/plugin"
-    "-DINSTALL_INCLUDEDIR=include/mysql"
-    "-DINSTALL_DOCREADMEDIR=share/mysql"
-    "-DINSTALL_SUPPORTFILESDIR=share/mysql"
-    "-DINSTALL_MYSQLSHAREDIR=share/mysql"
-    "-DINSTALL_MYSQLTESTDIR="
-    "-DINSTALL_DOCDIR=share/mysql/docs"
-    "-DINSTALL_SHAREDIR=share/mysql"
-  ];
+    cmakeFlags = [
+      "-DFORCE_UNSUPPORTED_COMPILER=1" # To configure on Darwin.
+      "-DWITH_ROUTER=OFF" # It may be packaged separately.
+      "-DWITH_SYSTEM_LIBS=ON"
+      "-DWITH_UNIT_TESTS=OFF"
+      "-DMYSQL_UNIX_ADDR=/run/mysqld/mysqld.sock"
+      "-DMYSQL_DATADIR=/var/lib/mysql"
+      "-DINSTALL_INFODIR=share/mysql/docs"
+      "-DINSTALL_MANDIR=share/man"
+      "-DINSTALL_PLUGINDIR=lib/mysql/plugin"
+      "-DINSTALL_INCLUDEDIR=include/mysql"
+      "-DINSTALL_DOCREADMEDIR=share/mysql"
+      "-DINSTALL_SUPPORTFILESDIR=share/mysql"
+      "-DINSTALL_MYSQLSHAREDIR=share/mysql"
+      "-DINSTALL_MYSQLTESTDIR="
+      "-DINSTALL_DOCDIR=share/mysql/docs"
+      "-DINSTALL_SHAREDIR=share/mysql"
+    ];
 
-  postInstall = ''
-    moveToOutput "lib/*.a" $static
-    so=${stdenv.hostPlatform.extensions.sharedLibrary}
-    ln -s libmysqlclient$so $out/lib/libmysqlclient_r$so
-  '';
+    postInstall = ''
+      moveToOutput "lib/*.a" $static
+      so=${stdenv.hostPlatform.extensions.sharedLibrary}
+      ln -s libmysqlclient$so $out/lib/libmysqlclient_r$so
+    '';
 
-  passthru = {
-    client = finalAttrs.finalPackage;
-    connector-c = finalAttrs.finalPackage;
-    server = finalAttrs.finalPackage;
-    mysqlVersion = lib.versions.majorMinor finalAttrs.version;
-    tests = {
-      mysql =
+    passthru = {
+      mysqlVersion = lib.versions.majorMinor finalAttrs.version;
+      tests.mysql =
         nixosTests.mysql."mysql${lib.versions.major finalAttrs.version}${lib.versions.minor finalAttrs.version}";
-      mysql-secure-root-by-default =
-        nixosTests.mysql-secure-root.secure-by-default."mysql${lib.versions.major finalAttrs.version}${lib.versions.minor finalAttrs.version}";
-      mysql-root-can-be-kept-insecure =
-        nixosTests.mysql-secure-root.can-be-insecure."mysql${lib.versions.major finalAttrs.version}${lib.versions.minor finalAttrs.version}";
+    };
+
+    meta = {
+      homepage = "https://www.mysql.com/";
+      description = "World's most popular open source database";
+      license = lib.licenses.gpl2;
+      maintainers = [
+      ];
+      platforms = lib.platforms.unix;
     };
   };
+  client = stdenv.mkDerivation (
+    finalAttrs:
+    let
+      common' = common finalAttrs;
+    in
+    common'
+    // {
+      pname = "mysql-client";
 
-  meta = {
-    homepage = "https://www.mysql.com/";
-    description = "World's most popular open source database";
-    license = lib.licenses.gpl2;
-    maintainers = [
-    ];
-    platforms = lib.platforms.unix;
-  };
-})
+      cmakeFlags = common'.cmakeFlags ++ [
+        "-DWITHOUT_SERVER=ON"
+        "-DINSTALL_MYSQLSHAREDIR=share/mysql-client"
+      ];
+      meta = common'.meta // {
+        mainProgram = "mysql";
+      };
+    }
+  );
+in
+
+stdenv.mkDerivation (
+  finalAttrs:
+  let
+    common' = common finalAttrs;
+  in
+  common'
+  // {
+    pname = "mysql";
+
+    meta = common'.meta // {
+      mainProgram = "mysqld";
+    };
+
+    passthru = lib.recursiveUpdate common'.passthru {
+      inherit client;
+      connector-c = client;
+      server = finalAttrs.finalPackage;
+      tests.mysql-secure-root-by-default =
+        nixosTests.mysql-secure-root.secure-by-default."mysql${lib.versions.major finalAttrs.version}${lib.versions.minor finalAttrs.version}";
+      tests.mysql-root-can-be-kept-insecure =
+        nixosTests.mysql-secure-root.can-be-insecure."mysql${lib.versions.major finalAttrs.version}${lib.versions.minor finalAttrs.version}";
+    };
+  }
+)

--- a/pkgs/by-name/sq/sqlite3-to-mysql/package.nix
+++ b/pkgs/by-name/sq/sqlite3-to-mysql/package.nix
@@ -37,7 +37,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     tabulate
     unidecode
     packaging
-    mysql84
+    mysql84.client
     python-dateutil
     sqlglot
   ];

--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -70,12 +70,12 @@ let
         ]
       );
 
-      common = rec {
+      common = finalAttrs: {
         # attributes common to both builds
         inherit version;
 
         src = fetchurl {
-          url = "https://archive.mariadb.org/mariadb-${version}/source/mariadb-${version}.tar.gz";
+          url = "https://archive.mariadb.org/mariadb-${finalAttrs.version}/source/mariadb-${finalAttrs.version}.tar.gz";
           inherit hash;
         };
 
@@ -104,7 +104,7 @@ let
             libkrb5
             systemd
           ]
-          ++ (if (lib.versionOlder version "10.6") then [ libaio ] else [ liburing ])
+          ++ (if (lib.versionOlder finalAttrs.version "10.6") then [ libaio ] else [ liburing ])
         )
         ++ lib.optionals stdenv.hostPlatform.isDarwin [
           cctools
@@ -134,7 +134,7 @@ let
         # Fixes a build issue as documented on
         # https://jira.mariadb.org/browse/MDEV-26769?focusedCommentId=206073&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-206073
         ++ lib.optional (
-          !stdenv.hostPlatform.isLinux && lib.versionAtLeast version "10.6"
+          !stdenv.hostPlatform.isLinux && lib.versionAtLeast finalAttrs.version "10.6"
         ) ./patch/macos-MDEV-26769-regression-fix.patch;
 
         cmakeFlags = [
@@ -175,7 +175,7 @@ let
           "-DCONNECT_WITH_JDBC=OFF"
           "-DCURSES_LIBRARY=${ncurses.out}/lib/libncurses.dylib"
         ]
-        ++ lib.optionals (stdenv.hostPlatform.isDarwin && lib.versionAtLeast version "10.6") [
+        ++ lib.optionals (stdenv.hostPlatform.isDarwin && lib.versionAtLeast finalAttrs.version "10.6") [
           # workaround for https://jira.mariadb.org/browse/MDEV-29925
           "-Dhave_C__Wl___as_needed="
         ]
@@ -206,7 +206,9 @@ let
 
         passthru.tests =
           let
-            testVersion = "mariadb_${builtins.replaceStrings [ "." ] [ "" ] (lib.versions.majorMinor version)}";
+            testVersion = "mariadb_${
+              builtins.replaceStrings [ "." ] [ "" ] (lib.versions.majorMinor finalAttrs.version)
+            }";
           in
           {
             mariadb-galera-rsync = nixosTests.mariadb-galera.${testVersion};
@@ -231,25 +233,29 @@ let
       };
 
       client = stdenv.mkDerivation (
-        common
+        finalAttrs:
+        let
+          common' = common finalAttrs;
+        in
+        common'
         // {
           pname = "mariadb-client";
 
-          patches = common.patches ++ [
+          patches = common'.patches ++ [
             ./patch/cmake-plugin-includedir.patch
           ];
 
           buildInputs =
-            common.buildInputs ++ lib.optionals (lib.versionAtLeast common.version "10.11") [ fmt ];
+            common'.buildInputs ++ lib.optionals (lib.versionAtLeast common'.version "10.11") [ fmt ];
 
-          cmakeFlags = common.cmakeFlags ++ [
+          cmakeFlags = common'.cmakeFlags ++ [
             "-DPLUGIN_AUTH_PAM=NO"
             "-DWITHOUT_SERVER=ON"
             "-DWITH_WSREP=OFF"
             "-DINSTALL_MYSQLSHAREDIR=share/mysql-client"
           ];
 
-          postInstall = common.postInstall + ''
+          postInstall = common'.postInstall + ''
             rm "$out"/bin/{mariadb-test,mysqltest}
             libmysqlclient_path=$(readlink -f $out/lib/libmysqlclient${libExt})
             rm "$out"/lib/{libmariadb${libExt},libmysqlclient${libExt},libmysqlclient_r${libExt}}
@@ -257,7 +263,7 @@ let
             ln -sv libmysqlclient${libExt} "$out"/lib/libmysqlclient_r${libExt}
           '';
 
-          meta = common.meta // {
+          meta = common'.meta // {
             mainProgram = "mariadb";
           };
         }
@@ -266,18 +272,21 @@ let
 
     stdenv.mkDerivation (
       finalAttrs:
-      common
+      let
+        common' = common finalAttrs;
+      in
+      common'
       // {
         pname = "mariadb-server";
 
-        nativeBuildInputs = common.nativeBuildInputs ++ [
+        nativeBuildInputs = common'.nativeBuildInputs ++ [
           bison
           boost.dev
           flex
         ];
 
         buildInputs =
-          common.buildInputs
+          common'.buildInputs
           ++ [
             bzip2
             lz4
@@ -299,7 +308,7 @@ let
             msgpack-cxx
             zeromq
           ]
-          ++ lib.optionals (lib.versionAtLeast common.version "10.11") [ fmt ];
+          ++ lib.optionals (lib.versionAtLeast common'.version "10.11") [ fmt ];
 
         propagatedBuildInputs = lib.optional withNuma numactl;
 
@@ -309,7 +318,7 @@ let
         '';
 
         cmakeFlags =
-          common.cmakeFlags
+          common'.cmakeFlags
           ++ [
             "-DMYSQL_DATADIR=/var/lib/mysql"
             "-DENABLED_LOCAL_INFILE=OFF"
@@ -323,7 +332,7 @@ let
             "-DWITHOUT_FEDERATED=1"
             "-DWITHOUT_TOKUDB=1"
           ]
-          ++ lib.optionals (lib.versionOlder version "11.4") [
+          ++ lib.optionals (lib.versionOlder finalAttrs.version "11.4") [
             # Fix the build with CMake 4.
             "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
           ]
@@ -354,7 +363,7 @@ let
         '';
 
         postInstall =
-          common.postInstall
+          common'.postInstall
           + ''
             rm -r "$out"/share/aclocal
             chmod +x "$out"/bin/wsrep_sst_common
@@ -367,16 +376,18 @@ let
             lib.optionalString
               (
                 !stdenv.hostPlatform.isDarwin
-                && lib.versionAtLeast common.version "10.6"
-                && lib.versionOlder common.version "10.11"
+                && lib.versionAtLeast common'.version "10.6"
+                && lib.versionOlder common'.version "10.11"
               )
               ''
                 mv "$out"/OFF/suite/plugins/pam/pam_mariadb_mtr.so "$out"/share/pam/lib/security
               ''
-          + lib.optionalString (!stdenv.hostPlatform.isDarwin && lib.versionAtLeast common.version "10.11") ''
-            mv "$out"/lib/mysql/plugin/test_pam_modules/pam_mariadb_mtr.so "$out"/share/pam/lib/security
-          ''
-          + lib.optionalString (!stdenv.hostPlatform.isDarwin && lib.versionAtLeast common.version "10.6") ''
+          +
+            lib.optionalString (!stdenv.hostPlatform.isDarwin && lib.versionAtLeast common'.version "10.11")
+              ''
+                mv "$out"/lib/mysql/plugin/test_pam_modules/pam_mariadb_mtr.so "$out"/share/pam/lib/security
+              ''
+          + lib.optionalString (!stdenv.hostPlatform.isDarwin && lib.versionAtLeast common'.version "10.6") ''
             mv "$out"/OFF/suite/plugins/pam/mariadb_mtr "$out"/share/pam/etc/security
             rm -r "$out"/OFF
           '';
@@ -385,14 +396,14 @@ let
           lib.optionalAttrs stdenv.hostPlatform.isi686 {
             CXXFLAGS = "-fpermissive";
           }
-          // (common.env or { });
+          // (common'.env or { });
 
         passthru = {
           inherit client;
           server = finalAttrs.finalPackage;
         };
 
-        meta = common.meta // {
+        meta = common'.meta // {
           mainProgram = "mariadbd";
         };
       }

--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -256,6 +256,10 @@ let
             mv "$libmysqlclient_path" "$out"/lib/libmysqlclient${libExt}
             ln -sv libmysqlclient${libExt} "$out"/lib/libmysqlclient_r${libExt}
           '';
+
+          meta = common.meta // {
+            mainProgram = "mariadb";
+          };
         }
       );
     in
@@ -386,6 +390,10 @@ let
         passthru = {
           inherit client;
           server = finalAttrs.finalPackage;
+        };
+
+        meta = common.meta // {
+          mainProgram = "mariadbd";
         };
       }
     );

--- a/pkgs/servers/sql/percona-server/8_4.nix
+++ b/pkgs/servers/sql/percona-server/8_4.nix
@@ -48,181 +48,233 @@
 
 assert !(withJemalloc && withTcmalloc);
 
-stdenv.mkDerivation (finalAttrs: {
-  pname = "percona-server";
-  version = "8.4.10-10";
+let
+  # baseline, used for building both client and server
+  common = finalAttrs: {
+    version = "8.4.10-10";
 
-  src = fetchurl {
-    url = "https://downloads.percona.com/downloads/Percona-Server-${lib.versions.majorMinor finalAttrs.version}/Percona-Server-${finalAttrs.version}/source/tarball/percona-server-${finalAttrs.version}.tar.gz";
-    hash = "sha256-IjHeflYc3AMd6hNXDEYegXm14wjyt9hX3gIVtOQzauU=";
-  };
-
-  nativeBuildInputs = [
-    bison
-    cmake
-    pkg-config
-    makeWrapper
-    # required for scripts/CMakeLists.txt
-    coreutils
-    gnugrep
-    procps
-  ]
-  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [ rpcsvc-proto ];
-
-  patches = [
-    ./no-force-outline-atomics.patch # Do not force compilers to turn on -moutline-atomics switch
-    ./coredumper-explicitly-import-unistd.patch # fix build on aarch64-linux
-  ];
-
-  ## NOTE: MySQL upstream frequently twiddles the invocations of libtool. When updating, you might proactively grep for libtool references.
-  postPatch = ''
-    substituteInPlace cmake/libutils.cmake --replace /usr/bin/libtool libtool
-    substituteInPlace cmake/os/Darwin.cmake --replace /usr/bin/libtool libtool
-    # The rocksdb setup script is called with `env -i` and cannot find anything in PATH.
-    patchShebangs storage/rocksdb/get_rocksdb_files.sh
-    substituteInPlace storage/rocksdb/get_rocksdb_files.sh --replace mktemp ${coreutils}/bin/mktemp
-    substituteInPlace storage/rocksdb/get_rocksdb_files.sh --replace "rm $MKFILE" "${coreutils}/bin/rm $MKFILE"
-    substituteInPlace storage/rocksdb/get_rocksdb_files.sh --replace "make --" "${gnumake}/bin/make --"
-  '';
-
-  buildInputs = [
-    boost
-    (curl.override { inherit openssl; })
-    icu
-    libedit
-    libevent
-    lz4
-    ncurses
-    openssl
-    protobuf
-    re2
-    readline
-    zlib
-    zstd
-    libfido2
-    openldap
-    perl
-    cyrus_sasl
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
-    numactl
-    libtirpc
-    systemd
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    cctools
-    developer_cmds
-    DarwinTools
-  ]
-  ++ lib.optional (stdenv.hostPlatform.isLinux && withJemalloc) jemalloc
-  ++ lib.optional (stdenv.hostPlatform.isLinux && withTcmalloc) gperftools;
-
-  outputs = [
-    "out"
-    "static"
-  ];
-
-  cmakeFlags = [
-    # Percona-specific flags.
-    "-DPORTABLE=1"
-    "-DWITH_LDAP=system"
-    "-DROCKSDB_DISABLE_AVX2=1"
-    "-DROCKSDB_DISABLE_MARCH_NATIVE=1"
-
-    # Flags taken from mysql package.
-    "-DFORCE_UNSUPPORTED_COMPILER=1" # To configure on Darwin.
-    "-DWITH_ROUTER=OFF" # It may be packaged separately.
-    "-DWITH_SYSTEM_LIBS=ON"
-    "-DWITH_UNIT_TESTS=OFF"
-    "-DMYSQL_UNIX_ADDR=/run/mysqld/mysqld.sock"
-    "-DMYSQL_DATADIR=/var/lib/mysql"
-    "-DINSTALL_INFODIR=share/mysql/docs"
-    "-DINSTALL_MANDIR=share/man"
-    "-DINSTALL_PLUGINDIR=lib/mysql/plugin"
-    "-DINSTALL_INCLUDEDIR=include/mysql"
-    "-DINSTALL_DOCREADMEDIR=share/mysql"
-    "-DINSTALL_SUPPORTFILESDIR=share/mysql"
-    "-DINSTALL_MYSQLSHAREDIR=share/mysql"
-    "-DINSTALL_MYSQLTESTDIR="
-    "-DINSTALL_DOCDIR=share/mysql/docs"
-    "-DINSTALL_SHAREDIR=share/mysql"
-
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
-    "-DWITH_SYSTEMD=1"
-    "-DWITH_SYSTEMD_DEBUG=1"
-  ]
-  ++ lib.optional (stdenv.hostPlatform.isLinux && withJemalloc) "-DWITH_JEMALLOC=1"
-  ++ lib.optional (stdenv.hostPlatform.isLinux && withTcmalloc) "-DWITH_TCMALLOC=1";
-
-  postInstall = ''
-    moveToOutput "lib/*.a" $static
-    so=${stdenv.hostPlatform.extensions.sharedLibrary}
-    ln -s libperconaserverclient$so $out/lib/libmysqlclient_r$so
-
-    wrapProgram $out/bin/mysqld_safe --prefix PATH : ${
-      lib.makeBinPath [
-        coreutils
-        procps
-        gnugrep
-        gnused
-        hostname
-      ]
-    }
-    wrapProgram $out/bin/mysql_config --prefix PATH : ${
-      lib.makeBinPath [
-        coreutils
-        gnused
-      ]
-    }
-    wrapProgram $out/bin/ps_mysqld_helper --prefix PATH : ${
-      lib.makeBinPath [
-        coreutils
-        gnugrep
-      ]
-    }
-    wrapProgram $out/bin/ps-admin --prefix PATH : ${
-      lib.makeBinPath [
-        coreutils
-        gnugrep
-      ]
-    }
-  ''
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    wrapProgram $out/bin/mysqld_multi --prefix PATH : ${
-      lib.makeBinPath [
-        coreutils
-        gnugrep
-      ]
-    }
-  '';
-
-  passthru = {
-    client = finalAttrs.finalPackage;
-    connector-c = finalAttrs.finalPackage;
-    server = finalAttrs.finalPackage;
-    mysqlVersion = lib.versions.majorMinor finalAttrs.version;
-    tests.percona-server =
-      nixosTests.mysql."percona-server_${lib.versions.major finalAttrs.version}_${lib.versions.minor finalAttrs.version}";
-    updateScript = gitUpdater {
-      url = "https://github.com/percona/percona-server";
-      rev-prefix = "Percona-Server-";
-      allowedVersions = "${lib.versions.major finalAttrs.version}\\.${lib.versions.minor finalAttrs.version}\\..+";
+    src = fetchurl {
+      url = "https://downloads.percona.com/downloads/Percona-Server-${lib.versions.majorMinor finalAttrs.version}/Percona-Server-${finalAttrs.version}/source/tarball/percona-server-${finalAttrs.version}.tar.gz";
+      hash = "sha256-IjHeflYc3AMd6hNXDEYegXm14wjyt9hX3gIVtOQzauU=";
     };
-  };
 
-  meta = {
-    homepage = "https://www.percona.com/software/mysql-database/percona-server";
-    description = ''
-      A free, fully compatible, enhanced, open source drop-in replacement for
-      MySQL® that provides superior performance, scalability and instrumentation.
-      Long-term support release.
-    '';
-    license = lib.licenses.gpl2Only;
-    maintainers = [
-      lib.maintainers.leona
-      lib.maintainers.osnyx
+    nativeBuildInputs = [
+      bison
+      cmake
+      pkg-config
+      makeWrapper
+      # required for scripts/CMakeLists.txt
+      coreutils
+      gnugrep
+      procps
+    ]
+    ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [ rpcsvc-proto ];
+
+    patches = [
+      ./no-force-outline-atomics.patch # Do not force compilers to turn on -moutline-atomics switch
+      ./coredumper-explicitly-import-unistd.patch # fix build on aarch64-linux
     ];
-    platforms = lib.platforms.unix;
+
+    ## NOTE: MySQL upstream frequently twiddles the invocations of libtool. When updating, you might proactively grep for libtool references.
+    postPatch = ''
+      substituteInPlace cmake/libutils.cmake --replace /usr/bin/libtool libtool
+      substituteInPlace cmake/os/Darwin.cmake --replace /usr/bin/libtool libtool
+      # The rocksdb setup script is called with `env -i` and cannot find anything in PATH.
+      patchShebangs storage/rocksdb/get_rocksdb_files.sh
+      substituteInPlace storage/rocksdb/get_rocksdb_files.sh --replace mktemp ${coreutils}/bin/mktemp
+      substituteInPlace storage/rocksdb/get_rocksdb_files.sh --replace "rm $MKFILE" "${coreutils}/bin/rm $MKFILE"
+      substituteInPlace storage/rocksdb/get_rocksdb_files.sh --replace "make --" "${gnumake}/bin/make --"
+    '';
+
+    buildInputs = [
+      boost
+      (curl.override { inherit openssl; })
+      icu
+      libedit
+      libevent
+      lz4
+      ncurses
+      openssl
+      protobuf
+      re2
+      readline
+      zlib
+      zstd
+      libfido2
+      openldap
+      perl
+      cyrus_sasl
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      numactl
+      libtirpc
+      systemd
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      cctools
+      developer_cmds
+      DarwinTools
+    ]
+    ++ lib.optional (stdenv.hostPlatform.isLinux && withJemalloc) jemalloc
+    ++ lib.optional (stdenv.hostPlatform.isLinux && withTcmalloc) gperftools;
+
+    outputs = [
+      "out"
+      "static"
+      "man"
+    ];
+
+    cmakeFlags = [
+      # Percona-specific flags.
+      "-DPORTABLE=1"
+      "-DWITH_LDAP=system"
+      "-DROCKSDB_DISABLE_AVX2=1"
+      "-DROCKSDB_DISABLE_MARCH_NATIVE=1"
+
+      # Flags taken from mysql package.
+      "-DFORCE_UNSUPPORTED_COMPILER=1" # To configure on Darwin.
+      "-DWITH_ROUTER=OFF" # It may be packaged separately.
+      "-DWITH_SYSTEM_LIBS=ON"
+      "-DWITH_UNIT_TESTS=OFF"
+      "-DMYSQL_UNIX_ADDR=/run/mysqld/mysqld.sock"
+      "-DMYSQL_DATADIR=/var/lib/mysql"
+      "-DINSTALL_INFODIR=share/mysql/docs"
+      "-DINSTALL_MANDIR=share/man"
+      "-DINSTALL_PLUGINDIR=lib/mysql/plugin"
+      "-DINSTALL_INCLUDEDIR=include/mysql"
+      "-DINSTALL_DOCREADMEDIR=share/mysql"
+      "-DINSTALL_SUPPORTFILESDIR=share/mysql"
+      "-DINSTALL_MYSQLSHAREDIR=share/mysql"
+      "-DINSTALL_MYSQLTESTDIR="
+      "-DINSTALL_DOCDIR=share/mysql/docs"
+      "-DINSTALL_SHAREDIR=share/mysql"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      "-DWITH_SYSTEMD=1"
+      "-DWITH_SYSTEMD_DEBUG=1"
+    ]
+    ++ lib.optional (stdenv.hostPlatform.isLinux && withJemalloc) "-DWITH_JEMALLOC=1"
+    ++ lib.optional (stdenv.hostPlatform.isLinux && withTcmalloc) "-DWITH_TCMALLOC=1";
+
+    postInstall = ''
+      moveToOutput "lib/*.a" $static
+      so=${stdenv.hostPlatform.extensions.sharedLibrary}
+      ln -s libperconaserverclient$so $out/lib/libmysqlclient_r$so
+    ''
+    + lib.optionalString stdenv.hostPlatform.isLinux ''
+      # support files are installed to an incorrect path `nix/store`<systemd-store-path>`,
+      # see cmake/systemd.cmake. These are: service units, tmpfiles rules
+      # But we do not need these anyways.
+      rm -r "$out"/nix/
+    '';
+
+    meta = {
+      homepage = "https://www.percona.com/software/mysql-database/percona-server";
+      description = ''
+        A free, fully compatible, enhanced, open source drop-in replacement for
+        MySQL® that provides superior performance, scalability and instrumentation.
+        Long-term support release.
+      '';
+      license = lib.licenses.gpl2Only;
+      maintainers = [
+        lib.maintainers.leona
+        lib.maintainers.osnyx
+      ];
+      platforms = lib.platforms.unix;
+    };
+
+    passthru = {
+      mysqlVersion = lib.versions.majorMinor finalAttrs.version;
+    };
+
   };
-})
+  client = stdenv.mkDerivation (
+    finalAttrs:
+    let
+      common' = common finalAttrs;
+    in
+    common'
+    // {
+      pname = "percona-client";
+      cmakeFlags = common'.cmakeFlags ++ [
+        "-DWITHOUT_SERVER=ON"
+        "-DINSTALL_MYSQLSHAREDIR=share/mysql-client"
+      ];
+
+      meta = common'.meta // {
+        mainProgram = "mysql";
+      };
+
+    }
+  );
+
+in
+stdenv.mkDerivation (
+  finalAttrs:
+  let
+    common' = common finalAttrs;
+  in
+  common'
+  // {
+    pname = "percona-server";
+
+    postInstall =
+      common'.postInstall
+      + ''
+
+        wrapProgram $out/bin/mysqld_safe --prefix PATH : ${
+          lib.makeBinPath [
+            coreutils
+            procps
+            gnugrep
+            gnused
+            hostname
+          ]
+        }
+        wrapProgram $out/bin/mysql_config --prefix PATH : ${
+          lib.makeBinPath [
+            coreutils
+            gnused
+          ]
+        }
+        wrapProgram $out/bin/ps_mysqld_helper --prefix PATH : ${
+          lib.makeBinPath [
+            coreutils
+            gnugrep
+          ]
+        }
+        wrapProgram $out/bin/ps-admin --prefix PATH : ${
+          lib.makeBinPath [
+            coreutils
+            gnugrep
+          ]
+        }
+      ''
+      + lib.optionalString stdenv.hostPlatform.isDarwin ''
+        wrapProgram $out/bin/mysqld_multi --prefix PATH : ${
+          lib.makeBinPath [
+            coreutils
+            gnugrep
+          ]
+        }
+      '';
+
+    meta = common'.meta // {
+      mainProgram = "mysqld";
+    };
+
+    passthru = {
+      inherit client;
+      connector-c = finalAttrs.finalPackage;
+      server = finalAttrs.finalPackage;
+      inherit (common'.passthru) mysqlVersion;
+      tests.percona-server =
+        nixosTests.mysql."percona-server_${lib.versions.major finalAttrs.version}_${lib.versions.minor finalAttrs.version}";
+      updateScript = gitUpdater {
+        url = "https://github.com/percona/percona-server";
+        rev-prefix = "Percona-Server-";
+        allowedVersions = "${lib.versions.major finalAttrs.version}\\.${lib.versions.minor finalAttrs.version}\\..+";
+      };
+    };
+  }
+)

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -9966,7 +9966,7 @@ with self;
     };
 
     nativeBuildInputs = [
-      pkgs.mysql84 # for mysql_config
+      pkgs.mysql84.client # for mysql_config
     ];
     buildInputs = [
       DevelChecklib


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Introduce a `.client` sub-package for mysql and percona, like already done for mariadb. This helps getting smaller closure sizes in cases where the actual database server parts are not needed.

The design pattern is basically copied from what mariadb currently does. The downside of that approach is that, due to the missing `finalAttrs` of the `common` attrs definition, overridability degrades a bit, especially of the `src`.

Additionally refactors the NixOS tests to utilise these client packages, fixes some cosmetic issues, and cleans up deprecated behaviour.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
