### PR TITLE
nixos/clamav: warn that TCPSocket/TCPAddr are ignored under socket activation

### DIFF
--- a/nixos/modules/services/security/clamav.nix
+++ b/nixos/modules/services/security/clamav.nix
@@ -211,6 +211,20 @@ in
       }
     ];
 
+    warnings = lib.optional (
+      cfg.daemon.enable && (cfg.daemon.settings ? TCPSocket || cfg.daemon.settings ? TCPAddr)
+    ) ''
+      services.clamav.daemon: `TCPSocket`/`TCPAddr` in `settings` have no effect.
+      clamd is started via systemd socket activation (the clamav-daemon.socket unit
+      passes it only the LocalSocket), and a socket-activated clamd uses only the file
+      descriptors it receives, ignoring the LocalSocket/TCPSocket/TCPAddr directives in
+      clamd.conf -- so clamd never listens on the configured TCP port. Connect via the
+      unix socket (services.clamav.daemon.settings.LocalSocket), or expose TCP by adding
+      it to the socket unit, e.g.
+        systemd.sockets.clamav-daemon.listenStreams = [ "127.0.0.1:3310" ];
+      (as Debian's packaging does). See https://bugs.debian.org/771911
+    '';
+
     environment.systemPackages = [ cfg.package ];
 
     users.users.${clamavUser} = {

--- a/nixos/modules/services/security/clamav.nix
+++ b/nixos/modules/services/security/clamav.nix
@@ -211,19 +211,20 @@ in
       }
     ];
 
-    warnings = lib.optional (
-      cfg.daemon.enable && (cfg.daemon.settings ? TCPSocket || cfg.daemon.settings ? TCPAddr)
-    ) ''
-      services.clamav.daemon: `TCPSocket`/`TCPAddr` in `settings` have no effect.
-      clamd is started via systemd socket activation (the clamav-daemon.socket unit
-      passes it only the LocalSocket), and a socket-activated clamd uses only the file
-      descriptors it receives, ignoring the LocalSocket/TCPSocket/TCPAddr directives in
-      clamd.conf -- so clamd never listens on the configured TCP port. Connect via the
-      unix socket (services.clamav.daemon.settings.LocalSocket), or expose TCP by adding
-      it to the socket unit, e.g.
-        systemd.sockets.clamav-daemon.listenStreams = [ "127.0.0.1:3310" ];
-      (as Debian's packaging does). See https://bugs.debian.org/771911
-    '';
+    warnings =
+      lib.optional
+        (cfg.daemon.enable && (cfg.daemon.settings ? TCPSocket || cfg.daemon.settings ? TCPAddr))
+        ''
+          services.clamav.daemon: `TCPSocket`/`TCPAddr` in `settings` have no effect.
+          clamd is started via systemd socket activation (the clamav-daemon.socket unit
+          passes it only the LocalSocket), and a socket-activated clamd uses only the file
+          descriptors it receives, ignoring the LocalSocket/TCPSocket/TCPAddr directives in
+          clamd.conf -- so clamd never listens on the configured TCP port. Connect via the
+          unix socket (services.clamav.daemon.settings.LocalSocket), or expose TCP by adding
+          it to the socket unit, e.g.
+            systemd.sockets.clamav-daemon.listenStreams = [ "127.0.0.1:3310" ];
+          (as Debian's packaging does). See https://bugs.debian.org/771911
+        '';
 
     environment.systemPackages = [ cfg.package ];
 


### PR DESCRIPTION
The clamav daemon is socket-activated with only its unix `LocalSocket`. A socket-activated clamd uses only the file descriptors systemd passes and ignores `LocalSocket`/`TCPSocket`/`TCPAddr` from clamd.conf (undocumented upstream; see Debian #771911). Since `services.clamav.daemon.settings` accepts `TCPSocket`/`TCPAddr`, users set them expecting clamd to listen on TCP -- it never does, with no feedback.

Real-world symptom: Nextcloud `files_antivirus` in daemon TCP mode then fails every upload with HTTP 415 "No connection to anti virus".

This adds a `warnings` entry pointing users to the unix socket, or to add the TCP listener to the socket unit. No behavior change.

Replaces #534412.