### PR TITLE
transmission_4-qt*: build only against latest Qt version

### DIFF
--- a/pkgs/by-name/tr/transmission_4-gtk/package.nix
+++ b/pkgs/by-name/tr/transmission_4-gtk/package.nix
@@ -1,3 +1,3 @@
 { transmission_4 }:
 
-transmission_4.override { enableGTK4 = true; }
+transmission_4.override { enableGTK = true; }

--- a/pkgs/by-name/tr/transmission_4-qt/package.nix
+++ b/pkgs/by-name/tr/transmission_4-qt/package.nix
@@ -1,0 +1,3 @@
+{ transmission_4 }:
+
+transmission_4.override { enableQt = true; }

--- a/pkgs/by-name/tr/transmission_4-qt5/package.nix
+++ b/pkgs/by-name/tr/transmission_4-qt5/package.nix
@@ -1,3 +1,0 @@
-{ transmission_4 }:
-
-transmission_4.override { enableQt5 = true; }

--- a/pkgs/by-name/tr/transmission_4-qt6/package.nix
+++ b/pkgs/by-name/tr/transmission_4-qt6/package.nix
@@ -1,3 +1,0 @@
-{ transmission_4 }:
-
-transmission_4.override { enableQt6 = true; }

--- a/pkgs/by-name/tr/transmission_4/package.nix
+++ b/pkgs/by-name/tr/transmission_4/package.nix
@@ -29,10 +29,8 @@
   libpthread-stubs,
   libayatana-appindicator,
   wrapGAppsHook4,
-  enableQt5 ? false,
-  enableQt6 ? false,
+  enableQt ? false,
   enableMac ? false,
-  qt5,
   qt6Packages,
   nixosTests,
   enableSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
@@ -100,7 +98,7 @@ stdenv.mkDerivation (finalAttrs: {
     (cmakeBool "ENABLE_DAEMON" enableDaemon)
     (cmakeBool "ENABLE_GTK" enableGTK4)
     (cmakeBool "ENABLE_MAC" enableMac)
-    (cmakeBool "ENABLE_QT" (enableQt5 || enableQt6))
+    (cmakeBool "ENABLE_QT" enableQt)
     (cmakeBool "INSTALL_LIB" installLib)
     (cmakeBool "RUN_CLANG_TIDY" false)
   ]
@@ -132,7 +130,7 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace CMakeLists.txt \
       --replace-fail 'find_package(UtfCpp)' 'find_package(utf8cpp)'
   ''
-  + optionalString (stdenv.hostPlatform.isDarwin && (enableQt5 || enableQt6)) ''
+  + optionalString (stdenv.hostPlatform.isDarwin && enableQt) ''
     substituteInPlace qt/CMakeLists.txt \
       --replace-fail \
         'transmission::qt_impl)' \
@@ -145,8 +143,7 @@ stdenv.mkDerivation (finalAttrs: {
     python3
   ]
   ++ optionals enableGTK4 [ wrapGAppsHook4 ]
-  ++ optionals enableQt5 [ qt5.wrapQtAppsHook ]
-  ++ optionals enableQt6 [ qt6Packages.wrapQtAppsHook ]
+  ++ optionals enableQt [ qt6Packages.wrapQtAppsHook ]
   ++ optionals enableMac [
     ibtool
     actool
@@ -171,14 +168,7 @@ stdenv.mkDerivation (finalAttrs: {
     utf8cpp
     zlib
   ]
-  ++ optionals enableQt5 (
-    with qt5;
-    [
-      qttools
-      qtbase
-    ]
-  )
-  ++ optionals enableQt6 (
+  ++ optionals enableQt (
     with qt6Packages;
     [
       qttools
@@ -230,7 +220,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Fast, easy and free BitTorrent client";
     mainProgram =
-      if (enableQt5 || enableQt6) then
+      if enableQt then
         "transmission-qt"
       else if enableGTK4 then
         "transmission-gtk"

--- a/pkgs/by-name/tr/transmission_4/package.nix
+++ b/pkgs/by-name/tr/transmission_4/package.nix
@@ -24,7 +24,7 @@
   dht,
   libnatpmp,
   # Build options
-  enableGTK4 ? false,
+  enableGTK ? false,
   gtkmm4,
   libpthread-stubs,
   libayatana-appindicator,
@@ -96,7 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (cmakeBool "ENABLE_CLI" enableCli)
     (cmakeBool "ENABLE_DAEMON" enableDaemon)
-    (cmakeBool "ENABLE_GTK" enableGTK4)
+    (cmakeBool "ENABLE_GTK" enableGTK)
     (cmakeBool "ENABLE_MAC" enableMac)
     (cmakeBool "ENABLE_QT" enableQt)
     (cmakeBool "INSTALL_LIB" installLib)
@@ -142,7 +142,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     python3
   ]
-  ++ optionals enableGTK4 [ wrapGAppsHook4 ]
+  ++ optionals enableGTK [ wrapGAppsHook4 ]
   ++ optionals enableQt [ qt6Packages.wrapQtAppsHook ]
   ++ optionals enableMac [
     ibtool
@@ -176,7 +176,7 @@ stdenv.mkDerivation (finalAttrs: {
       qtsvg
     ]
   )
-  ++ optionals enableGTK4 [
+  ++ optionals enableGTK [
     gtkmm4
     libpthread-stubs
     libayatana-appindicator
@@ -222,7 +222,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram =
       if enableQt then
         "transmission-qt"
-      else if enableGTK4 then
+      else if enableGTK then
         "transmission-gtk"
       else if enableMac then
         "transmission-mac"

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -2233,7 +2233,8 @@ mapAliases {
   transmission_3-gtk = throw "transmission_3-gtk has been removed in favour of transmission_4-gtk. Note that upgrade caused data loss for some users so backup is recommended (see NixOS 24.11 release notes for details)"; # Added 2025-10-26
   transmission_3-qt = throw "transmission_3-qt has been removed in favour of transmission_4-qt. Note that upgrade caused data loss for some users so backup is recommended (see NixOS 24.11 release notes for details)"; # Added 2025-10-26
   transmission_3_noSystemd = throw "transmission_3_noSystemd has been removed in favour of transmission_4. Note that upgrade caused data loss for some users so backup is recommended (see NixOS 24.11 release notes for details)"; # Added 2025-10-26
-  transmission_4-qt = transmission_4-qt5; # Added 2026-06-05
+  transmission_4-qt5 = lib.warnOnInstantiate "'transmission_4-qt5' has been removed in favour of 'transmission_4-qt'" transmission_4-qt; # Added 2026-06-25
+  transmission_4-qt6 = lib.warnOnInstantiate "'transmission_4-qt6' has been renamed to 'transmission_4-qt'" transmission_4-qt; # Added 2026-06-25
   travis = throw "'travis' has been removed because upstream has stopped maintaining it, and it contains dependencies with security vulnerabilities."; # Added 2026-02-14
   treefmt2 = throw "'treefmt2' has been renamed to/replaced by 'treefmt'"; # Converted to throw 2025-10-27
   tremor-language-server = throw "'tremor-language-server' has been removed because it is unmaintained"; # Added 2025-11-17


### PR DESCRIPTION
This is a continuation of #530986, where it was decided to maintain only only one GTK build.
This applies the same logic to the -qt{5,6} variants.

Hence, the -qt5 variant is dropped, and the -qt6 variant is renamed to simply -qt, for consistency and simplicity.

Appropriate aliases are provided to help users with the transition.

Finally, a minor stylistic fix is applied to the GTK build, leftover of the aforementioned PR.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
