### PR TITLE
cargo-auditable: disable `test_bare_linker`

### DIFF
--- a/pkgs/by-name/ca/cargo-auditable/builder.nix
+++ b/pkgs/by-name/ca/cargo-auditable/builder.nix
@@ -42,7 +42,20 @@ lib.extendMkDerivation {
         # https://github.com/rust-secure-code/cargo-auditable/issues/235
         "--skip=test_proc_macro"
         "--skip=test_self_hosting"
-      ];
+      ]
+      # TODO: Clean up on `staging`.
+      ++
+        lib.optionals
+          (
+            stdenv.hostPlatform.isMusl
+            || stdenv.hostPlatform.isAarch32
+            || stdenv.hostPlatform.isDarwin
+            || stdenv.hostPlatform.isMsvc
+          )
+          [
+            # Expects `linker = "rust-lld"` to work.
+            "--skip=test_bare_linker"
+          ];
 
       postInstall = ''
         installManPage cargo-auditable/cargo-auditable.1


### PR DESCRIPTION
This tries to use `linker = "rust-lld"` on `aarch64-darwin`, Linux Musl and ARMv7 targets, and MSVC Windows, but we deliberately don’t provide that.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
