### PR TITLE
kotlin-cli: init at 0.11.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7391,6 +7391,13 @@
     github = "DSeeLP";
     githubId = 46624152;
   };
+  dshatz = {
+    email = "dev@dshatz.com";
+    github = "dshatz";
+    githubId = 23437798;
+    name = "Daniels Šatcs";
+    keys = [ { fingerprint = "7452B4B47EA8F6635AB545CA4B974CC26375BB06"; } ];
+  };
   dsluijk = {
     name = "Dany Sluijk";
     email = "nix@dany.dev";

--- a/pkgs/by-name/ko/kotlin-cli/package.nix
+++ b/pkgs/by-name/ko/kotlin-cli/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  fetchurl,
+  stdenv,
+  jre,
+  makeWrapper,
+  nix-update-script,
+  jdk25,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "kotlin-cli";
+  version = "0.11.1";
+
+  src = fetchurl {
+    url = "https://packages.jetbrains.team/maven/p/amper/amper/org/jetbrains/kotlin/kotlin-cli/${finalAttrs.version}/kotlin-cli-${finalAttrs.version}-dist.tgz";
+    hash = "sha256-De0qQ09r8ZOyTiptVsO6RD9CMnIRVaZaqoNyeJQSES8=";
+  };
+  sourceRoot = ".";
+  dontBuild = true;
+  nativeBuildInputs = [ makeWrapper ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  installPhase = ''
+    mkdir -p $out/share/kotlin-cli
+    cp -r * $out/share/kotlin-cli/
+
+    mkdir -p $out/bin
+    chmod +x $out/share/kotlin-cli/bin/launcher.sh
+
+    # Override amper runtime JVM.
+    sed -i 's|^[[:space:]]*jre_url=.*|  jre_url=""|' $out/share/kotlin-cli/bin/launcher.sh
+    sed -i 's|^[[:space:]]*jre_target_dir=.*|  jre_target_dir="${jdk25}"|' $out/share/kotlin-cli/bin/launcher.sh
+
+    # Create the missing .flag file to satisfy the runtime check
+    touch $out/share/kotlin-cli/.flag
+
+    # Override kotlin toolchain launcher JVM.
+    makeWrapper $out/share/kotlin-cli/bin/launcher.sh $out/bin/kotlin \
+      --set KOTLIN_CLI_JAVA_HOME "${jdk25.home}"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--url=https://github.com/JetBrains/kotlin-toolchain"
+    ];
+  };
+
+  meta = {
+    description = "Kotlin Toolchain CLI";
+    homepage = "https://github.com/JetBrains/kotlin-toolchain";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.dshatz ];
+    platforms = jre.meta.platforms;
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+    mainProgram = "kotlin";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
