### PR TITLE
technitium-dns-server{,-library}: add update script

### DIFF
--- a/pkgs/by-name/te/technitium-dns-server-library/package.nix
+++ b/pkgs/by-name/te/technitium-dns-server-library/package.nix
@@ -3,7 +3,6 @@
   buildDotnetModule,
   fetchFromGitHub,
   dotnetCorePackages,
-  nix-update-script,
 }:
 buildDotnetModule rec {
   pname = "technitium-dns-server-library";
@@ -26,8 +25,6 @@ buildDotnetModule rec {
     "TechnitiumLibrary.Net/TechnitiumLibrary.Net.csproj"
     "TechnitiumLibrary.Security.OTP/TechnitiumLibrary.Security.OTP.csproj"
   ];
-
-  passthru.updateScript = nix-update-script { };
 
   meta = {
     changelog = "https://github.com/TechnitiumSoftware/DnsServer/blob/master/CHANGELOG.md";

--- a/pkgs/by-name/te/technitium-dns-server/package.nix
+++ b/pkgs/by-name/te/technitium-dns-server/package.nix
@@ -6,7 +6,6 @@
   technitium-dns-server-library,
   libmsquic,
   nixosTests,
-  nix-update-script,
 }:
 buildDotnetModule rec {
   pname = "technitium-dns-server";
@@ -45,7 +44,7 @@ buildDotnetModule rec {
     inherit (nixosTests) technitium-dns-server;
   };
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = ./update.sh;
 
   meta = {
     changelog = "https://github.com/TechnitiumSoftware/DnsServer/blob/master/CHANGELOG.md";

--- a/pkgs/by-name/te/technitium-dns-server/update.sh
+++ b/pkgs/by-name/te/technitium-dns-server/update.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=./. -i bash -p curl jq common-updater-scripts gnused nix coreutils
+
+set -euo pipefail
+
+latestVersion="$(curl -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "https://api.github.com/repos/TechnitiumSoftware/DnsServer/releases?per_page=1" | jq -r ".[0].tag_name" | sed 's/^v//')"
+currentVersion="${UPDATE_NIX_OLD_VERSION:-$(nix-instantiate --eval -E 'with import ./. {}; technitium-dns-server.version or (lib.getVersion technitium-dns-server)' | tr -d '"')}"
+
+if [[ "$currentVersion" == "$latestVersion" ]]; then
+  echo "technitium-dns-server is up-to-date: $currentVersion"
+  exit 0
+fi
+
+update-source-version technitium-dns-server-library "$latestVersion"
+update-source-version technitium-dns-server "$latestVersion"
+
+# Regenerate nuget dependencies for both packages
+$(nix-build . -A technitium-dns-server-library.fetch-deps --no-out-link)
+$(nix-build . -A technitium-dns-server.fetch-deps --no-out-link)


### PR DESCRIPTION
Replace `nix-update-script {}` in both packages with a custom `update.sh` that updates
`technitium-dns-server` and `technitium-dns-server-library` atomically. The library uses a non-standard tag format (`dns-server-v${version}`
in a separate repo) and must always land in the same PR as the server. The previous per-package
`nix-update-script` would update them independently, risking divergence. The script also
regenerates `nuget-deps.json` for both packages via their `fetch-deps` passthru.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


My Usage of AI:
I used Claude Code (with Sonnet 4.6) to help write the update.sh file. I understand what its doing and checked against other scripts like the one from Jellyfin. I also read up on the docs for nixpkgs-update.