### PR TITLE
openlinkhub: install binary to `$out/opt/OpenLinkHub`

### DIFF
--- a/pkgs/by-name/op/openlinkhub/package.nix
+++ b/pkgs/by-name/op/openlinkhub/package.nix
@@ -37,10 +37,12 @@ buildGoModule (finalAttrs: {
     runHook preInstall
 
     install -Dm 644 -t $out/etc/udev/rules.d 99-openlinkhub.rules
-    install -Dm 755 -t $out/bin $GOPATH/bin/OpenLinkHub
+    install -Dm 755 -t $out/opt/OpenLinkHub $GOPATH/bin/OpenLinkHub
 
-    mkdir -p $out/opt/OpenLinkHub
-    cp -r {database,static,web} $out/opt/OpenLinkHub
+    cp -rt $out/opt/OpenLinkHub database static web
+
+    mkdir -p $out/bin
+    ln -st $out/bin $out/opt/OpenLinkHub/OpenLinkHub
 
     runHook postInstall
   '';


### PR DESCRIPTION
**summary:** makes openlinkhub work out of the box, provided that `$out/opt/OpenLinkHub` is copied to a mutable directory and run from there.

now installs the binary to `$out/opt/OpenLinkHub` alongside its static dependencies and places a symlink to the binary in `$out/bin` for backwards compatibility with any existing modules.

see https://github.com/NixOS/nixpkgs/pull/511744 for additional context.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
