### PR TITLE
astal.source: 0-unstable-2025-11-26 -> 0-unstable-2026-5-16

### DIFF
--- a/pkgs/by-name/li/libcava/package.nix
+++ b/pkgs/by-name/li/libcava/package.nix
@@ -8,13 +8,13 @@
 cava.overrideAttrs (old: rec {
   pname = "libcava";
   # fork may not be updated when we update upstream
-  version = "0.10.6";
+  version = "0.10.7";
 
   src = fetchFromGitHub {
     owner = "LukashonakV";
     repo = "cava";
     tag = version;
-    hash = "sha256-63be1wypMiqhPA6sjMebmFE6yKpTj/bUE53sMWun554=";
+    hash = "sha256-zkyj1vBzHtoypX4Bxdh1Vmwh967DKKxN751v79hzmgQ=";
   };
 
   nativeBuildInputs = old.nativeBuildInputs ++ [

--- a/pkgs/by-name/wl/wl-vapi-gen/package.nix
+++ b/pkgs/by-name/wl/wl-vapi-gen/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  python3,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "wl-vapi-gen";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "kotontrion";
+    repo = "wl-vapi-gen";
+    tag = finalAttrs.version;
+    hash = "sha256-XdgYmxW0ndH6szq7VJ+XQEnWKHCyaWoBwEQREZnTm98=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    python3
+  ];
+
+  patchPhase = ''
+    patchShebangs wl-vapi-gen.py
+  '';
+
+  meta = {
+    description = "Generate vala bindings for wayland protocols";
+    homepage = "https://github.com/kotontrion/wl-vapi-gen";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ passivelemon ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/development/libraries/astal/buildAstalModule.nix
+++ b/pkgs/development/libraries/astal/buildAstalModule.nix
@@ -12,6 +12,7 @@
   vala,
   wayland,
   wayland-scanner,
+  wl-vapi-gen,
   python3,
 }:
 let
@@ -57,6 +58,7 @@ let
           vala
           wayland
           wayland-scanner
+          wl-vapi-gen
           python3
         ];
 

--- a/pkgs/development/libraries/astal/default.nix
+++ b/pkgs/development/libraries/astal/default.nix
@@ -22,4 +22,5 @@ self: {
   river = self.callPackage ./modules/river.nix { };
   tray = self.callPackage ./modules/tray.nix { };
   wireplumber = self.callPackage ./modules/wireplumber.nix { inherit wireplumber; };
+  wl = self.callPackage ./modules/wl.nix { };
 }

--- a/pkgs/development/libraries/astal/default.nix
+++ b/pkgs/development/libraries/astal/default.nix
@@ -9,6 +9,7 @@ self: {
   auth = self.callPackage ./modules/auth.nix { };
   battery = self.callPackage ./modules/battery.nix { };
   bluetooth = self.callPackage ./modules/bluetooth.nix { };
+  brightness = self.callPackage ./modules/brightness.nix { };
   cava = self.callPackage ./modules/cava.nix { };
   gjs = self.callPackage ./modules/gjs.nix { };
   greet = self.callPackage ./modules/greet.nix { };

--- a/pkgs/development/libraries/astal/default.nix
+++ b/pkgs/development/libraries/astal/default.nix
@@ -18,6 +18,7 @@ self: {
   network = self.callPackage ./modules/network.nix { };
   notifd = self.callPackage ./modules/notifd.nix { };
   powerprofiles = self.callPackage ./modules/powerprofiles.nix { };
+  quarrel = self.callPackage ./modules/quarrel.nix { };
   river = self.callPackage ./modules/river.nix { };
   tray = self.callPackage ./modules/tray.nix { };
   wireplumber = self.callPackage ./modules/wireplumber.nix { inherit wireplumber; };

--- a/pkgs/development/libraries/astal/modules/brightness.nix
+++ b/pkgs/development/libraries/astal/modules/brightness.nix
@@ -1,0 +1,13 @@
+{
+  buildAstalModule,
+  json-glib,
+  quarrel,
+}:
+buildAstalModule {
+  name = "brightness";
+  buildInputs = [
+    json-glib
+    quarrel
+  ];
+  meta.description = "Astal module for reading and controlling device brightness";
+}

--- a/pkgs/development/libraries/astal/modules/notifd.nix
+++ b/pkgs/development/libraries/astal/modules/notifd.nix
@@ -2,12 +2,14 @@
   buildAstalModule,
   json-glib,
   gdk-pixbuf,
+  quarrel,
 }:
 buildAstalModule {
   name = "notifd";
   buildInputs = [
     json-glib
     gdk-pixbuf
+    quarrel
   ];
   meta.description = "Astal module for notification daemon";
 }

--- a/pkgs/development/libraries/astal/modules/quarrel.nix
+++ b/pkgs/development/libraries/astal/modules/quarrel.nix
@@ -1,0 +1,5 @@
+{ buildAstalModule }:
+buildAstalModule {
+  name = "quarrel";
+  meta.description = "Astal module for command line argument parsing";
+}

--- a/pkgs/development/libraries/astal/modules/river.nix
+++ b/pkgs/development/libraries/astal/modules/river.nix
@@ -1,12 +1,9 @@
-{ buildAstalModule, json-glib }:
+{
+  buildAstalModule,
+  wl,
+}:
 buildAstalModule {
   name = "river";
-  buildInputs = [ json-glib ];
+  buildInputs = [ wl ];
   meta.description = "Astal module for River using IPC";
-
-  postUnpack = ''
-    rm -rf $sourceRoot/subprojects
-    mkdir -p $sourceRoot/subprojects
-    cp -r --remove-destination $src/lib/wayland-glib $sourceRoot/subprojects/wayland-glib
-  '';
 }

--- a/pkgs/development/libraries/astal/modules/wl.nix
+++ b/pkgs/development/libraries/astal/modules/wl.nix
@@ -1,9 +1,5 @@
-{
-  buildAstalModule,
-  wl-vapi-gen,
-}:
+{ buildAstalModule }:
 buildAstalModule {
   name = "wl";
-  buildInputs = [ wl-vapi-gen ];
   meta.description = "Astal module for wayland connection management";
 }

--- a/pkgs/development/libraries/astal/modules/wl.nix
+++ b/pkgs/development/libraries/astal/modules/wl.nix
@@ -1,0 +1,9 @@
+{
+  buildAstalModule,
+  wl-vapi-gen,
+}:
+buildAstalModule {
+  name = "wl";
+  buildInputs = [ wl-vapi-gen ];
+  meta.description = "Astal module for wayland connection management";
+}

--- a/pkgs/development/libraries/astal/source.nix
+++ b/pkgs/development/libraries/astal/source.nix
@@ -7,15 +7,15 @@ let
   originalDrv = fetchFromGitHub {
     owner = "Aylur";
     repo = "astal";
-    rev = "7d1fac8a4b2a14954843a978d2ddde86168c75ef";
-    hash = "sha256-Jh4VtPcK2Ov+RTcV9FtyQRsxiJmXFQGfqX6jjM7/mgc=";
+    rev = "e13855a58bd761f322fb16e06e85e340d7fb476b";
+    hash = "sha256-7roHaA1UsW2cyvfidFcefJIYsOGFEkyb0vysnXscK3I=";
   };
 in
 originalDrv.overrideAttrs (
   final: prev: {
     name = "${final.pname}-${final.version}"; # fetchFromGitHub already defines name
     pname = "astal-source";
-    version = "0-unstable-2025-11-26";
+    version = "0-unstable-2026-5-16";
 
     meta = prev.meta // {
       description = "Building blocks for creating custom desktop shells (source)";


### PR DESCRIPTION
Bump source to 0-unstable-2026-5-16
Bump libcava to 0.10.7 for astal.cava

Update astal.river packaging

Add [wl-vapi-gen](https://github.com/kotontrion/wl-vapi-gen) for astal.wl and astal.river
Add astal.quarrel
Add astal.wl
Add astal.brightness

I only updated what was necessary for astal [e13855a5](https://github.com/Aylur/astal/commit/e13855a58bd761f322fb16e06e85e340d7fb476b) for the brightness library

I won't tick "Tested basic functionality of all binary files" because I don't have a config that can test all of the changes. I could only verify that astal.brightness works.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
