### PR TITLE
hasciicam: init at 2.5.0

### DIFF
--- a/pkgs/by-name/ha/hasciicam/package.nix
+++ b/pkgs/by-name/ha/hasciicam/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  SDL2,
+  libx11,
+  ncurses,
+  nix-update-script,
+  enableSDL ? true,
+  enableGUI ? true,
+  enableX11 ? stdenv.hostPlatform.isLinux,
+  enableCurses ? true,
+  enableTests ? true,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hasciicam";
+  version = "2.5.0";
+
+  src = fetchFromGitHub {
+    owner = "dyne";
+    repo = "hasciicam";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-agwNuIxO+o4HHkjd3TikYuVNgO0vlDPikcZoLDVLCUc=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs =
+    lib.optionals enableSDL [ SDL2 ]
+    ++ lib.optionals enableX11 [ libx11 ]
+    ++ lib.optionals enableCurses [ ncurses ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "HASCIICAM_ENABLE_TESTS" enableTests)
+    (lib.cmakeBool "HASCIICAM_ENABLE_SDL" enableSDL)
+    (lib.cmakeBool "HASCIICAM_ENABLE_GUI" enableGUI)
+    (lib.cmakeBool "HASCIICAM_ENABLE_X11" enableX11)
+    (lib.cmakeBool "HASCIICAM_ENABLE_CURSES" enableCurses)
+  ];
+
+  doCheck = enableTests;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "ASCII art webcam and video viewer";
+    homepage = "https://github.com/dyne/hasciicam";
+    changelog = "https://github.com/dyne/hasciicam/releases/tag/v${finalAttrs.version}";
+    mainProgram = "hasciicam";
+    platforms = lib.platforms.unix;
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ castorNova2 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds [hasciicam](https://github.com/dyne/hasciicam) which is a webcam application that renders live video in ASCII art and can output it in terminal, html,SDL, etc.

- Some wayland machines could throw the error while opening the app, it seems to be mostly either the SDL bug or wayland issue since similar issue has happened to me in past where apps were not working on my wayland machine while same app is running on someone else wayland machine. To mitigate this issue set or use<mark> SDL_VIDEODRIVER=x11 </mark>.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
