### PR TITLE
snouty: 0.5.0 -> 0.6.1

### DIFF
--- a/pkgs/by-name/sn/snouty/hegeltest-c-deps.patch
+++ b/pkgs/by-name/sn/snouty/hegeltest-c-deps.patch
@@ -1,0 +1,149 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index a5e0e5f..a0a7a02 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -3868,3 +3868,144 @@ name = "zmij"
+ version = "1.0.21"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
++
++[[package]]
++name = "bitflags"
++version = "2.11.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
++
++[[package]]
++name = "cbindgen"
++version = "0.29.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "befbfd072a8e81c02f8c507aefce431fe5e7d051f83d48a23ffc9b9fe5a11799"
++dependencies = [
++ "clap",
++ "heck",
++ "indexmap",
++ "log",
++ "proc-macro2",
++ "quote",
++ "serde",
++ "serde_json",
++ "syn",
++ "tempfile",
++ "toml",
++]
++
++[[package]]
++name = "clap"
++version = "4.6.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
++dependencies = [
++ "clap_builder",
++]
++
++[[package]]
++name = "console"
++version = "0.16.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
++dependencies = [
++ "encode_unicode",
++ "libc",
++ "windows-sys",
++]
++
++[[package]]
++name = "ctor"
++version = "0.2.9"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
++dependencies = [
++ "quote",
++ "syn",
++]
++
++[[package]]
++name = "dashu-base"
++version = "0.4.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "c0b80bf6b85aa68c58ffea2ddb040109943049ce3fbdf4385d0380aef08ef289"
++
++[[package]]
++name = "dashu-int"
++version = "0.4.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "ee99d08031ca34a4d044efbbb21dff9b8c54bb9d8c82a189187c0651ffdb9fbf"
++dependencies = [
++ "cfg-if",
++ "dashu-base",
++ "num-modular",
++ "rustversion",
++ "static_assertions",
++]
++
++[[package]]
++name = "fastrand"
++version = "2.4.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
++
++[[package]]
++name = "hashbrown"
++version = "0.17.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
++
++[[package]]
++name = "insta"
++version = "1.47.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
++dependencies = [
++ "console",
++ "once_cell",
++ "similar",
++ "tempfile",
++]
++
++[[package]]
++name = "libc"
++version = "0.2.186"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
++
++[[package]]
++name = "libloading"
++version = "0.8.9"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
++dependencies = [
++ "cfg-if",
++ "windows-link",
++]
++
++[[package]]
++name = "num-modular"
++version = "0.6.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "17bb261bf36fa7d83f4c294f834e91256769097b3cb505d44831e0a179ac647f"
++
++[[package]]
++name = "similar"
++version = "2.7.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
++
++[[package]]
++name = "wasip2"
++version = "1.0.1+wasi-0.2.4"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
++dependencies = [
++ "wit-bindgen 0.46.0",
++]
++
++[[package]]
++name = "wit-bindgen"
++version = "0.46.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"

--- a/pkgs/by-name/sn/snouty/package.nix
+++ b/pkgs/by-name/sn/snouty/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   rustPlatform,
   fetchFromGitHub,
   installShellFiles,
@@ -7,22 +8,34 @@
   openssl,
   writableTmpDirAsHomeHook,
   podman,
+  docker-compose,
   versionCheckHook,
   nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "snouty";
-  version = "0.5.0";
+  version = "0.6.1";
 
   src = fetchFromGitHub {
     owner = "antithesishq";
     repo = "snouty";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-zO+2UFu/KD2dtE2AkUVv5A1EBFMsSTl8gP18bCxquI8=";
+    hash = "sha256-ob9Z20V7r126nFYsXnPaE1DFcmtbEYJjSlrrGucWpqg=";
   };
 
-  cargoHash = "sha256-fWdzaqyFT2ZFTy5AsejDgEm3E55syLKbYz5DW9Ra2PQ=";
+  cargoPatches = [
+    # merges snouty's Cargo.lock contents with hegeltest-c's Cargo.lock contents
+    ./hegeltest-c-deps.patch
+  ];
+
+  cargoHash = "sha256-EYVYpWS+Lg4CKDiYkypzAM080wdOBC09i+m3FD2lYTU=";
+
+  postPatch = ''
+    # the current rust setup hook leaves this unsubstituted file around unnecessarily
+    # but it makes hegeltest-c be unable to find the vendored deps
+    rm "$cargoDepsCopy"/.cargo/config.toml
+  '';
 
   nativeBuildInputs = [
     installShellFiles
@@ -35,10 +48,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   env.OPENSSL_NO_VENDOR = true;
 
-  postInstall = ''
-    installShellCompletion \
-      $releaseDir/build/snouty-*/out/snouty.{bash,fish} \
-      --zsh $releaseDir/build/snouty-*/out/_snouty
+  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+    installShellCompletion --cmd snouty \
+      --bash <($out/bin/snouty completions bash) \
+      --zsh <($out/bin/snouty completions zsh) \
+      --fish <($out/bin/snouty completions fish)
   '';
 
   useNextest = true;
@@ -46,6 +60,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeCheckInputs = [
     writableTmpDirAsHomeHook
     podman
+    docker-compose
   ];
 
   nativeInstallCheckInputs = [ versionCheckHook ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
