### PR TITLE
joplin-desktop: 3.6.14 -> 3.6.15, pin nodejs_22 to fix build on aarch64-darwin

### DIFF
--- a/pkgs/by-name/jo/joplin-desktop/package.nix
+++ b/pkgs/by-name/jo/joplin-desktop/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  nodejs,
+  nodejs_22,
   makeDesktopItem,
   copyDesktopItems,
   makeWrapper,
@@ -25,7 +25,9 @@
 }:
 
 let
-  yarn-berry = yarn-berry_4;
+  # nodejs pin should be obsolete once #522655 is in master
+  nodejs = nodejs_22;
+  yarn-berry = yarn-berry_4.override { inherit nodejs; };
 
   releaseData = lib.importJSON ./release-data.json;
 in

--- a/pkgs/by-name/jo/joplin-desktop/release-data.json
+++ b/pkgs/by-name/jo/joplin-desktop/release-data.json
@@ -1,6 +1,6 @@
 {
-  "version": "3.6.14",
-  "hash": "sha256-0mioVPCBhWmcXkVqCOku1KsPN29fGDp5jGhxnwD0MUk=",
+  "version": "3.6.15",
+  "hash": "sha256-uCF0nsHZowb9SuqBNni8/MWjGv9JyAUJs/gQprEoGjU=",
   "plugins": {
     "io.github.jackgruber.backup": {
       "name": "joplin-plugin-backup",


### PR DESCRIPTION
Supersedes #535427

Pins nodejs to nodejs_22 in order to fix a build failure on aarch64-darwin:
```
(node:59923) Warning: File descriptor 16 closed but not opened in unmanaged mode
(Use `node --trace-warnings ...` to show where the warning was created)
➤ YN0000: └ Completed in 13s 781ms
➤ YN0000: ┌ Link step
➤ YN0001: │ Error: While persisting /nix/var/nix/b/0nr3ai0dcdybsvxzdxsbf5jjhc/source/.yarn/cache/tar-npm-7.4.3-1dbbd1ffc3-12a2a4fc6d.zip/node_modules/tar/ -> /nix/var/nix/b/0nr3ai0dc>
➤ YN0000: └ Completed in 4s 767ms
➤ YN0000: · Failed with errors in 18s 981ms
```

The issue seems to be the same as #525627 and specific to nodejs_24 and aarch64-darwin, so should hopefully be fixed by #522655.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
