### PR TITLE
kea: 3.0.3 -> 3.2.0

### DIFF
--- a/nixos/modules/services/networking/kea.nix
+++ b/nixos/modules/services/networking/kea.nix
@@ -12,12 +12,6 @@ let
 
   chooseNotNull = x: y: if x != null then x else y;
 
-  ctrlAgentConfig = chooseNotNull cfg.ctrl-agent.configFile (
-    format.generate "kea-ctrl-agent.conf" {
-      Control-agent = cfg.ctrl-agent.settings;
-    }
-  );
-
   dhcp4Config = chooseNotNull cfg.dhcp4.configFile (
     format.generate "kea-dhcp4.conf" {
       Dhcp4 = cfg.dhcp4.settings;
@@ -37,47 +31,14 @@ let
   );
 in
 {
+  imports = [
+    (lib.mkRemovedOptionModule [ "services" "kea" "ctrl-agent" ] ''
+      https://kb.isc.org/docs/things-to-be-aware-of-when-upgrading-to-kea-3-2#the-kea-control-agent-ca
+    '')
+  ];
+
   options.services.kea = with lib.types; {
     package = lib.mkPackageOption pkgs "kea" { };
-
-    ctrl-agent = lib.mkOption {
-      description = ''
-        Kea Control Agent configuration
-      '';
-      default = { };
-      type = submodule {
-        options = {
-          enable = lib.mkEnableOption "Kea Control Agent";
-
-          extraArgs = lib.mkOption {
-            type = listOf str;
-            default = [ ];
-            description = ''
-              List of additional arguments to pass to the daemon.
-            '';
-          };
-
-          configFile = lib.mkOption {
-            type = nullOr path;
-            default = null;
-            description = ''
-              Kea Control Agent configuration as a path, see <https://kea.readthedocs.io/en/kea-${cfg.package.version}/arm/agent.html>.
-
-              Takes preference over [settings](#opt-services.kea.ctrl-agent.settings).
-              Most users should prefer using [settings](#opt-services.kea.ctrl-agent.settings) instead.
-            '';
-          };
-
-          settings = lib.mkOption {
-            type = format.type;
-            default = null;
-            description = ''
-              Kea Control Agent configuration as an attribute set, see <https://kea.readthedocs.io/en/kea-${cfg.package.version}/arm/agent.html>.
-            '';
-          };
-        };
-      };
-    };
 
     dhcp4 = lib.mkOption {
       description = ''
@@ -290,7 +251,7 @@ in
         UMask = "0077";
       };
     in
-    lib.mkIf (cfg.ctrl-agent.enable || cfg.dhcp4.enable || cfg.dhcp6.enable || cfg.dhcp-ddns.enable) (
+    lib.mkIf (cfg.dhcp4.enable || cfg.dhcp6.enable || cfg.dhcp-ddns.enable) (
       lib.mkMerge [
         {
           environment.systemPackages = [ cfg.package ];
@@ -301,58 +262,6 @@ in
           };
           users.groups.kea = { };
         }
-
-        (lib.mkIf cfg.ctrl-agent.enable {
-          assertions = [
-            {
-              assertion = lib.xor (cfg.ctrl-agent.settings == null) (cfg.ctrl-agent.configFile == null);
-              message = "Either services.kea.ctrl-agent.settings or services.kea.ctrl-agent.configFile must be set to a non-null value.";
-            }
-          ];
-
-          environment.etc."kea/ctrl-agent.conf".source = ctrlAgentConfig;
-
-          systemd.services.kea-ctrl-agent = {
-            description = "Kea Control Agent";
-            documentation = [
-              "man:kea-ctrl-agent(8)"
-              "https://kea.readthedocs.io/en/kea-${cfg.package.version}/arm/agent.html"
-            ];
-
-            wants = [
-              "network-online.target"
-            ];
-            after = [
-              "network-online.target"
-              "time-sync.target"
-            ];
-            wantedBy = [
-              "kea-dhcp4-server.service"
-              "kea-dhcp6-server.service"
-              "kea-dhcp-ddns-server.service"
-            ];
-
-            environment = commonEnvironment;
-
-            restartTriggers = [
-              ctrlAgentConfig
-            ];
-
-            serviceConfig = {
-              ExecStart = utils.escapeSystemdExecArgs (
-                [
-                  (lib.getExe' cfg.package "kea-ctrl-agent")
-                  "-c"
-                  "/etc/kea/ctrl-agent.conf"
-                ]
-                ++ cfg.ctrl-agent.extraArgs
-              );
-              KillMode = "process";
-              Restart = "on-failure";
-            }
-            // commonServiceConfig;
-          };
-        })
 
         (lib.mkIf cfg.dhcp4.enable {
           assertions = [

--- a/nixos/tests/kea.nix
+++ b/nixos/tests/kea.nix
@@ -77,7 +77,7 @@
 
             # Enable communication between dhcp4 and a local dhcp-ddns
             # instance.
-            # https://kea.readthedocs.io/en/kea-2.2.0/arm/dhcp4-srv.html#ddns-for-dhcpv4
+            # https://kea.readthedocs.io/en/kea-3.2.0/arm/dhcp4-srv.html#ddns-for-dhcpv4
             dhcp-ddns = {
               enable-updates = true;
             };
@@ -93,7 +93,7 @@
             forward-ddns = {
               # Configure updates of a forward zone named `lan.nixos.test`
               # hosted at the nameserver at 10.0.0.2
-              # https://kea.readthedocs.io/en/kea-2.2.0/arm/ddns.html#adding-forward-dns-servers
+              # https://kea.readthedocs.io/en/kea-3.2.0/arm/ddns.html#adding-forward-dns-servers
               ddns-domains = [
                 {
                   name = "lan.nixos.test.";
@@ -109,25 +109,6 @@
               ];
             };
           };
-        };
-
-        services.kea.ctrl-agent = {
-          enable = true;
-          settings = {
-            http-host = "127.0.0.1";
-            http-port = 8000;
-            control-sockets.dhcp4 = {
-              socket-type = "unix";
-              socket-name = "/run/kea/dhcp4.sock";
-            };
-          };
-        };
-
-        services.prometheus.exporters.kea = {
-          enable = true;
-          controlSocketPaths = [
-            "http://127.0.0.1:8000"
-          ];
         };
       };
 
@@ -236,9 +217,5 @@
 
       with subtest("DDNS"):
           nameserver.wait_until_succeeds("kdig +short client.lan.nixos.test @10.0.0.2 | grep -q 10.0.0.3")
-
-      with subtest("Prometheus Exporter"):
-          router.log(router.execute("curl 127.0.0.1:9547")[1])
-          router.succeed("curl --silent 127.0.0.1:9547 | grep -qE '^kea_dhcp4_addresses_assigned_total.*1.0$'")
     '';
 }

--- a/pkgs/by-name/ke/kea/dont-create-system-paths.patch
+++ b/pkgs/by-name/ke/kea/dont-create-system-paths.patch
@@ -1,14 +1,14 @@
 diff --git a/meson.build b/meson.build
-index 24ab9b5bd7..8f44076cf7 100644
+index eb7f261cef..72fa81daf7 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -1118,10 +1118,6 @@ top_docs = [
+@@ -1139,10 +1139,6 @@ top_docs = [
  ]
  install_data(top_docs, install_dir: DATADIR / 'doc/kea')
  
--install_emptydir(LOGDIR)
--install_emptydir(RUNSTATEDIR)
--install_emptydir(SHAREDSTATEDIR)
+-install_emptydir(LOGDIR, install_mode: 'rwxr-x---')
+-install_emptydir(RUNSTATEDIR, install_mode: 'rwxr-x---')
+-install_emptydir(SHAREDSTATEDIR, install_mode: 'rwxr-x---')
 -
  # Meson is annoying with its opinionated alteration of certain paths based on whether prefix is default or not.
  # So we revert what it does..

--- a/pkgs/by-name/ke/kea/package.nix
+++ b/pkgs/by-name/ke/kea/package.nix
@@ -29,18 +29,15 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "kea";
-  version = "3.0.3"; # only even minor versions are stable
+  version = "3.2.0"; # only even minor versions are stable
 
   src = fetchurl {
     url = "https://ftp.isc.org/isc/kea/${finalAttrs.version}/kea-${finalAttrs.version}.tar.xz";
-    hash = "sha256-CXAt2weLY36F3pI2y+3T+51698bnlwJsU4tFdIrU1jE=";
+    hash = "sha256-FL9pXTe2W5sb9VD+pdCtr5gGxQ5UGe8qF2pLjpqt498=";
   };
 
   patches = [
     ./dont-create-system-paths.patch
-    # backport of an upstream fix for boost-1.89:
-    #   https://gitlab.isc.org/isc-projects/kea/-/merge_requests/2771
-    ./boost-1.89.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
https://gitlab.isc.org/isc-projects/kea/-/wikis/Release-Notes/release-notes-3.2.0

Removes the ctrl-agent module options, because the service was removed.

Removes the prometheus exporter test which is not compatible with 3.2.0.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
