### PR TITLE
tabbyapi: unstable-2026-06-13 -> unstable-2026-06-27; nixos/tabbyapi: add writable HOME and cache 

### DIFF
--- a/nixos/modules/services/web-apps/tabbyapi.nix
+++ b/nixos/modules/services/web-apps/tabbyapi.nix
@@ -167,6 +167,13 @@ in
       wantedBy = [ "multi-user.target" ];
       description = "TabbyAPI - OAI compatible server for Exllama";
 
+      # Triton & huggingface downloader need writable cache folders
+      environment = {
+        HOME = "/var/lib/tabbyapi";
+        XDG_CACHE_HOME = "/var/lib/tabbyapi/.cache";
+        TRITON_CACHE_DIR = "/tmp/triton";
+      };
+
       serviceConfig = {
         ExecStart = "${lib.getExe cfg.package} --config=${configFile}";
         Restart = "on-failure";

--- a/pkgs/by-name/ta/tabbyapi/package.nix
+++ b/pkgs/by-name/ta/tabbyapi/package.nix
@@ -7,14 +7,14 @@
 }:
 python3Packages.buildPythonApplication {
   pname = "tabbyapi";
-  version = "0-unstable-2026-06-13";
+  version = "0-unstable-2026-06-27";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "theroyallab";
     repo = "tabbyAPI";
-    rev = "54850882315d509c984f9fe07fb8f5d04a0b4ba9";
-    hash = "sha256-rIpI3pCJtfU1AEHBwQCIwuOh4c14N/z8VlX0hdxOC60=";
+    rev = "3cf468c28362c28be1c8fc731ce1ccaf7b2206d0";
+    hash = "sha256-s97YFyij2/oYlClmV2laDrCkkoK4uVZgRsn5WwftLag=";
   };
 
   build-system = with python3Packages; [


### PR DESCRIPTION
Bumps tabbyapi & fixes issues with triton cache

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
