### PR TITLE
[27.05] ci/eval: clean up after `x86_64-darwin` removal

### DIFF
--- a/ci/eval/compare/default.nix
+++ b/ci/eval/compare/default.nix
@@ -123,7 +123,6 @@ let
             aarch64-darwin: ["package1", "package2"],
             aarch64-linux: ["package1", "package2"],
             x86_64-linux: ["package1", "package2", "package3"],
-            x86_64-darwin: ["package1"],
           },
         }
       - step-summary.md: A markdown render of the changes

--- a/ci/eval/compare/utils.nix
+++ b/ci/eval/compare/utils.nix
@@ -49,8 +49,6 @@ rec {
         "hello.aarch64-linux"
         "hello.x86_64-linux"
         "hello.aarch64-darwin"
-        "hello.x86_64-darwin"
-        "bye.x86_64-darwin"
         "bye.aarch64-darwin"
         "release-checks"  <- Will be dropped
       ]
@@ -59,9 +57,7 @@ rec {
         { name = "hello"; platform = "aarch64-linux"; packagePath = [ "hello" ]; }
         { name = "hello"; platform = "x86_64-linux"; packagePath = [ "hello" ]; }
         { name = "hello"; platform = "aarch64-darwin"; packagePath = [ "hello" ]; }
-        { name = "hello"; platform = "x86_64-darwin"; packagePath = [ "hello" ]; }
         { name = "bye"; platform = "aarch64-darwin"; packagePath = [ "hello" ]; }
-        { name = "bye"; platform = "x86_64-darwin"; packagePath = [ "hello" ]; }
       ]
   */
   convertToPackagePlatformAttrs =
@@ -76,8 +72,6 @@ rec {
         "hello.aarch64-linux"
         "hello.x86_64-linux"
         "hello.aarch64-darwin"
-        "hello.x86_64-darwin"
-        "bye.x86_64-darwin"
         "bye.aarch64-darwin"
       ]
     into
@@ -101,16 +95,13 @@ rec {
         { name = "hello"; platform = "aarch64-linux"; ... }
         { name = "hello"; platform = "x86_64-linux"; ... }
         { name = "hello"; platform = "aarch64-darwin"; ... }
-        { name = "hello"; platform = "x86_64-darwin"; ... }
         { name = "bye"; platform = "aarch64-darwin"; ... }
-        { name = "bye"; platform = "x86_64-darwin"; ... }
       ]
     into
       {
         aarch64-linux = [ "hello" ];
         x86_64-linux = [ "hello" ];
         aarch64-darwin = [ "hello" "bye" ];
-        x86_64-darwin = [ "hello" "bye" ];
       }
   */
   groupByPlatform =
@@ -126,9 +117,7 @@ rec {
   #   { name = "hello"; platform = "aarch64-linux"; ... }
   #   { name = "hello"; platform = "x86_64-linux"; ... }
   #   { name = "hello"; platform = "aarch64-darwin"; ... }
-  #   { name = "hello"; platform = "x86_64-darwin"; ... }
   #   { name = "bye"; platform = "aarch64-darwin"; ... }
-  #   { name = "bye"; platform = "x86_64-darwin"; ... }
   # ]
   #
   # into

--- a/ci/eval/outpaths.nix
+++ b/ci/eval/outpaths.nix
@@ -35,9 +35,6 @@ let
             allowVariants = !attrNamesOnly;
             checkMeta = true;
 
-            # Silence the `x86_64-darwin` deprecation warning.
-            allowDeprecatedx86_64Darwin = true;
-
             handleEvalIssue =
               reason: errormsg:
               let


### PR DESCRIPTION
This can only land after no supported branches support `x86_64-darwin`.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
