### PR TITLE
grok-build: init at 0.1.210

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28865,6 +28865,12 @@
     githubId = 122319;
     name = "Renato Alves";
   };
+  unreasonable0ne = {
+    name = "unreasonable0ne";
+    email = "unreasonable0ne@pm.me";
+    github = "unreasonable0ne";
+    githubId = 95241280;
+  };
   unrooted = {
     name = "Konrad Klawikowski";
     email = "konrad.root.klawikowski@gmail.com";

--- a/pkgs/by-name/gr/grok-build/package.nix
+++ b/pkgs/by-name/gr/grok-build/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  installShellFiles,
+  versionCheckHook,
+}:
+
+let
+  version = "0.1.210"; # = contents of .../cli/stable
+  base = "https://storage.googleapis.com/grok-build-public-artifacts/cli";
+
+  # upstream publishes no x86_64-darwin artifact
+  sources = {
+    x86_64-linux = {
+      url = "${base}/grok-${version}-linux-x86_64";
+      hash = "sha256-IowYyhIcRXfB1G/qne1DiCAs0B2MKz0zG1E3RPoGx5k=";
+    };
+    aarch64-linux = {
+      url = "${base}/grok-${version}-linux-aarch64";
+      hash = "sha256-zskTsNseNf8XGV4u6MVhPhUITkj4bdK6Jxn23sb2+8I=";
+    };
+    aarch64-darwin = {
+      url = "${base}/grok-${version}-macos-aarch64";
+      hash = "sha256-uQZgdxkLqdZfWGf+LOzVy2pH4toDVVroQb+iMqhWiUQ=";
+    };
+  };
+
+  source =
+    sources.${stdenv.hostPlatform.system}
+      or (throw "grok-build: unsupported platform ${stdenv.hostPlatform.system}");
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "grok-build";
+  inherit version;
+
+  src = fetchurl { inherit (source) url hash; };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [
+    installShellFiles
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 $src $out/bin/grok
+    ln -s grok $out/bin/agent
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "xAI's agentic coding CLI (Grok Build)";
+    homepage = "https://x.ai/cli";
+    license = lib.licenses.unfree;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    mainProgram = "grok";
+    maintainers = with lib.maintainers; [ unreasonable0ne ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+  };
+})

--- a/pkgs/by-name/gr/grok-build/update.sh
+++ b/pkgs/by-name/gr/grok-build/update.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl common-updater-scripts
+set -euo pipefail
+latest=$(curl -fsSL "https://storage.googleapis.com/grok-build-public-artifacts/cli/stable")
+update-source-version grok-build "$latest" \
+  --source-key=src \
+  --ignore-same-version


### PR DESCRIPTION
Adds `grok-build`, xAI's agentic coding CLI (the `grok` command), at 0.1.210.

Upstream distributes prebuilt platform binaries from a public GCS bucket (no auth needed to download; `grok login` handles runtime auth). The derivation fetches the per-platform binary, uses `autoPatchelfHook` on Linux to fix the ELF interpreter, and installs `grok` plus an `agent` symlink.

Notes for reviewers:

- **Unfree + binary.** License is `unfree` with `sourceProvenance = [ binaryNativeCode ]`, so Hydra/ofborg won't build it — local build log below.
- **Platforms.** Upstream publishes `x86_64-linux`, `aarch64-linux`, and `aarch64-darwin` only. There is no `x86_64-darwin` artifact (404/NoSuchKey on the GCS bucket), so it's intentionally omitted.
- **No completions.** The binary ships no completion generator (no `completion`/`completions` subcommand as of 0.1.210), so none are installed.
- **updateScript** refreshes the host platform's hash via the `cli/stable` version pointer; other platforms are bumped manually (single `--source-key`).
- Built and run on `x86_64-linux`; other platforms untested locally.

<details>
<summary>Local build log (x86_64-linux)</summary>

```
this derivation will be built:
  /nix/store/sw2c9qm890ys3310gwsjxa640rn8pc92-grok-build-0.1.210.drv
building '/nix/store/sw2c9qm890ys3310gwsjxa640rn8pc92-grok-build-0.1.210.drv'...
Using versionCheckHook
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
no configure script, doing nothing
Running phase: buildPhase
no Makefile or custom buildPhase, doing nothing
Running phase: installPhase
Running phase: fixupPhase
shrinking RPATHs of ELF executables and libraries in /nix/store/...-grok-build-0.1.210
patching script interpreter paths in /nix/store/...-grok-build-0.1.210
stripping (with command strip and flags -S -p) in /nix/store/...-grok-build-0.1.210/bin
automatically fixing dependencies for ELF files
searching for dependencies of /nix/store/...-grok-build-0.1.210/bin/grok
auto-patchelf: 0 dependencies could not be satisfied
Running phase: installCheckPhase
Executing versionCheckPhase
Successfully managed to find version 0.1.210 in the output of the command /nix/store/...-grok-build-0.1.210/bin/grok --version
grok 0.1.210 (8b63e9068)
Finished versionCheckPhase
/nix/store/...-grok-build-0.1.210
```

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---
Drafted with AI assistance (Claude, Anthropic). All code reviewed, built, and tested by me; I understand and stand behind every line.