### PR TITLE
neovimUtils: support wasm tree-sitter grammars

### DIFF
--- a/pkgs/applications/editors/neovim/to-nvim-treesitter-grammar.sh
+++ b/pkgs/applications/editors/neovim/to-nvim-treesitter-grammar.sh
@@ -4,7 +4,11 @@ toNvimTreesitterGrammar() {
     echo "Executing toNvimTreesitterGrammar"
 
     mkdir -p "$out/parser"
-    ln -s "$origGrammar/parser" "$out/parser/$grammarName.so"
+    if [ -e "$origGrammar/parser.wasm" ]; then
+        ln -s "$origGrammar/parser.wasm" "$out/parser/$grammarName.wasm"
+    else
+        ln -s "$origGrammar/parser" "$out/parser/$grammarName.so"
+    fi
 
     if [ "$installQueries" != 1 ]; then
         echo "Installing queries is disabled: installQueries=$installQueries"


### PR DESCRIPTION
Teach the existing grammar wrapper to install parser.wasm when users pass a WASI-built grammar.
https://github.com/neovim/neovim/blob/35b57441b0bac035dcfc591830e82abc560720b1/runtime/doc/treesitter.txt#L17-L60

Related https://github.com/NixOS/nixpkgs/pull/534687

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
