### PR TITLE
python3Packages.midea-local: 6.8.0 -> 6.9.0

### DIFF
--- a/pkgs/development/python-modules/midea-local/default.nix
+++ b/pkgs/development/python-modules/midea-local/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "midea-local";
-  version = "6.8.0";
+  version = "6.9.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "midea-lan";
     repo = "midea-local";
     tag = "v${version}";
-    hash = "sha256-tJxSAjugFWvlpmLE7A7+wqsxM8RlgPQGE0fH7cdwxxI=";
+    hash = "sha256-FOhz/3YvaqtfWfkhhW8moHkbdeLmk8dv32SPAJ4KblY=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/midea-local/default.nix
+++ b/pkgs/development/python-modules/midea-local/default.nix
@@ -14,7 +14,7 @@
   platformdirs,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "midea-local";
   version = "6.9.0";
   pyproject = true;
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "midea-lan";
     repo = "midea-local";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-FOhz/3YvaqtfWfkhhW8moHkbdeLmk8dv32SPAJ4KblY=";
   };
 
@@ -43,8 +43,8 @@ buildPythonPackage rec {
   meta = {
     description = "Control your Midea M-Smart appliances via local area network";
     homepage = "https://github.com/midea-lan/midea-local";
-    changelog = "https://github.com/midea-lan/midea-local/releases/tag/${src.tag}";
+    changelog = "https://github.com/midea-lan/midea-local/releases/tag/${finalAttrs.src.tag}";
     maintainers = with lib.maintainers; [ k900 ];
     license = lib.licenses.mit;
   };
-}
+})

--- a/pkgs/development/python-modules/midea-local/default.nix
+++ b/pkgs/development/python-modules/midea-local/default.nix
@@ -40,6 +40,8 @@ buildPythonPackage (finalAttrs: {
     platformdirs
   ];
 
+  pythonImportsCheck = [ "midealocal" ];
+
   meta = {
     description = "Control your Midea M-Smart appliances via local area network";
     homepage = "https://github.com/midea-lan/midea-local";

--- a/pkgs/development/python-modules/midea-local/default.nix
+++ b/pkgs/development/python-modules/midea-local/default.nix
@@ -1,17 +1,21 @@
 {
   lib,
-  buildPythonPackage,
-  fetchFromGitHub,
-  setuptools,
   aiofiles,
   aiohttp,
+  buildPythonPackage,
   colorlog,
   commonregex,
   defusedxml,
   deprecated,
+  fetchFromGitHub,
   ifaddr,
-  pycryptodome,
   platformdirs,
+  pycryptodome,
+  pytest-asyncio,
+  pytest-cov-stub,
+  pytestCheckHook,
+  setuptools,
+  typing-extensions,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -38,6 +42,13 @@ buildPythonPackage (finalAttrs: {
     ifaddr
     pycryptodome
     platformdirs
+  ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-cov-stub
+    pytestCheckHook
+    typing-extensions
   ];
 
   pythonImportsCheck = [ "midealocal" ];


### PR DESCRIPTION
Diff: https://github.com/midea-lan/midea-local/compare/v6.8.0...v6.9.0

Changelog: https://github.com/midea-lan/midea-local/releases/tag/v6.9.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
