### PR TITLE
retch: init at 0.3.25

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15154,6 +15154,12 @@
     githubId = 27364685;
     name = "Lorenzo Pasqui";
   };
+  l1a = {
+    email = "kentobias@gmail.com";
+    github = "l1a";
+    githubId = 634380;
+    name = "Ken Tobias";
+  };
   l1n = {
     github = "l1n";
     githubId = 1367322;

--- a/pkgs/by-name/re/retch/package.nix
+++ b/pkgs/by-name/re/retch/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  installShellFiles,
+  mandown,
+}:
+
+rustPlatform.buildRustPackage rec {
+  __structuredAttrs = true;
+
+  pname = "retch";
+  version = "0.3.25";
+
+  src = fetchFromGitHub {
+    owner = "l1a";
+    repo = "retch";
+    rev = "v${version}";
+    hash = "sha256-wUVqqPQEqLcZMerG8H1baczYF9kMb3SctRtWGJeAgUQ=";
+  };
+
+  cargoHash = "sha256-zF2PodKPYjKrhvNZUAxnkA0LlZQiAhEqralSPtTFJ0U=";
+
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+    mandown
+  ];
+
+  postBuild = ''
+    DATE="June 2026"
+    mandown docs/retch.1.md RETCH 1 | sed -e 's/\\fB\\fB/\\fB/g' -e 's/\\fP\\fP/\\fP/g' -e "s/\\.TH \"RETCH\" 1/\\.TH \"RETCH\" \"1\" \"$DATE\" \"retch ${version}\" \"System Information Fetcher\"/" > docs/retch.1
+  '';
+
+  postInstall = ''
+    installManPage docs/retch.1
+
+    installShellCompletion --cmd retch \
+      --bash <($out/bin/retch --completions bash) \
+      --zsh <($out/bin/retch --completions zsh) \
+      --fish <($out/bin/retch --completions fish)
+  '';
+
+  meta = {
+    description = "A fast, feature-rich system information fetcher written in Rust";
+    homepage = "https://github.com/l1a/retch";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.l1a ];
+    mainProgram = "retch";
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
+  };
+}


### PR DESCRIPTION
retch is a fast, feature-rich system information fetcher written in Rust. It uses scoped threads to run slow external queries (GPU, battery, network, motherboard, cameras, etc.) concurrently. It supports Linux, macOS, and Windows with rich hardware detection, ASCII/graphical distro logos, theming, and shell completions.

- Homepage: https://github.com/l1a/retch
- License: GPLv3

> **AI Disclosure**: This package derivation was developed with assistance from Claude Code (claude-sonnet-4-6). The output was reviewed and tested by the submitter. See `Assisted-by:` trailer in the commit.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test