### PR TITLE
ha-linky, nixos/ha-linky: init at 1.8.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -730,6 +730,7 @@
   ./services/home-automation/esphome.nix
   ./services/home-automation/evcc.nix
   ./services/home-automation/govee2mqtt.nix
+  ./services/home-automation/ha-linky.nix
   ./services/home-automation/home-assistant-matter-hub.nix
   ./services/home-automation/home-assistant.nix
   ./services/home-automation/homebridge.nix

--- a/nixos/modules/services/home-automation/ha-linky.nix
+++ b/nixos/modules/services/home-automation/ha-linky.nix
@@ -1,0 +1,87 @@
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    types
+    ;
+
+  cfg = config.services.ha-linky;
+  format = pkgs.formats.json { };
+in
+
+{
+  options.services.ha-linky = {
+    enable = mkEnableOption "A Home Assistant app to sync Energy dashboards with your Linky smart meter";
+
+    package = mkPackageOption pkgs "ha-linky" { };
+
+    environmentFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/run/secrets/ha-linky-secrets";
+      description = ''
+        Environment file use to pass variables and secrets into the runtime.
+      '';
+    };
+
+    settings = mkOption {
+      type = format.type;
+      description = ''
+        ha-linky configuraiton as a nix attribute set. It supports substitution using `envsubst` from the `environmentFile`.
+
+        Check [ha-linky's README](https://github.com/bokub/ha-linky) for possible options.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.ha-linky =
+      let
+        configFile = format.generate "options.json" cfg.settings;
+        configPath = "/run/ha-linky/options.json";
+      in
+      {
+        wants = [ "network-online.target" ];
+        after = [ "network-online.target" ];
+        wantedBy = [ "multi-user.target" ];
+
+        environment = {
+          CONFIG_PATH = configPath;
+        };
+
+        serviceConfig = {
+          EnvironmentFile = lib.optionals (cfg.environmentFile != null) [ cfg.environmentFile ];
+          ExecStartPre = utils.escapeSystemdExecArgs [
+            (lib.getExe pkgs.envsubst)
+            "-i"
+            configFile
+            "-o"
+            configPath
+          ];
+          ExecStart = utils.escapeSystemdExecArgs [
+            (lib.getExe cfg.package)
+          ];
+          DynamicUser = true;
+          PrivateTmp = true;
+          PrivateUsers = true;
+          ProtectHome = true;
+          Restart = "on-failure";
+          RuntimeDirectory = "ha-linky";
+          StateDirectory = "ha-linky";
+          User = "evcc";
+        };
+      };
+  };
+
+  meta.maintainers = with lib.maintainers; [ ratcornu ];
+}

--- a/nixos/modules/services/home-automation/ha-linky.nix
+++ b/nixos/modules/services/home-automation/ha-linky.nix
@@ -1,0 +1,87 @@
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    types
+    ;
+
+  cfg = config.services.ha-linky;
+  format = pkgs.formats.json { };
+in
+
+{
+  options.services.ha-linky = {
+    enable = mkEnableOption "Linky, an Home Assistant app to sync Energy dashboards with your Linky smart meter";
+
+    package = mkPackageOption pkgs "ha-linky" { };
+
+    environmentFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/run/secrets/ha-linky-secrets";
+      description = ''
+        Environment file use to pass variables and secrets into the runtime.
+      '';
+    };
+
+    settings = mkOption {
+      type = format.type;
+      description = ''
+        ha-linky configuraiton as a nix attribute set. It supports substitution using `envsubst` from the `environmentFile`.
+
+        Check [ha-linky's README](https://github.com/bokub/ha-linky) for possible options.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.ha-linky =
+      let
+        configFile = format.generate "options.json" cfg.settings;
+        configPath = "/run/ha-linky/options.json";
+      in
+      {
+        wants = [ "network-online.target" ];
+        after = [ "network-online.target" ];
+        wantedBy = [ "multi-user.target" ];
+
+        environment = {
+          CONFIG_PATH = configPath;
+        };
+
+        serviceConfig = {
+          EnvironmentFile = lib.optionals (cfg.environmentFile != null) [ cfg.environmentFile ];
+          ExecStartPre = utils.escapeSystemdExecArgs [
+            (lib.getExe pkgs.envsubst)
+            "-i"
+            configFile
+            "-o"
+            configPath
+          ];
+          ExecStart = utils.escapeSystemdExecArgs [
+            (lib.getExe cfg.package)
+          ];
+          DynamicUser = true;
+          PrivateTmp = true;
+          PrivateUsers = true;
+          ProtectHome = true;
+          Restart = "on-failure";
+          RuntimeDirectory = "ha-linky";
+          StateDirectory = "ha-linky";
+          User = "evcc";
+        };
+      };
+  };
+
+  meta.maintainers = with lib.maintainers; [ ratcornu ];
+}

--- a/pkgs/by-name/ha/ha-linky/config-path.patch
+++ b/pkgs/by-name/ha/ha-linky/config-path.patch
@@ -1,0 +1,19 @@
+--- a/src/config.ts
++++ b/src/config.ts
+@@ -1,5 +1,7 @@
+ import { readFileSync } from 'node:fs';
+
++const CONFIG_PATH = process.env.CONFIG_PATH || '/data/options.json'
++
+ export type MeterConfig = {
+   prm: string;
+   token: string;
+@@ -25,7 +27,7 @@ export function getUserConfig(): UserConfig {
+   let parsed: { meters?: any[]; costs?: any } = {};
+
+   try {
+-    parsed = JSON.parse(readFileSync('/data/options.json', 'utf8'));
++    parsed = JSON.parse(readFileSync(CONFIG_PATH, 'utf8'));
+   } catch (e) {
+     throw new Error('Cannot read user configuration: ' + e.toString());
+   }

--- a/pkgs/by-name/ha/ha-linky/package.nix
+++ b/pkgs/by-name/ha/ha-linky/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nodejs,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "ha-linky";
+  version = "1.7.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "bokub";
+    repo = "ha-linky";
+    tag = finalAttrs.version;
+    hash = "sha256-x8W/kR/L3uJ317MAayv3mUlPW3yw+Tnj4iD2c6CEnOQ=";
+  };
+
+  npmDepsHash = "sha256-y/64htlLa5RGemCIqXp9nxDgAK8zyVOq8kdW4azhY64=";
+
+  patches = [
+    ./config-path.patch
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/node_modules/ha-linky
+    mkdir $out/bin
+    mv * $out/lib/node_modules/ha-linky/
+    makeWrapper ${lib.getExe nodejs} $out/bin/ha-linky \
+      --add-flags "$out/lib/node_modules/ha-linky/dist/index.js" \
+      --set "NODE_PATH" "$out/lib/node_modules/ha-linky/node_modules"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A Home Assistant app to sync Energy dashboards with your Linky smart meter";
+    homepage = "https://github.com/bokub/ha-linky";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ratcornu ];
+    mainProgram = "ha-linky";
+  };
+})

--- a/pkgs/by-name/ha/ha-linky/package.nix
+++ b/pkgs/by-name/ha/ha-linky/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nodejs,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "ha-linky";
+  version = "1.8.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "bokub";
+    repo = "ha-linky";
+    tag = finalAttrs.version;
+    hash = "sha256-4hQ5bQ2CxlSDLw4yxakOpnij2gJ0FSyH8OWjX4iCkOE=";
+  };
+
+  npmDepsHash = "sha256-j8q0ouD9BSnQ3Yb2tsn+tON+YXh30fynnlDtNbtiVyQ=";
+
+  patches = [
+    ./config-path.patch
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/node_modules/ha-linky
+    mkdir $out/bin
+    mv node_modules package-lock.json repository.yaml tsconfig.json src \
+      config.yaml dist icon.png logo.png package.json $out/lib/node_modules/ha-linky/
+    makeWrapper ${lib.getExe nodejs} $out/bin/ha-linky \
+      --add-flags "$out/lib/node_modules/ha-linky/dist/index.js" \
+      --set "NODE_PATH" "$out/lib/node_modules/ha-linky/node_modules"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Home Assistant app to sync Energy dashboards with your Linky smart meter";
+    homepage = "https://github.com/bokub/ha-linky";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ratcornu ];
+    mainProgram = "ha-linky";
+  };
+})


### PR DESCRIPTION
[Linky](https://fr.wikipedia.org/wiki/Linky) is the most used french electricity meter. This service is a bridge between the API of the french electricity provider ENEDIS and home-assistant.

This PR adds the package ha-linky and an associated service.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
