### PR TITLE
postgresqlPackages.{age,pg_hint_plan,pg_safeupdate,pgaudit}: clean up sources

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/age.nix
+++ b/pkgs/servers/sql/postgresql/ext/age.nix
@@ -16,7 +16,6 @@ let
     "16" = "sha256-iukdi2c3CukGvjuTojybFFAZBlAw8GEfzFPr2qJuwTA=";
     "15" = "sha256-webZWgWZGnSoXwTpk816tjbtHV1UIlXkogpBDAEL4gM=";
     "14" = "sha256-jZXhcYBubpjIJ8M5JHXKV5f6VK/2BkypH3P7nLxZz3E=";
-    "13" = "sha256-HR6nnWt/V2a0rD5eHHUsFIZ1y7lmvLz36URt9pPJnCw=";
   };
 in
 postgresqlBuildExtension (finalAttrs: {

--- a/pkgs/servers/sql/postgresql/ext/pg_hint_plan.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_hint_plan.nix
@@ -27,10 +27,6 @@ let
       version = "1.4.4";
       hash = "sha256-8rJ4Ck0Axf9zKhOXaJ4EA/M783YZRLuWx+GMGccadVo=";
     };
-    "13" = {
-      version = "1.3.11";
-      hash = "sha256-XTxCw1Uj6rVLcXJuHoT3RkEhdKVLGjOdR7rhFI8YJas=";
-    };
   };
 
   source =

--- a/pkgs/servers/sql/postgresql/ext/pg_safeupdate.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_safeupdate.nix
@@ -7,10 +7,6 @@
 
 let
   sources = {
-    "13" = {
-      version = "1.4";
-      hash = "sha256-1cyvVEC9MQGMr7Tg6EUbsVBrMc8ahdFS3+CmDkmAq4Y=";
-    };
     "14" = {
       version = "1.5";
       hash = "sha256-RRSpkWLFuif+6RCncnsb1NnjKnIIRY9KgebKkjCN5cs=";

--- a/pkgs/servers/sql/postgresql/ext/pg_safeupdate.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_safeupdate.nix
@@ -5,55 +5,23 @@
   postgresqlBuildExtension,
 }:
 
-let
-  sources = {
-    "14" = {
-      version = "1.5";
-      hash = "sha256-RRSpkWLFuif+6RCncnsb1NnjKnIIRY9KgebKkjCN5cs=";
-    };
-    "15" = {
-      version = "1.5";
-      hash = "sha256-RRSpkWLFuif+6RCncnsb1NnjKnIIRY9KgebKkjCN5cs=";
-    };
-    "16" = {
-      version = "1.5";
-      hash = "sha256-RRSpkWLFuif+6RCncnsb1NnjKnIIRY9KgebKkjCN5cs=";
-    };
-    "17" = {
-      version = "1.5";
-      hash = "sha256-RRSpkWLFuif+6RCncnsb1NnjKnIIRY9KgebKkjCN5cs=";
-    };
-    "18" = {
-      version = "1.5";
-      hash = "sha256-RRSpkWLFuif+6RCncnsb1NnjKnIIRY9KgebKkjCN5cs=";
-    };
-  };
-
-  source =
-    sources."${lib.versions.major postgresql.version}" or {
-      version = "";
-      hash = throw "pg_safeupdate: version specification for pg ${postgresql.version} missing.";
-    };
-in
-
-postgresqlBuildExtension {
+postgresqlBuildExtension (finalAttrs: {
   pname = "pg-safeupdate";
-  inherit (source) version;
+  version = "1.6";
 
   src = fetchFromGitHub {
     owner = "eradman";
     repo = "pg-safeupdate";
-    tag = source.version;
-    inherit (source) hash;
+    tag = finalAttrs.version;
+    hash = "sha256-xky2tlb0EoKzyIYftVr7/2BYLdinhxHjXiVO3lR57MM=";
   };
 
   meta = {
-    broken = !builtins.elem (lib.versions.major postgresql.version) (builtins.attrNames sources);
     description = "Simple extension to PostgreSQL that requires criteria for UPDATE and DELETE";
     homepage = "https://github.com/eradman/pg-safeupdate";
-    changelog = "https://github.com/eradman/pg-safeupdate/raw/${source.version}/NEWS";
+    changelog = "https://github.com/eradman/pg-safeupdate/raw/${finalAttrs.version}/NEWS";
     platforms = postgresql.meta.platforms;
     maintainers = with lib.maintainers; [ wolfgangwalther ];
     license = lib.licenses.postgresql;
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/pgaudit.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgaudit.nix
@@ -9,7 +9,10 @@
 
 let
   sources = {
-    # v18: No upstream ticket, yet (2025-07-07)
+    "18" = {
+      version = "18.0";
+      hash = "sha256-+1YKJxMFkok7MsYeA9GRkc2FLxuBGRLpC+JzdK/xqoM=";
+    };
     "17" = {
       version = "17.1";
       hash = "sha256-9St/ESPiFq2NiPKqbwHLwkIyATKUkOGxFcUrWgT+Iqo=";

--- a/pkgs/servers/sql/postgresql/ext/pgaudit.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgaudit.nix
@@ -26,10 +26,6 @@ let
       version = "1.6.3";
       hash = "sha256-KgLidJHjUK9BTp6ffmGUj1chcwIe6IzlcadRpGCfNdM=";
     };
-    "13" = {
-      version = "1.5.3";
-      hash = "sha256-IU4Clec3DkKWT7+kw0VtQNybt94i7M2rSSgJG/XdcRs=";
-    };
   };
 
   source =


### PR DESCRIPTION
Some of the extensions manage their sources per PG major version - maintenance lagged a bit behind on these.

None of these are available for PG 19, yet, but that's more than expected at this stage.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
