### PR TITLE
esphome-device-builder: init at 1.6.1

### DIFF
--- a/pkgs/by-name/es/esphome-device-builder/frontend.nix
+++ b/pkgs/by-name/es/esphome-device-builder/frontend.nix
@@ -1,0 +1,54 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  nodejs,
+  fetchNpmDeps,
+  npmHooks,
+  pyprojectVersionPatchHook,
+  setuptools,
+  meta,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "esphome-device-builder-frontend";
+  version = "0.1.251";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "esphome";
+    repo = "device-builder-frontend";
+    tag = finalAttrs.version;
+    hash = "sha256-lt7uDtoKcymm5wWygS44ff6TmSs1lPM1WdbygsEHcUc=";
+  };
+
+  npmDeps = fetchNpmDeps {
+    inherit (finalAttrs) src;
+    hash = "sha256-JDpUk/aEgPpx8X2AuPlm7rCpvfOX0vfLHpSDlBRN/5o=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    npmHooks.npmConfigHook
+    pyprojectVersionPatchHook
+  ];
+
+  build-system = [
+    setuptools
+  ];
+
+  preBuild = ''
+    npm run build
+  '';
+
+  pythonImportsCheck = [
+    "esphome_device_builder_frontend"
+  ];
+
+  meta = meta // {
+    description = "Frontend for the ESPHome Device Builder";
+    homepage = "https://github.com/esphome/device-builder-frontend";
+    changelog = "https://github.com/esphome/device-builder/releases/tag/${finalAttrs.src.tag}";
+  };
+})

--- a/pkgs/by-name/es/esphome-device-builder/package.nix
+++ b/pkgs/by-name/es/esphome-device-builder/package.nix
@@ -1,0 +1,144 @@
+{
+  lib,
+  callPackage,
+  python3Packages,
+  fetchFromGitHub,
+  gitMinimal,
+  versionCheckHook,
+  esptool,
+  esphome,
+}:
+
+let
+  meta = {
+    description = "ESPHome Device Builder Dashboard";
+    homepage = "https://esphome.io/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      tmarkus
+      karlbeecken
+    ];
+    mainProgram = "esphome-device-builder";
+  };
+
+  pythonPackages = python3Packages.overrideScope (
+    self: super: {
+      esphome = self.toPythonModule esphome;
+      esphome-device-builder-frontend = self.callPackage ./frontend.nix {
+        inherit meta;
+      };
+    }
+  );
+in
+pythonPackages.buildPythonApplication (finalAttrs: {
+  pname = "esphome-device-builder";
+  version = "1.6.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "esphome";
+    repo = "device-builder";
+    tag = finalAttrs.version;
+    hash = "sha256-vzHG5nsECN3qAwpDGcELf9adgGiebr99pcdDqet79s4=";
+  };
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = with pythonPackages; [
+    pyprojectVersionPatchHook
+  ];
+
+  build-system = with pythonPackages; [
+    setuptools
+  ];
+
+  dependencies = with pythonPackages; [
+    esphome
+    esphome-device-builder-frontend
+
+    aiohttp
+    aiohttp-asyncmdnsresolver
+    colorlog
+    cryptography
+    fnv-hash-fast
+    ifaddr
+    icmplib
+    mashumaro
+    orjson
+    pyyaml
+    ruamel-yaml
+    voluptuous
+  ];
+
+  nativeCheckInputs = with pythonPackages; [
+    versionCheckHook
+    pytestCheckHook
+    pytest-aiohttp
+    pytest-codspeed
+    pytest-cov-stub
+    pytest-timeout
+    pytest-xdist
+    blockbuster
+  ];
+
+  postPatch = ''
+    substituteInPlace esphome_device_builder/controllers/firmware/helpers.py \
+      --replace-fail 'list(_find_sibling_cli("esphome"))' '["${lib.getExe pythonPackages.esphome}"]' \
+      --replace-fail 'list(_find_sibling_cli("esptool"))' '["${lib.getExe esptool}"]'
+
+    substituteInPlace esphome_device_builder/controllers/version_history/git_repo.py \
+      --replace-fail 'shutil.which("git")' '"${lib.getExe gitMinimal}"'
+
+    substituteInPlace tests/controllers/version_history/test_git_repo.py \
+      --replace-fail 'shutil.which("git")' '"${lib.getExe gitMinimal}"'
+    substituteInPlace tests/test_editor_controller.py \
+      --replace-fail 'controller._esphome_cmd = ["esphome"]' 'controller._esphome_cmd = ["${lib.getExe pythonPackages.esphome}"]'
+  '';
+
+  # Needed for tests
+  __darwinAllowLocalNetworking = true;
+
+  pytestFlags = [
+    "--timeout=30"
+  ];
+
+  disabledTestPaths = [
+    # presumably fails due to required network access to download LibreTiny
+    "tests/e2e/slow/boards/test_create_all_boards.py"
+  ];
+
+  disabledTests = [
+    # tests that try to access GitHub
+    "test_esp_idf_compile_download_round_trip"
+    "test_libretiny_bk7231n_compile_download_round_trip"
+
+    # timeout
+    "test_get_component_bodies_returns_full_batch_larger_than_cache"
+
+    # failed tests due to patched esphome location
+    "test_find_esphome_cmd_prefers_sibling_binary_when_present"
+    "test_find_esphome_cmd_falls_back_to_python_dash_m"
+    "test_find_esphome_cmd_does_not_substitute_sibling_python"
+    "test_find_esphome_cmd_picks_bare_esphome_on_posix"
+
+    # failed tests due to patched git location
+    "test_disabled_when_no_git"
+    "test_missing_git_binary_disables_feature"
+
+    # failed tests due to patched esptool location
+    "test_find_esptool_cmd_prefers_sibling_script"
+    "test_find_esptool_cmd_falls_back_to_python_dash_m"
+
+    # TOOD: requires patching the device state monitor
+    "test_start_logs_ping_count_at_debug"
+  ];
+
+  passthru = {
+    frontend = pythonPackages.esphome-device-builder-frontend;
+    updateScript = callPackage ./update.nix { };
+  };
+
+  meta = meta // {
+    changelog = "https://github.com/esphome/device-builder/releases/tag/${finalAttrs.src.tag}";
+  };
+})

--- a/pkgs/by-name/es/esphome-device-builder/update.nix
+++ b/pkgs/by-name/es/esphome-device-builder/update.nix
@@ -1,0 +1,34 @@
+{
+  writeShellScript,
+  lib,
+  curl,
+  git,
+  jq,
+  yq,
+  nix-update,
+}:
+
+writeShellScript "update-esphome-device-builder" ''
+  set -euo pipefail
+
+  PATH=${
+    lib.makeBinPath [
+      curl
+      git
+      jq
+      yq
+      nix-update
+    ]
+  }
+
+  LATEST=$(curl https://api.github.com/repos/esphome/device-builder/releases/latest | jq -r '.name')
+  echo "Latest version: $LATEST"
+
+  FRONTEND_VERSION=$(curl https://raw.githubusercontent.com/esphome/device-builder/$LATEST/pyproject.toml | \
+    tomlq -r '.project.dependencies|.[]|select(startswith("esphome-device-builder-frontend"))|match("[0-9.]+").string')
+
+  echo "Frontend version: $FRONTEND_VERSION"
+
+  nix-update esphome-device-builder.frontend --version $FRONTEND_VERSION
+  nix-update esphome-device-builder --version $LATEST
+''


### PR DESCRIPTION
See prior discussion in #534724. This PR also builds on top of the update in that PR and thus depends on it.

- https://github.com/esphome/device-builder
- https://github.com/esphome/device-builder-frontend
- https://esphome.io/changelog/2026.6.0/#esphome-device-builder-replaces-the-legacy-dashboard

~~For some reason though, the package currently doesn't find the frontend. I'm still looking into that.~~ Fixed.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
