### PR TITLE
dragonflydb: 1.34.2 -> 1.39.0

### DIFF
--- a/pkgs/by-name/dr/dragonflydb/external-libs.patch
+++ b/pkgs/by-name/dr/dragonflydb/external-libs.patch
@@ -1,5 +1,5 @@
 diff --git a/src/external_libs.cmake b/src/external_libs.cmake
-index 62e6e879..8934777f 100644
+index 5a98540..1c5ab6d 100644
 --- a/src/external_libs.cmake
 +++ b/src/external_libs.cmake
 @@ -1,7 +1,6 @@
@@ -11,11 +11,13 @@ index 62e6e879..8934777f 100644
    CONFIGURE_COMMAND echo
    BUILD_IN_SOURCE 1
    BUILD_COMMAND ${DFLY_TOOLS_MAKE} all
-@@ -19,18 +18,16 @@ endif()
+@@ -19,20 +18,16 @@ endif()
  
  add_third_party(
    dconv
--  URL https://github.com/google/double-conversion/archive/refs/tags/v3.3.0.tar.gz
+-  GIT_REPOSITORY https://github.com/google/double-conversion
+-  # URL https://github.com/google/double-conversion/archive/refs/tags/v3.3.1.tar.gz
+-  GIT_TAG 0604b4c
 -  PATCH_COMMAND ${SED_REPL} "/static const std::ctype/d"
 -                <SOURCE_DIR>/double-conversion/string-to-double.cc
 -  COMMAND ${SED_REPL} "/std::use_facet</d" <SOURCE_DIR>/double-conversion/string-to-double.cc
@@ -35,12 +37,12 @@ index 62e6e879..8934777f 100644
    CONFIGURE_COMMAND <SOURCE_DIR>/configure --disable-avx2 --prefix=${THIRD_PARTY_LIB_DIR}/reflex
            CXX=${CMAKE_CXX_COMPILER} CC=${CMAKE_C_COMPILER}
  )
-@@ -41,16 +38,14 @@ set(REFLEX "${THIRD_PARTY_LIB_DIR}/reflex/bin/reflex")
+@@ -41,16 +36,14 @@ set(REFLEX "${THIRD_PARTY_LIB_DIR}/reflex/bin/reflex")
  
  add_third_party(
    jsoncons
 -  GIT_REPOSITORY https://github.com/dragonflydb/jsoncons
--  GIT_TAG Dragonfly.178
+-  GIT_TAG Dragonfly1.5.0
 -  GIT_SHALLOW 1
 +  DOWNLOAD_COMMAND cp -r ${CMAKE_BINARY_DIR}/deps-nixpkgs/jsoncons/. <SOURCE_DIR>
    CMAKE_PASS_FLAGS "-DJSONCONS_BUILD_TESTS=OFF -DJSONCONS_HAS_POLYMORPHIC_ALLOCATOR=ON"
@@ -54,7 +56,7 @@ index 62e6e879..8934777f 100644
  
    BUILD_IN_SOURCE 1
    CONFIGURE_COMMAND echo skip
-@@ -65,7 +60,7 @@ set(MIMALLOC_C_FLAGS "-O3 -g -DMI_STAT=1 -DNDEBUG")
+@@ -65,7 +58,7 @@ set(MIMALLOC_C_FLAGS "-O3 -g -DMI_STAT=1 -DNDEBUG")
  file(MAKE_DIRECTORY ${MIMALLOC_INCLUDE_DIR})
  
  ExternalProject_Add(mimalloc2_project
@@ -63,7 +65,7 @@ index 62e6e879..8934777f 100644
    DOWNLOAD_DIR ${THIRD_PARTY_DIR}/mimalloc2
    SOURCE_DIR ${THIRD_PARTY_DIR}/mimalloc2
    # INSTALL_DIR ${MIMALLOC_ROOT_DIR}
-@@ -118,21 +113,21 @@ set_target_properties(TRDP::mimalloc2 PROPERTIES IMPORTED_LOCATION ${MIMALLOC_RO
+@@ -119,23 +112,21 @@ set_target_properties(TRDP::mimalloc2 PROPERTIES IMPORTED_LOCATION ${MIMALLOC_RO
  
  add_third_party(
    croncpp
@@ -78,17 +80,28 @@ index 62e6e879..8934777f 100644
 -    URL https://github.com/uni-algo/uni-algo/archive/refs/tags/v1.0.0.tar.gz
 +    DOWNLOAD_COMMAND cp -r ${CMAKE_BINARY_DIR}/deps-nixpkgs/uni-algo/. <SOURCE_DIR>
  
-     CMAKE_PASS_FLAGS "-DCMAKE_CXX_STANDARD:STRING=17"
+     CMAKE_PASS_FLAGS "-DCMAKE_CXX_STANDARD:STRING=20"
    )
  
    add_third_party(
      hnswlib
--    URL https://github.com/nmslib/hnswlib/archive/refs/tags/v0.7.0.tar.gz
+-    GIT_REPOSITORY https://github.com/dragonflydb/hnswlib.git
+-    # HEAD of dragonfly branch
+-    GIT_TAG d07dd1da2bf48b85d2f03b8396193ad7120f75c2
 +    DOWNLOAD_COMMAND cp -r ${CMAKE_BINARY_DIR}/deps-nixpkgs/hnswlib/. <SOURCE_DIR>
  
      BUILD_COMMAND echo SKIP
      INSTALL_COMMAND cp -R <SOURCE_DIR>/hnswlib ${THIRD_PARTY_LIB_DIR}/hnswlib/include/
-@@ -142,21 +137,20 @@ endif()
+@@ -145,7 +136,7 @@ if (WITH_SEARCH)
+   # No autoconf/cmake/install in upstream Makefile; manual install copy.
+   add_third_party(
+     stemmer
+-    URL https://github.com/snowballstem/snowball/archive/refs/tags/v3.0.1.tar.gz
++    DOWNLOAD_COMMAND cp -r ${CMAKE_BINARY_DIR}/deps-nixpkgs/stemmer/. <SOURCE_DIR>
+     BUILD_IN_SOURCE 1
+     CONFIGURE_COMMAND echo skip
+     BUILD_COMMAND ${DFLY_TOOLS_MAKE} -j4 CFLAGS=-O3\ -fPIC libstemmer.a
+@@ -159,21 +150,20 @@ endif()
  
  add_third_party(
    fast_float

--- a/pkgs/by-name/dr/dragonflydb/helio-third-party.patch
+++ b/pkgs/by-name/dr/dragonflydb/helio-third-party.patch
@@ -1,35 +1,52 @@
 diff --git a/helio/cmake/third_party.cmake b/helio/cmake/third_party.cmake
-index 810a8fa..8b11922 100644
+index 6cad93a..409e45f 100644
 --- a/helio/cmake/third_party.cmake
 +++ b/helio/cmake/third_party.cmake
-@@ -151,7 +151,7 @@ endfunction()
+@@ -189,24 +189,9 @@ function(download_and_validate url file out_status)
+   set(${out_status} "${st}" PARENT_SCOPE)
+ endfunction()
  
+-if(NOT EXISTS "${GTEST_TARBALL}")
+-  download_and_validate("${GTEST_RELEASE_URL}" "${GTEST_TARBALL}" st1)
+-  list(GET st1 0 rc1)
+-  if(NOT rc1 EQUAL 0)
+-    file(REMOVE "${GTEST_TARBALL}")
+-    message(STATUS "Primary download failed: ${st1}. Trying archive URL...")
+-    download_and_validate("${GTEST_ARCHIVE_URL}" "${GTEST_TARBALL}" st2)
+-    list(GET st2 0 rc2)
+-    if(NOT rc2 EQUAL 0)
+-      file(REMOVE "${GTEST_TARBALL}")
+-      message(FATAL_ERROR "Failed to download googletest.\nRelease: ${st1}\nArchive: ${st2}")
+-    endif()
+-  endif()
+-endif()
+-
  FetchContent_Declare(
    gtest
--  URL https://github.com/google/googletest/archive/v1.15.2.tar.gz
+-  URL "${GTEST_TARBALL}"
 +  DOWNLOAD_COMMAND true
  )
  
  FetchContent_GetProperties(gtest)
-@@ -162,7 +162,7 @@ endif ()
+@@ -217,7 +202,7 @@ endif ()
  
  FetchContent_Declare(
    benchmark
--  URL https://github.com/google/benchmark/archive/v1.9.1.tar.gz
+-  URL https://github.com/google/benchmark/archive/v1.9.5.tar.gz
 +  DOWNLOAD_COMMAND true
  )
  
  FetchContent_GetProperties(benchmark)
-@@ -181,7 +181,7 @@ endif ()
+@@ -236,7 +221,7 @@ endif ()
  
  FetchContent_Declare(
    abseil_cpp
 -  URL https://github.com/abseil/abseil-cpp/releases/download/20250512.1/abseil-cpp-20250512.1.tar.gz
 +  DOWNLOAD_COMMAND true
    PATCH_COMMAND patch -p1 < "${CMAKE_CURRENT_LIST_DIR}/../patches/abseil-20250512.1.patch"
+   COMMAND patch -p1 < "${CMAKE_CURRENT_LIST_DIR}/../patches/abseil-gcc-undefined-sanitizer-compilation-fix.patch"
  )
- 
-@@ -204,11 +204,7 @@ if (LEGACY_GLOG)
+@@ -263,11 +248,7 @@ if (LEGACY_GLOG)
  
    FetchContent_Declare(
      glog
@@ -42,36 +59,16 @@ index 810a8fa..8b11922 100644
    )
  
    FetchContent_GetProperties(glog)
-@@ -278,7 +274,7 @@ if (WITH_GPERF)
+@@ -337,7 +318,7 @@ if (WITH_GPERF)
  
    add_third_party(
      gperf
--    URL https://github.com/gperftools/gperftools/archive/gperftools-2.16.tar.gz
+-    URL https://github.com/gperftools/gperftools/archive/gperftools-2.18.1.tar.gz
 +    DOWNLOAD_COMMAND cp -r ${CMAKE_CURRENT_BINARY_DIR}/deps-nixpkgs/gperf/. <SOURCE_DIR>
  
      # GIT_SHALLOW TRUE
      # Remove building the unneeded programs (they fail on macos)
-@@ -312,9 +308,7 @@ set(MIMALLOC_INCLUDE_DIR ${THIRD_PARTY_LIB_DIR}/mimalloc/include)
- set (MIMALLOC_PATCH_COMMAND patch -p1 -d ${THIRD_PARTY_DIR}/mimalloc/ -i ${CMAKE_CURRENT_LIST_DIR}/../patches/mimalloc-v2.1.6.patch)
- 
- add_third_party(mimalloc
--   #GIT_REPOSITORY https://github.com/microsoft/mimalloc.git
--   #GIT_TAG 0f6d8293c74796fa913e4b5eb4361f1e4734f7c6
--   URL https://github.com/microsoft/mimalloc/archive/refs/tags/v2.1.6.tar.gz
-+   DOWNLOAD_COMMAND cp -r ${CMAKE_CURRENT_BINARY_DIR}/deps-nixpkgs/mimalloc216/. <SOURCE_DIR>
-    PATCH_COMMAND "${MIMALLOC_PATCH_COMMAND}"
-    # -DCMAKE_BUILD_TYPE=Release
-    # Add -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS=-O0 to debug
-@@ -328,7 +322,7 @@ add_third_party(mimalloc
- )
- 
- add_third_party(jemalloc
--  URL https://github.com/jemalloc/jemalloc/releases/download/5.2.1/jemalloc-5.2.1.tar.bz2
-+  DOWNLOAD_COMMAND cp -r ${CMAKE_CURRENT_BINARY_DIR}/deps-nixpkgs/jemalloc/. <SOURCE_DIR>
-   PATCH_COMMAND ./autogen.sh
-   CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=${THIRD_PARTY_LIB_DIR}/jemalloc --with-jemalloc-prefix=je_ --disable-libdl
- )
-@@ -336,7 +330,7 @@ add_third_party(jemalloc
+@@ -367,7 +348,7 @@ endif()
  
  add_third_party(
    xxhash
@@ -80,16 +77,16 @@ index 810a8fa..8b11922 100644
  
    # A bug in xxhash 0.8.1 that searches for a file that doesn't exist
    PATCH_COMMAND touch <SOURCE_DIR>/xxhsum.1
-@@ -347,7 +341,7 @@ add_third_party(
+@@ -378,7 +359,7 @@ add_third_party(
  
  add_third_party(
    uring
--  URL https://github.com/axboe/liburing/archive/refs/tags/liburing-2.8.tar.gz
+-  URL https://github.com/axboe/liburing/archive/refs/tags/liburing-2.13.tar.gz
 +  DOWNLOAD_COMMAND cp -r ${CMAKE_CURRENT_BINARY_DIR}/deps-nixpkgs/uring/. <SOURCE_DIR>
  
    CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=${THIRD_PARTY_LIB_DIR}/uring
    BUILD_COMMAND make -C src
-@@ -356,7 +350,7 @@ add_third_party(
+@@ -387,12 +368,12 @@ add_third_party(
  
  add_third_party(
    pugixml
@@ -98,28 +95,35 @@ index 810a8fa..8b11922 100644
  )
  
  if (WITH_AWS)
-@@ -364,9 +358,7 @@ if (WITH_AWS)
+   set (AWS_PATCH_COMMAND patch -p1 -d ${THIRD_PARTY_DIR}/aws/ -i ${CMAKE_CURRENT_LIST_DIR}/../patches/aws-sdk-cpp-1.11.717.patch)
+-  set(AWS_CMAKE_PASS_FLAGS "-DBUILD_ONLY=s3 -DNO_HTTP_CLIENT=ON -DENABLE_TESTING=OFF  -DENABLE_CURL_LOGGING=OFF -DAUTORUN_UNIT_TESTS=OFF -DBUILD_SHARED_LIBS=OFF -DAWS_SDK_WARNINGS_ARE_ERRORS=OFF -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_POLICY_VERSION_MINIMUM=3.5")
++  set(AWS_CMAKE_PASS_FLAGS "-DBUILD_ONLY=s3 -DNO_HTTP_CLIENT=ON -DENABLE_TESTING=OFF  -DENABLE_CURL_LOGGING=OFF -DAUTORUN_UNIT_TESTS=OFF -DBUILD_SHARED_LIBS=OFF -DAWS_SDK_WARNINGS_ARE_ERRORS=OFF -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DENFORCE_SUBMODULE_VERSIONS=OFF")
+ 
+   if (OPENSSL_CRYPTO_LIBRARY AND OPENSSL_INCLUDE_DIR)
+     string(APPEND AWS_CMAKE_PASS_FLAGS " -Dcrypto_LIBRARY=${OPENSSL_CRYPTO_LIBRARY} -Dcrypto_INCLUDE_DIR=${OPENSSL_INCLUDE_DIR}")
+@@ -410,10 +391,7 @@ if (WITH_AWS)
  
    add_third_party(
      aws
 -    GIT_REPOSITORY https://github.com/aws/aws-sdk-cpp.git
--    GIT_TAG 3e51fa016655eeb6b6610bdf8fe7cf33ebbf3e00
+-    GIT_TAG 1.11.717
 -    GIT_SHALLOW TRUE
+-    GIT_CONFIG      submodule.recurse=1 submodule.fetchJobs=10
 +    DOWNLOAD_COMMAND cp -r ${CMAKE_CURRENT_BINARY_DIR}/deps-nixpkgs/aws-sdk-cpp/. <SOURCE_DIR>
      PATCH_COMMAND "${AWS_PATCH_COMMAND}"
-     CMAKE_PASS_FLAGS "-DBUILD_ONLY=s3 -DNO_HTTP_CLIENT=ON -DENABLE_TESTING=OFF  -DAUTORUN_UNIT_TESTS=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+     CMAKE_PASS_FLAGS "${AWS_CMAKE_PASS_FLAGS}"
      LIB libaws-cpp-sdk-s3.a libaws-cpp-sdk-core.a libaws-crt-cpp.a libaws-c-mqtt.a libaws-c-event-stream.a libaws-c-s3.a libaws-c-auth.a  libaws-c-http.a libaws-c-io.a libs2n.a libaws-c-compression.a libaws-c-cal.a libaws-c-sdkutils.a libaws-checksums.a libaws-c-common.a
-@@ -376,8 +368,7 @@ endif()
- if (WITH_GCP)
-   add_third_party(
-     rapidjson
--    GIT_REPOSITORY https://github.com/Tencent/rapidjson.git
--    GIT_TAG ab1842a
-+    DOWNLOAD_COMMAND cp -r ${CMAKE_BINARY_DIR}/deps-nixpkgs/rapidjson/. <SOURCE_DIR>
-     CMAKE_PASS_FLAGS "-DRAPIDJSON_BUILD_TESTS=OFF -DRAPIDJSON_BUILD_EXAMPLES=OFF \
-                       -DRAPIDJSON_BUILD_DOC=OFF -DCMAKE_POLICY_VERSION_MINIMUM=3.5"
-     LIB "none"
-@@ -386,24 +377,23 @@ endif()
+@@ -422,8 +400,7 @@ endif()
+ 
+ add_third_party(
+   rapidjson
+-  GIT_REPOSITORY https://github.com/Tencent/rapidjson.git
+-  GIT_TAG ab1842a
++  DOWNLOAD_COMMAND cp -r ${CMAKE_BINARY_DIR}/deps-nixpkgs/rapidjson/. <SOURCE_DIR>
+   CMAKE_PASS_FLAGS "-DRAPIDJSON_BUILD_TESTS=OFF -DRAPIDJSON_BUILD_EXAMPLES=OFF \
+                     -DRAPIDJSON_BUILD_DOC=OFF -DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+   LIB "none"
+@@ -431,14 +408,14 @@ add_third_party(
  
  add_third_party(
    cares
@@ -134,11 +138,9 @@ index 810a8fa..8b11922 100644
 -  URL https://github.com/facebook/zstd/releases/download/v1.5.7/zstd-1.5.7.tar.zst
 +  DOWNLOAD_COMMAND cp -r ${CMAKE_CURRENT_BINARY_DIR}/deps-nixpkgs/zstd/. <SOURCE_DIR>
    SOURCE_SUBDIR "build/cmake"
--  
-+
+ 
    # for debug pass : "CFLAGS=-fPIC -O0 -ggdb"
-   CMAKE_PASS_FLAGS "-DZSTD_BUILD_SHARED=OFF -DZSTD_BUILD_PROGRAMS=OFF -DZSTD_BUILD_TESTS=OFF"
- )
+@@ -447,8 +424,7 @@ add_third_party(
  
  add_third_party(
    expected

--- a/pkgs/by-name/dr/dragonflydb/package.nix
+++ b/pkgs/by-name/dr/dragonflydb/package.nix
@@ -4,7 +4,6 @@
   stdenv,
 
   # Dependencies
-  abseil-cpp,
   c-ares,
   croncpp,
   double-conversion,
@@ -15,8 +14,6 @@
   gperftools,
   gtest,
   hdrhistogram_c,
-  hnswlib,
-  jemalloc,
   liburing,
   lz4,
   pcre2,
@@ -36,6 +33,7 @@
   cmake,
   gcc-unwrapped,
   ninja,
+  perl,
 
   # Runtime dependencies
   boost,
@@ -57,21 +55,31 @@
 
 let
   pname = "dragonflydb";
-  version = "1.34.2";
+  version = "1.39.0";
 
   src = fetchFromGitHub {
     owner = "dragonflydb";
     repo = "dragonfly";
     tag = "v${version}";
-    hash = "sha256-n70IB32tZDe665hVLrKC0BSSJutmYhtPJvfNa48xaqA=";
+    hash = "sha256-vLuuf3fVdVzcd06bafGiLtION6IwTnspiIJmZF9tUGg=";
     fetchSubmodules = true;
   };
 
-  aws-sdk-cpp-1-11-162 = fetchFromGitHub {
+  # dragonfly's helio applies patches written against this exact abseil
+  # release (see helio/patches/abseil-20250512.1.patch), so it's pinned here
+  # rather than taken from nixpkgs' abseil-cpp, which tracks a newer version.
+  abseil-cpp-20250512 = fetchFromGitHub {
+    owner = "abseil";
+    repo = "abseil-cpp";
+    tag = "20250512.1";
+    hash = "sha256-eB7OqTO9Vwts9nYQ/Mdq0Ds4T1KgmmpYdzU09VPWOhk=";
+  };
+
+  aws-sdk-cpp-1-11-717 = fetchFromGitHub {
     owner = "aws";
     repo = "aws-sdk-cpp";
-    tag = "1.11.162";
-    hash = "sha256-NxVE7H8BOetpbBkB2PTVBoHSXYm6cTp41F1LJmhtBbs=";
+    tag = "1.11.717";
+    hash = "sha256-stDZg9dvKljnbZZUHEn1KmlgDdvW6BK7H7RtGk/nyEI=";
     fetchSubmodules = true;
   };
 
@@ -85,8 +93,17 @@ let
   jsoncons-dragonfly = fetchFromGitHub {
     owner = "dragonflydb";
     repo = "jsoncons";
-    rev = "Dragonfly.178";
-    hash = "sha256-cxM95DFFo5z+eImgZzJw+ykaeSDtBF+hw5qo6gnL53s=";
+    rev = "Dragonfly1.5.0";
+    hash = "sha256-9W9GJpzKuqolXoz5iYiE1EbVWr7HiFqpMgZO1BQdi0s=";
+  };
+
+  # dragonfly's search module uses a fork of hnswlib with custom changes, so
+  # this can't come from nixpkgs' hnswlib (nmslib upstream).
+  hnswlib-dragonfly = fetchFromGitHub {
+    owner = "dragonflydb";
+    repo = "hnswlib";
+    rev = "d07dd1da2bf48b85d2f03b8396193ad7120f75c2";
+    hash = "sha256-GFBjKzDauznGGfkXZqSFgbvBKxDXbx2rETqY5BnCIiw=";
   };
 
   lua-dragonfly = fetchFromGitHub {
@@ -96,18 +113,20 @@ let
     hash = "sha256-uLNe+hLihu4wMW/wstGnYdPa2bGPC5UiNE+VyNIYY2c=";
   };
 
-  mimalloc216 = fetchFromGitHub {
-    owner = "microsoft";
-    repo = "mimalloc";
-    tag = "v2.1.6";
-    hash = "sha256-Ff3+RP+lAXCOeHJ87oG3c02rPP4WQIbg5L/CVe6gA3M=";
-  };
-
   mimalloc224 = fetchFromGitHub {
     owner = "microsoft";
     repo = "mimalloc";
     tag = "v2.2.4";
     hash = "sha256-+8xZT+mVEqlqabQc+1buVH/X6FZxvCd0rWMyjPu9i4o=";
+  };
+
+  # nixpkgs' libstemmer is older than the snowball release dragonfly's search
+  # module builds against, so the source is pinned and built in-tree here.
+  snowball-stemmer = fetchFromGitHub {
+    owner = "snowballstem";
+    repo = "snowball";
+    tag = "v3.0.1";
+    hash = "sha256-QPIPePddUqwpa0YMn0E7H9GZj3s2bEkJzZdXlrHeZbo=";
   };
 
   withUnwind = !stdenv.targetPlatform.isAarch64;
@@ -130,7 +149,7 @@ stdenv.mkDerivation {
 
     # Copy FetchContent dependencies (in helio/cmake/third_party.cmake)
     # These go to build/_deps/ where FetchContent expects them
-    cp -r --no-preserve=mode,ownership ${abseil-cpp.src} build/_deps/abseil_cpp-src
+    cp -r --no-preserve=mode,ownership ${abseil-cpp-20250512} build/_deps/abseil_cpp-src
     cp -r --no-preserve=mode,ownership ${gbenchmark.src} build/_deps/benchmark-src
     cp -r --no-preserve=mode,ownership ${glog-absl} build/_deps/glog-src
     cp -r --no-preserve=mode,ownership ${gtest.src} build/_deps/gtest-src
@@ -142,13 +161,12 @@ stdenv.mkDerivation {
     cp -r --no-preserve=mode,ownership ${fast-float.src} build/deps-nixpkgs/fast_float
     cp -r --no-preserve=mode,ownership ${flatbuffers_23.src} build/deps-nixpkgs/flatbuffers
     cp -r --no-preserve=mode,ownership ${hdrhistogram_c.src} build/deps-nixpkgs/hdr_histogram
-    cp -r --no-preserve=mode,ownership ${jemalloc.src} build/deps-nixpkgs/jemalloc
     cp -r --no-preserve=mode,ownership ${jsoncons-dragonfly} build/deps-nixpkgs/jsoncons
     cp -r --no-preserve=mode,ownership ${liburing.src} build/deps-nixpkgs/uring
     cp -r --no-preserve=mode,ownership ${lua-dragonfly} build/deps-nixpkgs/lua
     cp -r --no-preserve=mode,ownership ${lz4.src} build/deps-nixpkgs/lz4
-    cp -r --no-preserve=mode,ownership ${mimalloc216} build/deps-nixpkgs/mimalloc216
     cp -r --no-preserve=mode,ownership ${mimalloc224} build/deps-nixpkgs/mimalloc224
+    cp -r --no-preserve=mode,ownership ${rapidjson.src} build/deps-nixpkgs/rapidjson
     cp -r --no-preserve=mode,ownership ${pugixml.src} build/deps-nixpkgs/pugixml
     cp -r --no-preserve=mode,ownership ${re-flex.src} build/deps-nixpkgs/reflex
     cp -r --no-preserve=mode,ownership ${xxhash.src} build/deps-nixpkgs/xxhash
@@ -161,16 +179,7 @@ stdenv.mkDerivation {
     ${
       if withAws then
         ''
-          cp -r --no-preserve=mode,ownership ${aws-sdk-cpp-1-11-162} build/deps-nixpkgs/aws-sdk-cpp
-        ''
-      else
-        ""
-    }
-
-    ${
-      if withGcp then
-        ''
-          cp -r --no-preserve=mode,ownership ${rapidjson.src} build/deps-nixpkgs/rapidjson
+          cp -r --no-preserve=mode,ownership ${aws-sdk-cpp-1-11-717} build/deps-nixpkgs/aws-sdk-cpp
         ''
       else
         ""
@@ -188,7 +197,8 @@ stdenv.mkDerivation {
     ${
       if withSearch then
         ''
-          cp -r --no-preserve=mode,ownership ${hnswlib.src} build/deps-nixpkgs/hnswlib
+          cp -r --no-preserve=mode,ownership ${hnswlib-dragonfly} build/deps-nixpkgs/hnswlib
+          cp -r --no-preserve=mode,ownership ${snowball-stemmer} build/deps-nixpkgs/stemmer
           cp -r --no-preserve=mode,ownership ${uni-algo.src} build/deps-nixpkgs/uni-algo
         ''
       else
@@ -200,6 +210,14 @@ stdenv.mkDerivation {
     chmod u+x build/deps-nixpkgs/reflex/configure
     chmod u+x build/deps-nixpkgs/uring/configure
     touch build/deps-nixpkgs/xxhash/xxhsum.1
+
+    # snowball generates its C sources with perl scripts run via their shebang;
+    # the source copy drops their execute bit, so restore it and fix the
+    # /usr/bin/env shebang for the sandbox.
+    if [ -d build/deps-nixpkgs/stemmer ]; then
+      find build/deps-nixpkgs/stemmer -name '*.pl' -exec chmod +x {} +
+      patchShebangs build/deps-nixpkgs/stemmer
+    fi
   '';
 
   nativeBuildInputs = [
@@ -209,6 +227,7 @@ stdenv.mkDerivation {
     bison
     cmake
     ninja
+    perl
   ];
 
   buildInputs = [


### PR DESCRIPTION
Fixes CVE-2026-54341 (RESTORE operations may crash the server; affects versions < 1.39, tracked as #535962), and brings the package up to the current release.

The vendored dependency patches are regenerated against the v1.39.0 helio/dragonfly CMake files, which changed a large number of third-party declarations:

- Pin abseil-cpp to 20250512.1, the release helio's in-tree patches target (nixpkgs' abseil-cpp now tracks a newer version the patches no longer apply to), and bump the vendored aws-sdk-cpp and jsoncons pins.
- hnswlib now comes from dragonfly's fork rather than nixpkgs, matching upstream's switch away from nmslib's hnswlib.
- Vendor the new snowball stemmer dependency (built in-tree); nixpkgs' libstemmer is an older snowball release.
- Drop the mimalloc 2.1.6 and jemalloc pins, which helio no longer builds.
- Disable aws-sdk-cpp's git-dependent submodule-version enforcement, which cannot run in the sandbox (the source is already fetched at the exact tag with submodules).

> [!NOTE]
> I had Claude Opus 4.8 help me with the janitoring of the patches required to make DragonflyDB build under nixpkgs, but they're not meaningfully different from the old versions that I manually created when I last updated the package, just tweaked slightly due to dependency drift. I also had the model serve as a glorified bash script to batch-update all of the hashes for pinned dependencies to the versions appropriate to 1.39.0.
> 
> I've built it locally and confirmed that it works using `redis-cli`, including the new search features added since 1.34.2, and carefully reviewed the full diff for reasonableness. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

pbsds edit: closes #535962

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
