### PR TITLE
ci: use nixos-render-docs from tree

### DIFF
--- a/ci/default.nix
+++ b/ci/default.nix
@@ -38,6 +38,17 @@ let
       check = treefmt.check nixFilesSrc;
     };
 
+  # nixos-render-docs and nixos-render-docs-redirects
+  # Should be used from tree to build the matching in-tree documentation
+  docPkgs = pkgs.extend (
+    final: prev: {
+      nixos-render-docs = final.callPackage ../pkgs/by-name/ni/nixos-render-docs/package.nix { };
+      nixos-render-docs-redirects =
+        final.callPackage ../pkgs/by-name/ni/nixos-render-docs-redirects/package.nix
+          { };
+    }
+  );
+
 in
 rec {
   inherit pkgs fmt;
@@ -53,7 +64,7 @@ rec {
   # CI jobs
   lib-tests = import ../lib/tests/release.nix { inherit pkgs; };
   manual-nixos = (import ../nixos/release.nix { }).manual.${system} or null;
-  manual-nixpkgs = (import ../doc { inherit pkgs; });
+  manual-nixpkgs = (import ../doc { pkgs = docPkgs; });
   nixpkgs-vet = pkgs.callPackage ./nixpkgs-vet.nix {
     nix = pkgs.nixVersions.latest;
   };


### PR DESCRIPTION
This builds `nixos-render-docs` (a small Python package) in CI so that doc
builds use the renderer from the tree, instead of the one pinned to the
unstable channel.

## Motivation

The original driver (see #535662): new `nixos-render-docs` CLI flags cannot
be used in the same PR that introduces them.

`doc/default.nix` imports a pinned nixpkgs via `ci/default.nix`, so the doc
build invokes the channel-pinned nrd, not the in-tree one. Adding a flag and using it together therefore fails the
doc build, because the pinned nrd doesn't know the flag yet. Landing such a
change today requires:

1. merge the nrd change
2. wait for it to reach the unstable channel (and wait for its fixing if currently broken)
3. someone bumps `ci/pinned.json`
4. merge the usage change

After this PR we can land PRs like the linked one in one go.

## Secondary benefit

The renderer and `docs/style.css` must stay in sync, nrd emits the HTML structure that the style.css file targets. With nrd pinned to unstable channel while the stylesheet comes from the tree, a PR touching only one side can produce a visually broken manual. This only matters for local rendering during development and once docs are deployed from CI, which we don't do yet. Local rendering also uses the pinned ci version which means `ci view == local view != current code of nrd`

Since @NixOS/documentation-team is currently working on both concerns it might be a reasonable change

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
