### PR TITLE
python3Packages.dpcontracts: migrate to pyproject, enable __structuredAttrs

### DIFF
--- a/pkgs/development/python-modules/dpcontracts/default.nix
+++ b/pkgs/development/python-modules/dpcontracts/default.nix
@@ -2,12 +2,13 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
 }:
 
 buildPythonPackage {
   pname = "dpcontracts";
   version = "unstable-2018-11-20";
-  format = "setuptools";
+  pyproject = true;
 
   __structuredAttrs = true;
 
@@ -17,6 +18,10 @@ buildPythonPackage {
     rev = "45cb8542272c2ebe095c6efb97aa9407ddc8bf3c";
     hash = "sha256-FygJPXo7lZ9tlfqY6KmPJ3PLIilMGLBr3013uj9hCEs=";
   };
+
+  build-system = [
+    setuptools
+  ];
 
   # package does not have any tests
   doCheck = false;

--- a/pkgs/development/python-modules/dpcontracts/default.nix
+++ b/pkgs/development/python-modules/dpcontracts/default.nix
@@ -9,6 +9,8 @@ buildPythonPackage {
   version = "unstable-2018-11-20";
   format = "setuptools";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "deadpixi";
     repo = "contracts";

--- a/pkgs/development/python-modules/dpcontracts/default.nix
+++ b/pkgs/development/python-modules/dpcontracts/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
+  pytestCheckHook,
 }:
 
 buildPythonPackage {
@@ -19,12 +20,25 @@ buildPythonPackage {
     hash = "sha256-FygJPXo7lZ9tlfqY6KmPJ3PLIilMGLBr3013uj9hCEs=";
   };
 
+  # Replacements in README.rst are necessary to check it with doctest
+  postPatch = ''
+    substituteInPlace README.rst \
+      --replace-fail " PreconditionError" " dpcontracts.PreconditionError" \
+      --replace-fail " PostconditionError" " dpcontracts.PostconditionError" \
+      --replace-fail ">>> class Counter:" $'>>> from dpcontracts import preserve\n    >>> class Counter:'
+  '';
+
   build-system = [
     setuptools
   ];
 
-  # package does not have any tests
-  doCheck = false;
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  enabledTestPaths = [
+    "README.rst"
+  ];
 
   pythonImportsCheck = [ "dpcontracts" ];
 

--- a/pkgs/development/python-modules/dpcontracts/default.nix
+++ b/pkgs/development/python-modules/dpcontracts/default.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage {
   pname = "dpcontracts";
-  version = "unstable-2018-11-20";
+  version = "0.6.0-unstable-2018-11-20";
   pyproject = true;
 
   __structuredAttrs = true;


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/515974
- enable `__structuredAttrs`
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
