### PR TITLE
lumen: init at 2.30.0

### DIFF
--- a/pkgs/by-name/lu/lumen/package.nix
+++ b/pkgs/by-name/lu/lumen/package.nix
@@ -37,8 +37,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   meta = {
-    description = "A fast terminal diff viewer and code review TUI";
+    description = "Fast terminal diff viewer and code review TUI";
     homepage = "https://github.com/jnsahaj/lumen";
+    changelog = "https://github.com/jnsahaj/lumen/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ Br1ght0ne ];
     mainProgram = "lumen";

--- a/pkgs/by-name/lu/lumen/package.nix
+++ b/pkgs/by-name/lu/lumen/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "lumen";
+  version = "2.30.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "jnsahaj";
+    repo = "lumen";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-EoxMYlWHmuprjjhvj3GyCxGDIcT/d+JMda9j75pqs+k=";
+  };
+
+  cargoHash = "sha256-qTFRfy+Wutee5SbaMaqcYjXgr6xZKYYBIuyVA7jAGiY=";
+
+  strictDeps = true;
+
+  # use the non-vendored openssl
+  env.OPENSSL_NO_VENDOR = 1;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ];
+
+  # tests that require a git repository to run
+  checkFlags = [
+    "--skip=vcs::git::tests::test_get_merge_base_returns_ancestor"
+    "--skip=vcs::git::tests::test_working_copy_parent_ref_returns_head"
+  ];
+
+  meta = {
+    description = "A fast terminal diff viewer and code review TUI";
+    homepage = "https://github.com/jnsahaj/lumen";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ Br1ght0ne ];
+    mainProgram = "lumen";
+  };
+})


### PR DESCRIPTION
https://github.com/jnsahaj/lumen

Assisted-by: pi coding agent with kimi-k2.7-code


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
