### PR TITLE
caido: 0.56.2 -> 0.57.0

### DIFF
--- a/pkgs/by-name/ca/caido-cli/package.nix
+++ b/pkgs/by-name/ca/caido-cli/package.nix
@@ -9,25 +9,25 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "caido-cli";
-  version = "0.56.2";
+  version = "0.57.0";
 
   src = fetchurl (
     {
       x86_64-linux = {
         url = "https://caido.download/releases/v${finalAttrs.version}/caido-cli-v${finalAttrs.version}-linux-x86_64.tar.gz";
-        hash = "sha256-SUkysiFdH4ilA6MKYMiSqC80NkYZ9YVO/7CT0hQY++Q=";
+        hash = "sha256-ujpGYERNceUPartkgx4o38xUfPwWvnmiEnjkvmEbybA=";
       };
       aarch64-linux = {
         url = "https://caido.download/releases/v${finalAttrs.version}/caido-cli-v${finalAttrs.version}-linux-aarch64.tar.gz";
-        hash = "sha256-rYRzo3iYjWAvRGm1+wBLGkr3eUoAGbi71+AX0qmoIXs=";
+        hash = "sha256-d1xzF0N6emShCQpotFiQEj1wV3hdt1DK7R+6Smlxrmg=";
       };
       x86_64-darwin = {
         url = "https://caido.download/releases/v${finalAttrs.version}/caido-cli-v${finalAttrs.version}-mac-x86_64.zip";
-        hash = "sha256-mMWivNwgAmMYitERwnP/lAzgzua/2UDDDffSbgZXlr4=";
+        hash = "sha256-xh6kaYPJ7dwDHM1CkDzxYBHM4cKUex+XPXceqvQgWX4=";
       };
       aarch64-darwin = {
         url = "https://caido.download/releases/v${finalAttrs.version}/caido-cli-v${finalAttrs.version}-mac-aarch64.zip";
-        hash = "sha256-19eEV79yk6PCHdl7oTw4Gqt10B7rYnZCJxBebDssFZc=";
+        hash = "sha256-FwbKLEwjiFzZWdBS6RgsDtc/EkI9AT2CBGwdmgEdDnw=";
       };
     }
     .${stdenv.hostPlatform.system}

--- a/pkgs/by-name/ca/caido-desktop/package.nix
+++ b/pkgs/by-name/ca/caido-desktop/package.nix
@@ -9,24 +9,24 @@
 
 let
   pname = "caido-desktop";
-  version = "0.56.2";
+  version = "0.57.0";
 
   sources = {
     x86_64-linux = {
       url = "https://caido.download/releases/v${version}/caido-desktop-v${version}-linux-x86_64.AppImage";
-      hash = "sha256-GW8prdvR9+WNO7bdz9ok27Aqra9+jgpZyBnYIM+G5Ys=";
+      hash = "sha256-a+WHhJ+TvwhOqHOxU7Y5LXeXAJ6T8hk71meFuTR+ra8=";
     };
     aarch64-linux = {
       url = "https://caido.download/releases/v${version}/caido-desktop-v${version}-linux-aarch64.AppImage";
-      hash = "sha256-mN5wf9RUllfbR/CfLTE6Ywzoj8wKmEG1clVCKRqPUtU=";
+      hash = "sha256-B7dw9uoG++AqT264ZlyHxGpv68fH5SlYzDKUaIM8c14=";
     };
     x86_64-darwin = {
       url = "https://caido.download/releases/v${version}/caido-desktop-v${version}-mac-x86_64.dmg";
-      hash = "sha256-4B3DQJL8M6otnLpFjr4haZA4EWHpgVADQW4DcwsDhIM=";
+      hash = "sha256-0VCLjl0Lpe+4Mgnrp6X8ApJWjAjuhkaZOxQ4P3C8MSM=";
     };
     aarch64-darwin = {
       url = "https://caido.download/releases/v${version}/caido-desktop-v${version}-mac-aarch64.dmg";
-      hash = "sha256-kZdfcZueMmgEHpNTIPANsN7X4lnVOfZXbKHxComaalM=";
+      hash = "sha256-GmpMnaGR7gYz1RvSO5xj9AA3xU1mn2IBInakmVkuG7A=";
     };
   };
 


### PR DESCRIPTION
**v0.57.0**
This release adds major features such as WebSocket support in Replay and M&R, custom extractors in Automate, a new StreamQL query language for WebSocket filtering, and more.

<div align="center">
  <img width="240" height="334" alt="image" src="https://github.com/user-attachments/assets/804499a1-a1fc-4ca1-9321-aa31f3b1a9d7" />
</div>


---

This PR includes both caido-cli and caido-desktop (as separate commits). Both applications are related, so it makes sense to push them together.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test