### PR TITLE
caesura: 0.27.2 -> 0.31.0

### DIFF
--- a/pkgs/by-name/ca/caesura/package.nix
+++ b/pkgs/by-name/ca/caesura/package.nix
@@ -1,7 +1,10 @@
 {
   lib,
   fetchFromGitHub,
+  fetchpatch2,
   rustPlatform,
+  cacert,
+  writableTmpDirAsHomeHook,
   flac,
   lame,
   makeBinaryWrapper,
@@ -16,24 +19,37 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "caesura";
-  version = "0.27.2";
+  version = "0.31.0";
 
   src = fetchFromGitHub {
     owner = "RogueOneEcho";
     repo = "caesura";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ifaZ+rmMmWhn8HM25sRPXJKuXvWE5VG+5hFMi9hqxA0=";
+    hash = "sha256-+REt+MKImO7fnYWJ32P6mKzulGJTnxc+9ednVF5aCJU=";
   };
 
-  cargoHash = "sha256-g8Duhl5nZ6umIrAafW7s4vtDS+f06CWnFLoLSw0wa4o=";
+  patches = [
+    (fetchpatch2 {
+      name = "normalize-sox-dependent-full-spectrogram-widths.patch";
+      url = "https://github.com/RogueOneEcho/caesura/commit/3af818ae35a3e18f444c889d9d3b88294f4f110f.patch?full_index=1";
+      hash = "sha256-znAbk6hFVj198BUUwwDo76SWei0cKINeXzlYEFvTwHA=";
+    })
+  ];
+
+  cargoHash = "sha256-0+vZma8AC44XqVHzmJT/roV7sy8w6DYhujRK9N91J5c=";
 
   nativeBuildInputs = [
     makeBinaryWrapper
   ];
-  nativeCheckInputs = runtimeDeps;
+  nativeCheckInputs = [
+    cacert
+    writableTmpDirAsHomeHook
+  ]
+  ++ runtimeDeps;
 
   env = {
     CAESURA_NIX = "1";
+    SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
   };
 
   postPatch = ''


### PR DESCRIPTION
Updates caesura from 0.27.2 to 0.31.0.

Changelog: https://github.com/RogueOneEcho/caesura/compare/v0.27.2...v0.31.0

Keeps the upstream spectrogram snapshot tests enabled by normalizing SoX-dependent image widths on non-deterministic platforms.

Closes #535337.

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
