### PR TITLE
diffyml: init at 1.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26993,6 +26993,11 @@
     githubId = 203195;
     name = "Szczyp";
   };
+  szhekpisov = {
+    github = "szhekpisov";
+    githubId = 87662520;
+    name = "Sergei Zhekpisov";
+  };
   szkiba = {
     email = "iszkiba@gmail.com";
     github = "szkiba";

--- a/pkgs/by-name/di/diffyml/package.nix
+++ b/pkgs/by-name/di/diffyml/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "diffyml";
+  version = "1.7.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "szhekpisov";
+    repo = "diffyml";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DIKHvFY/eW3CAF/ojW+D737vFCcZk0peRrSb8I/an9Q=";
+  };
+
+  vendorHash = "sha256-QE/EwVzMqUO24ZAl0WBibGx6x0kNo1AUTZtfnQvX50k=";
+
+  # bench/compare and doc/gen-cli-ref are internal dev tools, not user-facing.
+  excludedPackages = [
+    "bench/compare"
+    "doc/gen-cli-ref"
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+    "-X main.commit=v${finalAttrs.version}"
+    "-X main.buildDate=1970-01-01"
+  ];
+
+  # test/ holds e2e (kind/kubectl) and repo-health suites that need network
+  # and external tooling; unsuitable for the sandboxed build.
+  preCheck = ''
+    rm -rf test
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Structural YAML diff tool with Kubernetes awareness and CI-friendly output";
+    homepage = "https://szhekpisov.github.io/diffyml/";
+    downloadPage = "https://github.com/szhekpisov/diffyml";
+    changelog = "https://github.com/szhekpisov/diffyml/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ szhekpisov ];
+    mainProgram = "diffyml";
+  };
+})


### PR DESCRIPTION
Adds [diffyml](https://github.com/szhekpisov/diffyml) 1.7.0, a structural YAML diff tool written in Go (single runtime dependency, `go.yaml.in/yaml/v3`). It compares YAML semantically — understanding key ordering, list identity, multi-document YAML, and Kubernetes resources — and supports several CI-friendly output formats.

- Homepage: https://github.com/szhekpisov/diffyml
- Changelog: https://github.com/szhekpisov/diffyml/releases/tag/v1.7.0

### Packaging notes

- `excludedPackages` skips `bench/compare` and `doc/gen-cli-ref`, which are internal dev tools, so only the `diffyml` binary is installed.
- `preCheck` removes `test/`, which holds e2e (kind/kubectl) and repo-health suites that require network access and external tooling and are unsuitable for the sandbox. The upstream Go unit tests still run in `checkPhase`.
- Requires Go ≥ 1.26.4 (now on `master`).

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Upstream Go unit tests run during `checkPhase`.
- [ ] Ran `nixpkgs-review` on this PR. (No local Nix toolchain available; relying on ofborg.)
- [x] Tested basic functionality of all binary files — `result/bin/diffyml --version` reports `1.7.0`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking. (N/A — new leaf package.)
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module. (N/A)
  - [ ] Module update: when the change is significant. (N/A)
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

## AI usage disclosure

This package was authored with AI assistance (Claude Code). I reviewed the derivation and verified the build, `checkPhase`, and `diffyml --version` in an `aarch64-linux` Nix sandbox (a `nixos/nix` container on an Apple Silicon host). I take responsibility for this contribution.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
