### PR TITLE
libxfce4ui: 4.20.2 -> 4.21.8

### DIFF
--- a/pkgs/by-name/li/libxfce4ui/package.nix
+++ b/pkgs/by-name/li/libxfce4ui/package.nix
@@ -5,7 +5,9 @@
   gettext,
   perl,
   pkg-config,
-  xfce4-dev-tools,
+  meson,
+  ninja,
+  python3,
   wrapGAppsHook3,
   libice,
   libsm,
@@ -27,7 +29,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libxfce4ui";
-  version = "4.20.2";
+  version = "4.21.8";
 
   outputs = [
     "out"
@@ -39,14 +41,16 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "xfce";
     repo = "libxfce4ui";
     tag = "libxfce4ui-${finalAttrs.version}";
-    hash = "sha256-NsTrJ2271v8vMMyiEef+4Rs0KBOkSkKPjfoJdgQU0ds=";
+    hash = "sha256-nyzqV0nSQzNqTC48mN/0DeyQ9BD0dg9LcOhchYW2c+A=";
   };
 
   nativeBuildInputs = [
     gettext
     perl
     pkg-config
-    xfce4-dev-tools
+    meson
+    ninja
+    python3
     wrapGAppsHook3
   ]
   ++ lib.optionals withIntrospection [
@@ -69,12 +73,15 @@ stdenv.mkDerivation (finalAttrs: {
     libxfce4util
   ];
 
-  configureFlags = [
-    "--enable-maintainer-mode"
-    "--with-vendor-info=NixOS"
+  mesonFlags = [
+    (lib.mesonOption "vendor-info" "NixOS")
   ];
 
   enableParallelBuilding = true;
+
+  postPatch = ''
+    patchShebangs xdt-gen-visibility
+  '';
 
   passthru.updateScript = gitUpdater {
     rev-prefix = "libxfce4ui-";


### PR DESCRIPTION
In preparation for the new xfwl4, I'm trying to update all of it's dependencies to the latest official version. libxfce4ui is one of them.

The [changelog](https://gitlab.xfce.org/xfce/libxfce4ui/-/tags) can be found in the xfce's own gitlab.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
