### PR TITLE
valkey-luajit: init at 1.0.0

### DIFF
--- a/pkgs/by-name/va/valkey-luajit/external-libs.patch
+++ b/pkgs/by-name/va/valkey-luajit/external-libs.patch
@@ -1,0 +1,46 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e56846e..c207b42 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -20,13 +20,13 @@ endif()
+ 
+ set(LUAJIT_SOURCE_DIR ${CMAKE_SOURCE_DIR}/deps/luajit)
+ set(LUAJIT_BUILD_DIR ${CMAKE_BINARY_DIR}/luajit-build)
+-set(LUAJIT_INCLUDE_DIR ${LUAJIT_SOURCE_DIR}/src)
++set(LUAJIT_INCLUDE_DIR @luajit_include@)
+ 
+ # Determine the static lib name
+ if(IS_MACOS)
+-    set(LUAJIT_STATIC_LIB ${LUAJIT_SOURCE_DIR}/src/libluajit.a)
++    set(LUAJIT_STATIC_LIB @luajit_lib@)
+ else()
+-    set(LUAJIT_STATIC_LIB ${LUAJIT_SOURCE_DIR}/src/libluajit.a)
++    set(LUAJIT_STATIC_LIB @luajit_lib@)
+ endif()
+ 
+ # Build LuaJIT using its Makefile
+@@ -80,14 +80,13 @@ add_custom_command(
+     VERBATIM
+ )
+ 
+-add_custom_target(luajit_build DEPENDS ${LUAJIT_STATIC_LIB})
+ 
+ # Create imported target for LuaJIT
+ add_library(luajit STATIC IMPORTED)
+ set_target_properties(luajit PROPERTIES
+     IMPORTED_LOCATION ${LUAJIT_STATIC_LIB}
+ )
+-add_dependencies(luajit luajit_build)
++add_dependencies(luajit)
+ 
+ # ---------------------------------------------------------------------------
+ # Embed FFI Lua files as C string literals
+@@ -151,7 +150,7 @@ target_include_directories(valkeyluajit PRIVATE
+ )
+ 
+ # Ensure embedded FFI header is generated before compiling
+-add_dependencies(valkeyluajit ffi_lua_embed luajit_build)
++add_dependencies(valkeyluajit ffi_lua_embed)
+ 
+ # Link LuaJIT static library
+ # Platform-specific linking to ensure luaopen_ffi and all FFI symbols are exported

--- a/pkgs/by-name/va/valkey-luajit/package.nix
+++ b/pkgs/by-name/va/valkey-luajit/package.nix
@@ -1,0 +1,43 @@
+{
+  cmake,
+  fetchFromGitHub,
+  lib,
+  luajit,
+  replaceVars,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "valkey-luajit";
+  version = "1.0.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "valkey-io";
+    repo = "valkey-luajit";
+    tag = finalAttrs.version;
+    hash = "sha256-8sI9hw3ALEtWNH2tBi1la+21MAv2opRsEcjNeZkTu1g=";
+  };
+
+  patches = [
+    (replaceVars ./external-libs.patch {
+      luajit_include = "${luajit}/include";
+      luajit_lib = "${luajit}/lib/libluajit-5.1.a";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ luajit ];
+
+  meta = {
+    changelog = "https://github.com/valkey-io/valkey-luajit/releases/tag/${finalAttrs.src.tag}";
+    description = "Module which replaces the built-in Lua with LuaJIT for Valkey";
+    homepage = "https://github.com/valkey-io/valkey-luajit";
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.all;
+    teams = [ lib.teams.redis ];
+  };
+})


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
