### PR TITLE
nixos/syncoid: allow `@timer` syscalls

### DIFF
--- a/nixos/modules/services/backup/syncoid.nix
+++ b/nixos/modules/services/backup/syncoid.nix
@@ -459,7 +459,8 @@ in
                 "~@privileged"
                 "~@resources"
                 "~@setuid"
-                "~@timer"
+                # NB: pv after 1.11.0 uses timer syscalls (specifically setitimer)
+                # "~@timer"
               ];
               SystemCallArchitectures = "native";
               # This is for BindPaths= and BindReadOnlyPaths=

--- a/pkgs/by-name/pv/pv/package.nix
+++ b/pkgs/by-name/pv/pv/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  nixosTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -12,6 +13,9 @@ stdenv.mkDerivation (finalAttrs: {
     url = "https://www.ivarch.com/programs/sources/pv-${finalAttrs.version}.tar.gz";
     hash = "sha256-/ALJ/CuCsgqSzI2Y+ES+Y/IqvZh1Go5KvIdeHYA2Yus=";
   };
+
+  # pv is used by syncoid (part of the sanoid package) by default
+  passthru.tests = nixosTests.sanoid;
 
   meta = {
     homepage = "https://www.ivarch.com/programs/pv.shtml";


### PR DESCRIPTION
Syncoid uses `pv` to display information about transfer speeds. During the pv bump from 1.10.5 to 1.11.0 in https://github.com/NixOS/nixpkgs/pull/531076 it started using the `setitimer` syscall (included by `@timer`) which would segfault given that the sandbox configuration was set to block all syscalls in the `@timer` group

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
