### PR TITLE
codebase-memory-mcp: init at 0.8.1

### DIFF
--- a/pkgs/by-name/co/codebase-memory-mcp/package.nix
+++ b/pkgs/by-name/co/codebase-memory-mcp/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gnumake,
+  zlib,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "codebase-memory-mcp";
+  version = "0.8.1";
+  src = fetchFromGitHub {
+    owner = "DeusData";
+    repo = "codebase-memory-mcp";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-H0l8H2JhPT1Rs0p+CJC1a1qYtnZNgLGe6n7PmM+WvE4=";
+  };
+  nativeBuildInputs = [ gnumake ];
+  buildInputs = [ zlib ];
+  strictDeps = true;
+  __structuredAttrs = true;
+  # scripts/build.sh verifies CC via `file`, which fails on Nix's compiler wrapper.
+  # Call make directly — mirrors upstream flake.nix.
+  buildPhase = ''
+    runHook preBuild
+    make -j$NIX_BUILD_CORES -f Makefile.cbm cbm CFLAGS_EXTRA='-DCBM_VERSION=\"${finalAttrs.version}\"'
+    runHook postBuild
+  '';
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 build/c/codebase-memory-mcp $out/bin/codebase-memory-mcp
+    runHook postInstall
+  '';
+  meta = {
+    homepage = "https://github.com/DeusData/codebase-memory-mcp";
+    description = "High-performance C11 MCP server that indexes codebases into a persistent knowledge graph";
+    mainProgram = "codebase-memory-mcp";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ gdifolco ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
Add https://github.com/DeusData/codebase-memory-mcp


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
