### PR TITLE
desktopToDarwinBundle: add fallback icon

### DIFF
--- a/pkgs/build-support/setup-hooks/desktop-to-darwin-bundle.sh
+++ b/pkgs/build-support/setup-hooks/desktop-to-darwin-bundle.sh
@@ -136,11 +136,13 @@ convertIconTheme() {
         local -r resultdir=$(mktemp -d)
 
         local -ar candidateIcons=(
-            "${sharePath}/icons/${theme}/"*"/${iconname}.png"
-            "${sharePath}/icons/${theme}/"*"/${iconname}.xpm"
+            "${sharePath}/icons/${theme}/"*"/apps/${iconname}.png"
+            "${sharePath}/icons/${theme}/"*"/apps/${iconname}.xpm"
+            "${sharePath}/icons/${iconname}.png"
+            "${sharePath}/icons/${iconname}.xpm"
         )
 
-        local -a scalableIcon=("${sharePath}/icons/${theme}/scalable/${iconname}.svg"*)
+        local -a scalableIcon=("${sharePath}/icons/${theme}/scalable/apps/${iconname}.svg"*)
         if [[ ${#scalableIcon[@]} = 0 ]]; then
             scalableIcon=('-')
         fi
@@ -206,7 +208,7 @@ convertIconTheme() {
         echo "$resultdir"
     }
 
-    iconsdir=$(getIcons "$sharePath" "apps/${iconName}" "$theme")
+    iconsdir=$(getIcons "$sharePath" "$iconName" "$theme")
     if [[ -n "$(ls -A1 "$iconsdir")" ]]; then
         icnsutil compose --toc "$out/${iconName}.icns" "$iconsdir/"*
     else

--- a/pkgs/build-support/setup-hooks/desktop-to-darwin-bundle.sh
+++ b/pkgs/build-support/setup-hooks/desktop-to-darwin-bundle.sh
@@ -91,7 +91,7 @@ convertIconTheme() {
         local dim=$((iconSize * scale))
 
         echo "desktopToDarwinBundle: resizing icon $in to $out, size $dim" >&2
-        magick convert -scale "${dim}x${dim}" -density "$density" -units PixelsPerInch "$in" "$out"
+        magick "$in" -scale "${dim}x${dim}" -density "$density" -units PixelsPerInch "$out"
         convertIfUnsupportedIcon "$out" "$iconSize" "$scale"
     }
 
@@ -107,7 +107,7 @@ convertIconTheme() {
 
             echo "desktopToDarwinBundle: rasterizing svg $in to $out, size $dim" >&2
             rsvg-convert --keep-aspect-ratio --width "$dim" --height "$dim" "$in" --output "$out"
-            magick convert -density "$density" -units PixelsPerInch "$out" "$out"
+            magick "$out" -density "$density" -units PixelsPerInch "$out"
             convertIfUnsupportedIcon "$out" "$iconSize" "$scale"
         else
             return 1
@@ -169,7 +169,7 @@ convertIconTheme() {
                 case $type in
                     fixed)
                         local density=$((72 * scale))x$((72 * scale))
-                        magick convert -density "$density" -units PixelsPerInch "$icon" "$result"
+                        magick "$icon" -density "$density" -units PixelsPerInch "$result"
                         convertIfUnsupportedIcon "$result" "$iconSize" "$scale"
                         foundIcon=OTHER
                         ;;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I added a fallback icon location to `desktopToDarwinBundle`, which aligns `desktopToDarwinBundle` with the changes made in #510472.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test