### PR TITLE
memos: backport finalattrs, ldflags

### DIFF
--- a/pkgs/by-name/me/memos/package.nix
+++ b/pkgs/by-name/me/memos/package.nix
@@ -11,22 +11,24 @@
 }:
 let
   pnpm = pnpm_10;
-
+in
+buildGoModule (finalAttrs: {
+  pname = "memos";
   version = "0.25.3";
   src = fetchFromGitHub {
     owner = "usememos";
     repo = "memos";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-lAKzPteGjGa7fnbB0Pm3oWId5DJekbVWI9dnPEGbiBo=";
   };
 
-  memos-web = stdenvNoCC.mkDerivation (finalAttrs: {
+  memos-web = stdenvNoCC.mkDerivation (finalWebAttrs: {
     pname = "memos-web";
-    inherit version src;
+    inherit (finalAttrs) version src;
     pnpmDeps = fetchPnpmDeps {
-      inherit (finalAttrs) pname version src;
+      inherit (finalWebAttrs) pname version src;
       inherit pnpm;
-      sourceRoot = "${finalAttrs.src.name}/web";
+      sourceRoot = "${finalWebAttrs.src.name}/web";
       fetcherVersion = 3;
       hash = "sha256-xEOnxCgBD4uLypcZzCO+31S4r0sSfz8PpgEmZASeRZ4=";
     };
@@ -47,20 +49,12 @@ let
       runHook postInstall
     '';
   });
-in
-buildGoModule {
-  pname = "memos";
-  inherit
-    version
-    src
-    memos-web
-    ;
 
   vendorHash = "sha256-BoJxFpfKS/LByvK4AlTNc4gA/aNIvgLzoFOgyal+aF8=";
 
   preBuild = ''
     rm -rf server/router/frontend/dist
-    cp -r ${memos-web} server/router/frontend/dist
+    cp -r ${finalAttrs.memos-web} server/router/frontend/dist
   '';
 
   passthru.updateScript = nix-update-script {
@@ -73,7 +67,7 @@ buildGoModule {
   meta = {
     homepage = "https://usememos.com";
     description = "Lightweight, self-hosted memo hub";
-    changelog = "https://github.com/usememos/memos/releases/tag/${src.rev}";
+    changelog = "https://github.com/usememos/memos/releases/tag/${finalAttrs.src.rev}";
     maintainers = with lib.maintainers; [
       indexyz
       kuflierl
@@ -81,4 +75,4 @@ buildGoModule {
     license = lib.licenses.mit;
     mainProgram = "memos";
   };
-}
+})

--- a/pkgs/by-name/me/memos/package.nix
+++ b/pkgs/by-name/me/memos/package.nix
@@ -52,6 +52,10 @@ buildGoModule (finalAttrs: {
 
   vendorHash = "sha256-BoJxFpfKS/LByvK4AlTNc4gA/aNIvgLzoFOgyal+aF8=";
 
+  ldflags = [
+    "-X github.com/usememos/memos/internal/version.Version=${finalAttrs.version}"
+  ];
+
   preBuild = ''
     rm -rf server/router/frontend/dist
     cp -r ${finalAttrs.memos-web} server/router/frontend/dist


### PR DESCRIPTION
Some changes to make it easier to override the package version and use with 3. party clients.
This change does not change the package version.

Rewrote the first commit to remove the version change.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
