### PR TITLE
nub: init at 0.2.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8467,6 +8467,12 @@
     github = "eum3l";
     name = "Emil";
   };
+  euphemism = {
+    email = "nixpkgs@sidwell.dev";
+    github = "euphemism";
+    githubId = 1179754;
+    name = "Nicholas Sidwell";
+  };
   eureka-cpu = {
     email = "github.eureka@gmail.com";
     github = "eureka-cpu";

--- a/pkgs/by-name/nu/nub/package.nix
+++ b/pkgs/by-name/nu/nub/package.nix
@@ -1,0 +1,147 @@
+{
+  autoPatchelfHook,
+  common-updater-scripts,
+  curl,
+  fetchurl,
+  installShellFiles,
+  jq,
+  lib,
+  makeWrapper,
+  stdenv,
+  stdenvNoCC,
+  writeShellScript,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "nub";
+
+  version = "0.2.3";
+
+  src =
+    finalAttrs.passthru.sources.${stdenvNoCC.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
+
+  sourceRoot = ".";
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+  ]
+  ++ lib.optionals stdenvNoCC.hostPlatform.isLinux [ autoPatchelfHook ];
+
+  # The prebuilt Linux binary and nub-native.node link glibc (libc, libm, libgcc_s)
+  # and hard-code a /lib64 interpreter — autoPatchelfHook rewrites both for the Nix store.
+  buildInputs = lib.optionals stdenvNoCC.hostPlatform.isLinux [
+    stdenv.cc.libc
+  ];
+
+  dontConfigure = true;
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out"
+    cp -r bin "$out/bin"
+    cp -r runtime "$out/runtime"
+    chmod +x "$out/bin/nub" "$out/bin/nubx"
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    sources = {
+      "x86_64-linux" = fetchurl {
+        url = "https://github.com/nubjs/nub/releases/download/v${finalAttrs.version}/nub-linux-x64.tar.gz";
+        hash = "sha256-QPUUjsQZiKI79tIu1mc6nAq2nAhOrtqiQaw2pZf4g9s=";
+      };
+      "aarch64-linux" = fetchurl {
+        url = "https://github.com/nubjs/nub/releases/download/v${finalAttrs.version}/nub-linux-arm64.tar.gz";
+        hash = "sha256-lEHMcwyw/fWswHYrKW+ZfyWQ4O0acco8qWqSo0p6hVI=";
+      };
+      "x86_64-darwin" = fetchurl {
+        url = "https://github.com/nubjs/nub/releases/download/v${finalAttrs.version}/nub-darwin-x64.tar.gz";
+        hash = "sha256-b4+lsazFqgR9FEfR6T0F1GrNQUbKMyokiSUttSk7MA0=";
+      };
+      "aarch64-darwin" = fetchurl {
+        url = "https://github.com/nubjs/nub/releases/download/v${finalAttrs.version}/nub-darwin-arm64.tar.gz";
+        hash = "sha256-tVDiXNEZ25XJ1W+xTOyXKVbh2DXOoVIoyGJc0TzXf5Q=";
+      };
+    };
+
+    tests = {
+      version = stdenvNoCC.mkDerivation {
+        name = "nub-version-test";
+
+        buildInputs = [ finalAttrs.finalPackage ];
+
+        dontBuild = true;
+
+        dontConfigure = true;
+
+        dontUnpack = true;
+
+        installPhase = ''
+          mkdir -p $out
+
+          if ! nub --version | grep -q v${finalAttrs.version}; then
+            echo "nub --version output incorrect"
+
+            exit 1
+          fi
+
+          if ! nubx --version | grep -q v${finalAttrs.version}; then
+            echo "nubx --version output incorrect"
+
+            exit 1
+          fi
+        '';
+      };
+    };
+
+    updateScript = writeShellScript "update-nub" ''
+      set -o errexit
+
+      export PATH="${
+        lib.makeBinPath [
+          common-updater-scripts
+          curl
+          jq
+        ]
+      }"
+
+      NEW_VERSION=$(
+        curl --silent https://api.github.com/repos/nubjs/nub/releases/latest \
+          | jq -r '.tag_name | ltrimstr("v")'
+      )
+
+      if [[ "${finalAttrs.version}" = "$NEW_VERSION" ]]; then
+        echo "The new version same as the old version."
+
+        exit 0
+      fi
+
+      for platform in ${lib.escapeShellArgs finalAttrs.meta.platforms}; do
+        update-source-version "nub" "$NEW_VERSION" \
+          --ignore-same-version \
+          --source-key="sources.$platform"
+      done
+    '';
+  };
+
+  meta = {
+    description = "Fast TypeScript-first runtime and pnpm-compatible package manager for Node";
+    homepage = "https://nubjs.com";
+    downloadPage = "https://github.com/nubjs/nub/releases";
+    license = lib.licenses.mit;
+    mainProgram = "nub";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = builtins.attrNames finalAttrs.passthru.sources;
+    maintainers = with lib.maintainers; [ euphemism ];
+  };
+})


### PR DESCRIPTION
https://nubjs.com/:
> ### The all-in-one JavaScript toolkit that augments Node.js instead of trying to replace it
> 
> A TypeScript-first toolchain for Node.js. Run TypeScript files, package.json scripts, and local CLIs on the node and package manager you already have. No new runtime, no lock-in.

- First time adding something to nixpkgs, probably going to need some hand-holding.
- Followed [the approach here](https://github.com/nubjs/nub/blob/98daa61a92d0e5144ee8bdaf24ddc9dab04d8094/flake.nix) of fetching CI-built binaries instead of building from source directly.
- Basic tests to invoke the two binaries and read the reported versions.
- Update script appears to work.



## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
