### PR TITLE
blender: respect cudaCapabilities

### DIFF
--- a/pkgs/by-name/bl/blender/package.nix
+++ b/pkgs/by-name/bl/blender/package.nix
@@ -9,6 +9,7 @@
   ceres-solver,
   cmake,
   config,
+  cudaArches ? cudaPackages.flags.realArches,
   cudaPackages,
   cudaSupport ? config.cudaSupport,
   dbus,
@@ -201,6 +202,7 @@ stdenv'.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "ALEMBIC_LIBRARY" "${lib.getLib alembic}/lib/libAlembic${stdenv.hostPlatform.extensions.sharedLibrary}")
   ]
   ++ lib.optionals cudaSupport [
+    (lib.cmakeFeature "CYCLES_CUDA_BINARIES_ARCH" (lib.concatStringsSep ";" cudaArches))
     (lib.cmakeFeature "OPTIX_ROOT_DIR" "${optix}")
     (lib.cmakeBool "WITH_CYCLES_CUDA_BINARIES" true)
   ]


### PR DESCRIPTION
this should speed up builds by not building binaries for unused cuda compute levels

see https://developer.nvidia.com/cuda/gpus
and https://github.com/blender/blender/blob/1f262d6832021d855a643c5c6afbb0ee60194356/CMakeLists.txt#L650-L653

this change won't show up in hydra/nixpkgs-review/... builds because nixpkgs needs something like

```nix
{ pkgs, ... }:
{
  nixpkgs.config = {
    cudaSupport = true;
    cudaCapabilities = [ "8.9" ];
    cudaForwardCompat = true;
    allowUnfreePredicate = pkgs._cuda.lib.allowUnfreeCudaPredicate;
  };
}
```

to kick in. so don't necessarily trust green checkmarks everywhere for this (but trust :sparkles:  _me_ :sparkles:, I tried it)

~~I haven't actually benchmarked build times to see if this _helps_ (38°C outside + cpu at full tilt for 20min = yikes), but imo setting the option is "correct" either way.~~
on my machine (7950x3d)  this yields ~14:45 -> ~12:30, so a 15% speedup (not sure how scientific that is)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
