### PR TITLE
pythonPackages.viztracer: init at 1.1.1

### DIFF
--- a/pkgs/development/python-modules/viztracer/default.nix
+++ b/pkgs/development/python-modules/viztracer/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  objprint,
+  orjson,
+  nix-update-script,
+}:
+
+buildPythonPackage rec {
+  __structuredAttrs = true;
+
+  pname = "viztracer";
+  version = "1.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "gaogaotiantian";
+    repo = "viztracer";
+    tag = version;
+    hash = "sha256-j+PbPZY9ZmOyF0nPEP/Ba34HPx2SUPNlaXAjj3GG9dc=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ objprint ];
+
+  optional-dependencies = {
+    full = [ orjson ];
+  };
+
+  pythonImportsCheck = [ "viztracer" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Debugging and profiling tool that can trace and visualize python code execution";
+    homepage = "https://github.com/gaogaotiantian/viztracer";
+    changelog = "https://github.com/gaogaotiantian/viztracer/releases/tag/${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nemeott ];
+    mainProgram = "viztracer";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21465,6 +21465,8 @@ self: super: with self; {
     inherit (pkgs.libsForQt5) wrapQtAppsHook;
   };
 
+  viztracer = callPackage ../development/python-modules/viztracer { };
+
   vl-convert-python = callPackage ../development/python-modules/vl-convert-python {
     inherit (pkgs) protobuf;
   };


### PR DESCRIPTION
Added `viztracer` to the list of Python packages. "VizTracer is a low-overhead logging/debugging/profiling tool that can trace and visualize your python code execution." Useful for debugging and visualizing Python program runtime. Repository found here: https://github.com/gaogaotiantian/viztracer

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
