### PR TITLE
nixos/systemd-sysusers: add packages option

### DIFF
--- a/nixos/modules/system/boot/systemd/sysusers.nix
+++ b/nixos/modules/system/boot/systemd/sysusers.nix
@@ -45,6 +45,11 @@ let
     )}
   '';
 
+  sysusersDir = pkgs.symlinkJoin {
+    name = "sysusers.d";
+    paths = [ sysusersConfig ] ++ map (p: p + "/lib/sysusers.d") cfg.packages;
+  };
+
   immutableEtc = config.system.etc.overlay.enable && !config.system.etc.overlay.mutable;
   # The location of the password files when using an immutable /etc.
   immutablePasswordFilesLocation = "/var/lib/nixos/etc";
@@ -75,6 +80,21 @@ in
           Note: This is experimental.
         '';
       };
+    };
+
+    systemd.sysusers.packages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      apply = map lib.getLib;
+      description = ''
+        List of packages containing {command}`systemd-sysusers` rules.
+
+        All files in {file}`«pkg»/lib/sysusers.d` will be included.
+
+        If a {file}`lib` output is available, rules are searched there and only there.
+        If there is no {file}`lib` output it will fall back to {file}`out`
+        and if that does not exist either, the default output will be used.
+      '';
     };
 
   };
@@ -184,7 +204,7 @@ in
 
     environment.etc = lib.mkMerge [
       {
-        "sysusers.d".source = sysusersConfig;
+        "sysusers.d".source = sysusersDir;
       }
 
       # Statically create the symlinks to immutablePasswordFilesLocation when

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1705,6 +1705,7 @@ in
   systemd-sysupdate = runTest ./systemd-sysupdate.nix;
   systemd-sysusers-immutable = runTest ./systemd-sysusers-immutable.nix;
   systemd-sysusers-mutable = runTest ./systemd-sysusers-mutable.nix;
+  systemd-sysusers-packages = runTest ./systemd-sysusers-packages.nix;
   systemd-sysusers-password-option-override-ordering = runTest ./systemd-sysusers-password-option-override-ordering.nix;
   systemd-timesyncd = runTest ./systemd-timesyncd.nix;
   systemd-timesyncd-nscd-dnssec = runTest ./systemd-timesyncd-nscd-dnssec.nix;

--- a/nixos/tests/systemd-sysusers-packages.nix
+++ b/nixos/tests/systemd-sysusers-packages.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  name = "systemd-sysusers-packages";
+  meta.maintainers = with lib.maintainers; [ haansn08 ];
+
+  nodes.machine = {
+    systemd.sysusers.enable = true;
+    systemd.sysusers.packages = [
+
+      (pkgs.writeTextDir "/lib/sysusers.d/test1.conf" ''
+        u! test1 - "test1 system user"
+        g test1group - -
+      '')
+
+      (pkgs.writeTextDir "/lib/sysusers.d/test2.conf" ''
+        u! test2 - "test2 system user"
+      '')
+
+    ];
+  };
+
+  testScript = ''
+    machine.wait_for_unit("systemd-sysusers.service")
+
+    with subtest("specified users and groups do exist"):
+      assert machine.succeed("userdbctl user test1")
+      assert machine.succeed("userdbctl user test2")
+      assert machine.succeed("userdbctl group test1group")
+  '';
+}


### PR DESCRIPTION
Allows packages to place files in /etc/sysusers.d, analogous to the options `systemd.packages` and `systemd.tmpfiles.packages`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
