### PR TITLE
bind: 9.20.24 -> 9.20.26, fix tests, enable structuredAttrs, adopt

### DIFF
--- a/pkgs/by-name/bi/bind/package.nix
+++ b/pkgs/by-name/bi/bind/package.nix
@@ -154,7 +154,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://downloads.isc.org/isc/bind9/cur/${lib.versions.majorMinor finalAttrs.version}/doc/arm/html/notes.html#notes-for-bind-${
       lib.replaceStrings [ "." ] [ "-" ] finalAttrs.version
     }";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ bartoostveen ];
     platforms = lib.platforms.unix;
 
     outputsToInstall = [

--- a/pkgs/by-name/bi/bind/package.nix
+++ b/pkgs/by-name/bi/bind/package.nix
@@ -111,6 +111,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
   strictDeps = true;
+  __structuredAttrs = true;
 
   doCheck = with stdenv.hostPlatform; !isStatic && isLinux;
   checkTarget = "unit";

--- a/pkgs/by-name/bi/bind/package.nix
+++ b/pkgs/by-name/bi/bind/package.nix
@@ -112,30 +112,15 @@ stdenv.mkDerivation (finalAttrs: {
   enableParallelBuilding = true;
   strictDeps = true;
 
-  doCheck = false;
-  # TODO: investigate failures; see this and linked discussions:
-  # https://github.com/NixOS/nixpkgs/pull/192962
-  /*
-    doCheck = with stdenv.hostPlatform; !isStatic && !(isAarch64 && isLinux)
-      # https://gitlab.isc.org/isc-projects/bind9/-/issues/4269
-      && !is32bit;
-  */
+  doCheck = with stdenv.hostPlatform; !isStatic && isLinux;
   checkTarget = "unit";
   checkInputs = [
     cmocka
-  ]
-  ++ lib.optionals (!stdenv.hostPlatform.isMusl) [
-    tzdata
   ];
-  preCheck =
-    lib.optionalString stdenv.hostPlatform.isMusl ''
-      # musl doesn't respect TZDIR, skip timezone-related tests
-      sed -i '/^ISC_TEST_ENTRY(isc_time_formatISO8601L/d' tests/isc/time_test.c
-    ''
-    + lib.optionalString stdenv.hostPlatform.isDarwin ''
-      # Test timeouts on Darwin
-      sed -i '/^ISC_TEST_ENTRY(tcpdns_recv_one/d' tests/isc/netmgr_test.c
-    '';
+  preCheck = ''
+    # skip timezone-related tests, they are flaky inside the nix sandbox
+    sed -i '/^ISC_TEST_ENTRY(isc_time_formatISO8601L/d' tests/isc/time_test.c
+  '';
 
   postFixup = ''
     remove-references-to -t "$out" "$dnsutils/bin/delv"

--- a/pkgs/by-name/bi/bind/package.nix
+++ b/pkgs/by-name/bi/bind/package.nix
@@ -30,11 +30,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "bind";
-  version = "9.20.24";
+  version = "9.20.26";
 
   src = fetchurl {
     url = "https://downloads.isc.org/isc/bind9/${finalAttrs.version}/bind-${finalAttrs.version}.tar.xz";
-    hash = "sha256-mJ/vH8iOpZ0EzYb4VNylpGFqIKmWi83ePBo2aKs2vgg=";
+    hash = "sha256-VSSN7w+HDExGs95yl46pcmFRMVFmYxiKRWTcodIL81A=";
   };
 
   outputs = [


### PR DESCRIPTION
- **bind: enable tests, always disable time_test partially**
- **bind: enable structuredAttrs**
- **bind: add bartoostveen as a maintainer**
- **bind: 9.20.24 -> 9.20.26**

Changelog: https://downloads.isc.org/isc/bind9/cur/9.20/doc/arm/html/notes.html#notes-for-bind-9-20-26

I noticed a few days ago that it was mentioned that bind9 does not have a maintainer. Since no one else (that might be more qualified) stepped up, I am willing to maintain it, given the fact that besides trivial bumps and testing, this probably only needs the migration to the meson build eventually (once a new even-numbered release gets cut), so I have more than enough time to maintain this. I use bind in a production environment as well as for my personal hobby infra.

Besides adopting, I also disabled a flaky test and made sure they all build:

```
$ nix-build -A bind.passthru.tests
/nix/store/p49qhibxk9q73alfbljpls1mc70jcrrj-vm-test-run-bind
/nix/store/72ih7qj031vziws1d26xsagrawb926f3-vm-test-run-kubernetes-dns-multinode
/nix/store/zgr254a2rajfg8lqg4cvx44xmmpqdbzx-vm-test-run-kubernetes-dns-singlenode
/nix/store/6qvf2g8mc8hi2xzb76q3w318bkrnysa4-container-test-run-prometheus-bind-exporter
/nix/store/crah9g0jmhsnj6q2pyxk3mv7wfnxn89q-bind-9.20.24
```

I also 'modernized' the package by turning on structuredAttrs.

I cannot reproduce the issues faced [almost four years ago](https://github.com/NixOS/nixpkgs/pull/192962#issuecomment-1686567566), so I'll test this on `aarch64-linux` first before marking as ready. Given these issues arised that long ago, it might've just been resolved upstream and does not need additional attention here.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
