### PR TITLE
lark-cli: init at 1.0.58

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -30997,6 +30997,11 @@
     githubId = 25164338;
     keys = [ { fingerprint = "065A 0A98 FE61 E1C1 41B0  AFE7 64FA BC62 F457 2875"; } ];
   };
+  zehuajun = {
+    github = "zehuajun";
+    githubId = 87254340;
+    name = "zehuajun";
+  };
   zelkourban = {
     name = "zelkourban";
     email = "zelo.urban@gmail.com";

--- a/pkgs/by-name/la/lark-cli/package.nix
+++ b/pkgs/by-name/la/lark-cli/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  fetchurl,
+  runCommand,
+  jq,
+  testers,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "lark-cli";
+  version = "1.0.58";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "larksuite";
+    repo = "cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MqaxcmzX/79vM2EI8wD4ZAFsUfqWvPAovlpmuDP1IWU=";
+  };
+
+  vendorHash = "sha256-M0/Y62Y+M/P1B/YIDjX5bEyB/GKihCWQakTWVd7zvBg=";
+
+  subPackages = [ "." ];
+
+  postPatch =
+    let
+      metaDataRaw = fetchurl {
+        name = "meta_dataraw.json";
+        url = "https://web.archive.org/web/20260626061256/https://open.feishu.cn/api/tools/open/api_definition?protocol=meta&client_version=v${finalAttrs.version}";
+        hash = "sha256-W6KOtDW6gkZIqGa0A5QL0rVjVkRjM+gwW4S3AddPN1M=";
+      };
+
+      metaData =
+        runCommand "meta_data.json"
+          {
+            nativeBuildInputs = [ jq ];
+          }
+          ''
+            jq '.data' ${metaDataRaw} > $out
+          '';
+    in
+    ''
+      cp ${metaData} internal/registry/meta_data.json
+    '';
+
+  postInstall = ''
+    mv $out/bin/cli $out/bin/lark-cli
+  '';
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/larksuite/cli/internal/build.Version=v${finalAttrs.version}"
+    "-X github.com/larksuite/cli/internal/build.Date=2026-06-01"
+  ];
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command = "lark-cli --version";
+    version = "v${finalAttrs.version}";
+  };
+
+  meta = {
+    description = "The official CLI for Lark/Feishu open platform";
+    homepage = "https://github.com/larksuite/cli";
+    changelog = "https://github.com/larksuite/cli/releases/tag/v${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ zehuajun ];
+    mainProgram = "lark-cli";
+  };
+})


### PR DESCRIPTION
lark-cli is the official command-line tool for the Lark/Feishu Open Platform. It enables access to and control over Lark/Feishu open platform capabilities via the command line, and is designed for use in automation scripts and by AI Agents.

Official repository: https://github.com/larksuite/cli

The script in postPatch is a rewritten implementation of the upstream [scripts/fetch_meta.py](https://github.com/larksuite/cli/blob/main/scripts/fetch_meta.py), as the upstream make build script requires running this network-dependent script.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
