### PR TITLE
nsd: 4.12.0 -> 4.14.3

### DIFF
--- a/pkgs/by-name/ns/nsd/package.nix
+++ b/pkgs/by-name/ns/nsd/package.nix
@@ -2,9 +2,12 @@
   lib,
   stdenv,
   fetchurl,
+  fstrm,
   libevent,
   openssl,
   pkg-config,
+  protobuf,
+  protobufc,
   systemdMinimal,
   nixosTests,
   config,
@@ -14,37 +17,42 @@
   bind8Stats ? config.nsd.bind8Stats or false,
   checking ? config.nsd.checking or false,
   ipv6 ? config.nsd.ipv6 or true,
-  mmap ? config.nsd.mmap or false,
   minimalResponses ? config.nsd.minimalResponses or true,
+  mmap ? config.nsd.mmap or false,
   nsec3 ? config.nsd.nsec3 or true,
   ratelimit ? config.nsd.ratelimit or false,
   recvmmsg ? config.nsd.recvmmsg or false,
   rootServer ? config.nsd.rootServer or false,
   rrtypes ? config.nsd.rrtypes or false,
   zoneStats ? config.nsd.zoneStats or false,
+  withDnstap ? true,
   withSystemd ? config.nsd.withSystemd or (lib.meta.availableOn stdenv.hostPlatform systemdMinimal),
   configFile ? config.nsd.configFile or "/etc/nsd/nsd.conf",
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nsd";
-  version = "4.12.0";
+  version = "4.14.3";
 
   src = fetchurl {
     url = "https://www.nlnetlabs.nl/downloads/nsd/nsd-${finalAttrs.version}.tar.gz";
-    hash = "sha256-+ezCz3m6UFgPLfYpGO/EQAhMW/EQV9tEwZqpZDzUteg=";
+    hash = "sha256-limtZNnBsBm74iKW1RSNeuZfWIziZaZCR1B0DwUrsSs=";
   };
 
   nativeBuildInputs = [
     pkg-config
-  ];
+  ]
+  ++ lib.optionals withDnstap [ protobuf ];
 
   buildInputs = [
     libevent
     openssl
   ]
-  ++ lib.optionals withSystemd [
-    systemdMinimal
+  ++ lib.optionals withSystemd [ systemdMinimal ]
+  ++ lib.optionals withDnstap [
+    fstrm
+    # NSD links against libprotobuf-c, it's not just a build-time dependency.
+    protobufc
   ];
 
   enableParallelBuilding = true;
@@ -73,6 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ edf rootServer "root-server"
     ++ edf rrtypes "draft-rrtypes"
     ++ edf zoneStats "zone-stats"
+    ++ edf withDnstap "dnstap"
     ++ edf withSystemd "systemd"
     ++ [
       "--with-ssl=${openssl.dev}"


### PR DESCRIPTION
We were severely behind on NSD, update to the latest version. [Changelog](https://github.com/NLnetLabs/nsd/releases/tag/NSD_4_14_3_REL). 4.14.3 is a security release that fixes 4 CVEs, but all of them were introduced after 4.12.0, so to my knowledge there are no known security issues with the previous packaged version, so landing this change is not security-sensitive.

Upstream added a new configure option, `--enable-dnstap`, which is enabled by default, so I enabled it by default here too. I didn't tie it to a NixOS configuration setting because I don't personally use that part and there is a todo about it, so let’s minimize the change surface.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. — This version is currently serving DNS for all my personal domains.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy]. Zero AI used in this PR.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
