### PR TITLE
asciidoctor.asciidoctor-vscode: 3.4.2 -> 3.4.5

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/asciidoctor.asciidoctor-vscode/commands-abspath.patch
+++ b/pkgs/applications/editors/vscode/extensions/asciidoctor.asciidoctor-vscode/commands-abspath.patch
@@ -1,13 +1,11 @@
-diff --git a/package.json b/package.json
-index 7ab70e8..2ebe541 100644
 --- a/package.json
 +++ b/package.json
 @@ -437,7 +437,7 @@
- 					},
- 					"asciidoc.asciidoctorpdf_command": {
- 						"type": "string",
--						"default": "asciidoctor-pdf",
-+						"default": "@ASCIIDOCTOR_PDF_BIN@",
- 						"markdownDescription": "%asciidoc.asciidoctorpdf_command.desc%",
- 						"markdownDeprecationMessage": "%asciidoc.asciidoctorpdf_command.deprecationMessage%",
- 						"scope": "resource"
+           },
+           "asciidoc.asciidoctorpdf_command": {
+             "type": "string",
+-            "default": "asciidoctor-pdf",
++            "default": "@ASCIIDOCTOR_PDF_BIN@",
+             "markdownDescription": "%asciidoc.asciidoctorpdf_command.desc%",
+             "markdownDeprecationMessage": "%asciidoc.asciidoctorpdf_command.deprecationMessage%",
+             "scope": "resource"

--- a/pkgs/applications/editors/vscode/extensions/asciidoctor.asciidoctor-vscode/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/asciidoctor.asciidoctor-vscode/default.nix
@@ -8,8 +8,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "asciidoctor-vscode";
     publisher = "asciidoctor";
-    version = "3.4.2";
-    hash = "sha256-HG3y7999xeE1erQZCnBgUPj/aC0Kwyn20PEZR9gKrxY=";
+    version = "3.4.5";
+    hash = "sha256-X7njFSqfb45l6ZTr7GDS3At6DMHyvBT41JoghOeVjwI=";
   };
 
   patches = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updates the VSCode editor extension `asciidoctor.asciidoctor-vscode` from `3.4.2` to `3.4.5`.  [See extension Release Notes](https://github.com/asciidoctor/asciidoctor-vscode/releases/tag/v3.4.5). 

Since this is my first contribution to nixpkgs 🤗 and I wanted to make sure everything was correct, I tested the change locally using the following nix flake:

```nix
{
  description = "A devshell with vscode and asciidoctor extension";

  inputs = {
    nixpkgs.url = "git+file:///<path-to-my-local-nixpkgs-fork>";
  };

  outputs = { self, nixpkgs }:
    let
      system = "x86_64-linux";
      pkgs = import nixpkgs {
        inherit system;
        config.allowUnfree = true;
      };
    in
    {
      devShells.${system}.default = pkgs.mkShell {
        buildInputs = [
          (pkgs.vscode-with-extensions.override {
            vscodeExtensions = with pkgs.vscode-extensions; [
              asciidoctor.asciidoctor-vscode
            ];
          })
        ];
      };
    };
}
```

Even though I've read the `Contributing.md` carefully, please let me know if I've missed anything. I'll make the necessary corrections.

---

Side note: If the [nix-community/nix-vscode-extensions overlay](https://github.com/nix-community/nix-vscode-extensions) is used, it is no longer necessary to overwrite the patch attributes, since this update also includes the necessary adjustments to the patch file.

No longer necessary:

```nix
(asciidoctor.asciidoctor-vscode.overrideAttrs (oldAttrs: {
  # This removes the failing patch from the build process
  patches = [ ];
  postPatch = '''';
}))
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
