### PR TITLE
nixos/gnome: add glycin-thumbnailer and gst-thumbnailers

### DIFF
--- a/nixos/modules/services/desktop-managers/gnome.nix
+++ b/nixos/modules/services/desktop-managers/gnome.nix
@@ -439,6 +439,7 @@ in
           optionalPackages = [
             pkgs.adwaita-icon-theme
             nixos-background-info
+            pkgs.glycin-thumbnailer # Image thumbnailers
             pkgs.gnome-backgrounds
             pkgs.gnome-bluetooth
             pkgs.gnome-color-manager
@@ -447,6 +448,7 @@ in
             pkgs.gnome-user-docs
             pkgs.glib # for gsettings program
             pkgs.gnome-menus
+            pkgs.gst-thumbnailers # Audio and video thumbnailers
             pkgs.gtk3.out # for gtk-launch program
             pkgs.xdg-user-dirs # Update user dirs as described in https://freedesktop.org/wiki/Software/xdg-user-dirs/
             pkgs.xdg-user-dirs-gtk # Used to create the default bookmarks

--- a/pkgs/by-name/gl/glycin-thumbnailer/package.nix
+++ b/pkgs/by-name/gl/glycin-thumbnailer/package.nix
@@ -55,16 +55,13 @@ stdenv.mkDerivation (finalAttrs: {
   # Thumbnailer files are in `glycin-loaders`, but we provide them in this package
   postInstall = ''
     mkdir -p $out/share/thumbnailers
-    (
-      shopt -s failglob
 
-      for loader in ${lib.concatStringsSep " " glycin-loaders.passthru.enabledLoaders}; do
-        substitute \
-          "../glycin-loaders/glycin-$loader/glycin-$loader.thumbnailer.in" \
-          "$out/share/thumbnailers/glycin-$loader.thumbnailer" \
-          --subst-var-by "BINDIR" "$out/bin"
-      done
-    )
+    for loader in ${lib.concatStringsSep " " glycin-loaders.passthru.enabledLoaders}; do
+      substitute \
+        "../glycin-loaders/glycin-$loader/glycin-$loader.thumbnailer.in" \
+        "$out/share/thumbnailers/glycin-$loader.thumbnailer" \
+        --subst-var-by "BINDIR" "$out/bin"
+    done
   '';
 
   passthru.tests = {


### PR DESCRIPTION
These are the new multimedia thumbnailers developed for GNOME.

gst-thumbnailers in particular is useful because it adds support for video thumbnailing back to default GNOME. Video thumbnailing was previously provided by totem, but totem isn't shipped by default anymore as it was replaced by showtime.

Adding them to `optionalPackages` as they are not core apps as per [`meta-gnome-core-apps.bst`](https://gitlab.gnome.org/GNOME/gnome-build-meta/-/blob/6be2940aa35c91133a909f8462a36cdd66defafb/elements/core/meta-gnome-core-apps.bst).

Tested thumbnailing in Nautilus in an `x86_64-linux` VM for both an HEIF image and an MP4 video. (Both formats are unsupported by the thumbnailers shipped with the default GNOME config before the changes in this PR.)

Follow-up to https://github.com/NixOS/nixpkgs/pull/503377#issuecomment-4588522022, cc @nekowinston

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. — `nixosTests.gnome`
  - [x] [Package tests] at `passthru.tests`. — `glycin-thumbnailer.passthru.tests`
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
