### PR TITLE
maintainers/test-driver: make maintainer-team github-based and add owners, rename from 'tests'

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -127,10 +127,6 @@ nixos/modules/installer/tools/nix-fallback-paths.nix  @Artturin @Ericson2314 @lo
 /doc/redirects.json                @GetPsyched
 /nixos/doc/manual/redirects.json   @GetPsyched
 
-# NixOS integration test driver
-/nixos/lib/test-driver  @tfc
-/nixos/lib/testing      @tfc
-
 # NixOS QEMU virtualisation
 /nixos/modules/virtualisation/qemu-vm.nix                 @raitobezarius
 /nixos/modules/services/backup/libvirtd-autosnapshot.nix  @6543
@@ -531,3 +527,9 @@ pkgs/by-name/wa/warp-terminal/  @emilytrau @imadnyc @FlameFlag @johnrtitor
 
 # Zellij plugins
 /pkgs/by-name/ze/zellij/plugins/   @PerchunPak
+
+# Test-driver
+/nixos/lib/test-driver                                      @NixOS/test-driver
+/nixos/lib/testing                                          @NixOS/test-driver
+/nixos/tests/nixos-test-driver                              @NixOS/test-driver
+/nixos/modules/virtualisation/nspawn-container/run-nspawn   @NixOS/test-driver

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -748,10 +748,8 @@ with lib.maintainers;
     enableFeatureFreezePing = true;
   };
 
-  tests = {
-    members = [ tfc ];
-    scope = "Maintain the NixOS VM test runner.";
-    shortName = "NixOS tests";
+  test-driver = {
+    github = "test-driver";
     enableFeatureFreezePing = true;
   };
 


### PR DESCRIPTION
Renaming from `tests` to make it explicit that we're maintaining the
driver and not all tests.

As briefly discussed with Jacek & Kierán.
We rely on pinging each other / being pinged and that seems better.

Talked with both of them in private, for completenes' sake, cc @kmein @tfc.

---

I created @NixOS/test-driver for that manner, apparently we need a confirmation (see https://github.com/orgs/NixOS/teams/test-driver/edit if you have access) from on org-owner to have this being used for review requests et al.. This is being requested, I'll ping org owners in a few days if nohting happens.

@jfly I briefly confirmed with Jacek & Kierán that they're fine with this. I'm not sure what your future plans are for the test-driver, so feel free to leave a comment here if you want to be a member. Didn't want to subscribe you to more notifications without asking :D 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
