### PR TITLE
openresty: 1.27.1.2 -> 1.31.1.1; add update script

### DIFF
--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -46,9 +46,7 @@ outer@{
   postInstall ? "",
   meta ? null,
   nginx-doc ? outer.nginx-doc,
-  passthru ? {
-    tests = { };
-  },
+  passthru ? { },
 }:
 
 let
@@ -281,25 +279,28 @@ stdenv.mkDerivation {
 
   passthru = {
     inherit modules;
-    tests = {
-      inherit (nixosTests)
-        nginx
-        nginx-auth
-        nginx-etag
-        nginx-etag-compression
-        nginx-globalredirect
-        nginx-http3
-        nginx-proxyprotocol
-        nginx-pubhtml
-        nginx-sso
-        nginx-status-page
-        nginx-unix-socket
-        ;
-      variants = lib.recurseIntoAttrs nixosTests.nginx-variants;
-      acme-integration = nixosTests.acme.nginx;
-      acme-integration-without-reload = nixosTests.acme.nginx-without-reload;
-    }
-    // passthru.tests;
+    tests =
+      passthru.tests or {
+        inherit (nixosTests)
+          nginx
+          nginx-auth
+          nginx-etag
+          nginx-etag-compression
+          nginx-globalredirect
+          nginx-http3
+          nginx-proxyprotocol
+          nginx-pubhtml
+          nginx-sso
+          nginx-status-page
+          nginx-unix-socket
+          ;
+        variants = lib.recurseIntoAttrs nixosTests.nginx-variants;
+        acme-integration = nixosTests.acme.nginx;
+        acme-integration-without-reload = nixosTests.acme.nginx-without-reload;
+      };
+  }
+  // lib.optionalAttrs (passthru ? updateScript) {
+    inherit (passthru) updateScript;
   };
 
   meta =

--- a/pkgs/servers/http/openresty/default.nix
+++ b/pkgs/servers/http/openresty/default.nix
@@ -67,6 +67,9 @@ callPackage ../nginx/generic.nix args rec {
 
     wrapProgram $out/bin/restydoc \
       --prefix PATH : ${groff}/bin
+
+    substituteInPlace $out/bin/resty \
+      --replace-fail "'bin/nginx'" "'$out/bin/nginx'"
   '';
 
   passthru = {

--- a/pkgs/servers/http/openresty/default.nix
+++ b/pkgs/servers/http/openresty/default.nix
@@ -7,17 +7,21 @@
   libpq,
   nixosTests,
   withPostgres ? true,
+  curl,
+  jq,
+  nix-update,
+  writeShellApplication,
   ...
 }@args:
 
 callPackage ../nginx/generic.nix args rec {
   pname = "openresty";
-  nginxVersion = "1.27.1";
-  version = "${nginxVersion}.2";
+  version = "1.27.1.2";
+  nginxVersion = lib.concatStringsSep "." (lib.init (lib.splitString "." version));
 
   src = fetchurl {
     url = "https://openresty.org/download/openresty-${version}.tar.gz";
-    sha256 = "sha256-dPB29+NksqmabF+btTHCdhDHiYWr6Va0QrGSoilfdUg=";
+    hash = "sha256-dPB29+NksqmabF+btTHCdhDHiYWr6Va0QrGSoilfdUg=";
   };
 
   # generic.nix applies fixPatch on top of every patch defined there.
@@ -59,8 +63,32 @@ callPackage ../nginx/generic.nix args rec {
     ln -s $out/nginx/html $out/html
   '';
 
-  passthru.tests = {
-    inherit (nixosTests) openresty-lua;
+  passthru = {
+    tests = {
+      inherit (nixosTests) openresty-lua;
+    };
+    updateScript = lib.getExe (writeShellApplication {
+      name = "openresty-update";
+      runtimeInputs = [
+        curl
+        jq
+        nix-update
+      ];
+      text = ''
+        version="$(
+          curl -fsSL https://api.github.com/repos/openresty/openresty/tags?per_page=1 |
+            jq -r '.[0].name' |
+            sed 's/^v//'
+        )"
+        echo "Local: ${version}"
+        echo "Latest: $version"
+
+        nix-update \
+          --override-filename="pkgs/servers/http/openresty/default.nix" \
+          --version="''${version}" \
+          openresty
+      '';
+    });
   };
 
   meta = {

--- a/pkgs/servers/http/openresty/default.nix
+++ b/pkgs/servers/http/openresty/default.nix
@@ -3,8 +3,10 @@
   runCommand,
   lib,
   fetchurl,
+  groff,
   perl,
   libpq,
+  makeWrapper,
   nixosTests,
   withPostgres ? true,
   curl,
@@ -40,6 +42,7 @@ callPackage ../nginx/generic.nix args rec {
 
   nativeBuildInputs = [
     libpq.pg_config
+    makeWrapper
     perl
   ];
 
@@ -61,6 +64,9 @@ callPackage ../nginx/generic.nix args rec {
     ln -s $out/nginx/bin/nginx $out/bin/nginx
     ln -s $out/nginx/conf $out/conf
     ln -s $out/nginx/html $out/html
+
+    wrapProgram $out/bin/restydoc \
+      --prefix PATH : ${groff}/bin
   '';
 
   passthru = {

--- a/pkgs/servers/http/openresty/default.nix
+++ b/pkgs/servers/http/openresty/default.nix
@@ -16,12 +16,12 @@
 
 callPackage ../nginx/generic.nix args rec {
   pname = "openresty";
-  version = "1.27.1.2";
+  version = "1.31.1.1";
   nginxVersion = lib.concatStringsSep "." (lib.init (lib.splitString "." version));
 
   src = fetchurl {
     url = "https://openresty.org/download/openresty-${version}.tar.gz";
-    hash = "sha256-dPB29+NksqmabF+btTHCdhDHiYWr6Va0QrGSoilfdUg=";
+    hash = "sha256-ZbeLqt0/CYQFXeib8T9KGTLlv+nDGTIDehNOorGgzkI=";
   };
 
   # generic.nix applies fixPatch on top of every patch defined there.

--- a/pkgs/servers/http/openresty/default.nix
+++ b/pkgs/servers/http/openresty/default.nix
@@ -66,6 +66,7 @@ callPackage ../nginx/generic.nix args rec {
   passthru = {
     tests = {
       inherit (nixosTests) openresty-lua;
+      inherit (nixosTests.nginx-variants) openresty;
     };
     updateScript = lib.getExe (writeShellApplication {
       name = "openresty-update";


### PR DESCRIPTION
https://openresty.org/en/changelog-1031001.html (1.31.x)
https://openresty.org/en/changelog-1029002.html (1.29.x)

Fixes:
CVE-2026-1642
CVE-2026-9256
CVE-2026-27651
CVE-2026-27654
CVE-2026-27784
CVE-2026-28753
CVE-2026-28755
CVE-2026-32647
CVE-2026-40460
CVE-2026-40701
CVE-2026-42934
CVE-2026-42945
CVE-2026-42946


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
