### PR TITLE
nixos/outline: fix crash at startup from "Failed to parse" on database URL

### DIFF
--- a/nixos/modules/services/web-apps/outline.nix
+++ b/nixos/modules/services/web-apps/outline.nix
@@ -836,12 +836,18 @@ in
           ${
             if (cfg.databaseUrl == "local") then
               ''
-                export DATABASE_URL="''${DATABASE_URL:-${lib.escapeShellArg localPostgresqlUrl}}"
+                if [ -z "''${DATABASE_URL:-}" ]; then
+                  DATABASE_URL=${lib.escapeShellArg localPostgresqlUrl}
+                fi
+                export DATABASE_URL
                 export PGSSLMODE="''${PGSSLMODE:-disable}"
               ''
             else
               ''
-                export DATABASE_URL="''${DATABASE_URL:-${lib.escapeShellArg cfg.databaseUrl}}"
+                if [ -z "''${DATABASE_URL:-}" ]; then
+                  DATABASE_URL=${lib.escapeShellArg cfg.databaseUrl}
+                fi
+                export DATABASE_URL
               ''
           }
 

--- a/nixos/tests/outline.nix
+++ b/nixos/tests/outline.nix
@@ -7,10 +7,7 @@
     xanderio
   ];
 
-  node.pkgsReadOnly = false;
-
-  nodes.outline = {
-    virtualisation.memorySize = 2 * 1024;
+  containers.outline = {
     services.outline = {
       enable = true;
       forceHttps = false;


### PR DESCRIPTION
- #532600 was recently merged to allow DATABASE_URL to be overridden from the environment.

However, in the case where it is *not* overridden, that change introduced extraneous quotation marks into the string, which led to the following crashloop:

```
"error":"Failed to parse: \"'postgres://localhost/outline?host=/run/postgresql'\". Ensure special characters in database URL are encoded"
```

There is a test in `nixos/tests/outline.nix` that correctly fails because of this, but (as I understand it?) Hydra / ofBorg doesn't run the test, because outline is under an unfree license.

There's plenty of ways of fixing this. Attached is the one that Claude came up with first. I also made a change to switch the test to use containers instead of VMs, since it seems to still do the job, but faster.

I did not test the case where DATABASE_URL *is* set, but eyeballing the code and generated script I think it's fine.

## AI automation

In short: I used AI as a labour-saving tool and I had it explain some things to me, but I'm confident that I could have written this PR by hand as well.

My full process:

* I noticed that outline was crashing on my server, asked Claude to look into why and write a regression test.
* Claude found the existing regression test and explained why it hadn't run, and proposed the fix that I give here. I could have written it myself but opted to use the fix it gave me.
* I additionally hand-wrote the changes to the test itself to swap it to a container to make it run faster. I asked Claude why `node.pkgsReadOnly` was there, and the explanation satisfied me that I could drop it, so I did. I reran the tests with and without the fix to verify for myself that it failed before and succeeded afterwards.
* Out of curiosity I also asked Claude to dig into what the exact condition was for a test to run on Hydra or ofBorg, and whether we could make this test do so, but ultimately decided not to make any changes there.
* I swapped the `Co-authored-by` trailer with an `Assisted-by` trailer, and mentioned Claude Code. I don't really understand why this is an improvement, but there you go.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
