### PR TITLE
wasmtime: 45.0.2 -> 46.0.1, python3Packages.wasmtime: 45.0.0 -> 46.0.1

### DIFF
--- a/pkgs/by-name/wa/wasmtime/package.nix
+++ b/pkgs/by-name/wa/wasmtime/package.nix
@@ -10,22 +10,22 @@
   nix-update-script,
   enableShared ? !stdenv.hostPlatform.isStatic,
   enableStatic ? stdenv.hostPlatform.isStatic,
-  majorVersion ? "46",
+  variant ? "main",
 }:
 let
   sources = {
-    "36" = {
+    lts-36 = {
       version = "36.0.11";
       hash = "sha256-rrSI2dSOA8/1CL7JhW0eQ7LaeS5EqTVnyn2HTI+/x20=";
       cargoHash = "sha256-S67/fv7179uDy4PpwycyXSWAknIC/7ZzvzWPOd6MD+8=";
     };
-    "46" = {
+    main = {
       version = "46.0.1";
       hash = "sha256-rPIO+wQSu5KWT/v3Wbjs29p5Aoqpnpb+TwSTT5CRb6U=";
       cargoHash = "sha256-cJD5iq342giBP+YdTem0/nOsMhI7DKRL4iiai5xayv8=";
     };
   };
-  source = sources.${majorVersion};
+  source = sources.${variant};
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "wasmtime";

--- a/pkgs/by-name/wa/wasmtime/package.nix
+++ b/pkgs/by-name/wa/wasmtime/package.nix
@@ -56,6 +56,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "lib"
   ];
 
+  __structuredAttrs = true;
+
   nativeBuildInputs = [
     cmake
     installShellFiles

--- a/pkgs/by-name/wa/wasmtime/package.nix
+++ b/pkgs/by-name/wa/wasmtime/package.nix
@@ -123,10 +123,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Standalone JIT-style runtime for WebAssembly, using Cranelift";
     homepage = "https://wasmtime.dev/";
-    license = [
-      lib.licenses.asl20
-      lib.licenses.llvm-exception
-    ];
+    license = lib.licenses.WITH lib.licenses.asl20 lib.licenses.llvm-exception;
     mainProgram = "wasmtime";
     maintainers = with lib.maintainers; [
       ereslibre

--- a/pkgs/by-name/wa/wasmtime/package.nix
+++ b/pkgs/by-name/wa/wasmtime/package.nix
@@ -10,7 +10,7 @@
   nix-update-script,
   enableShared ? !stdenv.hostPlatform.isStatic,
   enableStatic ? stdenv.hostPlatform.isStatic,
-  majorVersion ? "45",
+  majorVersion ? "46",
 }:
 let
   sources = {
@@ -19,11 +19,10 @@ let
       hash = "sha256-rrSI2dSOA8/1CL7JhW0eQ7LaeS5EqTVnyn2HTI+/x20=";
       cargoHash = "sha256-S67/fv7179uDy4PpwycyXSWAknIC/7ZzvzWPOd6MD+8=";
     };
-    "45" = {
-
-      version = "45.0.2";
-      hash = "sha256-LEQitwz+UDSX4mrjEecmoO/ZPgRnYTZ3DsD1pu8Jybs=";
-      cargoHash = "sha256-uTgEW2w0RSMetd2W1ucGiVMEEvz2A7CQ79SEsE8/+BM=";
+    "46" = {
+      version = "46.0.1";
+      hash = "sha256-rPIO+wQSu5KWT/v3Wbjs29p5Aoqpnpb+TwSTT5CRb6U=";
+      cargoHash = "sha256-cJD5iq342giBP+YdTem0/nOsMhI7DKRL4iiai5xayv8=";
     };
   };
   source = sources.${majorVersion};

--- a/pkgs/by-name/wa/wasmtime_36/package.nix
+++ b/pkgs/by-name/wa/wasmtime_36/package.nix
@@ -4,7 +4,7 @@
 }:
 
 # NOTE: LTS Version EOL August 20 2027
-(wasmtime.override { majorVersion = "36"; }).overrideAttrs (old: {
+(wasmtime.override { variant = "lts-36"; }).overrideAttrs (old: {
   __structuredAttrs = true;
 
   passthru = old.passthru // {

--- a/pkgs/by-name/wa/wasmtime_36/package.nix
+++ b/pkgs/by-name/wa/wasmtime_36/package.nix
@@ -5,8 +5,6 @@
 
 # NOTE: LTS Version EOL August 20 2027
 (wasmtime.override { variant = "lts-36"; }).overrideAttrs (old: {
-  __structuredAttrs = true;
-
   passthru = old.passthru // {
     updateScript = nix-update-script {
       extraArgs = [

--- a/pkgs/development/python-modules/wasmtime/default.nix
+++ b/pkgs/development/python-modules/wasmtime/default.nix
@@ -18,14 +18,14 @@ let
 in
 buildPythonPackage (finalAttrs: {
   pname = "wasmtime";
-  version = "45.0.0";
+  version = "46.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "bytecodealliance";
     repo = "wasmtime-py";
     tag = finalAttrs.version;
-    hash = "sha256-XlAWPJB34uE+hbEMGZ46Ll6kXP+/lZ2amTKdjslGrP4=";
+    hash = "sha256-PWMrmr9PPi98lQe5+KaY4bPLOYyJ5qYugMJwVwwnuwA=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/wasmtime/default.nix
+++ b/pkgs/development/python-modules/wasmtime/default.nix
@@ -84,10 +84,7 @@ buildPythonPackage (finalAttrs: {
     description = "Python WebAssembly runtime powered by Wasmtime";
     homepage = "https://github.com/bytecodealliance/wasmtime-py";
     changelog = "https://github.com/bytecodealliance/wasmtime-py/releases/tag/${finalAttrs.src.tag}";
-    license = [
-      lib.licenses.asl20
-      lib.licenses.llvm-exception
-    ];
+    license = lib.licenses.WITH lib.licenses.asl20 lib.licenses.llvm-exception;
     maintainers = with lib.maintainers; [ fab ];
   };
 })

--- a/pkgs/development/python-modules/wasmtime/default.nix
+++ b/pkgs/development/python-modules/wasmtime/default.nix
@@ -85,6 +85,6 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://github.com/bytecodealliance/wasmtime-py";
     changelog = "https://github.com/bytecodealliance/wasmtime-py/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.WITH lib.licenses.asl20 lib.licenses.llvm-exception;
-    maintainers = with lib.maintainers; [ fab ];
+    maintainers = [ lib.maintainers.fab ] ++ pkgs.wasmtime.meta.maintainers;
   };
 })


### PR DESCRIPTION
I split out a few more changes into separate commits:
- rename the majorVersion so we don't need to manually bump "45"->"46"->"47", etc.
- use structuredAttrs for both main &  LTS variant introduced in #534075 
- make use of the new compound licenses introduced in #468378
- adding wasmtime maintainers to the python bindings package, so we can merge-bot it ourselves when that's available

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
