### PR TITLE
[25.11] incus: backport 7.2 security fixes

### DIFF
--- a/pkgs/by-name/in/incus/package.nix
+++ b/pkgs/by-name/in/incus/package.nix
@@ -98,6 +98,56 @@ import ./generic.nix {
       url = "https://github.com/lxc/incus/commit/a6012422b45c86f3b1956788cff5d75c604ad838.patch?full_index=1";
       hash = "sha256-u3NLKE8Rh8i6HMbJ0KNhH7gbuwIpJ1SPqiyVoiuw9Sc=";
     })
+    (fetchpatch2 {
+      name = "incusd-instances_Check-source-instance-access-on-copy.patch";
+      url = "https://github.com/lxc/incus/commit/1e3ffc53a10950e55de62ac1e0d612be597b84eb.patch?full_index=1";
+      hash = "sha256-1foxIu1rWcK1QbpmAPoQ46Tl1mrPvoctPnDhKRTWbd0=";
+    })
+    (fetchpatch2 {
+      name = "incusd-storage_Check-source-volume-access-on-copy.patch";
+      url = "https://github.com/lxc/incus/commit/2e01078366e2653712719dec82318e51c6d21b28.patch?full_index=1";
+      hash = "sha256-FP9v/8V0ZFLgy1tODKLJlw5f/6qJ8AMP/yme2YhYSaA=";
+    })
+    (fetchpatch2 {
+      name = "incusd-images_Validate-fingerprint-on-direct-download.patch";
+      url = "https://github.com/lxc/incus/commit/46d6ef232186df5535c49ca9f3597cab381f9b86.patch?full_index=1";
+      hash = "sha256-R8gsvdmb7KVC6W1vFH1CojzhrGNgNiFOOTYbCrDAajg=";
+    })
+    (fetchpatch2 {
+      name = "shared-validate_Reject-compression-algorithm-arguments.patch";
+      url = "https://github.com/lxc/incus/commit/873a032a461df6b09b7586435b592873863a4e88.patch?full_index=1";
+      hash = "sha256-QvxGxwHvswUZFst71zA12ZdxNIErl1LkaNyQdcPiglI=";
+    })
+    (fetchpatch2 {
+      name = "incusd-instance_Confine-template-access-to-instance-root.patch";
+      url = "https://github.com/lxc/incus/commit/cbefa31ae0da8fd96361178aed3a3c631e098fef.patch?full_index=1";
+      hash = "sha256-ZOHqnlIG6LyIUO6WP76SZJKTeqoiw9qj2YByGxqGP+E=";
+    })
+    (fetchpatch2 {
+      name = "incusd-instance_Enforce-project-restrictions-on-snapshot-restore.patch";
+      url = "https://github.com/lxc/incus/commit/3fe3bc99891940fcd3e758d49f65a853104fcd6b.patch?full_index=1";
+      hash = "sha256-j+lTbDaUjnZRY0lmaOSH4oKNAeIe5GXTwd1oM50it+Y=";
+    })
+    (fetchpatch2 {
+      name = "incusd-exec_Reject-exec-output-symlink.patch";
+      url = "https://github.com/lxc/incus/commit/e109655d642c7cb7c9039b7c06323000407f76dd.patch?full_index=1";
+      hash = "sha256-v/H12n8u+aqm9+ZxrarBxQEQSMN1gpX13oyummGWXl8=";
+    })
+    (fetchpatch2 {
+      name = "incusd_Reject-rootfs-symlink-for-instances.patch";
+      url = "https://github.com/lxc/incus/commit/7e58425ca7ffeb21bb116869e71a0d002dae9e72.patch?full_index=1";
+      hash = "sha256-MU+Khx+DhYQWUVs71D05PnJGamrhRXxsahtdXZeSfvU=";
+    })
+    (fetchpatch2 {
+      name = "shared-logger_Add-WarnOnError-helper.patch";
+      url = "https://github.com/lxc/incus/commit/1bc4d3feb8cd3bd005b7406c0d44ad3ea59400bf.patch?full_index=1";
+      hash = "sha256-ima4IGl0CyL30yZVdQ2pmp9SukIzrdBftGkO/GUPB3g=";
+    })
+    (fetchpatch2 {
+      name = "incus-0001-incusd-daemon_images-Add-missing-import.patch";
+      url = "https://raw.githubusercontent.com/zabbly/incus/a7fd42d2f5115c4e6893b23e64209db511fff828/patches/incus-0001-incusd-daemon_images-Add-missing-import.patch";
+      hash = "sha256-xtuuASy9bck+BgXbea9goNhrMV8Yme9cmFp4WNrkIdI=";
+    })
   ];
   nixUpdateExtraArgs = [
     "--override-filename=pkgs/by-name/in/incus/package.nix"


### PR DESCRIPTION
Backport of the version 7.2 security patches from #535509 to 25.11.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
