### PR TITLE
rocqPackages.HoTT: init at 9.1

### DIFF
--- a/pkgs/development/rocq-modules/HoTT/default.nix
+++ b/pkgs/development/rocq-modules/HoTT/default.nix
@@ -1,37 +1,29 @@
 {
   lib,
-  mkCoqDerivation,
-  coq,
+  mkRocqDerivation,
+  rocq-core,
   version ? null,
 }:
 
-let
-derivation = mkCoqDerivation {
+mkRocqDerivation {
   pname = "HoTT";
   repo = "Coq-HoTT";
   owner = "HoTT";
   inherit version;
   defaultVersion =
     with lib.versions;
-    lib.switch coq.coq-version [
+    lib.switch rocq-core.rocq-version [
       {
-        case = range "8.14" "8.20";
-        out = coq.coq-version;
+        case = range "9.0" "9.1";
+        out = rocq-core.rocq-version;
       }
     ] null;
   releaseRev = v: "V${v}";
-  release."8.14".sha256 = "sha256-7kXk2pmYsTNodHA+Qts3BoMsewvzmCbYvxw9Sgwyvq0=";
-  release."8.15".sha256 = "sha256-JfeiRZVnrjn3SQ87y6dj9DWNwCzrkK3HBogeZARUn9g=";
-  release."8.16".sha256 = "sha256-xcEbz4ZQ+U7mb0SEJopaczfoRc2GSgF2BGzUSWI0/HY=";
-  release."8.17".sha256 = "sha256-GjTUpzL9UzJm4C2ilCaYEufLG3hcj7rJPc5Op+OMal8=";
-  release."8.18".sha256 = "sha256-URoUoQOsG0432wg9i6pTRomWQZ+ewutq2+V29TBrVzc=";
-  release."8.19".sha256 = "sha256-igG3mhR6uPXV+SCtPH9PBw/eAtTFFry6HPT5ypWj3tQ=";
-  release."8.20".sha256 = "sha256-XHAvomi0of11j4x5gpTgD5Mw53eF1FpnCyBvdbV3g6I=";
+  release."9.0".sha256 = "sha256-etdLH1qDyDc+ZM7K/65iib0MRlLhsnVmzWBCULUDD50=";
+  release."9.1".sha256 = "sha256-JntL5kQh3UZTbC/Crk+Fu3GBGkfrGx3cr9b7EBmCTts=";
 
-  # versions of HoTT for Coq 8.17 and onwards will use dune
-  # opam-name = if lib.versions.isLe "8.17" coq.coq-version then "coq-hott" else null;
   opam-name = "coq-hott";
-  useDune = lib.versions.isGe "8.17" coq.coq-version;
+  useDune = true;
 
   patchPhase = ''
     patchShebangs etc
@@ -60,13 +52,4 @@ derivation = mkCoqDerivation {
       siddharthist
     ];
   };
-};
-in
-# this is just a wrapper for rocqPackages.HoTT for Rocq >= 9.0
-if coq.rocqPackages ? HoTT then
-  coq.rocqPackages.HoTT.override {
-    inherit version;
-    inherit (coq.rocqPackages) rocq-core;
-  }
-else
-  derivation
+}

--- a/pkgs/top-level/rocq-packages.nix
+++ b/pkgs/top-level/rocq-packages.nix
@@ -38,6 +38,7 @@ let
 
       bignums = callPackage ../development/rocq-modules/bignums { };
       hierarchy-builder = callPackage ../development/rocq-modules/hierarchy-builder { };
+      HoTT = callPackage ../development/rocq-modules/HoTT { };
       iris = callPackage ../development/rocq-modules/iris { };
       mathcomp = callPackage ../development/rocq-modules/mathcomp { };
       mathcomp-boot = self.mathcomp.boot;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
