### PR TITLE
python3Packages.deeptutor: init at 1.4.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15957,6 +15957,12 @@
     githubId = 918448;
     name = "Anthony Lodi";
   };
+  LodWKobku = {
+    email = "lodwkobku+nixpkgs@gmail.com";
+    github = "LodWKobku";
+    githubId = 101132529;
+    name = "LodWKobku";
+  };
   logan-barnett = {
     email = "logustus+nixpkgs@gmail.com";
     github = "LoganBarnett";

--- a/pkgs/development/python-modules/bm25s/default.nix
+++ b/pkgs/development/python-modules/bm25s/default.nix
@@ -1,0 +1,115 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  # Build system
+  setuptools,
+  # Dependencies
+  numpy,
+  # Optional dependencies
+  orjson,
+  tqdm,
+  pystemmer,
+  numba,
+  huggingface-hub,
+  black,
+  jax,
+  scipy,
+  pytrec-eval,
+  mcp,
+  rich,
+  # Tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "bm25s";
+  version = "0.3.9";
+  pyproject = true;
+
+  # Set the version of the package in main.py
+  BM25S_VERSION = finalAttrs.version;
+
+  src = fetchFromGitHub {
+    owner = "xhluca";
+    repo = "bm25s";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-/aIQCJnOInjaxRTbAJgYMs20zEayWLz+uBKGhqX5ULM=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    numpy
+  ];
+
+  optional-dependencies = {
+    core = [
+      orjson
+      tqdm
+      pystemmer
+      numba
+    ];
+    stem = [
+      pystemmer
+    ];
+    hf = [
+      huggingface-hub
+    ];
+    dev = [
+      black
+    ];
+    selection = [
+      jax
+    ];
+    indexing = [
+      scipy
+    ];
+    evaluation = [
+      pytrec-eval
+    ];
+    mcp = [
+      mcp
+    ];
+    cli = [
+      rich
+    ];
+    full = [
+      orjson
+      tqdm
+      pystemmer
+      numba
+      huggingface-hub
+      black
+      jax
+      scipy
+      pytrec-eval
+      mcp
+      rich
+    ];
+  };
+
+  # Tests
+  pythonImportsCheck = [ "bm25s" ];
+  # Package tests require all optional dependencies
+  nativeCheckInputs = [ pytestCheckHook ] ++ finalAttrs.passthru.optional-dependencies.full;
+  enabledTestPaths = [
+    "tests"
+  ];
+  disabledTestPaths = [
+    # Tests under tests/comparison and tests/comparison_full require additional data
+    "tests/comparison"
+    "tests/comparison_full"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "An ultra-fast implementation of BM25 based on sparse matrices";
+    homepage = "https://github.com/xhluca/bm25s/";
+    changelog = "https://github.com/xhluca/bm25s/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ LodWKobku ];
+  };
+})

--- a/pkgs/development/python-modules/deeptutor/default.nix
+++ b/pkgs/development/python-modules/deeptutor/default.nix
@@ -1,0 +1,193 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  # Build system
+  setuptools,
+  # Dependencies
+  pyyaml,
+  jinja2,
+  openai,
+  tiktoken,
+  aiohttp,
+  httpx,
+  requests,
+  ddgs,
+  nest-asyncio,
+  tenacity,
+  pydantic,
+  pydantic-settings,
+  aiosqlite,
+  typer,
+  rich,
+  prompt-toolkit,
+  pyte,
+  anthropic,
+  dashscope,
+  perplexityai,
+  oauth-cli-kit,
+  llama-index,
+  llama-index-retrievers-bm25,
+  pymupdf,
+  numpy,
+  arxiv,
+  python-docx,
+  openpyxl,
+  python-pptx,
+  pypdf,
+  pdfplumber,
+  reportlab,
+  defusedxml,
+  fastapi,
+  uvicorn,
+  websockets,
+  python-multipart,
+  bcrypt,
+  python-jose,
+  pocketbase,
+  loguru,
+  json-repair,
+  # Optional dependencies
+  mcp,
+  python-telegram-bot,
+  wecom-aibot-sdk,
+  lark-oapi,
+  dingtalk-stream,
+  slack-sdk,
+  slackify-markdown,
+  qq-botpy,
+  python-socketio,
+  msgpack,
+  python-socks,
+  socksio,
+  websocket-client,
+  zulip,
+  pyjwt,
+  qrcode,
+  # Tests
+  git,
+  pytest-asyncio,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "deeptutor";
+  version = "1.4.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "HKUDS";
+    repo = "DeepTutor";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-7LwXsYAKTIj7jvuF5t0dzplVu8Ww+rh92cMJyFHHHrM=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    pyyaml
+    jinja2
+    openai
+    tiktoken
+    aiohttp
+    httpx
+    requests
+    ddgs
+    nest-asyncio
+    tenacity
+    pydantic
+    pydantic-settings
+    aiosqlite
+    typer
+    rich
+    prompt-toolkit
+    pyte
+    anthropic
+    dashscope
+    perplexityai
+    oauth-cli-kit
+    llama-index
+    llama-index-retrievers-bm25
+    pymupdf
+    numpy
+    arxiv
+    python-docx
+    openpyxl
+    python-pptx
+    pypdf
+    pdfplumber
+    reportlab
+    defusedxml
+    fastapi
+    uvicorn
+    websockets
+    python-multipart
+    bcrypt
+    python-jose
+    pocketbase
+    loguru
+    json-repair
+  ]
+  ++ python-jose.optional-dependencies.cryptography;
+
+  optional-dependencies = {
+    partners = [
+      mcp
+      python-telegram-bot
+      wecom-aibot-sdk
+      lark-oapi
+      dingtalk-stream
+      slack-sdk
+      slackify-markdown
+      qq-botpy
+      python-socketio
+      msgpack
+      python-socks
+      socksio
+      websocket-client
+      zulip
+      pyjwt
+      qrcode
+    ]
+    ++ python-telegram-bot.optional-dependencies.socks
+    ++ pyjwt.optional-dependencies.crypto;
+  };
+  pythonRelaxDeps = [
+    "json-repair"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    git
+  ]
+  ++ finalAttrs.passthru.optional-dependencies.partners;
+  pytestFlags = [
+    "--import-mode=importlib"
+  ];
+  pythonImportsCheck = [ "deeptutor" ];
+  enabledTestPaths = [
+    "tests"
+  ];
+  disabledTestPaths = [
+    "tests/scripts/test_cli_kit.py" # Missing _cli_kit.py file
+    "tests/services/rag/test_llamaindex_storage_layout.py" # KeyError: 'storage_path
+    "tests/services/config/test_chat_params_config.py" # Strict params requrements
+    "tests/services/search/test_web_search_runtime.py" # Regex error
+    "tests/services/test_prompt_manager.py" # Importing prompt fails becouse of wrong naming
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Agent-native, Open-sourced Personalized Tutoring";
+    mainProgram = "deeptutor";
+    homepage = "https://github.com/HKUDS/DeepTutor";
+    changelog = "https://github.com/HKUDS/DeepTutor/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      LodWKobku
+    ];
+  };
+})

--- a/pkgs/development/python-modules/dingtalk-stream/default.nix
+++ b/pkgs/development/python-modules/dingtalk-stream/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  # Build system
+  setuptools,
+  # Dependencies
+  aiohttp,
+  requests,
+  websockets,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "dingtalk-stream";
+  version = "0.24.3";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "open-dingtalk";
+    repo = "dingtalk-stream-sdk-python";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ShJwTb+ObaewGGki9pdW7VYOBK6CBXhcsTiBj/5N0kM=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    aiohttp
+    requests
+    websockets
+  ];
+
+  pythonImportsCheck = [
+    "dingtalk_stream"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Python SDK for DingTalk Stream Mode API";
+    homepage = "https://github.com/open-dingtalk/dingtalk-stream-sdk-python";
+    changelog = "https://github.com/open-dingtalk/dingtalk-stream-sdk-python/releases/tag/v${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ LodWKobku ];
+  };
+})

--- a/pkgs/development/python-modules/lark-oapi/default.nix
+++ b/pkgs/development/python-modules/lark-oapi/default.nix
@@ -2,14 +2,23 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  nix-update-script,
+  # Build system
   setuptools,
+  # Dependencies
   httpx,
   pycryptodome,
-  pytest-asyncio,
-  pytestCheckHook,
   requests,
   requests-toolbelt,
   websockets,
+  # Optional dependencies
+  aiohttp,
+  fastapi,
+  uvicorn,
+  flask,
+  # Tests
+  pytest-asyncio,
+  pytestCheckHook,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -34,9 +43,23 @@ buildPythonPackage (finalAttrs: {
     websockets
   ];
 
+  optional-dependencies = {
+    aiohttp = [
+      aiohttp
+    ];
+    fastapi = [
+      fastapi
+      uvicorn
+    ];
+    flask = [
+      flask
+    ];
+  };
+
   # websockets 16.0 is compatible despite the <16 metadata constraint
   pythonRelaxDeps = [ "websockets" ];
 
+  # Tests
   nativeCheckInputs = [
     pytest-asyncio
     pytestCheckHook
@@ -44,10 +67,23 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "lark_oapi" ];
 
+  enabledTestPaths = [
+    "lark_oapi/channel/tests"
+  ];
+
+  disabledTestPaths = [
+    "lark_oapi/channel/tests/test_client_lifecycle.py" # Inconsistent test
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Larksuite development interface SDK";
     homepage = "https://github.com/larksuite/oapi-sdk-python";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.knightfemale ];
+    maintainers = with lib.maintainers; [
+      knightfemale
+      LodWKobku
+    ];
   };
 })

--- a/pkgs/development/python-modules/llama-index-retrievers-bm25/default.nix
+++ b/pkgs/development/python-modules/llama-index-retrievers-bm25/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  nix-update-script,
+  # Build system
+  hatchling,
+  # Dependencies
+  bm25s,
+  llama-index-core,
+  pystemmer,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "llama-index-retrievers-bm25";
+  version = "0.7.1";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchPypi {
+    pname = "llama_index_retrievers_bm25";
+    inherit (finalAttrs) version;
+    hash = "sha256-Zb/5XFwTVIVDlCCUBtLTQv9eYpg/8oGP0rhdW+1wvtA=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    bm25s
+    llama-index-core
+    pystemmer
+  ];
+  pythonRelaxDeps = [
+    "pystemmer"
+  ];
+
+  pythonImportsCheck = [
+    "llama_index.retrievers.bm25"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Llama-index retrievers bm25 integration";
+    homepage = "https://pypi.org/project/llama-index-retrievers-bm25";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ LodWKobku ];
+  };
+})

--- a/pkgs/development/python-modules/oauth-cli-kit/default.nix
+++ b/pkgs/development/python-modules/oauth-cli-kit/default.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  # Build system
+  hatch-vcs,
+  hatchling,
+  # Dependencies
+  httpx,
+  platformdirs,
+  # Optional dependencies
+  pytest,
+  # Tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "oauth-cli-kit";
+  version = "0.1.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "pinhua33";
+    repo = "oauth-cli-kit";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-dJSiR/1fKvYbB8r7pU58vnDeREG/k1YmnhC5qEFtbo4=";
+  };
+
+  build-system = [
+    hatch-vcs
+    hatchling
+  ];
+
+  dependencies = [
+    httpx
+    platformdirs
+  ];
+
+  optional-dependencies = {
+    dev = [
+      pytest
+    ];
+  };
+
+  # Tests
+  nativeCheckInputs = [ pytestCheckHook ];
+  enabledTestPaths = [
+    "tests/"
+  ];
+  pythonImportsCheck = [
+    "oauth_cli_kit"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A small, reusable OAuth 2.0 + PKCE helper focused on CLI apps";
+    homepage = "https://github.com/pinhua33/oauth-cli-kit";
+    changelog = "https://github.com/pinhua33/oauth-cli-kit/releases/tag/v${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ LodWKobku ];
+  };
+})

--- a/pkgs/development/python-modules/pocketbase/default.nix
+++ b/pkgs/development/python-modules/pocketbase/default.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  # Build system
+  uv-build,
+  # Dependencies
+  httpx,
+  # Tests
+  pytestCheckHook,
+  pytest-httpx,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pocketbase";
+  version = "0.17.3";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "vaphes";
+    repo = "pocketbase";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-lHy2CPJ8LBtnVf3WSqZvKQZHdSuYVffiSLoNBN97sEE=";
+  };
+
+  build-system = [
+    uv-build
+  ];
+
+  dependencies = [
+    httpx
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-httpx
+  ];
+  pythonImportsCheck = [
+    "pocketbase"
+  ];
+  enabledTestPaths = [
+    "tests/"
+  ];
+  disabledTestPaths = [
+    # Tests under tests/integration requires additional dependencies.
+    "tests/integration"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "PocketBase client SDK for python";
+    homepage = "https://github.com/vaphes/pocketbase";
+    changelog = "https://github.com/vaphes/pocketbase/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ LodWKobku ];
+  };
+})

--- a/pkgs/development/python-modules/pytrec-eval/default.nix
+++ b/pkgs/development/python-modules/pytrec-eval/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  # Build system
+  setuptools,
+  # Dependencies
+  numpy,
+  scipy,
+  # Tests
+  unittestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pytrec-eval";
+  version = "0.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "cvangysel";
+    repo = "pytrec_eval";
+    tag = finalAttrs.version;
+    hash = "sha256-t76D3C5QMJgQMhAg8TGxdtjwaLQhlB8SufAdM3pAZg4=";
+    fetchSubmodules = true;
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  # trec_eval which is included in source code requres older C standard
+  CFLAGS = "-std=gnu89";
+
+  dependencies = [
+    numpy
+    scipy
+  ];
+
+  # Tests
+  nativeCheckInputs = [ unittestCheckHook ];
+  pythonImportsCheck = [
+    "pytrec_eval"
+  ];
+  unittestFlags = "-s tests -p *test* -v";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Pytrec_eval is an Information Retrieval evaluation tool for Python, based on the popular trec_eval";
+    homepage = "https://github.com/cvangysel/pytrec_eval";
+    changelog = "https://github.com/cvangysel/pytrec_eval/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ LodWKobku ];
+  };
+})

--- a/pkgs/development/python-modules/qq-botpy/default.nix
+++ b/pkgs/development/python-modules/qq-botpy/default.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  # Build system
+  setuptools,
+  # Dependencies
+  aiohttp,
+  apscheduler,
+  pre-commit,
+  pyyaml,
+  # Tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "qq-botpy";
+  version = "1.2.1";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "tencent-connect";
+    repo = "botpy";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+wc8yY/wY1Vlar+GH4U2Tjmb6sO5XdRJLERrsICJ4jc=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    aiohttp
+    apscheduler
+    pre-commit
+    pyyaml
+  ];
+
+  preCheck = ''
+    # Fix wrong test filename
+    cp tests/".test(demo).yaml" tests/.test.yaml
+  '';
+  nativeCheckInputs = [ pytestCheckHook ];
+  pythonImportsCheck = [
+    "botpy"
+  ];
+  enabledTestPaths = [
+    "tests/"
+  ];
+  disabledTestPaths = [
+    # Requires connection to QQ servers
+    "tests/test_api.py"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Python SDK for QQ channel bot";
+    homepage = "https://github.com/tencent-connect/botpy";
+    changelog = "https://github.com/tencent-connect/botpy/releases/tag/v${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ LodWKobku ];
+  };
+})

--- a/pkgs/development/python-modules/qq-botpy/default.nix
+++ b/pkgs/development/python-modules/qq-botpy/default.nix
@@ -8,7 +8,6 @@
   # Dependencies
   aiohttp,
   apscheduler,
-  pre-commit,
   pyyaml,
   # Tests
   pytestCheckHook,
@@ -34,7 +33,6 @@ buildPythonPackage (finalAttrs: {
   dependencies = [
     aiohttp
     apscheduler
-    pre-commit
     pyyaml
   ];
 

--- a/pkgs/development/python-modules/slackify-markdown/default.nix
+++ b/pkgs/development/python-modules/slackify-markdown/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  # Build system
+  setuptools,
+  wheel,
+  # Dependencies
+  markdown-it-py,
+  # Tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "slackify-markdown";
+  version = "0.2.4";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "thesmallstar";
+    repo = "slackify-markdown-python";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-w5oldcu0oVvZe/dEfm2rdeSwU38K27EAUme1gCZA3ak=";
+  };
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  dependencies = [
+    markdown-it-py
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+  pythonImportsCheck = [
+    "slackify_markdown"
+  ];
+  enabledTestPaths = [
+    "tests/"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Convert Markdown to Slack compatible markdown";
+    homepage = "https://github.com/thesmallstar/slackify-markdown-python";
+    changelog = "https://github.com/thesmallstar/slackify-markdown-python/releases/tag/v${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ LodWKobku ];
+  };
+})

--- a/pkgs/development/python-modules/wecom-aibot-sdk/default.nix
+++ b/pkgs/development/python-modules/wecom-aibot-sdk/default.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  # Build system
+  hatchling,
+  # Dependencies
+  cryptography,
+  httpx,
+  websockets,
+  # Optional dependencies
+  python-dotenv,
+  pytest,
+  pytest-asyncio,
+  # Tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "wecom-aibot-sdk";
+  version = "1.0.7";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "xiaowangzhixiao";
+    repo = "wecom-aibot-python-sdk";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-34+UByfMw2t1/E+Of58K/s5f6hRc6DPIpVHbDaOoh3Y=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    cryptography
+    httpx
+    websockets
+  ];
+
+  optional-dependencies = {
+    examples = [
+      python-dotenv
+    ];
+    test = [
+      pytest
+      pytest-asyncio
+    ];
+  };
+
+  nativeCheckInputs = [ pytestCheckHook ] ++ finalAttrs.passthru.optional-dependencies.test;
+  pythonImportsCheck = [
+    "wecom_aibot_sdk"
+  ];
+  enabledTestPaths = [
+    "tests"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "WeCom Enterprise Chatbot Python SDK";
+    homepage = "https://github.com/xiaowangzhixiao/wecom-aibot-python-sdk";
+    changelog = "https://github.com/xiaowangzhixiao/wecom-aibot-python-sdk/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ LodWKobku ];
+  };
+})

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -378,6 +378,7 @@ mapAliases {
   nixpkgs = throw "nixpkgs has been removed as its dependency pythonix was removed"; # added 2025-07-24
   nonbloat-db = throw "nonbloat-db has been removed because the upstream project was archived."; # added 2025-05-16
   Nuitka = throw "'Nuitka' has been renamed to/replaced by 'nuitka'"; # Converted to throw 2025-10-29
+  oapi-sdk-python = throw "This project have inconsistent naming, use pypi name 'lark-oapi'"; # added 2026-06-25
   oauth2 = throw "oauth2 has been removed as it is unmaintained"; # added 2025-05-16
   oauth = throw "oauth has been removed as it is unmaintained"; # added 2025-05-16
   objax = throw "objax has been removed because the upstream project was archived."; # Added 2025-10-04

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -157,6 +157,7 @@ mapAliases {
   dictpath = throw "'dictpath' has been renamed to/replaced by 'pathable'"; # Converted to throw 2025-10-29
   diff_cover = throw "'diff_cover' has been renamed to/replaced by 'diff-cover'"; # Converted to throw 2025-10-29
   digital-ocean = throw "'digital-ocean' has been renamed to/replaced by 'python-digitalocean'"; # Converted to throw 2025-10-29
+  dingtalk-stream-sdk-python = throw "'dingtalk-stream-sdk-python' has been renamed to/replaced by 'dingtalk-stream'"; # added 2026-06-25
   discogs_client = throw "'discogs_client' has been renamed to/replaced by 'discogs-client'"; # Converted to throw 2025-10-29
   distutils_extra = throw "'distutils_extra' has been renamed to/replaced by 'distutils-extra'"; # Converted to throw 2025-10-29
   dj-stripe = throw "dj-stripe has been removed because it is unused and broken"; # added 2025-07-21

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -655,6 +655,7 @@ mapAliases {
   Wand = throw "'Wand' has been renamed to/replaced by 'wand'"; # Converted to throw 2025-10-29
   WazeRouteCalculator = throw "'WazeRouteCalculator' has been renamed to/replaced by 'wazeroutecalculator'"; # Converted to throw 2025-10-29
   websocket_client = throw "'websocket_client' has been renamed to/replaced by 'websocket-client'"; # Converted to throw 2025-10-29
+  wecom-aibot-python-sdk = throw "'wecom-aibot-python-sdk' has been renamed to/replaced by 'wecom-aibot-sdk'"; # added 2026-06-25
   wgnlpy = throw "'wgnlpy' has been removed, as the upstream repository was unmaintained for several years"; # Converted to throw 2025-11-24
   worldengine = throw "worldengine has been removed because it has been marked as broken since at least November 2024."; # Added 2025-10-04
   WSME = throw "'WSME' has been renamed to/replaced by 'wsme'"; # Converted to throw 2025-10-29

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -121,6 +121,7 @@ mapAliases {
   bkcharts = throw "'bkcharts' has been removed as the upstream repository was archived in 2018"; # added 2025-08-26
   BlinkStick = throw "'BlinkStick' has been renamed to/replaced by 'blinkstick'"; # Converted to throw 2025-10-29
   boiboite-opener-framework = throw "'boiboite-opener-framework' has been removed as it was unmaintained upstream"; # Added 2026-03-23
+  botpy = "'botpy' has been renamed to/replaced by 'qq-botpy'"; # added 2026-06-25
   bsblan = throw "'bsblan' has been renamed to/replaced by 'python-bsblan'"; # Converted to throw 2025-10-29
   bsddb3 = throw "'bsddb3' has been removed because it was deprecated in favor of 'berkeleydb'"; # added 2026-01-20
   bt_proximity = throw "'bt_proximity' has been renamed to/replaced by 'bt-proximity'"; # Converted to throw 2025-10-29

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -155,6 +155,7 @@ mapAliases {
   dateutil = throw "'dateutil' has been renamed to/replaced by 'python-dateutil'"; # Converted to throw 2025-10-29
   debian = throw "'debian' has been renamed to/replaced by 'python-debian'"; # Converted to throw 2025-10-29
   deepsearch-glm = throw "'deepsearch-glm' has been removed due to lack of upstream maintenance"; # Added 2025-03-04
+  DeepTutor = throw "'DeepTutor' has been renamed to/replaced by 'deeptutor'"; # added 2026-06-25
   dictpath = throw "'dictpath' has been renamed to/replaced by 'pathable'"; # Converted to throw 2025-10-29
   diff_cover = throw "'diff_cover' has been renamed to/replaced by 'diff-cover'"; # Converted to throw 2025-10-29
   digital-ocean = throw "'digital-ocean' has been renamed to/replaced by 'python-digitalocean'"; # Converted to throw 2025-10-29

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -584,6 +584,7 @@ mapAliases {
   sip_4 = throw "'sip_4' has been renamed to/replaced by 'sip4'"; # Converted to throw 2025-10-29
   sipsimple = lib.warnOnInstantiate "'sipsimple' has been renamed to 'python3-sipsimple' to fit upstream naming" python3-sipsimple; # added 2026-01-05
   slackclient = throw "'slackclient' has been renamed to/replaced by 'slack-sdk'"; # Converted to throw 2025-10-29
+  slackify-markdown-python = throw "'slackify-markdown-python' has been renamed to/replaced by 'slackify-markdown'"; # added 2026-06-25
   sleekxmpp = throw "'sleekxmpp' has been removed because it was deprecated in favor of 'slixmpp'"; # added 2026-01-19
   smart_open = throw "'smart_open' has been renamed to/replaced by 'smart-open'"; # Converted to throw 2025-10-29
   smpp_pdu = throw "'smpp_pdu' has been renamed to/replaced by 'smpp-pdu'"; # Converted to throw 2025-10-29

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -522,6 +522,7 @@ mapAliases {
   pytorch-bin = throw "'pytorch-bin' has been renamed to/replaced by 'torch-bin'"; # Converted to throw 2025-10-29
   pytorchWithCuda = throw "'pytorchWithCuda' has been renamed to/replaced by 'torchWithCuda'"; # Converted to throw 2025-10-29
   pytorchWithoutCuda = throw "'pytorchWithoutCuda' has been renamed to/replaced by 'torchWithoutCuda'"; # Converted to throw 2025-10-29
+  pytrec_eval = throw "'pytrec_eval' has been renamed to/replaced by 'pytrec-eval'"; # added 2026-06-24
   pytwitchapi = throw "'pytwitchapi' has been renamed to/replaced by 'twitchapi'"; # Converted to throw 2025-10-29
   pyupdate = throw "'pyupdate' has been removed because it was unused and unmaintained upstream"; # added 2026-06-11
   pyvicare-neo = throw "'pyvicare-neo' has been renamed to/replaced by 'pyvicare'"; # Converted to throw 2025-10-29

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3840,6 +3840,8 @@ self: super: with self; {
 
   deeptoolsintervals = callPackage ../development/python-modules/deeptoolsintervals { };
 
+  deeptutor = callPackage ../development/python-modules/deeptutor { };
+
   deepwave = callPackage ../development/python-modules/deepwave { };
 
   deezer-py = callPackage ../development/python-modules/deezer-py { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18298,6 +18298,8 @@ self: super: with self; {
 
   slack-sdk = callPackage ../development/python-modules/slack-sdk { };
 
+  slackify-markdown = callPackage ../development/python-modules/slackify-markdown { };
+
   slapd = callPackage ../development/python-modules/slapd { };
 
   sleekxmppfs = callPackage ../development/python-modules/sleekxmppfs { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21628,6 +21628,8 @@ self: super: with self; {
 
   webthing-ws = callPackage ../development/python-modules/webthing-ws { };
 
+  wecom-aibot-sdk = callPackage ../development/python-modules/wecom-aibot-sdk { };
+
   weconnect = callPackage ../development/python-modules/weconnect { };
 
   weconnect-mqtt = callPackage ../development/python-modules/weconnect-mqtt { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9332,6 +9332,10 @@ self: super: with self; {
     callPackage ../development/python-modules/llama-index-readers-weather
       { };
 
+  llama-index-retrievers-bm25 =
+    callPackage ../development/python-modules/llama-index-retrievers-bm25
+      { };
+
   llama-index-vector-stores-chroma =
     callPackage ../development/python-modules/llama-index-vector-stores-chroma
       { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16820,6 +16820,8 @@ self: super: with self; {
 
   qpsolvers = callPackage ../development/python-modules/qpsolvers { };
 
+  qq-botpy = callPackage ../development/python-modules/qq-botpy { };
+
   qrcode = callPackage ../development/python-modules/qrcode { };
 
   qrcode-terminal = callPackage ../development/python-modules/qrcode-terminal { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3990,6 +3990,8 @@ self: super: with self; {
 
   dinghy = callPackage ../development/python-modules/dinghy { };
 
+  dingtalk-stream = callPackage ../development/python-modules/dingtalk-stream { };
+
   dingz = callPackage ../development/python-modules/dingz { };
 
   dio-chacon-wifi-api = callPackage ../development/python-modules/dio-chacon-wifi-api { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2220,6 +2220,8 @@ self: super: with self; {
 
   blurhash-python = callPackage ../development/python-modules/blurhash-python { };
 
+  bm25s = callPackage ../development/python-modules/bm25s { };
+
   bme280spi = callPackage ../development/python-modules/bme280spi { };
 
   bme680 = callPackage ../development/python-modules/bme680 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11585,6 +11585,8 @@ self: super: with self; {
 
   oathtool = callPackage ../development/python-modules/oathtool { };
 
+  oauth-cli-kit = callPackage ../development/python-modules/oauth-cli-kit { };
+
   oauth2-client = callPackage ../development/python-modules/oauth2-client { };
 
   oauth2client = callPackage ../development/python-modules/oauth2client { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13026,6 +13026,8 @@ self: super: with self; {
 
   pocket-tts = callPackage ../development/python-modules/pocket-tts { };
 
+  pocketbase = callPackage ../development/python-modules/pocketbase { };
+
   pocketsphinx = callPackage ../development/python-modules/pocketsphinx {
     inherit (pkgs) pocketsphinx;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16552,6 +16552,8 @@ self: super: with self; {
 
   pytransportnswv2 = callPackage ../development/python-modules/pytransportnswv2 { };
 
+  pytrec-eval = callPackage ../development/python-modules/pytrec-eval { };
+
   pytricia = callPackage ../development/python-modules/pytricia { };
 
   pytrydan = callPackage ../development/python-modules/pytrydan { };


### PR DESCRIPTION
[DeepTutor](https://github.com/HKUDS/DeepTutor) is an agent-native learning workspace.

Here is all of the changes:
* [python3Packages.deeptutor](https://github.com/HKUDS/DeepTutor): init at 1.4.2
  * [python3Packages.oauth-cli-kit](https://github.com/pinhua33/oauth-cli-kit): init at 0.1.3
  * [python3Packages.pocketbase](https://github.com/vaphes/pocketbase): init at 0.17.3
  * [python3Packages.llama-index-retrievers-bm25](https://pypi.org/project/llama-index-retrievers-bm25/): init at 0.7.1
    * [python3Packages.bm25s](https://github.com/xhluca/bm25s/): init at 0.3.9
      * [python3Packages.pytrec-eval](https://github.com/cvangysel/pytrec_eval): init at 0.5
  * [python3Packages.wecom-aibot-sdk](https://github.com/xiaowangzhixiao/wecom-aibot-python-sdk): init at 1.0.7
  * [python3Packages.lark-oapi](https://github.com/larksuite/oapi-sdk-python/): added package tests, nix-update-script, optional deps and alias
  * [python3Packages.dingtalk-stream](https://github.com/open-dingtalk/dingtalk-stream-sdk-python/): init at 0.24.3
  * [python3Packages.qq-botpy](https://github.com/tencent-connect/botpy): init at 1.2.1
  * [python3Packages.slackify-markdown](https://github.com/thesmallstar/slackify-markdown-python): init at 0.2.4

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test