### PR TITLE
crow: 1.3.0.0 -> 1.3.2

### DIFF
--- a/pkgs/by-name/cr/crow/cpm.patch
+++ b/pkgs/by-name/cr/crow/cpm.patch
@@ -1,17 +1,30 @@
+From 0cfacb99db5940dabc385e7bc4534dfefa60fcfd Mon Sep 17 00:00:00 2001
+From: fliiiix <hi@l33t.name>
+Date: Thu, 25 Jun 2026 10:46:35 +0200
+Subject: [PATCH] cpm
+
+---
+ CMakeLists.txt       |  4 ----
+ tests/CMakeLists.txt | 11 +----------
+ 2 files changed, 1 insertion(+), 14 deletions(-)
+
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 7dbc2c3..cfdd98d 100644
+index 51fade9b4..1b93bffd2 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -11,7 +11,6 @@ project(Crow
+@@ -60,10 +60,6 @@ option(CROW_ENABLE_SSL "Enable Crow's SSL feature for supporting https" OFF)
+ option(CROW_ENABLE_COMPRESSION "Enable Crow's Compression feature for supporting compressed http content" OFF)
+ option(CROW_ENABLE_TSAN "Enable ThreadSanitizer" OFF)
  
- set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
- 
--include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/CPM.cmake)
- 
- # Make sure Findasio.cmake module is found
- list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+-if(CROW_GENERATE_SBOM OR CROW_BUILD_TESTS)
+-	include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/CPM.cmake)
+-endif ()
+-
+ if(CROW_GENERATE_SBOM)
+   CPMAddPackage(
+     NAME cmake-sbom
 diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
-index 67c458c..2873530 100644
+index 80f6dd364..e01adeb2f 100644
 --- a/tests/CMakeLists.txt
 +++ b/tests/CMakeLists.txt
 @@ -5,18 +5,9 @@ set(CMAKE_POLICY_DEFAULT_CMP0077 new)
@@ -23,7 +36,7 @@ index 67c458c..2873530 100644
 +find_package(Catch2 REQUIRED)
  
 -CPMAddPackage(Catch2
--  VERSION 3.10.0
+-  VERSION 3.12.0
 -  GITHUB_REPOSITORY catchorg/Catch2
 -  OPTIONS
 -  "CATCH_INSTALL_DOCS Off"
@@ -34,3 +47,6 @@ index 67c458c..2873530 100644
  enable_testing()
  
  # list the test sources
+-- 
+2.43.0
+

--- a/pkgs/by-name/cr/crow/package.nix
+++ b/pkgs/by-name/cr/crow/package.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "crow";
-  version = "1.3.0.0";
+  version = "1.3.2";
 
   src = fetchFromGitHub {
     owner = "CrowCpp";
     repo = "Crow";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-QLYQ0RouqDDvhnBF79O/9M7IwlF0eQ3HTqR6bXWm574=";
+    hash = "sha256-MN2x1hgJ9TziZFPSZn6RuAEfl4mZv3ijU9LqQJkw6UM=";
   };
 
   patches = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Refresh patch and update to latest upstream release: https://github.com/CrowCpp/Crow/releases/tag/v1.3.2

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
