### PR TITLE
mpop: libidn -> libidn2

### DIFF
--- a/pkgs/by-name/mp/mpop/package.nix
+++ b/pkgs/by-name/mp/mpop/package.nix
@@ -5,7 +5,7 @@
   gnutls,
   openssl,
   gsasl,
-  libidn,
+  libidn2,
   pkg-config,
   nlsSupport ? true,
   idnSupport ? true,
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs =
     lib.optional gsaslSupport gsasl
-    ++ lib.optional idnSupport libidn
+    ++ lib.optional idnSupport libidn2
     ++ lib.optional (sslLibrary == "gnutls") gnutls
     ++ lib.optional (sslLibrary == "openssl") openssl;
 


### PR DESCRIPTION
as per the changelog entry for version 1.4.0 at https://git.marlam.de/gitweb/?p=mpop.git;a=blob;f=NEWS;h=8b8f2fd45a2109ba04c9720de7973a519bc4aeaf;hb=HEAD, libidn2 is used instead of libidn where IDN support is needed, so we migrate to that.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
