### PR TITLE
tuicr: init at 0.18.0

### DIFF
--- a/pkgs/by-name/tu/tuicr/package.nix
+++ b/pkgs/by-name/tu/tuicr/package.nix
@@ -11,6 +11,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tuicr";
   version = "0.18.0";
 
+__structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "agavra";
     repo = "tuicr";
@@ -22,9 +24,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   strictDeps = true;
 
-  nativeCheckInputs = [
-    git
-  ];
+  nativeCheckInputs = [ git ];
 
   checkFlags = [
     # expects to be run inside the upstream git repository

--- a/pkgs/by-name/tu/tuicr/package.nix
+++ b/pkgs/by-name/tu/tuicr/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  openssl,
+  git,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tuicr";
+  version = "0.18.0";
+
+  src = fetchFromGitHub {
+    owner = "agavra";
+    repo = "tuicr";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-cMIUVBEtyS+AB9QqqRSu+Rd+9dyMzw+EmHSIzY2UmiQ=";
+  };
+
+  cargoHash = "sha256-ErEpUo9RPOHMHlmlPH2S6jHvnVhi4DKO7EnoMToj5t0=";
+
+  strictDeps = true;
+
+  nativeCheckInputs = [
+    git
+  ];
+
+  checkFlags = [
+    # expects to be run inside the upstream git repository
+    "--skip=should_return_no_changes_for_clean_repo"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Review AI-generated diffs like a GitHub pull request, right from your terminal";
+    homepage = "https://tuicr.dev";
+    changelog = "https://github.com/agavra/tuicr/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ Br1ght0ne ];
+    mainProgram = "tuicr";
+  };
+})

--- a/pkgs/by-name/tu/tuicr/package.nix
+++ b/pkgs/by-name/tu/tuicr/package.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tuicr";
   version = "0.18.0";
 
-__structuredAttrs = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "agavra";


### PR DESCRIPTION
https://github.com/agavra/tuicr - Review AI-generated diffs like a GitHub pull request, right from your terminal

Assisted-by: pi coding agent with kimi-k2.7-code


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
