### PR TITLE
comaps: 2026.03.23-5 -> 2026.06.05-11

### DIFF
--- a/pkgs/by-name/co/comaps/package.nix
+++ b/pkgs/by-name/co/comaps/package.nix
@@ -1,32 +1,53 @@
 {
   lib,
-  organicmaps,
+  stdenv,
+  fetchFromGitHub,
   fetchurl,
   fetchFromCodeberg,
+  cmake,
   boost,
   expat,
-  gtest,
-  glm,
+  getopt,
   gflags,
+  glm,
+  gtest,
+  icu,
   imgui,
   jansson,
+  libxcursor,
+  libxinerama,
+  libxrandr,
+  ninja,
+  pkg-config,
+  pugixml,
   python3,
+  qt6,
   optipng,
   utf8cpp,
+  which,
   nix-update-script,
 }:
 let
-  # https://codeberg.org/comaps/comaps/src/branch/main/data/countries.txt
-  mapRev = 260321;
+  world_feed_integration_tests_data = fetchFromGitHub {
+    owner = "organicmaps";
+    repo = "world_feed_integration_tests_data";
+    rev = "30ecb0b3fe694a582edfacc2a7425b6f01f9fec6";
+    hash = "sha256-1FF658OhKg8a5kKX/7TVmsxZ9amimn4lB6bX9i7pnI4=";
+  };
+
+  # Update mapRev here based on v field near the top in https://codeberg.org/comaps/comaps/src/branch/main/data/countries.txt
+  mapRev = 260603;
 
   worldMap = fetchurl {
+    name = "World-${toString mapRev}.mwm";
     url = "https://cdn-fi-1.comaps.app/maps/${toString mapRev}/World.mwm";
-    hash = "sha256-pMmzPcWbS9drQzJCfiac2dfSMihiHDfhFyG5ux0pG54=";
+    hash = "sha256-1cq2gDiqeybA7VxjuSUFnlLagdZipdWiuAy5QI1LdZE=";
   };
 
   worldCoasts = fetchurl {
+    name = "WorldCoasts-${toString mapRev}.mwm";
     url = "https://cdn-fi-1.comaps.app/maps/${toString mapRev}/WorldCoasts.mwm";
-    hash = "sha256-5LI6itC6LhprVfgGbT/HYy1lzZLZLUe2QoSil0/7kIc=";
+    hash = "sha256-MLRUPEXvXW2GqYdlxfhS5ODRiiWya4i2U+mpXnqc6rY=";
   };
 
   pythonEnv = python3.withPackages (
@@ -35,26 +56,27 @@ let
     ]
   );
 in
-organicmaps.overrideAttrs (oldAttrs: rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "comaps";
-  version = "2026.03.23-5";
+  version = "2026.06.05-11";
 
   src = fetchFromCodeberg {
     owner = "comaps";
     repo = "comaps";
-    tag = "v${version}";
-    hash = "sha256-1bD0QiEZu6nB7wwBpfpEf+WypqbOd9XuXbq7FDTL7bw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-W05fZT82H78TqlH4MFaIexX1LYhjATYL1E6e0WCYrBI=";
     fetchSubmodules = true;
   };
 
   patches = [
     ./use-vendored-protobuf.patch
-
-    # Include missing editor_tests_support.
-    ./fix-editor-tests.patch
   ];
 
-  postPatch = (oldAttrs.postPatch or "") + ''
+  postPatch = ''
+    patchShebangs 3party/boost/tools/build/src/engine/build.sh
+
+    ln -s ${world_feed_integration_tests_data} data/test_data/world_feed_integration_tests_data
+
     rm -f 3party/boost/b2
     substituteInPlace configure.sh \
       --replace-fail "git submodule update --init --recursive --depth 1" ""
@@ -64,19 +86,34 @@ organicmaps.overrideAttrs (oldAttrs: rec {
       --replace-fail "/usr/bin/env python3" "${pythonEnv.interpreter}"
   '';
 
-  nativeBuildInputs = (builtins.filter (x: x != python3) oldAttrs.nativeBuildInputs or [ ]) ++ [
+  nativeBuildInputs = [
+    cmake
+    ninja
+    getopt
+    which
+    pkg-config
     pythonEnv
+    qt6.wrapQtAppsHook
     optipng
   ];
 
-  buildInputs = (oldAttrs.buildInputs or [ ]) ++ [
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtpositioning
+    qt6.qtsvg
+
     boost
     expat
     gtest
     gflags
     glm
+    icu
     imgui
     jansson
+    libxcursor
+    libxinerama
+    libxrandr
+    pugixml
     utf8cpp
   ];
 
@@ -85,6 +122,7 @@ organicmaps.overrideAttrs (oldAttrs: rec {
   '';
 
   cmakeFlags = [
+    (lib.cmakeBool "SKIP_TESTS" false)
     (lib.cmakeBool "WITH_SYSTEM_PROVIDED_3PARTY" true)
   ];
 
@@ -98,7 +136,6 @@ organicmaps.overrideAttrs (oldAttrs: rec {
   postInstall = ''
     install -Dm644 ${worldMap} $out/share/comaps/data/World.mwm
     install -Dm644 ${worldCoasts} $out/share/comaps/data/WorldCoasts.mwm
-    ln -s $out/bin/CoMaps $out/bin/comaps
   '';
 
   passthru.updateScript = nix-update-script {
@@ -108,11 +145,14 @@ organicmaps.overrideAttrs (oldAttrs: rec {
     ];
   };
 
-  meta = oldAttrs.meta // {
+  meta = {
+    broken = stdenv.hostPlatform.isDarwin;
     description = "Community-led fork of Organic Maps";
     homepage = "https://comaps.app";
-    changelog = "https://codeberg.org/comaps/comaps/releases/tag/v${version}";
+    changelog = "https://codeberg.org/comaps/comaps/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.ryand56 ];
-    mainProgram = "comaps";
+    platforms = lib.platforms.unix;
+    mainProgram = "CoMaps";
   };
 })

--- a/pkgs/by-name/co/comaps/use-vendored-protobuf.patch
+++ b/pkgs/by-name/co/comaps/use-vendored-protobuf.patch
@@ -1,21 +1,21 @@
 diff --git a/3party/CMakeLists.txt b/3party/CMakeLists.txt
-index dd851d7d..1b4e3ed3 100644
+index 2146a5fdcf..9fc67abfb3 100644
 --- a/3party/CMakeLists.txt
 +++ b/3party/CMakeLists.txt
-@@ -41,9 +41,6 @@ if (NOT WITH_SYSTEM_PROVIDED_3PARTY)
+@@ -41,9 +41,6 @@
    # Add pugixml library.
    add_subdirectory(pugixml)
-
+ 
 -  # Add protobuf library.
 -  add_subdirectory(protobuf)
 -
    if (NOT PLATFORM_LINUX)
      add_subdirectory(freetype)
      add_subdirectory(icu)
-@@ -55,6 +52,9 @@ if (NOT WITH_SYSTEM_PROVIDED_3PARTY)
+@@ -55,6 +52,9 @@
    target_include_directories(utf8cpp INTERFACE "${OMIM_ROOT}/3party/utfcpp/source")
  endif()
-
+ 
 +# Add protobuf library.
 +add_subdirectory(protobuf)
 +
@@ -23,13 +23,13 @@ index dd851d7d..1b4e3ed3 100644
  add_subdirectory(bsdiff-courgette)
  add_subdirectory(glaze)
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 3ba193a9..dd2df855 100644
+index 096d31389e..c6e4aabdeb 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -225,25 +225,6 @@ endif()
- # Used in qt/ and shaders/
- find_package(Python3 REQUIRED COMPONENTS Interpreter)
-
+@@ -212,26 +212,6 @@
+   message(STATUS "==> Python Virtual Environment detected : ${PYTHON_VENV_PATH}"  "  ==>  "  "Using python command: ${Python3_EXECUTABLE}" )
+ endif()
+ 
 -execute_process(
 -    COMMAND ${Python3_EXECUTABLE} -c "import google.protobuf; 
 -print(google.protobuf.__version__)"
@@ -40,15 +40,16 @@ index 3ba193a9..dd2df855 100644
 -)
 -
 -if(PROTOBUF_CHECK EQUAL 0)
--    if(PROTOBUF_VERSION VERSION_LESS "4.0.0")
--        message(STATUS "Python protobuf ${PROTOBUF_VERSION} found (< 4.0)")
+-    if(PROTOBUF_VERSION VERSION_LESS "3.20.0" OR PROTOBUF_VERSION VERSION_GREATER_EQUAL "4.0.0")
+-        message(FATAL_ERROR "Python protobuf ${PROTOBUF_VERSION} found, but version (>=3.20, <4.0) is required")
 -    else()
--        message(FATAL_ERROR "Python protobuf ${PROTOBUF_VERSION} found, but version < 4.0 required")
+-        message(STATUS "Python protobuf ${PROTOBUF_VERSION} found (>=3.20, <4.0)")
 -    endif()
 -else()
--    message(FATAL_ERROR "Python protobuf not found. Install version <4.0")
+-    message(FATAL_ERROR "Python protobuf not found. Install version (>=3.20, <4.0)")
 -endif()
 -
-
+-
  add_subdirectory(libs)
-
+ 
+ if (PLATFORM_DESKTOP)


### PR DESCRIPTION
https://codeberg.org/comaps/comaps/releases/tag/v2026.06.05-11
Diff: https://codeberg.org/comaps/comaps/compare/v2026.03.23-5...v2026.06.05-11

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
