### PR TITLE
libvlcpp: 0.1.0-unstable-2024-02-04 -> 0.1.0-unstable-2026-04-16

### DIFF
--- a/pkgs/by-name/li/libvlcpp/package.nix
+++ b/pkgs/by-name/li/libvlcpp/package.nix
@@ -2,26 +2,28 @@
   lib,
   stdenv,
   fetchFromGitLab,
-  autoreconfHook,
   pkg-config,
   libvlc,
+  meson,
+  ninja,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libvlcpp";
-  version = "0.1.0-unstable-2024-02-04";
+  version = "0.1.0-unstable-2026-04-16";
 
   src = fetchFromGitLab {
     domain = "code.videolan.org";
     owner = "videolan";
     repo = "libvlcpp";
-    rev = "44c1f48e56a66c3f418175af1e1ef3fd1ab1b118";
-    hash = "sha256-nnS4DMz/2VciCrhOBGRb1+kDbxj+ZOnEtQmzs/TJ870=";
+    rev = "33214afee13df36dc46309ef5416d681b56db5b9";
+    hash = "sha256-PjJzFrvkmrTsBjzmEG6hNU8VzDlofQrdfTGFhxkVPWU=";
   };
 
   nativeBuildInputs = [
+    meson
+    ninja
     pkg-config
-    autoreconfHook
   ];
 
   propagatedBuildInputs = [


### PR DESCRIPTION
## Things done

Update to latest master and switch to current build system.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
