### PR TITLE
yugabyte: init at 2025.2.4.0

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1877,6 +1877,7 @@ in
   };
   yggdrasil = runTest ./yggdrasil.nix;
   your_spotify = runTest ./your_spotify.nix;
+  yugabyte = runTestOn [ "x86_64-linux" "aarch64-linux" ] ./yugabyte.nix;
   zammad = runTest ./zammad.nix;
   zenohd = runTest ./zenohd.nix;
   zeronet-conservancy = runTest ./zeronet-conservancy.nix;

--- a/nixos/tests/yugabyte.nix
+++ b/nixos/tests/yugabyte.nix
@@ -1,0 +1,125 @@
+# End-to-end test of a two-node YugabyteDB cluster: a row written through the
+# YSQL endpoint of the first node must be readable through the YSQL endpoint of
+# the second node, demonstrating that the distributed SQL layer is working
+# across machines.
+#
+# Each node runs `yugabyted`, which supervises a yb-master (only the first node,
+# since the default fault-tolerance is "none" => replication factor 1) and a
+# yb-tserver. Every yb-tserver exposes a PostgreSQL-compatible YSQL server on
+# port 5433 that serves the whole distributed database, so we can write on one
+# node and read on the other.
+
+{ lib, ... }:
+
+let
+  node1Ip = "192.168.1.1";
+  node2Ip = "192.168.1.2";
+
+  baseDir = "/var/lib/yugabyte";
+
+  # YugabyteDB's hybrid clock crashes a node when the wall-clock skew between
+  # cluster members exceeds max_clock_skew_usec (default 0.5s). Two QEMU guests
+  # on a busy builder can briefly drift further than that, so widen the bound
+  # generously to keep this functional test from flaking. The value must match
+  # on yb-master and yb-tserver.
+  maxClockSkewUsec = 5000000;
+
+  startCommand =
+    {
+      advertiseAddress,
+      join ? null,
+    }:
+    lib.concatStringsSep " " (
+      [
+        "yugabyted start"
+        "--advertise_address ${advertiseAddress}"
+        "--base_dir ${baseDir}"
+        "--insecure"
+        "--ui false"
+        "--master_flags=max_clock_skew_usec=${toString maxClockSkewUsec}"
+        "--tserver_flags=max_clock_skew_usec=${toString maxClockSkewUsec}"
+      ]
+      ++ lib.optional (join != null) "--join ${join}"
+    );
+
+  node =
+    { pkgs, ... }:
+    {
+      # YugabyteDB (yb-master + yb-tserver + an embedded PostgreSQL for YSQL)
+      # needs a fair amount of RAM and CPU; on a single emulated core the
+      # processes start too slowly for yugabyted's internal startup timeouts.
+      virtualisation.memorySize = 4096;
+      virtualisation.cores = 4;
+
+      # yb-tserver rejects writes unless at least ~3 GB is free on the data
+      # directory (reject_writes_min_disk_space_mb defaults to
+      # max_disk_throughput_mbps * 10), so the default ~1 GB test disk is far
+      # too small. Give it room to accept writes.
+      virtualisation.diskSize = 8192;
+
+      # The nodes talk to each other over a handful of RPC/SQL ports; opening the
+      # firewall is overkill for a sandboxed test network.
+      networking.firewall.enable = false;
+
+      environment.systemPackages = [ pkgs.yugabyte ];
+    };
+in
+{
+  name = "yugabyte";
+  meta.maintainers = with lib.maintainers; [ layus ];
+
+  nodes = {
+    node1 = node;
+    node2 = node;
+  };
+
+  testScript = ''
+    def dump_diagnostics(node):
+        _, out = node.execute(
+            "echo '=== yugabyted status ==='; "
+            "yugabyted status --base_dir ${baseDir} 2>&1; "
+            "echo '=== listening sockets ==='; ss -tlnp; "
+            "echo '=== yugabyted.log ==='; tail -n 80 ${baseDir}/logs/yugabyted.log 2>&1; "
+            "echo '=== master logs ==='; "
+            "tail -n 120 $(ls -t ${baseDir}/data/yb-data/master/logs/*.INFO 2>/dev/null | head -n1) 2>&1; "
+            "echo '=== tserver logs ==='; "
+            "tail -n 120 $(ls -t ${baseDir}/data/yb-data/tserver/logs/*.INFO 2>/dev/null | head -n1) 2>&1"
+        )
+        print(out)
+
+    start_all()
+    node1.wait_for_unit("multi-user.target")
+    node2.wait_for_unit("multi-user.target")
+
+    ysqlsh1 = "ysqlsh -h ${node1Ip} -p 5433 -U yugabyte -d yugabyte"
+    ysqlsh2 = "ysqlsh -h ${node2Ip} -p 5433 -U yugabyte -d yugabyte"
+
+    try:
+        with subtest("first node starts and serves YSQL"):
+            node1.succeed("${startCommand { advertiseAddress = node1Ip; }} >&2")
+            node1.wait_until_succeeds(f"{ysqlsh1} -c 'SELECT 1'", timeout=600)
+
+        with subtest("second node joins the cluster and serves YSQL"):
+            node2.succeed("${
+              startCommand {
+                advertiseAddress = node2Ip;
+                join = node1Ip;
+              }
+            } >&2")
+            node2.wait_until_succeeds(f"{ysqlsh2} -c 'SELECT 1'", timeout=600)
+
+        with subtest("write on node1 is visible on node2"):
+            node1.succeed(
+                f"{ysqlsh1} -c \"CREATE TABLE items (id int PRIMARY KEY, name text)\"",
+                f"{ysqlsh1} -c \"INSERT INTO items VALUES (1, 'hello'), (2, 'world')\"",
+            )
+            rows = node2.succeed(
+                f"{ysqlsh2} -tAc 'SELECT name FROM items ORDER BY id'"
+            ).split()
+            assert rows == ["hello", "world"], f"unexpected rows read from node2: {rows!r}"
+    except Exception:
+        dump_diagnostics(node1)
+        dump_diagnostics(node2)
+        raise
+  '';
+}

--- a/pkgs/by-name/yu/yugabyte/package.nix
+++ b/pkgs/by-name/yu/yugabyte/package.nix
@@ -1,0 +1,150 @@
+{
+  lib,
+  stdenv,
+  stdenvNoCC,
+  fetchurl,
+  autoPatchelfHook,
+  bash,
+  python3,
+  nixosTests,
+}:
+
+let
+  # YugabyteDB is a very large C++/Java/Go project bundling its own LLVM,
+  # PostgreSQL fork and ~70 third-party libraries. Building it from source is
+  # impractical in nixpkgs (see also the cockroachdb package), so we consume the
+  # upstream release tarball. The binaries ship with $ORIGIN-relative rpaths
+  # pointing at the bundled lib/yb-thirdparty directory and only need glibc and
+  # libgcc_s from the host, which autoPatchelfHook wires up.
+  selectSystem =
+    attrs:
+    attrs.${stdenvNoCC.hostPlatform.system}
+      or (throw "yugabyte: unsupported system ${stdenvNoCC.hostPlatform.system}");
+
+  buildNumber = "122";
+
+  arch = selectSystem {
+    x86_64-linux = "linux-x86_64";
+    aarch64-linux = "el8-aarch64";
+  };
+
+  hash = selectSystem {
+    x86_64-linux = "sha256-AiM22yy8nYruyJt9RyrEh3p4jJIU+VgTl2PGojw0Z+Q=";
+    aarch64-linux = "sha256-Vvc5ruo+Eqk8Dsp5A0E9bC8YHuHkEZN6Lsz9vg64xNI=";
+  };
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "yugabyte";
+  version = "2025.2.4.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchurl {
+    url = "https://software.yugabyte.com/releases/${finalAttrs.version}/yugabyte-${finalAttrs.version}-b${buildNumber}-${arch}.tar.gz";
+    inherit hash;
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    # Provides libgcc_s; everything else the ELF binaries need is bundled.
+    (lib.getLib stdenv.cc.cc)
+    # Runtime interpreters for the bundled launchers: yugabyted/yb-ctl/ycqlsh
+    # are Python scripts and several helpers (configure, fips_install.sh, ...)
+    # are bash scripts. patchShebangs wires these from the runtime closure.
+    bash
+    python3
+  ];
+
+  # The shipped binaries carry debug info and rely on their bundled libraries;
+  # stripping them buys little and risks breaking the third-party objects.
+  dontStrip = true;
+
+  # autoPatchelf is invoked manually in postFixup so that the FIPS config
+  # generation, which needs the patched bundled openssl, can run afterwards.
+  dontAutoPatchelf = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/yugabyte
+    cp -a . $out/share/yugabyte
+
+    # The bundled OpenSSL provider modules ship with an upstream build-time rpath
+    # that contains patchelf's long padding placeholder, which trips up
+    # autoPatchelfHook. Point them at the bundled third-party libraries instead.
+    for mod in $out/share/yugabyte/lib/ossl-modules/*.so; do
+      patchelf --set-rpath '$ORIGIN/../yb-thirdparty' "$mod"
+    done
+
+    # yugabyted runs bin/post_install.sh on every `start` and aborts if it fails.
+    # Upstream's script performs the FIPS OpenSSL setup by writing into the
+    # install directory, which is a read-only path in the Nix store. We pre-run
+    # that setup at build time (see postFixup) and replace the runtime script
+    # with a no-op so starting a cluster does not try to mutate the store.
+    printf '%s\n' \
+      '#!/bin/sh' \
+      '# Disabled in nixpkgs: FIPS OpenSSL config is generated at build time.' \
+      'exit 0' \
+      > $out/share/yugabyte/bin/post_install.sh
+
+    # The launchers resolve the install root via realpath($0)/../.., so symlinks
+    # from $out/bin into the unpacked tree keep $ORIGIN and YUGABYTE_DIR correct.
+    mkdir -p $out/bin
+    for prog in \
+      yugabyted \
+      yb-master \
+      yb-tserver \
+      yb-admin \
+      yb-ts-cli \
+      yb-ctl \
+      ysqlsh \
+      ycqlsh; do
+      ln -s ../share/yugabyte/bin/$prog $out/bin/$prog
+    done
+
+    runHook postInstall
+  '';
+
+  # Patch the binaries first, then (now that the bundled openssl is runnable)
+  # generate the FIPS OpenSSL configuration into the store, replacing the
+  # runtime work that the disabled post_install.sh would normally do. $out is
+  # still writable during fixup.
+  postFixup = ''
+    autoPatchelf -- "$out"
+    ( cd $out/share/yugabyte && bin/fips_install.sh openssl-config )
+  '';
+
+  # No installCheck: yb-master/yb-tserver read /sys/devices/system/cpu/present
+  # at startup, which is unavailable in the Nix build sandbox.
+
+  passthru.tests = {
+    inherit (nixosTests) yugabyte;
+  };
+
+  meta = {
+    homepage = "https://www.yugabyte.com";
+    description = "High-performance distributed SQL database for global, internet-scale apps";
+    longDescription = ''
+      YugabyteDB is a high-performance, cloud-native, distributed SQL database
+      that aims to support all PostgreSQL features. It is best suited for
+      cloud-native OLTP (i.e. real-time, business-critical) applications that
+      need absolute data correctness and require at least one of the following:
+      scalability, high tolerance to failures or globally-distributed
+      deployments.
+
+      This package wraps the official upstream release binaries.
+    '';
+    license = lib.licenses.asl20;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "yugabyted";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    maintainers = with lib.maintainers; [ layus ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Packages [YugabyteDB](https://www.yugabyte.com), a distributed SQL database (a frequently-requested counterpart to the already-packaged `cockroachdb`).

Like `cockroachdb`, building YugabyteDB from source is impractical in nixpkgs (it bundles its own LLVM, a PostgreSQL fork and ~70 third-party libraries), so this wraps the official upstream release tarball:

- Uses `autoPatchelfHook`. The binaries ship with `$ORIGIN`-relative rpaths into the bundled `lib/yb-thirdparty` directory and only need `glibc` + `libgcc_s` from the host (autopatchelf reports 0 unsatisfied dependencies).
- The two bundled OpenSSL provider modules carry an upstream build-time rpath containing patchelf's long padding placeholder, which trips up `autoPatchelfHook`; their rpath is rewritten to the bundled third-party dir.
- `yugabyted` runs `bin/post_install.sh` (a FIPS OpenSSL setup) on every `start` and aborts if it fails. Upstream's script writes into the install directory, which is read-only in the Nix store, so the FIPS config is generated at build time and the runtime script is replaced with a no-op.
- Exposes `yugabyted`, `yb-master`, `yb-tserver`, `yb-admin`, `yb-ts-cli`, `yb-ctl`, `ysqlsh`, `ycqlsh`.

Also adds a two-node NixOS VM test (`nixosTests.yugabyte`): a row written through node1's YSQL endpoint is read back through node2's YSQL endpoint, exercising the distributed SQL layer across machines.

### Things done

- Built `yugabyte` on `x86_64-linux` and verified the binaries run (`yb-master`/`yb-tserver --version`, `ysqlsh`, `yugabyted --help`), plus a manual single-node cluster with a full SQL write/read roundtrip.
- The two-node `nixosTests.yugabyte` passes (`nix-build -A nixosTests.yugabyte`).
- Tested, as applicable:
  - [x] NixOS test (`nixos/tests/yugabyte.nix`)
  - [x] Built on platform(s): x86_64-linux (aarch64-linux declared but not built locally)
- Ran `nixfmt` on the changed files.
- Added myself as maintainer.

> [!NOTE]
> aarch64-linux is declared in `platforms` (upstream ships an `el8-aarch64` tarball) but I have only built/tested on x86_64-linux.
