### PR TITLE
python3Packages.xstatic-asciinema-player: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/xstatic-asciinema-player/default.nix
+++ b/pkgs/development/python-modules/xstatic-asciinema-player/default.nix
@@ -2,18 +2,21 @@
   buildPythonPackage,
   lib,
   fetchPypi,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "xstatic-asciinema-player";
   version = "2.6.1.1";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     pname = "XStatic-asciinema-player";
     inherit version;
     hash = "sha256-yA6WC067St82Dm6StaCKdWrRBhmNemswetIO8iodfcw=";
   };
+
+  build-system = [ setuptools ];
 
   # no tests implemented
   doCheck = false;

--- a/pkgs/development/python-modules/xstatic-asciinema-player/default.nix
+++ b/pkgs/development/python-modules/xstatic-asciinema-player/default.nix
@@ -5,14 +5,16 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "xstatic-asciinema-player";
   version = "2.6.1.1";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
     pname = "XStatic-asciinema-player";
-    inherit version;
+    inherit (finalAttrs) version;
     hash = "sha256-yA6WC067St82Dm6StaCKdWrRBhmNemswetIO8iodfcw=";
   };
 
@@ -21,10 +23,12 @@ buildPythonPackage rec {
   # no tests implemented
   doCheck = false;
 
+  pythonImportsCheck = [ "xstatic.pkg.asciinema_player" ];
+
   meta = {
     homepage = "https://github.com/python-xstatic/asciinema-player";
     description = "Asciinema-player packaged for python";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ aither64 ];
   };
-}
+})

--- a/pkgs/development/python-modules/xstatic-asciinema-player/default.nix
+++ b/pkgs/development/python-modules/xstatic-asciinema-player/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage (finalAttrs: {
   pythonImportsCheck = [ "xstatic.pkg.asciinema_player" ];
 
   meta = {
-    homepage = "https://github.com/python-xstatic/asciinema-player";
+    homepage = "https://github.com/xstatic-py/xstatic-asciinema-player";
     description = "Asciinema-player packaged for python";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ aither64 ];


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
