### PR TITLE
ais-catcher: init at 0.70

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6171,6 +6171,12 @@
     githubId = 39523942;
     name = "Alex Clarke";
   };
+  darkone = {
+    email = "darkone@darkone.yt";
+    github = "darkone-linux";
+    githubId = 162493435;
+    name = "Guillaume Ponçon";
+  };
   darkonion0 = {
     name = "Alexandre Peruggia";
     email = "darkgenius1@protonmail.com";

--- a/pkgs/by-name/ai/ais-catcher/package.nix
+++ b/pkgs/by-name/ai/ais-catcher/package.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  installShellFiles,
+  rtl-sdr,
+  libusb1,
+  zlib,
+  openssl,
+  soxr,
+  libsamplerate,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ais-catcher";
+  version = "0.70";
+
+  src = fetchFromGitHub {
+    owner = "jvde-github";
+    repo = "AIS-catcher";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-YDkqIoW3DDwUfAJftvfnmsIQYCq9ujYrB8RvZRiIexg=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    installShellFiles
+  ];
+
+  buildInputs = [
+    rtl-sdr
+    libusb1
+    zlib
+    openssl
+    soxr
+    libsamplerate
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "RTLSDR" true)
+    (lib.cmakeBool "ZLIB" true)
+    (lib.cmakeBool "OPENSSL" true)
+    (lib.cmakeBool "SOXR" true)
+    (lib.cmakeBool "SAMPLERATE" true)
+
+    # Proprietary or otherwise unused SDR backends and features.
+    (lib.cmakeBool "SOAPYSDR" false)
+    (lib.cmakeBool "AIRSPY" false)
+    (lib.cmakeBool "AIRSPYHF" false)
+    (lib.cmakeBool "SDRPLAY" false)
+    (lib.cmakeBool "HACKRF" false)
+    (lib.cmakeBool "HYDRASDR" false)
+    (lib.cmakeBool "ZMQ" false)
+    (lib.cmakeBool "PSQL" false)
+    (lib.cmakeBool "SQLITE" false)
+    (lib.cmakeBool "NMEA2000" false)
+    (lib.cmakeBool "WEBVIEWER" false)
+  ];
+
+  # Upstream ships no install rule; install the single binary directly.
+  installPhase = ''
+    runHook preInstall
+    installBin AIS-catcher
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "AIS receiver and decoder for RTL-SDR and other SDR hardware";
+    homepage = "https://github.com/jvde-github/AIS-catcher";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.darkone ];
+    mainProgram = "AIS-catcher";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Adds `ais-catcher`, a new package: an AIS receiver and decoder for RTL-SDR (and
other SDR) hardware. It decodes AIS from an SDR dongle and can forward NMEA 0183
over UDP (e.g. to Signal K). Here it is built with the RTL-SDR backend, zlib,
OpenSSL, soxr and libsamplerate enabled; proprietary/unneeded SDR backends
(SoapySDR, Airspy, SDRplay, HackRF, …) and the embedded web viewer are disabled.

Homepage: https://github.com/jvde-github/AIS-catcher
License: GPL-3.0-or-later

Built on `x86_64-linux` (native) and `aarch64-linux` (the intended Raspberry Pi
target, built via QEMU user-mode emulation); both produce the expected aarch64
ELF binary. Binaries smoke-tested on `x86_64-linux`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux (via QEMU emulation)
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Disclosure: the packaging was drafted with AI assistance and reviewed,
built and tested by the maintainer, who takes responsibility for the change.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
