### PR TITLE
 motioneye: 0.43.1 -> 0.44.0 

### DIFF
--- a/pkgs/by-name/mo/motioneye/package.nix
+++ b/pkgs/by-name/mo/motioneye/package.nix
@@ -2,6 +2,7 @@
   lib,
   python3Packages,
   fetchFromGitHub,
+  versionCheckHook,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -34,9 +35,16 @@ python3Packages.buildPythonApplication rec {
     pytestCheckHook
   ];
 
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
   pythonImportsCheck = [
     "motioneye"
   ];
+
+  versionCheckProgram = "${placeholder "out"}/bin/meyectl";
+  versionCheckProgramArg = "-v";
 
   meta = {
     description = "Web frontend for the motion daemon";

--- a/pkgs/by-name/mo/motioneye/package.nix
+++ b/pkgs/by-name/mo/motioneye/package.nix
@@ -2,30 +2,19 @@
   lib,
   python3Packages,
   fetchFromGitHub,
-  fetchpatch,
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "motioneye";
-  version = "0.43.1";
+  version = "0.44.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "motioneye-project";
     repo = "motioneye";
     tag = version;
-    hash = "sha256-ckOgYmOP5irjNutcC3FMZPBexn/CldG0UtFZ+tPYNJ4=";
+    hash = "sha256-4sXttSSkmMgsoZb7PXEXXh8KNORTSmqq4lYp3JBDmPo=";
   };
-
-  patches = [
-    # fix pytest
-    # https://github.com/motioneye-project/motioneye/pull/3271
-    (fetchpatch {
-      url = "https://github.com/motioneye-project/motioneye/commit/41c0727e2872af1b758743c41b529e76dcac6f84.patch";
-      hash = "sha256-0zDveoAN1T0SuCob0U/9GEGTh7pj2CXH/j4YrjO0VE0=";
-      includes = [ "conftest.py" ];
-    })
-  ];
 
   build-system = with python3Packages; [
     setuptools
@@ -38,6 +27,7 @@ python3Packages.buildPythonApplication rec {
     pillow
     pycurl
     tornado
+    argon2-cffi
   ];
 
   nativeCheckInputs = with python3Packages; [

--- a/pkgs/development/python-modules/tornado/default.nix
+++ b/pkgs/development/python-modules/tornado/default.nix
@@ -18,16 +18,16 @@
   urllib3,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "tornado";
-  version = "6.5.4";
+  version = "6.5.7";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tornadoweb";
     repo = "tornado";
-    tag = "v${version}";
-    hash = "sha256-d6lKg8yrQqaCeKxdPjQNzv7Nc23U/v8d5x3sE3trRM4=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-iE0Tf95zmPoZJhw7FDLzTmv8HaWds3ZU5xzZSMvxFH4=";
   };
 
   build-system = [ setuptools ];
@@ -63,9 +63,10 @@ buildPythonPackage rec {
   };
 
   meta = {
+    changelog = "https://www.tornadoweb.org/en/stable/releases/${finalAttrs.src.tag}.html";
     description = "Web framework and asynchronous networking library";
     homepage = "https://www.tornadoweb.org/";
     license = lib.licenses.asl20;
     maintainers = [ ];
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/motioneye-project/motioneye/compare/0.43.1...0.44.0

Fixes https://github.com/NixOS/nixpkgs/issues/535210 [CVE-2026-32315](https://nvd.nist.gov/vuln/detail/CVE-2026-32315)

I am still on deploying it on a real device. But that could take some days. The pytests are green already.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
