### PR TITLE
open5gs: 2.7.7 -> 2.8.0

### DIFF
--- a/pkgs/by-name/op/open5gs-webui/package.nix
+++ b/pkgs/by-name/op/open5gs-webui/package.nix
@@ -9,5 +9,5 @@ buildNpmPackage (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/webui";
 
-  npmDepsHash = "sha256-Epz+pCbgejkj7vcdwbPC2RfAkp2HRqGV0urXiiBrjZQ=";
+  npmDepsHash = "sha256-PtZzC9PWIAAuh4Hy/whZHgzzlnXykevhGT2f1Mc+VFM=";
 })

--- a/pkgs/by-name/op/open5gs/package.nix
+++ b/pkgs/by-name/op/open5gs/package.nix
@@ -26,7 +26,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "open5gs";
-  version = "2.7.7";
+  version = "2.8.0";
 
   diameter = fetchFromGitHub {
     owner = "open5gs";
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "open5gs";
     repo = "open5gs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ZK4q6m/9v+us+6dWpi0k188KfFu1b6G9pGE4VGAe4+4=";
+    hash = "sha256-e8iCcgJRJFEdVN3TeNwFFbBkShZebxKqvsCpBv/WLVk=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Changelog: https://github.com/open5gs/open5gs/releases/tag/v2.8.0
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
