### PR TITLE
webkitgtk_{4_1,6_0}: drop unused libidn dependency

### DIFF
--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -42,7 +42,6 @@
   nettle,
   libtasn1,
   p11-kit,
-  libidn,
   libedit,
   readline,
   libGL,
@@ -160,7 +159,6 @@ clangStdenv.mkDerivation (finalAttrs: {
     libgbm
     libgcrypt
     libgpg-error
-    libidn
     libintl
     lcms2
     libpthread-stubs


### PR DESCRIPTION
This dependency was introduced in https://github.com/NixOS/nixpkgs/commit/3fa62094395bd89e7978f224eec2e31729fc26e5 in 2017. It appears to be unused, with the only reference in the WebKit source tree being in `Source/ThirdParty/libwebrtc/Source/third_party/yasm/ABOUT-NLS`. We are having some difficulty tracing why it was added at all, so we are not 100% sure this is correct, but webkitgtk still builds fine with this and diffoscope does not report any differences from the parent commit other than store paths to webkitgtk itself.

## Things done

- Built on platform:
  - [x] x86_64-linux (`webkitgtk_4_1`, `webkitgtk_6_0`)
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`. (`webkitgtk_4_1.tests` and `webkitgtk_6_0.tests` on x86_64-linux)
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
