### PR TITLE
argc: use `pkgsCross.gnu64` for cross test on Darwin too

### DIFF
--- a/pkgs/by-name/ar/argc/package.nix
+++ b/pkgs/by-name/ar/argc/package.nix
@@ -55,14 +55,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     updateScript = nix-update-script { };
     tests = {
       cross =
-        (
-          if stdenv.hostPlatform.isDarwin then
-            if stdenv.hostPlatform.isAarch64 then pkgsCross.x86_64-darwin else pkgsCross.aarch64-darwin
-          else if stdenv.hostPlatform.isAarch64 then
-            pkgsCross.gnu64
-          else
-            pkgsCross.aarch64-multiplatform
-        ).argc;
+        (if stdenv.hostPlatform.isAarch64 then pkgsCross.gnu64 else pkgsCross.aarch64-multiplatform).argc;
     };
   };
 

--- a/pkgs/by-name/ar/argc/package.nix
+++ b/pkgs/by-name/ar/argc/package.nix
@@ -42,9 +42,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   env = {
     LANG = "C.UTF-8";
-  }
-  // lib.optionalAttrs (glibcLocales != null) {
-    LOCALE_ARCHIVE = "${glibcLocales}/lib/locale/locale-archive";
+    LOCALE_ARCHIVE = lib.optionalString (
+      finalAttrs.finalPackage.doInstallCheck && glibcLocales != null
+    ) "${glibcLocales}/lib/locale/locale-archive";
   };
 
   doInstallCheck = true;


### PR DESCRIPTION
Otherwise the `x86_64-darwin` drop breaks it.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
