### PR TITLE
bhash: init at 1.0.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1500,6 +1500,12 @@
     githubId = 169249;
     name = "Alex Brandt";
   };
+  aluoty = {
+    email = "alexanderluo0910@gmail.com";
+    github = "aluoty";
+    githubId = 291213059;
+    name = "Alexander Luo Tingyou";
+  };
   alx = {
     email = "nix@alexgirard.com";
     github = "alx";

--- a/pkgs/by-name/bh/bhash/package.nix
+++ b/pkgs/by-name/bh/bhash/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  zig,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bhash";
+  version = "1.0.4";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "aluoty";
+    repo = "bhash";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ebQGTTAam5tCpo7azvWstblouZS34YcrNvEu3UkYy+k=";
+  };
+
+  nativeBuildInputs = [
+    zig
+  ];
+
+  meta = {
+    description = "Hashing utility built using Zig";
+    homepage = "https://github.com/aluoty/bhash";
+    changelog = "https://github.com/aluoty/bhash/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "bhash";
+    maintainers = with lib.maintainers; [ aluoty ];
+    inherit (zig.meta) platforms;
+  };
+})


### PR DESCRIPTION
## Summary

Adds `bhash`, a lightweight hashing utility written in Zig.

Features:
- Multiple hashing algorithms
- Hash strings, files, and stdin
- Checksum verification (`--check`)
- Hex and Base64 output
- Simple command-line interface
- Contains help, version, and list

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].