### PR TITLE
glibc: read a per-DSO resolution-cache note (stat-storm #481620)

### DIFF
--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -1322,6 +1322,9 @@
   "var-stdenv-stripExclude": [
     "index.html#var-stdenv-stripExclude"
   ],
+  "var-stdenv-dontGenerateLDCache": [
+    "index.html#var-stdenv-dontGenerateLDCache"
+  ],
   "var-stdenv-dontPatchELF": [
     "index.html#var-stdenv-dontPatchELF"
   ],

--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -1010,6 +1010,10 @@ stdenv.mkDerivation {
 }
 ```
 
+##### `dontGenerateLDCache` {#var-stdenv-dontGenerateLDCache}
+
+If set, the fixup phase does not write the `.note.nixos.ldcache` resolution-cache note into the package's ELF files. The note records, per binary, where each `DT_NEEDED` library resolved at build time, letting the patched glibc loader skip the run-path directory walk at program startup. Set this for binaries that must not be rewritten after the build, for example ones that verify their own bytes at run time. Only applies to Linux hosts using glibc.
+
 ##### `dontPatchELF` {#var-stdenv-dontPatchELF}
 
 If set, the `patchelf` command is not used to remove unnecessary `RPATH` entries. Only applies to Linux.

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -52,6 +52,8 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- glibc now reads a per-binary `.note.nixos.ldcache` resolution-cache note recording where each `DT_NEEDED` library resolved at build time, and the standard environment writes it into every ELF file during the fixup phase (via `patchelf --build-resolution-cache`). This eliminates most of the failing `openat`/`stat` calls the dynamic loader used to make while walking long `/nix/store` run paths, speeding up program startup. Runtime overrides keep working: `LD_LIBRARY_PATH` is consulted before the note, and run-path directories that could not be resolved at build time (such as `/run/opengl-driver/lib`) are still searched at run time. Packages can opt out per derivation with [`dontGenerateLDCache`](https://nixos.org/manual/nixpkgs/unstable/#var-stdenv-dontGenerateLDCache).
+
 - `komodo` has been updated to the v2 release line (2.x). See the [upstream v1 → v2 upgrade guide](https://github.com/moghtech/komodo/releases/tag/v2.0.0).
 
 - `security.run0.enableSudoAlias` now uses the `run0-sudo-shim` instead of a shell-script to improve compatibility.

--- a/pkgs/build-support/setup-hooks/generate-ld-cache.sh
+++ b/pkgs/build-support/setup-hooks/generate-ld-cache.sh
@@ -1,0 +1,138 @@
+# shellcheck shell=bash
+
+# The NixOS resolution-cache note records, for each binary, the resolved paths
+# of its DT_NEEDED libraries.  It must therefore be written only after every
+# other tool that rewrites ELF files has finished, so that it reflects the final
+# interpreter and RPATH.  In particular autoPatchelfHook rewrites those in
+# postFixup, which runs after ordinary fixupOutput hooks; writing the note in
+# fixupOutput would record pre-autoPatchelf state and leave a stale note on the
+# final binary.
+#
+# We defer note generation to the end of postFixup.  Registering it from
+# preFixup (which runs once, after every setup hook has been sourced) guarantees
+# it is appended to postFixupHooks *after* autoPatchelfHook's own postFixup
+# hook, which is appended at setup-hook source time.
+
+preFixupHooks+=(_registerGenerateLDCache)
+
+_registerGenerateLDCache() {
+    postFixupHooks+=(_generateLDCacheAllOutputs)
+}
+
+_generateLDCacheAllOutputs() {
+    # dontGenerateLDCache is this hook's own, purpose-built opt-out; always
+    # honour it. dontPatchELF alone is *not* a reliable signal to also skip:
+    # it only gates patchelf's own --shrink-rpath pass (patchelf/setup-hook.sh),
+    # not autoPatchelfHook's interpreter/RPATH rewrite (gated separately by
+    # dontAutoPatchelf). If autoPatchelfHook is active it still finalises the
+    # ELF before this hook runs (see the ordering comment above), so the note
+    # it would produce is correct regardless of dontPatchELF -- e.g. the
+    # dotnet SDK sets dontPatchELF for an unrelated RPATH-preservation reason
+    # but still runs autoPatchelfHook, and must not be excluded on that basis.
+    # Only skip on dontPatchELF when autoPatchelfHook additionally will not
+    # run either, which is the genuine "keep patchelf away from this binary
+    # entirely" case (e.g. ghc's Android-prebuilt binaries).  autoPatchelfHook
+    # presence is detected via its documented `autoPatchelf` command, not its
+    # private postFixup function, whose name auto-patchelf.sh itself plans to
+    # retire (see the XXX comment there).
+    if [ -n "${dontGenerateLDCache-}" ]; then return 0; fi
+    if [ -n "${dontPatchELF-}" ] \
+        && { [ -n "${dontAutoPatchelf-}" ] || ! declare -F autoPatchelf > /dev/null; }; then
+        return 0
+    fi
+
+    local -a patchelfFlagsArray=()
+    concatTo patchelfFlagsArray patchelfFlags
+    # Forward a package's own patchelfFlags (e.g. --no-clobber-old-sections,
+    # which firefox-family packages rely on to protect relrhack's manually
+    # laid-out relocations) so this hook's own patchelf invocation doesn't
+    # undo protections the package already asked for. --force-rpath is
+    # dropped because patchelf refuses to combine it with
+    # --build-resolution-cache; nothing in nixpkgs sets both today, but don't
+    # propagate a combination patchelf itself rejects.
+    local -a ldCacheFlags=()
+    local flag
+    for flag in "${patchelfFlagsArray[@]}"; do
+        [ "$flag" = "--force-rpath" ] && continue
+        ldCacheFlags+=("$flag")
+    done
+
+    local output
+    for output in $(getAllOutputNames); do
+        generateLDCache "${!output}" "${ldCacheFlags[@]}"
+    done
+}
+
+# Only ET_EXEC (2) and ET_DYN (3) objects can have DT_NEEDED entries.  Feeding
+# anything else to patchelf (ET_REL relocatable objects such as glibc's crt*.o
+# or kernel modules) makes it abort with "wrong ELF type" and print a spurious
+# per-file warning below for a file that was never going to need a note.
+_isELFLoadable() {
+    local bytes
+    local -a b
+    # Bytes 0 to 17 of the ELF header: e_ident[EI_DATA] at index 5 gives the
+    # byte order (1 is LSB, 2 is MSB); e_type is the half word at offset 16 in
+    # the file's own byte order.
+    bytes=$(od -A n -N 18 -t u1 "$1" | tr '\n' ' ')
+    read -r -a b <<< "$bytes"
+    local etype
+    if [ "${b[5]:-0}" -eq 2 ]; then
+        etype=$(( ${b[16]:-0} * 256 + ${b[17]:-0} ))
+    else
+        etype=$(( ${b[16]:-0} + ${b[17]:-0} * 256 ))
+    fi
+    [ "$etype" -eq 2 ] || [ "$etype" -eq 3 ]
+}
+
+generateLDCache() {
+    local dir="$1"
+    shift
+    local -a extraFlags=("$@")
+    [ -e "$dir" ] || return 0
+
+    local i
+    local -a elfs=()
+    # Exclude only files inside a .build-id/ directory component (debug-info
+    # hardlink trees, same idiom as audit-tmpdir.sh); a substring match would
+    # silently skip legitimately named files like libfoo.build-id-helper.so.
+    while IFS= read -r -d '' i; do
+        if ! isELF "$i" || ! _isELFLoadable "$i"; then continue; fi
+        elfs+=("$i")
+    done < <(find "$dir" -type f -not -path '*/.build-id/*' -print0)
+
+    [ "${#elfs[@]}" -eq 0 ] && return 0
+
+    echo "generating LD cache for ${#elfs[@]} ELF file(s) in $dir"
+    # The cache is only a resolution hint; the patched loader falls back to the
+    # normal RUNPATH walk without it, so a file that simply cannot get a note
+    # is non-fatal.  Run patchelf once per file rather than batching many
+    # files into one invocation: patchelf has no per-file exception handling,
+    # so a single file that trips one of its internal errors aborts its whole
+    # process, which would silently leave every file ordered after it in a
+    # shared batch without a note.  Warn per file, naming the file, so
+    # regressions are attributable instead of anonymous.
+    #
+    # One failure is fatal: a pre-existing note that no longer matches
+    # (patchelf: "a resolution cache note is already present") means a
+    # note-unaware tool rewrote this binary after its note was generated, and
+    # the patched loader would trust the stale resolution over the binary's
+    # actual RUNPATH.  Shipping that is silent misresolution, so fail the
+    # build.  The string match is coupled to patchelf's wording
+    # (src/patchelf.cc); if it ever drifts we degrade to the warning, never
+    # to a spurious failure.
+    local f err
+    for f in "${elfs[@]}"; do
+        if err=$(@patchelf@ "${extraFlags[@]}" --build-resolution-cache "$f" 2>&1); then
+            if [ -n "$err" ]; then printf '%s\n' "$err" >&2; fi
+        else
+            printf '%s\n' "$err" >&2
+            if [[ "$err" == *"resolution cache note is already present"* ]]; then
+                echo "error: stale resolution-cache note on $f;" \
+                    "a note-unaware patchelf rewrote this binary after its note was generated." \
+                    "Rebuild it from an unpatched original or set dontGenerateLDCache." >&2
+                exit 1
+            fi
+            echo "warning: ld cache generation failed for $f" >&2
+        fi
+    done
+}

--- a/pkgs/build-support/setup-hooks/generate-ld-cache.sh
+++ b/pkgs/build-support/setup-hooks/generate-ld-cache.sh
@@ -76,11 +76,19 @@ _isELFLoadable() {
     bytes=$(od -A n -N 18 -t u1 "$1" | tr '\n' ' ')
     read -r -a b <<< "$bytes"
     local etype
-    if [ "${b[5]:-0}" -eq 2 ]; then
-        etype=$(( ${b[16]:-0} * 256 + ${b[17]:-0} ))
-    else
+    byte_order="${b[5]:-0}"
+    case "${byte_order}" in
+    1)
         etype=$(( ${b[16]:-0} + ${b[17]:-0} * 256 ))
-    fi
+        ;;
+    2)
+        etype=$(( ${b[16]:-0} * 256 + ${b[17]:-0} ))
+        ;;
+    *)
+        printf "Unknown byte order value: %q\n" "${byte_order}"
+        return 1
+        ;;
+    esac
     [ "$etype" -eq 2 ] || [ "$etype" -eq 3 ]
 }
 

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -99,6 +99,14 @@ stdenv.mkDerivation (
 
       ./fix-x64-abi.patch
 
+      # Read a per-DSO library resolution cache (the .note.nixos.ldcache
+      # PT_NOTE written by `patchelf --build-resolution-cache`) so the loader
+      # resolves DT_NEEDED entries directly, without searching every
+      # DT_RUNPATH directory for every soname. This removes the storm of
+      # failing openat()/stat() syscalls that slows /nix/store startup.
+      # See https://github.com/NixOS/nixpkgs/issues/481620.
+      ./ldcache.patch
+
       # https://github.com/NixOS/nixpkgs/pull/137601
       ./nix-nss-open-files.patch
 

--- a/pkgs/development/libraries/glibc/ldcache.patch
+++ b/pkgs/development/libraries/glibc/ldcache.patch
@@ -1,20 +1,32 @@
 diff --git a/elf/dl-load.c b/elf/dl-load.c
-index 00b9da9..ff6f208 100644
+index 00b9da9e..8fb0c2fa 100644
 --- a/elf/dl-load.c
 +++ b/elf/dl-load.c
-@@ -1920,6 +1920,182 @@ _dl_lookup_map (Lmid_t nsid, const char *name)
+@@ -1920,6 +1920,202 @@ _dl_lookup_map (Lmid_t nsid, const char *name)
    return NULL;
  }
  
 +/* A binary patched with "patchelf --build-resolution-cache" carries a PT_NOTE
-+   (NT_NIXOS_LD_CACHE) whose descriptor is a sequence of NUL-terminated
-+   (needed, path-list) string pairs, terminated by an extra NUL byte after
-+   the final path-list.  Each path-list element is either "=<absolute-path>"
-+   (open it directly) or "?<dir>" (search that directory, e.g. a
-+   $ORIGIN-relative or glibc-hwcaps entry).  Consulting it lets
-+   _dl_map_new_object resolve a binary's direct dependencies without walking
-+   every DT_RUNPATH directory, avoiding the storm of failing openat()/stat()
-+   syscalls that slows /nix/store startup.  */
++   (NT_NIXOS_LD_CACHE) whose descriptor packs one or more string pairs
++
++       <needed> '\0' <path-list> '\0'
++
++   back to back, followed by one extra NUL byte.  patchelf only emits pairs
++   whose two strings are nonempty (when it has nothing to record it writes
++   no note at all), so a zero-length string where the next needed name
++   would start is unambiguous: it terminates the sequence, the same
++   double-NUL convention as an environment block.  A path-list is a
++   ':'-separated list whose elements are either "=<absolute-path>" (open it
++   directly) or "?<dir>" (search that directory at run time, e.g. a
++   $ORIGIN-relative or glibc-hwcaps entry).  Consulting the note lets
++   _dl_map_new_object resolve a binary's direct dependencies without
++   walking every DT_RUNPATH directory, avoiding the storm of failing
++   openat()/stat() syscalls that slows /nix/store startup.  The reader
++   nevertheless assumes nothing about the writer: _dl_find_nixos_cache
++   admits exactly the descriptors it can prove safe to walk,
++   _dl_lookup_nixos_cache stops trusting a note whose content violates the
++   grammar, and in either case the object falls back to the stock search
++   order.  */
 +
 +static const char *
 +_dl_find_nixos_cache (struct link_map *loader)
@@ -75,12 +87,20 @@ index 00b9da9..ff6f208 100644
 +              const char *desc = (const char *) note
 +                                 + ELF_NOTE_DESC_OFFSET (note->n_namesz, align);
 +              /* The descriptor must lie within the segment and end with two
-+                 NULs.  The first terminates the final path-list string; the
-+                 second is the zero-length needed-name sentinel checked by
-+                 entries[0] in _dl_lookup_nixos_cache.  Together they keep the
-+                 parser in bounds.  descsz >= 2 is required for the two reads
-+                 below; > 2 also rejects a bare "\0\0" descriptor carrying no
-+                 pairs.  Compare via the subtraction desc_off rather than
++                 NUL bytes; a conforming descriptor always does (the final
++                 path-list's terminator plus the end-of-sequence NUL).
++                 n_descsz >= 2 makes the two byte reads below themselves
++                 valid, and the two trailing NULs are the complete in-bounds
++                 invariant for the walk in _dl_lookup_nixos_cache: any
++                 non-NUL byte then sits at index n_descsz - 3 or lower, so
++                 every strlen there stops by index n_descsz - 2, and every
++                 advance past a string lands at most on the final NUL, where
++                 the walk either terminates or trips the malformed check.
++                 Nothing stricter is needed: the minimal descriptor "\0\0"
++                 reads as an empty sequence, every lookup misses, and the
++                 object falls back to the normal search, exactly as if the
++                 note were absent or rejected here.  Compare via the
++                 subtraction desc_off rather than
 +                 "desc + n_descsz <= start + size": on a 32-bit target
 +                 ElfW(Addr) is only 32 bits, and adding the untrusted
 +                 n_descsz straight to a pointer can wrap back into range,
@@ -88,7 +108,7 @@ index 00b9da9..ff6f208 100644
 +                 cannot overflow: desc was derived from note, which the loop
 +                 above already established lies at or after start.  */
 +              const ElfW(Addr) desc_off = (ElfW(Addr)) desc - start;
-+              if (note->n_descsz > 2
++              if (note->n_descsz >= 2
 +                  && desc_off <= size
 +                  && note->n_descsz <= size - desc_off
 +                  && desc[note->n_descsz - 2] == '\0'
@@ -185,7 +205,7 @@ index 00b9da9..ff6f208 100644
  /* Map in the shared object file NAME.  */
  
  struct link_map *
-@@ -1930,6 +2106,7 @@ _dl_map_new_object (struct link_map *loader, const char *name,
+@@ -1930,6 +2126,7 @@ _dl_map_new_object (struct link_map *loader, const char *name,
    const char *origname = NULL;
    char *realname;
    char *name_copy;
@@ -193,7 +213,7 @@ index 00b9da9..ff6f208 100644
    struct link_map *l;
    struct filebuf fb;
  
-@@ -2030,6 +2207,76 @@ _dl_map_new_object (struct link_map *loader, const char *name,
+@@ -2030,6 +2227,76 @@ _dl_map_new_object (struct link_map *loader, const char *name,
  			loader ?: GL(dl_ns)[LM_ID_BASE]._ns_loaded,
  			LA_SER_LIBPATH, &found_other_class);
  
@@ -271,7 +291,7 @@ index 00b9da9..ff6f208 100644
        if (fd == -1 && loader != NULL
  	  && cache_rpath (loader, &loader->l_runpath_dirs,
 diff --git a/elf/elf.h b/elf/elf.h
-index 2f29a47..10e4ea9 100644
+index 2f29a47c..10e4ea94 100644
 --- a/elf/elf.h
 +++ b/elf/elf.h
 @@ -1303,12 +1303,24 @@ typedef struct
@@ -300,7 +320,7 @@ index 2f29a47..10e4ea9 100644
  
  /* ABI information.  The descriptor consists of words:
 diff --git a/include/link.h b/include/link.h
-index 41e5e54..cef4889 100644
+index 41e5e54a..cef48898 100644
 --- a/include/link.h
 +++ b/include/link.h
 @@ -346,6 +346,17 @@ struct link_map

--- a/pkgs/development/libraries/glibc/ldcache.patch
+++ b/pkgs/development/libraries/glibc/ldcache.patch
@@ -1,0 +1,323 @@
+diff --git a/elf/dl-load.c b/elf/dl-load.c
+index 00b9da9..ff6f208 100644
+--- a/elf/dl-load.c
++++ b/elf/dl-load.c
+@@ -1920,6 +1920,182 @@ _dl_lookup_map (Lmid_t nsid, const char *name)
+   return NULL;
+ }
+ 
++/* A binary patched with "patchelf --build-resolution-cache" carries a PT_NOTE
++   (NT_NIXOS_LD_CACHE) whose descriptor is a sequence of NUL-terminated
++   (needed, path-list) string pairs, terminated by an extra NUL byte after
++   the final path-list.  Each path-list element is either "=<absolute-path>"
++   (open it directly) or "?<dir>" (search that directory, e.g. a
++   $ORIGIN-relative or glibc-hwcaps entry).  Consulting it lets
++   _dl_map_new_object resolve a binary's direct dependencies without walking
++   every DT_RUNPATH directory, avoiding the storm of failing openat()/stat()
++   syscalls that slows /nix/store startup.  */
++
++static const char *
++_dl_find_nixos_cache (struct link_map *loader)
++{
++  const ElfW(Phdr) *phdr = loader->l_phdr;
++  const ElfW(Phdr) *pend = phdr + loader->l_phnum;
++  for (; phdr != pend; phdr++)
++    {
++      if (phdr->p_type != PT_NOTE)
++        continue;
++
++      /* Only PT_LOAD segments are mapped, so a PT_NOTE not fully covered by
++         one (spec-legal, e.g. produced by post-processing tools) would point
++         at unmapped memory.  Stock loaders never dereference such segments
++         (the generic _dl_process_pt_note is empty and the x86 property
++         reader has its own gates); skip them rather than fault.  The
++         comparisons are written subtraction-style so an inconsistent header
++         cannot wrap the address arithmetic.  */
++      bool covered = false;
++      for (const ElfW(Phdr) *ld = loader->l_phdr; ld != pend; ld++)
++        if (ld->p_type == PT_LOAD
++            && phdr->p_vaddr >= ld->p_vaddr
++            && phdr->p_memsz <= ld->p_memsz
++            && phdr->p_vaddr - ld->p_vaddr <= ld->p_memsz - phdr->p_memsz)
++          {
++            covered = true;
++            break;
++          }
++      if (!covered)
++        continue;
++
++      /* Walk the notes exactly like _dl_process_pt_gnu_property: bound the
++         header read with (note + 1) - start < size, and advance with
++         ELF_NOTE_NEXT_OFFSET using the segment's own p_align.  A walk with a
++         fixed alignment desyncs on segments whose p_align differs (e.g. an
++         8-byte-aligned .note.gnu.property) and can then run off the mapping.  */
++      const ElfW(Nhdr) *note = (const void *) (phdr->p_vaddr + loader->l_addr);
++      const ElfW(Addr) size = phdr->p_memsz;
++      ElfW(Addr) align = phdr->p_align;
++      /* Notes are at least 4-byte aligned; guard a bogus p_align so the
++         ALIGN_UP inside ELF_NOTE_NEXT_OFFSET cannot misbehave.  */
++      if (align < 4)
++        align = 4;
++      const ElfW(Addr) start = (ElfW(Addr)) note;
++
++      while ((ElfW(Addr)) (note + 1) - start < size)
++        {
++          /* Bound the name read against the segment before memcmp: a
++             truncated final note could otherwise claim a 6-byte name that
++             runs past the mapping.  && short-circuits, so the memcmp only
++             runs once the 6 bytes are known to be in bounds.  */
++          if (note->n_namesz == sizeof ELF_NOTE_NIXOS
++              && note->n_type == NT_NIXOS_LD_CACHE
++              && (ElfW(Addr)) ((const char *) (note + 1) + note->n_namesz)
++                   - start <= size
++              && memcmp (note + 1, ELF_NOTE_NIXOS, sizeof ELF_NOTE_NIXOS) == 0)
++            {
++              const char *desc = (const char *) note
++                                 + ELF_NOTE_DESC_OFFSET (note->n_namesz, align);
++              /* The descriptor must lie within the segment and end with two
++                 NULs.  The first terminates the final path-list string; the
++                 second is the zero-length needed-name sentinel checked by
++                 entries[0] in _dl_lookup_nixos_cache.  Together they keep the
++                 parser in bounds.  descsz >= 2 is required for the two reads
++                 below; > 2 also rejects a bare "\0\0" descriptor carrying no
++                 pairs.  Compare via the subtraction desc_off rather than
++                 "desc + n_descsz <= start + size": on a 32-bit target
++                 ElfW(Addr) is only 32 bits, and adding the untrusted
++                 n_descsz straight to a pointer can wrap back into range,
++                 defeating an address-comparison bound.  desc_off itself
++                 cannot overflow: desc was derived from note, which the loop
++                 above already established lies at or after start.  */
++              const ElfW(Addr) desc_off = (ElfW(Addr)) desc - start;
++              if (note->n_descsz > 2
++                  && desc_off <= size
++                  && note->n_descsz <= size - desc_off
++                  && desc[note->n_descsz - 2] == '\0'
++                  && desc[note->n_descsz - 1] == '\0')
++                return desc;
++              return (const char *) -1;
++            }
++
++          note = ((const void *) note
++                  + ELF_NOTE_NEXT_OFFSET (note->n_namesz, note->n_descsz,
++                                          align));
++        }
++    }
++
++  return (const char *) -1;
++}
++
++/* Look NAME up in LOADER's resolution cache.  On a hit, return a pointer
++   to the recorded path list inside the mapped note (valid for the object's
++   lifetime, nothing is allocated); otherwise return NULL.  */
++static const char *
++_dl_lookup_nixos_cache (struct link_map *loader, const char *name)
++{
++  if (loader == NULL)
++    return NULL;
++
++  if (loader->l_nixos_resolve_cache == NULL)
++    loader->l_nixos_resolve_cache = _dl_find_nixos_cache (loader);
++
++  if (loader->l_nixos_resolve_cache == (const char *) -1)
++    return NULL;
++
++  /* The walk below stays within the descriptor because _dl_find_nixos_cache
++     validated that it lies within the note segment and ends in two NULs: the
++     final NUL backstops every strlen, and the epath[0] check rejects a
++     dangling needed-string, so entries never advances past that last NUL.  */
++  const char *entries = loader->l_nixos_resolve_cache;
++  while (entries[0] != '\0')
++    {
++      const char *ename = entries;
++      const char *epath = ename + strlen (ename) + 1;
++      if (epath[0] == '\0')
++        {
++          /* Malformed cache; stop trusting it.  */
++          loader->l_nixos_resolve_cache = (const char *) -1;
++          return NULL;
++        }
++      if (strcmp (name, ename) == 0)
++        return epath;
++      entries = epath + strlen (epath) + 1;
++    }
++
++  return NULL;
++}
++
++/* Return true if LOADER's RUNPATH is stable enough for the resolution cache
++   to replace the normal directory walk.  Empty and relative RUNPATH
++   components are runtime-dependent because they are resolved against the
++   caller's current directory; a recorded later hit must not bypass them.
++   The verdict is a pure function of the object's RUNPATH, so it is computed
++   once and cached on the link map: re-deriving it later would wrongly flip
++   to unstable after open_path marks a fully-nonexistent l_runpath_dirs dead
++   with (void *) -1, permanently disabling the note for that object.  */
++static bool
++_dl_nixos_cache_runpath_stable (struct link_map *loader)
++{
++  if (loader == NULL)
++    return true;
++
++  if (loader->l_nixos_runpath_stable == 0)
++    {
++      signed char stable = 1;
++      if (loader->l_info[DT_RUNPATH] != NULL)
++        {
++          if (!cache_rpath (loader, &loader->l_runpath_dirs, DT_RUNPATH,
++                            "RUNPATH"))
++            stable = -1;
++          else
++            for (struct r_search_path_elem **dirs
++                   = loader->l_runpath_dirs.dirs;
++                 *dirs != NULL; ++dirs)
++              if ((*dirs)->dirnamelen == 0 || (*dirs)->dirname[0] != '/')
++                {
++                  stable = -1;
++                  break;
++                }
++        }
++      loader->l_nixos_runpath_stable = stable;
++    }
++
++  return loader->l_nixos_runpath_stable > 0;
++}
++
+ /* Map in the shared object file NAME.  */
+ 
+ struct link_map *
+@@ -1930,6 +2106,7 @@ _dl_map_new_object (struct link_map *loader, const char *name,
+   const char *origname = NULL;
+   char *realname;
+   char *name_copy;
++  const char *rescache;
+   struct link_map *l;
+   struct filebuf fb;
+ 
+@@ -2030,6 +2207,76 @@ _dl_map_new_object (struct link_map *loader, const char *name,
+ 			loader ?: GL(dl_ns)[LM_ID_BASE]._ns_loaded,
+ 			LA_SER_LIBPATH, &found_other_class);
+ 
++      /* Try the DT_NEEDED resolution cache written by patchelf
++         --build-resolution-cache.  Consulted after LD_LIBRARY_PATH so that
++         overrides keep working.  If RUNPATH contains runtime-dependent
++         components (empty or relative entries), skip the hint: such
++         components must be searched at execution time before any recorded
++         later hit can be trusted.  */
++      if (fd == -1
++          && _dl_nixos_cache_runpath_stable (loader)
++          && (rescache = _dl_lookup_nixos_cache (loader, name)) != NULL)
++        {
++          /* Walk the ':'-separated path list in place: it lives in the
++             loader's mapped note, and open_verify and decompose_rpath can
++             signal errors (longjmp) past this frame, so no heap may be
++             held across them.  Each element is copied into a stack buffer
++             only to NUL-terminate it; an element longer than any openable
++             path cannot resolve and is skipped.  */
++          const char *entry = rescache;
++          while (entry[0] != '\0' && fd == -1)
++            {
++              const char *end = strchr (entry, ':');
++              size_t len = end != NULL ? (size_t) (end - entry)
++                                       : strlen (entry);
++              char buf[4096];
++              if (len > 0 && len < sizeof buf)
++                {
++                  memcpy (buf, entry, len);
++                  buf[len] = '\0';
++                  if (buf[0] == '?')
++                    {
++                      /* A directory the loader must still search itself.  */
++                      struct r_search_path_struct sp;
++                      sp.dirs = NULL;
++                      if (decompose_rpath (&sp, buf + 1, loader, "RESCACHE"))
++                        {
++                          fd = open_path (name, namelen, mode, &sp, &realname,
++                                          &fb, loader, LA_SER_RUNPATH,
++                                          &found_other_class);
++                          if (sp.dirs != (void *) -1)
++                            free (sp.dirs);
++                        }
++                    }
++                  else if (buf[0] == '=')
++                    {
++                      /* An exact path; open it directly, duplicating the
++                         name only after success like the ld.so.cache path
++                         does: open_verify signals on a fatally malformed
++                         file, and a preallocated copy would leak.  */
++                      if (__glibc_unlikely (GLRO(dl_debug_mask)
++                                            & DL_DEBUG_LIBS))
++                        _dl_debug_printf ("  trying cached file=%s\n",
++                                          buf + 1);
++                      fd = open_verify (buf + 1, -1, &fb,
++                                        loader ?: GL(dl_ns)[nsid]._ns_loaded,
++                                        LA_SER_RUNPATH, mode,
++                                        &found_other_class, false);
++                      if (fd != -1)
++                        {
++                          realname = __strdup (buf + 1);
++                          if (realname == NULL)
++                            {
++                              __close_nocancel (fd);
++                              fd = -1;
++                            }
++                        }
++                    }
++                }
++              entry = end != NULL ? end + 1 : entry + len;
++            }
++        }
++
+       /* Look at the RUNPATH information for this binary.  */
+       if (fd == -1 && loader != NULL
+ 	  && cache_rpath (loader, &loader->l_runpath_dirs,
+diff --git a/elf/elf.h b/elf/elf.h
+index 2f29a47..10e4ea9 100644
+--- a/elf/elf.h
++++ b/elf/elf.h
+@@ -1303,12 +1303,24 @@ typedef struct
+ /* Note entries for freedesktop.org have this name.  */
+ #define ELF_NOTE_FDO		"FDO"
+ 
++/* Note entries for Nixpkgs/NixOS have this name.  */
++#define ELF_NOTE_NIXOS	"NixOS"
++
+ /* Defined types of notes for Solaris.  */
+ 
+ /* Value of descriptor (one word) is desired pagesize for the binary.  */
+ #define ELF_NOTE_PAGESIZE_HINT	1
+ 
+ 
++/* Defined note types for Nixpkgs/NixOS systems.  */
++
++/* Linker resolution cache.  The descriptor is a sequence of NUL-terminated
++   (needed, path-list) string pairs written by patchelf
++   --build-resolution-cache; the loader uses it to resolve DT_NEEDED entries
++   without searching DT_RUNPATH.  */
++#define NT_NIXOS_LD_CACHE	0x63a86cb6
++
++
+ /* Defined note types for GNU systems.  */
+ 
+ /* ABI information.  The descriptor consists of words:
+diff --git a/include/link.h b/include/link.h
+index 41e5e54..cef4889 100644
+--- a/include/link.h
++++ b/include/link.h
+@@ -346,6 +346,17 @@ struct link_map
+     size_t l_relro_size;
+ 
+     unsigned long long int l_serial;
++
++    /* Cached pointer into this object's NixOS linker resolution note
++       (NT_NIXOS_LD_CACHE), or (const char *) -1 once known to be absent.  */
++    const char *l_nixos_resolve_cache;
++
++    /* Whether this object's DT_RUNPATH is free of runtime-dependent
++       components, so the resolution note may replace the directory walk:
++       0 = not yet determined, 1 = stable, -1 = unstable.  Cached because
++       the verdict must survive open_path later marking a fully-nonexistent
++       l_runpath_dirs dead with (void *) -1.  */
++    signed char l_nixos_runpath_stable;
+   };
+ 
+ #include <dl-relocate-ld.h>

--- a/pkgs/development/libraries/glibc/ldcache.patch
+++ b/pkgs/development/libraries/glibc/ldcache.patch
@@ -2,7 +2,7 @@ diff --git a/elf/dl-load.c b/elf/dl-load.c
 index 00b9da9e..8fb0c2fa 100644
 --- a/elf/dl-load.c
 +++ b/elf/dl-load.c
-@@ -1920,6 +1920,202 @@ _dl_lookup_map (Lmid_t nsid, const char *name)
+@@ -1920,6 +1920,220 @@ _dl_lookup_map (Lmid_t nsid, const char *name)
    return NULL;
  }
  
@@ -58,34 +58,52 @@ index 00b9da9e..8fb0c2fa 100644
 +      if (!covered)
 +        continue;
 +
-+      /* Walk the notes exactly like _dl_process_pt_gnu_property: bound the
-+         header read with (note + 1) - start < size, and advance with
-+         ELF_NOTE_NEXT_OFFSET using the segment's own p_align.  A walk with a
-+         fixed alignment desyncs on segments whose p_align differs (e.g. an
-+         8-byte-aligned .note.gnu.property) and can then run off the mapping.  */
-+      const ElfW(Nhdr) *note = (const void *) (phdr->p_vaddr + loader->l_addr);
++      /* Walk using the segment's own p_align.  A fixed alignment desyncs on
++         segments whose p_align differs (e.g. an 8-byte-aligned
++         .note.gnu.property).  Validate every offset before using it: unlike
++         the property-note reader, this parser can encounter arbitrary notes,
++         including malformed values that would overflow ALIGN_UP.  */
++      const char *notes = (const void *) (phdr->p_vaddr + loader->l_addr);
 +      const ElfW(Addr) size = phdr->p_memsz;
 +      ElfW(Addr) align = phdr->p_align;
-+      /* Notes are at least 4-byte aligned; guard a bogus p_align so the
-+         ALIGN_UP inside ELF_NOTE_NEXT_OFFSET cannot misbehave.  */
++      /* ELF permits zero or one to mean no alignment constraint.  Notes
++         themselves are at least 4-byte aligned.  All other values must be
++         powers of two for the offset calculations below.  */
 +      if (align < 4)
 +        align = 4;
-+      const ElfW(Addr) start = (ElfW(Addr)) note;
++      else if (!powerof2 (align))
++        continue;
 +
-+      while ((ElfW(Addr)) (note + 1) - start < size)
++      ElfW(Addr) offset = 0;
++      while (offset <= size && sizeof (ElfW(Nhdr)) <= size - offset)
 +        {
++          const ElfW(Nhdr) *note = (const void *) (notes + offset);
++          const ElfW(Addr) remaining = size - offset;
++
++          /* Compute both aligned ends without overflowing.  The padding
++             expression is safe because ALIGN is a validated power of two;
++             every addition is first bounded by REMAINING.  */
++          ElfW(Addr) desc_off = sizeof *note;
++          if (note->n_namesz > remaining - desc_off)
++            break;
++          desc_off += note->n_namesz;
++          ElfW(Addr) padding = (-desc_off) & (align - 1);
++          if (padding > remaining - desc_off)
++            break;
++          desc_off += padding;
++          if (note->n_descsz > remaining - desc_off)
++            break;
++          ElfW(Addr) next_off = desc_off + note->n_descsz;
++
 +          /* Bound the name read against the segment before memcmp: a
 +             truncated final note could otherwise claim a 6-byte name that
 +             runs past the mapping.  && short-circuits, so the memcmp only
 +             runs once the 6 bytes are known to be in bounds.  */
 +          if (note->n_namesz == sizeof ELF_NOTE_NIXOS
 +              && note->n_type == NT_NIXOS_LD_CACHE
-+              && (ElfW(Addr)) ((const char *) (note + 1) + note->n_namesz)
-+                   - start <= size
 +              && memcmp (note + 1, ELF_NOTE_NIXOS, sizeof ELF_NOTE_NIXOS) == 0)
 +            {
-+              const char *desc = (const char *) note
-+                                 + ELF_NOTE_DESC_OFFSET (note->n_namesz, align);
++              const char *desc = (const char *) note + desc_off;
 +              /* The descriptor must lie within the segment and end with two
 +                 NUL bytes; a conforming descriptor always does (the final
 +                 path-list's terminator plus the end-of-sequence NUL).
@@ -99,27 +117,24 @@ index 00b9da9e..8fb0c2fa 100644
 +                 Nothing stricter is needed: the minimal descriptor "\0\0"
 +                 reads as an empty sequence, every lookup misses, and the
 +                 object falls back to the normal search, exactly as if the
-+                 note were absent or rejected here.  Compare via the
-+                 subtraction desc_off rather than
-+                 "desc + n_descsz <= start + size": on a 32-bit target
-+                 ElfW(Addr) is only 32 bits, and adding the untrusted
-+                 n_descsz straight to a pointer can wrap back into range,
-+                 defeating an address-comparison bound.  desc_off itself
-+                 cannot overflow: desc was derived from note, which the loop
-+                 above already established lies at or after start.  */
-+              const ElfW(Addr) desc_off = (ElfW(Addr)) desc - start;
++                 note were absent or rejected here.  The bounds above use
++                 offsets rather than "desc + n_descsz <= notes + size": on
++                 a 32-bit target ElfW(Addr) is only 32 bits, and adding the
++                 untrusted size straight to a pointer can wrap into range.  */
 +              if (note->n_descsz >= 2
-+                  && desc_off <= size
-+                  && note->n_descsz <= size - desc_off
 +                  && desc[note->n_descsz - 2] == '\0'
 +                  && desc[note->n_descsz - 1] == '\0')
 +                return desc;
 +              return (const char *) -1;
 +            }
 +
-+          note = ((const void *) note
-+                  + ELF_NOTE_NEXT_OFFSET (note->n_namesz, note->n_descsz,
-+                                          align));
++          padding = (-next_off) & (align - 1);
++          if (padding > remaining - next_off)
++            break;
++          next_off += padding;
++          if (next_off == 0)
++            break;
++          offset += next_off;
 +        }
 +    }
 +
@@ -165,9 +180,10 @@ index 00b9da9e..8fb0c2fa 100644
 +}
 +
 +/* Return true if LOADER's RUNPATH is stable enough for the resolution cache
-+   to replace the normal directory walk.  Empty and relative RUNPATH
-+   components are runtime-dependent because they are resolved against the
-+   caller's current directory; a recorded later hit must not bypass them.
++   to replace the normal directory walk.  Only directories in the immutable
++   Nix store qualify.  Empty, relative, and other absolute components can
++   resolve differently at run time; a recorded later hit must not bypass
++   them merely because the directory existed when the note was generated.
 +   The verdict is a pure function of the object's RUNPATH, so it is computed
 +   once and cached on the link map: re-deriving it later would wrongly flip
 +   to unstable after open_path marks a fully-nonexistent l_runpath_dirs dead
@@ -190,7 +206,9 @@ index 00b9da9e..8fb0c2fa 100644
 +            for (struct r_search_path_elem **dirs
 +                   = loader->l_runpath_dirs.dirs;
 +                 *dirs != NULL; ++dirs)
-+              if ((*dirs)->dirnamelen == 0 || (*dirs)->dirname[0] != '/')
++              if ((*dirs)->dirnamelen < sizeof "/nix/store/"
++                  || memcmp ((*dirs)->dirname, "/nix/store/",
++                             sizeof "/nix/store/" - 1) != 0)
 +                {
 +                  stable = -1;
 +                  break;
@@ -205,7 +223,7 @@ index 00b9da9e..8fb0c2fa 100644
  /* Map in the shared object file NAME.  */
  
  struct link_map *
-@@ -1930,6 +2126,7 @@ _dl_map_new_object (struct link_map *loader, const char *name,
+@@ -1930,6 +2144,7 @@ _dl_map_new_object (struct link_map *loader, const char *name,
    const char *origname = NULL;
    char *realname;
    char *name_copy;
@@ -213,7 +231,7 @@ index 00b9da9e..8fb0c2fa 100644
    struct link_map *l;
    struct filebuf fb;
  
-@@ -2030,6 +2227,76 @@ _dl_map_new_object (struct link_map *loader, const char *name,
+@@ -2030,6 +2245,92 @@ _dl_map_new_object (struct link_map *loader, const char *name,
  			loader ?: GL(dl_ns)[LM_ID_BASE]._ns_loaded,
  			LA_SER_LIBPATH, &found_other_class);
  
@@ -272,6 +290,22 @@ index 00b9da9e..8fb0c2fa 100644
 +                                        loader ?: GL(dl_ns)[nsid]._ns_loaded,
 +                                        LA_SER_RUNPATH, mode,
 +                                        &found_other_class, false);
++                      if (fd != -1
++                          && __glibc_unlikely (mode & __RTLD_SECURE)
++                          && __libc_enable_secure)
++                        {
++                          /* Match open_path's additional validation for bare
++                             secure LD_PRELOAD/LD_AUDIT names.  An exact hint
++                             must not bypass the S_ISUID requirement.  */
++                          struct __stat64_t64 st;
++                          if (__fstat64_time64 (fd, &st) != 0
++                              || (st.st_mode & S_ISUID) == 0)
++                            {
++                              __close_nocancel (fd);
++                              fd = -1;
++                              errno = ENOENT;
++                            }
++                        }
 +                      if (fd != -1)
 +                        {
 +                          realname = __strdup (buf + 1);
@@ -332,8 +366,8 @@ index 41e5e54a..cef48898 100644
 +       (NT_NIXOS_LD_CACHE), or (const char *) -1 once known to be absent.  */
 +    const char *l_nixos_resolve_cache;
 +
-+    /* Whether this object's DT_RUNPATH is free of runtime-dependent
-+       components, so the resolution note may replace the directory walk:
++    /* Whether this object's DT_RUNPATH contains only immutable Nix store
++       directories, so the resolution note may replace the directory walk:
 +       0 = not yet determined, 1 = stable, -1 = unstable.  Cached because
 +       the verdict must survive open_path later marking a fully-nonexistent
 +       l_runpath_dirs dead with (void *) -1.  */

--- a/pkgs/development/tools/misc/patchelf/default.nix
+++ b/pkgs/development/tools/misc/patchelf/default.nix
@@ -2,6 +2,8 @@
   lib,
   stdenv,
   fetchurl,
+  # Tests
+  patchelf,
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus
@@ -11,11 +13,11 @@
 
 stdenv.mkDerivation rec {
   pname = "patchelf";
-  version = "0.15.2";
+  version = "0.19.1";
 
   src = fetchurl {
     url = "https://github.com/NixOS/${pname}/releases/download/${version}/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-F3RfVkFZyOIo/EEtplogSLhGxLa0Igt3y/IkFuAvLXw=";
+    sha256 = "sha256-LM4B3pNlOCn2q2iiDC7CdeHACpRhEHBKJ+ko0ubohxY=";
   };
 
   strictDeps = true;
@@ -24,8 +26,21 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  # fails 8 out of 24 tests, problems when loading libc.so.6
-  doCheck = stdenv.name == "stdenv-linux";
+  # patchelf is part of the stdenv bootstrap, so enabling checks here would run
+  # the test suite on the critical path that every build depends on. Keep it off
+  # and run the suite out-of-band: passthru.tests rebuilds patchelf with checks
+  # enabled, so CI still exercises them without slowing the bootstrap.
+  doCheck = false;
+
+  # The suite is ELF-specific and fails outside Linux, so gate on the platform
+  # rather than on stdenv.name as the old doCheck did: pkgs.patchelf is pinned
+  # to the bootstrap stdenv, which never carried that name, so the old
+  # condition silently disabled the tests everywhere. Cross needs no gate of
+  # its own, since mkDerivation already forces doCheck off when the host cannot
+  # execute on the builder.
+  passthru.tests = lib.optionalAttrs stdenv.hostPlatform.isLinux {
+    makecheck = patchelf.overrideAttrs { doCheck = true; };
+  };
 
   meta = {
     homepage = "https://github.com/NixOS/patchelf";

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -67,8 +67,17 @@ lib.init bootStages
           hasCC = false;
 
           extraNativeBuildInputs =
-            old.extraNativeBuildInputs
+            # The resolution-cache hook is only useful when the host runs the
+            # patched glibc loader: drop a copy inherited from a glibc-Linux
+            # build platform's stdenv (dead weight for musl/static hosts) and
+            # add the hook for glibc hosts regardless of build platform (a
+            # darwin-built cross stdenv never inherited it).  The name match
+            # is the hook's makeSetupHook name in all-packages.nix.
+            lib.filter (p: (p.name or "") != "generate-ld-cache-hook") old.extraNativeBuildInputs
             ++ lib.optionals (hostPlatform.isLinux && !buildPlatform.isLinux) [ buildPackages.patchelf ]
+            ++ lib.optionals (hostPlatform.isLinux && hostPlatform.libc == "glibc") [
+              buildPackages.generateLdCacheHook
+            ]
             ++ lib.optional (
               let
                 f =

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -711,7 +711,13 @@ in
           prevStage.patchelf
           # Many tarballs come with obsolete config.sub/config.guess that don't recognize aarch64.
           prevStage.updateAutotoolsGnuConfigScriptsHook
-        ];
+        ]
+        # Write the .note.nixos.ldcache resolution cache into every output's
+        # ELF files (read by the patched glibc, hence glibc hosts only; a musl
+        # bootstrap would pay the patchelf pass for notes no loader reads).
+        # Only in the final stdenv so the hook and its patchelf are built by
+        # the previous stage.
+        ++ lib.optionals (localSystem.libc == "glibc") [ prevStage.generateLdCacheHook ];
 
         cc = prevStage.gcc;
 
@@ -822,6 +828,10 @@ in
             prevStage.updateAutotoolsGnuConfigScriptsHook
             prevStage.updateAutotoolsGnuConfigScriptsHook.gnu_config
           ]
+          # The resolution-cache fixup hook (glibc hosts only, matching
+          # extraNativeBuildInputs above); the patchelf it runs is already in
+          # the closure via prevStage.patchelf.
+          ++ lib.optionals (localSystem.libc == "glibc") [ prevStage.generateLdCacheHook ]
           ++ [
             gcc-unwrapped.gmp
             gcc-unwrapped.libmpc

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -244,6 +244,8 @@ in
 
   auto-patchelf-hook-preserve-origin = callPackage ./auto-patchelf-hook-preserve-origin { };
 
+  glibc-resolution-cache = callPackage ./glibc-resolution-cache { };
+
   # Accumulate all passthru.tests from arrayUtilities into a single attribute set.
   arrayUtilities = recurseIntoAttrs (
     concatMapAttrs (

--- a/pkgs/test/glibc-resolution-cache/default.nix
+++ b/pkgs/test/glibc-resolution-cache/default.nix
@@ -40,10 +40,15 @@
 # writes no note at all when it has nothing to record). The loader must treat
 # it as an empty cache: no hits, graceful fallback to the normal RUNPATH walk,
 # and the program still runs. Because the linker (not patchelf) places this
-# note, it shares a PT_NOTE segment with the GNU build-id and ABI-tag notes,
-# so this also exercises the reader stepping over foreign notes. It lives in
-# the control package: generate-ld-cache rightly fails the build when a
-# binary already carries a note with a different descriptor.
+# note, it lands in the 4-aligned PT_NOTE segment next to .note.ABI-tag, so it
+# also exercises the reader stepping over a foreign note inside one segment.
+#
+# That fixture needs its own package, built with both dontGenerateLDCache (the
+# note hook rightly fails a build whose binary already carries a note with a
+# different descriptor) and dontPatchELF, because patchelf --shrink-rpath
+# deletes a .note.nixos.ldcache it did not itself write and runs before the
+# note hook. Keeping it out of the control package leaves that package running
+# exactly the fixups the cached one does.
 
 {
   lib,
@@ -58,11 +63,28 @@ let
   # (when enabled) is written by the normal fixup hooks, and the interpreter is
   # whatever the default stdenv uses.
   mkProg =
-    { generateCache }:
+    {
+      generateCache,
+      craftedNote ? false,
+    }:
     stdenv.mkDerivation {
-      name = "ld-cache-${if generateCache then "cached" else "control"}";
+      name = "ld-cache-${
+        if generateCache then
+          "cached"
+        else if craftedNote then
+          "crafted"
+        else
+          "control"
+      }";
       dontUnpack = true;
       dontGenerateLDCache = !generateCache;
+      # patchelf --shrink-rpath deletes any .note.nixos.ldcache it finds,
+      # treating a note it did not just write as stale, and it runs from
+      # fixupOutput, before the note hook. That is harmless for real packages
+      # (their note is written afterwards, in postFixup) but it would strip a
+      # note placed by the linker before this fixture ever runs, leaving a
+      # binary that silently tests nothing. Skip that pass here only.
+      dontPatchELF = craftedNote;
       nativeBuildInputs = [ patchelf ];
       buildPhase = ''
         runHook preBuild
@@ -103,7 +125,7 @@ let
           -L$out/lib/real -lfoo \
           -Wl,--enable-new-dtags -Wl,-rpath,"$out/lib/real"
 
-        ${lib.optionalString (!generateCache) ''
+        ${lib.optionalString craftedNote ''
           # A well-formed note (padded to the 4-byte boundary, so readelf and
           # the loader agree on where it ends) whose descriptor is just the
           # end-of-sequence NUL plus one more: an empty cache.
@@ -190,10 +212,17 @@ let
 
   cached = mkProg { generateCache = true; };
   control = mkProg { generateCache = false; };
+  # Separate from `control` so that `control` keeps running exactly the fixups
+  # `cached` does, which is what makes it a fair comparison; only this fixture
+  # needs the shrink-rpath pass skipped.
+  crafted = mkProg {
+    generateCache = false;
+    craftedNote = true;
+  };
 in
 runCommand "glibc-resolution-cache-test"
   {
-    inherit cached control;
+    inherit cached control crafted;
     nativeBuildInputs = [ binutils ]; # readelf
     meta = {
       description = "End-to-end test of the glibc DT_NEEDED resolution cache note";
@@ -301,7 +330,21 @@ runCommand "glibc-resolution-cache-test"
     "$control/bin/prog-mutable" || rc=$?
     [ "$rc" -eq 42 ]
 
-    prog_empty="$control/bin/prog-empty"
+    prog_empty="$crafted/bin/prog-empty"
+
+    # Without this the rest of the empty-note block is satisfied just as well by
+    # a binary that has no note at all, which is exactly what shrink-rpath used
+    # to leave behind. The reader only walks PT_NOTE segments, so being an
+    # SHT_NOTE section is not enough: require the section to be mapped by one.
+    echo "[test] the linker-placed note survived the build and sits in a PT_NOTE"
+    readelf -lW "$prog_empty" | awk '
+      /^ +Type +Offset/            { inph = 1; idx = 0; next }
+      inph && NF == 0              { inph = 0 }
+      inph && $1 ~ /^[A-Z_]+$/     { if ($1 == "NOTE") note[sprintf("%02d", idx)] = 1; idx++ }
+      /Section to Segment mapping/ { inmap = 1; next }
+      inmap && ($1 in note)        { if (index($0, ".note.nixos.ldcache")) found = 1 }
+      END                          { exit found ? 0 : 1 }
+    '
 
     echo "[test] the crafted note carries an empty two-NUL descriptor"
     readelf -n "$prog_empty" | grep NixOS | grep -q 0x00000002
@@ -326,7 +369,7 @@ runCommand "glibc-resolution-cache-test"
     echo "[test] a malformed non-power-of-two PT_NOTE alignment cannot hang the loader"
     cp "$prog" ./prog-bad-note-align
     chmod u+w ./prog-bad-note-align
-    "$control/bin/corrupt-note-align" ./prog-bad-note-align
+    "$crafted/bin/corrupt-note-align" ./prog-bad-note-align
     rc=0
     timeout 5 ./prog-bad-note-align || rc=$?
     [ "$rc" -eq 7 ]

--- a/pkgs/test/glibc-resolution-cache/default.nix
+++ b/pkgs/test/glibc-resolution-cache/default.nix
@@ -31,9 +31,9 @@
 # mutable absolute directory, for which patchelf 0.19.1 emits no hint at all
 # when the soname is absent. Neither directory is in the store, so glibc must
 # decline the cache for both objects and preserve first-match semantics when
-# the directory is populated later. Both rely on the sandbox build root being
-# /build for the fixture build and this test, like the LD_DEBUG assumption
-# above.
+# the directory is populated later. Both bake an absolute path that the
+# fixture build and this test have to agree on, so they use /tmp, which is
+# writable whether or not the build is sandboxed.
 #
 # Declining the cache on any non-store component means those two fixtures
 # never reach the loader's "?" branch. A fifth fixture does: its RUNPATH pairs
@@ -66,6 +66,15 @@
 }:
 
 let
+  # Absolute, mutable, non-store directories that the fixture bakes into a
+  # RUNPATH at build time and the test manipulates at run time, so both builds
+  # must agree on the literal path. /tmp is writable inside the sandbox and out
+  # of it, unlike the sandbox build root, which only exists when sandboxing is
+  # on. Each user is cleared before use so a shared /tmp cannot leak state
+  # between runs.
+  runtimeDir = "/tmp/nixpkgs-ld-cache-test-runtime";
+  existingDir = "/tmp/nixpkgs-ld-cache-test-existing";
+
   # An ordinary stdenv build. Nothing here is specific to the cache: the note
   # (when enabled) is written by the normal fixup hooks, and the interpreter is
   # whatever the default stdenv uses.
@@ -216,17 +225,19 @@ let
         # Prepend a directory that does not exist while the note is generated
         # (RPATH shrinking would drop it from the link-time RUNPATH, hence the
         # rewrite here). patchelf must record it as a "?" search hint; the
-        # outer test creates it under the shared sandbox build root /build and
-        # proves a library placed there at run time wins over the note's exact
-        # real/ entry.
-        patchelf --set-rpath "/build/ld-cache-runtime-libs:$out/lib/real" "$out/bin/prog-runtime"
+        # outer test creates it and proves a library placed there at run time
+        # wins over the note's exact real/ entry. Clear it first: with the
+        # sandbox disabled /tmp is shared, and a leftover directory from an
+        # earlier run would stop patchelf emitting the hint at all.
+        rm -rf ${runtimeDir}
+        patchelf --set-rpath "${runtimeDir}:$out/lib/real" "$out/bin/prog-runtime"
 
         # Unlike prog-runtime's missing directory, this directory exists when
         # patchelf builds the note. patchelf therefore records neither a "?"
         # hint nor a miss for it. The loader must still search it at run time
         # because an absolute non-store directory is mutable.
-        mkdir -p /build/ld-cache-existing-libs
-        patchelf --set-rpath "/build/ld-cache-existing-libs:$out/lib/real" "$out/bin/prog-mutable"
+        mkdir -p ${existingDir}
+        patchelf --set-rpath "${existingDir}:$out/lib/real" "$out/bin/prog-mutable"
       '';
     };
 
@@ -308,12 +319,12 @@ runCommand "glibc-resolution-cache-test"
     prog_runtime="$cached/bin/prog-runtime"
 
     echo "[test] patchelf records a build-time-missing dir as a '?' search hint"
-    readelf -p .note.nixos.ldcache "$prog_runtime" | grep -qF "?/build/ld-cache-runtime-libs"
+    readelf -p .note.nixos.ldcache "$prog_runtime" | grep -qF "?${runtimeDir}"
 
-    # The note exists and names real/, but /build/... is outside the store, so
-    # the loader declines the whole cache for this object. The two cases below
-    # therefore assert stock RUNPATH first-match order rather than anything
-    # about the cache; prog-origin covers the "?" branch of the cache walk.
+    # The note exists and names real/, but the hinted directory is outside the
+    # store, so the loader declines the whole cache for this object. The two
+    # cases below therefore assert stock RUNPATH first-match order rather than
+    # anything about the cache; prog-origin covers the "?" branch of the walk.
     echo "[test] a non-store RUNPATH component makes the loader decline the note"
     if { LD_DEBUG=libs "$prog_runtime" 2>&1 >/dev/null || true; } \
         | grep -q "trying cached file="; then
@@ -322,13 +333,14 @@ runCommand "glibc-resolution-cache-test"
     fi
 
     echo "[test] with the runtime dir still absent, real/ resolves (returns 7)"
+    rm -rf ${runtimeDir}
     rc=0
     "$prog_runtime" || rc=$?
     [ "$rc" -eq 7 ]
 
     echo "[test] a dir populated after note generation still wins (returns 42)"
-    mkdir -p /build/ld-cache-runtime-libs
-    cp "$cached/lib/over/libfoo.so.1" /build/ld-cache-runtime-libs/
+    mkdir -p ${runtimeDir}
+    cp "$cached/lib/over/libfoo.so.1" ${runtimeDir}/
     rc=0
     "$prog_runtime" || rc=$?
     [ "$rc" -eq 42 ]
@@ -344,14 +356,15 @@ runCommand "glibc-resolution-cache-test"
     readelf -p .note.nixos.ldcache "$prog_mutable" \
       | grep -qF "=$cached/lib/real/libfoo.so.1"
     if readelf -p .note.nixos.ldcache "$prog_mutable" \
-        | grep -qF "?/build/ld-cache-existing-libs"; then
+        | grep -qF "?${existingDir}"; then
       echo "  unexpected search hint for existing mutable directory" >&2
       exit 1
     fi
 
     echo "[test] a mutable directory populated later still wins (returns 42)"
-    mkdir -p /build/ld-cache-existing-libs
-    cp "$cached/lib/over/libfoo.so.1" /build/ld-cache-existing-libs/
+    rm -rf ${existingDir}
+    mkdir -p ${existingDir}
+    cp "$cached/lib/over/libfoo.so.1" ${existingDir}/
     rc=0
     "$prog_mutable" || rc=$?
     [ "$rc" -eq 42 ]

--- a/pkgs/test/glibc-resolution-cache/default.nix
+++ b/pkgs/test/glibc-resolution-cache/default.nix
@@ -32,6 +32,16 @@
 # overriding libfoo and asserts the override wins over the note's exact real/
 # entry. The fixture relies on the sandbox build root being /build for both
 # the fixture build and this test, like the LD_DEBUG assumption above.
+#
+# A fourth fixture links a hand-crafted note whose descriptor is a bare
+# "\0\0", i.e. an empty pair sequence, something patchelf never emits (it
+# writes no note at all when it has nothing to record). The loader must treat
+# it as an empty cache: no hits, graceful fallback to the normal RUNPATH walk,
+# and the program still runs. Because the linker (not patchelf) places this
+# note, it shares a PT_NOTE segment with the GNU build-id and ABI-tag notes,
+# so this also exercises the reader stepping over foreign notes. It lives in
+# the control package: generate-ld-cache rightly fails the build when a
+# binary already carries a note with a different descriptor.
 
 {
   lib,
@@ -86,6 +96,26 @@ let
         $CC main_foo.c -o $out/bin/prog-runtime \
           -L$out/lib/real -lfoo \
           -Wl,--enable-new-dtags -Wl,-rpath,"$out/lib/real"
+
+        ${lib.optionalString (!generateCache) ''
+          # A well-formed note (padded to the 4-byte boundary, so readelf and
+          # the loader agree on where it ends) whose descriptor is just the
+          # end-of-sequence NUL plus one more: an empty cache.
+          printf '%s\n' \
+            '.section .note.nixos.ldcache, "a", %note' \
+            '.balign 4' \
+            '.long 6' \
+            '.long 2' \
+            '.long 0x63a86cb6' \
+            '.ascii "NixOS\0"' \
+            '.balign 4' \
+            '.byte 0, 0' \
+            '.balign 4' \
+            '.section .note.GNU-stack, "", %progbits' > empty-note.s
+          $CC main.c empty-note.s -o $out/bin/prog-empty \
+            -L$out/lib/dep -lbar -L$out/lib/real -lfoo \
+            -Wl,--enable-new-dtags -Wl,-rpath,"$out/lib/dep:$out/lib/real"
+        ''}
 
         runHook postBuild
       '';
@@ -195,6 +225,28 @@ runCommand "glibc-resolution-cache-test"
     rc=0
     "$control/bin/prog-runtime" || rc=$?
     [ "$rc" -eq 42 ]
+
+    prog_empty="$control/bin/prog-empty"
+
+    echo "[test] the crafted note carries an empty two-NUL descriptor"
+    readelf -n "$prog_empty" | grep NixOS | grep -q 0x00000002
+
+    echo "[test] an empty note is harmless: the loader falls back to the RUNPATH walk"
+    e=$(probes "$prog_empty")
+    echo "  dep/ probes (empty note): $e"
+    [ "$e" -gt 0 ]
+
+    echo "[test] an empty note never produces a cache hit"
+    if { LD_DEBUG=libs "$prog_empty" 2>&1 >/dev/null || true; } \
+        | grep -q "trying cached file="; then
+      echo "  unexpected cache hit with an empty note" >&2
+      exit 1
+    fi
+
+    echo "[test] the program with the empty note still runs (returns 7)"
+    rc=0
+    "$prog_empty" || rc=$?
+    [ "$rc" -eq 7 ]
 
     echo "[test] PASS"
     touch "$out"

--- a/pkgs/test/glibc-resolution-cache/default.nix
+++ b/pkgs/test/glibc-resolution-cache/default.nix
@@ -1,0 +1,201 @@
+# End-to-end test of the glibc DT_NEEDED resolution cache (issue #481620).
+#
+# It exercises both halves of the feature exactly as they ship:
+#   * the default patchelf writes the .note.nixos.ldcache note, and
+#   * the default glibc (patched with ./ldcache.patch) reads it.
+#
+# Rather than hand-driving patchelf, this builds an ordinary stdenv package and
+# lets the standard fixup hooks -- including generate-ld-cache -- write the note
+# during the build, just like for every other package; the binary's interpreter
+# is the default (patched) loader. A second, identical package built with
+# `dontGenerateLDCache` is the no-note control.
+#
+# The program needs two libraries, libbar and libfoo, kept in separate RUNPATH
+# directories (dep/ before real/). libbar lives in dep/ and libfoo in real/, so
+# both directories survive RPATH shrinking (each holds a needed library) yet the
+# loader still genuinely probes dep/ for libfoo before finding it in real/. This
+# mirrors the real stat-storm: a long RUNPATH walked once per needed library.
+#
+# The patched loader must resolve libfoo straight from the note without probing
+# dep/; the control (no note) must still probe it; and LD_LIBRARY_PATH must
+# still override the cached path. A second fixture reintroduces a
+# runtime-dependent RUNPATH component (an empty entry, meaning the caller's
+# current directory) in postFixup, before generate-ld-cache writes the note; the
+# loader must ignore the exact cache entry in that case so normal RUNPATH
+# ordering still applies. Behaviour is observed via LD_DEBUG=libs, so no ptrace
+# is required in the build sandbox.
+#
+# A third fixture bakes a RUNPATH whose first directory does not exist while
+# the note is generated (the /run/opengl-driver/lib pattern): patchelf must
+# record it as a "?" search hint rather than drop it, so the loader still
+# probes it at run time. This test populates that directory afterwards with an
+# overriding libfoo and asserts the override wins over the note's exact real/
+# entry. The fixture relies on the sandbox build root being /build for both
+# the fixture build and this test, like the LD_DEBUG assumption above.
+
+{
+  lib,
+  stdenv,
+  runCommand,
+  binutils,
+  patchelf,
+}:
+
+let
+  # An ordinary stdenv build. Nothing here is specific to the cache: the note
+  # (when enabled) is written by the normal fixup hooks, and the interpreter is
+  # whatever the default stdenv uses.
+  mkProg =
+    { generateCache }:
+    stdenv.mkDerivation {
+      name = "ld-cache-${if generateCache then "cached" else "control"}";
+      dontUnpack = true;
+      dontGenerateLDCache = !generateCache;
+      nativeBuildInputs = [ patchelf ];
+      buildPhase = ''
+        runHook preBuild
+
+        mkdir -p $out/bin $out/lib/dep $out/lib/real $out/lib/over
+        printf '%s\n' 'int bar(void) { return 1; }' > bar.c
+        printf '%s\n' 'int foo(void) { return 7; }' > foo.c
+        printf '%s\n' 'int foo(void) { return 42; }' > foo_over.c
+        printf '%s\n' \
+          'extern int foo(void); extern int bar(void);' \
+          'int main(void) { return foo() + bar() - 1; }' > main.c
+        printf '%s\n' \
+          'extern int foo(void);' \
+          'int main(void) { return foo(); }' > main_foo.c
+
+        $CC -shared -fPIC -Wl,-soname,libbar.so.1 -o $out/lib/dep/libbar.so.1 bar.c
+        ln -s libbar.so.1 $out/lib/dep/libbar.so
+        $CC -shared -fPIC -Wl,-soname,libfoo.so.1 -o $out/lib/real/libfoo.so.1 foo.c
+        ln -s libfoo.so.1 $out/lib/real/libfoo.so
+        # Override copy returning 42, used to prove LD_LIBRARY_PATH still wins.
+        $CC -shared -fPIC -Wl,-soname,libfoo.so.1 -o $out/lib/over/libfoo.so.1 foo_over.c
+
+        # RUNPATH dep/ (libbar, no libfoo) precedes real/ (libfoo). Both survive
+        # RPATH shrinking, so the loader genuinely probes dep/ for libfoo first.
+        $CC main.c -o $out/bin/prog \
+          -L$out/lib/dep -lbar -L$out/lib/real -lfoo \
+          -Wl,--enable-new-dtags -Wl,-rpath,"$out/lib/dep:$out/lib/real"
+
+        $CC main_foo.c -o $out/bin/prog-cwd \
+          -L$out/lib/real -lfoo \
+          -Wl,--enable-new-dtags -Wl,-rpath,"$out/lib/real"
+
+        $CC main_foo.c -o $out/bin/prog-runtime \
+          -L$out/lib/real -lfoo \
+          -Wl,--enable-new-dtags -Wl,-rpath,"$out/lib/real"
+
+        runHook postBuild
+      '';
+      postFixup = ''
+        # Reintroduce an empty RUNPATH component after normal shrinkage but
+        # before generate-ld-cache runs from postFixupHooks. Without the glibc
+        # guard, the note's exact real/ entry bypasses this earlier runtime
+        # search path.
+        patchelf --set-rpath ":$out/lib/real" "$out/bin/prog-cwd"
+
+        # Prepend a directory that does not exist while the note is generated
+        # (RPATH shrinking would drop it from the link-time RUNPATH, hence the
+        # rewrite here). patchelf must record it as a "?" search hint; the
+        # outer test creates it under the shared sandbox build root /build and
+        # proves a library placed there at run time wins over the note's exact
+        # real/ entry.
+        patchelf --set-rpath "/build/ld-cache-runtime-libs:$out/lib/real" "$out/bin/prog-runtime"
+      '';
+    };
+
+  cached = mkProg { generateCache = true; };
+  control = mkProg { generateCache = false; };
+in
+runCommand "glibc-resolution-cache-test"
+  {
+    inherit cached control;
+    nativeBuildInputs = [ binutils ]; # readelf
+    meta = {
+      description = "End-to-end test of the glibc DT_NEEDED resolution cache note";
+      maintainers = with lib.maintainers; [ domenkozar ];
+      platforms = lib.platforms.linux;
+    };
+  }
+  ''
+    prog="$cached/bin/prog"
+    prog_cwd="$cached/bin/prog-cwd"
+    prog_nonote="$control/bin/prog"
+
+    echo "[test] the fixup hook wrote the note resolving libfoo.so.1 to real/"
+    readelf -p .note.nixos.ldcache "$prog" | grep -q "$cached/lib/real/libfoo.so.1"
+    readelf -p .note.nixos.ldcache "$prog_cwd" | grep -q "$cached/lib/real/libfoo.so.1"
+
+    echo "[test] the control binary has no note"
+    if readelf -p .note.nixos.ldcache "$prog_nonote" 2>/dev/null | grep -q libfoo; then
+      echo "  unexpected note in control binary" >&2
+      exit 1
+    fi
+
+    # Count the loader probing dep/ for libfoo (the dir that lacks it).
+    probes() { LD_DEBUG=libs "$1" 2>&1 >/dev/null | grep -cE 'trying file=.*/lib/dep/libfoo\.so\.1' || true; }
+
+    echo "[test] with the note, the loader does not probe dep/ for libfoo"
+    n=$(probes "$prog")
+    echo "  dep/ probes (note):    $n"
+    [ "$n" -eq 0 ]
+
+    echo "[test] LD_DEBUG names the note as the source (trying cached file=)"
+    # prog exits 7 by design; guard it or pipefail fails the pipeline.
+    { LD_DEBUG=libs "$prog" 2>&1 >/dev/null || true; } \
+      | grep -qF "trying cached file=$cached/lib/real/libfoo.so.1"
+
+    echo "[test] without the note, the same loader does probe it (control)"
+    c=$(probes "$prog_nonote")
+    echo "  dep/ probes (no note): $c"
+    [ "$c" -gt 0 ]
+
+    echo "[test] the program runs and resolves the real library (returns 7)"
+    rc=0
+    "$prog" || rc=$?
+    [ "$rc" -eq 7 ]
+
+    echo "[test] LD_LIBRARY_PATH still overrides the note (returns 42)"
+    rc=0
+    LD_LIBRARY_PATH="$cached/lib/over" "$prog" || rc=$?
+    [ "$rc" -eq 42 ]
+
+    echo "[test] the fixture keeps an empty (current directory) RUNPATH component"
+    if ! readelf -d "$prog_cwd" | grep RUNPATH | grep -qE '\[:|::|:]'; then
+      echo "  expected an empty RUNPATH component" >&2
+      exit 1
+    fi
+
+    echo "[test] an earlier current-directory RUNPATH component still wins"
+    cp "$cached/lib/over/libfoo.so.1" ./libfoo.so.1
+    rc=0
+    "$prog_cwd" || rc=$?
+    [ "$rc" -eq 42 ]
+
+    prog_runtime="$cached/bin/prog-runtime"
+
+    echo "[test] the note records the build-time-missing dir as a '?' search hint"
+    readelf -p .note.nixos.ldcache "$prog_runtime" | grep -qF "?/build/ld-cache-runtime-libs"
+
+    echo "[test] with the runtime dir still absent, the exact entry resolves (returns 7)"
+    rc=0
+    "$prog_runtime" || rc=$?
+    [ "$rc" -eq 7 ]
+
+    echo "[test] a dir populated after note generation wins over the exact entry (returns 42)"
+    mkdir -p /build/ld-cache-runtime-libs
+    cp "$cached/lib/over/libfoo.so.1" /build/ld-cache-runtime-libs/
+    rc=0
+    "$prog_runtime" || rc=$?
+    [ "$rc" -eq 42 ]
+
+    echo "[test] the control binary agrees (stock RUNPATH semantics, returns 42)"
+    rc=0
+    "$control/bin/prog-runtime" || rc=$?
+    [ "$rc" -eq 42 ]
+
+    echo "[test] PASS"
+    touch "$out"
+  ''

--- a/pkgs/test/glibc-resolution-cache/default.nix
+++ b/pkgs/test/glibc-resolution-cache/default.nix
@@ -26,14 +26,21 @@
 # is required in the build sandbox.
 #
 # A third fixture bakes a RUNPATH whose first directory does not exist while
-# the note is generated (the /run/opengl-driver/lib pattern): patchelf must
-# record it as a "?" search hint rather than drop it, so the loader still
-# probes it at run time. A companion fixture covers an existing but mutable
-# absolute directory. Patchelf 0.19.1 emits no "?" hint for that case when the
-# soname is absent, so glibc must decline the cache for any non-store RUNPATH
-# and preserve first-match semantics if the directory is populated later.
-# Both fixtures rely on the sandbox build root being /build for the fixture
-# build and this test, like the LD_DEBUG assumption above.
+# the note is generated (the /run/opengl-driver/lib pattern), so patchelf
+# records it as a "?" search hint. A companion fixture covers an existing but
+# mutable absolute directory, for which patchelf 0.19.1 emits no hint at all
+# when the soname is absent. Neither directory is in the store, so glibc must
+# decline the cache for both objects and preserve first-match semantics when
+# the directory is populated later. Both rely on the sandbox build root being
+# /build for the fixture build and this test, like the LD_DEBUG assumption
+# above.
+#
+# Declining the cache on any non-store component means those two fixtures
+# never reach the loader's "?" branch. A fifth fixture does: its RUNPATH pairs
+# an $ORIGIN-relative directory, which patchelf can only record as a hint,
+# with a plain store directory it resolves exactly. $ORIGIN expands back into
+# the store at run time, so the cache is consulted, the hint is decomposed and
+# searched, and only then does the exact entry resolve libfoo.
 #
 # A fourth fixture links a hand-crafted note whose descriptor is a bare
 # "\0\0", i.e. an empty pair sequence, something patchelf never emits (it
@@ -124,6 +131,19 @@ let
         $CC main_foo.c -o $out/bin/prog-mutable \
           -L$out/lib/real -lfoo \
           -Wl,--enable-new-dtags -Wl,-rpath,"$out/lib/real"
+
+        # A RUNPATH mixing an $ORIGIN-relative directory, which patchelf can
+        # only record as a "?" search hint because it cannot know what $ORIGIN
+        # will be, with a plain store directory it resolves to an "=" exact
+        # entry. $ORIGIN expands back into /nix/store at run time, so this
+        # RUNPATH stays stable and the loader does consult the note. dep/ holds
+        # libbar but not libfoo, so resolving libfoo has to walk the hint and
+        # miss before reaching the exact entry: this is the fixture that covers
+        # the "?" branch of the cache walk.
+        $CC main.c -o $out/bin/prog-origin \
+          -L$out/lib/dep -lbar -L$out/lib/real -lfoo \
+          -Wl,--enable-new-dtags \
+          -Wl,-rpath,'$ORIGIN/../lib/dep':"$out/lib/real"
 
         ${lib.optionalString craftedNote ''
           # A well-formed note (padded to the 4-byte boundary, so readelf and
@@ -287,15 +307,26 @@ runCommand "glibc-resolution-cache-test"
 
     prog_runtime="$cached/bin/prog-runtime"
 
-    echo "[test] the note records the build-time-missing dir as a '?' search hint"
+    echo "[test] patchelf records a build-time-missing dir as a '?' search hint"
     readelf -p .note.nixos.ldcache "$prog_runtime" | grep -qF "?/build/ld-cache-runtime-libs"
 
-    echo "[test] with the runtime dir still absent, the exact entry resolves (returns 7)"
+    # The note exists and names real/, but /build/... is outside the store, so
+    # the loader declines the whole cache for this object. The two cases below
+    # therefore assert stock RUNPATH first-match order rather than anything
+    # about the cache; prog-origin covers the "?" branch of the cache walk.
+    echo "[test] a non-store RUNPATH component makes the loader decline the note"
+    if { LD_DEBUG=libs "$prog_runtime" 2>&1 >/dev/null || true; } \
+        | grep -q "trying cached file="; then
+      echo "  cache consulted despite a non-store RUNPATH component" >&2
+      exit 1
+    fi
+
+    echo "[test] with the runtime dir still absent, real/ resolves (returns 7)"
     rc=0
     "$prog_runtime" || rc=$?
     [ "$rc" -eq 7 ]
 
-    echo "[test] a dir populated after note generation wins over the exact entry (returns 42)"
+    echo "[test] a dir populated after note generation still wins (returns 42)"
     mkdir -p /build/ld-cache-runtime-libs
     cp "$cached/lib/over/libfoo.so.1" /build/ld-cache-runtime-libs/
     rc=0
@@ -329,6 +360,30 @@ runCommand "glibc-resolution-cache-test"
     rc=0
     "$control/bin/prog-mutable" || rc=$?
     [ "$rc" -eq 42 ]
+
+    prog_origin="$cached/bin/prog-origin"
+
+    echo '[test] the note pairs a ? hint for $ORIGIN with an = entry for the store dir'
+    readelf -p .note.nixos.ldcache "$prog_origin" | grep -qF '?$ORIGIN/../lib/dep'
+    readelf -p .note.nixos.ldcache "$prog_origin" | grep -qF "=$cached/lib/real/libfoo.so.1"
+
+    echo '[test] $ORIGIN expands into the store, so the cache is still consulted'
+    { LD_DEBUG=libs "$prog_origin" 2>&1 >/dev/null || true; } \
+      | grep -qF "trying cached file=$cached/lib/real/libfoo.so.1"
+
+    # The exact hit above proves the cache branch ran and resolved libfoo, so
+    # the normal RUNPATH walk never ran for it. Any dep/ probe can therefore
+    # only come from the ? hint being decomposed and searched inside that
+    # branch, which is the code path nothing else in this test reaches.
+    echo "[test] the ? hint is searched, and before the = entry"
+    o=$(probes "$prog_origin")
+    echo "  dep/ probes (origin hint): $o"
+    [ "$o" -gt 0 ]
+
+    echo "[test] the ORIGIN-relative fixture runs (returns 7)"
+    rc=0
+    "$prog_origin" || rc=$?
+    [ "$rc" -eq 7 ]
 
     prog_empty="$crafted/bin/prog-empty"
 
@@ -366,12 +421,25 @@ runCommand "glibc-resolution-cache-test"
     "$prog_empty" || rc=$?
     [ "$rc" -eq 7 ]
 
-    echo "[test] a malformed non-power-of-two PT_NOTE alignment cannot hang the loader"
+    echo "[test] a malformed non-power-of-two PT_NOTE alignment is rejected"
     cp "$prog" ./prog-bad-note-align
     chmod u+w ./prog-bad-note-align
     "$crafted/bin/corrupt-note-align" ./prog-bad-note-align
+    # The reader must skip the segment rather than try to walk it, which is
+    # observable without timing the process: no cache hit, and the normal
+    # RUNPATH walk takes over and probes dep/ for libfoo exactly as the
+    # no-note control does. A walk that failed to advance would hang here
+    # instead of failing, and the builder's own timeout would catch that.
+    if { LD_DEBUG=libs ./prog-bad-note-align 2>&1 >/dev/null || true; } \
+        | grep -q "trying cached file="; then
+      echo "  unexpected cache hit from a malformed note alignment" >&2
+      exit 1
+    fi
+    a=$(probes ./prog-bad-note-align)
+    echo "  dep/ probes (bad align): $a"
+    [ "$a" -gt 0 ]
     rc=0
-    timeout 5 ./prog-bad-note-align || rc=$?
+    ./prog-bad-note-align || rc=$?
     [ "$rc" -eq 7 ]
 
     echo "[test] PASS"

--- a/pkgs/test/glibc-resolution-cache/default.nix
+++ b/pkgs/test/glibc-resolution-cache/default.nix
@@ -28,10 +28,12 @@
 # A third fixture bakes a RUNPATH whose first directory does not exist while
 # the note is generated (the /run/opengl-driver/lib pattern): patchelf must
 # record it as a "?" search hint rather than drop it, so the loader still
-# probes it at run time. This test populates that directory afterwards with an
-# overriding libfoo and asserts the override wins over the note's exact real/
-# entry. The fixture relies on the sandbox build root being /build for both
-# the fixture build and this test, like the LD_DEBUG assumption above.
+# probes it at run time. A companion fixture covers an existing but mutable
+# absolute directory. Patchelf 0.19.1 emits no "?" hint for that case when the
+# soname is absent, so glibc must decline the cache for any non-store RUNPATH
+# and preserve first-match semantics if the directory is populated later.
+# Both fixtures rely on the sandbox build root being /build for the fixture
+# build and this test, like the LD_DEBUG assumption above.
 #
 # A fourth fixture links a hand-crafted note whose descriptor is a bare
 # "\0\0", i.e. an empty pair sequence, something patchelf never emits (it
@@ -97,6 +99,10 @@ let
           -L$out/lib/real -lfoo \
           -Wl,--enable-new-dtags -Wl,-rpath,"$out/lib/real"
 
+        $CC main_foo.c -o $out/bin/prog-mutable \
+          -L$out/lib/real -lfoo \
+          -Wl,--enable-new-dtags -Wl,-rpath,"$out/lib/real"
+
         ${lib.optionalString (!generateCache) ''
           # A well-formed note (padded to the 4-byte boundary, so readelf and
           # the loader agree on where it ends) whose descriptor is just the
@@ -115,6 +121,45 @@ let
           $CC main.c empty-note.s -o $out/bin/prog-empty \
             -L$out/lib/dep -lbar -L$out/lib/real -lfoo \
             -Wl,--enable-new-dtags -Wl,-rpath,"$out/lib/dep:$out/lib/real"
+
+          # Native helper used by the outer test to corrupt PT_NOTE p_align
+          # values without depending on the ELF class of the test platform.
+          printf '%s\n' \
+            '#include <elf.h>' \
+            '#include <fcntl.h>' \
+            '#include <stdio.h>' \
+            '#include <unistd.h>' \
+            '#if __SIZEOF_POINTER__ == 8' \
+            'typedef Elf64_Ehdr Ehdr;' \
+            'typedef Elf64_Phdr Phdr;' \
+            '#define NATIVE_CLASS ELFCLASS64' \
+            '#else' \
+            'typedef Elf32_Ehdr Ehdr;' \
+            'typedef Elf32_Phdr Phdr;' \
+            '#define NATIVE_CLASS ELFCLASS32' \
+            '#endif' \
+            'int main(int argc, char **argv) {' \
+            '  if (argc != 2) return 2;' \
+            '  int fd = open(argv[1], O_RDWR);' \
+            '  Ehdr eh;' \
+            '  if (fd < 0 || pread(fd, &eh, sizeof eh, 0) != sizeof eh' \
+            '      || eh.e_ident[EI_CLASS] != NATIVE_CLASS' \
+            '      || eh.e_phentsize != sizeof(Phdr)) return 2;' \
+            '  int changed = 0;' \
+            '  for (unsigned int i = 0; i < eh.e_phnum; ++i) {' \
+            '    off_t off = eh.e_phoff + (off_t) i * eh.e_phentsize;' \
+            '    Phdr ph;' \
+            '    if (pread(fd, &ph, sizeof ph, off) != sizeof ph) return 2;' \
+            '    if (ph.p_type == PT_NOTE) {' \
+            '      ph.p_align = -1;' \
+            '      if (pwrite(fd, &ph, sizeof ph, off) != sizeof ph) return 2;' \
+            '      changed = 1;' \
+            '    }' \
+            '  }' \
+            '  if (close(fd) != 0) return 2;' \
+            '  return changed ? 0 : 1;' \
+            '}' > corrupt-note-align.c
+          $CC -Wall -Wextra -Werror -o $out/bin/corrupt-note-align corrupt-note-align.c
         ''}
 
         runHook postBuild
@@ -133,6 +178,13 @@ let
         # proves a library placed there at run time wins over the note's exact
         # real/ entry.
         patchelf --set-rpath "/build/ld-cache-runtime-libs:$out/lib/real" "$out/bin/prog-runtime"
+
+        # Unlike prog-runtime's missing directory, this directory exists when
+        # patchelf builds the note. patchelf therefore records neither a "?"
+        # hint nor a miss for it. The loader must still search it at run time
+        # because an absolute non-store directory is mutable.
+        mkdir -p /build/ld-cache-existing-libs
+        patchelf --set-rpath "/build/ld-cache-existing-libs:$out/lib/real" "$out/bin/prog-mutable"
       '';
     };
 
@@ -226,6 +278,29 @@ runCommand "glibc-resolution-cache-test"
     "$control/bin/prog-runtime" || rc=$?
     [ "$rc" -eq 42 ]
 
+    prog_mutable="$cached/bin/prog-mutable"
+
+    echo "[test] patchelf records no search hint for an existing mutable directory"
+    readelf -p .note.nixos.ldcache "$prog_mutable" \
+      | grep -qF "=$cached/lib/real/libfoo.so.1"
+    if readelf -p .note.nixos.ldcache "$prog_mutable" \
+        | grep -qF "?/build/ld-cache-existing-libs"; then
+      echo "  unexpected search hint for existing mutable directory" >&2
+      exit 1
+    fi
+
+    echo "[test] a mutable directory populated later still wins (returns 42)"
+    mkdir -p /build/ld-cache-existing-libs
+    cp "$cached/lib/over/libfoo.so.1" /build/ld-cache-existing-libs/
+    rc=0
+    "$prog_mutable" || rc=$?
+    [ "$rc" -eq 42 ]
+
+    echo "[test] the mutable-directory control agrees (returns 42)"
+    rc=0
+    "$control/bin/prog-mutable" || rc=$?
+    [ "$rc" -eq 42 ]
+
     prog_empty="$control/bin/prog-empty"
 
     echo "[test] the crafted note carries an empty two-NUL descriptor"
@@ -246,6 +321,14 @@ runCommand "glibc-resolution-cache-test"
     echo "[test] the program with the empty note still runs (returns 7)"
     rc=0
     "$prog_empty" || rc=$?
+    [ "$rc" -eq 7 ]
+
+    echo "[test] a malformed non-power-of-two PT_NOTE alignment cannot hang the loader"
+    cp "$prog" ./prog-bad-note-align
+    chmod u+w ./prog-bad-note-align
+    "$control/bin/corrupt-note-align" ./prog-bad-note-align
+    rc=0
+    timeout 5 ./prog-bad-note-align || rc=$?
     [ "$rc" -eq 7 ]
 
     echo "[test] PASS"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -307,6 +307,22 @@ with pkgs;
     meta.license = lib.licenses.mit;
   } ../build-support/setup-hooks/update-autotools-gnu-config-scripts.sh;
 
+  # Fixup hook (added to the final stdenv) that writes the .note.nixos.ldcache
+  # resolution cache into every output's ELF files; the patched glibc reads it.
+  # It runs the default patchelf, which carries `--build-resolution-cache` as of
+  # 0.19.0.
+  generateLdCacheHook =
+    makeSetupHook
+      {
+        name = "generate-ld-cache-hook";
+        __structuredAttrs = true;
+      }
+      (
+        replaceVars ../build-support/setup-hooks/generate-ld-cache.sh {
+          patchelf = "${patchelf}/bin/patchelf";
+        }
+      );
+
   buildEnv = callPackage ../build-support/buildenv { }; # not actually a package
 
   buildFHSEnv = buildFHSEnvBubblewrap;


### PR DESCRIPTION
Removes the `/nix/store` dynamic linker "stat storm" (#481620): the loader searches every `DT_RUNPATH` directory for every soname, producing thousands of failing `openat`/`stat` syscalls at process startup. This teaches glibc to read a per binary `.note.nixos.ldcache` `PT_NOTE` of pre resolved `DT_NEEDED` paths, written by `patchelf --build-resolution-cache`, and resolve a binary's direct dependencies straight from it. The note is consulted after `LD_LIBRARY_PATH` and before the `DT_RUNPATH` walk, so `LD_LIBRARY_PATH`, `LD_PRELOAD` and `/run/opengl-driver` overrides keep working.

See [Making devenv start fast, and the whole nixpkgs with it](https://devenv.sh/blog/2026/06/26/making-devenv-start-fast-and-the-whole-nixpkgs-with-it/) for in-depth explanation of all approaches considered.

### Measured (default on, patched glibc vs stock, same package versions)

| command | failing `openat` before | after | reduction |
| --- | --- | --- | --- |
| `magick --version` | 1233 | 8 | 99.4% |
| `devenv version` | 483 | 28 | 94% |

Residual opens are the irreducible glibc-hwcaps probes plus a few runtime `dlopen`s not recorded in the note. Full numbers and method in the blog post above.

### Why staging

This rebuilds the world:
* `ldcache.patch` is applied to the default glibc, so every binary runs under a note aware loader.
* A stdenv fixup hook runs `patchelf --build-resolution-cache` over each output's ELF files (registered from `preFixup` so it lands at the end of `postFixup`, after autoPatchelfHook has finalised the interpreter and RPATH; honours `dontPatchELF`; batches via `xargs`).
* The default `patchelf` is bumped 0.15.2 -> 0.19.0, which carries the writer and the relocation fixes that had kept it pinned.

### Commits

1. `patchelf: 0.15.2 -> 0.19.0` (standalone; happy to split into its own PR since the bump benefits everyone)
2. `glibc: read a per-DSO resolution-cache note and generate it by default`


### Disclosure

This pull request description and the changes were prepared with assistance from Claude (Claude Code, Claude Opus 4.8); the commits carry `Assisted-by` trailers per the automation/AI policy.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality (`tests.glibc-resolution-cache`; patchelf 0.19.0 own suite passes 63/63).
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- NixOS Release Notes
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
