### PR TITLE
nixos/zfs: add snapshot before activation option

### DIFF
--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -18,6 +18,7 @@ let
   cfgScrub = config.services.zfs.autoScrub;
   cfgTrim = config.services.zfs.trim;
   cfgZED = config.services.zfs.zed;
+  cfgSBA = config.services.zfs.snapshotBeforeActivation;
 
   selectModulePackage = package: config.boot.kernelPackages.${package.kernelModuleAttribute};
   clevisDatasets = lib.attrNames (
@@ -262,6 +263,20 @@ let
           lib.err "this value is" (toString v);
     } "=";
   } cfgZED.settings;
+
+  datasetsSBA =
+    if cfgSBA.datasets != null then
+      cfgSBA.datasets
+    else
+      (lib.listToAttrs (
+        map (
+          n:
+          lib.nameValuePair n {
+            name = n;
+            recursive = null;
+          }
+        ) allPools
+      ));
 in
 
 {
@@ -657,6 +672,94 @@ in
           {manpage}`zed(8)`
           for details on ZED and the scripts in /etc/zfs/zed.d to find the possible variables
         '';
+      };
+    };
+
+    services.zfs.snapshotBeforeActivation = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        description = ''
+          Take a snapshot of all datasets before activation.
+
+          If taking a snapshot failed, the activation will be aborted.
+        '';
+        default = false;
+      };
+
+      template = lib.mkOption {
+        type = lib.types.str;
+        description = ''
+          Bash command to generate the snapshot name. $1 is the path to the new generation.
+
+          The default will produce a snapshot name like so:
+
+          ```text
+          pre-260625T071305-96vzsj6qmcpk4jhaqp24d60kvif92bai-nixos-system-hostname-26.11pre
+          ```
+        '';
+        default = ''pre-$(date --utc '+%y%m%dT%H%M%S')-$(basename "$1")'';
+      };
+
+      datasets = lib.mkOption {
+        type = lib.types.nullOr (
+          lib.types.attrsOf (
+            lib.types.submodule (
+              { name, ... }:
+              {
+                options = {
+                  name = lib.mkOption {
+                    type = lib.types.str;
+                    description = ''
+                      Dataset name.
+
+                      By default, the attr name.
+                    '';
+                    example = "root/home";
+                    default = name;
+                  };
+
+                  recursive = lib.mkOption {
+                    type = lib.types.nullOr lib.types.bool;
+                    description = ''
+                      Sets whether or not to take a recursive snapshot of this dataset.
+
+                      If set to null, the default, then takes the value from the global
+                      `services.zfs.snapshotBeforeActivation.recursive` option.
+                    '';
+                    default = null;
+                  };
+                };
+              }
+            )
+          )
+        );
+        default = null;
+        example = {
+          "root/home" = { };
+          "root/var" = {
+            recursive = true;
+          };
+        };
+        description = ''
+          Defines all datasets to take a snapshot of.
+
+          If set to `null`, the default, uses all identified pools.
+
+          The snapshots are not recursive unless specificed in the `services.zfs.snapshotBeforeActivation.recursive` option,
+          which can also be overriden per dataset.
+        '';
+      };
+
+      recursive = lib.mkOption {
+        type = lib.types.bool;
+        description = ''
+          Sets whether or not to take a recursive snapshot of the datasets.
+
+          This sets the default and each dataset can override this value with the
+          `services.zfs.snapshotBeforeActivation.datasets.<name>.recursive` option.
+        '';
+        default = false;
+        example = true;
       };
     };
   };
@@ -1107,6 +1210,26 @@ in
         Persistent = lib.mkDefault "yes";
         RandomizedDelaySec = cfgTrim.randomizedDelaySec;
       };
+    })
+
+    (lib.mkIf (cfgZfs.enabled && cfgSBA.enable) {
+      system.preSwitchChecks."shb-zfs-snapshot" = (
+        ''
+          snapshot="${cfgSBA.template}"
+        ''
+        + (lib.concatMapStringsSep "\n" (
+          ds:
+          let
+            recursiveFlag = lib.optionalString (
+              if ds.recursive != null then ds.recursive else cfgSBA.recursive
+            ) "-r";
+          in
+          ''
+            echo "Taking ZFS snapshot {ds}@$snapshot"
+            zfs snapshot ${recursiveFlag} ${ds.name}@"$snapshot"
+          ''
+        ) (lib.attrValues datasetsSBA))
+      );
     })
   ];
 }

--- a/nixos/tests/zfs.nix
+++ b/nixos/tests/zfs.nix
@@ -314,4 +314,157 @@ in
           exit(1)
       '';
   };
+
+  snapshot-before-activation = runTest {
+    name = "snapshot-before-activation";
+    nodes = {
+      machine =
+        { pkgs, lib, ... }:
+        {
+          networking.hostId = "deadbeef";
+          boot.supportedFilesystems = [ "zfs" ];
+
+          virtualisation = {
+            emptyDiskImages = [
+              512
+              512
+            ];
+          };
+
+          boot.zfs.forceImportRoot = lib.mkDefault false;
+
+          systemd.services."zfs-zpool-create" = {
+            unitConfig.DefaultDependencies = false;
+            after = [ "systemd-modules-load.service" ];
+            requiredBy = [
+              "zfs-import-root.service"
+              "zfs-import-data.service"
+              "zfs-mount.service"
+            ];
+            before = [
+              "zfs-import-root.service"
+              "zfs-import-data.service"
+              "zfs-mount.service"
+            ];
+            script = ''
+              if [ ! -f /var/done ]; then
+                ${pkgs.zfs}/bin/zpool create -m none -O acltype=posixacl root /dev/vdb
+                ${pkgs.zfs}/bin/zpool create -m none -O acltype=posixacl data /dev/vdc
+                ${pkgs.zfs}/bin/zfs create root/one
+                ${pkgs.zfs}/bin/zfs create root/two
+                ${pkgs.zfs}/bin/zfs create data/one
+                ${pkgs.zfs}/bin/zfs create data/two
+                sync
+              fi
+              touch /var/done
+            '';
+          };
+
+          boot.zfs.extraPools = [
+            "root"
+            "data"
+          ];
+
+          services.zfs.snapshotBeforeActivation = {
+            enable = true;
+            recursive = true;
+          };
+
+          specialisation = {
+            all.configuration = { };
+            rootOnly.configuration = {
+              services.zfs.snapshotBeforeActivation = {
+                enable = true;
+                datasets = {
+                  "root" = { };
+                };
+                recursive = true;
+              };
+            };
+            dataNotRecursive.configuration = {
+              services.zfs.snapshotBeforeActivation = {
+                enable = true;
+                datasets = {
+                  "root" = { };
+                  "data" = {
+                    recursive = false;
+                  };
+                };
+                recursive = true;
+              };
+            };
+            fail.configuration = {
+              # A plus sign is not allowed as the snapshot name so it will make it fail.
+              services.zfs.snapshotBeforeActivation.template = "+";
+            };
+          };
+        };
+    };
+
+    testScript =
+      { nodes, ... }:
+      let
+        specialisations = "${nodes.machine.system.build.toplevel}/specialisation";
+        switch = name: "${specialisations}/${name}/bin/switch-to-configuration test";
+      in
+      ''
+        def assert_count_snapshots(name, count):
+            out = machine.succeed(f"zfs list -Ht snapshot {name}")
+            print(out)
+            got = len(out.splitlines())
+            if count != got:
+                raise Exception(f"Expected {count} dataset, got {got}")
+
+        start_all()
+        machine.wait_for_unit("default.target")
+
+        with subtest("no snapshot yet"):
+            print(machine.succeed("zpool list"))
+            print(machine.succeed("zfs list"))
+            assert_count_snapshots("root", 0)
+            assert_count_snapshots("root/one", 0)
+            assert_count_snapshots("root/two", 0)
+            assert_count_snapshots("data", 0)
+            assert_count_snapshots("data/one", 0)
+            assert_count_snapshots("data/two", 0)
+
+        machine.succeed("${switch "all"}")
+
+        with subtest("snapshot created for all"):
+            print(machine.succeed("zpool list"))
+            print(machine.succeed("zfs list"))
+            assert_count_snapshots("root", 1)
+            assert_count_snapshots("root/one", 1)
+            assert_count_snapshots("root/two", 1)
+            assert_count_snapshots("data", 1)
+            assert_count_snapshots("data/one", 1)
+            assert_count_snapshots("data/two", 1)
+
+        machine.succeed("${switch "rootOnly"}")
+
+        with subtest("snapshot created for root only"):
+            print(machine.succeed("zpool list"))
+            print(machine.succeed("zfs list"))
+            assert_count_snapshots("root", 2)
+            assert_count_snapshots("root/one", 2)
+            assert_count_snapshots("root/two", 2)
+            assert_count_snapshots("data", 1)
+            assert_count_snapshots("data/one", 1)
+            assert_count_snapshots("data/two", 1)
+
+        machine.succeed("${switch "dataNotRecursive"}")
+
+        with subtest("snapshot created for data not recursive"):
+            print(machine.succeed("zpool list"))
+            print(machine.succeed("zfs list"))
+            assert_count_snapshots("root", 3)
+            assert_count_snapshots("root/one", 3)
+            assert_count_snapshots("root/two", 3)
+            assert_count_snapshots("data", 2)
+            assert_count_snapshots("data/one", 1)
+            assert_count_snapshots("data/two", 1)
+
+        machine.fail("${switch "fail"}")
+      '';
+  };
 }


### PR DESCRIPTION
Adds a new `services.zfs.snapshotBeforeActivation` submodule which enables ZFS to take a snapshot of all or selected ZFS datasets before activation.

This makes it easy to rollback state if something happens.
For example, when updating Nextcloud to a new version, it will migrate the database.
But if something bad happens and we want to rollback the deployment, we are doomed because Nextcloud does not support rollbacks.
Here, we can stop Nextcloud, rollback to the latest ZFS snapshot manually, then activate the previous deployment.

I think it's clear this is better than just having hourly snapshots as rolling back to one of those would probably lead to losing more data than rolling back to the snapshot just before the deploy.

This has been tested on my own server for about a month with no issue.

I'm not sure what's going on in the lint tests. They pass locally for me.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
