### PR TITLE
fbpdf: init at 2025-01-25

### DIFF
--- a/pkgs/by-name/fb/fbpdf/package.nix
+++ b/pkgs/by-name/fb/fbpdf/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  mupdf,
+  djvulibre,
+  libjpeg,
+  poppler,
+  installShellFiles,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fbpdf";
+  version = "0-unstable-2025-01-25";
+
+  src = fetchFromGitHub {
+    owner = "aligrudi";
+    repo = "fbpdf";
+    rev = "6a0d77f06f6f03085a5b786d1feb8a041318b30a";
+    hash = "sha256-7NlOiPaGradi+brjd5X9IjvEGbWdTTTQ+PMAx6xw0Uk=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+  ];
+
+  buildInputs = [
+    mupdf
+    djvulibre
+    libjpeg
+    poppler
+  ];
+
+  #nixpkg's mupdf exposes a single shared libmupdf while fbpdf's upstream
+  #Makefile links against older split mupdf libraries (libmupdf-third,
+  #libmupdf-pkcs7, libmupdf-threads). Patch the link flags to match
+  #current nixpkgs mupdf.
+  postPatch = ''
+    substituteInPlace Makefile  \
+      --replace-fail "-lmupdf -lmupdf-third -lmupdf-pkcs7 -lmupdf-threads -lm" "-lmupdf -lm"
+  '';
+
+  buildFlags = [
+    "fbpdf"
+    "fbdjvu"
+    "fbpdf2"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 fbpdf $out/bin/fbpdf
+    install -Dm755 fbdjvu $out/bin/fbdjvu
+    install -Dm755 fbpdf2 $out/bin/fbpdf2
+    installManPage fbpdf.1
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Linux framebuffer PDF, DjVu, EPUB, XPS, and CBZ viewer";
+    homepage = "https://github.com/aligrudi/fbpdf";
+    mainProgram = "fbpdf";
+    platforms = lib.platforms.linux;
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ castorNova2 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds [fbpdf](https://github.com/aligrudi/fbpdf) which is a framebuffer PDF and DjVu viewer.

- <mark> readelf </mark> confirms correct dynamic linkage
- runtime framebuffer test could not be performed on my machine because Fedora Wayland session has no <mark> /dev/fb0 </mark> available

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
