### PR TITLE
sail-riscv: 0.8 -> 0.12; adopt

### DIFF
--- a/pkgs/by-name/sa/sail-riscv/package.nix
+++ b/pkgs/by-name/sa/sail-riscv/package.nix
@@ -10,18 +10,24 @@
   ocamlPackages,
 
   gmp,
+  cli11,
+  jsoncons,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sail-riscv";
-  version = "0.8";
+  version = "0.12";
 
   src = fetchFromGitHub {
     owner = "riscv";
     repo = "sail-riscv";
-    rev = finalAttrs.version;
-    hash = "sha256-50ATe3DQcdyNOqP85mEMyEwxzpBOplzRN9ulaJNo9zo=";
+    tag = finalAttrs.version;
+    hash = "sha256-pi/XP6+NX/wNpBESmnEg2d5cppMpMwFripDPk9vTx9I=";
   };
+
+  patches = [
+    ./unvendor-deps.patch
+  ];
 
   nativeBuildInputs = [
     z3
@@ -32,16 +38,22 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   buildInputs = [
     gmp
+    # Header-only
+    jsoncons
+    cli11
   ];
   strictDeps = true;
 
-  # sail-riscv 0.8 fails to install without compressed_changelog
-  ninjaFlags = [ "compressed_changelog" ];
+  cmakeFlags = [
+    (lib.cmakeBool "ENABLE_LTO" true)
+  ];
 
   meta = {
     homepage = "https://github.com/riscv/sail-riscv";
     description = "Formal specification of the RISC-V architecture, written in Sail";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [
+      xokdvium
+    ];
     license = lib.licenses.bsd2;
   };
 })

--- a/pkgs/by-name/sa/sail-riscv/unvendor-deps.patch
+++ b/pkgs/by-name/sa/sail-riscv/unvendor-deps.patch
@@ -1,0 +1,57 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2446abb8..8946820c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -194,6 +194,8 @@ option(COVERAGE "Compile with Sail coverage collection enabled.")
+ include(GNUInstallDirs)
+ 
+ # Third party dependencies.
++find_package(CLI11 REQUIRED)
++find_package(jsoncons REQUIRED)
+ add_subdirectory("dependencies")
+ 
+ # Sail C runtime.
+diff --git a/c_emulator/CMakeLists.txt b/c_emulator/CMakeLists.txt
+index 349d2c68..3d121b75 100644
+--- a/c_emulator/CMakeLists.txt
++++ b/c_emulator/CMakeLists.txt
+@@ -60,7 +60,7 @@ target_include_directories(riscv_model
+ )
+ 
+ target_link_libraries(riscv_model
+-    PUBLIC elfio softfloat sail_runtime jsoncons default_config
++    PUBLIC elfio softfloat sail_runtime jsoncons::jsoncons default_config
+ )
+ 
+ add_dependencies(riscv_model generated_sail_riscv_model generated_config_schema)
+@@ -94,7 +94,7 @@ set_source_files_properties(
+ add_dependencies(sail_riscv_sim generated_sail_riscv_model)
+ 
+ target_link_libraries(sail_riscv_sim
+-    PRIVATE CLI11 riscv_model
++    PRIVATE CLI11::CLI11 riscv_model
+ )
+ 
+ # After the emulator is built, use it to validate the generated config files.
+diff --git a/c_emulator/riscv_sim.cpp b/c_emulator/riscv_sim.cpp
+index b50bb4cb..d8a59db1 100644
+--- a/c_emulator/riscv_sim.cpp
++++ b/c_emulator/riscv_sim.cpp
+@@ -18,7 +18,7 @@
+ #include <unistd.h>
+ #include <vector>
+ 
+-#include "CLI11.hpp"
++#include "CLI/CLI.hpp"
+ #include "elf_loader.h"
+ #include "jsoncons/config/version.hpp"
+ #include "jsoncons/json.hpp"
+diff --git a/dependencies/CMakeLists.txt b/dependencies/CMakeLists.txt
+index 95600694..66692022 100644
+--- a/dependencies/CMakeLists.txt
++++ b/dependencies/CMakeLists.txt
+@@ -1,4 +1,2 @@
+-add_subdirectory("CLI11")
+ add_subdirectory("elfio")
+ add_subdirectory("softfloat")
+-add_subdirectory("jsoncons")


### PR DESCRIPTION
The patch was the best way I could figure out to nuke the weird FetchContent that upstream does. I'll try to make this slightly less annoying upstream.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
