### PR TITLE
[staging-next] systemd: fix build on musl

### DIFF
--- a/pkgs/by-name/mu/musl/package.nix
+++ b/pkgs/by-name/mu/musl/package.nix
@@ -98,6 +98,14 @@ stdenv.mkDerivation (finalAttrs: {
     # drop next release
     # https://git.musl-libc.org/cgit/musl/commit/?id=fde29c04adbab9d5b081bf6717b5458188647f1c
     ./stdio-skip-empty-iovec-when-buffering-is-disabled.patch
+    # Backport addition of statx fields needed by systemd
+    ./statx.patch
+    # Backport addition of statx attrs needed by systemd
+    ./statx-attr.patch
+    # Backport even more statx stuff for systemd
+    ./statx-linux-6.11.patch
+    # Backport addition of renameat2 syscall wrapper needed by systemd
+    ./renameat2.patch
   ];
 
   env = {

--- a/pkgs/by-name/mu/musl/renameat2.patch
+++ b/pkgs/by-name/mu/musl/renameat2.patch
@@ -1,0 +1,55 @@
+From 05ce67fea99ca09cd4b6625cff7aec9cc222dd5a Mon Sep 17 00:00:00 2001
+From: Tony Ambardar <tony.ambardar@gmail.com>
+Date: Mon, 6 May 2024 20:28:32 -0700
+Subject: add renameat2 linux syscall wrapper
+
+This syscall is available since Linux 3.15 and also implemented in
+glibc from version 2.28. It is commonly used in filesystem or security
+contexts.
+
+Constants RENAME_NOREPLACE, RENAME_EXCHANGE, RENAME_WHITEOUT are
+guarded by _GNU_SOURCE as with glibc.
+---
+ include/stdio.h       |  7 +++++++
+ src/linux/renameat2.c | 11 +++++++++++
+ 2 files changed, 18 insertions(+)
+ create mode 100644 src/linux/renameat2.c
+
+diff --git a/include/stdio.h b/include/stdio.h
+index cb858618..4ea4c170 100644
+--- a/include/stdio.h
++++ b/include/stdio.h
+@@ -158,6 +158,13 @@ char *ctermid(char *);
+ #define L_ctermid 20
+ #endif
+ 
++#if defined(_GNU_SOURCE)
++#define RENAME_NOREPLACE (1 << 0)
++#define RENAME_EXCHANGE  (1 << 1)
++#define RENAME_WHITEOUT  (1 << 2)
++
++int renameat2(int, const char *, int, const char *, unsigned);
++#endif
+ 
+ #if defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) \
+  || defined(_BSD_SOURCE)
+diff --git a/src/linux/renameat2.c b/src/linux/renameat2.c
+new file mode 100644
+index 00000000..b8060388
+--- /dev/null
++++ b/src/linux/renameat2.c
+@@ -0,0 +1,11 @@
++#define _GNU_SOURCE
++#include <stdio.h>
++#include "syscall.h"
++
++int renameat2(int oldfd, const char *old, int newfd, const char *new, unsigned flags)
++{
++#ifdef SYS_renameat
++	if (!flags) return syscall(SYS_renameat, oldfd, old, newfd, new);
++#endif
++	return syscall(SYS_renameat2, oldfd, old, newfd, new, flags);
++}
+-- 
+cgit v1.2.1
+

--- a/pkgs/by-name/mu/musl/statx-attr.patch
+++ b/pkgs/by-name/mu/musl/statx-attr.patch
@@ -1,0 +1,35 @@
+From cbf1c7b605d979bb7fdde8b8e6a66acdba18c6b0 Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Wed, 24 Apr 2024 13:26:03 -0400
+Subject: add missing STATX_ATTR_* macros omitted when statx was added
+
+commit b817541f1cfd38e4b81257b3215e276ea9d0fc61 added statx and the
+mask constant macros, but not the stx_attributes[_mask] ones.
+---
+ include/sys/stat.h | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/include/sys/stat.h b/include/sys/stat.h
+index 6690192d..57d640d7 100644
+--- a/include/sys/stat.h
++++ b/include/sys/stat.h
+@@ -121,6 +121,16 @@ int lchmod(const char *, mode_t);
+ #define STATX_BTIME 0x800U
+ #define STATX_ALL 0xfffU
+ 
++#define STATX_ATTR_COMPRESSED 0x4
++#define STATX_ATTR_IMMUTABLE 0x10
++#define STATX_ATTR_APPEND 0x20
++#define STATX_ATTR_NODUMP 0x40
++#define STATX_ATTR_ENCRYPTED 0x800
++#define STATX_ATTR_AUTOMOUNT 0x1000
++#define STATX_ATTR_MOUNT_ROOT 0x2000
++#define STATX_ATTR_VERITY 0x100000
++#define STATX_ATTR_DAX 0x200000
++
+ struct statx_timestamp {
+ 	int64_t tv_sec;
+ 	uint32_t tv_nsec, __pad;
+-- 
+cgit v1.2.1
+

--- a/pkgs/by-name/mu/musl/statx-linux-6.11.patch
+++ b/pkgs/by-name/mu/musl/statx-linux-6.11.patch
@@ -1,0 +1,49 @@
+From fcdff46a3203400e08a2264c34b3c7fb62bf6969 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=2E=20Neusch=C3=A4fer?= <j.neuschaefer@gmx.net>
+Date: Thu, 24 Oct 2024 01:19:30 +0200
+Subject: statx: add Linux 6.11 fields/constants
+
+As of Linux 6.11, these fields and mask macros have been added to
+include/uapi/linux/stat.h.
+---
+ include/sys/stat.h | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/include/sys/stat.h b/include/sys/stat.h
+index c924ce2f..4f7dc2b1 100644
+--- a/include/sys/stat.h
++++ b/include/sys/stat.h
+@@ -123,6 +123,8 @@ int lchmod(const char *, mode_t);
+ #define STATX_MNT_ID 0x1000U
+ #define STATX_DIOALIGN 0x2000U
+ #define STATX_MNT_ID_UNIQUE 0x4000U
++#define STATX_SUBVOL 0x8000U
++#define STATX_WRITE_ATOMIC 0x10000U
+ 
+ #define STATX_ATTR_COMPRESSED 0x4
+ #define STATX_ATTR_IMMUTABLE 0x10
+@@ -133,6 +135,7 @@ int lchmod(const char *, mode_t);
+ #define STATX_ATTR_MOUNT_ROOT 0x2000
+ #define STATX_ATTR_VERITY 0x100000
+ #define STATX_ATTR_DAX 0x200000
++#define STATX_ATTR_WRITE_ATOMIC 0x400000
+ 
+ struct statx_timestamp {
+ 	int64_t tv_sec;
+@@ -164,7 +167,12 @@ struct statx {
+ 	uint32_t stx_dio_mem_align;
+ 	uint32_t stx_dio_offset_align;
+ 	uint64_t stx_subvol;
+-	uint64_t __pad1[11];
++	uint32_t stx_atomic_write_unit_min;
++	uint32_t stx_atomic_write_unit_max;
++	uint32_t stx_atomic_write_segments_max;
++	uint32_t __pad1[1];
++	uint64_t __pad2[9];
++
+ };
+ 
+ int statx(int, const char *__restrict, int, unsigned, struct statx *__restrict);
+-- 
+cgit v1.2.1
+

--- a/pkgs/by-name/mu/musl/statx.patch
+++ b/pkgs/by-name/mu/musl/statx.patch
@@ -1,0 +1,39 @@
+From 23ab04a8630225371455d5f4538fd078665bb646 Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Fri, 13 Sep 2024 17:21:17 -0400
+Subject: statx: add new struct statx fields and corresponding mask macros
+
+---
+ include/sys/stat.h | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/include/sys/stat.h b/include/sys/stat.h
+index 57d640d7..0c10dc21 100644
+--- a/include/sys/stat.h
++++ b/include/sys/stat.h
+@@ -120,6 +120,9 @@ int lchmod(const char *, mode_t);
+ #define STATX_BASIC_STATS 0x7ffU
+ #define STATX_BTIME 0x800U
+ #define STATX_ALL 0xfffU
++#define STATX_MNT_ID 0x1000U
++#define STATX_DIOALIGN 0x2000U
++#define STATX_MNT_ID_UNIQUE 0x4000U
+ 
+ #define STATX_ATTR_COMPRESSED 0x4
+ #define STATX_ATTR_IMMUTABLE 0x10
+@@ -157,7 +160,11 @@ struct statx {
+ 	uint32_t stx_rdev_minor;
+ 	uint32_t stx_dev_major;
+ 	uint32_t stx_dev_minor;
+-	uint64_t __pad1[14];
++	uint64_t stx_mnt_id;
++	uint32_t stx_dio_mem_align;
++	uint32_t stx_dio_offet_align;
++	uint64_t stx_subvol;
++	uint64_t __pad1[11];
+ };
+ 
+ int statx(int, const char *__restrict, int, unsigned, struct statx *__restrict);
+-- 
+cgit v1.2.1
+

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -319,7 +319,14 @@ stdenv.mkDerivation (finalAttrs: {
     buildPackages.llvmPackages.libllvm
   ];
 
-  autoPatchelfFlags = [ "--keep-libc" ];
+  autoPatchelfFlags = [
+    "--keep-libc"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isMusl [
+    # TODO: can be unconditionalized on staging.
+    # Nixpkgs does not rely on gettext for libintl for musl.
+    "--ignore-missing=libintl.so.8"
+  ];
 
   buildInputs = [
     libxcrypt

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -34,6 +34,7 @@
   acl,
   lz4,
   openssl,
+  libucontext,
   libgcrypt,
   libidn2,
   curl,
@@ -325,7 +326,9 @@ stdenv.mkDerivation (finalAttrs: {
     libuuid
     linuxHeaders
   ]
-
+  ++ lib.optionals stdenv.hostPlatform.isMusl [
+    libucontext
+  ]
   ++ lib.optionals withGcrypt [
     libgcrypt
   ]


### PR DESCRIPTION
- Backports some musl API additions that are now needed by systemd.  I'll try to upgrade musl next cycle, but it won't make it for this one.
- Adds new musl-only libucontext dependency
- Doesn't try to patchelf libintl.so.8, since in Nixpkgs the necessary functionality is part of musl.  (They seem to be assuming Alpine behaviour where they don't use this part of musl and instead use gettext.)  (Have brought this up upstream so we can figure out the proper fix.)

~I've only built to pkgsMusl.systemdMinimal so far.  Hopefully there's not even more…~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
