### PR TITLE
sd: do not install workspace xtask helper

### DIFF
--- a/pkgs/by-name/sd/sd/package.nix
+++ b/pkgs/by-name/sd/sd/package.nix
@@ -18,6 +18,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-iOCIX7hq8RqRihVQrVoU2qCTSziuJePxsexkDSCZS9c=";
 
+  # Only build the CLI; the workspace also has a build-only `xtask` helper.
+  cargoBuildFlags = [ "--package=sd-cli" ];
+  cargoTestFlags = [ "--package=sd-cli" ];
+
   nativeBuildInputs = [ installShellFiles ];
 
   postInstall = ''


### PR DESCRIPTION
## Summary

`sd` 1.1.0 is a Cargo workspace that includes both the CLI (`sd-cli`, installs as `sd`) and an internal build helper (`xtask`). Building the full workspace installed `xtask` into `$out/bin`, which is not meant for end users.

Restrict `cargoBuildFlags` / `cargoTestFlags` to `--package=sd-cli` so only the intended binary is built and installed. Man pages and shell completions continue to come from the committed `gen/` tree.

Resolves #512682

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

### Verification

```console
$ ls result/bin/
sd
$ result/bin/sd --version
sd 1.0.0
$ echo "hello world" | result/bin/sd world nix
hello nix
```

Build also ran the package's cargo tests (22 passed, 1 ignored).

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test