### PR TITLE
adslib: 0-unstable-2026-04-27 -> 113.0.34-1

### DIFF
--- a/pkgs/by-name/ad/adslib/package.nix
+++ b/pkgs/by-name/ad/adslib/package.nix
@@ -5,18 +5,17 @@
   meson,
   ninja,
   pkg-config,
-  unstableGitUpdater,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "adslib";
-  version = "0-unstable-2026-04-27";
+  version = "113.0.34-1";
 
   src = fetchFromGitHub {
     owner = "stlehmann";
     repo = "ADS";
-    rev = "77953d58f2690436e82db9954e2e55878c5edaa4";
-    hash = "sha256-UDPuzqD1krEZa7436k1NvE0lJUmNYG4kiP5fstoRDMc=";
+    tag = finalAttrs.version;
+    hash = "sha256-Kh8BDioZdwSdATHPgZ7Ar3/E0y3eRRpG/38/2uHZEEQ=";
   };
 
   nativeBuildInputs = [
@@ -27,11 +26,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   postInstall = ''
     # Downstream consumers (e.g. pyads) load the shared library as
-    # `adslib.so` rather than the meson default `libadslib.so`.
-    ln -s libadslib.so $out/lib/adslib.so
+    # `adslib.so` rather than the meson default `libAdsLib.so`.
+    ln -s libAdsLib.so $out/lib/adslib.so
   '';
-
-  passthru.updateScript = unstableGitUpdater { };
 
   meta = {
     description = "Beckhoff protocol to communicate with TwinCAT devices";


### PR DESCRIPTION
adslib's first tagged release. Upstream renamed the shared library to `libAdsLib.so`, so the `adslib.so` symlink (loaded by pyads) now points there. The updater also moves to `gitUpdater` since upstream tags releases now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
