### PR TITLE
appimageTools: allow `override` and `overrideAppImage`

### DIFF
--- a/pkgs/build-support/appimage/default.nix
+++ b/pkgs/build-support/appimage/default.nix
@@ -83,22 +83,26 @@ rec {
     args@{
       src,
       extraPkgs ? pkgs: [ ],
+      extraInstallCommands ? "",
       ...
     }:
+    let
+      appimageContents = extract (
+        lib.filterAttrs (
+          key: value:
+          builtins.elem key [
+            "pname"
+            "version"
+            "src"
+          ]
+        ) args
+      );
+    in
     wrapAppImage (
       args
       // {
         inherit extraPkgs;
-        src = extract (
-          lib.filterAttrs (
-            key: value:
-            builtins.elem key [
-              "pname"
-              "version"
-              "src"
-            ]
-          ) args
-        );
+        src = appimageContents;
 
         # passthru src to make nix-update work
         # hack to keep the origin position (unsafeGetAttrPos)
@@ -109,9 +113,14 @@ rec {
             (removeAttrs args)
           ]
           // {
+            inherit appimageContents;
             overrideAppImage = f: wrapType2 (args // (if lib.isFunction f then f args else f));
           }
           // args.passthru or { };
+      }
+      // lib.optionalAttrs (args ? extraInstallCommands) {
+        extraInstallCommands =
+          lib.toShellVar "appimageContents" appimageContents + "\n" + extraInstallCommands;
       }
     )
   );

--- a/pkgs/build-support/appimage/default.nix
+++ b/pkgs/build-support/appimage/default.nix
@@ -79,7 +79,7 @@ rec {
       // (removeAttrs args (builtins.attrNames (builtins.functionArgs wrapAppImage)))
     );
 
-  wrapType2 =
+  wrapType2 = lib.makeOverridable (
     args@{
       src,
       extraPkgs ? pkgs: [ ],
@@ -108,9 +108,13 @@ rec {
             (lib.remove "src")
             (removeAttrs args)
           ]
+          // {
+            overrideAppImage = f: wrapType2 (args // (if lib.isFunction f then f args else f));
+          }
           // args.passthru or { };
       }
-    );
+    )
+  );
 
   defaultFhsEnvArgs = {
     # Most of the packages were taken from the Steam chroot

--- a/pkgs/by-name/os/osu-lazer-bin/package.nix
+++ b/pkgs/by-name/os/osu-lazer-bin/package.nix
@@ -95,21 +95,17 @@ else
       "--ro-bind-try /etc/egl/egl_external_platform.d /etc/egl/egl_external_platform.d"
     ];
 
-    extraInstallCommands =
-      let
-        contents = appimageTools.extract { inherit pname version src; };
-      in
-      ''
-        . ${makeWrapper}/nix-support/setup-hook
-        mv -v $out/bin/${pname} $out/bin/osu!
+    extraInstallCommands = ''
+      . ${makeWrapper}/nix-support/setup-hook
+      mv -v $out/bin/${pname} $out/bin/osu!
 
-        wrapProgram $out/bin/osu! \
-          ${lib.optionalString nativeWayland "--set SDL_VIDEODRIVER wayland"} \
-          --set OSU_EXTERNAL_UPDATE_PROVIDER 1
+      wrapProgram $out/bin/osu! \
+        ${lib.optionalString nativeWayland "--set SDL_VIDEODRIVER wayland"} \
+        --set OSU_EXTERNAL_UPDATE_PROVIDER 1
 
-        install -m 444 -D ${contents}/osu!.desktop -t $out/share/applications
-        for i in 16 32 48 64 96 128 256 512 1024; do
-          install -D ${contents}/osu.png $out/share/icons/hicolor/''${i}x$i/apps/osu.png
-        done
-      '';
+      install -m 444 -D $appimageContents/osu!.desktop -t $out/share/applications
+      for i in 16 32 48 64 96 128 256 512 1024; do
+        install -D $appimageContents/osu.png $out/share/icons/hicolor/''${i}x$i/apps/osu.png
+      done
+    '';
   }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

closes https://github.com/nixos/nixpkgs/issues/345717

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
