### PR TITLE
python3Packages.fuzzywuzzy: migrate to pyproject, enable __structuredAttrs, use finalAttrs, enable tests

### DIFF
--- a/pkgs/development/python-modules/fuzzywuzzy/default.nix
+++ b/pkgs/development/python-modules/fuzzywuzzy/default.nix
@@ -13,6 +13,8 @@ buildPythonPackage (finalAttrs: {
   version = "0.18.0";
   format = "setuptools";
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
     inherit (finalAttrs) version;
     pname = "fuzzywuzzy";

--- a/pkgs/development/python-modules/fuzzywuzzy/default.nix
+++ b/pkgs/development/python-modules/fuzzywuzzy/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   levenshtein,
   pycodestyle,
   hypothesis,
@@ -11,7 +12,7 @@
 buildPythonPackage (finalAttrs: {
   pname = "fuzzywuzzy";
   version = "0.18.0";
-  format = "setuptools";
+  pyproject = true;
 
   __structuredAttrs = true;
 
@@ -21,7 +22,10 @@ buildPythonPackage (finalAttrs: {
     sha256 = "1s00zn75y2dkxgnbw8kl8dw4p1mc77cv78fwfa4yb0274s96w0a5";
   };
 
-  propagatedBuildInputs = [ levenshtein ];
+  build-system = [ setuptools ];
+
+  dependencies = [ levenshtein ];
+
   nativeCheckInputs = [
     pycodestyle
     hypothesis

--- a/pkgs/development/python-modules/fuzzywuzzy/default.nix
+++ b/pkgs/development/python-modules/fuzzywuzzy/default.nix
@@ -2,11 +2,10 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  pytestCheckHook,
   setuptools,
   levenshtein,
   pycodestyle,
-  hypothesis,
-  pytest,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -27,9 +26,12 @@ buildPythonPackage (finalAttrs: {
   dependencies = [ levenshtein ];
 
   nativeCheckInputs = [
+    pytestCheckHook
     pycodestyle
-    hypothesis
-    pytest
+  ];
+
+  pythonImportsCheck = [
+    "fuzzywuzzy"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/fuzzywuzzy/default.nix
+++ b/pkgs/development/python-modules/fuzzywuzzy/default.nix
@@ -8,13 +8,14 @@
   pytest,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "fuzzywuzzy";
   version = "0.18.0";
   format = "setuptools";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) version;
+    pname = "fuzzywuzzy";
     sha256 = "1s00zn75y2dkxgnbw8kl8dw4p1mc77cv78fwfa4yb0274s96w0a5";
   };
 
@@ -31,4 +32,4 @@ buildPythonPackage rec {
     license = lib.licenses.gpl2;
     maintainers = with lib.maintainers; [ erikarvstedt ];
   };
-}
+})

--- a/pkgs/development/python-modules/fuzzywuzzy/default.nix
+++ b/pkgs/development/python-modules/fuzzywuzzy/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Fuzzy string matching for Python";
     homepage = "https://github.com/seatgeek/fuzzywuzzy";
-    license = lib.licenses.gpl2;
+    license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [ erikarvstedt ];
   };
 })


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/515974
- use `finalAttrs`
- enable `__structuredAttrs`
- enable tests

The upstream repo states that the packages has been renamed to the `thefuzz` which we already package. However, `fuzzywuzzy` is still used by a number of other packages which would all require patching if we would drop it.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
