### PR TITLE
busybox: backport tar symlink bug fix

### DIFF
--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -270,12 +270,6 @@ stdenv.mkDerivation (finalAttrs: {
         # Relies on suid/guid bits
         skip-testcase cpio.tests "cpio restores suid/sgid bits"
 
-        # Weird failures, looks related to our sandbox
-        skip-testcase tar.tests "tar does not extract into symlinks"
-        skip-testcase tar.tests "tar -k does not extract into symlinks"
-        skip-testcase tar.tests "tar Symlink attack: create symlink and then write through it"
-        skip-testcase tar.tests "tar Symlinks and hardlinks coexist"
-
         popd
       '';
     });

--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -99,6 +99,13 @@ stdenv.mkDerivation (finalAttrs: {
       excludes = [ "networking/httpd_ratelimit_cgi.c" ]; # New since release.
       hash = "sha256-Msm9sDZrVx7ofunnvnTS73SPKUUpR3Tv5xZ/wBd+rts=";
     })
+    # tar: only strip unsafe components from hardlinks, not symlinks
+    # fix issue introduced by the previous patch (CVE-2026-26157_CVE-2026-26158.patch)
+    (fetchpatch {
+      name = "CVE-2026-26157_CVE-2026-26158-2.patch";
+      url = "https://github.com/vda-linux/busybox_mirror/commit/599f5dd8fac390c18b79cba4c14c334957605dae.patch";
+      hash = "sha256-go/KHSsuMSm21nC0yvKEtAQs8Jnjjqdcs5i8RWBGwT4=";
+    })
     # syslogd: fix writing to local log file
     # https://lists.busybox.net/pipermail/busybox/2024-October/090969.html
     (fetchpatch {


### PR DESCRIPTION
The patch included by the commit https://github.com/NixOS/nixpkgs/commit/3aa07b8f89138341cedacc7eb49e25ecfa11232a introduced a bug (also present upstream). This PR adds yet another patch to fix this bug.

Note: at the time this PR was created, git.busybox.net is not working as expected. Therefore, the URL for the patch is for the GitHub mirror advertised on the [project web page](https://busybox.net/source.html).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
