### PR TITLE
aws-sso-cli: 2.2.4 -> 2.3.1

### DIFF
--- a/pkgs/by-name/aw/aws-sso-cli/package.nix
+++ b/pkgs/by-name/aw/aws-sso-cli/package.nix
@@ -6,19 +6,20 @@
   lib,
   makeWrapper,
   stdenv,
+  writableTmpDirAsHomeHook,
   xdg-utils,
 }:
 buildGoModule (finalAttrs: {
   pname = "aws-sso-cli";
-  version = "2.2.4";
+  version = "2.3.1";
 
   src = fetchFromGitHub {
     owner = "synfinatic";
     repo = "aws-sso-cli";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-JkCHzIbIeFvmXrIkQaybjUtPDzmZ2XPv6tz3fA6ni44=";
+    hash = "sha256-JFaCTgvH6qzQ8gMt5QgqAPBal2m8FZEemTgbqyECFck=";
   };
-  vendorHash = "sha256-euqhgbyz8H/fQ1RAP0k4GMOjOu7gVeYzQv75tjCh5z0=";
+  vendorHash = "sha256-f9qSnEOUw8QWbc0rgStyzuL6lWtfy3UFhjqDAnJkKJA=";
 
   nativeBuildInputs = [
     makeWrapper
@@ -41,7 +42,14 @@ buildGoModule (finalAttrs: {
       --zsh <($out/bin/aws-sso setup completions --source --shell=zsh)
   '';
 
-  nativeCheckInputs = [ getent ];
+  nativeCheckInputs = [
+    getent
+    writableTmpDirAsHomeHook
+  ];
+
+  preCheck = ''
+    mkdir -p "$HOME/.config/aws-sso"
+  '';
 
   checkFlags =
     let
@@ -51,6 +59,7 @@ buildGoModule (finalAttrs: {
         "TestAWSConsoleUrlEU"
         "TestAWSConsoleUrlUSEast"
         "TestAWSConsoleUrlUSGov"
+        "TestGetScriptsAutoDetect"
       ]
       ++ lib.optionals stdenv.hostPlatform.isDarwin [ "TestDetectShellBash" ];
     in


### PR DESCRIPTION
https://github.com/synfinatic/aws-sso-cli/compare/v2.2.4...v2.3.1

new upstream tests requires a writable `$HOME` with a config directory and a supported login shell:

- added `writableTmpDirAsHomeHook` and a `preCheck` creating `~/.config/aws-sso` for the new `TestLoadSecureStoreJSON` test
- skipped `TestGetScriptsAutoDetect`, which depends on the build user's login shell

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
