### PR TITLE
sampo: 0.18.0 -> 0.18.1

### DIFF
--- a/pkgs/by-name/sa/sampo/package.nix
+++ b/pkgs/by-name/sa/sampo/package.nix
@@ -9,21 +9,24 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sampo";
-  version = "0.18.0";
+  version = "0.18.1";
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "bruits";
     repo = "sampo";
     tag = "cargo-sampo-v${finalAttrs.version}";
-    hash = "sha256-LPgY/UA2AF871bid8wqxzIhTDnsHsQ7IhY/eNYE6Npk=";
+    hash = "sha256-F1x/GKTrNHbXFvjdqkLtdt0jXx3+pBBZzYcQEaTj9rQ=";
   };
 
-  cargoHash = "sha256-U52xGXJlz7cM1fJWZMp51iNgYQRA8AKJ0OkbxlAB5C8=";
+  cargoHash = "sha256-SGCkuL/34eOpI4HpJPW4Z2P95WLHv2R/BEB0EAxbZoA=";
 
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ openssl ];
+
+  # Disable self-update
+  buildNoDefaultFeatures = true;
 
   cargoBuildFlags = [
     "-p"


### PR DESCRIPTION
- Update to [0.18.1](https://github.com/bruits/sampo/blob/cargo-sampo-v0.18.1/crates/sampo/CHANGELOG.md)
- Disable self-update feature

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
