### PR TITLE
nginx.tests: migrate most to nspawn containers

### DIFF
--- a/nixos/tests/nginx-auth.nix
+++ b/nixos/tests/nginx-auth.nix
@@ -1,8 +1,7 @@
-{ pkgs, ... }:
 {
   name = "nginx-auth";
 
-  nodes = {
+  containers = {
     webserver =
       { pkgs, lib, ... }:
       {

--- a/nixos/tests/nginx-etag-compression.nix
+++ b/nixos/tests/nginx-etag-compression.nix
@@ -2,7 +2,7 @@
 {
   name = "nginx-etag-compression";
 
-  nodes.machine =
+  containers.machine =
     { pkgs, lib, ... }:
     {
       services.nginx = {
@@ -28,7 +28,7 @@
     };
 
   testScript =
-    { nodes, ... }:
+    { containers, ... }:
     ''
       machine.wait_for_unit("nginx")
       machine.wait_for_open_port(80)

--- a/nixos/tests/nginx-globalredirect.nix
+++ b/nixos/tests/nginx-globalredirect.nix
@@ -2,7 +2,7 @@
 {
   name = "nginx-globalredirect";
 
-  nodes = {
+  containers = {
     webserver =
       { pkgs, lib, ... }:
       {

--- a/nixos/tests/nginx-http3.nix
+++ b/nixos/tests/nginx-http3.nix
@@ -13,7 +13,7 @@ builtins.listToAttrs (
         name = "nginx-http3-${pkgs.lib.getName nginxPackage}";
         meta.maintainers = with pkgs.lib.maintainers; [ izorkin ];
 
-        nodes = {
+        containers = {
           server =
             { lib, pkgs, ... }:
             {

--- a/nixos/tests/nginx-lua.nix
+++ b/nixos/tests/nginx-lua.nix
@@ -4,7 +4,7 @@
 
   meta.maintainers = [ lib.maintainers.kranzes ];
 
-  nodes.machine = {
+  containers.machine = {
     services.nginx = {
       enable = true;
       lua = {

--- a/nixos/tests/nginx-mime.nix
+++ b/nixos/tests/nginx-mime.nix
@@ -1,9 +1,9 @@
-{ lib, pkgs, ... }:
+{ pkgs, ... }:
 {
   name = "nginx-mime";
   meta.maintainers = with pkgs.lib.maintainers; [ izorkin ];
 
-  nodes = {
+  containers = {
     server =
       { pkgs, ... }:
       {

--- a/nixos/tests/nginx-modsecurity.nix
+++ b/nixos/tests/nginx-modsecurity.nix
@@ -2,7 +2,7 @@
 {
   name = "nginx-modsecurity";
 
-  nodes.machine =
+  containers.machine =
     {
       config,
       lib,

--- a/nixos/tests/nginx-moreheaders.nix
+++ b/nixos/tests/nginx-moreheaders.nix
@@ -2,7 +2,7 @@
 {
   name = "nginx-more-headers";
 
-  nodes = {
+  containers = {
     webserver =
       { pkgs, ... }:
       {

--- a/nixos/tests/nginx-njs.nix
+++ b/nixos/tests/nginx-njs.nix
@@ -1,8 +1,7 @@
-{ pkgs, lib, ... }:
 {
   name = "nginx-njs";
 
-  nodes.machine =
+  containers.machine =
     {
       config,
       lib,

--- a/nixos/tests/nginx-pubhtml.nix
+++ b/nixos/tests/nginx-pubhtml.nix
@@ -2,7 +2,7 @@
 {
   name = "nginx-pubhtml";
 
-  nodes.machine =
+  containers.machine =
     { pkgs, ... }:
     {
       systemd.services.nginx.serviceConfig.ProtectHome = "read-only";

--- a/nixos/tests/nginx-redirectcode.nix
+++ b/nixos/tests/nginx-redirectcode.nix
@@ -3,7 +3,7 @@
   name = "nginx-redirectcode";
   meta.maintainers = with lib.maintainers; [ misterio77 ];
 
-  nodes = {
+  containers = {
     webserver =
       { pkgs, lib, ... }:
       {

--- a/nixos/tests/nginx-sso.nix
+++ b/nixos/tests/nginx-sso.nix
@@ -5,7 +5,7 @@
     maintainers = with pkgs.lib.maintainers; [ ambroisie ];
   };
 
-  nodes.machine = {
+  containers.machine = {
     services.nginx.sso = {
       enable = true;
       configuration = {

--- a/nixos/tests/nginx-status-page.nix
+++ b/nixos/tests/nginx-status-page.nix
@@ -5,12 +5,13 @@
     maintainers = [ h7x4 ];
   };
 
-  nodes = {
+  containers = {
     webserver =
       { ... }:
       {
         virtualisation.vlans = [ 1 ];
 
+        services.resolved.enable = false;
         networking = {
           useNetworkd = true;
           useDHCP = false;
@@ -36,6 +37,7 @@
       {
         virtualisation.vlans = [ 1 ];
 
+        services.resolved.enable = false;
         networking = {
           useNetworkd = true;
           useDHCP = false;

--- a/nixos/tests/nginx-tmpdir.nix
+++ b/nixos/tests/nginx-tmpdir.nix
@@ -5,7 +5,7 @@ in
 {
   name = "nginx-tmpdir";
 
-  nodes.machine =
+  containers.machine =
     { pkgs, ... }:
     {
       environment.etc."tmpfiles.d/nginx-uploads.conf".text = "d ${dst-dir} 0755 nginx nginx 1d";

--- a/nixos/tests/nginx-unix-socket.nix
+++ b/nixos/tests/nginx-unix-socket.nix
@@ -6,7 +6,7 @@ in
 {
   name = "nginx-unix-socket";
 
-  nodes = {
+  containers = {
     webserver =
       { pkgs, lib, ... }:
       {

--- a/nixos/tests/nginx-variants.nix
+++ b/nixos/tests/nginx-variants.nix
@@ -1,4 +1,4 @@
-{ pkgs, runTest, ... }:
+{ runTest, ... }:
 builtins.listToAttrs (
   map
     (packageName: {
@@ -6,7 +6,7 @@ builtins.listToAttrs (
       value = runTest {
         name = "nginx-variant-${packageName}";
 
-        nodes.machine =
+        containers.machine =
           { pkgs, ... }:
           {
             services.nginx = {


### PR DESCRIPTION
With a few exceptions where one relies on specialisations and the other was proxyprotocol.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
