### PR TITLE
mailspring: fix indefinite build hang during electron packaging

### DIFF
--- a/pkgs/by-name/ma/mailspring/package.nix
+++ b/pkgs/by-name/ma/mailspring/package.nix
@@ -7,7 +7,6 @@
   makeBinaryWrapper,
   pkg-config,
   wrapGAppsHook3,
-  zip,
 
   electron_41,
   html-tidy,
@@ -67,7 +66,6 @@ buildNpmPackage (finalAttrs: {
     makeBinaryWrapper
     pkg-config
     wrapGAppsHook3
-    zip
   ];
 
   npmFlags = [ "--ignore-scripts" ];
@@ -97,20 +95,26 @@ buildNpmPackage (finalAttrs: {
     export npm_config_target="${electron.version}"
     export npm_config_nodedir="${electron.headers}"
 
-    # Create the electron archive to be used by electron-packager
+    # Provide a pre-extracted electron dist for @electron/packager.
     cp -r ${electron.dist} electron-dist
     chmod -R u+w electron-dist
 
-    pushd electron-dist
-    zip -0Xqr ../electron.zip .
-    popd
-
-    rm -r electron-dist
-
-    # force @electron/packager to use our electron instead of downloading it
+    # Force @electron/packager to use our electron instead of downloading it.
+    #
+    # @electron/packager normally unzips an electron release archive, but its
+    # extract-zip dependency intermittently deadlocks mid-extraction on newer
+    # node (a lost stream-completion event leaves the build hung forever, see
+    # https://github.com/NixOS/nixpkgs/issues/535781). Since we already have an
+    # unpacked dist, hand it to @electron/packager directly and turn its
+    # extract step into a plain recursive copy, avoiding extract-zip entirely.
     substituteInPlace \
       node_modules/@electron/packager/dist/packager.js \
-      --replace-fail "await this.getElectronZipPath(downloadOpts)" "'$(pwd)/electron.zip'"
+      --replace-fail "await this.getElectronZipPath(downloadOpts)" "'$(pwd)/electron-dist'"
+
+    substituteInPlace \
+      node_modules/@electron/packager/dist/unzip.js \
+      --replace-fail "await (0, extract_zip_1.default)(zipPath, { dir: targetDir });" \
+      "require('fs').cpSync(zipPath, targetDir, { recursive: true, dereference: true });"
 
     pushd app
     npm rebuild


### PR DESCRIPTION
## Description

`mailspring` hangs forever during its build (the Electron packaging step), both on Hydra and reproducibly locally. See #535781 and the [Hydra log](https://hydra.nixos.org/build/332813026/nixlog/8).

### Root cause

The build zips the already-unpacked `${electron.dist}` into `electron.zip` only so that `@electron/packager` (18.3.6) can unzip it again. Its `extract-zip` (2.0.1) dependency intermittently **deadlocks mid-extraction** on newer Node: the write stream for an entry never fires its completion event, so extraction `await`s a promise that never resolves. The process goes completely idle (all libuv workers parked in `futex_do_wait`, main thread in `epoll_wait`, ~0 syscalls) while the `---> Packaging for Ns` timer ticks on forever.

I confirmed this by reproducing the exact Hydra derivation locally and stracing the hung `node app/build/build.js`: it had FDs open on `electron.zip` (read) and a half-written `libvk_swiftshader.so` (write), with no pending I/O. Because the failure depends on stream timing, it passed `nixpkgs-review` but hangs on Hydra.

### Fix

Skip the zip round-trip entirely: hand `@electron/packager` the unpacked Electron dist and replace its extract step with a recursive copy (`fs.cpSync`), avoiding `extract-zip`. Also drops the now-unused `zip` `nativeBuildInput`.

Verified with a local `nix build .#mailspring`: the build now completes instead of hanging, producing a working `bin/mailspring` that wraps `electron-41.7.2` with the assembled `app.asar`.

Fixes #535781

cc @wrench-exile-legacy

## Things done

- Built on platform(s):
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality: built and confirmed the indefinite hang is resolved; `result/bin/mailspring` is produced and references electron + the `app.asar`.
- [x] Ran `nixpkgs-review`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md) and other READMEs
