### PR TITLE
github-copilot-desktop: init at 1.0.21

### DIFF
--- a/pkgs/by-name/gi/github-copilot-desktop/package.nix
+++ b/pkgs/by-name/gi/github-copilot-desktop/package.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  zstd,
+}:
+
+let
+  inherit (stdenv.hostPlatform) system;
+  throwSystem = throw "github-copilot-desktop: arch ${system} not supported";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "github-copilot-desktop";
+  version = "1.0.21";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src =
+    if stdenv.hostPlatform.isLinux then
+      let
+        arch =
+          {
+            x86_64-linux = "x64";
+            aarch64-linux = "arm64";
+          }
+          .${system} or throwSystem;
+      in
+      fetchurl {
+        url = "https://github.com/github/app/releases/download/v${finalAttrs.version}/GitHub-Copilot-linux-${arch}.deb";
+        hash =
+          {
+            x86_64-linux = "sha256-C0ssWQ/rYweLgGrzevTmMhg1I4AyM4MVo9pT2qgTCFo=";
+            aarch64-linux = "sha256-bp6Q4ZRL5q175e60VOc2xkx7s2dyZF33SC08+SJnXgM=";
+          }
+          .${system} or throwSystem;
+      }
+    else if stdenv.hostPlatform.isDarwin then
+      let
+        arch =
+          {
+            x86_64-darwin = "x64";
+            aarch64-darwin = "arm64";
+          }
+          .${system} or throwSystem;
+      in
+      fetchurl {
+        url = "https://github.com/github/app/releases/download/v${finalAttrs.version}/GitHub-Copilot-darwin-${arch}.tar.gz";
+        hash =
+          {
+            x86_64-darwin = "sha256-Ve+x3X76oYZMgXbOmZx2cDyRcowR57Rl/ouPlKP7JMs=";
+            aarch64-darwin = "sha256-WrMc6NLZFRDAnSfmVOKBMSafr2/c/abEPOe/VFcnfHI=";
+          }
+          .${system} or throwSystem;
+      }
+    else
+      throwSystem;
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ zstd ];
+
+  installPhase =
+    if stdenv.hostPlatform.isLinux then
+      ''
+        tmpdir=$(mktemp -d)
+        ar x "$src" --output="$tmpdir"
+        ${zstd}/bin/zstd -d "$tmpdir/data.tar.zst" -o "$tmpdir/data.tar"
+        mkdir -p "$out"
+        tar xf "$tmpdir/data.tar" -C "$out" ./usr
+        mkdir -p "$out/bin"
+        ln -s "$out/usr/bin/github" "$out/bin/github"
+        ln -s "$out/usr/bin/git-credential-copilot" "$out/bin/git-credential-copilot"
+      ''
+    else
+      ''
+        mkdir -p "$out/Applications" "$out/bin"
+        tar xzf "$src" -C "$out/Applications"
+        ln -s "$out/Applications/GitHub Copilot.app/Contents/MacOS/github" "$out/bin/github"
+        ln -s "$out/Applications/GitHub Copilot.app/Contents/MacOS/git-credential-copilot" "$out/bin/git-credential-copilot"
+      '';
+
+  meta = {
+    description = "GitHub Copilot app is an agent-native desktop experience for agent-driven development";
+    downloadPage = "https://github.com/github/app/releases";
+    homepage = "https://github.com/features/ai/github-app";
+    license = lib.licenses.unfree;
+    maintainers = [ ];
+    mainProgram = "github";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
Add `github-copilot-desktop` package — the official [GitHub Copilot Desktop App](https://github.com/features/ai/github-app), an agent-native desktop experience for agent-driven development built natively on GitHub.

- Add `github-copilot-desktop` package to `pkgs/by-name/gi/`
- Supports Linux x86_64/aarch64 and macOS x86_64/aarch64
- Linux: downloads official `.deb` package from [GitHub releases](https://github.com/github/app/releases) (v1.0.9)
- macOS: downloads official `.tar.gz` package from [GitHub releases](https://github.com/github/app/releases) (v1.0.9)
- Includes `github` binary and `git-credential-copilot` helper
- Package requires an active paid GitHub Copilot subscription to use

Homepage: https://github.com/features/ai/github-app

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test