### PR TITLE
nixos/nixpkgs: add zstd flavored nixexprs tarballs

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -4,7 +4,17 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- Create the first release note entry in this section!
+- The {file}`nixexprs.tar.xz` tarball will be discontinued together with Nixpkgs
+  27.05 after 2027-12-31. Migrate to the {file}`nixexprs.tar.zst` tarball
+  instead.
+
+  This affects for example users who pull Nixpkgs as a flake input from
+  https://channels.nixos.org:
+
+  ```diff
+  -nixpkgs.url = "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz";
+  +nixpkgs.url = "https://channels.nixos.org/nixos-26.05/nixexprs.tar.zst";
+  ```
 
 ## Backward Incompatibilities {#sec-nixpkgs-release-26.11-incompatibilities}
 

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -4,7 +4,17 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- Create the first release note entry in this section!
+- The {file}`nixexprs.tar.xz` tarball will be discontinued together with Nixpkgs
+  27.05 after 2027-12-31. Migrate to the {file}`nixexprs.tar.zst` tarball
+  instead.
+
+  This affects for example users who pull Nixpkgs as a flake input from
+  https://channels.nixos.org:
+
+  ```diff
+  -nixpkgs.url = "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz";
+  +nixpkgs.url = "https://channels.nixos.org/nixos-26.05/nixexprs.tar.zst";
+  ```
 
 ## New Modules {#sec-release-26.11-new-modules}
 

--- a/nixos/lib/make-channel.nix
+++ b/nixos/lib/make-channel.nix
@@ -35,11 +35,32 @@ pkgs.releaseTools.makeSourceTarball {
     NIX_STATE_DIR=$TMPDIR nix-env -f ../$releaseName/default.nix -qaP --meta --show-trace --xml \* > /dev/null
     cd ..
     chmod -R u+w $releaseName
-    tar cfJ $out/tarballs/$releaseName.tar.xz $releaseName
+    XZ_OPT="-T0" tar \
+      --create \
+      --file=$out/tarballs/$releaseName.tar.xz \
+      --xz \
+      --absolute-names \
+      --owner=0 \
+      --group=0 \
+      --numeric-owner \
+      --format=gnu \
+      --sort=name \
+      --mtime="@$SOURCE_DATE_EPOCH" \
+      --hard-dereference \
+      $releaseName
+
     tar \
       --create \
       --file="$out/tarballs/$releaseName.tar.zst" \
-      --use-compress-program="zstd -19 -T$NIX_BUILD_CORES" \
+      --use-compress-program="zstd -19 -T0" \
+      --absolute-names \
+      --owner=0 \
+      --group=0 \
+      --numeric-owner \
+      --format=gnu \
+      --sort=name \
+      --mtime="@$SOURCE_DATE_EPOCH" \
+      --hard-dereference \
       $releaseName
   '';
 }

--- a/nixos/lib/make-channel.nix
+++ b/nixos/lib/make-channel.nix
@@ -18,7 +18,10 @@ pkgs.releaseTools.makeSourceTarball {
   officialRelease = false; # FIXME: fix this in makeSourceTarball
   inherit version versionSuffix;
 
-  buildInputs = [ pkgs.nix ];
+  buildInputs = with pkgs; [
+    nix
+    zstd
+  ];
 
   distPhase = ''
     rm -rf .git
@@ -33,5 +36,10 @@ pkgs.releaseTools.makeSourceTarball {
     cd ..
     chmod -R u+w $releaseName
     tar cfJ $out/tarballs/$releaseName.tar.xz $releaseName
+    tar \
+      --create \
+      --file="$out/tarballs/$releaseName.tar.zst" \
+      --use-compress-program="zstd -19 -T$NIX_BUILD_CORES" \
+      $releaseName
   '';
 }

--- a/nixos/lib/make-channel.nix
+++ b/nixos/lib/make-channel.nix
@@ -35,6 +35,9 @@ pkgs.releaseTools.makeSourceTarball {
     NIX_STATE_DIR=$TMPDIR nix-env -f ../$releaseName/default.nix -qaP --meta --show-trace --xml \* > /dev/null
     cd ..
     chmod -R u+w $releaseName
+
+    # The compression tasks are shortlived; use all available CPUs (-T0) to
+    # prioritize fast channel advancement.
     XZ_OPT="-T0" tar \
       --create \
       --file=$out/tarballs/$releaseName.tar.xz \

--- a/pkgs/top-level/make-tarball.nix
+++ b/pkgs/top-level/make-tarball.nix
@@ -24,6 +24,7 @@ pkgs.releaseTools.sourceTarball {
     jq
     lib-tests
     brotli
+    zstd
   ];
 
   configurePhase = ''
@@ -67,6 +68,23 @@ pkgs.releaseTools.sourceTarball {
       --create \
       --xz \
       --file=$out/tarballs/$releaseName.tar.xz \
+      --absolute-names \
+      --transform="s|^$src|$releaseName|g" \
+      --transform="s|^$(pwd)|$releaseName|g" \
+      --owner=0 \
+      --group=0 \
+      --numeric-owner \
+      --format=gnu \
+      --sort=name \
+      --mtime="@$SOURCE_DATE_EPOCH" \
+      --mode=ug+w \
+      --hard-dereference \
+      $src $(pwd)/{.version-suffix,.git-revision}
+
+    tar \
+      --create \
+      --use-compress-program="zstd -19 -T0" \
+      --file=$out/tarballs/$releaseName.tar.zst \
       --absolute-names \
       --transform="s|^$src|$releaseName|g" \
       --transform="s|^$(pwd)|$releaseName|g" \

--- a/pkgs/top-level/make-tarball.nix
+++ b/pkgs/top-level/make-tarball.nix
@@ -64,6 +64,9 @@ pkgs.releaseTools.sourceTarball {
   #   Some context: https://github.com/NixOS/infra/issues/438
   distPhase = ''
     mkdir -p $out/tarballs
+
+    # The compression tasks are shortlived; use all available CPUs (-T0) to
+    # prioritize fast channel advancement.
     XZ_OPT="-T0" tar \
       --create \
       --xz \


### PR DESCRIPTION
This can significantly speed up consumption of nixexprs because zstd
decompress is generally 10x faster than xz.

Depends on  https://github.com/NixOS/infra/pull/1103 :white_check_mark: 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
