### PR TITLE
m1n1: 1.5.2 -> 1.6.0, fix font

### DIFF
--- a/pkgs/by-name/m1/m1n1/package.nix
+++ b/pkgs/by-name/m1/m1n1/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchFromGitHub,
   imagemagick,
-  source-code-pro,
   python3Packages,
   nix-update-script,
   nixos-icons,
@@ -61,14 +60,6 @@ stdenv.mkDerivation (finalAttrs: {
     rustPackages.cargo
     rustPlatform.cargoSetupHook
   ];
-
-  postConfigure = ''
-    patchShebangs --build font/makefont.sh
-    FONT_PATH=${source-code-pro}/share/fonts/opentype/SourceCodePro-Bold.otf
-    rm font/{SourceCodePro-Bold.ttf,font.bin,font_retina.bin}
-    ./font/makefont.sh 8 16 12 $FONT_PATH font/font.bin
-    ./font/makefont.sh 16 32 25 $FONT_PATH font/font_retina.bin
-  '';
 
   makeFlags = [
     "ARCH=${stdenv.cc.targetPrefix}"

--- a/pkgs/by-name/m1/m1n1/package.nix
+++ b/pkgs/by-name/m1/m1n1/package.nix
@@ -32,17 +32,23 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "m1n1";
-  version = "1.5.2";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "AsahiLinux";
     repo = "m1n1";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-rxop5r+EVXnp1OVkGT6MUwcl6yNTJxJSJuruZiaou7g=";
+    hash = "sha256-yYXB2DhLcLqxaqwP5mII+j2PMIoXdZ35bpx/d0WSZA8=";
     fetchSubmodules = true;
   };
 
-  cargoVendorDir = ".";
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version;
+    src = "${finalAttrs.src}/rust";
+    sourceRoot = "rust";
+    hash = "sha256-iuiRp2FA5jnb3uh/p1gpc7Sznt1s4/UR91wEtXTf97o=";
+  };
+  cargoRoot = "rust";
 
   postPatch = lib.optionalString (customLogo != null) ''
     magick ${customLogo} -resize 128x128 data/custom_128.png


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
