### PR TITLE
maturinBuildHook: respect dontStrip when calling hook

### DIFF
--- a/pkgs/build-support/rust/hooks/maturin-build-hook.sh
+++ b/pkgs/build-support/rust/hooks/maturin-build-hook.sh
@@ -22,10 +22,13 @@ maturinBuildHook() {
         "--offline"
         "--target" "@rustcTargetSpec@"
         "--manylinux" "off"
-        "--strip"
         "--out" "$dist"
         "--interpreter" "$interpreter_name"
     )
+
+    if [ -z "${dontStrip-}" ]; then
+      flagsArray+=("--strip")
+    fi
 
     if [ -n "${maturinBuildProfile}" ]; then
       flagsArray+=("--profile" "${maturinBuildProfile}")


### PR DESCRIPTION
This PR makes it so that using `dontStrip = true;` in a derivation using `maturinBuildHook` also drops the `--strip` flag used by maturin. Most of the time this is undesirable, however with #462746, maturin *always* uses library mode to generate uniffi bindings. This is a problem, as `--strip` will strip the library before uniffi can generate any bindings, so in this case we have to drop the flag. So far I've only found 1 package this behaviour breaks, `glean-sdk`, which is addressed in #541224

Of course `dontStrip = true;` implies some other things, so if a better implementation is already available and I missed it or anyone has an idea, I'd be happy to hear it! Had an idea for like a `maturinExcludeFlags` but not sure how to make that :D

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
