### PR TITLE
google-cloud-sdk: use vendored protobuf extensions only 

### DIFF
--- a/pkgs/by-name/go/google-cloud-sdk/cloudsdk-vendored-protobuf-upb.patch
+++ b/pkgs/by-name/go/google-cloud-sdk/cloudsdk-vendored-protobuf-upb.patch
@@ -1,0 +1,22 @@
+diff --git a/lib/third_party/cloudsdk/google/protobuf/internal/api_implementation.py b/lib/third_party/cloudsdk/google/protobuf/internal/api_implementation.py
+--- a/lib/third_party/cloudsdk/google/protobuf/internal/api_implementation.py
++++ b/lib/third_party/cloudsdk/google/protobuf/internal/api_implementation.py
+@@ -55,7 +55,7 @@ _implementation_type = 'python'
+ if _implementation_type is None:
+-  if _CanImport('google._upb._message'):
++  if _CanImport('cloudsdk.google._upb._message'):
+     _implementation_type = 'upb'
+-  elif _CanImport('google.protobuf.pyext._message'):
++  elif _CanImport('cloudsdk.google.protobuf.pyext._message'):
+     _implementation_type = 'cpp'
+   else:
+     _implementation_type = 'python'
+@@ -96,7 +96,7 @@ if _implementation_type == 'cpp':
+ if _implementation_type == 'upb':
+   try:
+     # pylint: disable=g-import-not-at-top
+-    from google._upb import _message
++    from cloudsdk.google._upb import _message
+     _c_module = _message
+     del _message
+   except ImportError:

--- a/pkgs/by-name/go/google-cloud-sdk/package.nix
+++ b/pkgs/by-name/go/google-cloud-sdk/package.nix
@@ -70,6 +70,9 @@ stdenv.mkDerivation rec {
     ./gcloud-path.patch
     # Disable checking for updates for the package
     ./gsutil-disable-updates.patch
+    # Cloud SDK vendors protobuf under the cloudsdk.google.protobuf namespace.
+    # Keep that vendored runtime from loading external google._upb modules.
+    ./cloudsdk-vendored-protobuf-upb.patch
   ];
 
   installPhase = ''
@@ -185,6 +188,12 @@ stdenv.mkDerivation rec {
     # Avoid trying to write logs to homeless-shelter
     export HOME=$(mktemp -d)
     $out/bin/gcloud version --format json | jq '."Google Cloud SDK"' | grep "${version}"
+    $out/bin/gcloud storage ls --help > /dev/null
+    # Exercises generated clients that use Cloud SDK's vendored protobuf. This
+    # catches regressions where external protobuf/upb is selected instead of the
+    # vendored pure-Python protobuf implementation.
+    $out/bin/gcloud kms asymmetric-sign --help > /dev/null
+    PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=upb $out/bin/gcloud kms asymmetric-sign --help > /dev/null
     $out/bin/gsutil version | grep -w "$(cat platform/gsutil/VERSION)"
   '';
 


### PR DESCRIPTION
## Summary

`google-cloud-sdk` crashes with:

```
A Message class can only inherit from Message, not (<class 'cloudsdk.google.protobuf.message.Message'>,)
```

`google-cloud-sdk` vendors protobuf as `cloudsdk.google.protobuf`, but its vendored runtime could still import external `google._upb`. `PYTHONPATH` in the wrapper includes `protobuf` via `grpcio`, making external `google._upb` importable. This can mix vendored protobuf classes with the external protobuf runtime, causing the crash.

## Repro steps

```sh
$ nix build .#google-cloud-sdk
$ PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=upb ./result/bin/gcloud kms asymmetric-sign --help
ERROR: gcloud crashed (TypeError): A Message class can only inherit from Message, not (<class 'cloudsdk.google.protobuf.message.Message'>,)
```
`gcloud storage` also has the same issue:
```
$ PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=upb ./result/bin/gcloud storage ls --help
ERROR: gcloud crashed (CommandLoadFailure): Problem loading gcloud.storage.ls: A Message class can only inherit from Message, not (<class 'cloudsdk.google.protobuf.message.Message'>,).
```

The patch in this PR fixes the issue.

## Things done

This patch makes the vendored protobuf runtime look for C extensions only in the matching vendored namespace, so it falls back to its pure-Python vendored protobuf when no vendored extension exists. It also adds install checks for affected `gcloud` command paths.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
