### PR TITLE
llvmPackages_22.libclc: fix eval + build

### DIFF
--- a/pkgs/by-name/sp/spirv-headers/package.nix
+++ b/pkgs/by-name/sp/spirv-headers/package.nix
@@ -24,6 +24,12 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/KhronosGroup/SPIRV-Headers/commit/1a22b167081842915a1c78a0b5b5a353a23284aa.diff";
       hash = "sha256-XUHfPHnk7bWK4vnozfW/84vaZN+rbFJUZSa6Og8GUAU=";
     })
+    # Backport new predicated load/store instructions, needed by spirv-llvm-translator
+    # Not in any tagged releases yet, should exist in the next release after 1.4.350.1.
+    (fetchpatch {
+      url = "https://github.com/KhronosGroup/SPIRV-Headers/commit/b8a32968473ce852a809b9de5f04f02a5a9dfa78.patch";
+      hash = "sha256-59jmN28ifEhAxySXCpuGZ62jo1WVsRPnVosK8X4yrjM=";
+    })
   ];
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/sp/spirv-llvm-translator/package.nix
+++ b/pkgs/by-name/sp/spirv-llvm-translator/package.nix
@@ -16,6 +16,11 @@ let
   llvmMajor = lib.versions.major llvm.version;
 
   versions = {
+    "22" = rec {
+      version = "22.1.3";
+      rev = "v${version}";
+      hash = "sha256-u/OytBH9LgAyGF9PX+5lmAbGPQ7iVv52w8mwQ+6fi/s=";
+    };
     "21" = rec {
       version = "21.1.0";
       rev = "v${version}";

--- a/pkgs/by-name/sp/spirv-llvm-translator/package.nix
+++ b/pkgs/by-name/sp/spirv-llvm-translator/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  srcOnly,
   fetchFromGitHub,
   fetchpatch,
   cmake,
@@ -84,7 +85,7 @@ stdenv.mkDerivation {
     "-DLLVM_SPIRV_BUILD_EXTERNAL=YES"
     # RPATH of binary /nix/store/.../bin/llvm-spirv contains a forbidden reference to /build/
     "-DCMAKE_SKIP_BUILD_RPATH=ON"
-    "-DLLVM_EXTERNAL_SPIRV_HEADERS_SOURCE_DIR=${spirv-headers.src}"
+    "-DLLVM_EXTERNAL_SPIRV_HEADERS_SOURCE_DIR=${srcOnly spirv-headers}"
   ]
   ++ lib.optional (
     lib.toInt llvmMajor >= 19

--- a/pkgs/development/compilers/llvm/common/libclc/default.nix
+++ b/pkgs/development/compilers/llvm/common/libclc/default.nix
@@ -97,7 +97,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [ llvm ];
   strictDeps = true;
 
-  postInstall = ''
+  postInstall = lib.optionalString (lib.versionOlder finalAttrs.version "22.1") ''
     install -Dt $dev/bin prepare_builtins
   '';
 


### PR DESCRIPTION
I noticed the new llvmPackages_22 set has a broken libclc, mostly due to greater requirements for its underlying SPIRV dependencies. This fixes those, as well as a small tweak to keep libclc building after `prepare_builtins` was removed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
