### PR TITLE
haskellPackages.optics: pick patches that make test suite pass with 9.12

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1141,12 +1141,33 @@ with haskellLib;
   tailfile-hinotify = doJailbreak (dontCheck super.tailfile-hinotify);
 
   # 2025-09-01: Merged patch from upstream to fix bounds:
-  optics = appendPatch (fetchpatch {
-    name = "optics-fix-inspection-testing-bound";
-    url = "https://github.com/well-typed/optics/commit/d16b1ac5476c89cc94fb108fe1be268791affca6.patch";
-    sha256 = "sha256-w0L/EXSWRQkCkFnvXYel0BNgQQhxn6zATkD3GZS5gz8=";
-    relative = "optics";
-  }) super.optics;
+  optics = appendPatches [
+    (fetchpatch {
+      name = "optics-fix-inspection-testing-bound";
+      url = "https://github.com/well-typed/optics/commit/d16b1ac5476c89cc94fb108fe1be268791affca6.patch";
+      sha256 = "sha256-w0L/EXSWRQkCkFnvXYel0BNgQQhxn6zATkD3GZS5gz8=";
+      relative = "optics";
+    })
+    # Test suite changes from development branch which make it pass with GHC == 9.12.*
+    (fetchpatch {
+      name = "optics-inspection-testing-lower-bound.patch";
+      url = "https://github.com/well-typed/optics/commit/121554907e4216c4a88323d441c7c11f19016062.patch";
+      hash = "sha256-L7HEK3l7lGvu1Rp8ygkQEZFnJW9R+dgaYGz4c7zVYiE=";
+      relative = "optics";
+    })
+    (fetchpatch {
+      name = "optics-inspection-testing-ghc-9.12-changes.patch";
+      url = "https://github.com/well-typed/optics/commit/aa3cf444b881b7e19a6a9764bcc0462c9ab00724.patch";
+      hash = "sha256-n2hnZXJV3fjRbHTRaM/eabTyS61T/+4mSU4AZBsEEkM=";
+      relative = "optics";
+    })
+    (fetchpatch {
+      name = "optics-inspection-ghc-9.12-skips.patch";
+      url = "https://github.com/well-typed/optics/commit/397fcf242257a7e3553b845e48d4531015f0478d.patch";
+      hash = "sha256-r/NPdUckh37Ed9gA7OXmDdZmMp3zjuGCB+0P8/Ce4i4=";
+      relative = "optics";
+    })
+  ] super.optics;
 
   # 2025-02-10: Too strict bounds on text < 2.1
   digestive-functors-blaze = doJailbreak super.digestive-functors-blaze;


### PR DESCRIPTION
I'm not 100% clear whether there is still some kind of GHC regression involved here, but I think we can pick these patches from upstream's development branch. Also @MangoIV is aware of these (original) failures with 9.12.5-rc2.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
