### PR TITLE
docs: add header feature to nrd to inject a custom headers 

### DIFF
--- a/doc/doc-support/header.html
+++ b/doc/doc-support/header.html
@@ -1,0 +1,7 @@
+<div class="manual-header">
+    <nav class="manual-header--tabs">
+        <a class="manual-header--tab manual-header--tab-active" href="#">Nixpkgs</a>
+        <a class="manual-header--tab" href="https://nixos.org/manual/nixos/stable/">NixOS</a>
+    </nav>
+    <span class="manual-header--title">Nixpkgs Reference Manual</span>
+</div>

--- a/doc/doc-support/header.html
+++ b/doc/doc-support/header.html
@@ -3,5 +3,5 @@
         <a class="manual-header--tab manual-header--tab-active" href="#">Nixpkgs</a>
         <a class="manual-header--tab" href="https://nixos.org/manual/nixos/stable/">NixOS</a>
     </nav>
-    <span class="manual-header--title">Nixpkgs Reference Manual</span>
+    <span class="manual-header--title">Nixpkgs Manual</span>
 </div>

--- a/doc/doc-support/package.nix
+++ b/doc/doc-support/package.nix
@@ -119,6 +119,8 @@ stdenvNoCC.mkDerivation (
         --script ./anchor-use.js \
         --sidebar-depth 3 \
         --nav ./nav.json \
+        --header ${./header.html}\
+        --no-navheader \
         manual.md \
         out/index.html
 

--- a/doc/style.css
+++ b/doc/style.css
@@ -398,6 +398,7 @@ div.appendix .variablelist .term {
 
 :root {
   --sidebar-width: 20rem;
+  --header-height: 3rem;
   --background: #fff;
   --main-text-color: #000;
   --link-color: #405d99;
@@ -528,7 +529,7 @@ nav.toc-sidebar summary {
     min-height: 0;
     display: grid;
     grid-template-columns: minmax(0, 1fr);
-    grid-template-rows: auto minmax(0, 1fr);
+    grid-template-rows: var(--header-height) auto minmax(0, 1fr);
   }
 
   body:has(> nav.toc-sidebar) {
@@ -537,7 +538,7 @@ nav.toc-sidebar summary {
 
   .navheader {
     grid-column: 1 / -1;
-    grid-row: 1;
+    grid-row: 2;
   }
 
   nav.toc-sidebar {
@@ -548,7 +549,7 @@ nav.toc-sidebar summary {
     /*  */
     margin: 0;
     grid-column: 1;
-    grid-row: 2;
+    grid-row: 3;
     max-height: none;
     overflow-y: auto;
     border: none;
@@ -562,12 +563,82 @@ nav.toc-sidebar summary {
 
   main.content {
     grid-column: 1 / -1;
-    grid-row: 2;
+    grid-row: 3;
     overflow-y: auto;
     padding: 0 1rem;
   }
 
   body:has(> nav.toc-sidebar) main.content {
     grid-column: 2;
+  }
+}
+
+.manual-header {
+  background-color: var(--background);
+  border-bottom: 0.0625rem solid #d8d8d8;
+  display: flex;
+  flex-direction: column;
+}
+
+.manual-header--title {
+  order: -1;
+  padding: 0.5rem 1rem 0;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--small-heading-color);
+  text-align: center;
+}
+
+.manual-header--tabs {
+  display: flex;
+  align-items: stretch;
+  justify-content: space-around;
+  margin: 0;
+  padding: 0;
+}
+
+.manual-header--tab {
+  display: flex;
+  align-items: center;
+  padding: 0 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--main-text-color);
+  text-decoration: none;
+  border-bottom: 0.1875rem solid transparent;
+  border-top: 0.1875rem solid transparent;
+  transition: border-bottom-color 0.15s ease;
+}
+
+.manual-header--tab:hover {
+  border-bottom-color: var(--heading-color);
+  color: var(--main-text-color);
+}
+
+.manual-header--tab-active {
+  border-bottom-color: var(--heading-color);
+  color: var(--heading-color);
+  font-weight: 700;
+}
+
+@media screen and (min-width: 768px) {
+  .manual-header {
+    height: var(--header-height);
+    flex-direction: row;
+    align-items: stretch;
+    grid-column: 1 / -1;
+    grid-row: 1;
+  }
+
+  .manual-header--title {
+    order: 0;
+    margin-left: auto;
+    padding: 0 1rem;
+    align-self: center;
+  }
+
+  .manual-header--tabs {
+    justify-content: flex-start;
+    padding: 0 1rem;
   }
 }

--- a/nixos/doc/manual/default.nix
+++ b/nixos/doc/manual/default.nix
@@ -202,6 +202,8 @@ rec {
           --script ./anchor.min.js \
           --script ./anchor-use.js \
           --sidebar-depth 2 \
+          --header ${./header.html}\
+          --no-navheader \
           ./manual.md \
           $dst/${common.indexPath}
 

--- a/nixos/doc/manual/header.html
+++ b/nixos/doc/manual/header.html
@@ -1,0 +1,7 @@
+<div class="manual-header">
+    <nav class="manual-header--tabs">
+        <a class="manual-header--tab" href="https://nixos.org/manual/nixos/stable/">Nixpkgs</a>
+        <a class="manual-header--tab manual-header--tab-active" href="#">NixOS</a>
+    </nav>
+    <span class="manual-header--title">Nixos Manual</span>
+</div>

--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/manual.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/manual.py
@@ -265,6 +265,8 @@ class HTMLParameters(NamedTuple):
     sidebar_depth: int
     media_dir: Path
     sidebar_open: frozenset[str] = frozenset()
+    header: Path | None = None
+    no_navheader: bool = False
 
 class ManualHTMLRenderer(RendererMixin, HTMLRenderer):
     _base_path: Path
@@ -344,7 +346,8 @@ class ManualHTMLRenderer(RendererMixin, HTMLRenderer):
         if toc.next:
             next_link = f'<link rel="next" href="{toc.next.target.href()}" title="{toc.next.target.title}" />'
             next_a = f'<a accesskey="n" href="{toc.next.target.href()}">Next</a>'
-        if toc.prev or toc.parent or toc.next:
+        # nav_header is not disabled
+        if not self._html_params.no_navheader and (toc.prev or toc.parent or toc.next):
             nav_html = "\n".join([
                 '  <div class="navheader">',
                 '   <table width="100%" summary="Navigation header">',
@@ -381,6 +384,10 @@ class ManualHTMLRenderer(RendererMixin, HTMLRenderer):
                 });
             });
         """
+        header_content = ""
+        if self._html_params.header:
+            with open(self._html_params.header) as header_file:
+                header_content = header_file.read()
 
         return "\n".join([
             '<?xml version="1.0" encoding="utf-8" standalone="no"?>',
@@ -406,6 +413,7 @@ class ManualHTMLRenderer(RendererMixin, HTMLRenderer):
             ('  <button type="button" class="toc-toggle" popovertarget="manual-toc"'
              ' popovertargetaction="toggle" aria-label="Toggle table of contents">'
              '☰</button>') if sidebar else "",
+            header_content,
             nav_html,
             f'  <nav id="manual-toc" class="toc-sidebar" popover="auto">{sidebar}</nav>' if sidebar else "",
             '  <main class="content">',
@@ -757,6 +765,9 @@ def _build_cli_html(p: argparse.ArgumentParser) -> None:
     p.add_argument('--chunk-toc-depth', nargs='?', action=_DeprecatedDepthFlag, default=None)
     p.add_argument('--section-toc-depth', nargs='?', action=_DeprecatedDepthFlag, default=None)
     # Positional
+    p.add_argument('--no-navheader', default=False, action='store_true')
+    p.add_argument('--header', type=Path,
+                   help='Inject any html fragment into the <body> as first child')
     p.add_argument('infile', type=Path)
     p.add_argument('outfile', type=Path)
 
@@ -774,7 +785,7 @@ def _run_cli_html(args: argparse.Namespace) -> None:
         md = HTMLConverter(
             args.revision,
             HTMLParameters(args.generator, args.stylesheet, args.script,
-                           args.sidebar_depth, args.media_dir, sidebar_open),
+                           args.sidebar_depth, args.media_dir, sidebar_open, args.header, args.no_navheader),
             json.load(manpage_urls), redirects)
         md.convert(args.infile, args.outfile)
 

--- a/pkgs/by-name/ni/nixos-render-docs/src/tests/test_html_header.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/tests/test_html_header.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+import pytest
+from nixos_render_docs.manual import HTMLConverter, HTMLParameters
+
+SAMPLE_BOOK = "# Title {#book-title}\n## Subtitle\n"
+
+def render(tmp_path: Path, header: Path | None) -> str:
+    infile = tmp_path / "index.md"
+    infile.write_text(SAMPLE_BOOK)
+    outfile = tmp_path / "index.html"
+    params = HTMLParameters("", [], [], 2, sidebar_open = [], media_dir=tmp_path, header = header)
+    HTMLConverter("1.0.0", params, {}).convert(infile, outfile)
+    return outfile.read_text()
+
+
+def test_html_header_injected_at_start_of_body(tmp_path: Path) -> None:
+    fragment = '<header class="corp-nav">corporate navigation</header>'
+    header = tmp_path / "header.html"
+    header.write_text(fragment)
+
+    out = render(tmp_path, header)
+    assert fragment in out
+    # verify markers appear in this order
+    assert out.index(" <body>") < out.index(fragment) < out.index('<main class="content">')
+
+
+def test_html_header_absent_when_not_given(tmp_path: Path) -> None:
+    out = render(tmp_path, None)
+    assert "corp-nav" not in out


### PR DESCRIPTION
Add `header` feature to nixos-render-docs and untilize it in the following two commits.

The header may contain arbitrary content.
In case of nixpkgs / nixos we use it to display am improved nav bar to jump between manuals.

The nix-manual may still be added as another tab later, we excluded that for now, because there is no way back from the nix manual

Screenshots of different resolutions blow.

## Nixpkgs manual

### Desktop

<img width="2558" height="738" alt="image" src="https://github.com/user-attachments/assets/74f41478-f094-49d7-b6a3-cdf22a76f522" />


### Mobile

<img width="630" height="752" alt="image" src="https://github.com/user-attachments/assets/a1536933-0c0e-479c-9e6c-8f3452e3e1f8" />


## Nixos manual

### Desktop

<img width="2558" height="738" alt="image" src="https://github.com/user-attachments/assets/84fa1d96-7b91-4c15-b72d-0af653917950" />


### Mobile

<img width="630" height="752" alt="image" src="https://github.com/user-attachments/assets/8824283b-52c1-4b97-bb48-cc2d3517fc7d" />

## Appendixes

Look also fine to me.

## Concerns

- switching tabs is a very heavy job for the browser (exhaustive manual lenght)
  - this will improve once we can split the pages
  



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
