### PR TITLE
tinygo: build with go 1.26

### DIFF
--- a/pkgs/by-name/ti/tinygo/package.nix
+++ b/pkgs/by-name/ti/tinygo/package.nix
@@ -1,11 +1,11 @@
 {
   stdenv,
   lib,
-  buildGo125Module,
+  buildGo126Module,
   fetchFromGitHub,
   makeWrapper,
   llvmPackages_20,
-  go_1_25,
+  go_1_26,
   xar,
   binaryen,
   avrdude,
@@ -18,8 +18,8 @@
 let
   # nixpkgs typically updates default llvm and go versions faster than tinygo releases
   # which ends up breaking this build. Use fixed versions for each release.
-  buildGoModule = buildGo125Module;
-  go = go_1_25;
+  buildGoModule = buildGo126Module;
+  go = go_1_26;
   llvmMajor = lib.versions.major llvm.version;
   inherit (llvmPackages_20)
     llvm


### PR DESCRIPTION
TinyGo 0.41 officially supports Go 1.26, but the package is still pinned to
`go_1_25` / `buildGo125Module`. As a result, TinyGo refuses to compile projects
when a Go 1.26 toolchain is present, failing with:

    cannot compile with Go toolchain version go1.26 (TinyGo was built using toolchain version go1.25.11)

This builds TinyGo with Go 1.26 instead, keeping the existing per-release
explicit version pins (`buildGo126Module` / `go_1_26`). LLVM stays at
`llvmPackages_20`.

Upstream Go 1.26 support: https://github.com/tinygo-org/tinygo/releases/tag/v0.41.0

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].