### PR TITLE
doc/neovim: document WASM treesitter parsers

### DIFF
--- a/doc/languages-frameworks/neovim.section.md
+++ b/doc/languages-frameworks/neovim.section.md
@@ -248,6 +248,43 @@ You can install the standalone parsers and queries directly without installing `
 })
 ```
 
+### Treesitter setup using WASM parsers and queries {#neovim-plugin-treesitter-wasm}
+
+Neovim can load WASM parsers when it is built with Wasmtime support.
+In nixpkgs, WASM parser plugins are available from the `wasi32` cross package set:
+
+```nix
+(pkgs.wrapNeovim (pkgs.neovim-unwrapped.override { wasmSupport = true; }) {
+  configure = {
+    packages.myPlugins =
+      with pkgs.pkgsCross.wasi32.vimPlugins;
+      let
+        # Select the grammars you need
+        treesitter-grammars = with nvim-treesitter-parsers; [
+          nix
+          python
+        ];
+        # Queries are needed for treesitter based syntax highlighting and folds.
+        treesitter-queries = map (p: p.associatedQuery) treesitter-grammars;
+      in
+      {
+        start = [
+          # regular plugins
+        ]
+        ++ treesitter-grammars
+        ++ treesitter-queries;
+      };
+  };
+})
+```
+
+Do not install both native and WASM parsers for the same language.
+For example, installing both `pkgs.vimPlugins.nvim-treesitter-parsers.nix` and
+`pkgs.pkgsCross.wasi32.vimPlugins.nvim-treesitter-parsers.nix` is invalid because Neovim
+loads the first `parser/nix.*` found on `runtimepath`.
+
+Use `:checkhealth vim.treesitter` to verify Nix-managed WASM parsers.
+
 You can enable treesitter features for installed grammars in a `FileType` autocommand
 or in an `ftplugin/<language>.lua` script, e.g.
 

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -224,6 +224,9 @@
   "neovim-luarocks-based-plugins": [
     "index.html#neovim-luarocks-based-plugins"
   ],
+  "neovim-plugin-treesitter-wasm": [
+    "index.html#neovim-plugin-treesitter-wasm"
+  ],
   "nixpkgs-manual": [
     "index.html#nixpkgs-manual"
   ],


### PR DESCRIPTION
Show how to use the existing wasi32 cross parser set with wasm-enabled Neovim, and explain why native and WASM parsers should not be mixed for one language.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
