### PR TITLE
haskellPackages.wai-app-file-cgi: pin to < 3.2.0 for mighttpd2

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -846,6 +846,16 @@ with haskellLib;
   xmlgen = dontCheck super.xmlgen;
   wai-cors = dontCheck super.wai-cors;
 
+  # Apply patch from 3.2.1 (which we can't use yet due to mighttpd2)
+  # for compat with http-types >= 0.12.5
+  wai-app-file-cgi = appendPatches [
+    (pkgs.fetchpatch {
+      name = "wai-app-file-cgi-http-types-0.12.5.patch";
+      url = "https://github.com/kazu-yamamoto/wai-app-file-cgi/commit/45d749338c4125335ad8a605d6fa81553e81aad8.patch";
+      hash = "sha256-gchBTsGohgfJ+gJxE1VwgEQfsSLMuSUXJw1xAyNRqjc=";
+    })
+  ] super.wai-app-file-cgi;
+
   # Apply patch fixing an incorrect QuickCheck property which occasionally causes false negatives
   # https://github.com/Philonous/xml-picklers/issues/5
   xml-picklers = appendPatch (pkgs.fetchpatch {

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -55,6 +55,8 @@ default-package-overrides:
   - pandoc-crossref == 0.3.21
   # 2025-12-19: Needs to match Stackage version of rhine
   - rhine-bayes < 1.6
+  # 2026-06-24: compatibility with mighttpd2-4.0.9
+  - wai-app-file-cgi < 3.2
   # 2026-02-08: compatibility with crypton-x509* in Stackage LTS 24
   - x509-ocsp < 0.4.1.0
 # keep-sorted end


### PR DESCRIPTION
Requires picking a compat patch from 3.2.1 for http-types-0.12.5.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
