### PR TITLE
{,ungoogled-}chromium,chromedriver: 149.0.7827.196 -> 149.0.7827.200

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,10 +1,10 @@
 {
   "chromium": {
-    "version": "149.0.7827.196",
+    "version": "149.0.7827.200",
     "chromedriver": {
-      "version": "149.0.7827.197",
-      "hash_darwin": "sha256-tN7s6s/pbfAGRCMcoT3QWYHD8QRq2gcHfFSXoSG9V5Y=",
-      "hash_darwin_aarch64": "sha256-DZ8CZ4Obp67Zo2m4iyqUnShyhTK8+/75cJ/WmZZqQhE="
+      "version": "149.0.7827.201",
+      "hash_darwin": "sha256-MHCcid+7wdYm8uIdrUIlXrk8ADHNUUXzPyMPFGP98WY=",
+      "hash_darwin_aarch64": "sha256-Gwmdo9qNyV/BnCj18f0BFpNgDf28e8vjNF98e5/vVjQ="
     },
     "deps": {
       "depot_tools": {
@@ -21,8 +21,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "43eb30368c6ca3d14d540487954abb2780aeae3a",
-        "hash": "sha256-pwSfASgR4SiQTJBERhOVyR8mANYJk67f+u2pmCCW6ko=",
+        "rev": "c35c164b1b6d1adca9eddf914ed6d0d0743dba6a",
+        "hash": "sha256-b2gBRUzRjqVZEb/tWUL1JF6Afq5gHJ3aOM02My1FyYU=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {

--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -823,7 +823,7 @@
     }
   },
   "ungoogled-chromium": {
-    "version": "149.0.7827.196",
+    "version": "149.0.7827.200",
     "deps": {
       "depot_tools": {
         "rev": "45dedc4c3b87c982fd846b3dc599b233ed3aff90",
@@ -835,16 +835,16 @@
         "hash": "sha256-oFs7fZAZEs/gQ7X1A4uigo9+Y+iEN9sMMQYwAjEuD04="
       },
       "ungoogled-patches": {
-        "rev": "149.0.7827.196-1",
-        "hash": "sha256-nRcMTP+su+mFP/JkyLBIDrG+dKYhvPANFw0Y8qVWzrA="
+        "rev": "149.0.7827.200-1",
+        "hash": "sha256-D7c1ToAoUzAMpXoe60YPimRqe6/LRe0T95TduXUeTFo="
       },
       "npmHash": "sha256-pF0JtwFpPC4/fodbhSJnQKkczA9WlDg4VqEAy9aDVLg="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "43eb30368c6ca3d14d540487954abb2780aeae3a",
-        "hash": "sha256-pwSfASgR4SiQTJBERhOVyR8mANYJk67f+u2pmCCW6ko=",
+        "rev": "c35c164b1b6d1adca9eddf914ed6d0d0743dba6a",
+        "hash": "sha256-b2gBRUzRjqVZEb/tWUL1JF6Afq5gHJ3aOM02My1FyYU=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {


### PR DESCRIPTION
https://chromereleases.googleblog.com/2026/06/stable-channel-update-for-desktop_01245939337.html

This update includes 3 security fixes.

CVEs:
CVE-2026-13281 CVE-2026-13282 CVE-2026-13283

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
