### PR TITLE
python3Packages.afdko: fix build on darwin

### DIFF
--- a/pkgs/development/python-modules/afdko/0001-addfeatures-hmtx-avoid-unsigned-integer-underflow.patch
+++ b/pkgs/development/python-modules/afdko/0001-addfeatures-hmtx-avoid-unsigned-integer-underflow.patch
@@ -1,0 +1,34 @@
+From 91833ab6c1a769f82f30dbf126362d079905bfc6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=A9clairevoyant?=
+ <848000+eclairevoyant@users.noreply.github.com>
+Date: Fri, 26 Jun 2026 21:28:41 -0400
+Subject: [PATCH] addfeatures/hmtx: avoid unsigned integer underflow
+
+---
+ c/addfeatures/hotconv/hmtx.cpp | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/c/addfeatures/hotconv/hmtx.cpp b/c/addfeatures/hotconv/hmtx.cpp
+index 9336c986..2d8ca98e 100644
+--- a/c/addfeatures/hotconv/hmtx.cpp
++++ b/c/addfeatures/hotconv/hmtx.cpp
+@@ -52,12 +52,12 @@ int hmtxFill(hotCtx g) {
+     /* Optimize metrics */
+     FWord width = hmtx.advanceWidth.back();
+     size_t i;
+-    for (i = hmtx.advanceWidth.size() - 2; i >= 0; i--) {
+-        if (hmtx.advanceWidth[i] != width)
++    for (i = hmtx.advanceWidth.size(); i >= 2; i--) {
++        if (hmtx.advanceWidth[i-2] != width)
+             break;
+     }
+-    if (i + 2 != hmtx.advanceWidth.size())
+-        hmtx.advanceWidth.resize(i+2);
++    if (i != hmtx.advanceWidth.size())
++        hmtx.advanceWidth.resize(i);
+ 
+     return hmtx.Fill();
+ }
+-- 
+2.54.0
+

--- a/pkgs/development/python-modules/afdko/default.nix
+++ b/pkgs/development/python-modules/afdko/default.nix
@@ -69,6 +69,10 @@ buildPythonPackage (finalAttrs: {
 
     # Use antlr4 runtime from nixpkgs and link it dynamically
     ./use-dynamic-system-antlr4-runtime.patch
+
+    # integer underflow causes incorrect behavior
+    # patch submitted upstream as https://github.com/adobe-type-tools/afdko/pull/1843
+    ./0001-addfeatures-hmtx-avoid-unsigned-integer-underflow.patch
   ];
 
   env = {


### PR DESCRIPTION

fixes #535868
upstream pr: https://github.com/adobe-type-tools/afdko/pull/1843

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
