### PR TITLE
ocamlPackages.landmarks: 1.5 → 1.7

### DIFF
--- a/pkgs/development/ocaml-modules/landmarks-ppx/default.nix
+++ b/pkgs/development/ocaml-modules/landmarks-ppx/default.nix
@@ -1,8 +1,5 @@
 {
-  lib,
   buildDunePackage,
-  fetchpatch,
-  ocaml,
   landmarks,
   ppxlib,
 }:
@@ -10,17 +7,14 @@
 buildDunePackage {
   pname = "landmarks-ppx";
 
-  inherit (landmarks) src version;
+  minimalOCamlVersion = "5.3";
 
-  patches = lib.optional (lib.versionAtLeast ppxlib.version "0.36") (fetchpatch {
-    url = "https://github.com/LexiFi/landmarks/commit/367c229e3275a83f81343ba116374bb68abc9d83.patch";
-    hash = "sha256-Qxue+++sNV6EHJGX1mbIeY2E2D5NuFpmIIBkTyvGvo8=";
-  });
+  inherit (landmarks) src version;
 
   buildInputs = [ ppxlib ];
   propagatedBuildInputs = [ landmarks ];
 
-  doCheck = lib.versionAtLeast ocaml.version "5.1";
+  doCheck = true;
 
   meta = landmarks.meta // {
     description = "Preprocessor instrumenting code using the landmarks library";

--- a/pkgs/development/ocaml-modules/landmarks/default.nix
+++ b/pkgs/development/ocaml-modules/landmarks/default.nix
@@ -2,25 +2,23 @@
   lib,
   fetchFromGitHub,
   buildDunePackage,
-  ocaml,
 }:
 
 buildDunePackage (finalAttrs: {
   pname = "landmarks";
-  version = "1.5";
-  minimalOCamlVersion = "4.08";
+  version = "1.7";
 
   src = fetchFromGitHub {
     owner = "LexiFi";
     repo = "landmarks";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-eIq02D19OzDOrMDHE1Ecrgk+T6s9vj2X6B2HY+z+K8Q=";
+    hash = "sha256-9o9jf0M3zKc+Xojs4dqPRctYswSYqIo0jeOvkfdLfZ4=";
   };
 
-  doCheck = lib.versionAtLeast ocaml.version "4.08" && lib.versionOlder ocaml.version "5.0";
+  doCheck = true;
 
   meta = {
-    inherit (finalAttrs.src.meta) homepage;
+    homepage = "https://github.com/LexiFi/landmarks";
     description = "Simple Profiling Library for OCaml";
     longDescription = ''
       Landmarks is a simple profiling library for OCaml. It provides


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
