### PR TITLE
lobster: 2026.1 -> 2026.4

### DIFF
--- a/pkgs/by-name/lo/lobster/package.nix
+++ b/pkgs/by-name/lo/lobster/package.nix
@@ -4,34 +4,57 @@
   fetchFromGitHub,
   cmake,
   callPackage,
+  pkg-config,
 
   # Linux deps
   libGL,
+  libxcursor,
   libxext,
+  libxi,
   libx11,
+  libxrandr,
+  libxscrnsaver,
+  libxtst,
 
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lobster";
-  version = "2026.1";
+  version = "2026.4";
 
   src = fetchFromGitHub {
     owner = "aardappel";
     repo = "lobster";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-kN4KYd0wTHqF3J4wFGHLmHifkxsb6J+Ex7gGRGnFiGk=";
+    hash = "sha256-kqKOf0zrHyqRTs+57owHR5sORZgNIgGghtjUtSaFjZw=";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
   buildInputs = lib.optionals (!stdenv.hostPlatform.isDarwin) [
+    # TODO devendor sdl3 and remove these
     libGL
+    libxcursor
     libx11
     libxext
+    libxi
+    libxrandr
+    libxscrnsaver
+    libxtst
   ];
 
   preConfigure = ''
     cd dev
+  '';
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  # The test suite expects the executable to be in any of a number of locations
+  # that do not include the bin directory.
+  preCheck = ''
+    ln -s ../../bin/lobster lobster
   '';
 
   passthru.tests.can-run-hello-world = callPackage ./test-can-run-hello-world.nix { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
