### PR TITLE
rocqPackages.rocqnavi: init at 0.5.0

### DIFF
--- a/pkgs/development/rocq-modules/rocqnavi/default.nix
+++ b/pkgs/development/rocq-modules/rocqnavi/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  mkRocqDerivation,
+  rocq-core,
+  version ? null,
+}:
+
+with lib;
+mkRocqDerivation {
+  pname = "rocqnavi";
+  owner = "affeldt-aist";
+
+  inherit version;
+  defaultVersion =
+    let
+      case = case: out: { inherit case out; };
+    in
+    with versions;
+    switch rocq-core.rocq-version [
+      (case (range "9.0" "9.2") "0.5.0")
+    ] null;
+  release = {
+    "0.5.0".hash = "sha256-pmK4gD5ccerjr2UVgwGIVbjH/RiXdYQq79/XFetiHZg=";
+  };
+  releaseRev = v: "rocqnavi." + v;
+
+  nativeBuildInputs =
+    let
+      ocamlpkgs = rocq-core.ocamlPackages;
+    in
+    [
+      ocamlpkgs.yojson
+      ocamlpkgs.dune-glob
+    ];
+
+  ## Does the package contain OCaml code?
+  mlPlugin = true;
+  buildPhase = "make";
+  preInstallPhase = "mkdir $(out)/bin";
+  installFlags = [ "BINDIR=$(out)/bin" ];
+
+  meta = {
+    description = "Rocqnavi: an HTML documentation generator for Rocq prover";
+    maintainers = with maintainers; [ cohencyril ];
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/rocq-packages.nix
+++ b/pkgs/top-level/rocq-packages.nix
@@ -62,6 +62,7 @@ let
       parseque = callPackage ../development/rocq-modules/parseque { };
       relation-algebra = callPackage ../development/rocq-modules/relation-algebra { };
       rocq-elpi = callPackage ../development/rocq-modules/rocq-elpi { };
+      rocqnavi = callPackage ../development/rocq-modules/rocqnavi { };
       stdlib = callPackage ../development/rocq-modules/stdlib { };
       stdpp = callPackage ../development/rocq-modules/stdpp { };
       vsrocq-language-server = callPackage ../development/rocq-modules/vsrocq-language-server { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
