### PR TITLE
[Backport release-26.05] python3Packages.mlflow: 3.12.0 -> 3.14.0

### DIFF
--- a/pkgs/development/python-modules/mlflow-skinny/default.nix
+++ b/pkgs/development/python-modules/mlflow-skinny/default.nix
@@ -1,6 +1,7 @@
 {
   buildPythonPackage,
   mlflow,
+  fetchFromGitHub,
 
   # build-system
   setuptools,
@@ -30,9 +31,16 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "mlflow-skinny";
-  inherit (mlflow) version src;
+  inherit (mlflow) version;
   pyproject = true;
   __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "mlflow";
+    repo = "mlflow";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-e11ZncpvThb1Nt6OH+O6Do74N3dphxBiK/HIeLQMxAw=";
+  };
 
   sourceRoot = "${finalAttrs.src.name}/libs/skinny";
 

--- a/pkgs/development/python-modules/mlflow-tracing/default.nix
+++ b/pkgs/development/python-modules/mlflow-tracing/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   mlflow,
+  fetchFromGitHub,
 
   # build-system
   setuptools,
@@ -25,7 +26,12 @@ buildPythonPackage (finalAttrs: {
   pyproject = true;
   __structuredAttrs = true;
 
-  inherit (mlflow) src;
+  src = fetchFromGitHub {
+    owner = "mlflow";
+    repo = "mlflow";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-e11ZncpvThb1Nt6OH+O6Do74N3dphxBiK/HIeLQMxAw=";
+  };
 
   sourceRoot = "${finalAttrs.src.name}/libs/tracing";
 

--- a/pkgs/development/python-modules/mlflow/default.nix
+++ b/pkgs/development/python-modules/mlflow/default.nix
@@ -1,10 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
-
-  # build-system
-  setuptools,
+  fetchPypi,
 
   # dependencies
   aiohttp,
@@ -30,27 +27,33 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "mlflow";
-  version = "3.12.0";
-  pyproject = true;
+  version = "3.14.0";
+  format = "wheel";
   __structuredAttrs = true;
 
-  src = fetchFromGitHub {
-    owner = "mlflow";
-    repo = "mlflow";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-OxhM+KCem0sb9cwtyzrUD/MGfoiiCfgU47qipYRDaFk=";
+  # We build from the PyPI wheel rather than fetchFromGitHub, because the mlflow-server
+  # JS UI is absent from GitHub but provided in the wheel.
+  src = fetchPypi {
+    pname = "mlflow";
+    inherit (finalAttrs) version;
+    format = "wheel";
+    dist = "py3";
+    python = "py3";
+    hash = "sha256-2/d/fNtbXA7Fm0ZxxhcwsbkUtN/3ookuJnpUfLVFT1Y=";
   };
 
-  # ppyproject.release.toml is the one shipped in the Pypi package, so we use it too.
-  postPatch = ''
-    mv pyproject.release.toml pyproject.toml
+  # Nix-wrapped python populates sys.path via NIX_PYTHONPATH/site hooks,
+  # but PYTHONPATH stays unset in os.environ. mlflow spawns the server
+  # in a subprocess with a curated env, so without this patch the child
+  # interpreter cannot import uvicorn / mlflow itself.
+  postInstall = ''
+    patch -p1 -d "$out/lib/python"*/site-packages < ${./subprocess-pythonpath.patch}
   '';
-
-  build-system = [ setuptools ];
 
   pythonRelaxDeps = [
     "cryptography"
   ];
+
   dependencies = [
     aiohttp
     alembic
@@ -85,8 +88,12 @@ buildPythonPackage (finalAttrs: {
     description = "Open source platform for the machine learning lifecycle";
     mainProgram = "mlflow";
     homepage = "https://github.com/mlflow/mlflow";
-    changelog = "https://github.com/mlflow/mlflow/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/mlflow/mlflow/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.asl20;
+    # Build from wheel which contains pure Python and pre-built JS bundle.
+    sourceProvenance = with lib.sourceTypes; [
+      binaryBytecode
+    ];
     maintainers = with lib.maintainers; [
       GaetanLepage
     ];

--- a/pkgs/development/python-modules/mlflow/subprocess-pythonpath.patch
+++ b/pkgs/development/python-modules/mlflow/subprocess-pythonpath.patch
@@ -1,0 +1,14 @@
+--- a/mlflow/server/__init__.py
++++ b/mlflow/server/__init__.py
+@@ -474,6 +474,11 @@
+             else tempfile.mkdtemp()
+         )
++    # In Nix-packaged environments sys.path is populated by wrappers but
++    # PYTHONPATH is never set in os.environ, so subprocesses (uvicorn,
++    # gunicorn) cannot find packages. Propagate it when not already set.
++    if "PYTHONPATH" not in os.environ:
++        env_map.setdefault("PYTHONPATH", os.pathsep.join(p for p in sys.path if p))
+
+     server_proc = _exec_cmd(
+         full_command,
+         extra_env=env_map,

--- a/pkgs/development/python-modules/mmengine/default.nix
+++ b/pkgs/development/python-modules/mmengine/default.nix
@@ -109,6 +109,11 @@ buildPythonPackage (finalAttrs: {
     '';
 
   disabledTestPaths = [
+    # MlflowVisBackend uses the deprecated mlflow filesystem store, which is
+    # throws an error since mlflow 3.13. See upstream issue:
+    # https://github.com/open-mmlab/mmengine/issues/1687
+    "tests/test_visualizer/test_vis_backend.py::TestMLflowVisBackend"
+
     # Require unpackaged aim
     "tests/test_visualizer/test_vis_backend.py::TestAimVisBackend"
 

--- a/pkgs/development/python-modules/torchtune/default.nix
+++ b/pkgs/development/python-modules/torchtune/default.nix
@@ -133,6 +133,10 @@ buildPythonPackage (finalAttrs: {
   ];
 
   disabledTestPaths = [
+    # MLFlowLogger uses the deprecated mlflow filesystem store, which throws an
+    # error since mlflow 3.13. See https://github.com/NixOS/nixpkgs/pull/532943
+    "tests/torchtune/training/test_metric_logging.py::TestMLFlowLogger"
+
     # TypeError: HfHubHTTPError.__init__() missing 1 required keyword-only argument: 'response'
     "tests/torchtune/_cli/test_download.py::TestTuneDownloadCommand::test_download_calls_snapshot"
     "tests/torchtune/_cli/test_download.py::TestTuneDownloadCommand::test_gated_repo_error_no_token"


### PR DESCRIPTION
### DO NOT MERGE 

Manual backport of #532943 

Please review carefully as I had to make multiple adjustments to pick up changes since branchoff.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
