### PR TITLE
singularityapp: init at 12.4.1

### DIFF
--- a/pkgs/by-name/si/singularityapp/package.nix
+++ b/pkgs/by-name/si/singularityapp/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  squashfsTools,
+  makeWrapper,
+  imagemagick,
+  electron,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "singularityapp";
+  version = "12.4.1";
+  revision = "141";
+
+  src = fetchurl {
+    url = "https://api.snapcraft.io/api/v1/snaps/download/MGxJGb96XBV8UshTS2iqLOI4ylXW8xwY_${finalAttrs.revision}.snap";
+    hash = "sha512-vKisK0y2pSxjwiGzfKkE/HxN0CaN6YIxynW8vYPBns1Z8mU9Ki9MYtgsh/oTzCW7KEM8GAMqjEU68x5ALGL+wQ==";
+  };
+
+  nativeBuildInputs = [
+    squashfsTools
+    makeWrapper
+    imagemagick
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    unsquashfs -dest squashfs-root "$src"
+
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/share/singularityapp"
+    cp -r squashfs-root/resources/app.asar squashfs-root/resources/app.asar.unpacked \
+      "$out/share/singularityapp/"
+
+    install -Dm644 squashfs-root/meta/gui/singularityapp.desktop \
+      "$out/share/applications/singularityapp.desktop"
+    substituteInPlace "$out/share/applications/singularityapp.desktop" \
+      --replace-fail 'Icon=''${SNAP}/meta/gui/icon.png' 'Icon=singularityapp'
+
+    # hicolor only indexes sizes up to 512x512; downscale the 1024px source.
+    for size in 16 32 48 64 128 256 512; do
+      dir="$out/share/icons/hicolor/''${size}x''${size}/apps"
+      mkdir -p "$dir"
+      magick squashfs-root/meta/gui/icon.png -resize "''${size}x''${size}" "$dir/singularityapp.png"
+    done
+
+    makeWrapper ${lib.getExe electron} "$out/bin/singularityapp" \
+      --add-flags "$out/share/singularityapp/app.asar" \
+      --set-default ELECTRON_OZONE_PLATFORM_HINT auto
+
+    runHook postInstall
+  '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "All-in-one productivity app: to-do list, calendar, planner, notepad, and habit tracker";
+    homepage = "https://singularity-app.com/";
+    downloadPage = "https://snapcraft.io/singularityapp";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    maintainers = with lib.maintainers; [ qweered ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "singularityapp";
+  };
+})

--- a/pkgs/by-name/si/singularityapp/package.nix
+++ b/pkgs/by-name/si/singularityapp/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  squashfs-tools,
+  makeWrapper,
+  imagemagick,
+  electron,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "singularityapp";
+  version = "12.4.1";
+  revision = "141";
+
+  src = fetchurl {
+    url = "https://api.snapcraft.io/api/v1/snaps/download/MGxJGb96XBV8UshTS2iqLOI4ylXW8xwY_${finalAttrs.revision}.snap";
+    hash = "sha512-vKisK0y2pSxjwiGzfKkE/HxN0CaN6YIxynW8vYPBns1Z8mU9Ki9MYtgsh/oTzCW7KEM8GAMqjEU68x5ALGL+wQ==";
+  };
+
+  nativeBuildInputs = [
+    squashfs-tools
+    makeWrapper
+    imagemagick
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    unsquashfs -dest squashfs-root "$src"
+
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/share/singularityapp"
+    cp -r squashfs-root/resources/app.asar squashfs-root/resources/app.asar.unpacked \
+      "$out/share/singularityapp/"
+
+    install -Dm644 squashfs-root/meta/gui/singularityapp.desktop \
+      "$out/share/applications/singularityapp.desktop"
+    substituteInPlace "$out/share/applications/singularityapp.desktop" \
+      --replace-fail 'Icon=''${SNAP}/meta/gui/icon.png' 'Icon=singularityapp'
+
+    # hicolor only indexes sizes up to 512x512; downscale the 1024px source.
+    for size in 16 32 48 64 128 256 512; do
+      dir="$out/share/icons/hicolor/''${size}x''${size}/apps"
+      mkdir -p "$dir"
+      magick squashfs-root/meta/gui/icon.png -resize "''${size}x''${size}" "$dir/singularityapp.png"
+    done
+
+    makeWrapper ${lib.getExe electron} "$out/bin/singularityapp" \
+      --add-flags "$out/share/singularityapp/app.asar" \
+      --set-default ELECTRON_OZONE_PLATFORM_HINT auto
+
+    runHook postInstall
+  '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "All-in-one productivity app: to-do list, calendar, planner, notepad, and habit tracker";
+    homepage = "https://singularity-app.com/";
+    downloadPage = "https://snapcraft.io/singularityapp";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    maintainers = with lib.maintainers; [ qweered ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "singularityapp";
+  };
+})

--- a/pkgs/by-name/si/singularityapp/update.sh
+++ b/pkgs/by-name/si/singularityapp/update.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash -p common-updater-scripts curl jq
+
+# SingularityApp only ships a snap for Linux. This queries the snapcraft API
+# for the latest version, revision and hash, then updates package.nix.
+#
+# The snap CDN keys downloads by an opaque `revision` (which forms the download
+# URL), whereas `version` is only for human consumption, so we update both.
+#
+# An optional argument selects the snapcraft channel (default `stable`); only
+# stable updates should be pushed to nixpkgs.
+
+set -eu -o pipefail
+
+channel="${1:-stable}"
+
+data=$(curl -fsS -H 'X-Ubuntu-Series: 16' \
+  "https://api.snapcraft.io/api/v1/snaps/details/singularityapp?channel=$channel&fields=download_sha512,revision,version")
+
+version=$(jq -r .version <<<"$data")
+revision=$(jq -r .revision <<<"$data")
+hash=$(nix-hash --to-sri --type sha512 "$(jq -r .download_sha512 <<<"$data")")
+
+attr="${UPDATE_NIX_ATTR_PATH:-singularityapp}"
+
+update-source-version "$attr" "$version" "$hash"
+update-source-version --ignore-same-hash --version-key=revision \
+  "$attr" "$revision" "$hash"


### PR DESCRIPTION
All-in-one productivity app (to-do list, calendar, planner, notepad, habit tracker). Upstream ships only a snap for Linux, so the app bundle (app.asar) is extracted from the snap squashfs and run against nixpkgs' electron. The app is pure JavaScript (no native node modules), so it is not tied to the Electron major (v35) it was built against.

Assisted-by: claude-code with claude-opus-4-8[1m]-high

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
