### PR TITLE
linux: forward features into passthru

### DIFF
--- a/pkgs/os-specific/linux/kernel/build.nix
+++ b/pkgs/os-specific/linux/kernel/build.nix
@@ -80,8 +80,7 @@ lib.makeOverridable (
 
     # Whether to utilize the controversial import-from-derivation feature to parse the config
     allowImportFromDerivation ? false,
-    # ignored
-    features ? null,
+    features ? { },
     lib ? lib_,
     stdenv ? stdenv_,
   }:
@@ -530,6 +529,9 @@ lib.makeOverridable (
       inherit
         isZen
         withRust
+        # Forwarded into passthru so features survive kernel.override() call chains
+        # used by the NixOS module system (see boot.kernelPackages apply in kernel.nix).
+        features
         ;
       baseVersion = lib.head (lib.splitString "-rc" version);
       kernelOlder = lib.versionOlder baseVersion;


### PR DESCRIPTION
`build.nix` accepted `features` as a parameter but discarded it, never placing it into the derivation's passthru.

The NixOS boot.kernelPackages apply function calls kernel.override() on every evaluation, re-running build.nix from scratch; any features added via `overrideAttrs` were silently lost, causing assertions like `hardware.graphics.enable32Bit` (which checks `kernel.features.ia32Emulation`) to always fail for `linuxManualConfig`-based kernels.




