### PR TITLE
[Backport release-25.11] Allow meta.problems while preventing internal use of certain kinds

### DIFF
--- a/ci/eval/chunk.nix
+++ b/ci/eval/chunk.nix
@@ -18,6 +18,7 @@ let
   unfiltered = import ./outpaths.nix {
     inherit path;
     inherit includeBroken systems;
+    inherit (preEvalResult) attrPathsDisallowedForInternalUse;
     extraNixpkgsConfig = builtins.fromJSON extraNixpkgsConfigJson;
   };
 

--- a/ci/eval/chunk.nix
+++ b/ci/eval/chunk.nix
@@ -2,8 +2,8 @@
 {
   lib ? import ../../lib,
   path ? ../..,
-  # The file containing all available attribute paths, which are split into chunks here
-  attrpathFile,
+  # The file containing the preEval result
+  preEvalFile,
   chunkSize,
   myChunk,
   includeBroken,
@@ -12,8 +12,8 @@
 }:
 
 let
-  attrpaths = lib.importJSON attrpathFile;
-  myAttrpaths = lib.sublist (chunkSize * myChunk) chunkSize attrpaths;
+  preEvalResult = lib.importJSON preEvalFile;
+  myAttrpaths = lib.sublist (chunkSize * myChunk) chunkSize preEvalResult.paths;
 
   unfiltered = import ./outpaths.nix {
     inherit path;

--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -38,7 +38,7 @@ let
       fileset = unions (
         map (lib.path.append ../..) [
           ".version"
-          "ci/eval/attrpaths.nix"
+          "ci/eval/pre-eval.nix"
           "ci/eval/chunk.nix"
           "ci/eval/outpaths.nix"
           "default.nix"
@@ -56,11 +56,11 @@ let
     builtins.readFile ../../pkgs/top-level/release-supported-systems.json
   );
 
-  attrpathsSuperset =
+  preEval =
     {
       evalSystem,
     }:
-    runCommand "attrpaths-superset.json"
+    runCommand "pre-eval"
       {
         src = nixpkgs;
         # Don't depend on -dev outputs to reduce closure size for CI.
@@ -73,15 +73,15 @@ let
         export NIX_STATE_DIR=$(mktemp -d)
         mkdir $out
         export GC_INITIAL_HEAP_SIZE=4g
-        command time -f "Attribute eval done [%MKB max resident, %Es elapsed] %C" \
+        command time -f "Pre-eval done [%MKB max resident, %Es elapsed] %C" \
           nix-instantiate --eval --strict --json --show-trace \
-            "$src/ci/eval/attrpaths.nix" \
-            -A paths \
+            "$src/ci/eval/pre-eval.nix" \
+            -A result \
             -I "$src" \
             --argstr extraNixpkgsConfigJson ${lib.escapeShellArg (builtins.toJSON extraNixpkgsConfig)} \
             --option restrict-eval true \
             --option allow-import-from-derivation false \
-            --option eval-system "${evalSystem}" > $out/paths.json
+            --option eval-system "${evalSystem}" > $out/result.json
       '';
 
   singleSystem =
@@ -90,8 +90,8 @@ let
       # Note that this is intentionally not called `system`,
       # because `--argstr system` would only be passed to the ci/default.nix file!
       evalSystem ? builtins.currentSystem,
-      # The path to the `paths.json` file from `attrpathsSuperset`
-      attrpathFile ? "${attrpathsSuperset { inherit evalSystem; }}/paths.json",
+      # The path to the `result.json` file from `preEval`
+      preEvalFile ? "${preEval { inherit evalSystem; }}/result.json",
     }:
     let
       singleChunk = writeShellScript "single-chunk" ''
@@ -121,12 +121,12 @@ let
           --show-trace \
           --arg chunkSize "$chunkSize" \
           --arg myChunk "$myChunk" \
-          --arg attrpathFile "${attrpathFile}" \
+          --arg preEvalFile "${preEvalFile}" \
           --arg systems "[ \"$system\" ]" \
           --arg includeBroken ${lib.boolToString includeBroken} \
           --argstr extraNixpkgsConfigJson ${lib.escapeShellArg (builtins.toJSON extraNixpkgsConfig)} \
           -I ${nixpkgs} \
-          -I ${attrpathFile} \
+          -I ${preEvalFile} \
           > "$outputDir/result/$myChunk" \
           2> "$outputDir/stderr/$myChunk"
         exitCode=$?
@@ -164,7 +164,7 @@ let
         echo "System: $evalSystem"
         cores=$NIX_BUILD_CORES
         echo "Cores: $cores"
-        attrCount=$(jq length "${attrpathFile}")
+        attrCount=$(jq '.paths | length' "${preEvalFile}")
         echo "Attribute count: $attrCount"
         echo "Chunk size: $chunkSize"
         # Same as `attrCount / chunkSize` but rounded up
@@ -316,7 +316,7 @@ let
 in
 {
   inherit
-    attrpathsSuperset
+    preEval
     singleSystem
     diff
     combine

--- a/ci/eval/outpaths.nix
+++ b/ci/eval/outpaths.nix
@@ -6,7 +6,7 @@
   includeBroken ? true, # set this to false to exclude meta.broken packages from the output
   path ? ./../..,
 
-  # used by ./attrpaths.nix
+  # used by ./pre-eval.nix
   attrNamesOnly ? false,
 
   # Set this to `null` to build for builtins.currentSystem only

--- a/ci/eval/outpaths.nix
+++ b/ci/eval/outpaths.nix
@@ -14,6 +14,8 @@
     builtins.readFile (path + "/pkgs/top-level/release-supported-systems.json")
   ),
 
+  attrPathsDisallowedForInternalUse ? [ ],
+
   # Customize the config used to evaluate nixpkgs
   extraNixpkgsConfig ? { },
 }:
@@ -34,6 +36,22 @@ let
             allowInsecurePredicate = x: true;
             allowVariants = !attrNamesOnly;
             checkMeta = true;
+
+            # We don't need to care about problems being caught using the
+            # standard mechanism, because any problems whose kind is not
+            # nixpkgsInternalUseAllowed cause the corresponding attributes to
+            # be disallowed entirely for internal use with
+            # attrPathsDisallowedForInternalUse, see also ./pre-eval.nix
+            problems.matchers = lib.mkForce [
+              # We only need to set the broken handler to error, so that CI
+              # doesn't evaluate those. No reason it couldn't evaluate them
+              # afaik, but this is how it's been before.
+              {
+                kind = "broken";
+                handler = "error";
+              }
+            ];
+            inherit attrPathsDisallowedForInternalUse;
 
             # Silence the `x86_64-darwin` deprecation warning.
             allowDeprecatedx86_64Darwin = true;

--- a/ci/eval/pre-eval.nix
+++ b/ci/eval/pre-eval.nix
@@ -1,5 +1,6 @@
 # This file does a fast pre-evaluation of Nixpkgs to determine:
 # - paths: A *superset* of all attrpaths of derivations which might be part of a release on *any* platform.
+# - attrPathsDisallowedForInternalUse: Attribute paths whose meta.problems has problems whose kinds should not be used internally in Nixpkgs
 #
 # This expression runs single-threaded under all current Nix
 # implementations, but much faster and with much less memory
@@ -23,21 +24,25 @@ let
 
   # TODO: Use mapAttrsToListRecursiveCond when this PR lands:
   # https://github.com/NixOS/nixpkgs/pull/395160
-  justAttrNames =
+  listAttrs =
     path: value:
     let
       result =
         if path == [ "AAAAAASomeThingsFailToEvaluate" ] || !(lib.isAttrs value) then
           [ ]
         else if lib.isDerivation value then
-          [ path ]
+          [
+            {
+              inherit path value;
+            }
+          ]
         else
           lib.pipe value [
             (lib.mapAttrsToList (
               name: value:
               lib.addErrorContext "while evaluating package set attribute path '${
                 lib.showAttrPath (path ++ [ name ])
-              }'" (justAttrNames (path ++ [ name ]) value)
+              }'" (listAttrs (path ++ [ name ]) value)
             ))
             lib.concatLists
           ];
@@ -50,39 +55,74 @@ let
     attrNamesOnly = true;
   };
 
-  paths = [
-    # Some of the following are based on variants, which are disabled with `attrNamesOnly = true`.
-    # Until these have been removed from release.nix / hydra, we manually add them to the list.
-    [
-      "pkgsLLVM"
-      "stdenv"
-    ]
-    [
-      "pkgsArocc"
-      "stdenv"
-    ]
-    [
-      "pkgsZig"
-      "stdenv"
-    ]
-    [
-      "pkgsStatic"
-      "stdenv"
-    ]
-    [
-      "pkgsMusl"
-      "stdenv"
-    ]
-  ]
-  ++ justAttrNames [ ] outpaths;
-
+  list =
+    map
+      (path: {
+        inherit path;
+        # This looks a bit weird, but the only reason we care about this value
+        # is for the meta.problems check below, and stdenv's certainly don't
+        # have any problems, so this is fine :)
+        value = { };
+      })
+      [
+        # Some of the following are based on variants, which are disabled with `attrNamesOnly = true`.
+        # Until these have been removed from release.nix / hydra, we manually add them to the list.
+        [
+          "pkgsLLVM"
+          "stdenv"
+        ]
+        [
+          "pkgsArocc"
+          "stdenv"
+        ]
+        [
+          "pkgsZig"
+          "stdenv"
+        ]
+        [
+          "pkgsStatic"
+          "stdenv"
+        ]
+        [
+          "pkgsMusl"
+          "stdenv"
+        ]
+      ]
+    ++ listAttrs [ ] outpaths;
+  paths = map (attrs: attrs.path) list;
   names = map lib.showAttrPath paths;
 
+  inherit (import ../../pkgs/stdenv/generic/problems.nix { inherit lib; })
+    disallowNixpkgsInternalUseKinds
+    ;
+
+  # Determine the list of attributes whose packages have any meta.problems
+  # with a kind that's disallowed from internal Nixpkgs use
+  attrPathsDisallowedForInternalUse = lib.pipe list [
+    (lib.map (
+      attrs:
+      attrs
+      // {
+        problematicProblems = builtins.tryEval (
+          lib.filterAttrs (name: problem: disallowNixpkgsInternalUseKinds ? ${problem.kind}) (
+            attrs.value.meta.problems or { }
+          )
+        );
+      }
+    ))
+    (lib.filter (attrs: attrs.problematicProblems.success && attrs.problematicProblems.value != { }))
+    (lib.map (attrs: {
+      attrPath = attrs.path;
+      reason = "it has certain meta.problems whose kinds are disallowed: ${
+        lib.generators.toPretty { } attrs.problematicProblems.value
+      }";
+    }))
+  ];
 in
 {
   # TODO: Do we still need these? Probably not
   inherit paths names;
   result = {
-    inherit paths;
+    inherit paths attrPathsDisallowedForInternalUse;
   };
 }

--- a/ci/eval/pre-eval.nix
+++ b/ci/eval/pre-eval.nix
@@ -1,0 +1,88 @@
+# This file does a fast pre-evaluation of Nixpkgs to determine:
+# - paths: A *superset* of all attrpaths of derivations which might be part of a release on *any* platform.
+#
+# This expression runs single-threaded under all current Nix
+# implementations, but much faster and with much less memory
+# used than ./outpaths.nix itself.
+#
+# Once you have the list of attrnames you can split it up into
+# $NUM_CORES batches and evaluate the outpaths separately for each
+# batch, in parallel.
+#
+# To dump the result:
+#
+#   nix-instantiate --eval --strict --json ci/eval/pre-eval.nix -A result
+#
+{
+  lib ? import (path + "/lib"),
+  trace ? false,
+  path ? ./../..,
+  extraNixpkgsConfigJson ? "{}",
+}:
+let
+
+  # TODO: Use mapAttrsToListRecursiveCond when this PR lands:
+  # https://github.com/NixOS/nixpkgs/pull/395160
+  justAttrNames =
+    path: value:
+    let
+      result =
+        if path == [ "AAAAAASomeThingsFailToEvaluate" ] || !(lib.isAttrs value) then
+          [ ]
+        else if lib.isDerivation value then
+          [ path ]
+        else
+          lib.pipe value [
+            (lib.mapAttrsToList (
+              name: value:
+              lib.addErrorContext "while evaluating package set attribute path '${
+                lib.showAttrPath (path ++ [ name ])
+              }'" (justAttrNames (path ++ [ name ]) value)
+            ))
+            lib.concatLists
+          ];
+    in
+    lib.traceIf trace "** ${lib.showAttrPath path}" result;
+
+  outpaths = import ./outpaths.nix {
+    inherit path;
+    extraNixpkgsConfig = builtins.fromJSON extraNixpkgsConfigJson;
+    attrNamesOnly = true;
+  };
+
+  paths = [
+    # Some of the following are based on variants, which are disabled with `attrNamesOnly = true`.
+    # Until these have been removed from release.nix / hydra, we manually add them to the list.
+    [
+      "pkgsLLVM"
+      "stdenv"
+    ]
+    [
+      "pkgsArocc"
+      "stdenv"
+    ]
+    [
+      "pkgsZig"
+      "stdenv"
+    ]
+    [
+      "pkgsStatic"
+      "stdenv"
+    ]
+    [
+      "pkgsMusl"
+      "stdenv"
+    ]
+  ]
+  ++ justAttrNames [ ] outpaths;
+
+  names = map lib.showAttrPath paths;
+
+in
+{
+  # TODO: Do we still need these? Probably not
+  inherit paths names;
+  result = {
+    inherit paths;
+  };
+}

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -51,6 +51,38 @@ let
       internal = true;
     };
 
+    attrPathsDisallowedForInternalUse = mkOption {
+      type = types.listOf (
+        types.submodule {
+          options.attrPath = lib.mkOption {
+            type = types.listOf types.str;
+            description = ''
+              Attribute path to disallow.
+              This option has no effect on 25.11.
+            '';
+          };
+          options.reason = lib.mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            example = /* because */ "it's dangerous.";
+            description = ''
+              Reason for it being disallowed.
+              This option has no effect on 25.11.
+            '';
+          };
+        }
+      );
+      internal = true;
+      default = [ ];
+      description = ''
+        List of attribute paths that may not be used by other packages in Nixpkgs.
+
+        Should usually only be defined by Nixpkgs CI.
+
+        This option has no effect on 25.11.
+      '';
+    };
+
     # Config options
 
     warnUndeclaredOptions = mkOption {


### PR DESCRIPTION
Backported only the CI-touching aspects of #533376, as `meta.problems` itself does not exist on 25.11.

Very much untested and in need of review, but it's late here and I'm heading for bed.
Can be merged, but only if you're confident and/or available to revert.
