### PR TITLE
zfs_2_4: apply patch for #18366 (dedup=on data corruption)

### DIFF
--- a/pkgs/os-specific/linux/zfs/2_4.nix
+++ b/pkgs/os-specific/linux/zfs/2_4.nix
@@ -18,6 +18,15 @@ callPackage ./generic.nix args {
   # this package should point to the latest release.
   version = "2.4.3";
 
+  extraPatches = [
+    # https://github.com/openzfs/zfs/issues/18366
+    # dedup data corruption fix unreleased as of OpenZFS 2.4.3
+    (fetchpatch {
+      url = "https://github.com/openzfs/zfs/commit/6fb72fda0f60d9efb591e320f83f78b19ec451cc.patch?full_index=1";
+      hash = "sha256-UuSVmO61Ux5S3F+JAtRnHyeVS4EFobDTKBuD5s8PI+k=";
+    })
+  ];
+
   tests = {
     inherit (nixosTests.zfs) series_2_4;
   }


### PR DESCRIPTION
This was reproducible with substitution of large NARs with a lot of files and a dedup=on Nix store. While Nix would correctly produce a signature verification error if the hash was known, builds could silently be corrupt.

TrueNAS backported this, so let's as well so this doesn't bite anyone else.

See: https://github.com/truenas/zfs/pull/390
See: https://github.com/openzfs/zfs/issues/18366
See: https://github.com/openzfs/zfs/pull/18544


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
