### PR TITLE
ocamlPackages_5_5.ocaml: init at 5.5.0

### DIFF
--- a/pkgs/by-name/fr/frama-c/package.nix
+++ b/pkgs/by-name/fr/frama-c/package.nix
@@ -134,6 +134,8 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     platforms = lib.platforms.unix;
     mainProgram = "frama-c";
-    broken = !lib.versionAtLeast ocamlPackages.ocaml.version "4.14";
+    broken =
+      !lib.versionAtLeast ocamlPackages.ocaml.version "4.14"
+      || lib.versionAtLeast ocamlPackages.ocaml.version "5.5";
   };
 })

--- a/pkgs/development/compilers/ocaml/5.5.nix
+++ b/pkgs/development/compilers/ocaml/5.5.nix
@@ -1,0 +1,6 @@
+import ./generic.nix {
+  major_version = "5";
+  minor_version = "5";
+  patch_version = "0";
+  sha256 = "sha256-/MauZl0exR1SUQ6qx4NKhqmAa/WiWLt8ynhzP8zwFbo=";
+}

--- a/pkgs/development/ocaml-modules/batteries/default.nix
+++ b/pkgs/development/ocaml-modules/batteries/default.nix
@@ -3,19 +3,18 @@
   fetchFromGitHub,
   buildDunePackage,
   ocaml,
+  fetchpatch,
   ounit,
   qtest,
   qcheck,
   num,
   camlp-streams,
-  doCheck ? lib.versionAtLeast ocaml.version "4.08",
+  doCheck ? true,
 }:
 
 buildDunePackage (finalAttrs: {
   pname = "batteries";
   version = "3.10.0";
-
-  minimalOCamlVersion = "4.05";
 
   src = fetchFromGitHub {
     owner = "ocaml-batteries-team";
@@ -23,6 +22,11 @@ buildDunePackage (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-cD0O4kEDE58yCYnUuS83O1CJNHJuCGVhvKJSKQeQGkc=";
   };
+
+  patches = lib.optional (lib.versionAtLeast ocaml.version "5.5") (fetchpatch {
+    url = "https://github.com/ocaml-batteries-team/batteries-included/commit/f6e091266599aea93c8a94115cf08f50e88c5dd0.patch";
+    hash = "sha256-6CUcq24x4fnumduK4BJ5cVQ5DHPbVLyLUxl57q2JVtw=";
+  });
 
   nativeCheckInputs = [ qtest ];
   checkInputs = [

--- a/pkgs/development/ocaml-modules/janestreet/0.17.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.17.nix
@@ -60,6 +60,7 @@ with self;
     pname = "accessor_core";
     hash = "sha256-ku83ZfLtVI8FvQhrKcnJmhmoNlYcVMKx1tor5N8Nq7M=";
     meta.description = "Accessors for Core types, for use with the Accessor library";
+    meta.broken = lib.versionAtLeast ocaml.version "5.5";
     propagatedBuildInputs = [
       accessor_base
       core_kernel

--- a/pkgs/development/ocaml-modules/ocaml-lsp/jsonrpc.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/jsonrpc.nix
@@ -9,7 +9,9 @@
   lib,
   ocaml,
   version ?
-    if lib.versionAtLeast ocaml.version "5.4" then
+    if lib.versionAtLeast ocaml.version "5.5" then
+      "1.27.0"
+    else if lib.versionAtLeast ocaml.version "5.4" then
       "1.26.0"
     else if lib.versionAtLeast ocaml.version "5.3" then
       "1.23.1"
@@ -28,6 +30,11 @@
 let
   params =
     {
+      "1.27.0" = {
+        name = "lsp";
+        minimalOCamlVersion = "5.3";
+        sha256 = "sha256-BDrNaSP4pcuq2RVFI1cKsTlzuu72mOK1VTIT3WN5JxU=";
+      };
       "1.26.0" = {
         name = "lsp";
         minimalOCamlVersion = "5.3";

--- a/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
@@ -25,7 +25,9 @@
   ocamlformat-rpc-lib,
   ocaml,
   version ?
-    if lib.versionAtLeast ocaml.version "5.4" then
+    if lib.versionAtLeast ocaml.version "5.5" then
+      "1.27.0"
+    else if lib.versionAtLeast ocaml.version "5.4" then
       "1.26.0"
     else if lib.versionAtLeast ocaml.version "5.3" then
       "1.23.1"

--- a/pkgs/development/ocaml-modules/ppx_import/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_import/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchurl,
+  ocaml,
   buildDunePackage,
   ounit,
   ppx_deriving,
@@ -53,5 +54,6 @@ buildDunePackage {
     description = "Syntax extension for importing declarations from interface files";
     license = lib.licenses.mit;
     homepage = "https://github.com/ocaml-ppx/ppx_import";
+    broken = lib.versionAtLeast ocaml.version "5.5";
   };
 }

--- a/pkgs/development/tools/ocaml/camlp4/default.nix
+++ b/pkgs/development/tools/ocaml/camlp4/default.nix
@@ -83,6 +83,10 @@ let
       version = "5.4";
       sha256 = "sha256-7FsKEr0cRVF4LIOvROWMyXBefRTBaS66ZqwtP2VLefM=";
     };
+    "5.5" = {
+      version = "5.5+1";
+      sha256 = "sha256-ERzTg6CFXm1Z0/NSXP5MwM0H/fSpN/4D2ISFcJa1qSI=";
+    };
   };
   param = {
     # Dummy version to let the `meta` attribute set evaluate

--- a/pkgs/development/tools/ocaml/camlp4/default.nix
+++ b/pkgs/development/tools/ocaml/camlp4/default.nix
@@ -9,150 +9,153 @@
   findlib,
 }:
 
-if lib.versionAtLeast ocaml.version "5.5" then
-  throw "camlp4 is not available for OCaml ${ocaml.version}"
-else
-
-  let
-    param =
-      {
-        "4.02" = {
-          version = "4.02+6";
-          sha256 = "06yl4q0qazl7g25b0axd1gdkfd4qpqzs1gr5fkvmkrcbz113h1hj";
-        };
-        "4.03" = {
-          version = "4.03+1";
-          sha256 = "1f2ndch6f1m4fgnxsjb94qbpwjnjgdlya6pard44y6n0dqxi1wsq";
-        };
-        "4.04" = {
-          version = "4.04+1";
-          sha256 = "1ad7rygqjxrc1im95gw9lp8q83nhdaf383f2808f1p63yl42xm7k";
-        };
-        "4.05" = {
-          version = "4.05+1";
-          sha256 = "0wm795hpwvwpib9c9z6p8kw2fh7p7b2hml6g15z8zry3y7w738sv";
-        };
-        "4.06" = {
-          version = "4.06+1";
-          sha256 = "0fazfw2l7wdmbwnqc22xby5n4ri1wz27lw9pfzhsbcdrighykysf";
-        };
-        "4.07" = {
-          version = "4.07+1";
-          sha256 = "0cxl4hkqcvspvkx4f2k83217rh6051fll9i2yz7cw6m3bq57mdvl";
-        };
-        "4.08" = {
-          version = "4.08+1";
-          sha256 = "0qplawvxwai25bi27niw2cgz2al01kcnkj8wxwhxslpi21z6pyx1";
-        };
-        "4.09" = {
-          version = "4.09+1";
-          sha256 = "1gr33x6xs1rs0bpyq4vzyfxd6vn47jfkg8imi81db2r0cbs0kxx1";
-        };
-        "4.10" = {
-          version = "4.10+1";
-          sha256 = "093bc1c28wid5li0jwglnd4p3csxw09fmbs9ffybq2z41a5mgay6";
-        };
-        "4.11" = {
-          version = "4.11+1";
-          sha256 = "0sn7f6im940qh0ixmx1k738xrwwdvy9g7r19bv5218jb6mh0g068";
-        };
-        "4.12" = {
-          version = "4.12+1";
-          sha256 = "1cfk5ppnd511vzsr9gc0grxbafmh0m3m897aij198rppzxps5kyz";
-        };
-        "4.13" = {
-          version = "4.13+1";
-          sha256 = "0fzxa1zdhk74mlxpin7p90flks6sp4gkc0mfclmj9zak15rii55n";
-        };
-        "4.14" = {
-          version = "4.14+1";
-          sha256 = "sha256-cPN3GioZT/Zt6uzbjGUPEGVJcPQdsAnCkU/AQoPfvuo=";
-        };
-        "5.0" = {
-          version = "5.0";
-          sha256 = "sha256-oZptFNPUEAq5YlcqAoDWfLghGMF9AN7E7hUN55SAX+4=";
-        };
-        "5.1" = {
-          version = "5.1";
-          sha256 = "sha256-Ubedjg3BeHA0bJbEalQN9eEk5+LRAI/er+8mWfVYchg=";
-        };
-        "5.2" = {
-          version = "5.2";
-          sha256 = "sha256-lzbc9xsgeYlbVf71O+PWYS14QivAH1aPdnvWhe0HHME=";
-        };
-        "5.3" = {
-          version = "5.3";
-          sha256 = "sha256-V/kKhTP9U4jWDFuQKuB7BS3XICg1lq/2Avj7UJR55+k=";
-        };
-        "5.4" = {
-          version = "5.4";
-          sha256 = "sha256-7FsKEr0cRVF4LIOvROWMyXBefRTBaS66ZqwtP2VLefM=";
-        };
-      }
-      .${ocaml.meta.branch};
-  in
-
-  stdenv.mkDerivation rec {
-    pname = "camlp4";
-    inherit (param) version;
-
-    src = fetchzip {
-      url = "https://github.com/ocaml/camlp4/archive/${version}.tar.gz";
-      inherit (param) sha256;
+let
+  params = {
+    "4.02" = {
+      version = "4.02+6";
+      sha256 = "06yl4q0qazl7g25b0axd1gdkfd4qpqzs1gr5fkvmkrcbz113h1hj";
     };
-
-    strictDeps = true;
-
-    nativeBuildInputs = [
-      which
-      ocaml
-      ocamlbuild
-    ]
-    ++ lib.optionals (lib.versionAtLeast ocaml.version "5.0") [
-      findlib
-    ];
-
-    buildInputs = lib.optionals (lib.versionAtLeast ocaml.version "5.0") [
-      camlp-streams
-      ocamlbuild
-    ];
-
-    # build fails otherwise
-    enableParallelBuilding = false;
-
-    dontAddPrefix = true;
-
-    preConfigure = ''
-      # increase stack space for spacetime variant of the compiler
-      # https://github.com/ocaml/ocaml/issues/7435
-      # but disallowed by darwin sandbox
-      ulimit -s unlimited || true
-
-      configureFlagsArray=(
-        --bindir=$out/bin
-        --libdir=$out/lib/ocaml/${ocaml.version}/site-lib
-        --pkgdir=$out/lib/ocaml/${ocaml.version}/site-lib
-      )
-    '';
-
-    postConfigure = ''
-      substituteInPlace camlp4/META.in \
-      --replace +camlp4 $out/lib/ocaml/${ocaml.version}/site-lib/camlp4
-    '';
-
-    makeFlags = [ "all" ];
-
-    installTargets = [
-      "install"
-      "install-META"
-    ];
-
-    dontStrip = true;
-
-    meta = {
-      description = "Software system for writing extensible parsers for programming languages";
-      homepage = "https://github.com/ocaml/camlp4";
-      platforms = ocaml.meta.platforms or [ ];
-      license = lib.licenses.WITH lib.licenses.lgpl2Only lib.licenses.ocamlLgplLinkingException;
+    "4.03" = {
+      version = "4.03+1";
+      sha256 = "1f2ndch6f1m4fgnxsjb94qbpwjnjgdlya6pard44y6n0dqxi1wsq";
     };
+    "4.04" = {
+      version = "4.04+1";
+      sha256 = "1ad7rygqjxrc1im95gw9lp8q83nhdaf383f2808f1p63yl42xm7k";
+    };
+    "4.05" = {
+      version = "4.05+1";
+      sha256 = "0wm795hpwvwpib9c9z6p8kw2fh7p7b2hml6g15z8zry3y7w738sv";
+    };
+    "4.06" = {
+      version = "4.06+1";
+      sha256 = "0fazfw2l7wdmbwnqc22xby5n4ri1wz27lw9pfzhsbcdrighykysf";
+    };
+    "4.07" = {
+      version = "4.07+1";
+      sha256 = "0cxl4hkqcvspvkx4f2k83217rh6051fll9i2yz7cw6m3bq57mdvl";
+    };
+    "4.08" = {
+      version = "4.08+1";
+      sha256 = "0qplawvxwai25bi27niw2cgz2al01kcnkj8wxwhxslpi21z6pyx1";
+    };
+    "4.09" = {
+      version = "4.09+1";
+      sha256 = "1gr33x6xs1rs0bpyq4vzyfxd6vn47jfkg8imi81db2r0cbs0kxx1";
+    };
+    "4.10" = {
+      version = "4.10+1";
+      sha256 = "093bc1c28wid5li0jwglnd4p3csxw09fmbs9ffybq2z41a5mgay6";
+    };
+    "4.11" = {
+      version = "4.11+1";
+      sha256 = "0sn7f6im940qh0ixmx1k738xrwwdvy9g7r19bv5218jb6mh0g068";
+    };
+    "4.12" = {
+      version = "4.12+1";
+      sha256 = "1cfk5ppnd511vzsr9gc0grxbafmh0m3m897aij198rppzxps5kyz";
+    };
+    "4.13" = {
+      version = "4.13+1";
+      sha256 = "0fzxa1zdhk74mlxpin7p90flks6sp4gkc0mfclmj9zak15rii55n";
+    };
+    "4.14" = {
+      version = "4.14+1";
+      sha256 = "sha256-cPN3GioZT/Zt6uzbjGUPEGVJcPQdsAnCkU/AQoPfvuo=";
+    };
+    "5.0" = {
+      version = "5.0";
+      sha256 = "sha256-oZptFNPUEAq5YlcqAoDWfLghGMF9AN7E7hUN55SAX+4=";
+    };
+    "5.1" = {
+      version = "5.1";
+      sha256 = "sha256-Ubedjg3BeHA0bJbEalQN9eEk5+LRAI/er+8mWfVYchg=";
+    };
+    "5.2" = {
+      version = "5.2";
+      sha256 = "sha256-lzbc9xsgeYlbVf71O+PWYS14QivAH1aPdnvWhe0HHME=";
+    };
+    "5.3" = {
+      version = "5.3";
+      sha256 = "sha256-V/kKhTP9U4jWDFuQKuB7BS3XICg1lq/2Avj7UJR55+k=";
+    };
+    "5.4" = {
+      version = "5.4";
+      sha256 = "sha256-7FsKEr0cRVF4LIOvROWMyXBefRTBaS66ZqwtP2VLefM=";
+    };
+  };
+  param = {
+    # Dummy version to let the `meta` attribute set evaluate
+    version = "";
+    sha256 = lib.fakeSha256;
   }
+  // (params.${ocaml.meta.branch} or {
+  }
+  );
+in
+
+stdenv.mkDerivation rec {
+  pname = "camlp4";
+  inherit (param) version;
+
+  src = fetchzip {
+    url = "https://github.com/ocaml/camlp4/archive/${version}.tar.gz";
+    inherit (param) sha256;
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    which
+    ocaml
+    ocamlbuild
+  ]
+  ++ lib.optionals (lib.versionAtLeast ocaml.version "5.0") [
+    findlib
+  ];
+
+  buildInputs = lib.optionals (lib.versionAtLeast ocaml.version "5.0") [
+    camlp-streams
+    ocamlbuild
+  ];
+
+  # build fails otherwise
+  enableParallelBuilding = false;
+
+  dontAddPrefix = true;
+
+  preConfigure = ''
+    # increase stack space for spacetime variant of the compiler
+    # https://github.com/ocaml/ocaml/issues/7435
+    # but disallowed by darwin sandbox
+    ulimit -s unlimited || true
+
+    configureFlagsArray=(
+      --bindir=$out/bin
+      --libdir=$out/lib/ocaml/${ocaml.version}/site-lib
+      --pkgdir=$out/lib/ocaml/${ocaml.version}/site-lib
+    )
+  '';
+
+  postConfigure = ''
+    substituteInPlace camlp4/META.in \
+    --replace +camlp4 $out/lib/ocaml/${ocaml.version}/site-lib/camlp4
+  '';
+
+  makeFlags = [ "all" ];
+
+  installTargets = [
+    "install"
+    "install-META"
+  ];
+
+  dontStrip = true;
+
+  meta = {
+    description = "Software system for writing extensible parsers for programming languages";
+    homepage = "https://github.com/ocaml/camlp4";
+    platforms = ocaml.meta.platforms;
+    license = lib.licenses.WITH lib.licenses.lgpl2Only lib.licenses.ocamlLgplLinkingException;
+    broken = !(params ? ${ocaml.meta.branch});
+  };
+}

--- a/pkgs/development/tools/ocaml/merlin/4.x.nix
+++ b/pkgs/development/tools/ocaml/merlin/4.x.nix
@@ -34,6 +34,7 @@
       "5.3.0" = "5.6-503";
       "5.4.0" = "5.7.1-504";
       "5.4.1" = "5.7.1-504";
+      "5.5.0" = "5.8-505";
     }
     ."${ocaml.version}",
 }:
@@ -54,6 +55,7 @@ let
     "5.6-503" = "sha256-sNytCSqq96I/ZauaCJ6HYb1mXMcjV5CeCsbCGC9PwtQ=";
     "5.6-504" = "sha256-gtZIpBgNbVqjoIMhjii/GX9OnxR4hN6TArtoEa2Yt38=";
     "5.7.1-504" = "sha256-E5sHPPkUs4tyXFT3W4tkL2VMNJjQpLqM+oMf8CqJcNU=";
+    "5.8-505" = "sha256-VkLN6EhqhKrZj6XFkLcOjcxgdNf72zubjEayxbQvZTs=";
   };
 
 in

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -2400,7 +2400,9 @@ rec {
 
   ocamlPackages_5_4 = mkOcamlPackages (callPackage ../development/compilers/ocaml/5.4.nix { });
 
-  ocamlPackages_latest = ocamlPackages_5_4;
+  ocamlPackages_5_5 = mkOcamlPackages (callPackage ../development/compilers/ocaml/5.5.nix { });
+
+  ocamlPackages_latest = ocamlPackages_5_5;
 
   ocamlPackages = ocamlPackages_5_4;
 


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
