### PR TITLE
gimp: install missing pygimp.interp for plugins

### DIFF
--- a/pkgs/applications/graphics/gimp/default.nix
+++ b/pkgs/applications/graphics/gimp/default.nix
@@ -104,14 +104,6 @@ stdenv.mkDerivation (finalAttrs: {
       cc_version = stdenv.cc.cc.name;
     })
 
-    # Use absolute paths instead of relying on PATH
-    # to make sure plug-ins are loaded by the correct interpreter.
-    # TODO: This now only appears to be used on Windows.
-    (replaceVars ./hardcode-plugin-interpreters.patch {
-      python_interpreter = python.interpreter;
-      PYTHON_EXE = null;
-    })
-
     # D-Bus configuration is not available in the build sandbox
     # so we need to pick up the one from the package.
     (replaceVars ./tests-dbus-conf.patch {
@@ -300,6 +292,17 @@ stdenv.mkDerivation (finalAttrs: {
     # Fix storing recent file list in tests
     export HOME="$TMPDIR"
     export XDG_DATA_DIRS="${glib.getSchemaDataDirPath gtk3}:${adwaita-icon-theme}/share:$XDG_DATA_DIRS"
+  '';
+
+  # pygimp.interp not installed by Meson on Linux (only Windows/macOS).
+  # Without it, GIMP falls back to /usr/bin/env python3 for third-party
+  # Python plugins, which lacks pygobject3/gi.
+  postInstall = ''
+        mkdir -p "$out/lib/gimp/3.0/interpreters"
+        cat > "$out/lib/gimp/3.0/interpreters/pygimp.interp" <<EOF
+    python3=${python}/bin/python3
+    :Python:E::py::${python}/bin/python3:
+    EOF
   '';
 
   preFixup = ''

--- a/pkgs/applications/graphics/gimp/hardcode-plugin-interpreters.patch
+++ b/pkgs/applications/graphics/gimp/hardcode-plugin-interpreters.patch
@@ -1,8 +1,0 @@
---- a/plug-ins/python/pygimp.interp.in
-+++ b/plug-ins/python/pygimp.interp.in
-@@ -2,4 +2,4 @@ python=@PYTHON_EXE@
- python3=@PYTHON_EXE@
- /usr/bin/python=@PYTHON_EXE@
- /usr/bin/python3=@PYTHON_EXE@
--:Python:E::py::python3:
-+:Python:E::py::@python_interpreter@:


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
1. Remove the `hardcode-plugin-intepreters.patch` since Meson only built it on Windows/Macos
2. Create `pygimp.interp` at `postInstall` with shebang & extensions  registration, see [this](https://gitlab.gnome.org/GNOME/gimp/-/raw/master/data/interpreters/default.interp):
```
python3=/nix/store/<hash>-python3-3.12-env/bin/python3
:Python:E::py::/nix/store/<hash>-python3-3.12-env/bin/python3:
```

This fixes the error 
```
Traceback (most recent call last):
  File "/home/toni/.config/GIMP/3.0/plug-ins/gimp3_upscale/gimp3_upscale.py", line 23, in <module>
    import gi  # type: ignore
    ^^^^^^^^^
ModuleNotFoundError: No module named 'gi'
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
