### PR TITLE
nixos/tests/fontconfig-default-fonts: switch to containers, don't use cantarell-fonts

### DIFF
--- a/nixos/tests/fontconfig-default-fonts.nix
+++ b/nixos/tests/fontconfig-default-fonts.nix
@@ -6,20 +6,19 @@
     jtojnar
   ];
 
-  nodes.machine =
+  containers.machine =
     { config, pkgs, ... }:
     {
       fonts.enableDefaultPackages = true; # Background fonts
       fonts.packages = with pkgs; [
         noto-fonts-color-emoji
-        cantarell-fonts
         twitter-color-emoji
         source-code-pro
         gentium
       ];
       fonts.fontconfig.defaultFonts = {
         serif = [ "Gentium" ];
-        sansSerif = [ "Cantarell" ];
+        sansSerif = [ "DejaVu Sans" ];
         monospace = [ "Source Code Pro" ];
         emoji = [ "Twitter Color Emoji" ];
       };
@@ -27,7 +26,7 @@
 
   testScript = ''
     machine.succeed("fc-match serif | grep '\"Gentium\"'")
-    machine.succeed("fc-match sans-serif | grep '\"Cantarell\"'")
+    machine.succeed("fc-match sans-serif | grep '\"DejaVu Sans\"'")
     machine.succeed("fc-match monospace | grep '\"Source Code Pro\"'")
     machine.succeed("fc-match emoji | grep '\"Twitter Color Emoji\"'")
   '';


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
