### PR TITLE
python3Packages.locust-cloud: disable set of flaky tests

### DIFF
--- a/pkgs/development/python-modules/locust-cloud/default.nix
+++ b/pkgs/development/python-modules/locust-cloud/default.nix
@@ -58,17 +58,13 @@ buildPythonPackage rec {
     export LOCUSTCLOUD_PASSWORD=dummy
   '';
 
-  disabledTests = [
-    # AssertionError
-    "test_recursive_imports"
-    "test_from_import_file"
-  ];
-
   disabledTestPaths = [
     # Tests require network access
     "tests/web_login_test.py"
     "tests/cloud_test.py"
     "tests/websocket_test.py"
+    # AssertionError
+    "tests/import_finder_test.py"
   ];
 
   meta = {


### PR DESCRIPTION
Disabled all tests that use `from locust_cloud.import_finder import get_imported_files` as they sporadically fail on `aarch64-linux` architecture leading to `locust` also failing due to `locust-cloud` being a dependency. See [Hydra](https://hydra.nixos.org/eval/1826388?filter=locust&compare=1826377&full=) for an example failure.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
