### PR TITLE
canboat: init at 6.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6171,6 +6171,12 @@
     githubId = 39523942;
     name = "Alex Clarke";
   };
+  darkone = {
+    email = "darkone@darkone.yt";
+    github = "darkone-linux";
+    githubId = 162493435;
+    name = "Guillaume Ponçon";
+  };
   darkonion0 = {
     name = "Alexandre Peruggia";
     email = "darkgenius1@protonmail.com";

--- a/pkgs/by-name/ca/canboat/package.nix
+++ b/pkgs/by-name/ca/canboat/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  installShellFiles,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "canboat";
+  version = "6.2.2";
+
+  src = fetchFromGitHub {
+    owner = "canboat";
+    repo = "canboat";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ptuhp5cvMbfc2+RmdygzsegGwWgIgkgAk3NQ76j1pMw=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  enableParallelBuilding = true;
+
+  # Upstream ships no usable install rule; binaries land in rel/<uname>-<arch>/.
+  installPhase = ''
+    runHook preInstall
+    installBin rel/*/*
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "NMEA 2000/CAN analysis and conversion toolkit";
+    homepage = "https://github.com/canboat/canboat";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.darkone ];
+    mainProgram = "analyzer";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Adds `canboat`, a new package: an NMEA 2000 / CAN analysis and conversion
toolkit (`analyzer`, `n2kd`, `replay`, `actisense-serial`, `ikonvert-serial`,
`socketcan-writer`, …). It decodes an NMEA 2000 bus into human-readable text or
JSON and bridges SocketCAN / Actisense / iKonvert gateways — the CLI companion
to `can-utils` for marine NMEA 2000 networks.

Homepage: https://github.com/canboat/canboat
License: Apache-2.0

Built on `x86_64-linux` (native) and `aarch64-linux` (the intended Raspberry Pi
target, built via QEMU user-mode emulation); both produce the expected aarch64
ELF binaries. Binaries smoke-tested on `x86_64-linux`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux (via QEMU emulation)
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Disclosure: the packaging was drafted with AI assistance and reviewed,
built and tested by the maintainer, who takes responsibility for the change.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
