### PR TITLE
mlt: 7.38.0 -> 7.40.0, add new dep rnnoise

### DIFF
--- a/pkgs/by-name/ml/mlt/package.nix
+++ b/pkgs/by-name/ml/mlt/package.nix
@@ -18,6 +18,7 @@
   makeWrapper,
   movit,
   opencv4,
+  rnnoise,
   rtaudio,
   rubberband,
   sox,
@@ -44,13 +45,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mlt";
-  version = "7.38.0";
+  version = "7.40.0";
 
   src = fetchFromGitHub {
     owner = "mltframework";
     repo = "mlt";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-tZWkgDffNZwJgfrFQNKfS+QzpcjaM0SEBbyxrVBqubc=";
+    hash = "sha256-rw1jnQJzbtpGsIe/AFMiy7k/3X0vkfkY3rG4E419aVM=";
     # The submodule contains glaxnimate code, since MLT uses internally some functions defined in glaxnimate.
     # Since glaxnimate is not available as a library upstream, we cannot remove for now this dependency on
     # submodules until upstream exports glaxnimate as a library: https://gitlab.com/mattbas/glaxnimate/-/issues/545
@@ -84,6 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
     libvorbis
     libxml2
     movit
+    rnnoise
     rtaudio
     rubberband
     sox

--- a/pkgs/by-name/ml/mlt/package.nix
+++ b/pkgs/by-name/ml/mlt/package.nix
@@ -1,4 +1,5 @@
 {
+  alsa-lib,
   config,
   lib,
   stdenv,
@@ -8,16 +9,22 @@
   which,
   ffmpeg,
   fftw,
+  fontconfig,
   frei0r,
   libdv,
+  libebur128,
+  libexif,
   libjack2,
   libsamplerate,
+  libspatialaudio,
   libvorbis,
   libxml2,
   libx11,
+  lilv,
   makeWrapper,
   movit,
   opencv4,
+  pango,
   rnnoise,
   rtaudio,
   rubberband,
@@ -78,18 +85,27 @@ stdenv.mkDerivation (finalAttrs: {
     (opencv4.override { ffmpeg-headless = ffmpeg; })
     ffmpeg
     fftw
+    fontconfig
     frei0r
     libdv
+    libebur128
+    libexif
     libjack2
     libsamplerate
+    libspatialaudio
     libvorbis
     libxml2
+    lilv
     movit
+    pango
     rnnoise
     rtaudio
     rubberband
     sox
     vid-stab
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    alsa-lib
   ]
   ++ lib.optionals cudaSupport [
     cudaPackages.cuda_cudart

--- a/pkgs/by-name/ml/mlt/package.nix
+++ b/pkgs/by-name/ml/mlt/package.nix
@@ -152,7 +152,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postFixup = ''
     substituteInPlace "$dev"/lib/pkgconfig/mlt-framework-7.pc \
-      --replace '=''${prefix}//' '=/'
+      --replace-fail '=''${prefix}//' '=/'
   '';
 
   passthru = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
### ~~DO NOT MERGE UNTIL PR #524863 MAKES IT TO MASTER WILL NOT BUILD WITHOUT IT~~
**This has been rebased and builds no issues, therefore ready for review**
## Summary
Update MLT from 7.38.0 → 7.40.0.

**New hard dependency:** `rnnoise` (required by upstream v7.40.0; builds successfully and loads as plugin).

**Additional modules enabled:** Previously optional/missing deps now included to match upstream's recommended build:
- `alsa-lib` (Linux-only): rtaudio backend stability
- `fontconfig` + `pango`: reliable text/subtitle rendering
- `libexif`: EXIF metadata support in image producers
- `libebur128`: EBU R128 loudness metering/filter
- `lilv`: LV2 audio plugin hosting
- `libspatialaudio`: spatial audio module prep (Qt6 gated)

These enable better feature support within Kdenlive, Shotcut, and similar editors. Minor fix: replaced deprecated `--replace` with `--replace-fail` in postFixup. Added the opencv change mentioned in PR above as not to overwrite it.
## Changelogs
https://github.com/mltframework/mlt/releases/tag/v7.40.0
[v7.38.0...v7.40.0](https://github.com/mltframework/mlt/compare/v7.38.0...v7.40.0) - Full(every commit)
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
