### PR TITLE
secretspec: 0.12.0 -> 0.12.2

### DIFF
--- a/pkgs/by-name/se/secretspec/package.nix
+++ b/pkgs/by-name/se/secretspec/package.nix
@@ -9,14 +9,14 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "secretspec";
-  version = "0.12.0";
+  version = "0.12.2";
 
   src = fetchCrate {
     inherit (finalAttrs) pname version;
-    hash = "sha256-gPavr9V/mtr7mfdmgaVkE6GwIfal44JUOPR/SW1ZPqY=";
+    hash = "sha256-Oj1CaiL0uGhlyrJK+xfKLH3f9wYDQTIiDTxop3BTnNs=";
   };
 
-  cargoHash = "sha256-ZO+vwclanqZ8z8mXTP3ytwMqsKauMceR/soPC3vXNmo=";
+  cargoHash = "sha256-5VKiagAQnUIL1i36hQ+zUgScfBkg0uwKG3FMQdrlIq4=";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ dbus ];


### PR DESCRIPTION
Bumps secretspec from 0.12.0 to 0.12.2.

Changelog: https://github.com/cachix/secretspec/releases/tag/v0.12.2

0.12.1 fixes a bug between secretspec and proton-pass-cli >= 2.0.3 which made the proton-pass provider unusable.

Resolves #535495

### Things done

- Built on `x86_64-linux`
- Ran the resulting binary: `secretspec 0.12.2`