### PR TITLE
[Backport release-26.05] pnpmBuildHook: init

### DIFF
--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -718,6 +718,7 @@ rec {
       meta ? { },
       passthru ? { },
       substitutions ? { },
+      __structuredAttrs ? false,
     }@args:
     script:
     runCommand name
@@ -730,7 +731,7 @@ rec {
           # TODO(@Artturin:) substitutions should be inside the env attrset
           # but users are likely passing non-substitution arguments through substitutions
           # turn off __structuredAttrs to unbreak substituteAll
-          __structuredAttrs = false;
+          inherit __structuredAttrs;
           pname = name;
           version = "26.05pre-git";
           inherit meta;

--- a/pkgs/by-name/pn/pnpmBuildHook/package.nix
+++ b/pkgs/by-name/pn/pnpmBuildHook/package.nix
@@ -1,0 +1,10 @@
+{
+  makeSetupHook,
+}:
+makeSetupHook {
+  # Shouldn't need to propagate anything because for this to do anything useful,
+  # the config hook must also be used.
+  name = "pnpm-build-hook";
+
+  __structuredAttrs = true;
+} ./pnpm-build-hook.sh

--- a/pkgs/by-name/pn/pnpmBuildHook/pnpm-build-hook.sh
+++ b/pkgs/by-name/pn/pnpmBuildHook/pnpm-build-hook.sh
@@ -1,0 +1,52 @@
+# shellcheck shell=bash
+
+pnpmBuildHook() {
+    echo "Executing pnpmBuildHook"
+
+    if [[ $pnpmRoot ]]; then
+      pushd "$pnpmRoot"
+    fi
+
+    # Add workspace flags before the other flags
+    local -a pnpmWorkspacesArray
+    concatTo pnpmWorkspacesArray pnpmWorkspaces
+
+    local -a pnpmBuildFlagsArray
+    concatTo pnpmBuildFlagsArray pnpmFlags pnpmBuildFlags
+
+
+    echo
+    echo "Running"
+    echo "pnpm run ${pnpmWorkspacesArray[*]/#/--filter=} ${pnpmBuildScript:-build} ${pnpmBuildFlagsArray[*]}"
+    echo
+
+    if ! pnpm run "${pnpmWorkspacesArray[@]/#/--filter=}" "${pnpmBuildScript:-build}" "${pnpmBuildFlagsArray[@]}"; then
+        echo
+        echo "ERROR: 'pnpm run ${pnpmBuildScript:-build}' failed"
+        echo
+        echo "Here are a few things you can try, depending on the error:"
+        echo "1. Make sure your build script (${pnpmBuildScript:-build}) exists"
+        echo '   If there isnt one, set `dontPnpmBuild = true`.'
+        echo
+
+        exit 1
+    fi
+
+    if [[ $pnpmRoot ]]; then
+      popd
+    fi
+
+    echo "Finished pnpmBuildHook"
+}
+
+pnpmBuildPhase() {
+  runHook preBuild
+
+  pnpmBuildHook
+
+  runHook postBuild
+}
+
+if [ -z "${dontPnpmBuild-}" ] && [ -z "${buildPhase-}" ]; then
+    buildPhase=pnpmBuildPhase
+fi


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Partial backport of https://github.com/NixOS/nixpkgs/pull/487046 to unblock https://github.com/NixOS/nixpkgs/pull/532457. Tested that the `signal-desktop` builds on top of this.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
