### PR TITLE
hebbot: 2.1 -> 3.0

### DIFF
--- a/pkgs/by-name/he/hebbot/package.nix
+++ b/pkgs/by-name/he/hebbot/package.nix
@@ -8,22 +8,21 @@
   openssl,
   autoconf,
   automake,
-  unstableGitUpdater,
   sqlite,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "hebbot";
-  version = "2.1-unstable-2024-09-20";
+  version = "3.0";
 
   src = fetchFromGitHub {
     owner = "haecker-felix";
     repo = "hebbot";
-    rev = "4c7152a3ce88ecfbac06f823abd4fd849e0c30d1";
-    hash = "sha256-y+KpxiEzVAggFoPvTOy0IEmAo2V6mOpM0VzEScUOtsM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-log2h3mWSBQu1zjki6mMW7Lcph2dht0ksVkdacum0Jc=";
   };
 
-  cargoHash = "sha256-xRTl6Z6sn44yaEIFxG2vVKlbruDmOS2CdPZeVmWYOoA=";
+  cargoHash = "sha256-cfHD66uf6zIeml69VRGy9bjbdS3PkOfNBdTam5UCzso=";
 
   nativeBuildInputs = [
     pkg-config
@@ -46,13 +45,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     ];
   };
 
-  passthru.updateScript = unstableGitUpdater { };
-
   meta = {
     description = "Matrix bot which can generate \"This Week in X\" like blog posts ";
     homepage = "https://github.com/haecker-felix/hebbot";
-    changelog = "https://github.com/haecker-felix/hebbot/releases/tag/v2.1";
-    license = lib.licenses.agpl3Only;
+    changelog = "https://github.com/haecker-felix/hebbot/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [ agpl3Only ];
     mainProgram = "hebbot";
     maintainers = with lib.maintainers; [ a-kenji ];
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
