### PR TITLE
lmstudio: 0.4.16-2 -> 0.4.18-1

### DIFF
--- a/pkgs/by-name/lm/lmstudio/package.nix
+++ b/pkgs/by-name/lm/lmstudio/package.nix
@@ -7,12 +7,12 @@
 let
   pname = "lmstudio";
 
-  version_aarch64-linux = "0.4.16-2";
-  hash_aarch64-linux = "sha256-shn3W+il66OX8VDj7+hYFgL/N8GZ1APB2MH84uoCHOM=";
-  version_aarch64-darwin = "0.4.16-2";
-  hash_aarch64-darwin = "sha256-Gj8mMrNNDXNDyFj2p3emic2xms4tWSoVS2XXLsEeEC4=";
-  version_x86_64-linux = "0.4.16-2";
-  hash_x86_64-linux = "sha256-faLtj/9M59KRdEMHHgTCPLG4Gl5C7hkdAgmaS/O5rOk=";
+  version_aarch64-linux = "0.4.18-1";
+  hash_aarch64-linux = "sha256-dSRgbf2Xo7JxqTP+2VqtNFbHHFINdaucPMCMnwUIYPM=";
+  version_aarch64-darwin = "0.4.18-1";
+  hash_aarch64-darwin = "sha256-H82Pj00m8sC+E56zQIZ0M4wdYCX/3xOfoYxYTILYW9I=";
+  version_x86_64-linux = "0.4.18-1";
+  hash_x86_64-linux = "sha256-KpznZu1tiXhtW9XDvbMCgH9xyGyaO37/F1sWqK1RCUk=";
 
   meta = {
     description = "LM Studio is an easy to use desktop app for experimenting with local and open-source Large Language Models (LLMs)";


### PR DESCRIPTION
lmstudio: 0.4.16-2 -> 0.4.18-1
Changelog: https://lmstudio.ai/changelog/lmstudio-v0.4.18
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
