### PR TITLE
textlint: 15.2.1 -> 15.7.1

### DIFF
--- a/pkgs/by-name/te/textlint/package.nix
+++ b/pkgs/by-name/te/textlint/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   makeWrapper,
   nodejs-slim,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   versionCheckHook,
@@ -29,13 +29,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "textlint";
-  version = "15.2.1";
+  version = "15.7.1";
 
   src = fetchFromGitHub {
     owner = "textlint";
     repo = "textlint";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-xjtmYz+O+Sn697OrBkPddv1Ma5UsOkO5v4SGlhsaYWA=";
+    hash = "sha256-Dt0AprnI/ixezMwU6JG6WhfJTU1xTRu2M4xwbY4uOko=";
   };
 
   patches = [
@@ -57,16 +57,16 @@ stdenv.mkDerivation (finalAttrs: {
       src
       patches
       ;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-TYMhAcmfWHbj/0yLNYiJXWd1GiYb+zqBLj2/83cGbzg=";
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-dWcLm8cTo8LC6IqMEe1zDxVJ7ioytKigEwYna6hiO8A=";
   };
 
   nativeBuildInputs = [
     makeWrapper
     nodejs-slim
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
   ];
 
   buildPhase = ''

--- a/pkgs/by-name/te/textlint/remove-overrides.patch
+++ b/pkgs/by-name/te/textlint/remove-overrides.patch
@@ -1,10 +1,10 @@
 diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
-index 1f0e8f8b..68a9c06a 100644
+index 9ee6370f6..552beed1b 100644
 --- a/pnpm-lock.yaml
 +++ b/pnpm-lock.yaml
-@@ -4,9 +4,6 @@ settings:
-   autoInstallPeers: true
-   excludeLinksFromLockfile: false
+@@ -295,9 +295,6 @@ catalogs:
+       specifier: ^3.25.76
+       version: 3.25.76
  
 -overrides:
 -  '@textlint/ast-node-types': workspace:*
@@ -12,3 +12,15 @@ index 1f0e8f8b..68a9c06a 100644
  importers:
  
    .:
+diff --git a/pnpm-workspace.yaml b/pnpm-workspace.yaml
+index 300a519e0..bf41d5370 100644
+--- a/pnpm-workspace.yaml
++++ b/pnpm-workspace.yaml
+@@ -130,7 +130,5 @@ minimumReleaseAgeExclude:
+ # Force all @textlint/ast-node-types references to use the workspace version
+ # This prevents version conflicts where some packages might reference old versions (e.g., 13.4.1)
+ # that cause TypeScript type incompatibility errors in monorepo
+-overrides:
+-  "@textlint/ast-node-types": "workspace:*"
+ # https://pnpm.io/settings#verifydepsbeforerun
+ verifyDepsBeforeRun: "install"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Related  #529285
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
