### PR TITLE
pythonPackages.hypothesis: Fix CI=1 leaking into nix-shell invocations.

### DIFF
--- a/pkgs/development/python-modules/hypothesis/default.nix
+++ b/pkgs/development/python-modules/hypothesis/default.nix
@@ -58,28 +58,25 @@ buildPythonPackage rec {
   inherit doCheck;
 
   # tox.ini changes how pytest runs and breaks it.
-  # Activate the CI profile (similar to setupHook below)
-  # by setting HYPOTHESIS_PROFILE [1].
+  # Activate the CI profile by setting HYPOTHESIS_PROFILE=ci [1].
   #
-  # [1]: https://github.com/HypothesisWorks/hypothesis/blob/hypothesis-python-6.130.9/hypothesis-python/tests/common/setup.py#L78
-  preCheck = ''
-    rm tox.ini
-    export HYPOTHESIS_PROFILE=ci
-  '';
-
-  enabledTestPaths = [ "tests/cover" ];
-
-  # Hypothesis by default activates several "Health Checks", including one that fires if the builder is "too slow".
-  # This check is disabled [1] if Hypothesis detects a CI environment, i.e. either `CI` or `TF_BUILD` is defined [2].
-  # We set `CI=1` here using a setup hook to avoid spurious failures [3].
+  # We also set `CI=1` here to disable Hypothesis' "Health Checks", one of which fires if the builder is "too slow".
+  # That check is disabled [2] if Hypothesis detects a CI environment, i.e. either `CI` or `TF_BUILD` is defined [3].
   #
   # Example error message for reference:
   # hypothesis.errors.FailedHealthCheck: Data generation is extremely slow: Only produced 2 valid examples in 1.28 seconds (1 invalid ones and 0 exceeded maximum size). Try decreasing size of the data you're generating (with e.g. max_size or max_leaves parameters).
   #
-  # [1]: https://github.com/HypothesisWorks/hypothesis/blob/hypothesis-python-6.130.9/hypothesis-python/src/hypothesis/_settings.py#L816-L828
-  # [2]: https://github.com/HypothesisWorks/hypothesis/blob/hypothesis-python-6.130.9/hypothesis-python/src/hypothesis/_settings.py#L756
-  # [3]: https://github.com/NixOS/nixpkgs/issues/393637
-  setupHook = ./setup-hook.sh;
+  # [1]: https://github.com/HypothesisWorks/hypothesis/blob/hypothesis-python-6.130.9/hypothesis-python/tests/common/setup.py#L78
+  # [2]: https://github.com/HypothesisWorks/hypothesis/blob/hypothesis-python-6.130.9/hypothesis-python/src/hypothesis/_settings.py#L816-L828
+  # [3]: https://github.com/HypothesisWorks/hypothesis/blob/hypothesis-python-6.130.9/hypothesis-python/src/hypothesis/_settings.py#L756
+  # [4]: https://github.com/NixOS/nixpkgs/issues/393637
+  preCheck = ''
+    rm tox.ini
+    export HYPOTHESIS_PROFILE=ci
+    export CI=1
+  '';
+
+  enabledTestPaths = [ "tests/cover" ];
 
   disabledTests = [
     # racy, fails to find a file sometimes

--- a/pkgs/development/python-modules/hypothesis/setup-hook.sh
+++ b/pkgs/development/python-modules/hypothesis/setup-hook.sh
@@ -1,5 +1,0 @@
-hypothesisActivateProfileForCI() {
-    export CI=1
-}
-
-postHooks+=(hypothesisActivateProfileForCI)


### PR DESCRIPTION
Unitl now, when a nix-shell included `hyphothesis` `CI=1` was accidentally set, causing weird behaviour in other Python packages, such as in `tqdm_loggable`, which disables interactive progress bars in that case:

https://github.com/tradingstrategy-ai/tqdm-loggable/blob/5083a123a4df17b6cb3cf3a80c0206c39eb5ec0b/tqdm_loggable/utils.py#L93-L102

The `CI=1` seems to be relevant only for running tests, so remove the `setupHook` and move it to `preCheck`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

CC @fliegendewurst from:

* https://github.com/benaco/nixpkgs/commit/55cb5e1e0641a1d6e2e10e78eda83e7ed86e8f22#diff-2781425906b39d8a3a7fd94636e2d8953468e7c924579dbd3e702a2022216bebR2
* https://github.com/NixOS/nixpkgs/issues/393637