### PR TITLE
ocamlPackages.ansi: init at 0.7.0

### DIFF
--- a/pkgs/development/ocaml-modules/ansi/default.nix
+++ b/pkgs/development/ocaml-modules/ansi/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildDunePackage,
+  fetchFromGitHub,
+  astring,
+  fmt,
+  tyxml,
+  alcotest,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "ansi";
+  version = "0.7.0";
+
+  minimalOCamlVersion = "4.10";
+
+  src = fetchFromGitHub {
+    owner = "ocurrent";
+    repo = "ansi";
+    tag = finalAttrs.version;
+    hash = "sha256-VZR8hz2v4gAvTkizBt59DSYr3tGPWT1Iid8m8YQx48Y=";
+  };
+
+  propagatedBuildInputs = [
+    astring
+    fmt
+    tyxml
+  ];
+
+  checkInputs = [
+    alcotest
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "ANSI escape sequence parser";
+    longDescription = ''
+      This package provides a basic ANSI escape parser. Program output (such as
+      build logs) often includes ANSI escape codes to colour and style the output.
+      This library interprets some of the common codes and can convert them to
+      HTML, producing basic styled output (e.g. highlighting errors in red).
+    '';
+    homepage = "https://github.com/ocurrent/ansi";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ otini ];
+  };
+})

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -50,6 +50,8 @@ let
 
         angstrom-unix = callPackage ../development/ocaml-modules/angstrom-unix { };
 
+        ansi = callPackage ../development/ocaml-modules/ansi { };
+
         ansiterminal = callPackage ../development/ocaml-modules/ansiterminal { };
 
         ao = callPackage ../development/ocaml-modules/ao { };


### PR DESCRIPTION
Adds `ocamlPackages.ansi` (version 0.7.0), [an ANSI escape sequence parser from the OCurrent project](https://github.com/ocurrent/ansi) present in the opam repository.

This package is a dependency of the latest version of `slipshow` (upgrade planned for a follow-up PR).

AI disclosure: Patch generated by Claude Sonnet 4.6 (Anthropic), reviewed by me in its entirety and I’ll answer for it.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
