### PR TITLE
nixos/vouch-proxy: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -29,7 +29,7 @@
 - [Unpackerr](https://unpackerr.zip), extracts downloads for Radarr, Sonarr, Lidarr, Readarr, and/or a Watch folder. Available as [services.unpackerr](#opt-services.unpackerr.enable).
 
 - [Matrix Authentication Service](https://github.com/element-hq/matrix-authentication-service) is an OAuth2.0 and OpenID Connect provider for Matrix homeservers (such as Synapse). It replaces standard password authentication with modern OpenID Connect flows, and can delegate authentication to upstream OIDC providers. Available as [services.matrix-authentication-service](#opt-services.matrix-authentication-service.enable).
-  
+
 - [vouch-proxy](https://github.com/vouch/vouch-proxy) An SSO solution for Nginx using the auth_request module. Vouch Proxy forces visitors to login and authenticate with an IdP before allowing them access to a website. Available as [services.vouch-proxy](#opt-services.vouch-proxy.enable).
 
 ## Backward Incompatibilities {#sec-release-26.11-incompatibilities}

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -9,6 +9,7 @@
 ## New Modules {#sec-release-26.11-new-modules}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
+- [vouch-proxy](https://github.com/vouch/vouch-proxy) An SSO solution for Nginx using the auth_request module. Vouch Proxy forces visitors to login and authenticate with an IdP before allowing them access to a website. Available as [services.vouch-proxy](#opt-services.vouch-proxy.enable).
 
 - [tranquil](https://tangled.org/tranquil.farm/tranquil-pds) is an ATProto PDS (personal data server) implementation in Rust. A featureful, spec conscious and community driven alternative to the Bluesky reference implementation PDS. Available as [services.tranquil-pds](#opt-services.tranquil-pds.enable).
 

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -9,6 +9,7 @@
 ## New Modules {#sec-release-26.11-new-modules}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
+
 - [tranquil](https://tangled.org/tranquil.farm/tranquil-pds) is an ATProto PDS (personal data server) implementation in Rust. A featureful, spec conscious and community driven alternative to the Bluesky reference implementation PDS. Available as [services.tranquil-pds](#opt-services.tranquil-pds.enable).
 
 - [scx_loader](https://github.com/sched-ext/scx-loader), a system daemon and DBus-based loader for sched_ext schedulers. `scxctl` is the command-line client for interacting with the loader, allowing users to switch schedulers, modes, and arguments dynamically. Available as [services.scx-loader](#opt-services.scx-loader.enable)

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -9,8 +9,6 @@
 ## New Modules {#sec-release-26.11-new-modules}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
-- [vouch-proxy](https://github.com/vouch/vouch-proxy) An SSO solution for Nginx using the auth_request module. Vouch Proxy forces visitors to login and authenticate with an IdP before allowing them access to a website. Available as [services.vouch-proxy](#opt-services.vouch-proxy.enable).
-
 - [tranquil](https://tangled.org/tranquil.farm/tranquil-pds) is an ATProto PDS (personal data server) implementation in Rust. A featureful, spec conscious and community driven alternative to the Bluesky reference implementation PDS. Available as [services.tranquil-pds](#opt-services.tranquil-pds.enable).
 
 - [scx_loader](https://github.com/sched-ext/scx-loader), a system daemon and DBus-based loader for sched_ext schedulers. `scxctl` is the command-line client for interacting with the loader, allowing users to switch schedulers, modes, and arguments dynamically. Available as [services.scx-loader](#opt-services.scx-loader.enable)
@@ -30,6 +28,9 @@
 - [Unpackerr](https://unpackerr.zip), extracts downloads for Radarr, Sonarr, Lidarr, Readarr, and/or a Watch folder. Available as [services.unpackerr](#opt-services.unpackerr.enable).
 
 - [Matrix Authentication Service](https://github.com/element-hq/matrix-authentication-service) is an OAuth2.0 and OpenID Connect provider for Matrix homeservers (such as Synapse). It replaces standard password authentication with modern OpenID Connect flows, and can delegate authentication to upstream OIDC providers. Available as [services.matrix-authentication-service](#opt-services.matrix-authentication-service.enable).
+  
+- [vouch-proxy](https://github.com/vouch/vouch-proxy) An SSO solution for Nginx using the auth_request module. Vouch Proxy forces visitors to login and authenticate with an IdP before allowing them access to a website. Available as [services.vouch-proxy](#opt-services.vouch-proxy.enable).
+
 
 ## Backward Incompatibilities {#sec-release-26.11-incompatibilities}
 

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -32,7 +32,6 @@
   
 - [vouch-proxy](https://github.com/vouch/vouch-proxy) An SSO solution for Nginx using the auth_request module. Vouch Proxy forces visitors to login and authenticate with an IdP before allowing them access to a website. Available as [services.vouch-proxy](#opt-services.vouch-proxy.enable).
 
-
 ## Backward Incompatibilities {#sec-release-26.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1561,6 +1561,7 @@
   ./services/security/vault-agent.nix
   ./services/security/vault.nix
   ./services/security/vaultwarden/default.nix
+  ./services/security/vouch-proxy.nix
   ./services/security/warpgate.nix
   ./services/security/yubikey-agent.nix
   ./services/system/automatic-timezoned.nix

--- a/nixos/modules/services/security/vouch-proxy.nix
+++ b/nixos/modules/services/security/vouch-proxy.nix
@@ -33,11 +33,6 @@ in
       '';
     };
 
-    domain = lib.mkOption {
-      type = lib.types.str;
-      description = "The domain vouch-proxy runs under in the oauth2-login-flow, used e.g. in the callback_url.";
-    };
-
     clients = lib.mkOption {
       default = { };
       description = ''

--- a/nixos/modules/services/security/vouch-proxy.nix
+++ b/nixos/modules/services/security/vouch-proxy.nix
@@ -1,0 +1,288 @@
+{
+  options,
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.services.vouch-proxy;
+  yaml = pkgs.formats.yaml { };
+in
+
+{
+  options.services.vouch-proxy = {
+    enable = lib.mkEnableOption "vouch-proxy";
+
+    package = lib.mkPackageOption pkgs "vouch-proxy" { };
+
+    configureNginx = lib.mkOption {
+      default = true;
+      type = lib.types.bool;
+      description = ''
+        Automatic configuration of `services.nginx.virtualHosts.''${services.vouch-proxy.clients.<name>.domain}` to use vouch-proxy, for every client defined in `services.vouch-proxy.clients`.
+      '';
+    };
+
+    kanidmDomain = lib.mkOption {
+      default = null;
+      type = lib.types.nullOr lib.types.str;
+      description = ''
+        If kanidm is used as an oauth2 provider, this can be set to the domain kanidm manages. From this setting, `settings.oauth.auth_url`, `settings.oauth.token_url` and `settings.oauth.user_info_url` are set accordingly for every client.
+      '';
+    };
+
+    domain = lib.mkOption {
+      type = lib.types.str;
+      description = "The domain vouch-proxy runs under in the oauth2-login-flow, used e.g. in the callback_url.";
+    };
+
+    clients = lib.mkOption {
+      default = { };
+      description = ''
+        Set of oauth2 clients. A vouch-proxy systemd unit with the name of the client will be run for every client in this set.
+        Each of these sets should at least define the `port` attribute that defines the port this client's specific vouch-proxy instance listens on.
+
+        If `configureNginx` is set to `true`, the `domain` attribute defining the name of the nginx virtualHost (`services.nginx.virtualHost.<name>`) that this client is running under should also be set.
+      '';
+      type = lib.types.attrsOf (
+        lib.types.submodule {
+          options = {
+            port = lib.mkOption {
+              type = lib.types.port;
+              description = ''
+                The port the vouch-proxy instance protecting this client is listening on.
+              '';
+            };
+            domain = lib.mkOption {
+              type = lib.types.str;
+              description = ''
+                The domain of the nginx.virtualHost this client is running under. This should match the corresponding attribute name in `services.nginx.virtualHost.<name>`.
+              '';
+            };
+            environmentFile = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+              description = ''
+                Environment file as defined in {manpage}`systemd.exec(5)`.
+
+                The environment variables definid therein are passed to the vouch-proxy instance protecting this client.
+                You can use environment variables to pass secrets to the service without adding
+                them to the world-redable nix store.
+              '';
+            };
+            settings = lib.mkOption {
+              default = {
+              };
+              description = ''
+                Free-form settings written to the `config.yml` file used by vouch-proxy.
+                These settings override the global settings set in `services.vouch-proxy.settings` for this specific client.
+                A sample config can be found at <https://github.com/vouch/vouch-proxy/blob/master/config/config.yml_example>.
+              '';
+              type = lib.types.submodule {
+                freeformType = yaml.type;
+                options = { };
+              };
+            };
+          };
+        }
+      );
+    };
+
+    user = lib.mkOption {
+      default = "vouch-proxy";
+      type = lib.types.str;
+      description = "The unix user all vouch-proxy instances run as.";
+    };
+
+    group = lib.mkOption {
+      default = "vouch-proxy";
+      type = lib.types.str;
+      description = "The unix group all vouch-proxy instances run as.";
+    };
+
+    settings = lib.mkOption {
+      default = {
+      };
+      description = ''
+        Free-form settings written to the `config.yml` file used by vouch-proxy.
+        These settings will be used globally for all clients running behind vouch-proxy.
+        A sample config can be found at <https://github.com/vouch/vouch-proxy/blob/master/config/config.yml_example>.
+      '';
+      type = lib.types.submodule {
+        freeformType = yaml.type;
+        options = {
+          vouch = {
+            listen = lib.mkOption {
+              default = "[::1]";
+              type = lib.types.str;
+              description = "The address vouch-proxy listens on.";
+            };
+            document_root = lib.mkOption {
+              default = "/vouch";
+              type = lib.types.str;
+              description = "The location within every client's host where its corresponding vouch-proxy is served.";
+            };
+            allowAllUsers = lib.mkOption {
+              default = cfg.settings.vouch.domains == null;
+              type = lib.types.bool;
+              description = "Accept anyone who can authenticate at the configured provider. This is the fallback if no granular configuration is defined in `services.vouch-proxy.settings.vouch.domains`.";
+            };
+            domains = lib.mkOption {
+              default = null;
+              type = lib.types.nullOr (lib.types.listOf lib.types.str);
+              description = ''
+                List of domains protected by vouch-proxy. Each $domain in this list must serve the url `https://vouch.$domain`.
+              '';
+            };
+          };
+          oauth = {
+            provider = lib.mkOption {
+              default = "oidc";
+              type = lib.types.enum [
+                "adfs"
+                "google"
+                "github"
+                "indieauth"
+                "oidc"
+              ];
+              description = "The oauth2 provider to use.";
+            };
+            code_challenge_method = lib.mkOption {
+              default = "S256";
+              type = lib.types.str;
+              description = "PKCE method if enabled, S256 is currently supported.";
+            };
+            scopes = lib.mkOption {
+              default = [
+                "openid"
+                "email"
+              ];
+              type = lib.types.listOf lib.types.str;
+              description = "List of oauth2 scopes requested by vouch-proxy.";
+            };
+          };
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+
+    users.users."${cfg.user}" = {
+      isSystemUser = true;
+      group = "${cfg.group}";
+    };
+    users.groups."${cfg.group}" = { };
+
+    systemd.services = lib.mapAttrs' (client: clientAttrs: {
+      name = "${client}";
+      value = {
+        description = "Vouch Proxy for ${client}.";
+        after = [ "network.target" ];
+        wantedBy = [ "default.target" ];
+        serviceConfig = {
+          Type = "simple";
+          DevicePolicy = "closed";
+          DynamicUser = true;
+          User = cfg.user;
+          Group = cfg.group;
+          EnvironmentFile = clientAttrs.environmentFile;
+          ExecStart = "${cfg.package}/bin/vouch-proxy -config ${
+            yaml.generate "config.yml" (
+              lib.recursiveUpdate (lib.recursiveUpdate cfg.settings {
+                vouch = {
+                  port = clientAttrs.port;
+                }
+                // (lib.optionalAttrs cfg.settings.vouch.allowAllUsers {
+                  cookie.domain = clientAttrs.domain;
+                });
+                oauth = {
+                  client_id = "${client}";
+                  callback_url = "https://${clientAttrs.domain}${cfg.settings.vouch.document_root}/auth";
+                }
+                // (lib.optionalAttrs (cfg.kanidmDomain != null) {
+                  auth_url = "https://${cfg.kanidmDomain}/ui/oauth2";
+                  token_url = "https://${cfg.kanidmDomain}/oauth2/token";
+                  user_info_url = "https://${cfg.kanidmDomain}/oauth2/openid/${client}/userinfo";
+                });
+              }) cfg.clients.${client}.settings
+            )
+          }";
+          Restart = "on-failure";
+          RestartSec = 5;
+          StartLimitBurst = 3;
+          StateDirectory = "vouch-${client}";
+          RuntimeDirectory = "vouch-${client}";
+          WorkingDirectory = "/var/lib/vouch-${client}";
+
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          NoNewPrivileges = true;
+          ProtectClock = true;
+          ProtectControlGroups = true;
+          ProtectHome = true;
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          ProtectProc = "invisible";
+          ProtectSystem = "strict";
+          PrivateDevices = true;
+          PrivateMounts = true;
+          PrivateTmp = true;
+          PrivateUsers = true;
+          PrivateIPC = true;
+          RemoveIPC = true;
+          RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+            "AF_UNIX"
+          ];
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          SystemCallArchitectures = "native";
+          SystemCallFilter = [
+            "@system-service @resources"
+            "~@clock @debug @module @mount @reboot @swap @cpu-emulation @obsolete @timer @chown @setuid @privileged @keyring @ipc"
+          ];
+          SystemCallErrorNumber = "EPERM";
+        };
+      };
+    }) cfg.clients;
+
+    services.nginx.virtualHosts = lib.mkIf cfg.configureNginx (
+      lib.mapAttrs' (_: clientAttrs: {
+        name = clientAttrs.domain;
+        value = {
+          extraConfig = ''
+            error_page 401 = @error401;
+          '';
+          locations."@error401".return = ''
+            302 https://${clientAttrs.domain}${cfg.settings.vouch.document_root}/login?url=$scheme://$http_host$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err
+          '';
+
+          locations."/".extraConfig = ''
+            auth_request /vouch/validate;
+          '';
+
+          locations."${cfg.settings.vouch.document_root}" = {
+            proxyPass = "http://[::1]:${builtins.toString clientAttrs.port}";
+            extraConfig = ''
+              proxy_set_header X-Forwarded-Host $host;
+              proxy_pass_request_body off;
+              proxy_set_header Content-Length "";
+
+              auth_request_set $auth_resp_jwt $upstream_http_x_vouch_jwt;
+              auth_request_set $auth_resp_err $upstream_http_x_vouch_err;
+              auth_request_set $auth_resp_failcount $upstream_http_x_vouch_failcount;
+            '';
+          };
+        };
+      }) cfg.clients
+    );
+
+  };
+}

--- a/nixos/modules/services/security/vouch-proxy.nix
+++ b/nixos/modules/services/security/vouch-proxy.nix
@@ -177,7 +177,7 @@ in
     users.groups."${cfg.group}" = { };
 
     systemd.services = lib.mapAttrs' (client: clientAttrs: {
-      name = "${client}";
+      name = "vouch-${client}";
       value = {
         description = "Vouch Proxy for ${client}.";
         after = [ "network.target" ];

--- a/nixos/modules/services/security/vouch-proxy.nix
+++ b/nixos/modules/services/security/vouch-proxy.nix
@@ -62,7 +62,7 @@ in
               description = ''
                 Environment file as defined in {manpage}`systemd.exec(5)`.
 
-                The environment variables definid therein are passed to the vouch-proxy instance protecting this client.
+                The environment variables defined therein are passed to the vouch-proxy instance protecting this client.
                 You can use environment variables to pass secrets to the service without adding
                 them to the world-redable nix store.
               '';

--- a/nixos/modules/services/security/vouch-proxy.nix
+++ b/nixos/modules/services/security/vouch-proxy.nix
@@ -77,7 +77,19 @@ in
               '';
               type = lib.types.submodule {
                 freeformType = yaml.type;
-                options = { };
+                options = {
+                  vouch = {
+                    domains = lib.mkOption {
+                      default = [ ];
+                      type = lib.types.listOf lib.types.str;
+                      description = ''
+                        Explicit list of domains protected by this vouch-proxy instance. Each $domain in this list must serve the url `https://vouch.$domain`.
+
+                        If left empty, anyone who can authenticate with the configured provider will be accepted.
+                      '';
+                    };
+                  };
+                };
               };
             };
           };
@@ -119,18 +131,6 @@ in
               type = lib.types.str;
               description = "The location within every client's host where its corresponding vouch-proxy is served.";
             };
-            allowAllUsers = lib.mkOption {
-              default = cfg.settings.vouch.domains == null;
-              type = lib.types.bool;
-              description = "Accept anyone who can authenticate at the configured provider. This is the fallback if no granular configuration is defined in `services.vouch-proxy.settings.vouch.domains`.";
-            };
-            domains = lib.mkOption {
-              default = null;
-              type = lib.types.nullOr (lib.types.listOf lib.types.str);
-              description = ''
-                List of domains protected by vouch-proxy. Each $domain in this list must serve the url `https://vouch.$domain`.
-              '';
-            };
           };
           oauth = {
             provider = lib.mkOption {
@@ -171,7 +171,7 @@ in
     };
     users.groups."${cfg.group}" = { };
 
-    systemd.services = lib.mapAttrs' (client: clientAttrs: {
+    systemd.services = lib.mapAttrs' (client: clientConfig: {
       name = "vouch-${client}";
       value = {
         description = "Vouch Proxy for ${client}.";
@@ -183,19 +183,20 @@ in
           DynamicUser = true;
           User = cfg.user;
           Group = cfg.group;
-          EnvironmentFile = clientAttrs.environmentFile;
+          EnvironmentFile = clientConfig.environmentFile;
           ExecStart = "${cfg.package}/bin/vouch-proxy -config ${
             yaml.generate "config.yml" (
               lib.recursiveUpdate (lib.recursiveUpdate cfg.settings {
                 vouch = {
-                  port = clientAttrs.port;
+                  port = clientConfig.port;
                 }
-                // (lib.optionalAttrs cfg.settings.vouch.allowAllUsers {
-                  cookie.domain = clientAttrs.domain;
+                // (lib.optionalAttrs (clientConfig.settings.vouch.domains == [ ]) {
+                  allowAllUsers = true;
+                  cookie.domain = clientConfig.domain;
                 });
                 oauth = {
                   client_id = "${client}";
-                  callback_url = "https://${clientAttrs.domain}${cfg.settings.vouch.document_root}/auth";
+                  callback_url = "https://${clientConfig.domain}${cfg.settings.vouch.document_root}/auth";
                 }
                 // (lib.optionalAttrs (cfg.kanidmDomain != null) {
                   auth_url = "https://${cfg.kanidmDomain}/ui/oauth2";
@@ -249,14 +250,14 @@ in
     }) cfg.clients;
 
     services.nginx.virtualHosts = lib.mkIf cfg.configureNginx (
-      lib.mapAttrs' (_: clientAttrs: {
-        name = clientAttrs.domain;
+      lib.mapAttrs' (_: clientConfig: {
+        name = clientConfig.domain;
         value = {
           extraConfig = ''
             error_page 401 = @error401;
           '';
           locations."@error401".return = ''
-            302 https://${clientAttrs.domain}${cfg.settings.vouch.document_root}/login?url=$scheme://$http_host$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err
+            302 https://${clientConfig.domain}${cfg.settings.vouch.document_root}/login?url=$scheme://$http_host$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err
           '';
 
           locations."/".extraConfig = ''
@@ -264,7 +265,7 @@ in
           '';
 
           locations."${cfg.settings.vouch.document_root}" = {
-            proxyPass = "http://[::1]:${builtins.toString clientAttrs.port}";
+            proxyPass = "http://[::1]:${builtins.toString clientConfig.port}";
             extraConfig = ''
               proxy_set_header X-Forwarded-Host $host;
               proxy_pass_request_body off;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Another attempt at a module for https://github.com/vouch/vouch-proxy. Should address https://github.com/NixOS/nixpkgs/pull/299381#issuecomment-2030991986.

The module is intended to run one instance of vouch-proxy per domain/app to be protected (that is, per entry in `services.vouch-proxy.clients`), as oauth2 clients should not be shared between applications. By default, it configures every nginx virtualHost matched by a `services.vouch-proxy.clients.<name>.domain` to use vouch-proxy.

Minimal working example below, where everything runs on the same host. 
`services.nginx.virtualHosts.myAppDomain1` and `services.nginx.virtualHosts.myAppDomain2` are already defined as they would be without vouch-proxy, and with the clients `myoauthclient1` and `myoauthclient2` configured for vouch-proxy in the oauth2 provider.
This example uses kanidm, which the module takes care of (for every client) on vouch-proxy's side if `kanidmUrl` is set. 
For other oauth2 providers, the correct `auth_url`, `token_url` and `user_info_url` need to be set either globally, under `services.vouch-proxy.settings.oauth`,  or, if required (as is with kanidm for `user_info_url`), per client under `services.vouch-proxy.clients.<name>.settings.oauth`.

```
  services.vouch-proxy = {
    enable = true;
    kanidmUrl = config.services.kanidm.server.settings.domain;
  };

  services.vouch-proxy.clients = {
    myoauthclient1 = {
      port = 12345;
      domain = "myAppDomain1";
      environmentFile = "./myApp1.env"; # this file should contain `VOUCH_JWT_SECRET` and `OAUTH_CLIENT_SECRET`
    };
    myoauthclient2 = {
      port = 23456;
      domain = "myAppDomain2";
      environmentFile = "./myApp2.env";
    };
  };
```



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
