### PR TITLE
servarr-ffmpeg: align config flags on upstream

### DIFF
--- a/pkgs/by-name/se/servarr-ffmpeg/package.nix
+++ b/pkgs/by-name/se/servarr-ffmpeg/package.nix
@@ -38,6 +38,8 @@ in
   withCudaLLVM = false;
   withCuvid = false;
   withDrm = false;
+  withGmp = false;
+  withNetwork = false;
   withNvcodec = false;
   withFontconfig = false;
   withFreetype = false;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Disable new options added to generic.nix but not used upstream by servarr-ffmpeg

Before:
```
[nixos@nixos:~]$ diff -u upstream.log nixpkgs_old.log
--- upstream.log        2026-06-26 09:50:08.501964301 +0000
+++ nixpkgs_old.log     2026-06-26 09:50:00.962075958 +0000
@@ -2,6 +2,7 @@
 C compiler                gcc
 C library                 glibc
 ARCH                      x86 (generic)
+version string suffix     Servarr
 big-endian                no
 runtime cpu detection     yes
 standalone assembly       yes
@@ -24,14 +25,14 @@
 CMOV is fast              yes
 EBX available             yes
 EBP available             yes
-debug symbols             yes
-strip symbols             yes
+debug symbols             no
+strip symbols             no
 optimize for size         no
 optimizations             yes
-static                    yes
-shared                    no
+static                    no
+shared                    yes
 postprocessing support    no
-network support           no
+network support           yes
 threading support         pthreads
 safe bitstream reader     yes
 texi2html enabled         no
@@ -42,7 +43,7 @@
 xmllint enabled           no

 External libraries:
-libdav1d
+gmp                     libdav1d

 External libraries providing hardware acceleration:

@@ -231,121 +232,124 @@
 dvaudio                 mpegaudio               xma

 Enabled demuxers:
-aa                      hnm                     pcm_alaw
-aac                     ico                     pcm_f32be
-aax                     idcin                   pcm_f32le
-ac3                     idf                     pcm_f64be
-ace                     iff                     pcm_f64le
-acm                     ifv                     pcm_mulaw
-act                     ilbc                    pcm_s16be
-adf                     image2                  pcm_s16le
-adp                     image2_alias_pix        pcm_s24be
-ads                     image2_brender_pix      pcm_s24le
-adx                     image2pipe              pcm_s32be
-aea                     image_bmp_pipe          pcm_s32le
-afc                     image_cri_pipe          pcm_s8
-aiff                    image_dds_pipe          pcm_u16be
-aix                     image_dpx_pipe          pcm_u16le
-alp                     image_exr_pipe          pcm_u24be
-amr                     image_gem_pipe          pcm_u24le
-amrnb                   image_gif_pipe          pcm_u32be
-amrwb                   image_j2k_pipe          pcm_u32le
-anm                     image_jpeg_pipe         pcm_u8
-apc                     image_jpegls_pipe       pcm_vidc
-ape                     image_jpegxl_pipe       pjs
-apm                     image_pam_pipe          pmp
-apng                    image_pbm_pipe          pp_bnk
-aptx                    image_pcx_pipe          pva
-aptx_hd                 image_pfm_pipe          pvf
-aqtitle                 image_pgm_pipe          qcp
-argo_asf                image_pgmyuv_pipe       r3d
-argo_brp                image_pgx_pipe          rawvideo
-argo_cvg                image_phm_pipe          realtext
-asf                     image_photocd_pipe      redspark
-asf_o                   image_pictor_pipe       rl2
-ass                     image_png_pipe          rm
-ast                     image_ppm_pipe          roq
-au                      image_psd_pipe          rpl
-av1                     image_qdraw_pipe        rsd
-avi                     image_qoi_pipe          rso
-avr                     image_sgi_pipe          s337m
-avs                     image_sunrast_pipe      sami
-avs2                    image_svg_pipe          sbc
-avs3                    image_tiff_pipe         sbg
-bethsoftvid             image_vbn_pipe          scc
-bfi                     image_webp_pipe         scd
-bfstm                   image_xbm_pipe          sdr2
-bink                    image_xpm_pipe          sds
-binka                   image_xwd_pipe          sdx
-bintext                 ingenient               segafilm
-bit                     ipmovie                 ser
-bitpacked               ipu                     sga
-bmv                     ircam                   shorten
-boa                     iss                     siff
-brstm                   iv8                     simbiosis_imx
-c93                     ivf                     sln
-caf                     ivr                     smacker
-cavsvideo               jacosub                 smjpeg
-cdg                     jv                      smush
-cdxl                    kux                     sol
-cine                    kvag                    sox
-codec2                  live_flv                spdif
-codec2raw               lmlm4                   srt
-concat                  loas                    stl
-data                    lrc                     str
-daud                    luodat                  subviewer
-dcstr                   lvf                     subviewer1
-derf                    lxf                     sup
-dfa                     m4v                     svag
-dfpwm                   matroska                svs
-dhav                    mca                     swf
-dirac                   mcc                     tak
-dnxhd                   mgsts                   tedcaptions
-dsf                     microdvd                thp
-dsicin                  mjpeg                   threedostr
-dss                     mjpeg_2000              tiertexseq
-dts                     mlp                     tmv
-dtshd                   mlv                     truehd
-dv                      mm                      tta
-dvbsub                  mmf                     tty
-dvbtxt                  mods                    txd
-dxa                     moflex                  ty
-ea                      mov                     v210
-ea_cdata                mp3                     v210x
-eac3                    mpc                     vag
-epaf                    mpc8                    vc1
-ffmetadata              mpegps                  vc1t
-filmstrip               mpegts                  vividas
-fits                    mpegtsraw               vivo
-flac                    mpegvideo               vmd
-flic                    mpjpeg                  vobsub
-flv                     mpl2                    voc
-fourxm                  mpsub                   vpk
-frm                     msf                     vplayer
-fsb                     msnwc_tcp               vqf
-fwse                    msp                     w64
-g722                    mtaf                    wav
-g723_1                  mtv                     wc3
-g726                    musx                    webm_dash_manifest
-g726le                  mv                      webvtt
-g729                    mvi                     wsaud
-gdv                     mxf                     wsd
-genh                    mxg                     wsvqa
-gif                     nc                      wtv
-gsm                     nistsphere              wv
-gxf                     nsp                     wve
-h261                    nsv                     xa
-h263                    nut                     xbin
-h264                    nuv                     xmv
-hca                     obu                     xvag
-hcom                    ogg                     xwma
-hevc                    oma                     yop
-hls                     paf                     yuv4mpegpipe
+aa                      idcin                   pcm_f64le
+aac                     idf                     pcm_mulaw
+aax                     iff                     pcm_s16be
+ac3                     ifv                     pcm_s16le
+ace                     ilbc                    pcm_s24be
+acm                     image2                  pcm_s24le
+act                     image2_alias_pix        pcm_s32be
+adf                     image2_brender_pix      pcm_s32le
+adp                     image2pipe              pcm_s8
+ads                     image_bmp_pipe          pcm_u16be
+adx                     image_cri_pipe          pcm_u16le
+aea                     image_dds_pipe          pcm_u24be
+afc                     image_dpx_pipe          pcm_u24le
+aiff                    image_exr_pipe          pcm_u32be
+aix                     image_gem_pipe          pcm_u32le
+alp                     image_gif_pipe          pcm_u8
+amr                     image_j2k_pipe          pcm_vidc
+amrnb                   image_jpeg_pipe         pjs
+amrwb                   image_jpegls_pipe       pmp
+anm                     image_jpegxl_pipe       pp_bnk
+apc                     image_pam_pipe          pva
+ape                     image_pbm_pipe          pvf
+apm                     image_pcx_pipe          qcp
+apng                    image_pfm_pipe          r3d
+aptx                    image_pgm_pipe          rawvideo
+aptx_hd                 image_pgmyuv_pipe       realtext
+aqtitle                 image_pgx_pipe          redspark
+argo_asf                image_phm_pipe          rl2
+argo_brp                image_photocd_pipe      rm
+argo_cvg                image_pictor_pipe       roq
+asf                     image_png_pipe          rpl
+asf_o                   image_ppm_pipe          rsd
+ass                     image_psd_pipe          rso
+ast                     image_qdraw_pipe        rtp
+au                      image_qoi_pipe          rtsp
+av1                     image_sgi_pipe          s337m
+avi                     image_sunrast_pipe      sami
+avr                     image_svg_pipe          sap
+avs                     image_tiff_pipe         sbc
+avs2                    image_vbn_pipe          sbg
+avs3                    image_webp_pipe         scc
+bethsoftvid             image_xbm_pipe          scd
+bfi                     image_xpm_pipe          sdp
+bfstm                   image_xwd_pipe          sdr2
+bink                    ingenient               sds
+binka                   ipmovie                 sdx
+bintext                 ipu                     segafilm
+bit                     ircam                   ser
+bitpacked               iss                     sga
+bmv                     iv8                     shorten
+boa                     ivf                     siff
+brstm                   ivr                     simbiosis_imx
+c93                     jacosub                 sln
+caf                     jv                      smacker
+cavsvideo               kux                     smjpeg
+cdg                     kvag                    smush
+cdxl                    live_flv                sol
+cine                    lmlm4                   sox
+codec2                  loas                    spdif
+codec2raw               lrc                     srt
+concat                  luodat                  stl
+data                    lvf                     str
+daud                    lxf                     subviewer
+dcstr                   m4v                     subviewer1
+derf                    matroska                sup
+dfa                     mca                     svag
+dfpwm                   mcc                     svs
+dhav                    mgsts                   swf
+dirac                   microdvd                tak
+dnxhd                   mjpeg                   tedcaptions
+dsf                     mjpeg_2000              thp
+dsicin                  mlp                     threedostr
+dss                     mlv                     tiertexseq
+dts                     mm                      tmv
+dtshd                   mmf                     truehd
+dv                      mods                    tta
+dvbsub                  moflex                  tty
+dvbtxt                  mov                     txd
+dxa                     mp3                     ty
+ea                      mpc                     v210
+ea_cdata                mpc8                    v210x
+eac3                    mpegps                  vag
+epaf                    mpegts                  vc1
+ffmetadata              mpegtsraw               vc1t
+filmstrip               mpegvideo               vividas
+fits                    mpjpeg                  vivo
+flac                    mpl2                    vmd
+flic                    mpsub                   vobsub
+flv                     msf                     voc
+fourxm                  msnwc_tcp               vpk
+frm                     msp                     vplayer
+fsb                     mtaf                    vqf
+fwse                    mtv                     w64
+g722                    musx                    wav
+g723_1                  mv                      wc3
+g726                    mvi                     webm_dash_manifest
+g726le                  mxf                     webvtt
+g729                    mxg                     wsaud
+gdv                     nc                      wsd
+genh                    nistsphere              wsvqa
+gif                     nsp                     wtv
+gsm                     nsv                     wv
+gxf                     nut                     wve
+h261                    nuv                     xa
+h263                    obu                     xbin
+h264                    ogg                     xmv
+hca                     oma                     xvag
+hcom                    paf                     xwma
+hevc                    pcm_alaw                yop
+hls                     pcm_f32be               yuv4mpegpipe
+hnm                     pcm_f32le
+ico                     pcm_f64be

 Enabled muxers:

 Enabled protocols:
-file
+file                    rtp                     udp
+http                    tcp

 Enabled filters:

@@ -357,5 +361,4 @@

 Enabled outdevs:

-License: LGPL version 2.1 or later
-
+License: GPL version 3 or later
```

After:
```
[nixos@nixos:~]$ diff -u upstream.log nixpkgs.log
--- upstream.log        2026-06-26 09:50:08.501964301 +0000
+++ nixpkgs.log 2026-06-26 09:49:51.226221031 +0000
@@ -2,6 +2,7 @@
 C compiler                gcc
 C library                 glibc
 ARCH                      x86 (generic)
+version string suffix     Servarr
 big-endian                no
 runtime cpu detection     yes
 standalone assembly       yes
@@ -24,12 +25,12 @@
 CMOV is fast              yes
 EBX available             yes
 EBP available             yes
-debug symbols             yes
-strip symbols             yes
+debug symbols             no
+strip symbols             no
 optimize for size         no
 optimizations             yes
-static                    yes
-shared                    no
+static                    no
+shared                    yes
 postprocessing support    no
 network support           no
 threading support         pthreads
@@ -357,5 +358,4 @@

 Enabled outdevs:

-License: LGPL version 2.1 or later
-
+License: GPL version 3 or later
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
