### PR TITLE
discord: stage discord_voice as a writable copy so background blur works

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/linux.nix
@@ -150,13 +150,33 @@ let
 
   # Symlink native modules from the nix store into the user config dir
   # where Discord's JS moduleUpdater expects them.
+  # Exception: discord_voice bundles Google MediaPipe's selfie-segmentation
+  # `.tflite` models, which the native voice engine opens read-write (O_RDWR).
+  # A symlink into the read-only Nix store makes that open fail with EACCES, so
+  # the segmentation graph errors on every frame and background blur / virtual
+  # backgrounds render a fully black camera image. Stage that one module as a
+  # writable copy instead, cached per version so we don't re-copy ~130 MB on
+  # every launch.
   stageModules = writeShellScript "discord-stage-modules" ''
     store_modules="$1"
-    modules_dir="''${XDG_CONFIG_HOME:-$HOME/.config}/${lib.toLower binaryName}/${version}/modules"
+    config_dir="''${XDG_CONFIG_HOME:-$HOME/.config}/${lib.toLower binaryName}"
+    modules_dir="$config_dir/${version}/modules"
     rm -rf "$modules_dir"
     mkdir -p "$modules_dir"
     for m in ${lib.concatStringsSep " " (lib.attrNames moduleSrcs)}; do
-      ln -sn "$store_modules/$m" "$modules_dir/$m"
+      if [ "$m" = "discord_voice" ]; then
+        voice_copy="$config_dir/${version}/modules-writable/discord_voice"
+        if [ ! -e "$voice_copy/.nix-staged" ]; then
+          rm -rf "$voice_copy"
+          mkdir -p "$voice_copy"
+          cp -RL "$store_modules/$m/." "$voice_copy/"
+          chmod -R u+w "$voice_copy"
+          : > "$voice_copy/.nix-staged"
+        fi
+        ln -sn "$voice_copy" "$modules_dir/$m"
+      else
+        ln -sn "$store_modules/$m" "$modules_dir/$m"
+      fi
     done
     echo '${builtins.toJSON (lib.mapAttrs (_: mod: { installedVersion = mod; }) moduleVersions)}' \
       > "$modules_dir/installed.json"


### PR DESCRIPTION
I noticed that enabling a virtual background (e.g blur) rendered my own video black. Disabling this feature resolved the problem. 

Discord's background blur / virtual backgrounds run MediaPipe's selfie-segmentation model from the discord_voice module. The native voice engine opens the bundled .tflite model read-write (O_RDWR), which fails with EACCES because the module is symlinked into the read-only Nix store; the segmentation graph then errors on every frame and the camera renders fully black.

My proposed solution is to stage discord_voice as a writable copy (cached per version) instead of a store symlink so the model can be opened read-write. I tried partial symlinking but  MediaPipe resolves the model relative to libmediapipe.so, so it re-resolves into the store. So I decided to copy the whole module. 

The copy is ~130MB. It is copied once per Discord version, not each launch.

AI Disclaimer: I used AI to find the source of the problem and used it to review my changes. (It also grammar checked this PR text). 



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
