### PR TITLE
teamtype: De-vendor libgit2

### DIFF
--- a/pkgs/by-name/te/teamtype/package.nix
+++ b/pkgs/by-name/te/teamtype/package.nix
@@ -50,8 +50,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mainProgram = "teamtype";
     teams = [ lib.teams.ngi ];
     maintainers = with lib.maintainers; [
-      prince213
+      alerque
       ethancedwards8
+      prince213
     ];
   };
 })

--- a/pkgs/by-name/te/teamtype/package.nix
+++ b/pkgs/by-name/te/teamtype/package.nix
@@ -5,6 +5,8 @@
   versionCheckHook,
   installShellFiles,
   nix-update-script,
+  pkg-config,
+  libgit2,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -22,7 +24,18 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-OIOffnCC9PlT/SXPOuTnKx3feZnkHP+jzbQIJWX0tzk=";
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [
+    installShellFiles
+    pkg-config
+  ];
+
+  buildInputs = [
+    libgit2
+  ];
+
+  env = {
+    LIBGIT2_NO_VENDOR = 1;
+  };
 
   postInstall = ''
     installManPage \


### PR DESCRIPTION
I've been working on this project upstream and recently setup a Flake for it. I just noticed today I forgot to provide Nix's libgit2 package to the build so we were getting a vendored one. That made me think to check here, and that optimization seems to have been missed here too.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [-] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [-] Module addition: when adding a new NixOS module.
  - [-] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
