### PR TITLE
python3Packages.dbus-fast: fix tests on darwin

### DIFF
--- a/pkgs/development/python-modules/dbus-fast/default.nix
+++ b/pkgs/development/python-modules/dbus-fast/default.nix
@@ -11,6 +11,7 @@
   pytest-cov-stub,
   python,
   setuptools,
+  stdenv,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -55,16 +56,33 @@ buildPythonPackage (finalAttrs: {
     "dbus_fast.message"
   ];
 
-  checkPhase = ''
-    runHook preCheck
+  checkPhase =
+    let
+      setupSessionConf =
+        if stdenv.hostPlatform.isDarwin then
+          # The session.conf that dbus ships on Darwin listens via launchd, which is
+          # not available inside the build sandbox. Generate one that listens on a
+          # private unix socket so dbus-run-session can spin up a throwaway bus for
+          # the tests, the same way it does on Linux.
+          ''
+            sessionConf="$TMPDIR/session.conf"
+            substitute ${./session.darwin.conf} "$sessionConf" --subst-var TMPDIR
+          ''
+        else
+          "sessionConf=${dbus}/share/dbus-1/session.conf";
+    in
+    ''
+      runHook preCheck
 
-    # test_peer_interface times out
-    dbus-run-session \
-      --config-file=${dbus}/share/dbus-1/session.conf \
-      ${python.interpreter} -m pytest -k "not test_peer_interface"
+      ${setupSessionConf}
 
-    runHook postCheck
-  '';
+      # test_peer_interface times out
+      dbus-run-session \
+        --config-file="$sessionConf" \
+        ${python.interpreter} -m pytest -k "not test_peer_interface"
+
+      runHook postCheck
+    '';
 
   meta = {
     description = "Faster version of dbus-next";

--- a/pkgs/development/python-modules/dbus-fast/session.darwin.conf
+++ b/pkgs/development/python-modules/dbus-fast/session.darwin.conf
@@ -1,0 +1,10 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <type>session</type>
+  <listen>unix:tmpdir=@TMPDIR@</listen>
+  <policy context="default">
+    <allow send_destination="*"/>
+    <allow eavesdrop="true"/>
+    <allow own="*"/>
+  </policy>
+</busconfig>


### PR DESCRIPTION
I do not use `dbus-fast` myself. I just noticed it does not build on Darwin while working on a related package, so here is a fix.

On Linux, dbus-fast has many reverse dependencies, so even this Darwin-focused fix triggers a mass rebuild there. For that reason this PR targets staging rather than master.

Assisted-by: Claude Code (Claude Opus 4.8)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
