### PR TITLE
pnpm_10_29_2: mark insecure

### DIFF
--- a/pkgs/development/tools/pnpm/default.nix
+++ b/pkgs/development/tools/pnpm/default.nix
@@ -20,6 +20,15 @@ let
     "10_29_2" = {
       version = "10.29.2";
       hash = "sha256-hAL2daH0zJ1PJ7v6s1wtSi4dfrATHfA9rQlhnoZnTQw=";
+      knownVulnerabilities = [
+        "CVE-2026-48995"
+        "CVE-2026-50014"
+        "CVE-2026-50015"
+        "CVE-2026-50016"
+        "CVE-2026-50017"
+        "CVE-2026-50573"
+        "CVE-2026-55699"
+      ];
     };
     "10" = {
       version = "10.34.0";
@@ -35,6 +44,7 @@ let
     variant:
     callPackage ./generic.nix {
       inherit (variant) version hash;
+      knownVulnerabilities = variant.knownVulnerabilities or [ ];
       #FIXME: remove this hack in a future version.
       nodejs = null; # Passing null to detect out-of-tree overrides
     };

--- a/pkgs/development/tools/pnpm/generic.nix
+++ b/pkgs/development/tools/pnpm/generic.nix
@@ -17,6 +17,7 @@
   withNode ? true,
   version,
   hash,
+  knownVulnerabilities,
 }:
 let
   majorVersion = lib.versions.major version;
@@ -170,5 +171,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     ];
     platforms = lib.platforms.all;
     mainProgram = "pnpm";
+    inherit knownVulnerabilities;
   };
 })


### PR DESCRIPTION
fixes https://github.com/NixOS/nixpkgs/issues/535580

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
