### PR TITLE
Revert "gcc15: 15.2.0 -> 15.3.0"

### DIFF
--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -54,8 +54,6 @@
 
   # GCC
   gcc = [
-    "https://gcc.gnu.org/pub/gcc/"
-    "https://sourceware.org/pub/gcc/"
     "https://mirror.koddos.net/gcc/"
     "https://bigsearcher.com/mirrors/gcc/"
     "ftp://ftp.nluug.nl/mirror/languages/gcc/"

--- a/pkgs/development/compilers/gcc/ng/default.nix
+++ b/pkgs/development/compilers/gcc/ng/default.nix
@@ -14,7 +14,7 @@
 }@packageSetArgs:
 let
   versions = {
-    "15.3.0".officialRelease.sha256 = "sha256-+lnBvu+JlfJ8TXHB3yJ1hxiTFdPm+v8btDBuYbDFMOs=";
+    "15.2.0".officialRelease.sha256 = "sha256-Q4/ZloJrDIJIWinaA6ctcdbjVBqD7HAt9Ccfb+Al0k4=";
   }
   // gccVersions;
 

--- a/pkgs/development/compilers/gcc/patches/15/aarch64-sve-rtx.patch
+++ b/pkgs/development/compilers/gcc/patches/15/aarch64-sve-rtx.patch
@@ -1,0 +1,87 @@
+Without the change `libhwy-1.3.0` ICEs when built for aarch64-linux as:
+https://github.com/NixOS/nixpkgs/pull/320616#issuecomment-3764400891
+
+Upstream report: http://gcc.gnu.org/PR120718
+Upstream fix: https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=d755aa03db0ad5b71ee7f39b09c92870789f2f00
+Fetched as:
+$ curl -L 'https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff_plain;h=d755aa03db0ad5b71ee7f39b09c92870789f2f00' > aarch64-sve-rtx.patch
+
+From: Richard Sandiford <richard.sandiford@arm.com>
+Date: Thu, 14 Aug 2025 16:56:50 +0000 (+0100)
+Subject: Remove MODE_COMPOSITE_P test from simplify_gen_subreg [PR120718]
+X-Git-Url: https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff_plain;h=d755aa03db0ad5b71ee7f39b09c92870789f2f00
+
+Remove MODE_COMPOSITE_P test from simplify_gen_subreg [PR120718]
+
+simplify_gen_subreg rejected subregs of literal constants if
+MODE_COMPOSITE_P.  This was added by the fix for PR96648 in
+g:c0f772894b6b3cd8ed5c5dd09d0c7917f51cf70f.  Jakub said:
+
+  As for the simplify_gen_subreg change, I think it would be desirable
+  to just avoid creating SUBREGs of constants on all targets and for all
+  constants, if simplify_immed_subreg simplified, fine, otherwise punt,
+  but as we are late in GCC11 development, the patch instead guards this
+  behavior on MODE_COMPOSITE_P (outermode) - i.e. only conversions to
+  powerpc{,64,64le} double double long double - and only for the cases where
+  simplify_immed_subreg was called.
+
+I'm not sure about relaxing the codes further, since subregs might
+be wanted for CONST, SYMBOL_REF and LABEL_REF.  But removing the
+MODE_COMPOSITE_P is needed to fix PR120718, where we get an ICE
+from generating a subreg of a V2SI const_vector.
+
+Unlike the trunk version, this backport does not remove the
+VOIDmode test; see PR121501.
+
+gcc/
+	PR rtl-optimization/120718
+	* simplify-rtx.cc (simplify_context::simplify_gen_subreg):
+	Remove MODE_COMPOSITE_P condition.
+
+gcc/testsuite/
+	PR rtl-optimization/120718
+	* gcc.target/aarch64/sve/acle/general/pr120718.c: New test.
+---
+
+diff --git a/gcc/simplify-rtx.cc b/gcc/simplify-rtx.cc
+index 88d31a71c05a..8d4cbf1371a3 100644
+--- a/gcc/simplify-rtx.cc
++++ b/gcc/simplify-rtx.cc
+@@ -8317,14 +8317,11 @@ simplify_context::simplify_gen_subreg (machine_mode outermode, rtx op,
+ 
+   if (GET_CODE (op) == SUBREG
+       || GET_CODE (op) == CONCAT
+-      || GET_MODE (op) == VOIDmode)
+-    return NULL_RTX;
+-
+-  if (MODE_COMPOSITE_P (outermode)
+-      && (CONST_SCALAR_INT_P (op)
+-	  || CONST_DOUBLE_AS_FLOAT_P (op)
+-	  || CONST_FIXED_P (op)
+-	  || GET_CODE (op) == CONST_VECTOR))
++      || GET_MODE (op) == VOIDmode
++      || CONST_SCALAR_INT_P (op)
++      || CONST_DOUBLE_AS_FLOAT_P (op)
++      || CONST_FIXED_P (op)
++      || GET_CODE (op) == CONST_VECTOR)
+     return NULL_RTX;
+ 
+   if (validate_subreg (outermode, innermode, op, byte))
+diff --git a/gcc/testsuite/gcc.target/aarch64/sve/acle/general/pr120718.c b/gcc/testsuite/gcc.target/aarch64/sve/acle/general/pr120718.c
+new file mode 100644
+index 000000000000..9ca0938e36bf
+--- /dev/null
++++ b/gcc/testsuite/gcc.target/aarch64/sve/acle/general/pr120718.c
+@@ -0,0 +1,12 @@
++/* { dg-options "-O2" } */
++
++#include <arm_sve.h>
++typedef int __attribute__((vector_size(8))) v2si;
++typedef struct { int x; int y; } A;
++void bar(A a);
++void foo()
++{
++    A a;
++    *(v2si *)&a = (v2si){0, (int)svcntd_pat(SV_ALL)};
++    bar(a);
++}

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -112,6 +112,9 @@ optionals noSysDirs (
 # c++tools: Don't check --enable-default-pie.
 # --enable-default-pie breaks bootstrap gcc otherwise, because libiberty.a is not found
 ++ optional (is14 || is15) ./c++tools-dont-check-enable-default-pie.patch
+# http://gcc.gnu.org/PR120718 backport (will be inclkuded in 15.3.0) to
+# fix `highway-1.3.0` ICE on aarch64-linux.
+++ optional is15 ./15/aarch64-sve-rtx.patch
 
 ## 2. Patches relevant on specific platforms ####################################
 

--- a/pkgs/development/compilers/gcc/versions.nix
+++ b/pkgs/development/compilers/gcc/versions.nix
@@ -1,7 +1,7 @@
 let
   majorMinorToVersionMap = {
     "16" = "16.1.0";
-    "15" = "15.3.0";
+    "15" = "15.2.0";
     "14" = "14.3.0";
     "13" = "13.4.0";
   };
@@ -15,7 +15,7 @@ let
       # 3 digits: releases (14.2.0)
       # 4 digits: snapshots (14.2.1.20250322)
       "16.1.0" = "sha256-UO+02Uwzl6/zsNYaWr10i03THZ0/Kre+BbFx02pRD3k=";
-      "15.3.0" = "sha256-+lnBvu+JlfJ8TXHB3yJ1hxiTFdPm+v8btDBuYbDFMOs=";
+      "15.2.0" = "sha256-Q4/ZloJrDIJIWinaA6ctcdbjVBqD7HAt9Ccfb+Al0k4=";
       "14.3.0" = "sha256-4Nx3KXYlYxrI5Q+pL//v6Jmk63AlktpcMu8E4ik6yjo=";
       "13.4.0" = "sha256-nEzm27BAVo/cVFWIrAPFy8lajb8MeqSQFwhDr7WcqPU=";
     }


### PR DESCRIPTION
Broke `aarch64-linux` and Darwin. Reverting pending fixes.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
