### PR TITLE
qwt: fix generated pkg-config file

### DIFF
--- a/pkgs/development/libraries/qwt/0001-pkgconfig-for-Qt-5-6-adjustments.patch
+++ b/pkgs/development/libraries/qwt/0001-pkgconfig-for-Qt-5-6-adjustments.patch
@@ -1,0 +1,49 @@
+From b225ea23753ce35356ad1b53c0854813004bb605 Mon Sep 17 00:00:00 2001
+From: rathmann <Uwe.Rathmann@tigertal.de>
+Date: Thu, 22 May 2025 15:33:04 +0200
+Subject: [PATCH] pkgconfig for Qt 5/6 adjustments
+
+---
+ src/src.pro | 15 ++++++++++-----
+ 1 file changed, 10 insertions(+), 5 deletions(-)
+
+diff --git a/src/src.pro b/src/src.pro
+index 96e0624..8990ece 100644
+--- a/src/src.pro
++++ b/src/src.pro
+@@ -81,22 +81,27 @@ contains(QWT_CONFIG, QwtPkgConfig) {
+ 
+     greaterThan(QT_MAJOR_VERSION, 4) {
+ 
+-        QMAKE_PKGCONFIG_FILE = Qt$${QT_MAJOR_VERSION}$${QMAKE_PKGCONFIG_NAME}
+-        QMAKE_PKGCONFIG_REQUIRES = Qt5Widgets Qt5Concurrent Qt5PrintSupport
++        QTLIB_PREFIX = Qt$${QT_MAJOR_VERSION}  # e.g., "Qt5"
++        QMAKE_PKGCONFIG_FILE = $${QTLIB_PREFIX}$${QMAKE_PKGCONFIG_NAME}  # e.g., "Qt5Qwt6"
++
++        # Base Qt library requirements
++        QMAKE_PKGCONFIG_REQUIRES = $${QTLIB_PREFIX}Widgets
++        QMAKE_PKGCONFIG_REQUIRES += $${QTLIB_PREFIX}Concurrent
++        QMAKE_PKGCONFIG_REQUIRES += $${QTLIB_PREFIX}PrintSupport
+ 
+         contains(QWT_CONFIG, QwtSvg) {
+-            QMAKE_PKGCONFIG_REQUIRES += Qt5Svg
++            QMAKE_PKGCONFIG_REQUIRES += $${QTLIB_PREFIX}Svg
+         }
+ 
+         contains(QWT_CONFIG, QwtOpenGL) {
+-            QMAKE_PKGCONFIG_REQUIRES += Qt5OpenGL
++            QMAKE_PKGCONFIG_REQUIRES += $${QTLIB_PREFIX}OpenGL
+         }
+ 
+         QMAKE_DISTCLEAN += $${DESTDIR}/$${QMAKE_PKGCONFIG_DESTDIR}/$${QMAKE_PKGCONFIG_FILE}.pc
+     }
+     else {
+ 
+-        # there is no QMAKE_PKGCONFIG_FILE fo Qt4
++        # there is no QMAKE_PKGCONFIG_FILE for Qt4
+         QMAKE_PKGCONFIG_REQUIRES = QtGui 
+ 
+         contains(QWT_CONFIG, QwtSvg) {
+-- 
+2.54.0
+

--- a/pkgs/development/libraries/qwt/default.nix
+++ b/pkgs/development/libraries/qwt/default.nix
@@ -23,6 +23,19 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-3LCFiWwoquxVGMvAjA7itOYK2nrJKdgmOfYYmFGmEpo=";
   };
 
+  patches = [
+    # Fix the generated pkg-config file when built against Qt6.
+    # The file wrongly pulled in an unsatisfied dependency to Qt5.
+    #
+    # When building Qwt using Qt6, the constructed pkgconfig .pc file was
+    # previously set up to only look for Qt5 libraries. This fix now matches
+    # the library dependency to the Qt version used in building Qwt.
+    #
+    # See upstream commit b225ea23753ce35356ad1b53c0854813004bb605.
+    # https://sourceforge.net/p/qwt/git/ci/b225ea23753ce35356ad1b53c0854813004bb605/basic
+    ./0001-pkgconfig-for-Qt-5-6-adjustments.patch
+  ];
+
   propagatedBuildInputs = [
     qtbase
     qtsvg


### PR DESCRIPTION
Apply a patch to fix the generated Qt6Qwt6.pc when qwt is built against Qt6. The file otherwise contains requires: for Qt5 libraries.

I didn't find a way to fetchpatch from sourceforge, so I extracted the patch from the git repo.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `d03bfa9cc2bfc0c2549e0a8275efec58ad8f6ef3`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 1 package marked as broken and skipped:</summary>
  <ul>
    <li>sonic-pi</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 23 packages built:</summary>
  <ul>
    <li>elmerfem</li>
    <li>gnss-sdr</li>
    <li>gnuradio</li>
    <li>gnuradioPackages.bladeRF</li>
    <li>gnuradioPackages.fosphor</li>
    <li>gnuradioPackages.gr-difi</li>
    <li>gnuradioPackages.lora_sdr</li>
    <li>gnuradioPackages.osmosdr</li>
    <li>gplates</li>
    <li>gr-dect2</li>
    <li>guglielmo</li>
    <li>kdePackages.qwt</li>
    <li>libsForQt5.qwt</li>
    <li>opl3bankeditor</li>
    <li>opn2bankeditor</li>
    <li>qctools</li>
    <li>qgis</li>
    <li>qgis-ltr</li>
    <li>qradiolink</li>
    <li>qstopmotion</li>
    <li>smuview</li>
    <li>testdisk-qt</li>
    <li>trunk-recorder</li>
  </ul>
</details>