### PR TITLE
nixos/treewide: use security.pam.pam_unixModulePath everywhere

### DIFF
--- a/nixos/modules/services/display-managers/gdm.nix
+++ b/nixos/modules/services/display-managers/gdm.nix
@@ -421,7 +421,7 @@ in
             {
               name = "unix";
               control = "sufficient";
-              modulePath = "${config.security.pam.package}/lib/security/pam_unix.so";
+              modulePath = config.security.pam.pam_unixModulePath;
             }
           ];
 
@@ -567,7 +567,7 @@ in
             {
               name = "unix";
               control = "sufficient";
-              modulePath = "${config.security.pam.package}/lib/security/pam_unix.so";
+              modulePath = config.security.pam.pam_unixModulePath;
             }
           ];
 
@@ -575,7 +575,7 @@ in
             {
               name = "unix";
               control = "requisite";
-              modulePath = "${config.security.pam.package}/lib/security/pam_unix.so";
+              modulePath = config.security.pam.pam_unixModulePath;
               settings.nullok = true;
               settings.yescrypt = true;
             }

--- a/nixos/modules/services/display-managers/plasma-login-manager.nix
+++ b/nixos/modules/services/display-managers/plasma-login-manager.nix
@@ -201,7 +201,7 @@ in
               # Setup session
               name = "unix";
               control = "required";
-              modulePath = "${config.security.pam.package}/lib/security/pam_unix.so";
+              modulePath = config.security.pam.pam_unixModulePath;
             }
             {
               name = "systemd";

--- a/nixos/modules/services/display-managers/sddm.nix
+++ b/nixos/modules/services/display-managers/sddm.nix
@@ -442,7 +442,7 @@ in
             {
               name = "unix";
               control = "sufficient";
-              modulePath = "${config.security.pam.package}/lib/security/pam_unix.so";
+              modulePath = config.security.pam.pam_unixModulePath;
             }
           ];
 

--- a/nixos/modules/services/ttys/kmscon.nix
+++ b/nixos/modules/services/ttys/kmscon.nix
@@ -214,7 +214,7 @@ in
           {
             name = "unix";
             control = "required";
-            modulePath = "${config.security.pam.package}/lib/security/pam_unix.so";
+            modulePath = config.security.pam.pam_unixModulePath;
           }
         ];
         session = utils.pam.autoOrderRules [
@@ -230,7 +230,7 @@ in
           {
             name = "unix";
             control = "required";
-            modulePath = "${config.security.pam.package}/lib/security/pam_unix.so";
+            modulePath = config.security.pam.pam_unixModulePath;
           }
           {
             name = "systemd";

--- a/nixos/modules/services/wayland/cage.nix
+++ b/nixos/modules/services/wayland/cage.nix
@@ -113,7 +113,7 @@ in
           {
             name = "unix";
             control = "required";
-            modulePath = "${config.security.pam.package}/lib/security/pam_unix.so";
+            modulePath = config.security.pam.pam_unixModulePath;
             settings.nullok = true;
           }
         ];
@@ -121,14 +121,14 @@ in
           {
             name = "unix";
             control = "required";
-            modulePath = "${config.security.pam.package}/lib/security/pam_unix.so";
+            modulePath = config.security.pam.pam_unixModulePath;
           }
         ];
         session = utils.pam.autoOrderRules [
           {
             name = "unix";
             control = "required";
-            modulePath = "${config.security.pam.package}/lib/security/pam_unix.so";
+            modulePath = config.security.pam.pam_unixModulePath;
           }
           {
             name = "env";

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -362,7 +362,7 @@ in
           {
             name = "unix";
             control = "sufficient";
-            modulePath = "${config.security.pam.package}/lib/security/pam_unix.so";
+            modulePath = config.security.pam.pam_unixModulePath;
           }
         ];
 
@@ -446,7 +446,7 @@ in
           {
             name = "unix";
             control = "sufficient";
-            modulePath = "${config.security.pam.package}/lib/security/pam_unix.so";
+            modulePath = config.security.pam.pam_unixModulePath;
           }
         ];
 
@@ -454,7 +454,7 @@ in
           {
             name = "unix";
             control = "requisite";
-            modulePath = "${config.security.pam.package}/lib/security/pam_unix.so";
+            modulePath = config.security.pam.pam_unixModulePath;
             settings.nullok = true;
             settings.yescrypt = true;
           }


### PR DESCRIPTION
overlooked in #453557

This allows using `account-utils` on graphical desktop setups.

<details><summary>Tested with the following patch to enable account-utils in the relevant nixos tests</summary>
<p>

```patch
diff --git a/nixos/tests/cage.nix b/nixos/tests/cage.nix
index fa0c8125862d..18f5ab3c95ea 100644
--- a/nixos/tests/cage.nix
+++ b/nixos/tests/cage.nix
@@ -14,6 +14,8 @@
 
       fonts.packages = with pkgs; [ dejavu_fonts ];
 
+      security.account-utils.enable = true;
+
       services.cage = {
         enable = true;
         user = "alice";
diff --git a/nixos/tests/gnome.nix b/nixos/tests/gnome.nix
index 41dfdf43f79c..8ddfe2a4cae7 100644
--- a/nixos/tests/gnome.nix
+++ b/nixos/tests/gnome.nix
@@ -14,6 +14,8 @@
         debug = true;
       };
 
+      security.account-utils.enable = true;
+
       services.displayManager.autoLogin = {
         enable = true;
         user = "alice";
diff --git a/nixos/tests/kmscon.nix b/nixos/tests/kmscon.nix
index 130db8f0bc4a..c3e8e7175ab5 100644
--- a/nixos/tests/kmscon.nix
+++ b/nixos/tests/kmscon.nix
@@ -16,6 +16,8 @@
 
       hardware.graphics.enable = true;
 
+      security.account-utils.enable = true;
+
       fonts = {
         fontconfig.enable = true;
         packages = [ pkgs.nerd-fonts.jetbrains-mono ];
diff --git a/nixos/tests/lightdm.nix b/nixos/tests/lightdm.nix
index f561f89df221..8dbc6a28db1c 100644
--- a/nixos/tests/lightdm.nix
+++ b/nixos/tests/lightdm.nix
@@ -13,6 +13,7 @@
       services.xserver.displayManager.lightdm.enable = true;
       services.displayManager.defaultSession = "none+icewm";
       services.xserver.windowManager.icewm.enable = true;
+      security.account-utils.enable = true;
     };
 
   enableOCR = true;
diff --git a/nixos/tests/plasma6.nix b/nixos/tests/plasma6.nix
index 330dea78edcf..cce641a4efd0 100644
--- a/nixos/tests/plasma6.nix
+++ b/nixos/tests/plasma6.nix
@@ -11,6 +11,7 @@
 
     {
       imports = [ ./common/user-account.nix ];
+      security.account-utils.enable = true;
       services.xserver.enable = true;
       services.displayManager.plasma-login-manager.enable = true;
       # FIXME: this should be testing Wayland
diff --git a/nixos/tests/sddm.nix b/nixos/tests/sddm.nix
index ad51e63570e9..65399f64ba11 100644
--- a/nixos/tests/sddm.nix
+++ b/nixos/tests/sddm.nix
@@ -9,6 +9,7 @@
       services.displayManager.sddm.enable = true;
       services.displayManager.defaultSession = "none+icewm";
       services.xserver.windowManager.icewm.enable = true;
+      security.account-utils.enable = true;
     };
 
     enableOCR = true;

```

</p>
</details> 

Replace done using ripgrep + sed:
```
rg pam_unix.so -l | xargs sed -i -e 's@"${config.security.pam.package}/lib/security/pam_unix.so"@config.security.pam.pam_unixModulePath@g'
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
