### PR TITLE
python3Packages.pytest-mpl: 0.18.0 -> 0.19.0

### DIFF
--- a/pkgs/development/python-modules/pytest-mpl/default.nix
+++ b/pkgs/development/python-modules/pytest-mpl/default.nix
@@ -12,16 +12,16 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pytest-mpl";
-  version = "0.18.0";
+  version = "0.19.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "matplotlib";
     repo = "pytest-mpl";
-    tag = "v${version}";
-    hash = "sha256-9fMhVgeEL4bjNIegmJV7lisrdzp27h0syn9pMwzX4Gg=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-qSOGGq2lOikm3kwZmGI1hFkuPU+zuh0iGL9TbH6ktEQ=";
   };
 
   build-system = [
@@ -43,6 +43,10 @@ buildPythonPackage rec {
   disabledTestPaths = [
     # Following are broken since at least a1548780dbc79d76360580691dc1bb4af4e837f6
     "tests/subtests/test_subtest.py"
+    # https://github.com/matplotlib/pytest-mpl/issues/263
+    "tests/test_baseline_path.py::test_config"
+    "tests/test_results_always.py::test_config"
+    "tests/test_use_full_test_name.py::test_config"
   ];
 
   # need to set MPLBACKEND=agg for headless matplotlib for darwin
@@ -59,9 +63,10 @@ buildPythonPackage rec {
   '';
 
   meta = {
+    changelog = "https://github.com/matplotlib/pytest-mpl/blob/${finalAttrs.src.tag}/CHANGES.md";
     description = "Pytest plugin to help with testing figures output from Matplotlib";
     homepage = "https://github.com/matplotlib/pytest-mpl";
     license = lib.licenses.bsd3;
     maintainers = [ ];
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/matplotlib/pytest-mpl/compare/v0.18.0...v0.19.0

Changelog: https://github.com/matplotlib/pytest-mpl/releases/tag/v0.19.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
