### PR TITLE
textract: init at 1.2.0

### DIFF
--- a/pkgs/by-name/te/textract/package.nix
+++ b/pkgs/by-name/te/textract/package.nix
@@ -1,0 +1,152 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchPypi,
+  python3,
+  antiword,
+  ghostscript,
+  poppler-utils,
+  sox,
+  tesseract,
+  unrtf,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+let
+  #textract's xlsx parser uses xlrd.open_workbook() which requires
+  #xlrd < 2.0.0 because xlrd 2.x removed .xlsx support
+  #
+  #Upstream issue:
+  #https://github.com/deanmalmgren/textract/pull/543#issuecomment-2684619988
+
+  xlrd1 = python3.pkgs.buildPythonPackage (finalAttrs: {
+    pname = "xlrd";
+    version = "1.2.0";
+
+    pyproject = true;
+
+    src = fetchPypi {
+      inherit (finalAttrs) pname version;
+      hash = "sha256-VG6zbO6NtAw+qkbDUeZ//ubutfomULcbxMdYopobKbI=";
+    };
+
+    build-system = with python3.pkgs; [ setuptools ];
+
+    pythonImportsCheck = [ "xlrd" ];
+
+    meta = {
+      description = "Library for reading data and formatting information from Excel files";
+      homepage = "https://xlrd.readthedocs.io/";
+      license = with lib.licenses; [
+        bsd3
+        bsdOriginal
+      ];
+    };
+  });
+in
+
+python3.pkgs.buildPythonPackage (finalAttrs: {
+  pname = "textract";
+  version = "2.0.0";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "deanmalmgren";
+    repo = "textract";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MZfK3eVYgrb2yoxzkzS4MqWE4vo6NAv+qQrldhn13C4=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  build-system = with python3.pkgs; [ uv-build ];
+
+  dependencies = with python3.pkgs; [
+    argcomplete
+    beautifulsoup4
+    chardet
+    docx2txt
+    extract-msg
+    lxml
+    pdfminer-six
+    pillow
+    pocketsphinx
+    python-pptx
+    speechrecognition
+    xlrd1
+  ];
+
+  nativeCheckInputs =
+    with python3.pkgs;
+    [
+      pytestCheckHook
+    ]
+    ++ [
+      antiword
+      ghostscript
+      poppler-utils
+      sox
+      tesseract
+      unrtf
+    ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  #Skip test that require network access
+  preCheck = ''
+    export SKIP_NETWORK_TESTS=true
+
+    export PATH="$out/bin:${
+      lib.makeBinPath [
+        antiword
+        ghostscript
+        poppler-utils
+        sox
+        tesseract
+        unrtf
+      ]
+    }:$PATH"
+  '';
+
+  disabledTestPaths = [
+    #Tesseract OCR output varies by version
+    "tests/test_jpg.py"
+    "tests/test_png.py"
+    "tests/test_tiff.py"
+  ];
+
+  disabledTests = [
+    #Skip tests requiring network access
+    "test_mp3"
+    "test_mp3_google"
+
+    #Google Speech recognition output has changed over time
+    #instead of "Everything is Awesome", causing these strict
+    #comparison to fail
+    "test_raw_text_cli"
+    "test_raw_text_python"
+    "test_filename_spaces"
+    "test_standardized_text_cli"
+    "test_standardized_text_python"
+  ];
+
+  pythonImportsCheck = [
+    "textract"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Extract text from any document";
+    homepage = "https://textract.readthedocs.io/";
+    downloadPage = "https://github.com/deanmalmgren/textract";
+    changelog = "https://github.com/deanmalmgren/textract/releases/tag/v${finalAttrs.version}";
+    platforms = lib.platforms.unix;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ castorNova2 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds [textract](https://github.com/deanmalmgren/textract) which extracts text from a variety of document formats, including PDF, DOC, DOCX, XLS, images, and audio files, etc.

- Pins xlrd to 1.2.0 since textract requires .xlsx support which is removed in xlrd 2.x (https://xlrd.readthedocs.io/en/latest/changes.html#id1).
- Disables network dependent audio recognition tests and OCR tests.

TODO: Open an upstream issue regarding test case failure due to audio tests depending on Google Speech API have become different causing strict checks to fail. Although it seems package functionality itself is unaffected.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
