### PR TITLE
mirth: rename bin mirth → mirthc

### DIFF
--- a/pkgs/by-name/mi/mirth/package.nix
+++ b/pkgs/by-name/mi/mirth/package.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation {
     install -Dm644 LICENSE README.md -t "$doc/share/doc/mirth"
 
     # stages 0–2 aren’t needed anymore
-    install -Dm755 bin/mirth3 "$bin/bin/mirth"
+    install -Dm755 bin/mirth3 "$bin/bin/mirthc"
 
     runHook postInstall
   '';
@@ -87,7 +87,7 @@ stdenv.mkDerivation {
   # it here, it will be more flexible towards allowing users to wrap the Mirth
   # binary with their own stdlib & other packages.
   postFixup = ''
-    makeBinaryWrapper "$bin/bin/mirth" "$out/bin/mirth" \
+    makeBinaryWrapper "$bin/bin/mirthc" "$out/bin/mirthc" \
       --add-flags "-P $lib/lib/mirth"
   '';
 
@@ -99,7 +99,7 @@ stdenv.mkDerivation {
     '';
     homepage = "https://git.sr.ht/~typeswitch/mirth";
     license = lib.licenses.bsd0;
-    mainProgram = "mirth";
+    mainProgram = "mirthc";
     # https://git.sr.ht/~typeswitch/mirth/tree/main/item/src/mirth.h#L4-22
     platforms = [
       "aarch64-darwin"


### PR DESCRIPTION
The iteration numbers recursively compile themselves & one could run 2 or 3 & it doesn’t matter/change output, so I chose `mirth`, numberless, as it’s not relevant to the user. However, since it’s not a complete suite of tools & just a compiler, the name `mirthc` actually makes more sense as the numberless compiler.


<!--
^ Please summarize the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.

