### PR TITLE
nodejs: call configure.py directly

### DIFF
--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -347,9 +347,7 @@ let
 
       dontDisableStatic = true;
 
-      configureScript = writeScript "nodejs-configure" ''
-        exec ${python.executable} configure.py "$@"
-      '';
+      configureScript = "${python.interpreter} configure.py";
 
       # In order to support unsupported cross configurations, we copy some intermediate executables
       # from a native build and replace all the build-system tools with a script which simply touches


### PR DESCRIPTION
## Description

`nodejs.nix` currently creates `configureScript` with `writeScript`:

```nix
configureScript = writeScript "nodejs-configure" ''
  exec ${python.executable} configure.py "$@"
'';
```

This produces an executable text file without a shebang. configurePhase then
runs that file as `$configureScript`.

While debugging an aarch64-darwin configurePhase failure in nodejs-slim_26, I
found that this path can enter the shell ENOEXEC fallback before configure.py
starts. In my failing build, the crashed process was bash, not Python or Node.

The wrapper does not add any logic beyond invoking Python, so call configure.py
through the Python interpreter directly instead:

```nix
configureScript = "${python.interpreter} configure.py";
```

This also stops relying on python.executable being resolved through PATH.

## Testing

Evaluated `nodejs-slim_26.configureScript` locally on aarch64-darwin and verified
that it resolves to an absolute Python interpreter invocation.

With this change applied locally, nodejs-slim_26 passed configurePhase and
continued into the normal C++ build.
