### PR TITLE
coder: add bpmct, developmentcats, phorcys420 to maintainers

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3946,6 +3946,12 @@
     githubId = 140968250;
     keys = [ { fingerprint = "8321 ED3A 8DB9 99A5 1F3B  F80F F268 2914 EA42 DE26"; } ];
   };
+  bpmct = {
+    name = "Ben Potter";
+    email = "ben@coder.com";
+    github = "bpmct";
+    githubId = 22407953;
+  };
   Br1ght0ne = {
     name = "Oleksii Filonenko";
     email = "nixpkgs@brightone.cloud";
@@ -6806,6 +6812,12 @@
     email = "developerguyn@gmail.com";
     github = "developer-guy";
     githubId = 16693043;
+  };
+  developmentcats = {
+    name = "Christofer";
+    email = "christofer@coder.com";
+    github = "DevelopmentCats";
+    githubId = 176868952;
   };
   devhell = {
     email = ''"^"@regexmail.net'';
@@ -21755,6 +21767,12 @@
     github = "phodina";
     githubId = 2997905;
     name = "Petr Hodina";
+  };
+  phorcys420 = {
+    name = "Adele";
+    email = "adele@coder.com";
+    github = "phorcys420";
+    githubId = 57866459;
   };
   photex = {
     email = "photex@gmail.com";

--- a/pkgs/by-name/co/coder/package.nix
+++ b/pkgs/by-name/co/coder/package.nix
@@ -102,8 +102,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     license = lib.licenses.agpl3Only;
     mainProgram = "coder";
     maintainers = with lib.maintainers; [
+      bpmct
+      developmentcats
       ghuntley
       kylecarbs
+      phorcys420
     ];
   };
 


### PR DESCRIPTION
Adds the Coder team (`@bpmct`, `@DevelopmentCats`, `@phorcys420`) as maintainers of the `coder` package so we can keep it current and act on `@r-ryantm` update PRs (e.g. the long-open #483203). `@ghuntley` is intentionally left in place here; their removal is being handled separately to follow the inactive-maintainer process in `maintainers/README.md`.

Metadata-only change, no rebuilds. The new `maintainer-list.nix` entries are added in a separate commit per the commit conventions.

cc @DevelopmentCats @phorcys420 to acknowledge being added as maintainers.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Notes:
- `nixfmt` (v1.3.1) `--check` passes on both changed files.
- `maintainer-list.nix` entries are alphabetically sorted; `github`/`githubId` pairs verified against the GitHub API.

---

**Automation/AI disclosure:** This PR was prepared by Coder Agents (Anthropic Claude). The contribution was reviewed by the responsible, accountable human, @bpmct (Ben Potter). Each commit carries an `Assisted-by:` trailer per the automation/AI policy.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test