### PR TITLE
oscar: 1.7.1 -> 2.0.1

### DIFF
--- a/pkgs/by-name/os/oscar/package.nix
+++ b/pkgs/by-name/os/oscar/package.nix
@@ -1,41 +1,47 @@
 {
   lib,
   stdenv,
-  qt5,
+  qt6,
   fetchFromGitLab,
   libGLU,
   nix-update-script,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "oscar";
-  version = "1.7.1";
+  version = "2.0.1";
 
   src = fetchFromGitLab {
     owner = "CrimsonNape";
-    repo = "OSCAR-code";
+    repo = "oscar-sql";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-cOhbWihTHGkBxiMGZhBZ3ejo8kOxlWDctun3Mz5h7AQ=";
+    hash = "sha256-ivOEAP7/pc5yS6mhc/6ButbSjfFmOP4PM7c/S23oyYw=";
   };
 
   buildInputs = [
-    qt5.qtbase
-    qt5.qttools
-    qt5.qtserialport
+    qt6.qtbase
+    qt6.qttools
     libGLU
   ];
   nativeBuildInputs = [
-    qt5.wrapQtAppsHook
-    qt5.qmake
+    qt6.wrapQtAppsHook
+    qt6.qmake
+    qt6.qtserialport
   ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
   postPatch = ''
-    substituteInPlace oscar/oscar.pro --replace "/bin/bash" "${stdenv.shell}"
+    substituteInPlace oscar/oscar.pro \
+      --replace-fail "/bin/bash" "${stdenv.shell}" \
+      --replace-fail "\$\$[QT_INSTALL_BINS]/lrelease" "${qt6.qttools}/bin/lrelease"
   '';
 
   qmakeFlags = [ "OSCAR_QT.pro" ];
 
   installPhase = ''
     runHook preInstall
-    install -D oscar/OSCAR -t $out/bin
+    install -D oscar/OSCAR20 -t $out/bin
     # help browser was removed 'temporarily' in https://gitlab.com/pholy/OSCAR-code/-/commit/57c3e4c33ccdd2d0eddedbc24c0e4f2969da3841
     # install -D oscar/Help/* -t $out/share/OSCAR/Help
     install -D oscar/Html/* -t $out/share/OSCAR/Html


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Updates oscar to 2.0.1. Also upgrades to qt6. 
It seems like the upstream repo has changed to: https://gitlab.com/CrimsonNape/oscar-sql
Release Notes: https://www.sleepfiles.com/OSCAR/

Closes: #535540

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy]. Used for understanding error log

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
