### PR TITLE
home-assistant-custom-components.blueprints-updater: 2.8.1 -> 2.9.0

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/blueprints-updater/allow-symlinked-blueprints.diff
+++ b/pkgs/servers/home-assistant/custom-components/blueprints-updater/allow-symlinked-blueprints.diff
@@ -1,24 +1,24 @@
 diff --git a/custom_components/blueprints_updater/coordinator.py b/custom_components/blueprints_updater/coordinator.py
-index 441b870..54551d1 100644
+index dfc001c..5017b84 100644
 --- a/custom_components/blueprints_updater/coordinator.py
 +++ b/custom_components/blueprints_updater/coordinator.py
-@@ -3731,19 +3731,6 @@ def scan_blueprints(
+@@ -3752,19 +3752,6 @@ def _scan_single_blueprint_file(
+     ) -> BlueprintMetadata | None:
+         """Scan and process a single blueprint file."""
+         real_full_path = os.path.realpath(full_path)
+-        try:
+-            if (
+-                os.path.commonpath([real_full_path, context.real_blueprint_path])
+-                != context.real_blueprint_path
+-            ):
+-                _LOGGER.warning(
+-                    "Security alert: Ignoring blueprint symlink outside root: %s",
+-                    full_path,
+-                )
+-                return None
+-        except (ValueError, OSError):
+-            _LOGGER.warning("Skipping blueprint with invalid path: %s", full_path)
+-            return None
  
-                     full_path = os.path.join(root, file)
-                     real_full_path = os.path.realpath(full_path)
--                    try:
--                        if (
--                            os.path.commonpath([real_full_path, real_blueprint_path])
--                            != real_blueprint_path
--                        ):
--                            _LOGGER.warning(
--                                "Security alert: Ignoring blueprint symlink outside root: %s",
--                                full_path,
--                            )
--                            continue
--                    except (ValueError, OSError):
--                        _LOGGER.warning("Skipping blueprint with invalid path: %s", full_path)
--                        continue
- 
-                     if relative_path := get_blueprint_relative_path(hass, full_path):
-                         try:
+         relative_path = get_blueprint_relative_path(context.hass, full_path)
+         if not relative_path:

--- a/pkgs/servers/home-assistant/custom-components/blueprints-updater/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/blueprints-updater/package.nix
@@ -13,13 +13,13 @@
 buildHomeAssistantComponent rec {
   owner = "luuquangvu";
   domain = "blueprints_updater";
-  version = "2.8.1";
+  version = "2.9.0";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = "blueprints-updater";
     tag = version;
-    hash = "sha256-aqufiwH9yJmyr5Bd3Etwf5aK9dAfa7srXpBcmXDFAoY=";
+    hash = "sha256-zIkK7ZhUC8fPycWJqXP706XbOdhVlNAOwZBTYTII3dE=";
   };
 
   patches = [


### PR DESCRIPTION
Changelog: https://github.com/luuquangvu/blueprints-updater/releases/tag/2.9.0
Diff: https://github.com/luuquangvu/blueprints-updater/compare/2.8.1...2.9.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
