### PR TITLE
paper-mono: init at 0.300

### DIFF
--- a/pkgs/by-name/pa/paper-mono/package.nix
+++ b/pkgs/by-name/pa/paper-mono/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  installFonts,
+  nix-update-script,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "paper-mono";
+  version = "0.300";
+  __structuredAttrs = true;
+
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
+  src = fetchzip {
+    url = "https://github.com/paper-design/paper-mono/releases/download/v${finalAttrs.version}/paper-mono-v${finalAttrs.version}.zip";
+    hash = "sha256-coWJoVnVrzap8iG5UV84UVQOSDQzgF+a9G5/pn8nD6A=";
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [ installFonts ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Beautiful monospace font for design and code by Paper";
+    homepage = "https://github.com/paper-design/paper-mono";
+    changelog = "https://github.com/paper-design/paper-mono/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.ofl;
+    maintainers = with lib.maintainers; [ HeitorAugustoLN ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds [Paper Mono](https://github.com/paper-design/paper-mono) font, a beautiful monospace font for design and code by [Paper](https://paper.design/).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
