### PR TITLE
gdm: add warning for missing 'defaultSession' if GDM takes fallback path

### DIFF
--- a/nixos/modules/services/display-managers/gdm.nix
+++ b/nixos/modules/services/display-managers/gdm.nix
@@ -200,7 +200,22 @@ in
 
   config = lib.mkIf cfg.enable {
 
-    warnings = lib.optional config.services.pulseaudio.enable "Support for Pulseaudio + gdm will be removed in NixOS 26.11";
+    warnings =
+      lib.optional config.services.pulseaudio.enable "Support for Pulseaudio + gdm will be removed in NixOS 26.11"
+      ++
+        lib.optional
+          (
+            defaultSessionName == null
+            && !(lib.elem "gnome" config.services.displayManager.sessionData.sessionNames)
+          )
+          ''
+            GDM is enabled but `services.displayManager.defaultSession` is not set, and no GNOME
+            session is installed. GDM falls back to launching gnome-session, which will fail with
+            "Session never registered, failing" and return you to the login screen.
+
+            Set services.displayManager.defaultSession to one of:
+                ${lib.concatStringsSep ", " config.services.displayManager.sessionData.sessionNames}
+          '';
 
     services.xserver.displayManager.lightdm.enable = false;
 


### PR DESCRIPTION
Addresses partially #490431.

Assisted-by: Claude 4.8
 + refactored and reviewed by me.

When there is no `defaultSession` configured and GDM falls back to the `gnome-session` it will fail if that session type is not installed.
I added a warning to notify the user that GDM will probably fail.

The better fix maybe is to drop the conditional in `preStart` and set it to all possible `sessionNames` if that is possible and doesnt break things?

```
preStart = lib.optionalString (defaultSessionName != null) ''
  # Set default session in session chooser to a specified values – basically ignore session history.
  ${setSessionScript}/bin/set-session ${config.services.displayManager.sessionData.autologinSession}
'';
```

Another thing is, *sway.desktop* gets detected by gnome but it anway launches `gnome-session` (if not explicitly set with `defaultSessioName` which I dont use.
Maybe this fix also points towards a misconfiguration in how gnome selects/launches the session types?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
