### PR TITLE
[Backport release-26.05] seaweedfs: 4.19 -> 4.36

### DIFF
--- a/pkgs/by-name/se/seaweedfs/package.nix
+++ b/pkgs/by-name/se/seaweedfs/package.nix
@@ -9,7 +9,7 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "seaweedfs";
-  version = "4.31";
+  version = "4.34";
 
   src = fetchFromGitHub {
     owner = "seaweedfs";
@@ -22,10 +22,10 @@ buildGoModule (finalAttrs: {
       find "$out" -name .git -print0 | xargs -0 rm -rf
       popd
     '';
-    hash = "sha256-jhhLOjA+CXhtNyVHePT7dN3T5u5K3dHJj1gmxOh+RJU=";
+    hash = "sha256-lKpNBdiynDEnqCujgDRFUXvyVops4Q5l6n9P/7pm8hc=";
   };
 
-  vendorHash = "sha256-eB5fkFDGOqw4q2iHe4acLfIx2/a1Ys1EmARGX/vIN84=";
+  vendorHash = "sha256-MF8aLFKUFq0io7CL1EGZp+TUB2co/Hf0fwK2wZybx8Y=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/se/seaweedfs/package.nix
+++ b/pkgs/by-name/se/seaweedfs/package.nix
@@ -9,7 +9,7 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "seaweedfs";
-  version = "4.34";
+  version = "4.36";
 
   src = fetchFromGitHub {
     owner = "seaweedfs";
@@ -22,10 +22,10 @@ buildGoModule (finalAttrs: {
       find "$out" -name .git -print0 | xargs -0 rm -rf
       popd
     '';
-    hash = "sha256-lKpNBdiynDEnqCujgDRFUXvyVops4Q5l6n9P/7pm8hc=";
+    hash = "sha256-y42opbGNVMxWU/k0j5g27RWLBF0PLcOPlXU9eVg0jwY=";
   };
 
-  vendorHash = "sha256-MF8aLFKUFq0io7CL1EGZp+TUB2co/Hf0fwK2wZybx8Y=";
+  vendorHash = "sha256-peRhKuZ1D+y8Uhw1+P8Ogc1HrOh1/kYVd29lR89+rIo=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/se/seaweedfs/package.nix
+++ b/pkgs/by-name/se/seaweedfs/package.nix
@@ -93,5 +93,6 @@ buildGoModule (finalAttrs: {
       wozeparrot
     ];
     mainProgram = "weed";
+    broken = stdenv.hostPlatform.isDarwin;
   };
 })

--- a/pkgs/by-name/se/seaweedfs/package.nix
+++ b/pkgs/by-name/se/seaweedfs/package.nix
@@ -5,13 +5,14 @@
   installShellFiles,
   lib,
   libredirect,
+  glibc,
   nix-update-script,
   stdenv,
   versionCheckHook,
 }:
 buildGoModule (finalAttrs: {
   pname = "seaweedfs";
-  version = "4.19";
+  version = "4.24";
 
   src = fetchFromGitHub {
     owner = "seaweedfs";
@@ -24,7 +25,7 @@ buildGoModule (finalAttrs: {
       find "$out" -name .git -print0 | xargs -0 rm -rf
       popd
     '';
-    hash = "sha256-xMfV3WE10iP8MqxYd5w8JRUL5O7vO6ATN1ZEHB8MRxg=";
+    hash = "sha256-PYVCoeO+EYZ87gNwd9r+wgkpoeLhKKmV8fOimKkqR6w";
   };
 
   postPatch = ''
@@ -32,7 +33,11 @@ buildGoModule (finalAttrs: {
     rm -rf unmaintained
   '';
 
-  vendorHash = "sha256-mGiA91y6ebbbdAu0+ZDylUDuZb8vcNaqeGv70/IFx9k=";
+  vendorHash = "sha256-lTCfs/4FrICgb+uESM3XZBdinQw9Z0GrHkCIwmKSRh8";
+
+  buildInputs = [
+    glibc.static
+  ];
 
   nativeBuildInputs = [
     installShellFiles
@@ -64,6 +69,7 @@ buildGoModule (finalAttrs: {
   };
 
   preBuild = ''
+    export NIX_CFLAGS_LINK="-L${glibc.static}/lib"
     ldflags+=" -X \"github.com/seaweedfs/seaweedfs/weed/util/version.COMMIT=$(<COMMIT)\""
   '';
 
@@ -71,9 +77,10 @@ buildGoModule (finalAttrs: {
     # Test all targets.
     unset subPackages
 
+    export NIX_CFLAGS_LINK="-L${glibc.static}/lib"
     # Remove tests that require specialized environment or additional setup
     # that's not possible to achieve inside a sandbox.
-    for i in test/{fuse_integration,kafka,s3,sftp,volume_server}; do
+    for i in test/{fuse_dlm,fuse_integration,fuse_p2p,kafka,nfs,s3,sftp,volume_server}; do
       find "$i" -name '*_test.go' -delete
     done
 

--- a/pkgs/by-name/se/seaweedfs/package.nix
+++ b/pkgs/by-name/se/seaweedfs/package.nix
@@ -43,11 +43,13 @@ buildGoModule (finalAttrs: {
 
   ldflags = [
     "-s"
+  ]
+  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
     "-extldflags=-static"
   ];
 
   env = {
-    CGO_ENABLED = 0;
+    CGO_ENABLED = if stdenv.hostPlatform.isDarwin then 1 else 0;
     GODEBUG = "http2client=0";
   };
 
@@ -93,6 +95,5 @@ buildGoModule (finalAttrs: {
       wozeparrot
     ];
     mainProgram = "weed";
-    broken = stdenv.hostPlatform.isDarwin;
   };
 })

--- a/pkgs/by-name/se/seaweedfs/package.nix
+++ b/pkgs/by-name/se/seaweedfs/package.nix
@@ -1,18 +1,15 @@
 {
   buildGoModule,
   fetchFromGitHub,
-  iana-etc,
   installShellFiles,
   lib,
-  libredirect,
-  glibc,
   nix-update-script,
   stdenv,
   versionCheckHook,
 }:
 buildGoModule (finalAttrs: {
   pname = "seaweedfs";
-  version = "4.24";
+  version = "4.31";
 
   src = fetchFromGitHub {
     owner = "seaweedfs";
@@ -25,26 +22,12 @@ buildGoModule (finalAttrs: {
       find "$out" -name .git -print0 | xargs -0 rm -rf
       popd
     '';
-    hash = "sha256-PYVCoeO+EYZ87gNwd9r+wgkpoeLhKKmV8fOimKkqR6w";
+    hash = "sha256-jhhLOjA+CXhtNyVHePT7dN3T5u5K3dHJj1gmxOh+RJU=";
   };
 
-  postPatch = ''
-    # Remove unmaintained code that's not used and generates various issues.
-    rm -rf unmaintained
-  '';
+  vendorHash = "sha256-eB5fkFDGOqw4q2iHe4acLfIx2/a1Ys1EmARGX/vIN84=";
 
-  vendorHash = "sha256-lTCfs/4FrICgb+uESM3XZBdinQw9Z0GrHkCIwmKSRh8";
-
-  buildInputs = [
-    glibc.static
-  ];
-
-  nativeBuildInputs = [
-    installShellFiles
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    libredirect.hook
-  ];
+  nativeBuildInputs = [ installShellFiles ];
 
   subPackages = [ "weed" ];
 
@@ -69,31 +52,14 @@ buildGoModule (finalAttrs: {
   };
 
   preBuild = ''
-    export NIX_CFLAGS_LINK="-L${glibc.static}/lib"
     ldflags+=" -X \"github.com/seaweedfs/seaweedfs/weed/util/version.COMMIT=$(<COMMIT)\""
   '';
 
-  preCheck = ''
-    # Test all targets.
-    unset subPackages
-
-    export NIX_CFLAGS_LINK="-L${glibc.static}/lib"
-    # Remove tests that require specialized environment or additional setup
-    # that's not possible to achieve inside a sandbox.
-    for i in test/{fuse_dlm,fuse_integration,fuse_p2p,kafka,nfs,s3,sftp,volume_server}; do
-      find "$i" -name '*_test.go' -delete
-    done
-
-    # Required for reusing build artifacts in tests.
-    export PATH="$PATH:$NIX_BUILD_TOP/go/bin"
-  ''
-  + lib.optionalString (finalAttrs.env.CGO_ENABLED == 0) ''
-    # Depends on CGO.
-    rm -rf weed/mq/offset/{benchmark,end_to_end,sql_storage}_test.go
-  ''
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    export NIX_REDIRECTS=/etc/protocols=${iana-etc}/etc/protocols:/etc/services=${iana-etc}/etc/services
-  '';
+  # Tests frequently break (mostly because of sandboxing) and keeping track of
+  # changes every release is becoming too much of a hassle resulting in Nixpkgs
+  # versions lagging behind which is not ideal for a package with a rapid
+  # release cycle.
+  doCheck = false;
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     for shell in bash fish zsh; do
@@ -108,8 +74,6 @@ buildGoModule (finalAttrs: {
   versionCheckProgramArg = "version";
 
   passthru.updateScript = nix-update-script { };
-
-  __darwinAllowLocalNetworking = true;
 
   meta = {
     description = "Simple and highly scalable distributed file system";


### PR DESCRIPTION
https://github.com/seaweedfs/seaweedfs/compare/4.19...4.36

Fixes: #535590

I've decided to backport all changes from master to the stable release. This includes fixes for Darwin and a version bump to the latest release. I can't vouch for backwards compatibility of the upstream code. Speaking from personal experience of using the software between those versions: it shouldn't break anything.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
