### PR TITLE
Youtubedr: init at 2.10.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15719,6 +15719,17 @@
     githubId = 124475;
     name = "Olli Helenius";
   };
+  ligerothetiger = {
+    email = "ligero@ligerothetiger.com";
+    name = "LigeroTheTiger";
+    github = "LigeroTheTiger";
+    githubId = 42996211;
+    keys = [
+      {
+        fingerprint = "5zLV9yqjL18GsG1qan0tGM5341niQNYnU/hiBCscn04";
+      }
+    ];
+  };
   lightbulbjim = {
     email = "chris@killred.net";
     github = "lightbulbjim";

--- a/pkgs/by-name/yo/youtubedr/package.nix
+++ b/pkgs/by-name/yo/youtubedr/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  buildGoModule,
+  versionCheckHook,
+  fetchFromGitHub,
+}:
+
+let
+  # Disabled because tests rely on network requests
+  disabledTests = [
+    "TestTranscript"
+    "TestSimpleTest"
+    "TestGetPlaylist"
+    "TestGetBigPlaylist"
+    "TestDownload_SensitiveContent"
+    "TestGetVideo_MultiLanguage"
+    "TestParseVideo"
+    "TestParse_PublishDate"
+    "TestDownload_WhenPlayabilityStatusIsNotOK"
+    "TestDownload_Regular"
+    "TestYoutube_GetItagInfo"
+    "TestClient_httpGetBodyBytes"
+    "TestClient_httpGetBodyBytes"
+    "TestGetStream"
+    "TestGetVideoWithManifestURL"
+    "TestWebClientGetVideoWithoutManifestURL"
+    "TestGetVideoWithoutManifestURL"
+    "TestClient_httpGetBodyBytes"
+    "TestDownload_FirstStream"
+  ];
+in
+buildGoModule (finalAttrs: {
+  pname = "youtubedr";
+  version = "2.10.6";
+
+  src = fetchFromGitHub {
+    owner = "kkdai";
+    repo = "youtube";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rkkqLBH4P5DMrbfsZwVgBjnQG1/fHdjVL4mU6amYUxM=";
+  };
+
+  __structuredAttrs = true;
+
+  vendorHash = "sha256-DIdDDS8U4UR3ZPmwqrhsOfejUJ4UHmwcr4JCpjkwOzs=";
+
+  ldflags = [
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  checkFlags = [
+    "-skip=${lib.concatStringsSep "|" disabledTests}"
+  ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  versionCheckProgramArg = "version";
+  versionCheckKeepEnvironment = [ "HOME" ];
+  doInstallCheck = true;
+
+  meta = {
+    homepage = "https://github.com/kkdai/youtube";
+    description = "YouTube video download CLI";
+    mainProgram = "youtubedr";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.ligerothetiger ];
+  };
+})


### PR DESCRIPTION
Added youtubedr package (https://github.com/kkdai/youtube) at version 2.10.6 to nixpkgs

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
