### PR TITLE
awscli2: 2.34.24 -> 2.35.11

### DIFF
--- a/pkgs/by-name/aw/awscli2/package.nix
+++ b/pkgs/by-name/aw/awscli2/package.nix
@@ -54,14 +54,14 @@ let
 in
 py.pkgs.buildPythonApplication rec {
   pname = "awscli2";
-  version = "2.34.24"; # N.B: if you change this, check if overrides are still up-to-date
+  version = "2.35.11"; # N.B: if you change this, check if overrides are still up-to-date
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "aws";
     repo = "aws-cli";
     tag = version;
-    hash = "sha256-PDoztQYKfH6FjdSyMQGsT8No3LB56naQ/AxTPN/dslQ=";
+    hash = "sha256-sjbuzDRFvqTD087vSwOM2IyG++El3NaDNCqHlyQwsxo=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/gi/git-remote-codecommit/package.nix
+++ b/pkgs/by-name/gi/git-remote-codecommit/package.nix
@@ -2,7 +2,7 @@
   lib,
   fetchFromGitHub,
   python3Packages,
-  awscli2,
+  awscli,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
@@ -30,7 +30,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   dependencies = with python3Packages; [ botocore ];
 
   nativeCheckInputs = [
-    awscli2
+    awscli
   ]
   ++ (with python3Packages; [
     pytestCheckHook


### PR DESCRIPTION
https://github.com/aws/aws-cli/compare/2.34.24...2.35.11

- replace `awscli2` with `awscli` in `git-remote-codecommit` to [match upstream](https://github.com/aws/git-remote-codecommit/blob/1.17/requirements.txt), avoiding collision with awscli2's vendored `botocore`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
