### PR TITLE
your_spotify: switch to pnpm 11

### DIFF
--- a/nixos/tests/your_spotify.nix
+++ b/nixos/tests/your_spotify.nix
@@ -6,6 +6,7 @@
   };
 
   nodes.machine = {
+    services.mongodb.package = pkgs.mongodb-ce;
     services.your_spotify = {
       enable = true;
       spotifySecretFile = pkgs.writeText "spotifySecretFile" "deadbeef";

--- a/pkgs/by-name/yo/your_spotify/client.nix
+++ b/pkgs/by-name/yo/your_spotify/client.nix
@@ -6,7 +6,7 @@
   pnpmDeps,
   apiEndpoint ? "http://localhost:3000",
   pnpmConfigHook,
-  pnpm_9,
+  pnpm_11,
   nodejs,
 }:
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [
     pnpmConfigHook
-    pnpm_9
+    pnpm_11
     nodejs
   ];
 

--- a/pkgs/by-name/yo/your_spotify/package.nix
+++ b/pkgs/by-name/yo/your_spotify/package.nix
@@ -4,14 +4,13 @@
   fetchFromGitHub,
   fetchPnpmDeps,
   pnpmConfigHook,
-  pnpm_9,
+  pnpm_11,
   nodejs,
   makeWrapper,
   callPackage,
   nixosTests,
   nix-update-script,
 }:
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "your_spotify_server";
   version = "1.20.0";
@@ -25,15 +24,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-j6COg8Q0uj+5TjN/BUVst2UMhXLT3drLWUzdG/x51rk=";
+    pnpm = pnpm_11;
+    fetcherVersion = 4;
+    hash = "sha256-eUAzQ+LV+RZs/QEb5r7l9cisBjjWU8eGMm2r9ZNXmX8=";
   };
 
   nativeBuildInputs = [
     makeWrapper
     pnpmConfigHook
-    pnpm_9
+    pnpm_11
     nodejs
   ];
 


### PR DESCRIPTION
PNPM 9 EOL
part of #529285

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
