### PR TITLE
gnuplot: enable bitmap terminals

### DIFF
--- a/pkgs/by-name/gn/gnuplot/package.nix
+++ b/pkgs/by-name/gn/gnuplot/package.nix
@@ -29,6 +29,7 @@
   coreutils,
   withQt ? false,
   qt5,
+  withBitmapTerminals ? true,
 }:
 
 let
@@ -85,6 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
     (if withX then "--with-x" else "--without-x")
     (if withQt then "--with-qt=qt5" else "--without-qt")
     (if aquaterm then "--with-aquaterm" else "--without-aquaterm")
+    (if withBitmapTerminals then "--with-bitmap-terminals" else "--without-bitmap-terminals")
   ]
   ++ lib.optional withCaca "--with-caca"
   ++ lib.optional withTeXLive "--with-texdir=${placeholder "out"}/share/texmf/tex/latex/gnuplot";


### PR DESCRIPTION
Enable gnuplot bitmap terminals by passing `--with-bitmap-terminals` to configure.

This is a duplicate of https://github.com/NixOS/nixpkgs/pull/533595, as I accidentally broke the branch history due to using a shallow clone.

This enables legacy bitmap-based terminal drivers (e.g. pbm, epson, hpljii, hp500c) without introducing additional dependencies.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

- Tested, as applicable:
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`:
    - `gnuplot -e "set term"` shows additional bitmap terminals

- [ ] [Nixpkgs tests] in [nixos/tests].
- [ ] [Package tests] at `passthru.tests`.
- [x] Ran `nixpkgs-review` on this PR.
- [ ] NixOS Release Notes / Package update (not applicable)
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs
- [x] Follows the automation/AI policy