### PR TITLE
 openmpCheckPhaseHook: init 

### DIFF
--- a/doc/hooks/index.md
+++ b/doc/hooks/index.md
@@ -34,6 +34,7 @@ nodejs-install-manuals.section.md
 npm-build-hook.section.md
 npm-config-hook.section.md
 npm-install-hook.section.md
+openmp-check-hook.section.md
 patch-rc-path-hooks.section.md
 perl.section.md
 pkg-config.section.md

--- a/doc/hooks/openmp-check-hook.section.md
+++ b/doc/hooks/openmp-check-hook.section.md
@@ -1,0 +1,10 @@
+# openmpCheckPhaseHook {#setup-hook-omp-check}
+
+
+This hook can be used to setup a check phase that
+requires running a OpenMP application. It mostly
+serves to limit `OMP_NUM_THREADS` to avoid overloading
+build machines.
+
+This hook will not attempt to override an already existing
+definition of `OMP_NUM_THREADS` in the environment.

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -2881,6 +2881,9 @@
   "setup-hook-mpi-check": [
     "index.html#setup-hook-mpi-check"
   ],
+  "setup-hook-omp-check": [
+    "index.html#setup-hook-omp-check"
+  ],
   "ninja": [
     "index.html#ninja"
   ],

--- a/pkgs/by-name/bl/blas/package.nix
+++ b/pkgs/by-name/bl/blas/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   lapack-reference,
   openblas,
+  openmpCheckPhaseHook,
   isILP64 ? false,
   blasProvider ? openblas,
 }:
@@ -184,6 +185,10 @@ stdenv.mkDerivation {
   outputs = [
     "out"
     "dev"
+  ];
+
+  propagatedNativeBuildInputs = [
+    openmpCheckPhaseHook
   ];
 
   meta = (blasProvider'.meta or { }) // {

--- a/pkgs/by-name/cp/cpcm-x/package.nix
+++ b/pkgs/by-name/cp/cpcm-x/package.nix
@@ -89,10 +89,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
 
-  preCheck = ''
-    export OMP_NUM_THREADS=2
-  '';
-
   passthru.updateScript = nix-update-script { };
 
   meta = {

--- a/pkgs/by-name/df/dftd4/package.nix
+++ b/pkgs/by-name/df/dftd4/package.nix
@@ -81,10 +81,6 @@ stdenv.mkDerivation (finalAttrs: {
       app/tester.py
   '';
 
-  preCheck = ''
-    export OMP_NUM_THREADS=2
-  '';
-
   meta = {
     description = "Generally Applicable Atomic-Charge Dependent London Dispersion Correction";
     changelog = "https://github.com/dftd4/dftd4/releases/tag/${finalAttrs.src.tag}";

--- a/pkgs/by-name/el/elpa/package.nix
+++ b/pkgs/by-name/el/elpa/package.nix
@@ -116,9 +116,6 @@ stdenv.mkDerivation (finalAttrs: {
   preCheck = ''
     #patchShebangs ./
 
-    # Run dual threaded
-    export OMP_NUM_THREADS=2
-
     # Reduce test problem sizes
     export TEST_FLAGS="1500 50 16"
   '';

--- a/pkgs/by-name/er/ergoscf/package.nix
+++ b/pkgs/by-name/er/ergoscf/package.nix
@@ -39,7 +39,6 @@ stdenv.mkDerivation (finalAttrs: {
       "-lblas"
       "-llapack"
     ];
-    OMP_NUM_THREADS = 2; # required for check phase
   };
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/gr/greenx/package.nix
+++ b/pkgs/by-name/gr/greenx/package.nix
@@ -34,10 +34,6 @@ stdenv.mkDerivation (finalAttrs: {
   # Uses a hacky python setup run by cmake, which is hard to get running
   doCheck = false;
 
-  preCheck = ''
-    export OMP_NUM_THREADS=2
-  '';
-
   meta = {
     description = "Library for Green’s function based electronic structure theory calculations";
     license = [ lib.licenses.asl20 ];

--- a/pkgs/by-name/mc/mctc-lib/package.nix
+++ b/pkgs/by-name/mc/mctc-lib/package.nix
@@ -63,10 +63,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
 
-  preCheck = ''
-    export OMP_NUM_THREADS=2
-  '';
-
   postPatch = ''
     patchShebangs --build config/install-mod.py
   '';

--- a/pkgs/by-name/mc/mctc-lib/package.nix
+++ b/pkgs/by-name/mc/mctc-lib/package.nix
@@ -10,6 +10,7 @@
   pkg-config,
   python3,
   jonquil,
+  openmpCheckPhaseHook,
 }:
 
 assert (
@@ -43,6 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     gfortran
     pkg-config
     python3
+    openmpCheckPhaseHook
   ]
   ++ lib.optionals (buildType == "meson") [
     meson

--- a/pkgs/by-name/mo/mopac/package.nix
+++ b/pkgs/by-name/mo/mopac/package.nix
@@ -39,10 +39,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
 
-  preCheck = ''
-    export OMP_NUM_THREADS=2
-  '';
-
   meta = {
     description = "Semiempirical quantum chemistry";
     homepage = "https://github.com/openmopac/mopac";

--- a/pkgs/by-name/mp/mpb/package.nix
+++ b/pkgs/by-name/mp/mpb/package.nix
@@ -59,8 +59,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
 
-  preCheck = "export OMP_NUM_THREADS=2";
-
   meta = {
     description = "MIT Photonic-Bands: computation of photonic band structures in periodic media";
     homepage = "https://mpb.readthedocs.io/en/latest/";

--- a/pkgs/by-name/mp/mpiCheckPhaseHook/mpi-check-hook.sh
+++ b/pkgs/by-name/mp/mpiCheckPhaseHook/mpi-check-hook.sh
@@ -72,8 +72,5 @@ setupMpiCheck() {
       export HWLOC_XMLFILE="@topology@"
       ;;
   esac
-
-  # Limit number of OpenMP threads. Default is "all cores".
-  export OMP_NUM_THREADS=1
 }
 

--- a/pkgs/by-name/mp/mpiCheckPhaseHook/package.nix
+++ b/pkgs/by-name/mp/mpiCheckPhaseHook/package.nix
@@ -1,8 +1,8 @@
 {
   lib,
-  callPackage,
   makeSetupHook,
   stdenv,
+  openmpCheckPhaseHook,
 }:
 
 makeSetupHook {
@@ -12,6 +12,10 @@ makeSetupHook {
     iface = if stdenv.hostPlatform.isDarwin then "lo0" else "lo";
     topology = ./topology.xml;
   };
+
+  propagatedNativeBuildInputs = [
+    openmpCheckPhaseHook
+  ];
 
   meta.license = lib.licenses.mit;
 } ./mpi-check-hook.sh

--- a/pkgs/by-name/mu/multicharge/package.nix
+++ b/pkgs/by-name/mu/multicharge/package.nix
@@ -80,10 +80,6 @@ stdenv.mkDerivation (finalAttrs: {
     echo 'set(custom-lapack_FOUND TRUE)' >> config/cmake/Findcustom-lapack.cmake
   '';
 
-  preCheck = ''
-    export OMP_NUM_THREADS=2
-  '';
-
   meta = {
     description = "Electronegativity equilibration model for atomic partial charges";
     mainProgram = "multicharge";

--- a/pkgs/by-name/nu/numsa/package.nix
+++ b/pkgs/by-name/nu/numsa/package.nix
@@ -90,10 +90,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
 
-  preCheck = ''
-    export OMP_NUM_THREADS=2
-  '';
-
   passthru.updateScript = nix-update-script { };
 
   meta = {

--- a/pkgs/by-name/op/openmpCheckPhaseHook/omp-check-hook.sh
+++ b/pkgs/by-name/op/openmpCheckPhaseHook/omp-check-hook.sh
@@ -1,0 +1,11 @@
+preCheckHooks+=('setupOmpCheck')
+preInstallCheckHooks+=('setupOmpCheck')
+
+
+setupOmpCheck() {
+  # Limit number of OpenMP threads. Default is "all cores".
+  # Using all cores causes high load on builders if checks are executed with NIX_BUILD_CORE parallelism.
+  # This gets even worse if multiple builds are scheduled on the same machine, potentially growing O(n^3) without explicit core limits.
+  export OMP_NUM_THREADS="${OMP_NUM_THREADS:-1}"
+}
+

--- a/pkgs/by-name/op/openmpCheckPhaseHook/package.nix
+++ b/pkgs/by-name/op/openmpCheckPhaseHook/package.nix
@@ -1,0 +1,12 @@
+{
+  lib,
+  makeSetupHook,
+}:
+
+makeSetupHook {
+  name = "omp-checkPhase-hook";
+
+  __structuredAttrs = true;
+
+  meta.license = lib.licenses.mit;
+} ./omp-check-hook.sh

--- a/pkgs/by-name/pi/pixman/package.nix
+++ b/pkgs/by-name/pi/pixman/package.nix
@@ -61,11 +61,6 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dneon=disabled"
   ];
 
-  preConfigure = ''
-    # https://gitlab.freedesktop.org/pixman/pixman/-/issues/62
-    export OMP_NUM_THREADS=$((NIX_BUILD_CORES > 184 ? 184 : NIX_BUILD_CORES))
-  '';
-
   enableParallelBuilding = true;
 
   doCheck = !stdenv.hostPlatform.isDarwin;

--- a/pkgs/by-name/pi/pixman/package.nix
+++ b/pkgs/by-name/pi/pixman/package.nix
@@ -6,6 +6,7 @@
   ninja,
   pkg-config,
   libpng,
+  openmpCheckPhaseHook,
   glib, # just passthru
 
   # for passthru.tests
@@ -46,6 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     meson
     ninja
     pkg-config
+    openmpCheckPhaseHook
     __flattenIncludeHackHook
   ];
 

--- a/pkgs/by-name/wa/wannier90/package.nix
+++ b/pkgs/by-name/wa/wannier90/package.nix
@@ -73,9 +73,6 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = true;
   checkInputs = [ python3 ];
   checkTarget = [ "test-serial" ];
-  preCheck = ''
-    export OMP_NUM_THREADS=4
-  '';
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/xt/xtb/package.nix
+++ b/pkgs/by-name/xt/xtb/package.nix
@@ -89,9 +89,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   doCheck = true;
-  preCheck = ''
-    export OMP_NUM_THREADS=2
-  '';
 
   passthru.updateScript = nix-update-script {
     extraArgs = [ "--version=branch" ];

--- a/pkgs/development/compilers/llvm/common/openmp/default.nix
+++ b/pkgs/development/compilers/llvm/common/openmp/default.nix
@@ -19,7 +19,7 @@
   ompdSupport ? true,
   ompdGdbSupport ? ompdSupport,
   getVersionFile,
-  fetchpatch,
+  openmpCheckPhaseHook,
 }:
 
 assert lib.assertMsg (ompdGdbSupport -> ompdSupport) "OMPD GDB support requires OMPD support!";
@@ -58,6 +58,10 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
     pkg-config
     lit
+  ];
+
+  propagatedNativeBuildInputs = [
+    openmpCheckPhaseHook
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/science/chemistry/simple-dftd3/default.nix
+++ b/pkgs/development/libraries/science/chemistry/simple-dftd3/default.nix
@@ -64,9 +64,6 @@ stdenv.mkDerivation rec {
   ];
 
   doCheck = true;
-  preCheck = ''
-    export OMP_NUM_THREADS=2
-  '';
 
   meta = {
     description = "Reimplementation of the DFT-D3 program";

--- a/pkgs/development/libraries/science/chemistry/tblite/default.nix
+++ b/pkgs/development/libraries/science/chemistry/tblite/default.nix
@@ -100,10 +100,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = buildType == "meson";
 
-  preCheck = ''
-    export OMP_NUM_THREADS=2
-  '';
-
   meta = {
     description = "Light-weight tight-binding framework";
     mainProgram = "tblite";

--- a/pkgs/development/python-modules/astropy/default.nix
+++ b/pkgs/development/python-modules/astropy/default.nix
@@ -143,10 +143,6 @@ buildPythonPackage rec {
 
   preCheck = ''
     export HOME="$(mktemp -d)"
-    export OMP_NUM_THREADS=$(( $NIX_BUILD_CORES / 4 ))
-    if [ $OMP_NUM_THREADS -eq 0 ]; then
-      export OMP_NUM_THREADS=1
-    fi
 
     # See https://github.com/astropy/astropy/issues/17649 and see
     # --hypothesis-profile=ci pytest flag below.

--- a/pkgs/development/python-modules/captum/default.nix
+++ b/pkgs/development/python-modules/captum/default.nix
@@ -52,10 +52,6 @@ buildPythonPackage rec {
     scikit-learn
   ];
 
-  preCheck = ''
-    export OMP_NUM_THREADS=1
-  '';
-
   disabledTestPaths =
     lib.optionals stdenv.hostPlatform.isDarwin [
       # These tests may fail if multiple builds run them at the same time due

--- a/pkgs/development/python-modules/geometric/default.nix
+++ b/pkgs/development/python-modules/geometric/default.nix
@@ -28,10 +28,6 @@ buildPythonPackage rec {
     six
   ];
 
-  preCheck = ''
-    export OMP_NUM_THREADS=2
-  '';
-
   nativeCheckInputs = [ pytestCheckHook ];
 
   meta = {

--- a/pkgs/development/python-modules/imread/default.nix
+++ b/pkgs/development/python-modules/imread/default.nix
@@ -49,7 +49,6 @@ buildPythonPackage rec {
   preCheck = ''
     cd $TMPDIR
     export HOME=$TMPDIR
-    export OMP_NUM_THREADS=1
   '';
 
   meta = {

--- a/pkgs/development/python-modules/linearmodels/default.nix
+++ b/pkgs/development/python-modules/linearmodels/default.nix
@@ -67,8 +67,6 @@ buildPythonPackage (finalAttrs: {
 
   preCheck = ''
     rm linearmodels/__init__.py
-
-    export OMP_NUM_THREADS=1
   '';
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/mace-torch/default.nix
+++ b/pkgs/development/python-modules/mace-torch/default.nix
@@ -82,10 +82,6 @@ buildPythonPackage (finalAttrs: {
     writableTmpDirAsHomeHook
   ];
 
-  preCheck = ''
-    export OMP_NUM_THREADS=1
-  '';
-
   disabledTests = [
     # _pickle.PickleError: ScriptFunction cannot be pickled
     "test_run_eval_fail_with_wrong_model"

--- a/pkgs/development/python-modules/numpy/1.nix
+++ b/pkgs/development/python-modules/numpy/1.nix
@@ -18,6 +18,8 @@
   blas,
   lapack,
 
+  openmpCheckPhaseHook,
+
   # Reverse dependency
   sage,
 
@@ -93,7 +95,6 @@ buildPythonPackage (finalAttrs: {
   # see https://github.com/OpenMathLib/OpenBLAS/issues/2993
   preConfigure = ''
     sed -i 's/-faltivec//' numpy/distutils/system_info.py
-    export OMP_NUM_THREADS=$((NIX_BUILD_CORES > 64 ? 64 : NIX_BUILD_CORES))
   '';
 
   preBuild = ''
@@ -108,6 +109,10 @@ buildPythonPackage (finalAttrs: {
     hypothesis
     setuptools
     typing-extensions
+  ];
+
+  propagatedNativeBuildInputs = [
+    openmpCheckPhaseHook
   ];
 
   preCheck = ''

--- a/pkgs/development/python-modules/numpy/2.nix
+++ b/pkgs/development/python-modules/numpy/2.nix
@@ -19,6 +19,8 @@
   coreutils,
   lapack,
 
+  openmpCheckPhaseHook,
+
   # Reverse dependency
   sage,
 
@@ -121,6 +123,10 @@ buildPythonPackage (finalAttrs: {
     ln -s $out/${python.sitePackages}/numpy/_core/lib/pkgconfig $out/lib/pkgconfig
     ln -s ${placeholder "out"}/${finalAttrs.passthru.coreIncludeInnerDir} $out/include
   '';
+
+  propagatedNativeBuildInputs = [
+    openmpCheckPhaseHook
+  ];
 
   preCheck = ''
     pushd $out

--- a/pkgs/development/python-modules/numpy/2.nix
+++ b/pkgs/development/python-modules/numpy/2.nix
@@ -93,10 +93,6 @@ buildPythonPackage (finalAttrs: {
   ]
   ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [ mesonEmulatorHook ];
 
-  preConfigure = ''
-    export OMP_NUM_THREADS=$((NIX_BUILD_CORES > 64 ? 64 : NIX_BUILD_CORES))
-  '';
-
   buildInputs = [
     blas
     lapack

--- a/pkgs/development/python-modules/pyscf/default.nix
+++ b/pkgs/development/python-modules/pyscf/default.nix
@@ -80,7 +80,6 @@ buildPythonPackage (finalAttrs: {
   preCheck = ''
     # Set config used by tests to ensure reproducibility
     echo 'pbc_tools_pbc_fft_engine = "NUMPY"' > pyscf/pyscf_config.py
-    export OMP_NUM_THREADS=1
     ulimit -s 20000
     export PYSCF_CONFIG_FILE=$(pwd)/pyscf/pyscf_config.py
   '';

--- a/pkgs/development/python-modules/qutip/default.nix
+++ b/pkgs/development/python-modules/qutip/default.nix
@@ -62,7 +62,6 @@ buildPythonPackage (finalAttrs: {
   # This is due to the Cython-compiled modules not being in the correct location
   # of the source tree.
   preCheck = ''
-    export OMP_NUM_THREADS=$NIX_BUILD_CORES
     mkdir -p test && cd test
   '';
 

--- a/pkgs/development/python-modules/scikit-bio/default.nix
+++ b/pkgs/development/python-modules/scikit-bio/default.nix
@@ -62,10 +62,6 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
   ];
 
-  preCheck = ''
-    export OMP_NUM_THREADS=1
-  '';
-
   # only the $out dir contains the built cython extensions, so we run the tests inside there
   enabledTestPaths = [ "${placeholder "out"}/${python.sitePackages}/skbio" ];
 

--- a/pkgs/development/python-modules/scikit-learn/default.nix
+++ b/pkgs/development/python-modules/scikit-learn/default.nix
@@ -116,7 +116,6 @@ buildPythonPackage rec {
   preCheck = ''
     cd $TMPDIR
     export HOME=$TMPDIR
-    export OMP_NUM_THREADS=1
   '';
 
   pythonImportsCheck = [ "sklearn" ];

--- a/pkgs/development/python-modules/scipy/default.nix
+++ b/pkgs/development/python-modules/scipy/default.nix
@@ -175,11 +175,6 @@ buildPythonPackage (finalAttrs: {
   '';
 
   preCheck = ''
-    export OMP_NUM_THREADS=$(( $NIX_BUILD_CORES / 4 ))
-    if [ $OMP_NUM_THREADS -eq 0 ]; then
-      export OMP_NUM_THREADS=1
-    fi
-
     cd $out
   '';
 

--- a/pkgs/development/python-modules/torch-geometric/default.nix
+++ b/pkgs/development/python-modules/torch-geometric/default.nix
@@ -185,10 +185,6 @@ buildPythonPackage (finalAttrs: {
     writableTmpDirAsHomeHook
   ];
 
-  preCheck = ''
-    export OMP_NUM_THREADS=1
-  '';
-
   pytestFlags = [
     # DeprecationWarning: Failing to pass a value to the 'type_params' parameter of
     # 'typing._eval_type' is deprecated, as it leads to incorrect behaviour when calling

--- a/pkgs/development/python-modules/x-transformers/default.nix
+++ b/pkgs/development/python-modules/x-transformers/default.nix
@@ -42,10 +42,6 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  preCheck = ''
-    export OMP_NUM_THREADS=1
-  '';
-
   # RuntimeError: torch.compile is not supported on Python 3.14+
   disabledTests = lib.optionals (pythonAtLeast "3.14") [ "test_up" ];
 


### PR DESCRIPTION
Tests using blas/lapack stack (typically via numpy/scipy) may use OpenMP to do parallelism. This messes with our build scheduling on hydra, because OpenMP does not respect `NIX_BUILD_CORES`, causing massively overloaded systems. As a solution, `openmpCheckPhaseHook` is introduced, fixing `OMP_NUM_THREADS` to 1 by default. This should fix most of the issues we were seeing, at least from python things.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
