### PR TITLE
ocamlPackages.grace: init at 0.3.0

### DIFF
--- a/pkgs/development/ocaml-modules/grace/default.nix
+++ b/pkgs/development/ocaml-modules/grace/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildDunePackage,
+  fetchFromGitHub,
+  fmt,
+  iter,
+  uutf,
+  sexplib,
+  ppx_sexp_conv,
+  core,
+  ppx_jane,
+  dedent ? null,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "grace";
+  version = "0.3.0";
+
+  minimalOCamlVersion = "4.14";
+
+  src = fetchFromGitHub {
+    owner = "johnyob";
+    repo = "grace";
+    tag = finalAttrs.version;
+    hash = "sha256-V5K9RGk47K/R+q4wS1FU02kMi1uWSCgdUjKHk7uXuGw=";
+  };
+
+  propagatedBuildInputs = [
+    fmt
+    iter
+    uutf
+    sexplib
+    ppx_sexp_conv
+  ];
+
+  checkInputs = [
+    core
+    ppx_jane
+    dedent
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "A fancy diagnostics library that allows your compilers to exit with grace";
+    homepage = "https://github.com/johnyob/grace";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ otini ];
+  };
+})

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -768,6 +768,8 @@ let
           inherit (pkgs) gnuplot;
         };
 
+        grace = callPackage ../development/ocaml-modules/grace { };
+
         graphics =
           if lib.versionOlder "4.09" ocaml.version then
             callPackage ../development/ocaml-modules/graphics { }


### PR DESCRIPTION
Adds `ocamlPackages.grace`. Grace is a diagnostics library for compiler authors providing structured error and warning reporting with source spans, ANSI-coloured terminal output, and an HTML renderer. It is a dependency of the latest version of `ocamlPackages.slipshow` (upgrade planned for a follow-up PR). It is part of the opam repository.

AI disclosure: Patch generated by Claude Sonnet 4.6 (Anthropic), reviewed by me in entirety and I’ll answer for it.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
