### PR TITLE
pypilot: init at 0.70

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6178,6 +6178,12 @@
     githubId = 39523942;
     name = "Alex Clarke";
   };
+  darkone = {
+    email = "darkone@darkone.yt";
+    github = "darkone-linux";
+    githubId = 162493435;
+    name = "Guillaume Ponçon";
+  };
   darkonion0 = {
     name = "Alexandre Peruggia";
     email = "darkgenius1@protonmail.com";

--- a/pkgs/by-name/py/pypilot/package.nix
+++ b/pkgs/by-name/py/pypilot/package.nix
@@ -1,0 +1,112 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  swig,
+  pkg-config,
+  libgpiod,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "pypilot";
+  version = "0.70";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "pypilot";
+    repo = "pypilot";
+    rev = "33a12b06869ba21f854d9d2e1bca12c842421231";
+    hash = "sha256-2EKTHBErpUsm1m7gHcQnQDGMvY22D9+14KEoXqAQO6M=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  # Keep the control head idle when its LCD is disabled (driver "none"); without
+  # this the screen subprocess busy-loops a core. Use the HTTP status code
+  # (r.status_code) instead of the JSON body's 'statusCode' field in
+  # request_access, and handle HTTP 404 (security disabled on the server) by
+  # skipping token-based auth.
+  patches = [
+    ./pypilot-headless-lcd.patch
+    ./pypilot-signalk-access.patch
+  ];
+
+  build-system = [ python3Packages.setuptools ];
+
+  # swig is the binary tool here (the pyproject build-requirement of the same
+  # name is the PyPI shim for it, dropped in postPatch).
+  nativeBuildInputs = [
+    pkg-config
+    swig
+  ];
+
+  # libgpiod lets setup.py build the HAT display (ugfx) bindings with GPIO.
+  buildInputs = [ libgpiod ];
+
+  # Drop the git+https direct references so the deps resolve to Nix packages.
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"RTIMULib @ git+https://github.com/seandepagnier/RTIMULib2@master#subdirectory=Linux/python",' '"RTIMULib",' \
+      --replace-fail '"pypilot_data @ git+https://github.com/pypilot/pypilot_data@1df915910725d586cb846cdca42ee445c2709ff6"' '"pypilot_data"' \
+      --replace-fail 'requires = ["setuptools>=64", "swig"]' 'requires = ["setuptools>=64"]'
+  '';
+
+  # The wheel build runs build_py before build_ext, so SWIG's generated .py
+  # wrappers would be missing from the package. Generate the extensions (and
+  # their wrappers) in-place first so build_py picks them up.
+  preBuild = ''
+    python setup.py build_ext --inplace
+  '';
+
+  dependencies = with python3Packages; [
+    pyserial
+    numpy
+    scipy
+    rtimulib2
+    pypilot-data
+    ujson
+    pyudev
+    inotify
+    zeroconf
+    requests
+    websocket-client
+    flask
+    gevent-websocket
+    python-socketio
+    flask-socketio
+    flask-babel
+    libgpiod
+    pillow
+    wxpython
+    pyopengl
+    pyglet
+    pywavefront
+    importlib-metadata
+  ];
+
+  # Pi 4 GPU (V3D) exposes only desktop GL 3.1; pyglet (pypilot_calibration /
+  # pypilot_scope 3D views) needs >= 3.3 and dies with "Could not create GL
+  # context". Force the llvmpipe software renderer (GL 4.5). No-op for the
+  # non-GL tools (daemon, web, hat).
+  makeWrapperArgs = [
+    "--set"
+    "LIBGL_ALWAYS_SOFTWARE"
+    "1"
+  ];
+
+  # Smoke-test that the SWIG extensions load.
+  pythonImportsCheck = [
+    "pypilot.linebuffer"
+    "pypilot.arduino_servo.arduino_servo"
+  ];
+
+  meta = {
+    description = "Free autopilot for sailboats, supporting SignalK and NMEA";
+    homepage = "http://pypilot.org/";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.darkone ];
+    mainProgram = "pypilot";
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/py/pypilot/pypilot-headless-lcd.patch
+++ b/pkgs/by-name/py/pypilot/pypilot-headless-lcd.patch
@@ -1,0 +1,20 @@
+Idle the control head's LCD subprocess when no screen is driven.
+
+With the HAT's SPI display disabled (pypilot_hat started with driver "none",
+because the generic SD image has no working device-tree for SPI — see
+doc/probleme-hat-lcd.md), lcd.poll() returns immediately and the subprocess
+busy-loops a CPU core forever. Sleep when there is no screen so the control
+head stays light while keypad/IR/RF keep working.
+
+--- a/hat/hat.py
++++ b/hat/hat.py
+@@ -316,6 +316,9 @@
+                 glutMainLoop()
+             else:
+                 while True:
+                     self.lcd.poll()
++                    if self.lcd.screen is None:
++                        # headless: no LCD to drive, idle (avoid busy-loop)
++                        time.sleep(1)
+
+         super().create(process)

--- a/pkgs/by-name/py/pypilot/pypilot-signalk-access.patch
+++ b/pkgs/by-name/py/pypilot/pypilot-signalk-access.patch
@@ -1,0 +1,38 @@
+Use r.status_code instead of contents['statusCode'] for HTTP status of
+the SignalK access request response. The JSON body does not always
+carry a 'statusCode' field (notably on 404 when security is disabled),
+so reading it from there raises a KeyError.
+
+Also handle HTTP 404: when signalk-server returns 404 on
+POST /signalk/v1/access/requests, it means server security is not
+enabled and no access token is needed. In that case skip further
+access requests and connect to the WebSocket stream without
+authentication.
+
+--- a/pypilot/signalk.py
++++ b/pypilot/signalk.py
+@@ -420,9 +420,12 @@
+ 
+             contents = pyjson.loads(r.content)
+             print('signalk post', contents)
+-            if contents['statusCode'] == 202 or contents['statusCode'] == 400:
++            if r.status_code == 202 or r.status_code == 400:
+                 self.signalk_access_url = base + contents['href']
+                 print('signalk ' + _('request access url'), self.signalk_access_url)
++            elif r.status_code == 404:
++                print('signalk ' + _('security not enabled, connecting without token'))
++                self.token = 'none'
+         except Exception as e:
+             print('signalk ' + _('error posting access'), e)
+             import traceback
+@@ -454,7 +457,9 @@
+         self.signalk_values = {}
+         self.keep_token = False
+         try:
+-            connect_kwargs = {'header': {'Authorization': 'JWT ' + self.token}}
++            connect_kwargs = {}
++            if self.token and self.token != 'none':
++                connect_kwargs['header'] = {'Authorization': 'JWT ' + self.token}
+             # For a wss:// stream with verification disabled, tell
+             # websocket-client to skip certificate checks (self-signed
+             # certs). It also clears check_hostname when cert_reqs is

--- a/pkgs/development/python-modules/pypilot-data/default.nix
+++ b/pkgs/development/python-modules/pypilot-data/default.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+}:
+
+buildPythonPackage {
+  pname = "pypilot-data";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "pypilot";
+    repo = "pypilot_data";
+    rev = "1df915910725d586cb846cdca42ee445c2709ff6";
+    hash = "sha256-UN4QuiLdRKXzOhYZKvRCeWr/BqEr8EdvYQ+5L1Z4L+M=";
+  };
+
+  pyproject = true;
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "pypilot_data" ];
+
+  meta = {
+    description = "Shared data files for the pypilot autopilot";
+    homepage = "https://github.com/pypilot/pypilot_data";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.darkone ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/rtimulib2/default.nix
+++ b/pkgs/development/python-modules/rtimulib2/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "rtimulib2";
+
+  # Version comes from RTIMULibVersion.txt; the wheel reports the same.
+  version = "8.1.0";
+
+  src = fetchFromGitHub {
+    owner = "seandepagnier";
+    repo = "RTIMULib2";
+    rev = "810272f36db3b8b8486ac1f495b6d6222edb480c";
+    hash = "sha256-AZ3q2MEa5orJm3GCpPGfvzVFKV88Uwux4wul8QXttEA=";
+  };
+
+  # setup.py reads ../../RTIMULibVersion.txt and ../../RTIMULib relative to
+  # this dir; both resolve into the unpacked tree.
+  sourceRoot = "${src.name}/Linux/python";
+
+  pyproject = true;
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "RTIMU" ];
+
+  meta = {
+    description = "richards-tech IMU sensor fusion library, Python binding (pypilot fork)";
+    homepage = "https://github.com/seandepagnier/RTIMULib2";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.darkone ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15075,6 +15075,8 @@ self: super: with self; {
 
   pypillowfight = callPackage ../development/python-modules/pypillowfight { };
 
+  pypilot-data = callPackage ../development/python-modules/pypilot-data { };
+
   pypinyin = callPackage ../development/python-modules/pypinyin { };
 
   pypiserver = callPackage ../development/python-modules/pypiserver { };
@@ -17623,6 +17625,8 @@ self: super: with self; {
   rtfde = callPackage ../development/python-modules/rtfde { };
 
   rtfunicode = callPackage ../development/python-modules/rtfunicode { };
+
+  rtimulib2 = callPackage ../development/python-modules/rtimulib2 { };
 
   rtmapi = callPackage ../development/python-modules/rtmapi { };
 


### PR DESCRIPTION
Adds [pypilot](http://pypilot.org/), a free autopilot for sailboats (SignalK +
NMEA), together with its two new Python dependencies that are not yet in
nixpkgs.

New packages:
- `pypilot` (`pkgs/by-name/py/pypilot`) — the autopilot application (daemon, web
  UI, HAT control head and wx GUI tools). Builds the SWIG C/C++ extensions
  (linebuffer / arduino_servo / ugfx / spireader).
- `python3Packages.rtimulib2` — IMU sensor-fusion `RTIMU` binding (pypilot fork).
- `python3Packages.pypilot-data` — shared data files pulled by pypilot as a git
  dependency upstream; split out so the build needs no network access.

Notes:
- Two small downstream patches are carried on pypilot (with comments): keep the
  control head idle when the LCD is disabled, and use the HTTP status code in the
  SignalK `request_access` flow.
- The git+https direct references in `pyproject.toml` are rewritten to plain
  names so they resolve to the nixpkgs Python packages.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux (via QEMU user-mode emulation)
  - [ ] aarch64-darwin
  - [ ] x86_64-darwin
- Tested, as applicable:
  - [ ] NixOS tests in nixos/tests.
  - [ ] Package tests at `passthru.tests`.
  - [ ] Tests in lib/tests or pkgs/test for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.
- [x] Follows the automation/AI policy.

Disclosure: drafted with AI assistance, reviewed/built/tested by the maintainer,
who takes responsibility for the change.
