### PR TITLE
unrar-wrapper: migrate to pyproject, enable __structuredAttrs, enable tests

### DIFF
--- a/pkgs/by-name/un/unrar-wrapper/package.nix
+++ b/pkgs/by-name/un/unrar-wrapper/package.nix
@@ -8,7 +8,7 @@
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "unrar-wrapper";
   version = "1.0.0";
-  format = "setuptools";
+  pyproject = true;
 
   __structuredAttrs = true;
 
@@ -18,6 +18,10 @@ python3Packages.buildPythonApplication (finalAttrs: {
     rev = "unrar_wrapper-${finalAttrs.version}";
     sha256 = "sha256-HjrUif8MrbtLjRQMAPZ/Y2o43rGSDj0HHY4fZQfKz5w=";
   };
+
+  build-system = [
+    python3Packages.setuptools
+  ];
 
   makeWrapperArgs = [
     "--prefix"

--- a/pkgs/by-name/un/unrar-wrapper/package.nix
+++ b/pkgs/by-name/un/unrar-wrapper/package.nix
@@ -23,6 +23,10 @@ python3Packages.buildPythonApplication (finalAttrs: {
     python3Packages.setuptools
   ];
 
+  nativeCheckInputs = [
+    python3Packages.pytestCheckHook
+  ];
+
   makeWrapperArgs = [
     "--prefix"
     "PATH"

--- a/pkgs/by-name/un/unrar-wrapper/package.nix
+++ b/pkgs/by-name/un/unrar-wrapper/package.nix
@@ -10,6 +10,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
   version = "1.0.0";
   format = "setuptools";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "openSUSE";
     repo = "unrar_wrapper";

--- a/pkgs/by-name/un/unrar-wrapper/package.nix
+++ b/pkgs/by-name/un/unrar-wrapper/package.nix
@@ -15,7 +15,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   src = fetchFromGitHub {
     owner = "openSUSE";
     repo = "unrar_wrapper";
-    rev = "unrar_wrapper-${finalAttrs.version}";
+    tag = "unrar_wrapper-${finalAttrs.version}";
     sha256 = "sha256-HjrUif8MrbtLjRQMAPZ/Y2o43rGSDj0HHY4fZQfKz5w=";
   };
 


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/515974
- enable `__structuredAttrs`
- enable tests
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
