### PR TITLE
ocamlPackages.ocsipersist: 2.0.0 → 2.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/ocsipersist/lib.nix
+++ b/pkgs/development/ocaml-modules/ocsipersist/lib.nix
@@ -1,41 +1,30 @@
 {
   lib,
   buildDunePackage,
-  applyPatches,
-  fetchpatch,
   fetchFromGitHub,
+  js_of_ocaml,
   lwt_ppx,
   lwt,
 }:
 
 buildDunePackage (finalAttrs: {
   pname = "ocsipersist-lib";
-  version = "2.0.0";
+  version = "2.1.0";
 
-  src = applyPatches {
+  minimalOCamlVersion = "4.13";
 
-    src = fetchFromGitHub {
-      owner = "ocsigen";
-      repo = "ocsipersist";
-      tag = finalAttrs.version;
-      hash = "sha256-7CKKwJxqxUpCMNs4xGbsMZ6Qud9AnczBStTXS+N21DU=";
-    };
-
-    patches = [
-      # Migrate to logs
-      (fetchpatch {
-        url = "https://github.com/ocsigen/ocsipersist/commit/1fc0088b4dc2226f01863dd25f8ed56528c5543d.patch";
-        hash = "sha256-WR7SW8jAAo47AIQ7UMQNF8FTXgj6FbxIqFjrLhu7wFs=";
-        excludes = [
-          "*.opam"
-          "dune-project"
-        ];
-      })
-    ];
+  src = fetchFromGitHub {
+    owner = "ocsigen";
+    repo = "ocsipersist";
+    tag = finalAttrs.version;
+    hash = "sha256-YJzfgeyNXgBXAK607ROUXUmSpMKYx63ofZaBB8dnsq4=";
   };
 
   buildInputs = [ lwt_ppx ];
-  propagatedBuildInputs = [ lwt ];
+  propagatedBuildInputs = [
+    js_of_ocaml
+    lwt
+  ];
 
   meta = {
     description = "Persistent key/value storage (for Ocsigen) - support library";


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
