### PR TITLE
herdr: fix darwin build

### DIFF
--- a/pkgs/by-name/he/herdr/package.nix
+++ b/pkgs/by-name/he/herdr/package.nix
@@ -1,11 +1,36 @@
 {
   lib,
+  stdenv,
   rustPlatform,
   fetchFromGitHub,
+  writeShellScriptBin,
   zig_0_15,
   nix-update-script,
+  apple-sdk,
+  cctools,
 }:
 
+let
+  useDarwinSdkTools = stdenv.buildPlatform.isDarwin && stdenv.hostPlatform.isDarwin;
+  darwinSdkRoot = "${apple-sdk}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk";
+  darwinDeveloperDir = "${apple-sdk}/Platforms/MacOSX.platform/Developer";
+  darwinXcodeSelect = writeShellScriptBin "xcode-select" ''
+    if [ "$1" = "--print-path" ]; then
+      echo ${lib.escapeShellArg darwinDeveloperDir}
+      exit 0
+    fi
+    echo "unsupported xcode-select invocation: $*" >&2
+    exit 1
+  '';
+  darwinXcrun = writeShellScriptBin "xcrun" ''
+    if [ "$1" = "--sdk" ] && [ "$3" = "--show-sdk-path" ]; then
+      echo ${lib.escapeShellArg darwinSdkRoot}
+      exit 0
+    fi
+    echo "unsupported xcrun invocation: $*" >&2
+    exit 1
+  '';
+in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "herdr";
   version = "0.7.0";
@@ -28,7 +53,18 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-pgGu8+NwvFcj6SrN4VaTHLeHdA7QY731ctyrHZwgFAc=";
   };
 
-  nativeBuildInputs = [ zig_0_15.hook ];
+  nativeBuildInputs = [
+    zig_0_15.hook
+  ]
+  ++ lib.optionals useDarwinSdkTools [
+    cctools
+    darwinXcodeSelect
+    darwinXcrun
+  ];
+
+  env = lib.optionalAttrs useDarwinSdkTools {
+    SDKROOT = darwinSdkRoot;
+  };
 
   # Upstream binary tests are renamed, added, or changed between releases and
   # depend on host process details, so Nix-only patches for them are brittle.


### PR DESCRIPTION
Fix Herdr's Darwin build by making the vendored `libghostty-vt` Zig build see the Apple SDK tools it probes for.

Herdr's build script runs `zig build` for vendored `libghostty-vt`. On Darwin, Zig 0.15 calls `xcode-select --print-path` and `xcrun --sdk macosx --show-sdk-path` while resolving the native libc/SDK. The Nix build environment did not provide those commands, so the package failed with `DarwinSdkNotFound`.

This adds Darwin-only shims for those SDK discovery commands and adds `cctools` for `libtool`.

Upstream issue: https://github.com/ogulcancelik/herdr/issues/830

Validation:
- `git diff --check`
- Reproduced the underlying Zig failure on macOS by hiding Apple SDK tools from `PATH`
- Verified the same vendored Zig build succeeds with equivalent `xcode-select`/`xcrun` shims plus `libtool`
- Confirmed by another affected Darwin user here: https://github.com/ogulcancelik/herdr/issues/830#issuecomment-4817549745

AI assistance was used to investigate the failure and prepare this patch. I reviewed the resulting change.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
