### PR TITLE
python3Packages.hdf5plugin: 6.0.0 -> 7.0.0

### DIFF
--- a/pkgs/development/python-modules/hdf5plugin/default.nix
+++ b/pkgs/development/python-modules/hdf5plugin/default.nix
@@ -90,17 +90,20 @@ buildPythonPackage (finalAttrs: {
     mkdir src/hdf5plugin/plugins
 
     mkdir -p pkg-config
-    ln -s ${lib.getDev bzip2}/lib/pkgconfig/bzip2.pc pkg-config/bz2.pc
-    # zfp ships only a CMake config; synthesise the pkg-config module hdf5plugin probes for
-    {
-      echo "includedir=${lib.getDev zfp'}/include"
-      echo "Name: zfp"
-      echo "Version: ${zfp'.version}"
-      echo "Description: zfp"
-      echo "Libs: -L${lib.getLib zfp'}/lib -lzfp"
-      echo "Cflags: -I${lib.getDev zfp'}/include"
-    } > pkg-config/zfp.pc
     export PKG_CONFIG_PATH="$PWD/pkg-config''${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+
+    # add expected alias for bzip2
+    ln -s ${lib.getDev bzip2}/lib/pkgconfig/bzip2.pc pkg-config/bz2.pc
+
+    # zfp ships only a CMake config; synthesise the pkg-config module hdf5plugin probes for
+    cat >pkg-config/zfp.pc <<EOF
+    includedir=${lib.getDev zfp'}/include
+    Name: zfp
+    Version: ${zfp'.version}
+    Description: zfp
+    Libs: -L${lib.getLib zfp'}/lib -lzfp
+    Cflags: -I${lib.getDev zfp'}/include
+    EOF
   '';
 
   meta = {

--- a/pkgs/development/python-modules/hdf5plugin/default.nix
+++ b/pkgs/development/python-modules/hdf5plugin/default.nix
@@ -57,6 +57,16 @@ buildPythonPackage (finalAttrs: {
     zstd
   ];
 
+  # devendor
+  postPatch = ''
+    rm -rf lib/c-blosc
+    rm -rf lib/c-blosc2
+    rm -rf lib/bzip2
+    rm -rf lib/charls
+    rm -rf lib/zfp
+    rm -rf lib/zstd
+  '';
+
   # opt-in to use use system libs instead
   env.HDF5PLUGIN_SYSTEM_LIBRARIES = lib.concatStringsSep "," [
     "blosc"

--- a/pkgs/development/python-modules/hdf5plugin/default.nix
+++ b/pkgs/development/python-modules/hdf5plugin/default.nix
@@ -28,14 +28,14 @@ let
 in
 buildPythonPackage (finalAttrs: {
   pname = "hdf5plugin";
-  version = "6.0.0";
+  version = "7.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "silx-kit";
     repo = "hdf5plugin";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-LW6rY+zLta4hENBbTll+1amf9TYJiuAumwzgpk1LZ3M=";
+    hash = "sha256-wi5EITlRI8tgAXUV5u/CA3eiWjNAVs5ynT+PUsqcqVA=";
   };
 
   build-system = [
@@ -61,7 +61,7 @@ buildPythonPackage (finalAttrs: {
   env.HDF5PLUGIN_SYSTEM_LIBRARIES = lib.concatStringsSep "," [
     "blosc"
     "blosc2"
-    "bz2"
+    "bzip2"
     "charls"
     "lz4"
     # "sperr" # not packaged?
@@ -91,9 +91,6 @@ buildPythonPackage (finalAttrs: {
 
     mkdir -p pkg-config
     export PKG_CONFIG_PATH="$PWD/pkg-config''${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
-
-    # add expected alias for bzip2
-    ln -s ${lib.getDev bzip2}/lib/pkgconfig/bzip2.pc pkg-config/bz2.pc
 
     # zfp ships only a CMake config; synthesise the pkg-config module hdf5plugin probes for
     cat >pkg-config/zfp.pc <<EOF


### PR DESCRIPTION
- **python3Packages.hdf5plugin: cleanup**
- **python3Packages.hdf5plugin: 6.0.0 -> 7.0.0**
- **python3Packages.hdf5plugin: devendor some libs**

now a failed devendor should be loud.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
