### PR TITLE
dnsmasq: libidn -> libidn2

### DIFF
--- a/pkgs/by-name/dn/dnsmasq/package.nix
+++ b/pkgs/by-name/dn/dnsmasq/package.nix
@@ -4,7 +4,7 @@
   fetchurl,
   pkg-config,
   nettle,
-  libidn,
+  libidn2,
   libnetfilter_conntrack,
   nftables,
   buildPackages,
@@ -16,7 +16,7 @@
 let
   copts = lib.concatStringsSep " " (
     [
-      "-DHAVE_IDN"
+      "-DHAVE_LIBIDN2"
       "-DHAVE_DNSSEC"
     ]
     ++ lib.optionals dbusSupport [
@@ -91,7 +91,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
     nettle
-    libidn
+    libidn2
   ]
   ++ lib.optionals dbusSupport [ dbus ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [


### PR DESCRIPTION
upstream libidn recommends migrating to libidn2 wherever possible, see https://codeberg.org/libidn/libidn. dnsmasq supports building against libidn2, and the upstream debian packaging does so as well: https://thekelleys.org.uk/gitweb-noai/?p=dnsmasq-debian.git;a=blob;f=debian/control;h=211c8fa5a3d9a26e8ef41763f37afa20cce24bcc;hb=HEAD#l10 (if you get login-walled for this link, username and password are `gitweb` and `gitweb`. it's an anti-scraping measure). thus, we should probably do the same.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
