### PR TITLE
herdr: fix Darwin builds

### DIFF
--- a/pkgs/by-name/he/herdr/package.nix
+++ b/pkgs/by-name/he/herdr/package.nix
@@ -1,11 +1,14 @@
 {
   lib,
+  stdenv,
   rustPlatform,
   fetchFromGitHub,
   zig_0_15,
+  cctools,
+  xcbuild,
+  versionCheckHook,
   nix-update-script,
 }:
-
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "herdr";
   version = "0.7.0";
@@ -28,7 +31,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-pgGu8+NwvFcj6SrN4VaTHLeHdA7QY731ctyrHZwgFAc=";
   };
 
-  nativeBuildInputs = [ zig_0_15.hook ];
+  nativeBuildInputs = [
+    zig_0_15.hook
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    cctools
+    xcbuild
+  ];
 
   # Upstream binary tests are renamed, added, or changed between releases and
   # depend on host process details, so Nix-only patches for them are brittle.
@@ -44,13 +53,21 @@ rustPlatform.buildRustPackage (finalAttrs: {
     chmod -R u+w "$ZIG_GLOBAL_CACHE_DIR/p"
   '';
 
-  passthru.updateScript = nix-update-script { };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--custom-dep"
+      "zigDeps"
+    ];
+  };
 
   meta = {
     description = "Agent multiplexer that lives in your terminal";
-    homepage = "https://github.com/ogulcancelik/herdr";
+    homepage = "https://herdr.dev";
     changelog = "https://github.com/ogulcancelik/herdr/releases/tag/v${finalAttrs.version}";
-    license = lib.licenses.agpl3Only;
+    license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [ kevinpita ];
     mainProgram = "herdr";
     platforms = lib.platforms.unix;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

herdr wasn't building on Darwin systems as can be see in these hydra logs: https://hydra.nixos.org/build/332986051/nixlog/1
To fix this, I added an Xcode select script inspired by the upstream repo and their `package.nix` and the cctools. With this, the problem has been fixed.

I also added a versionCheckHook just in case (I guess rust projects don't need it really, but better to be safe than sorry).

I checked the licence of the project, and it is an `agpl3Plus`, not `agpl3Only`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
