### PR TITLE
cyberchef: 11.0.0 -> 11.2.0

### DIFF
--- a/pkgs/by-name/cy/cyberchef/package.nix
+++ b/pkgs/by-name/cy/cyberchef/package.nix
@@ -21,15 +21,16 @@ let
       categories = [ "Development" ];
     }
   );
-  version = "11.0.0";
+  version = "11.2.0";
+  commit = "d358d82cbcb269d764a2deb598a37043bd054f45";
 in
 stdenv.mkDerivation {
   pname = "cyberchef";
   inherit version;
 
   src = fetchzip {
-    url = "https://github.com/gchq/CyberChef/releases/download/v${version}/CyberChef_v${version}.zip";
-    hash = "sha256-Hom0YFel1GVdyx/1q7N93se6uLUVutp0Lu31WNhkPPA=";
+    url = "https://github.com/gchq/CyberChef/releases/download/v${version}/CyberChef_${commit}.zip";
+    hash = "sha256-3DXIrxCefiEYqZOPs8pO5jWdHFj7cPGgrwZcwE4ESPg=";
     stripRoot = false;
   };
 


### PR DESCRIPTION
They modified their release naming to include the hash of the git commit that it's based on, so this adds a commit variable to support that.

Diff: https://github.com/gchq/CyberChef/compare/v11.0.0...v11.2.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
