### PR TITLE
linux: fixes systemd-boot assertion issue introduced by #535309

### DIFF
--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -67,7 +67,7 @@ in
             kernel = super.kernel.override (originalArgs: {
               inherit randstructSeed;
               kernelPatches = (originalArgs.kernelPatches or [ ]) ++ kernelPatches;
-              features = lib.recursiveUpdate super.kernel.features features;
+              features = lib.recursiveUpdate (super.kernel.features or { }) features;
             });
           }
         );

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -531,7 +531,7 @@ in
         message = "The XBOOTLDR mount point '${toString cfg.xbootldrMountPoint}' cannot be the same as the ESP mount point '${toString efi.efiSysMountPoint}'";
       }
       {
-        assertion = (config.boot.kernelPackages.kernel.features or { efiBootStub = true; }) ? efiBootStub;
+        assertion = config.boot.kernelPackages.kernel.features.efiBootStub or true;
         message = "This kernel does not support the EFI boot stub";
       }
       {

--- a/pkgs/os-specific/linux/kernel/build.nix
+++ b/pkgs/os-specific/linux/kernel/build.nix
@@ -80,7 +80,7 @@ lib.makeOverridable (
 
     # Whether to utilize the controversial import-from-derivation feature to parse the config
     allowImportFromDerivation ? false,
-    features ? { },
+    features ? null,
     lib ? lib_,
     stdenv ? stdenv_,
   }:
@@ -529,13 +529,21 @@ lib.makeOverridable (
       inherit
         isZen
         withRust
-        # Forwarded into passthru so features survive kernel.override() call chains
-        # used by the NixOS module system (see boot.kernelPackages apply in kernel.nix).
-        features
         ;
       baseVersion = lib.head (lib.splitString "-rc" version);
       kernelOlder = lib.versionOlder baseVersion;
       kernelAtLeast = lib.versionAtLeast baseVersion;
+      # Only forward features into passthru when explicitly provided and non-empty.
+      # Using null as a sentinel for "not declared" preserves the pre-existing
+      # behaviour for linuxManualConfig kernels that don't declare features:
+      # kernel.features remains a missing attribute, so downstream `or` fallbacks
+      # (e.g. in systemd-boot.nix) continue to fire as before.
+      # An empty set is excluded for the same reason: the NixOS apply function in
+      # kernel.nix always passes at least `{}` via lib.recursiveUpdate, so without
+      # this guard features would leak into passthru on every override() call even
+      # for kernels that never declared any.
+    } // lib.optionalAttrs (features != null && features != { }) {
+      inherit features;
     };
 
     # Some image types need special install targets (e.g. uImage is installed with make uinstall on arm)


### PR DESCRIPTION
@K900 About https://github.com/NixOS/nixpkgs/pull/535309 , I didn't investigate further myself but I sent Claude Sonnet 4.6 (thinking effort: high) on it.

I didn't really read his analysis but I asked it to write as many tests as needed to validate that all corners cases are really fixed.

So NOT_FOR_MERGE, but only for information, here are its changes and description:

## Context

`linuxManualConfig` (`build.nix`) accepted `features` as a parameter but silently discarded it — the value was never forwarded into `passthru`. The NixOS `boot.kernelPackages` option's `apply` function **always** calls `kernel.override()` on whatever kernel is assigned, which re-runs `build.nix` from scratch. Because `features` was not in `passthru`, any features set on a `linuxManualConfig`-based kernel were lost on every `override()` call. This caused NixOS module assertions that check `kernel.features.*` (e.g. `hardware.graphics.enable32Bit → ia32Emulation`) to silently always fail for `linuxManualConfig` kernels.

## What was tried first (and why it was wrong)

The obvious fix — change `features ? null` to `features ? {}` and add `inherit features;` to `passthru` — introduced a regression reported by @<reporter>:

The NixOS `apply` function does:
```nix
features = lib.recursiveUpdate super.kernel.features features;
```
With `features ? {}` as the new default, every `linuxManualConfig` kernel (even those declaring no features) now had `features = {}` in `passthru`. This broke the `systemd-boot` assertion:
```nix
# before fix: (kernel.features or { efiBootStub = true; }) ? efiBootStub
```
Nix's `or` only fires on **missing** attribute errors. With `features = {}` now *present* (just empty), the `or` fallback never triggered, and `{} ? efiBootStub` evaluated to `false` → assertion failure for any `linuxManualConfig` user with systemd-boot.

## What this PR does

Three coordinated changes:

**`pkgs/os-specific/linux/kernel/build.nix`** — restore `features ? null` as the sentinel for "not declared", but now actually forward it into `passthru` when it is explicitly provided and non-empty:
```nix
} // lib.optionalAttrs (features != null && features != { }) {
  inherit features;
};
```
The `!= {}` guard is necessary because the `apply` function always produces at least `{}` from `lib.recursiveUpdate`; without it, `{}` would leak into `passthru` on every `override()` call for kernels that never declared any features, recreating the regression.

**`nixos/modules/system/boot/kernel.nix`** — make the `apply` function robust to a missing `super.kernel.features`:
```nix
features = lib.recursiveUpdate (super.kernel.features or { }) features;
```
Without this, forcing `features` in `passthru` (to decide whether to include it via `optionalAttrs`) would cause `super.kernel.features` to be evaluated and throw "attribute missing" for kernels with no declared features.

**`nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix`** — fix the efiBootStub assertion to handle all cases correctly:
```nix
# before
assertion = (config.boot.kernelPackages.kernel.features or { efiBootStub = true; }) ? efiBootStub;
# after
assertion = config.boot.kernelPackages.kernel.features.efiBootStub or true;
```
The old form used `?` (has-attribute check) on a set, which cannot distinguish "feature absent" from "feature explicitly false". The new form correctly returns `true` when `efiBootStub` is undeclared (missing `features`, empty `features`, or partial `features`), and `false` only when explicitly set to `false`. This also covers the case where a user passes partial features to `linuxManualConfig` (e.g. only `{ ia32Emulation = true; }`) without declaring `efiBootStub`.

## Net behaviour

| Scenario | `kernel ? features` | `kernel.features.efiBootStub or true` | `hardware.graphics.enable32Bit` assertion |
|---|---|---|---|
| `linuxManualConfig` no features (before) | `false` | `true` ✓ | always `false` ✗ |
| `linuxManualConfig` no features (after) | `false` | `true` ✓ | `false` (correct — not declared) |
| `linuxManualConfig` with `features = { ia32Emulation = true; }` (after) | `true` | `true` ✓ | `true` ✓ |
| `buildLinux` kernels | unchanged ✓ | unchanged ✓ | unchanged ✓ |

## Testing

26 automated `nix eval` tests, none requiring a build:

- **18 unit tests** (`test-kernel-features.nix`): passthru presence, stability through `override()`, idempotency of double-apply, systemd-boot `or true` pattern for all feature combinations, `buildLinux` kernels unaffected.
- **8 integration tests** (`test-kernel-features-nixos.nix`): evaluated through the real NixOS module system (real `boot.kernelPackages` apply function), covering systemd-boot and ia32Emulation assertions for no-features, explicit-features, and default `buildLinux` kernels.
`