### PR TITLE
python3Packages.xstatic-jquery-file-upload: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/xstatic-jquery-file-upload/default.nix
+++ b/pkgs/development/python-modules/xstatic-jquery-file-upload/default.nix
@@ -2,13 +2,14 @@
   buildPythonPackage,
   lib,
   fetchPypi,
+  setuptools,
   xstatic-jquery,
 }:
 
 buildPythonPackage rec {
   pname = "xstatic-jquery-file-upload";
   version = "10.31.0.1";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     pname = "XStatic-jQuery-File-Upload";
@@ -16,10 +17,12 @@ buildPythonPackage rec {
     sha256 = "7d716f26aca14732c35c54f0ba6d38187600ab472fc98a91d972d12c5a70db27";
   };
 
+  build-system = [ setuptools ];
+
   # no tests implemented
   doCheck = false;
 
-  propagatedBuildInputs = [ xstatic-jquery ];
+  dependencies = [ xstatic-jquery ];
 
   meta = {
     homepage = "https://plugins.jquery.com/project/jQuery-File-Upload";

--- a/pkgs/development/python-modules/xstatic-jquery-file-upload/default.nix
+++ b/pkgs/development/python-modules/xstatic-jquery-file-upload/default.nix
@@ -6,15 +6,17 @@
   xstatic-jquery,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "xstatic-jquery-file-upload";
   version = "10.31.0.1";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
     pname = "XStatic-jQuery-File-Upload";
-    inherit version;
-    sha256 = "7d716f26aca14732c35c54f0ba6d38187600ab472fc98a91d972d12c5a70db27";
+    inherit (finalAttrs) version;
+    hash = "sha256-fXFvJqyhRzLDXFTwum04GHYAq0cvyYqR2XLRLFpw2yc=";
   };
 
   build-system = [ setuptools ];
@@ -24,10 +26,12 @@ buildPythonPackage rec {
 
   dependencies = [ xstatic-jquery ];
 
+  pythonImportsCheck = [ "xstatic.pkg.jquery_file_upload" ];
+
   meta = {
     homepage = "https://plugins.jquery.com/project/jQuery-File-Upload";
     description = "jquery-file-upload packaged static files for python";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ makefu ];
   };
-}
+})

--- a/pkgs/development/python-modules/xstatic-jquery-file-upload/default.nix
+++ b/pkgs/development/python-modules/xstatic-jquery-file-upload/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage (finalAttrs: {
   pythonImportsCheck = [ "xstatic.pkg.jquery_file_upload" ];
 
   meta = {
-    homepage = "https://plugins.jquery.com/project/jQuery-File-Upload";
+    homepage = "https://github.com/blueimp/jQuery-File-Upload";
     description = "jquery-file-upload packaged static files for python";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ makefu ];


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
