### PR TITLE
nixos/clash-verge: fix process name resolution in service mode

### DIFF
--- a/nixos/modules/programs/clash-verge.nix
+++ b/nixos/modules/programs/clash-verge.nix
@@ -69,7 +69,6 @@
           ProtectSystem = "strict";
           NoNewPrivileges = true;
           ProtectHostname = true;
-          ProtectProc = "invisible";
           ProcSubset = "pid";
           SystemCallArchitectures = "native";
           PrivateTmp = true;
@@ -90,7 +89,7 @@
             "AF_INET AF_INET6 AF_NETLINK AF_PACKET AF_UNIX"
           ];
           CapabilityBoundingSet = [
-            "CAP_NET_ADMIN CAP_NET_RAW CAP_SYS_ADMIN CAP_DAC_OVERRIDE CAP_SETUID CAP_SETGID CAP_CHOWN CAP_MKNOD"
+            "CAP_NET_ADMIN CAP_NET_RAW CAP_SYS_ADMIN CAP_DAC_OVERRIDE CAP_SETUID CAP_SETGID CAP_CHOWN CAP_MKNOD CAP_SYS_PTRACE CAP_DAC_READ_SEARCH"
           ];
           SystemCallFilter = [
             "~@aio @chown @clock @cpu-emulation @debug @keyring @memlock @module @mount @obsolete @pkey @privileged @raw-io @reboot @sandbox @setuid @swap @timer"


### PR DESCRIPTION
## Things done

When clash-verge runs as a systemd service with the existing hardening configuration, it cannot resolve connection process names. This breaks `PROCESS-NAME` and similar process-based rules because the service lacks the necessary Linux capabilities to read `/proc/<pid>` entries of other processes.
This is the same issue reported for mihomo https://github.com/MetaCubeX/mihomo/issues/961, which was fixed in nixpkgs via an opt-in processesInfo option  #436367.

Meanwhile, because the systemd unit runs as the root user and has the `CAP_SYS_PTRACE` capability, the `ProtectProc` parameter becomes ineffective, so I removed it directly from the `serviceConfig`.
See also: https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#ProtectProc=

The above summary has been polished and translated by LLM.

cc @HHR2020 for reviewing.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic fsunctionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
