### PR TITLE
goldilocks: init at 4.15.1

### DIFF
--- a/pkgs/by-name/go/goldilocks/package.nix
+++ b/pkgs/by-name/go/goldilocks/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "goldilocks";
+  version = "4.15.1";
+
+  src = fetchFromGitHub {
+    owner = "FairwindsOps";
+    repo = "goldilocks";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ubfhj9pYSFpfWkYO1LkA+sW8wwh/dDgQnH91GhKMwKA=";
+  };
+
+  vendorHash = "sha256-dtVNxumYkzWihfI42R7LuXLGtELg5EnxH9FUMCL4u/4=";
+
+  __structuredAttrs = true;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+
+  meta = {
+    description = "Get your resource requests \"Just Right\"";
+    longDescription = ''
+      Goldilocks is a utility that can help you identify a starting point for
+      resource requests and limits. By using the Kubernetes
+      VerticalPodAutoscaler in recommendation mode, it gives you a dashboard
+      with suggested resource requests and limits for each workload, so you can
+      set them "just right".
+    '';
+    homepage = "https://goldilocks.docs.fairwinds.com/";
+    changelog = "https://github.com/FairwindsOps/goldilocks/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ELHart05 ];
+    mainProgram = "goldilocks";
+  };
+})


### PR DESCRIPTION
Adds goldilocks, a tool from Fairwinds that helps you right-size Kubernetes
workloads (https://goldilocks.docs.fairwinds.com/). It runs the
VerticalPodAutoscaler in recommendation mode and shows a dashboard with
suggested CPU and memory requests and limits, so you have a real starting point
instead of guessing. It's a single Go binary, packaged with buildGoModule. I'm
adding myself as the maintainer.

Fairwinds' other tools are already here (kubernetes-polaris, pluto, nova), and
goldilocks was the one still missing, so I followed the same convention they
use.

The upstream test suite runs in the sandbox without needing a cluster, so I left
the checks enabled. versionCheckHook is pointed at the `version` subcommand,
since the root command doesn't take a `--version` flag.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests).
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`.
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage).
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.
- [x] Follows the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy).

Notes on the boxes: built locally on x86_64-linux and ran the binary
(`goldilocks version` prints `Version:4.15.1 Commit:n/a`, `goldilocks --help`
works); the full upstream test suite also runs during the build. The other
platforms are covered by CI rather than a local build. No NixOS module, so no
release-note entry.
