### PR TITLE
[release-26.05] pretix: 2026.4.3 -> 2026.4.4

### DIFF
--- a/pkgs/by-name/pr/pretix/package.nix
+++ b/pkgs/by-name/pr/pretix/package.nix
@@ -51,13 +51,13 @@ let
   };
 
   pname = "pretix";
-  version = "2026.4.3";
+  version = "2026.4.4";
 
   src = fetchFromGitHub {
     owner = "pretix";
     repo = "pretix";
     tag = "v${version}";
-    hash = "sha256-fzM6WlqXH+ehPxHsvzNeM21Vupj0GBYXhFL0tpBp1uY=";
+    hash = "sha256-aDOI2XZF0n653ZgTtgEOb+JL/R0zDsdHOFvBsQdbwRw=";
   };
 
   npmDeps = buildNpmPackage {

--- a/pkgs/by-name/pr/pretix/plugins/mollie/package.nix
+++ b/pkgs/by-name/pr/pretix/plugins/mollie/package.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "pretix-mollie";
-  version = "2.5.5";
+  version = "2.5.6";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pretix";
     repo = "pretix-mollie";
     tag = "v${version}";
-    hash = "sha256-EqitdAoTm6mpXp8g2HftvxRbg+6gXxR7xUsC+aYfv8U=";
+    hash = "sha256-XInwUecuC3sEcRpuS+xa7Gb2Isb18SexbZ2+CcUF7/E=";
   };
 
   build-system = [

--- a/pkgs/by-name/pr/pretix/plugins/mollie/package.nix
+++ b/pkgs/by-name/pr/pretix/plugins/mollie/package.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "pretix-mollie";
-  version = "2.5.4";
+  version = "2.5.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pretix";
     repo = "pretix-mollie";
     tag = "v${version}";
-    hash = "sha256-lDICcpO8Qod++eM2okq4CJirIBM18zYnbM6Bbwb9e34=";
+    hash = "sha256-EqitdAoTm6mpXp8g2HftvxRbg+6gXxR7xUsC+aYfv8U=";
   };
 
   build-system = [

--- a/pkgs/by-name/pr/pretix/plugins/pages/package.nix
+++ b/pkgs/by-name/pr/pretix/plugins/pages/package.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "pretix-pages";
-  version = "1.6.3";
+  version = "1.6.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pretix";
     repo = "pretix-pages";
     rev = "v${version}";
-    hash = "sha256-ZM38zHlFB5013PvoJwm7YC5/wHg2GZWmrhvreXuqNc8=";
+    hash = "sha256-whpO8aE0VUSrByf3P0JaIoruYbJi8wj4nZo/2tx+XLU=";
   };
 
   build-system = [


### PR DESCRIPTION
https://pretix.eu/about/en/blog/20260625-release-2026-5-2/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
