### PR TITLE
python3Packages.darabonba-core: init at 1.0.7

### DIFF
--- a/pkgs/development/python-modules/darabonba-core/default.nix
+++ b/pkgs/development/python-modules/darabonba-core/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  aiohttp,
+  alibabacloud-tea,
+  buildPythonPackage,
+  fetchPypi,
+  requests,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "darabonba-core";
+  version = "1.0.7";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchPypi {
+    pname = "darabonba_core";
+    inherit (finalAttrs) version;
+    hash = "sha256-wt4u4mBoK0wIyexneT3maivfMWNjuRZfFSuayqFrTcM=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    aiohttp
+    alibabacloud-tea
+    requests
+  ];
+
+  pythonImportsCheck = [ "Tea" ];
+
+  # Module has no tests
+  doCheck = false;
+
+  meta = {
+    description = "The darabonba module of alibabaCloud Python SDK";
+    homepage = "https://github.com/aliyun/tea-python";
+    changelog = "https://github.com/aliyun/tea-python/blob/master/ChangeLog.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3583,6 +3583,8 @@ self: super: with self; {
 
   daqp = callPackage ../development/python-modules/daqp { };
 
+  darabonba-core = callPackage ../development/python-modules/darabonba-core { };
+
   darkdetect = callPackage ../development/python-modules/darkdetect { };
 
   dartsim = toPythonModule (


### PR DESCRIPTION
The darabonba module of alibabaCloud Python SDK

https://github.com/aliyun/tea-python


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
