### PR TITLE
xfconf: 4.20.0 -> 4.21.2

### DIFF
--- a/pkgs/by-name/xf/xfconf/package.nix
+++ b/pkgs/by-name/xf/xfconf/package.nix
@@ -7,7 +7,9 @@
   perl,
   pkg-config,
   vala,
-  xfce4-dev-tools,
+  meson,
+  ninja,
+  python3,
   wrapGAppsNoGuiHook,
   libxfce4util,
   glib,
@@ -20,7 +22,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xfconf";
-  version = "4.20.0";
+  version = "4.21.2";
 
   outputs = [
     "out"
@@ -32,14 +34,16 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "xfce";
     repo = "xfconf";
     tag = "xfconf-${finalAttrs.version}";
-    hash = "sha256-U+Sk7ubBr1ZD1GLQXlxrx0NQdhV/WpVBbnLcc94Tjcw=";
+    hash = "sha256-2WB392mViHRbi9FclnU1A+AW+iPGSpdWZVU9oBOvqlg=";
   };
 
   nativeBuildInputs = [
     gettext
     perl
     pkg-config
-    xfce4-dev-tools
+    meson
+    ninja
+    python3
     wrapGAppsNoGuiHook
   ]
   ++ lib.optionals withIntrospection [
@@ -51,8 +55,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   propagatedBuildInputs = [ glib ];
 
-  configureFlags = [ "--enable-maintainer-mode" ];
   enableParallelBuilding = true;
+
+  postPatch = ''
+    patchShebangs xdt-gen-visibility
+  '';
 
   passthru.updateScript = gitUpdater {
     rev-prefix = "xfconf-";


### PR DESCRIPTION
In preparation for the new xfwl4, I'm trying to update all of it's dependencies to the latest official version. xfconf is one of them.

The [changelog](https://gitlab.xfce.org/xfce/xfconf/-/tags) can be found in the xfce's own gitlab.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
