### PR TITLE
cliamp: skip unix-socket IPC test on darwin

### DIFF
--- a/pkgs/by-name/cl/cliamp/package.nix
+++ b/pkgs/by-name/cl/cliamp/package.nix
@@ -54,6 +54,13 @@ buildGoModule (finalAttrs: {
   # this is set due to failure of testset `net/http/httptest` on darwin
   __darwinAllowLocalNetworking = true;
 
+  # TestServerMultipleRequestsSameConnection binds a unix-domain socket inside
+  # the build sandbox; on Darwin that path exceeds the 104-byte sun_path limit,
+  # so bind() fails with EINVAL. Skip just that test there.
+  checkFlags = lib.optionals stdenv.hostPlatform.isDarwin [
+    "-skip=^TestServerMultipleRequestsSameConnection$"
+  ];
+
   passthru.updateScript = nix-update-script { };
 
   meta = {


### PR DESCRIPTION
Closes #535493

## Description of changes

`cliamp` fails to build on aarch64-darwin (and any Darwin) because one test
in its check phase can't bind a unix-domain socket:

```
--- FAIL: TestServerMultipleRequestsSameConnection (0.00s)
    client_test.go:189: NewServer: ipc: listen: listen unix /nix/var/nix/builds/nix-44617-2709901054/TestServerMultipleRequestsSameConnection3822053512/001/cliamp.sock: bind: invalid argument
FAIL    cliamp/ipc
```

The test binds a socket via `t.TempDir()`, which is rooted in the sandbox
build directory. The resulting path is **107 bytes**, which exceeds macOS's
**104-byte** `sun_path` limit, so `bind()` returns `EINVAL`. On Linux the
limit is 108 bytes, so the same path stays just under it — which is why Hydra
(Linux) never catches this and it only fails on Darwin. The existing
`__darwinAllowLocalNetworking` flag doesn't help, as it only affects TCP /
`net/http/httptest`, not unix sockets.

This skips just that one test on Darwin via `checkFlags`. The rest of the
suite (including the other `cliamp/ipc` tests) still runs and passes.

Verified building `1.57.1` on aarch64-darwin with this change — the build
completes and all remaining tests pass.

## Things done

- Built on platform(s)
  - [x] aarch64-darwin
  - [ ] x86_64-darwin
  - [ ] x86_64-linux (unaffected; builds already pass there)
  - [ ] aarch64-linux
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (It is on by default on darwin.)
- [x] Tested, as applicable:
  - Built the package with the change and ran it.
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` — N/A, leaf package with no reverse dependencies.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
