### PR TITLE
mlc: 3.9a -> 3.12, use requireFile

### DIFF
--- a/pkgs/by-name/ml/mlc/package.nix
+++ b/pkgs/by-name/ml/mlc/package.nix
@@ -1,16 +1,17 @@
 {
   lib,
   stdenv,
-  fetchurl,
   patchelf,
+  requireFile,
 }:
 stdenv.mkDerivation rec {
   pname = "mlc";
-  version = "3.9a";
+  version = "3.12";
 
-  src = fetchurl {
-    url = "https://downloadmirror.intel.com/736634/mlc_v${version}.tgz";
-    sha256 = "EDa5V56qCPQxgCu4eddYiWDrk7vkYS0jisnG004L+jQ=";
+  src = requireFile {
+    url = "https://www.intel.com/content/www/us/en/download/736633/intel-memory-latency-checker-intel-mlc.html";
+    sha256 = "4b8f7685d71998dd5d445432ab40c2115158462bfcd359113ae551a84e250c50";
+    name = "mlc_v${version}.tgz";
   };
 
   sourceRoot = "Linux";


### PR DESCRIPTION
Trying to download outside a browser yields an empty file, so automated download is no longer possible, it seems. Older versions are not available, so eventually this will fail.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
