### PR TITLE
 comlsldd: init at 0-unstable-2026-06-27 

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -16,6 +16,8 @@
 
 - [Nezha](https://github.com/nezhahq/nezha), a self-hosted, lightweight server and website monitoring and O&M tool. Available as [services.nezha](#opt-services.nezha.enable).
 
+- [comlsldd](https://codeberg.org/Pandapip1/comlsldd), a daemon that exposes various devices (primarily EEGs) as LSL streams
+
 - [mail-tlsa-check-exporter](https://github.com/ietf-tools/mail-tlsa-check-exporter), validates SMTP / IMAP server certificates against a TLSA record as a Prometheus exporter. Available as [services.prometheus.exporters.mail-tlsa-check](#opt-services.prometheus.exporters.mail-tlsa-check.enable).
 
 - [CastSponsorSkip](https://github.com/gabe565/CastSponsorSkip/), skips YouTube sponsorships (and sometimes ads) on all local Google Cast devices.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -665,6 +665,7 @@
   ./services/hardware/bolt.nix
   ./services/hardware/brltty.nix
   ./services/hardware/buffyboard.nix
+  ./services/hardware/comlsldd.nix
   ./services/hardware/ddccontrol.nix
   ./services/hardware/deepcool-digital-linux.nix
   ./services/hardware/dell-bios-fan-control.nix

--- a/nixos/modules/services/hardware/comlsldd.nix
+++ b/nixos/modules/services/hardware/comlsldd.nix
@@ -1,0 +1,104 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkDefault
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    types
+    ;
+
+  cfg = config.services.comlsldd;
+
+  generateEvenOddPortsFromRange =
+    from: range:
+    if range <= 0 then [ ] else [ from ] ++ (generateEvenOddPortsFromRange (from + 2) (range - 2));
+
+  portsToOpen =
+    let
+      portRange = if (cfg ? liblslConfig.ports.PortRange) then cfg.liblslConfig.ports.PortRange else 32;
+      multicastPort =
+        if (cfg ? liblslConfig.ports.MulticastPort) then cfg.liblslConfig.ports.MulticastPort else 16571;
+      basePort = if (cfg ? liblslConfig.ports.BasePort) then cfg.liblslConfig.ports.BasePort else 16572;
+    in
+    (generateEvenOddPortsFromRange multicastPort portRange)
+    ++ (generateEvenOddPortsFromRange basePort portRange);
+in
+{
+  options.services.comlsldd = {
+    enable = mkEnableOption "COMmon LSL Driver Daemon service";
+
+    package = mkPackageOption pkgs "comlsldd" { };
+
+    openFirewall = mkEnableOption "firewall rules to expose LSL";
+
+    liblslConfig = mkOption {
+      type = lib.types.attrs;
+      default = { };
+      description = ''
+        liblsl configuration options
+
+        See https://labstreaminglayer.readthedocs.io/info/lslapicfg.html for more information
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.comlsldd = {
+      inherit (cfg.package.meta) description;
+      wantedBy = [ "multi-user.target" ];
+
+      environment = {
+        RUST_LOG = mkDefault "info";
+        LSLAPICFG = pkgs.writers.writeTOML "lsl_api.cfg" cfg.liblslConfig;
+      };
+
+      serviceConfig = {
+        ExecStart = lib.getExe cfg.package;
+        Type = "notify";
+
+        # Hardening
+        AmbientCapabilities = [ "CAP_SYS_NICE" ];
+        CapabilityBoundingSet = [ "CAP_SYS_NICE" ];
+        DynamicUser = true;
+        KeyringMode = "private";
+        ProtectHome = true;
+        ProcSubset = "pid";
+        ProtectControlGroups = true;
+        ProtectHostname = true;
+        ProtectProc = "invisible";
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectClock = true;
+        PrivateDevices = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        RestrictAddressFamilies = [
+          # D-Bus
+          "AF_UNIX"
+          # LSL
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictNamespaces = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [ "@system-service" ];
+      };
+    };
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = portsToOpen;
+      allowedUDPPorts = portsToOpen;
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ pandapip1 ];
+}

--- a/pkgs/by-name/co/comlsldd/package.nix
+++ b/pkgs/by-name/co/comlsldd/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchFromCodeberg,
+  rustPlatform,
+  cmake,
+  dbus,
+  liblsl,
+  pkg-config,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "comlsldd";
+  version = "0-unstable-2026-06-29";
+
+  src = fetchFromCodeberg {
+    owner = "Pandapip1";
+    repo = "comlsldd";
+    rev = "ff049524c883350c42307d00339dabf8dec08951";
+    hash = "sha256-GvKOylQrlDQZ9bw6WIXJBf4Pkrnd3m/hSvnClJKiw3k=";
+  };
+
+  cargoHash = "sha256-HmcG2pzgfZIdBecvDtTnmFPSOr414u5v1PncTvvNO+s=";
+
+  separateDebugInfo = true;
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+  buildInputs = [
+    dbus
+    liblsl
+  ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    homepage = "https://codeberg.org/Pandapip1/comlsldd";
+    description = "COMmon LSL Driver Daemon";
+    mainProgram = "comlsldd";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ pandapip1 ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/li/liblsl/0001-pkg-config.patch
+++ b/pkgs/by-name/li/liblsl/0001-pkg-config.patch
@@ -1,0 +1,51 @@
+From da435e3db6033e2bff2388e3d35ea48b029e9ebd Mon Sep 17 00:00:00 2001
+From: Gavin John <gavinnjohn@gmail.com>
+Date: Sat, 27 Jun 2026 16:00:57 -0400
+Subject: [PATCH] feat: add pkg-config support
+
+---
+ cmake/Installation.cmake | 14 ++++++++++++++
+ lsl.pc.in                |  9 +++++++++
+ 2 files changed, 23 insertions(+)
+ create mode 100644 lsl.pc.in
+
+diff --git a/cmake/Installation.cmake b/cmake/Installation.cmake
+index 4114d29a..4ed7d6e6 100644
+--- a/cmake/Installation.cmake
++++ b/cmake/Installation.cmake
+@@ -83,6 +83,20 @@ install(
+     DESTINATION ${LSL_CONFIG_INSTALL_DIR}
+ )
+ 
++# Generate pkg-config file
++if(LSL_UNIXFOLDERS AND NOT LSL_FRAMEWORK)
++    configure_file(
++        ${CMAKE_CURRENT_SOURCE_DIR}/lsl.pc.in
++        ${CMAKE_CURRENT_BINARY_DIR}/lsl.pc
++        @ONLY
++    )
++    install(
++        FILES ${CMAKE_CURRENT_BINARY_DIR}/lsl.pc
++        COMPONENT liblsl
++        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
++    )
++endif()
++
+ if(APPLE AND LSL_FRAMEWORK AND NOT IOS)
+     # Create symlinks for the framework. The variables we want to use to identify the symlink locations
+     #  are not available at install time. Instead, we create a script during configuration time that will
+diff --git a/lsl.pc.in b/lsl.pc.in
+new file mode 100644
+index 00000000..49f90967
+--- /dev/null
++++ b/lsl.pc.in
+@@ -0,0 +1,9 @@
++prefix=@CMAKE_INSTALL_PREFIX@
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@
++includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
++
++Name: liblsl
++Description: @PROJECT_DESCRIPTION@
++Version: @PROJECT_VERSION@
++Libs: -L${libdir} -llsl
++Cflags: -I${includedir}

--- a/pkgs/by-name/li/liblsl/0002-use-i8-for-i8-channels.patch
+++ b/pkgs/by-name/li/liblsl/0002-use-i8-for-i8-channels.patch
@@ -1,0 +1,484 @@
+From bbbd115f96f7de480b89f052dde2f5f609f91835 Mon Sep 17 00:00:00 2001
+From: Gavin John <gavinnjohn@gmail.com>
+Date: Mon, 29 Jun 2026 14:25:28 -0400
+Subject: [PATCH] fix(treewide): use correct type for int8 channels
+
+Char is unsigned on some non-x86 platforms. However, since int8_t and char are the same length and format, this maintains C ABI compatibility. For the C++ non-extern "C" compatibility, since the mangling is different, we unfortunately have to keep the char variants of all the functions.
+---
+ include/lsl/inlet.h         |  4 ++--
+ include/lsl/outlet.h        | 16 +++++++-------
+ include/lsl_cpp.h           | 43 ++++++++++++++++++++++++++++++++-----
+ src/data_receiver.cpp       |  2 +-
+ src/lsl_inlet_c.cpp         |  4 ++--
+ src/lsl_outlet_c.cpp        | 16 +++++++-------
+ src/sample.cpp              |  4 ++--
+ src/stream_inlet_impl.h     |  4 ++--
+ src/stream_outlet_impl.cpp  |  6 +++---
+ src/stream_outlet_impl.h    |  4 ++--
+ testing/common/lsltypes.hpp |  2 +-
+ testing/ext/DataType.cpp    |  2 +-
+ testing/ext/sync_outlet.cpp |  2 +-
+ testing/ext/time.cpp        |  4 ++--
+ 14 files changed, 73 insertions(+), 40 deletions(-)
+
+diff --git a/include/lsl/inlet.h b/include/lsl/inlet.h
+index 78aa60d90..c027ba887 100644
+--- a/include/lsl/inlet.h
++++ b/include/lsl/inlet.h
+@@ -168,7 +168,7 @@ extern LIBLSL_C_API double lsl_pull_sample_d(lsl_inlet in, double *buffer, int32
+ extern LIBLSL_C_API double lsl_pull_sample_l(lsl_inlet in, int64_t *buffer, int32_t buffer_elements, double timeout, int32_t *ec);
+ extern LIBLSL_C_API double lsl_pull_sample_i(lsl_inlet in, int32_t *buffer, int32_t buffer_elements, double timeout, int32_t *ec);
+ extern LIBLSL_C_API double lsl_pull_sample_s(lsl_inlet in, int16_t *buffer, int32_t buffer_elements, double timeout, int32_t *ec);
+-extern LIBLSL_C_API double lsl_pull_sample_c(lsl_inlet in, char *buffer, int32_t buffer_elements, double timeout, int32_t *ec);
++extern LIBLSL_C_API double lsl_pull_sample_c(lsl_inlet in, int8_t *buffer, int32_t buffer_elements, double timeout, int32_t *ec);
+ extern LIBLSL_C_API double lsl_pull_sample_str(lsl_inlet in, char **buffer, int32_t buffer_elements, double timeout, int32_t *ec);
+ ///@}
+ 
+@@ -233,7 +233,7 @@ extern LIBLSL_C_API unsigned long lsl_pull_chunk_d(lsl_inlet in, double *data_bu
+ extern LIBLSL_C_API unsigned long lsl_pull_chunk_l(lsl_inlet in, int64_t *data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int32_t *ec);
+ extern LIBLSL_C_API unsigned long lsl_pull_chunk_i(lsl_inlet in, int32_t *data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int32_t *ec);
+ extern LIBLSL_C_API unsigned long lsl_pull_chunk_s(lsl_inlet in, int16_t *data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int32_t *ec);
+-extern LIBLSL_C_API unsigned long lsl_pull_chunk_c(lsl_inlet in, char *data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int32_t *ec);
++extern LIBLSL_C_API unsigned long lsl_pull_chunk_c(lsl_inlet in, int8_t *data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int32_t *ec);
+ extern LIBLSL_C_API unsigned long lsl_pull_chunk_str(lsl_inlet in, char **data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int32_t *ec);
+ 
+ ///@}
+diff --git a/include/lsl/outlet.h b/include/lsl/outlet.h
+index 937fde47b..db61c2bc1 100644
+--- a/include/lsl/outlet.h
++++ b/include/lsl/outlet.h
+@@ -63,7 +63,7 @@ extern LIBLSL_C_API int32_t lsl_push_sample_d(lsl_outlet out, const double *data
+ extern LIBLSL_C_API int32_t lsl_push_sample_l(lsl_outlet out, const int64_t *data);
+ extern LIBLSL_C_API int32_t lsl_push_sample_i(lsl_outlet out, const int32_t *data);
+ extern LIBLSL_C_API int32_t lsl_push_sample_s(lsl_outlet out, const int16_t *data);
+-extern LIBLSL_C_API int32_t lsl_push_sample_c(lsl_outlet out, const char *data);
++extern LIBLSL_C_API int32_t lsl_push_sample_c(lsl_outlet out, const int8_t *data);
+ extern LIBLSL_C_API int32_t lsl_push_sample_str(lsl_outlet out, const char **data);
+ extern LIBLSL_C_API int32_t lsl_push_sample_v(lsl_outlet out, const void *data);
+ /// @}
+@@ -77,7 +77,7 @@ extern LIBLSL_C_API int32_t lsl_push_sample_dt(lsl_outlet out, const double *dat
+ extern LIBLSL_C_API int32_t lsl_push_sample_lt(lsl_outlet out, const int64_t *data, double timestamp);
+ extern LIBLSL_C_API int32_t lsl_push_sample_it(lsl_outlet out, const int32_t *data, double timestamp);
+ extern LIBLSL_C_API int32_t lsl_push_sample_st(lsl_outlet out, const int16_t *data, double timestamp);
+-extern LIBLSL_C_API int32_t lsl_push_sample_ct(lsl_outlet out, const char *data, double timestamp);
++extern LIBLSL_C_API int32_t lsl_push_sample_ct(lsl_outlet out, const int8_t *data, double timestamp);
+ extern LIBLSL_C_API int32_t lsl_push_sample_strt(lsl_outlet out, const char **data, double timestamp);
+ extern LIBLSL_C_API int32_t lsl_push_sample_vt(lsl_outlet out, const void *data, double timestamp);
+ /// @}
+@@ -92,7 +92,7 @@ extern LIBLSL_C_API int32_t lsl_push_sample_dtp(lsl_outlet out, const double *da
+ extern LIBLSL_C_API int32_t lsl_push_sample_ltp(lsl_outlet out, const int64_t *data, double timestamp, int32_t pushthrough);
+ extern LIBLSL_C_API int32_t lsl_push_sample_itp(lsl_outlet out, const int32_t *data, double timestamp, int32_t pushthrough);
+ extern LIBLSL_C_API int32_t lsl_push_sample_stp(lsl_outlet out, const int16_t *data, double timestamp, int32_t pushthrough);
+-extern LIBLSL_C_API int32_t lsl_push_sample_ctp(lsl_outlet out, const char *data, double timestamp, int32_t pushthrough);
++extern LIBLSL_C_API int32_t lsl_push_sample_ctp(lsl_outlet out, const int8_t *data, double timestamp, int32_t pushthrough);
+ extern LIBLSL_C_API int32_t lsl_push_sample_strtp(lsl_outlet out, const char **data, double timestamp, int32_t pushthrough);
+ extern LIBLSL_C_API int32_t lsl_push_sample_vtp(lsl_outlet out, const void *data, double timestamp, int32_t pushthrough);
+ ///@}
+@@ -131,7 +131,7 @@ extern LIBLSL_C_API int32_t lsl_push_chunk_d(lsl_outlet out, const double *data,
+ extern LIBLSL_C_API int32_t lsl_push_chunk_l(lsl_outlet out, const int64_t *data, unsigned long data_elements);
+ extern LIBLSL_C_API int32_t lsl_push_chunk_i(lsl_outlet out, const int32_t *data, unsigned long data_elements);
+ extern LIBLSL_C_API int32_t lsl_push_chunk_s(lsl_outlet out, const int16_t *data, unsigned long data_elements);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_c(lsl_outlet out, const char *data, unsigned long data_elements);
++extern LIBLSL_C_API int32_t lsl_push_chunk_c(lsl_outlet out, const int8_t *data, unsigned long data_elements);
+ extern LIBLSL_C_API int32_t lsl_push_chunk_str(lsl_outlet out, const char **data, unsigned long data_elements);
+ /// @}
+ 
+@@ -147,7 +147,7 @@ extern LIBLSL_C_API int32_t lsl_push_chunk_dt(lsl_outlet out, const double *data
+ extern LIBLSL_C_API int32_t lsl_push_chunk_lt(lsl_outlet out, const int64_t *data, unsigned long data_elements, double timestamp);
+ extern LIBLSL_C_API int32_t lsl_push_chunk_it(lsl_outlet out, const int32_t *data, unsigned long data_elements, double timestamp);
+ extern LIBLSL_C_API int32_t lsl_push_chunk_st(lsl_outlet out, const int16_t *data, unsigned long data_elements, double timestamp);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_ct(lsl_outlet out, const char *data, unsigned long data_elements, double timestamp);
++extern LIBLSL_C_API int32_t lsl_push_chunk_ct(lsl_outlet out, const int8_t *data, unsigned long data_elements, double timestamp);
+ extern LIBLSL_C_API int32_t lsl_push_chunk_strt(lsl_outlet out, const char **data, unsigned long data_elements, double timestamp);
+ /// @}
+ 
+@@ -162,7 +162,7 @@ extern LIBLSL_C_API int32_t lsl_push_chunk_dtp(lsl_outlet out, const double *dat
+ extern LIBLSL_C_API int32_t lsl_push_chunk_ltp(lsl_outlet out, const int64_t *data, unsigned long data_elements, double timestamp, int32_t pushthrough);
+ extern LIBLSL_C_API int32_t lsl_push_chunk_itp(lsl_outlet out, const int32_t *data, unsigned long data_elements, double timestamp, int32_t pushthrough);
+ extern LIBLSL_C_API int32_t lsl_push_chunk_stp(lsl_outlet out, const int16_t *data, unsigned long data_elements, double timestamp, int32_t pushthrough);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_ctp(lsl_outlet out, const char *data, unsigned long data_elements, double timestamp, int32_t pushthrough);
++extern LIBLSL_C_API int32_t lsl_push_chunk_ctp(lsl_outlet out, const int8_t *data, unsigned long data_elements, double timestamp, int32_t pushthrough);
+ extern LIBLSL_C_API int32_t lsl_push_chunk_strtp(lsl_outlet out, const char **data, unsigned long data_elements, double timestamp, int32_t pushthrough);
+ /// @}
+ /** @copydoc lsl_push_chunk_f
+@@ -174,7 +174,7 @@ extern LIBLSL_C_API int32_t lsl_push_chunk_dtn(lsl_outlet out, const double *dat
+ extern LIBLSL_C_API int32_t lsl_push_chunk_ltn(lsl_outlet out, const int64_t *data, unsigned long data_elements, const double *timestamps);
+ extern LIBLSL_C_API int32_t lsl_push_chunk_itn(lsl_outlet out, const int32_t *data, unsigned long data_elements, const double *timestamps);
+ extern LIBLSL_C_API int32_t lsl_push_chunk_stn(lsl_outlet out, const int16_t *data, unsigned long data_elements, const double *timestamps);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_ctn(lsl_outlet out, const char *data, unsigned long data_elements, const double *timestamps);
++extern LIBLSL_C_API int32_t lsl_push_chunk_ctn(lsl_outlet out, const int8_t *data, unsigned long data_elements, const double *timestamps);
+ extern LIBLSL_C_API int32_t lsl_push_chunk_strtn(lsl_outlet out, const char **data, unsigned long data_elements, const double *timestamps);
+ /// @}
+ 
+@@ -189,7 +189,7 @@ extern LIBLSL_C_API int32_t lsl_push_chunk_dtnp(lsl_outlet out, const double *da
+ extern LIBLSL_C_API int32_t lsl_push_chunk_ltnp(lsl_outlet out, const int64_t *data, unsigned long data_elements, const double *timestamps, int32_t pushthrough);
+ extern LIBLSL_C_API int32_t lsl_push_chunk_itnp(lsl_outlet out, const int32_t *data, unsigned long data_elements, const double *timestamps, int32_t pushthrough);
+ extern LIBLSL_C_API int32_t lsl_push_chunk_stnp(lsl_outlet out, const int16_t *data, unsigned long data_elements, const double *timestamps, int32_t pushthrough);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_ctnp(lsl_outlet out, const char *data, unsigned long data_elements, const double *timestamps, int32_t pushthrough);
++extern LIBLSL_C_API int32_t lsl_push_chunk_ctnp(lsl_outlet out, const int8_t *data, unsigned long data_elements, const double *timestamps, int32_t pushthrough);
+ extern LIBLSL_C_API int32_t lsl_push_chunk_strtnp(lsl_outlet out, const char **data, unsigned long data_elements, const double *timestamps, int32_t pushthrough);
+ ///@}
+ 
+diff --git a/include/lsl_cpp.h b/include/lsl_cpp.h
+index f249d4596..220aff157 100644
+--- a/include/lsl_cpp.h
++++ b/include/lsl_cpp.h
+@@ -477,9 +477,12 @@ class stream_outlet {
+ 	void push_sample(const int16_t *data, double timestamp = 0.0, bool pushthrough = true) {
+ 		lsl_push_sample_stp(obj.get(), (data), timestamp, pushthrough);
+ 	}
+-	void push_sample(const char *data, double timestamp = 0.0, bool pushthrough = true) {
++	void push_sample(const int8_t *data, double timestamp = 0.0, bool pushthrough = true) {
+ 		lsl_push_sample_ctp(obj.get(), (data), timestamp, pushthrough);
+ 	}
++	void push_sample(const char *data, double timestamp = 0.0, bool pushthrough = true) {
++		lsl_push_sample_ctp(obj.get(), reinterpret_cast<const int8_t *>(data), timestamp, pushthrough);
++	}
+ 	void push_sample(const std::string *data, double timestamp = 0.0, bool pushthrough = true) {
+ 		std::vector<uint32_t> lengths(channel_count);
+ 		std::vector<const char *> pointers(channel_count);
+@@ -680,10 +683,15 @@ class stream_outlet {
+ 		double timestamp = 0.0, bool pushthrough = true) {
+ 		lsl_push_chunk_stp(obj.get(), buffer, static_cast<unsigned long>(buffer_elements), timestamp, pushthrough);
+ 	}
+-	void push_chunk_multiplexed(const char *buffer, std::size_t buffer_elements,
++	void push_chunk_multiplexed(const int8_t *buffer, std::size_t buffer_elements,
+ 		double timestamp = 0.0, bool pushthrough = true) {
+ 		lsl_push_chunk_ctp(obj.get(), buffer, static_cast<unsigned long>(buffer_elements), timestamp, pushthrough);
+ 	}
++	void push_chunk_multiplexed(const char *buffer, std::size_t buffer_elements,
++		double timestamp = 0.0, bool pushthrough = true) {
++		lsl_push_chunk_ctp(obj.get(), reinterpret_cast<const int8_t *>(buffer),
++			static_cast<unsigned long>(buffer_elements), timestamp, pushthrough);
++	}
+ 	void push_chunk_multiplexed(const std::string *buffer, std::size_t buffer_elements,
+ 		double timestamp = 0.0, bool pushthrough = true) {
+ 		if (buffer_elements) {
+@@ -736,11 +744,16 @@ class stream_outlet {
+ 		lsl_push_chunk_stnp(obj.get(), data_buffer, static_cast<unsigned long>(data_buffer_elements),
+ 			(timestamp_buffer), pushthrough);
+ 	}
+-	void push_chunk_multiplexed(const char *data_buffer, const double *timestamp_buffer,
++	void push_chunk_multiplexed(const int8_t *data_buffer, const double *timestamp_buffer,
+ 		std::size_t data_buffer_elements, bool pushthrough = true) {
+ 		lsl_push_chunk_ctnp(obj.get(), data_buffer, static_cast<unsigned long>(data_buffer_elements),
+ 			(timestamp_buffer), pushthrough);
+ 	}
++	void push_chunk_multiplexed(const char *data_buffer, const double *timestamp_buffer,
++		std::size_t data_buffer_elements, bool pushthrough = true) {
++		lsl_push_chunk_ctnp(obj.get(), reinterpret_cast<const int8_t *>(data_buffer),
++			static_cast<unsigned long>(data_buffer_elements), (timestamp_buffer), pushthrough);
++	}
+ 
+ 	void push_chunk_multiplexed(const std::string *data_buffer, const double *timestamp_buffer,
+ 		std::size_t data_buffer_elements, bool pushthrough = true) {
+@@ -1070,6 +1083,10 @@ class stream_inlet {
+ 		sample.resize(channel_count);
+ 		return pull_sample(&sample[0], (int32_t)sample.size(), timeout);
+ 	}
++	double pull_sample(std::vector<int8_t> &sample, double timeout = FOREVER) {
++		sample.resize(channel_count);
++		return pull_sample(&sample[0], (int32_t)sample.size(), timeout);
++	}
+ 	double pull_sample(std::vector<char> &sample, double timeout = FOREVER) {
+ 		sample.resize(channel_count);
+ 		return pull_sample(&sample[0], (int32_t)sample.size(), timeout);
+@@ -1121,12 +1138,18 @@ class stream_inlet {
+ 		check_error(ec);
+ 		return res;
+ 	}
+-	double pull_sample(char *buffer, int32_t buffer_elements, double timeout = FOREVER) {
++	double pull_sample(int8_t *buffer, int32_t buffer_elements, double timeout = FOREVER) {
+ 		int32_t ec = 0;
+ 		double res = lsl_pull_sample_c(obj.get(), buffer, buffer_elements, timeout, &ec);
+ 		check_error(ec);
+ 		return res;
+ 	}
++	double pull_sample(char *buffer, int32_t buffer_elements, double timeout = FOREVER) {
++		int32_t ec = 0;
++		double res = lsl_pull_sample_c(obj.get(), reinterpret_cast<int8_t *>(buffer), buffer_elements, timeout, &ec);
++		check_error(ec);
++		return res;
++	}
+ 	double pull_sample(std::string *buffer, int32_t buffer_elements, double timeout = FOREVER) {
+ 		int32_t ec = 0;
+ 		if (buffer_elements) {
+@@ -1316,7 +1339,7 @@ class stream_inlet {
+ 		check_error(ec);
+ 		return res;
+ 	}
+-	std::size_t pull_chunk_multiplexed(char *data_buffer, double *timestamp_buffer,
++	std::size_t pull_chunk_multiplexed(int8_t *data_buffer, double *timestamp_buffer,
+ 		std::size_t data_buffer_elements, std::size_t timestamp_buffer_elements,
+ 		double timeout = 0.0) {
+ 		int32_t ec = 0;
+@@ -1326,6 +1349,16 @@ class stream_inlet {
+ 		check_error(ec);
+ 		return res;
+ 	}
++	std::size_t pull_chunk_multiplexed(char *data_buffer, double *timestamp_buffer,
++		std::size_t data_buffer_elements, std::size_t timestamp_buffer_elements,
++		double timeout = 0.0) {
++		int32_t ec = 0;
++		std::size_t res = lsl_pull_chunk_c(obj.get(), reinterpret_cast<int8_t *>(data_buffer), timestamp_buffer,
++			static_cast<unsigned long>(data_buffer_elements), static_cast<unsigned long>(timestamp_buffer_elements), timeout,
++			&ec);
++		check_error(ec);
++		return res;
++	}
+ 	std::size_t pull_chunk_multiplexed(std::string *data_buffer, double *timestamp_buffer,
+ 		std::size_t data_buffer_elements, std::size_t timestamp_buffer_elements,
+ 		double timeout = 0.0) {
+diff --git a/src/data_receiver.cpp b/src/data_receiver.cpp
+index 7266c2039..77e55f142 100644
+--- a/src/data_receiver.cpp
++++ b/src/data_receiver.cpp
+@@ -112,7 +112,7 @@ double data_receiver::pull_sample_typed(T *buffer, uint32_t buffer_elements, dou
+ 	return 0.0;
+ }
+ 
+-template double data_receiver::pull_sample_typed<char>(char *, uint32_t, double);
++template double data_receiver::pull_sample_typed<int8_t>(int8_t *, uint32_t, double);
+ template double data_receiver::pull_sample_typed<int16_t>(int16_t *, uint32_t, double);
+ template double data_receiver::pull_sample_typed<int32_t>(int32_t *, uint32_t, double);
+ template double data_receiver::pull_sample_typed<int64_t>(int64_t *, uint32_t, double);
+diff --git a/src/lsl_inlet_c.cpp b/src/lsl_inlet_c.cpp
+index 4cc20498c..48289c2dc 100644
+--- a/src/lsl_inlet_c.cpp
++++ b/src/lsl_inlet_c.cpp
+@@ -113,7 +113,7 @@ LIBLSL_C_API double lsl_pull_sample_s(
+ }
+ 
+ LIBLSL_C_API double lsl_pull_sample_c(
+-	lsl_inlet in, char *buffer, int32_t buffer_elements, double timeout, int32_t *ec) {
++	lsl_inlet in, int8_t *buffer, int32_t buffer_elements, double timeout, int32_t *ec) {
+ 	return in->pull_sample_noexcept(buffer, buffer_elements, timeout, (lsl_error_code_t *)ec);
+ }
+ 
+@@ -213,7 +213,7 @@ LIBLSL_C_API unsigned long lsl_pull_chunk_s(lsl_inlet in, int16_t *data_buffer,
+ 		timestamp_buffer_elements, timeout, (lsl_error_code_t *)ec);
+ }
+ 
+-LIBLSL_C_API unsigned long lsl_pull_chunk_c(lsl_inlet in, char *data_buffer,
++LIBLSL_C_API unsigned long lsl_pull_chunk_c(lsl_inlet in, int8_t *data_buffer,
+ 	double *timestamp_buffer, unsigned long data_buffer_elements,
+ 	unsigned long timestamp_buffer_elements, double timeout, int32_t *ec) {
+ 	return in->pull_chunk_multiplexed_noexcept(data_buffer, timestamp_buffer, data_buffer_elements,
+diff --git a/src/lsl_outlet_c.cpp b/src/lsl_outlet_c.cpp
+index b79ba3153..b79682ed4 100644
+--- a/src/lsl_outlet_c.cpp
++++ b/src/lsl_outlet_c.cpp
+@@ -98,16 +98,16 @@ LIBLSL_C_API int32_t lsl_push_sample_stp(
+ 	return out->push_sample_noexcept(data, timestamp, pushthrough);
+ }
+ 
+-LIBLSL_C_API int32_t lsl_push_sample_c(lsl_outlet out, const char *data) {
++LIBLSL_C_API int32_t lsl_push_sample_c(lsl_outlet out, const int8_t *data) {
+ 	return out->push_sample_noexcept(data);
+ }
+ 
+-LIBLSL_C_API int32_t lsl_push_sample_ct(lsl_outlet out, const char *data, double timestamp) {
++LIBLSL_C_API int32_t lsl_push_sample_ct(lsl_outlet out, const int8_t *data, double timestamp) {
+ 	return out->push_sample_noexcept(data, timestamp);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_sample_ctp(
+-	lsl_outlet out, const char *data, double timestamp, int32_t pushthrough) {
++	lsl_outlet out, const int8_t *data, double timestamp, int32_t pushthrough) {
+ 	return out->push_sample_noexcept(data, timestamp, pushthrough);
+ }
+ 
+@@ -198,7 +198,7 @@ LIBLSL_C_API int32_t lsl_push_chunk_s(
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_c(
+-	lsl_outlet out, const char *data, unsigned long data_elements) {
++	lsl_outlet out, const int8_t *data, unsigned long data_elements) {
+ 	return out->push_chunk_multiplexed_noexcept(data, data_elements);
+ }
+ 
+@@ -228,7 +228,7 @@ LIBLSL_C_API int32_t lsl_push_chunk_st(
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_ct(
+-	lsl_outlet out, const char *data, unsigned long data_elements, double timestamp) {
++	lsl_outlet out, const int8_t *data, unsigned long data_elements, double timestamp) {
+ 	return out->push_chunk_multiplexed_noexcept(data, data_elements, timestamp);
+ }
+ 
+@@ -257,7 +257,7 @@ LIBLSL_C_API int32_t lsl_push_chunk_stp(lsl_outlet out, const int16_t *data,
+ 	return out->push_chunk_multiplexed_noexcept(data, data_elements, timestamp, pushthrough);
+ }
+ 
+-LIBLSL_C_API int32_t lsl_push_chunk_ctp(lsl_outlet out, const char *data,
++LIBLSL_C_API int32_t lsl_push_chunk_ctp(lsl_outlet out, const int8_t *data,
+ 	unsigned long data_elements, double timestamp, int32_t pushthrough) {
+ 	return out->push_chunk_multiplexed_noexcept(data, data_elements, timestamp, pushthrough);
+ }
+@@ -288,7 +288,7 @@ LIBLSL_C_API int32_t lsl_push_chunk_stn(
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_ctn(
+-	lsl_outlet out, const char *data, unsigned long data_elements, const double *timestamps) {
++	lsl_outlet out, const int8_t *data, unsigned long data_elements, const double *timestamps) {
+ 	return out->push_chunk_multiplexed_noexcept(data, timestamps, data_elements);
+ }
+ 
+@@ -317,7 +317,7 @@ LIBLSL_C_API int32_t lsl_push_chunk_stnp(lsl_outlet out, const int16_t *data,
+ 	return out->push_chunk_multiplexed_noexcept(data, timestamps, data_elements, pushthrough);
+ }
+ 
+-LIBLSL_C_API int32_t lsl_push_chunk_ctnp(lsl_outlet out, const char *data,
++LIBLSL_C_API int32_t lsl_push_chunk_ctnp(lsl_outlet out, const int8_t *data,
+ 	unsigned long data_elements, const double *timestamps, int32_t pushthrough) {
+ 	return out->push_chunk_multiplexed_noexcept(data, timestamps, data_elements, pushthrough);
+ }
+diff --git a/src/sample.cpp b/src/sample.cpp
+index b95521b0e..4ebe8418e 100644
+--- a/src/sample.cpp
++++ b/src/sample.cpp
+@@ -482,14 +482,14 @@ void factory::reclaim_sample(sample *s) {
+ // template instantiations
+ template void lsl::sample::assign_typed(float const *);
+ template void lsl::sample::assign_typed(double const *);
+-template void lsl::sample::assign_typed(char const *);
++template void lsl::sample::assign_typed(int8_t const *);
+ template void lsl::sample::assign_typed(int16_t const *);
+ template void lsl::sample::assign_typed(int32_t const *);
+ template void lsl::sample::assign_typed(int64_t const *);
+ template void lsl::sample::assign_typed(std::string const *);
+ template void lsl::sample::retrieve_typed(float *);
+ template void lsl::sample::retrieve_typed(double *);
+-template void lsl::sample::retrieve_typed(char *);
++template void lsl::sample::retrieve_typed(int8_t *);
+ template void lsl::sample::retrieve_typed(int16_t *);
+ template void lsl::sample::retrieve_typed(int32_t *);
+ template void lsl::sample::retrieve_typed(int64_t *);
+diff --git a/src/stream_inlet_impl.h b/src/stream_inlet_impl.h
+index b3ad7e618..e5c397b5c 100644
+--- a/src/stream_inlet_impl.h
++++ b/src/stream_inlet_impl.h
+@@ -89,7 +89,7 @@ class stream_inlet_impl {
+ 		data.resize(conn_.type_info().channel_count());
+ 		return pull_sample(data.data(), (int32_t)data.size(), timeout);
+ 	}
+-	double pull_sample(std::vector<char> &data, double timeout = FOREVER) {
++	double pull_sample(std::vector<int8_t> &data, double timeout = FOREVER) {
+ 		data.resize(conn_.type_info().channel_count());
+ 		return pull_sample(data.data(), (int32_t)data.size(), timeout);
+ 	}
+@@ -127,7 +127,7 @@ class stream_inlet_impl {
+ 	double pull_sample(int16_t *buffer, int32_t buffer_elements, double timeout = FOREVER) {
+ 		return postprocess(data_receiver_.pull_sample_typed(buffer, buffer_elements, timeout));
+ 	}
+-	double pull_sample(char *buffer, int32_t buffer_elements, double timeout = FOREVER) {
++	double pull_sample(int8_t *buffer, int32_t buffer_elements, double timeout = FOREVER) {
+ 		return postprocess(data_receiver_.pull_sample_typed(buffer, buffer_elements, timeout));
+ 	}
+ 	double pull_sample(std::string *buffer, int32_t buffer_elements, double timeout = FOREVER) {
+diff --git a/src/stream_outlet_impl.cpp b/src/stream_outlet_impl.cpp
+index 62f9a38fc..279b3d7c9 100644
+--- a/src/stream_outlet_impl.cpp
++++ b/src/stream_outlet_impl.cpp
+@@ -210,7 +210,7 @@ void stream_outlet_impl::enqueue(const T *data, double timestamp, bool pushthrou
+ 	}
+ }
+ 
+-template void stream_outlet_impl::enqueue<char>(const char *data, double, bool);
++template void stream_outlet_impl::enqueue<int8_t>(const int8_t *data, double, bool);
+ template void stream_outlet_impl::enqueue<int16_t>(const int16_t *data, double, bool);
+ template void stream_outlet_impl::enqueue<int32_t>(const int32_t *data, double, bool);
+ template void stream_outlet_impl::enqueue<int64_t>(const int64_t *data, double, bool);
+@@ -289,8 +289,8 @@ void stream_outlet_impl::enqueue_chunk_sync(
+ }
+ 
+ // Explicit template instantiations for enqueue_chunk_sync
+-template void stream_outlet_impl::enqueue_chunk_sync<char>(
+-	const char *, std::size_t, double, bool);
++template void stream_outlet_impl::enqueue_chunk_sync<int8_t>(
++	const int8_t *, std::size_t, double, bool);
+ template void stream_outlet_impl::enqueue_chunk_sync<int16_t>(
+ 	const int16_t *, std::size_t, double, bool);
+ template void stream_outlet_impl::enqueue_chunk_sync<int32_t>(
+diff --git a/src/stream_outlet_impl.h b/src/stream_outlet_impl.h
+index e8fb3116a..7bee13187 100644
+--- a/src/stream_outlet_impl.h
++++ b/src/stream_outlet_impl.h
+@@ -96,7 +96,7 @@ class stream_outlet_impl {
+ 		enqueue(data.data(), timestamp, pushthrough);
+ 	}
+ 	void push_sample(
+-		const std::vector<char> &data, double timestamp = 0.0, bool pushthrough = true) {
++		const std::vector<int8_t> &data, double timestamp = 0.0, bool pushthrough = true) {
+ 		check_numchan((int32_t)data.size());
+ 		enqueue(data.data(), timestamp, pushthrough);
+ 	}
+@@ -134,7 +134,7 @@ class stream_outlet_impl {
+ 	void push_sample(const int16_t *data, double timestamp = 0.0, bool pushthrough = true) {
+ 		enqueue(data, timestamp, pushthrough);
+ 	}
+-	void push_sample(const char *data, double timestamp = 0.0, bool pushthrough = true) {
++	void push_sample(const int8_t *data, double timestamp = 0.0, bool pushthrough = true) {
+ 		enqueue(data, timestamp, pushthrough);
+ 	}
+ 	void push_sample(const std::string *data, double timestamp = 0.0, bool pushthrough = true) {
+diff --git a/testing/common/lsltypes.hpp b/testing/common/lsltypes.hpp
+index a14ef9237..678a33542 100644
+--- a/testing/common/lsltypes.hpp
++++ b/testing/common/lsltypes.hpp
+@@ -9,7 +9,7 @@ template <typename T> struct SampleType {
+ 	static const char *fmt_string();
+ };
+ 
+-template <> struct SampleType<char> {
++template <> struct SampleType<int8_t> {
+ 	static const lsl_channel_format_t chan_fmt = cft_int8;
+ 	static const char *fmt_string() { return "cf_int8"; }
+ };
+diff --git a/testing/ext/DataType.cpp b/testing/ext/DataType.cpp
+index f09103159..2438a9a7d 100644
+--- a/testing/ext/DataType.cpp
++++ b/testing/ext/DataType.cpp
+@@ -10,7 +10,7 @@
+ // clazy:excludeall=non-pod-global-static
+ 
+ TEMPLATE_TEST_CASE(
+-	"datatransfer", "[datatransfer][basic]", char, int16_t, int32_t, int64_t, float, double) {
++	"datatransfer", "[datatransfer][basic]", int8_t, int16_t, int32_t, int64_t, float, double) {
+ 	const int numBounces = sizeof(TestType) * 8;
+ 	double timestamps[numBounces][2];
+ 	const char *name = SampleType<TestType>::fmt_string();
+diff --git a/testing/ext/sync_outlet.cpp b/testing/ext/sync_outlet.cpp
+index adc78a95e..06463ec99 100644
+--- a/testing/ext/sync_outlet.cpp
++++ b/testing/ext/sync_outlet.cpp
+@@ -48,7 +48,7 @@ TEST_CASE("sync_outlet_basic", "[sync][basic]") {
+ }
+ 
+ TEMPLATE_TEST_CASE(
+-	"sync_outlet_datatypes", "[sync][datatransfer]", char, int16_t, int32_t, int64_t, float, double) {
++	"sync_outlet_datatypes", "[sync][datatransfer]", int8_t, int16_t, int32_t, int64_t, float, double) {
+ 	const int nchannels = 2;
+ 	const int nsamples = 32;
+ 	const char *name = SampleType<TestType>::fmt_string();
+diff --git a/testing/ext/time.cpp b/testing/ext/time.cpp
+index 0a62243a5..1d38fc42e 100644
+--- a/testing/ext/time.cpp
++++ b/testing/ext/time.cpp
+@@ -29,14 +29,14 @@ TEST_CASE("timeouts", "[pull][basic]") {
+ 
+ 	// Push a sample after some time so the test can continue even if the timeout isn't honored
+ 	std::thread saver([&]() {
+-		char val;
++		int8_t val;
+ 		auto end = lsl::local_clock() + 2;
+ 		while (!done && lsl::local_clock() < end)
+ 			std::this_thread::sleep_for(std::chrono::milliseconds(50));
+ 		sp.out_.push_sample(&val);
+ 	});
+ 
+-	char val;
++	int8_t val;
+ 	REQUIRE(sp.in_.pull_sample(&val, 1, 0.5) == Catch::Approx(0.0));
+ 	done = true;
+ 	saver.join();

--- a/pkgs/by-name/li/liblsl/0003-use-sizet-for-message-count.patch
+++ b/pkgs/by-name/li/liblsl/0003-use-sizet-for-message-count.patch
@@ -1,0 +1,767 @@
+From 085f71ed6387053d6a13a2244032c7c22a00616e Mon Sep 17 00:00:00 2001
+From: Gavin John <gavinnjohn@gmail.com>
+Date: Mon, 29 Jun 2026 14:34:38 -0400
+Subject: [PATCH] fix(treewide): inconsistent use of unsigned long vs size_t
+
+On *most* platforms, these are the same. However, there are certain platforms (e.g. mingw on windows 32-bit) where unsigned long is less than 64 bits (namely, 32 bits) while a size_t (which is what the cpp header accepts) is 64 bits.
+
+This technically breaks ABI compatibility on mingw 32-bit specifically, but this won't actually have broken anything because any program that used the previous behaviour was already broken. On all other currently supported platforms, like with the previous change, size_t and unsigned long happen to be the same, and so we maintain ABI and source backwards compatibility there.
+---
+ include/lsl/inlet.h  | 18 +++++----
+ include/lsl/outlet.h | 82 +++++++++++++++++++++--------------------
+ include/lsl_cpp.h    | 52 +++++++++++++-------------
+ src/lsl_inlet_c.cpp  | 48 ++++++++++++------------
+ src/lsl_outlet_c.cpp | 88 ++++++++++++++++++++++----------------------
+ 5 files changed, 146 insertions(+), 142 deletions(-)
+
+diff --git a/include/lsl/inlet.h b/include/lsl/inlet.h
+index c027ba88..8335a55e 100644
+--- a/include/lsl/inlet.h
++++ b/include/lsl/inlet.h
+@@ -2,6 +2,8 @@
+ #include "common.h"
+ #include "types.h"
+ 
++#include <stddef.h>
++
+ 
+ /// @file inlet.h Stream inlet functions
+ 
+@@ -228,13 +230,13 @@ extern LIBLSL_C_API double lsl_pull_sample_v(lsl_inlet in, void *buffer, int32_t
+  * @return data_elements_written Number of channel data elements written to the data buffer.
+  * @{
+  */
+-extern LIBLSL_C_API unsigned long lsl_pull_chunk_f(lsl_inlet in, float *data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int32_t *ec);
+-extern LIBLSL_C_API unsigned long lsl_pull_chunk_d(lsl_inlet in, double *data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int32_t *ec);
+-extern LIBLSL_C_API unsigned long lsl_pull_chunk_l(lsl_inlet in, int64_t *data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int32_t *ec);
+-extern LIBLSL_C_API unsigned long lsl_pull_chunk_i(lsl_inlet in, int32_t *data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int32_t *ec);
+-extern LIBLSL_C_API unsigned long lsl_pull_chunk_s(lsl_inlet in, int16_t *data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int32_t *ec);
+-extern LIBLSL_C_API unsigned long lsl_pull_chunk_c(lsl_inlet in, int8_t *data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int32_t *ec);
+-extern LIBLSL_C_API unsigned long lsl_pull_chunk_str(lsl_inlet in, char **data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int32_t *ec);
++extern LIBLSL_C_API size_t lsl_pull_chunk_f(lsl_inlet in, float *data_buffer, double *timestamp_buffer, size_t data_buffer_elements, size_t timestamp_buffer_elements, double timeout, int32_t *ec);
++extern LIBLSL_C_API size_t lsl_pull_chunk_d(lsl_inlet in, double *data_buffer, double *timestamp_buffer, size_t data_buffer_elements, size_t timestamp_buffer_elements, double timeout, int32_t *ec);
++extern LIBLSL_C_API size_t lsl_pull_chunk_l(lsl_inlet in, int64_t *data_buffer, double *timestamp_buffer, size_t data_buffer_elements, size_t timestamp_buffer_elements, double timeout, int32_t *ec);
++extern LIBLSL_C_API size_t lsl_pull_chunk_i(lsl_inlet in, int32_t *data_buffer, double *timestamp_buffer, size_t data_buffer_elements, size_t timestamp_buffer_elements, double timeout, int32_t *ec);
++extern LIBLSL_C_API size_t lsl_pull_chunk_s(lsl_inlet in, int16_t *data_buffer, double *timestamp_buffer, size_t data_buffer_elements, size_t timestamp_buffer_elements, double timeout, int32_t *ec);
++extern LIBLSL_C_API size_t lsl_pull_chunk_c(lsl_inlet in, int8_t *data_buffer, double *timestamp_buffer, size_t data_buffer_elements, size_t timestamp_buffer_elements, double timeout, int32_t *ec);
++extern LIBLSL_C_API size_t lsl_pull_chunk_str(lsl_inlet in, char **data_buffer, double *timestamp_buffer, size_t data_buffer_elements, size_t timestamp_buffer_elements, double timeout, int32_t *ec);
+ 
+ ///@}
+ 
+@@ -267,7 +269,7 @@ extern LIBLSL_C_API unsigned long lsl_pull_chunk_str(lsl_inlet in, char **data_b
+  * @return data_elements_written Number of channel data elements written to the data buffer.
+  */
+ 
+-extern LIBLSL_C_API unsigned long lsl_pull_chunk_buf(lsl_inlet in, char **data_buffer, uint32_t *lengths_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int32_t *ec);
++extern LIBLSL_C_API size_t lsl_pull_chunk_buf(lsl_inlet in, char **data_buffer, uint32_t *lengths_buffer, double *timestamp_buffer, size_t data_buffer_elements, size_t timestamp_buffer_elements, double timeout, int32_t *ec);
+ 
+ /**
+ * Query whether samples are currently available for immediate pickup.
+diff --git a/include/lsl/outlet.h b/include/lsl/outlet.h
+index db61c2bc..e0f4b033 100644
+--- a/include/lsl/outlet.h
++++ b/include/lsl/outlet.h
+@@ -2,6 +2,8 @@
+ #include "./common.h"
+ #include "types.h"
+ 
++#include <stddef.h>
++
+ /// @file outlet.h Stream outlet functions
+ 
+ /** @defgroup outlet The lsl_outlet object
+@@ -126,13 +128,13 @@ extern LIBLSL_C_API int32_t lsl_push_sample_buftp(lsl_outlet out, const char **d
+  * @return Error code of the operation (usually attributed to the wrong data type).
+  * @{
+  */
+-extern LIBLSL_C_API int32_t lsl_push_chunk_f(lsl_outlet out, const float *data, unsigned long data_elements);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_d(lsl_outlet out, const double *data, unsigned long data_elements);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_l(lsl_outlet out, const int64_t *data, unsigned long data_elements);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_i(lsl_outlet out, const int32_t *data, unsigned long data_elements);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_s(lsl_outlet out, const int16_t *data, unsigned long data_elements);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_c(lsl_outlet out, const int8_t *data, unsigned long data_elements);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_str(lsl_outlet out, const char **data, unsigned long data_elements);
++extern LIBLSL_C_API int32_t lsl_push_chunk_f(lsl_outlet out, const float *data, size_t data_elements);
++extern LIBLSL_C_API int32_t lsl_push_chunk_d(lsl_outlet out, const double *data, size_t data_elements);
++extern LIBLSL_C_API int32_t lsl_push_chunk_l(lsl_outlet out, const int64_t *data, size_t data_elements);
++extern LIBLSL_C_API int32_t lsl_push_chunk_i(lsl_outlet out, const int32_t *data, size_t data_elements);
++extern LIBLSL_C_API int32_t lsl_push_chunk_s(lsl_outlet out, const int16_t *data, size_t data_elements);
++extern LIBLSL_C_API int32_t lsl_push_chunk_c(lsl_outlet out, const int8_t *data, size_t data_elements);
++extern LIBLSL_C_API int32_t lsl_push_chunk_str(lsl_outlet out, const char **data, size_t data_elements);
+ /// @}
+ 
+ /** @copydoc lsl_push_chunk_f
+@@ -142,13 +144,13 @@ extern LIBLSL_C_API int32_t lsl_push_chunk_str(lsl_outlet out, const char **data
+  * stream.
+  * @{
+  */
+-extern LIBLSL_C_API int32_t lsl_push_chunk_ft(lsl_outlet out, const float *data, unsigned long data_elements, double timestamp);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_dt(lsl_outlet out, const double *data, unsigned long data_elements, double timestamp);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_lt(lsl_outlet out, const int64_t *data, unsigned long data_elements, double timestamp);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_it(lsl_outlet out, const int32_t *data, unsigned long data_elements, double timestamp);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_st(lsl_outlet out, const int16_t *data, unsigned long data_elements, double timestamp);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_ct(lsl_outlet out, const int8_t *data, unsigned long data_elements, double timestamp);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_strt(lsl_outlet out, const char **data, unsigned long data_elements, double timestamp);
++extern LIBLSL_C_API int32_t lsl_push_chunk_ft(lsl_outlet out, const float *data, size_t data_elements, double timestamp);
++extern LIBLSL_C_API int32_t lsl_push_chunk_dt(lsl_outlet out, const double *data, size_t data_elements, double timestamp);
++extern LIBLSL_C_API int32_t lsl_push_chunk_lt(lsl_outlet out, const int64_t *data, size_t data_elements, double timestamp);
++extern LIBLSL_C_API int32_t lsl_push_chunk_it(lsl_outlet out, const int32_t *data, size_t data_elements, double timestamp);
++extern LIBLSL_C_API int32_t lsl_push_chunk_st(lsl_outlet out, const int16_t *data, size_t data_elements, double timestamp);
++extern LIBLSL_C_API int32_t lsl_push_chunk_ct(lsl_outlet out, const int8_t *data, size_t data_elements, double timestamp);
++extern LIBLSL_C_API int32_t lsl_push_chunk_strt(lsl_outlet out, const char **data, size_t data_elements, double timestamp);
+ /// @}
+ 
+ /** @copydoc lsl_push_chunk_ft
+@@ -157,25 +159,25 @@ extern LIBLSL_C_API int32_t lsl_push_chunk_strt(lsl_outlet out, const char **dat
+  * precedence over the pushthrough flag.
+  * @{
+  */
+-extern LIBLSL_C_API int32_t lsl_push_chunk_ftp(lsl_outlet out, const float *data, unsigned long data_elements, double timestamp, int32_t pushthrough);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_dtp(lsl_outlet out, const double *data, unsigned long data_elements, double timestamp, int32_t pushthrough);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_ltp(lsl_outlet out, const int64_t *data, unsigned long data_elements, double timestamp, int32_t pushthrough);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_itp(lsl_outlet out, const int32_t *data, unsigned long data_elements, double timestamp, int32_t pushthrough);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_stp(lsl_outlet out, const int16_t *data, unsigned long data_elements, double timestamp, int32_t pushthrough);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_ctp(lsl_outlet out, const int8_t *data, unsigned long data_elements, double timestamp, int32_t pushthrough);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_strtp(lsl_outlet out, const char **data, unsigned long data_elements, double timestamp, int32_t pushthrough);
++extern LIBLSL_C_API int32_t lsl_push_chunk_ftp(lsl_outlet out, const float *data, size_t data_elements, double timestamp, int32_t pushthrough);
++extern LIBLSL_C_API int32_t lsl_push_chunk_dtp(lsl_outlet out, const double *data, size_t data_elements, double timestamp, int32_t pushthrough);
++extern LIBLSL_C_API int32_t lsl_push_chunk_ltp(lsl_outlet out, const int64_t *data, size_t data_elements, double timestamp, int32_t pushthrough);
++extern LIBLSL_C_API int32_t lsl_push_chunk_itp(lsl_outlet out, const int32_t *data, size_t data_elements, double timestamp, int32_t pushthrough);
++extern LIBLSL_C_API int32_t lsl_push_chunk_stp(lsl_outlet out, const int16_t *data, size_t data_elements, double timestamp, int32_t pushthrough);
++extern LIBLSL_C_API int32_t lsl_push_chunk_ctp(lsl_outlet out, const int8_t *data, size_t data_elements, double timestamp, int32_t pushthrough);
++extern LIBLSL_C_API int32_t lsl_push_chunk_strtp(lsl_outlet out, const char **data, size_t data_elements, double timestamp, int32_t pushthrough);
+ /// @}
+ /** @copydoc lsl_push_chunk_f
+  * @param timestamps Buffer holding one time stamp for each sample in the data buffer.
+  * @{
+  */
+-extern LIBLSL_C_API int32_t lsl_push_chunk_ftn(lsl_outlet out, const float *data, unsigned long data_elements, const double *timestamps);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_dtn(lsl_outlet out, const double *data, unsigned long data_elements, const double *timestamps);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_ltn(lsl_outlet out, const int64_t *data, unsigned long data_elements, const double *timestamps);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_itn(lsl_outlet out, const int32_t *data, unsigned long data_elements, const double *timestamps);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_stn(lsl_outlet out, const int16_t *data, unsigned long data_elements, const double *timestamps);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_ctn(lsl_outlet out, const int8_t *data, unsigned long data_elements, const double *timestamps);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_strtn(lsl_outlet out, const char **data, unsigned long data_elements, const double *timestamps);
++extern LIBLSL_C_API int32_t lsl_push_chunk_ftn(lsl_outlet out, const float *data, size_t data_elements, const double *timestamps);
++extern LIBLSL_C_API int32_t lsl_push_chunk_dtn(lsl_outlet out, const double *data, size_t data_elements, const double *timestamps);
++extern LIBLSL_C_API int32_t lsl_push_chunk_ltn(lsl_outlet out, const int64_t *data, size_t data_elements, const double *timestamps);
++extern LIBLSL_C_API int32_t lsl_push_chunk_itn(lsl_outlet out, const int32_t *data, size_t data_elements, const double *timestamps);
++extern LIBLSL_C_API int32_t lsl_push_chunk_stn(lsl_outlet out, const int16_t *data, size_t data_elements, const double *timestamps);
++extern LIBLSL_C_API int32_t lsl_push_chunk_ctn(lsl_outlet out, const int8_t *data, size_t data_elements, const double *timestamps);
++extern LIBLSL_C_API int32_t lsl_push_chunk_strtn(lsl_outlet out, const char **data, size_t data_elements, const double *timestamps);
+ /// @}
+ 
+ /** @copydoc lsl_push_chunk_ftn
+@@ -184,13 +186,13 @@ extern LIBLSL_C_API int32_t lsl_push_chunk_strtn(lsl_outlet out, const char **da
+  * precedence over the pushthrough flag.
+  * @{
+  */
+-extern LIBLSL_C_API int32_t lsl_push_chunk_ftnp(lsl_outlet out, const float *data, unsigned long data_elements, const double *timestamps, int32_t pushthrough);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_dtnp(lsl_outlet out, const double *data, unsigned long data_elements, const double *timestamps, int32_t pushthrough);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_ltnp(lsl_outlet out, const int64_t *data, unsigned long data_elements, const double *timestamps, int32_t pushthrough);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_itnp(lsl_outlet out, const int32_t *data, unsigned long data_elements, const double *timestamps, int32_t pushthrough);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_stnp(lsl_outlet out, const int16_t *data, unsigned long data_elements, const double *timestamps, int32_t pushthrough);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_ctnp(lsl_outlet out, const int8_t *data, unsigned long data_elements, const double *timestamps, int32_t pushthrough);
+-extern LIBLSL_C_API int32_t lsl_push_chunk_strtnp(lsl_outlet out, const char **data, unsigned long data_elements, const double *timestamps, int32_t pushthrough);
++extern LIBLSL_C_API int32_t lsl_push_chunk_ftnp(lsl_outlet out, const float *data, size_t data_elements, const double *timestamps, int32_t pushthrough);
++extern LIBLSL_C_API int32_t lsl_push_chunk_dtnp(lsl_outlet out, const double *data, size_t data_elements, const double *timestamps, int32_t pushthrough);
++extern LIBLSL_C_API int32_t lsl_push_chunk_ltnp(lsl_outlet out, const int64_t *data, size_t data_elements, const double *timestamps, int32_t pushthrough);
++extern LIBLSL_C_API int32_t lsl_push_chunk_itnp(lsl_outlet out, const int32_t *data, size_t data_elements, const double *timestamps, int32_t pushthrough);
++extern LIBLSL_C_API int32_t lsl_push_chunk_stnp(lsl_outlet out, const int16_t *data, size_t data_elements, const double *timestamps, int32_t pushthrough);
++extern LIBLSL_C_API int32_t lsl_push_chunk_ctnp(lsl_outlet out, const int8_t *data, size_t data_elements, const double *timestamps, int32_t pushthrough);
++extern LIBLSL_C_API int32_t lsl_push_chunk_strtnp(lsl_outlet out, const char **data, size_t data_elements, const double *timestamps, int32_t pushthrough);
+ ///@}
+ 
+ /** @copybrief lsl_push_chunk_ftp
+@@ -202,30 +204,30 @@ extern LIBLSL_C_API int32_t lsl_push_chunk_strtnp(lsl_outlet out, const char **d
+  * @param data_elements The number of data values in the data buffer.
+  * Must be a multiple of the channel count.
+  */
+-extern LIBLSL_C_API int32_t lsl_push_chunk_buf(lsl_outlet out, const char **data, const uint32_t *lengths, unsigned long data_elements);
++extern LIBLSL_C_API int32_t lsl_push_chunk_buf(lsl_outlet out, const char **data, const uint32_t *lengths, size_t data_elements);
+ 
+ /** @copydoc lsl_push_chunk_buf @sa lsl_push_chunk_ftp @sa lsl_push_chunk_buf
+  * @param timestamp Optionally the capture time of the most recent sample, in agreement with
+  * lsl_local_clock(); if omitted, the current time is used.
+  * The time stamps of other samples are automatically derived based on the sampling rate of the
+  * stream. */
+-extern LIBLSL_C_API int32_t lsl_push_chunk_buft(lsl_outlet out, const char **data, const uint32_t *lengths, unsigned long data_elements, double timestamp);
++extern LIBLSL_C_API int32_t lsl_push_chunk_buft(lsl_outlet out, const char **data, const uint32_t *lengths, size_t data_elements, double timestamp);
+ 
+ /** @copydoc lsl_push_chunk_buft @sa lsl_push_chunk_ftp @sa lsl_push_chunk_buf
+  * @param pushthrough Whether to push the chunk through to the receivers instead of buffering it
+  * with subsequent samples. Note that the chunk_size, if specified at outlet construction, takes
+  * precedence over the pushthrough flag. */
+-extern LIBLSL_C_API int32_t lsl_push_chunk_buftp(lsl_outlet out, const char **data, const uint32_t *lengths, unsigned long data_elements, double timestamp, int32_t pushthrough);
++extern LIBLSL_C_API int32_t lsl_push_chunk_buftp(lsl_outlet out, const char **data, const uint32_t *lengths, size_t data_elements, double timestamp, int32_t pushthrough);
+ 
+ /** @copydoc lsl_push_chunk_buf @sa lsl_push_chunk_ftp @sa lsl_push_chunk_buf
+  * @param timestamps Buffer holding one time stamp for each sample in the data buffer. */
+-extern LIBLSL_C_API int32_t lsl_push_chunk_buftn(lsl_outlet out, const char **data, const uint32_t *lengths, unsigned long data_elements, const double *timestamps);
++extern LIBLSL_C_API int32_t lsl_push_chunk_buftn(lsl_outlet out, const char **data, const uint32_t *lengths, size_t data_elements, const double *timestamps);
+ 
+ /** @copydoc lsl_push_chunk_buftn @sa lsl_push_chunk_ftp @sa lsl_push_chunk_buf
+  * @param pushthrough Whether to push the chunk through to the receivers instead of buffering it
+  * with subsequent samples. Note that the chunk_size, if specified at outlet construction, takes
+  * precedence over the pushthrough flag. */
+-extern LIBLSL_C_API int32_t lsl_push_chunk_buftnp(lsl_outlet out, const char **data, const uint32_t *lengths, unsigned long data_elements, const double *timestamps, int32_t pushthrough);
++extern LIBLSL_C_API int32_t lsl_push_chunk_buftnp(lsl_outlet out, const char **data, const uint32_t *lengths, size_t data_elements, const double *timestamps, int32_t pushthrough);
+ 
+ /**
+ * Check whether consumers are currently registered.
+diff --git a/include/lsl_cpp.h b/include/lsl_cpp.h
+index 220aff15..41d64d79 100644
+--- a/include/lsl_cpp.h
++++ b/include/lsl_cpp.h
+@@ -629,7 +629,7 @@ class stream_outlet {
+ 		const std::vector<T> &buffer, double timestamp = 0.0, bool pushthrough = true) {
+ 		if (!buffer.empty())
+ 			push_chunk_multiplexed(
+-				buffer.data(), static_cast<unsigned long>(buffer.size()), timestamp, pushthrough);
++				buffer.data(), static_cast<size_t>(buffer.size()), timestamp, pushthrough);
+ 	}
+ 
+ 	/** Push a chunk of multiplexed data into the outlet. One timestamp per sample is provided.
+@@ -647,7 +647,7 @@ class stream_outlet {
+ 		const std::vector<double> &timestamps, bool pushthrough = true) {
+ 		if (!buffer.empty() && !timestamps.empty())
+ 			push_chunk_multiplexed(
+-				buffer.data(), static_cast<unsigned long>(buffer.size()), timestamps.data(), pushthrough);
++				buffer.data(), static_cast<size_t>(buffer.size()), timestamps.data(), pushthrough);
+ 	}
+ 
+ 	/** Push a chunk of multiplexed samples into the outlet. Single timestamp provided.
+@@ -665,32 +665,32 @@ class stream_outlet {
+ 	 */
+ 	void push_chunk_multiplexed(const float *buffer, std::size_t buffer_elements,
+ 		double timestamp = 0.0, bool pushthrough = true) {
+-		lsl_push_chunk_ftp(obj.get(), buffer, static_cast<unsigned long>(buffer_elements), timestamp, pushthrough);
++		lsl_push_chunk_ftp(obj.get(), buffer, static_cast<size_t>(buffer_elements), timestamp, pushthrough);
+ 	}
+ 	void push_chunk_multiplexed(const double *buffer, std::size_t buffer_elements,
+ 		double timestamp = 0.0, bool pushthrough = true) {
+-		lsl_push_chunk_dtp(obj.get(), buffer, static_cast<unsigned long>(buffer_elements), timestamp, pushthrough);
++		lsl_push_chunk_dtp(obj.get(), buffer, static_cast<size_t>(buffer_elements), timestamp, pushthrough);
+ 	}
+ 	void push_chunk_multiplexed(const int64_t *buffer, std::size_t buffer_elements,
+ 		double timestamp = 0.0, bool pushthrough = true) {
+-		lsl_push_chunk_ltp(obj.get(), buffer, static_cast<unsigned long>(buffer_elements), timestamp, pushthrough);
++		lsl_push_chunk_ltp(obj.get(), buffer, static_cast<size_t>(buffer_elements), timestamp, pushthrough);
+ 	}
+ 	void push_chunk_multiplexed(const int32_t *buffer, std::size_t buffer_elements,
+ 		double timestamp = 0.0, bool pushthrough = true) {
+-		lsl_push_chunk_itp(obj.get(), buffer, static_cast<unsigned long>(buffer_elements), timestamp, pushthrough);
++		lsl_push_chunk_itp(obj.get(), buffer, static_cast<size_t>(buffer_elements), timestamp, pushthrough);
+ 	}
+ 	void push_chunk_multiplexed(const int16_t *buffer, std::size_t buffer_elements,
+ 		double timestamp = 0.0, bool pushthrough = true) {
+-		lsl_push_chunk_stp(obj.get(), buffer, static_cast<unsigned long>(buffer_elements), timestamp, pushthrough);
++		lsl_push_chunk_stp(obj.get(), buffer, static_cast<size_t>(buffer_elements), timestamp, pushthrough);
+ 	}
+ 	void push_chunk_multiplexed(const int8_t *buffer, std::size_t buffer_elements,
+ 		double timestamp = 0.0, bool pushthrough = true) {
+-		lsl_push_chunk_ctp(obj.get(), buffer, static_cast<unsigned long>(buffer_elements), timestamp, pushthrough);
++		lsl_push_chunk_ctp(obj.get(), buffer, static_cast<size_t>(buffer_elements), timestamp, pushthrough);
+ 	}
+ 	void push_chunk_multiplexed(const char *buffer, std::size_t buffer_elements,
+ 		double timestamp = 0.0, bool pushthrough = true) {
+ 		lsl_push_chunk_ctp(obj.get(), reinterpret_cast<const int8_t *>(buffer),
+-			static_cast<unsigned long>(buffer_elements), timestamp, pushthrough);
++			static_cast<size_t>(buffer_elements), timestamp, pushthrough);
+ 	}
+ 	void push_chunk_multiplexed(const std::string *buffer, std::size_t buffer_elements,
+ 		double timestamp = 0.0, bool pushthrough = true) {
+@@ -702,7 +702,7 @@ class stream_outlet {
+ 				lengths[k] = (uint32_t)buffer[k].size();
+ 			}
+ 			lsl_push_chunk_buftp(obj.get(), pointers.data(), lengths.data(),
+-				static_cast<unsigned long>(buffer_elements), timestamp, pushthrough);
++				static_cast<size_t>(buffer_elements), timestamp, pushthrough);
+ 		}
+ 	}
+ 
+@@ -721,38 +721,38 @@ class stream_outlet {
+ 	 */
+ 	void push_chunk_multiplexed(const float *data_buffer, const double *timestamp_buffer,
+ 		std::size_t data_buffer_elements, bool pushthrough = true) {
+-		lsl_push_chunk_ftnp(obj.get(), data_buffer, static_cast<unsigned long>(data_buffer_elements),
++		lsl_push_chunk_ftnp(obj.get(), data_buffer, static_cast<size_t>(data_buffer_elements),
+ 			(timestamp_buffer), pushthrough);
+ 	}
+ 	void push_chunk_multiplexed(const double *data_buffer, const double *timestamp_buffer,
+ 		std::size_t data_buffer_elements, bool pushthrough = true) {
+-		lsl_push_chunk_dtnp(obj.get(), data_buffer, static_cast<unsigned long>(data_buffer_elements),
++		lsl_push_chunk_dtnp(obj.get(), data_buffer, static_cast<size_t>(data_buffer_elements),
+ 			(timestamp_buffer), pushthrough);
+ 	}
+ 	void push_chunk_multiplexed(const int64_t *data_buffer, const double *timestamp_buffer,
+ 		std::size_t data_buffer_elements, bool pushthrough = true) {
+-		lsl_push_chunk_ltnp(obj.get(), data_buffer, static_cast<unsigned long>(data_buffer_elements),
++		lsl_push_chunk_ltnp(obj.get(), data_buffer, static_cast<size_t>(data_buffer_elements),
+ 			(timestamp_buffer), pushthrough);
+ 	}
+ 	void push_chunk_multiplexed(const int32_t *data_buffer, const double *timestamp_buffer,
+ 		std::size_t data_buffer_elements, bool pushthrough = true) {
+-		lsl_push_chunk_itnp(obj.get(), data_buffer, static_cast<unsigned long>(data_buffer_elements),
++		lsl_push_chunk_itnp(obj.get(), data_buffer, static_cast<size_t>(data_buffer_elements),
+ 			(timestamp_buffer), pushthrough);
+ 	}
+ 	void push_chunk_multiplexed(const int16_t *data_buffer, const double *timestamp_buffer,
+ 		std::size_t data_buffer_elements, bool pushthrough = true) {
+-		lsl_push_chunk_stnp(obj.get(), data_buffer, static_cast<unsigned long>(data_buffer_elements),
++		lsl_push_chunk_stnp(obj.get(), data_buffer, static_cast<size_t>(data_buffer_elements),
+ 			(timestamp_buffer), pushthrough);
+ 	}
+ 	void push_chunk_multiplexed(const int8_t *data_buffer, const double *timestamp_buffer,
+ 		std::size_t data_buffer_elements, bool pushthrough = true) {
+-		lsl_push_chunk_ctnp(obj.get(), data_buffer, static_cast<unsigned long>(data_buffer_elements),
++		lsl_push_chunk_ctnp(obj.get(), data_buffer, static_cast<size_t>(data_buffer_elements),
+ 			(timestamp_buffer), pushthrough);
+ 	}
+ 	void push_chunk_multiplexed(const char *data_buffer, const double *timestamp_buffer,
+ 		std::size_t data_buffer_elements, bool pushthrough = true) {
+ 		lsl_push_chunk_ctnp(obj.get(), reinterpret_cast<const int8_t *>(data_buffer),
+-			static_cast<unsigned long>(data_buffer_elements), (timestamp_buffer), pushthrough);
++			static_cast<size_t>(data_buffer_elements), (timestamp_buffer), pushthrough);
+ 	}
+ 
+ 	void push_chunk_multiplexed(const std::string *data_buffer, const double *timestamp_buffer,
+@@ -765,7 +765,7 @@ class stream_outlet {
+ 				lengths[k] = (uint32_t)data_buffer[k].size();
+ 			}
+ 			lsl_push_chunk_buftnp(obj.get(), pointers.data(), lengths.data(),
+-				static_cast<unsigned long>(data_buffer_elements), timestamp_buffer, pushthrough);
++				static_cast<size_t>(data_buffer_elements), timestamp_buffer, pushthrough);
+ 		}
+ 	}
+ 
+@@ -1294,7 +1294,7 @@ class stream_inlet {
+ 		double timeout = 0.0) {
+ 		int32_t ec = 0;
+ 		std::size_t res = lsl_pull_chunk_f(obj.get(), data_buffer, timestamp_buffer,
+-			(unsigned long)data_buffer_elements, (unsigned long)timestamp_buffer_elements, timeout,
++			(size_t)data_buffer_elements, (size_t)timestamp_buffer_elements, timeout,
+ 			&ec);
+ 		check_error(ec);
+ 		return res;
+@@ -1304,7 +1304,7 @@ class stream_inlet {
+ 		double timeout = 0.0) {
+ 		int32_t ec = 0;
+ 		std::size_t res = lsl_pull_chunk_d(obj.get(), data_buffer, timestamp_buffer,
+-			(unsigned long)data_buffer_elements, (unsigned long)timestamp_buffer_elements, timeout,
++			(size_t)data_buffer_elements, (size_t)timestamp_buffer_elements, timeout,
+ 			&ec);
+ 		check_error(ec);
+ 		return res;
+@@ -1314,7 +1314,7 @@ class stream_inlet {
+ 		double timeout = 0.0) {
+ 		int32_t ec = 0;
+ 		std::size_t res = lsl_pull_chunk_l(obj.get(), data_buffer, timestamp_buffer,
+-			(unsigned long)data_buffer_elements, (unsigned long)timestamp_buffer_elements, timeout,
++			(size_t)data_buffer_elements, (size_t)timestamp_buffer_elements, timeout,
+ 			&ec);
+ 		check_error(ec);
+ 		return res;
+@@ -1324,7 +1324,7 @@ class stream_inlet {
+ 		double timeout = 0.0) {
+ 		int32_t ec = 0;
+ 		std::size_t res = lsl_pull_chunk_i(obj.get(), data_buffer, timestamp_buffer,
+-			(unsigned long)data_buffer_elements, (unsigned long)timestamp_buffer_elements, timeout,
++			(size_t)data_buffer_elements, (size_t)timestamp_buffer_elements, timeout,
+ 			&ec);
+ 		check_error(ec);
+ 		return res;
+@@ -1334,7 +1334,7 @@ class stream_inlet {
+ 		double timeout = 0.0) {
+ 		int32_t ec = 0;
+ 		std::size_t res = lsl_pull_chunk_s(obj.get(), data_buffer, timestamp_buffer,
+-			(unsigned long)data_buffer_elements, (unsigned long)timestamp_buffer_elements, timeout,
++			(size_t)data_buffer_elements, (size_t)timestamp_buffer_elements, timeout,
+ 			&ec);
+ 		check_error(ec);
+ 		return res;
+@@ -1344,7 +1344,7 @@ class stream_inlet {
+ 		double timeout = 0.0) {
+ 		int32_t ec = 0;
+ 		std::size_t res = lsl_pull_chunk_c(obj.get(), data_buffer, timestamp_buffer,
+-			static_cast<unsigned long>(data_buffer_elements), static_cast<unsigned long>(timestamp_buffer_elements), timeout,
++			static_cast<size_t>(data_buffer_elements), static_cast<size_t>(timestamp_buffer_elements), timeout,
+ 			&ec);
+ 		check_error(ec);
+ 		return res;
+@@ -1367,8 +1367,8 @@ class stream_inlet {
+ 			std::vector<char *> result_strings(data_buffer_elements);
+ 			std::vector<uint32_t> result_lengths(data_buffer_elements);
+ 			std::size_t num = lsl_pull_chunk_buf(obj.get(), result_strings.data(), result_lengths.data(),
+-				timestamp_buffer, static_cast<unsigned long>(data_buffer_elements),
+-				static_cast<unsigned long>(timestamp_buffer_elements), timeout, &ec);
++				timestamp_buffer, static_cast<size_t>(data_buffer_elements),
++				static_cast<size_t>(timestamp_buffer_elements), timeout, &ec);
+ 			check_error(ec);
+ 			for (std::size_t k = 0; k < num; k++) {
+ 				data_buffer[k].assign(result_strings[k], result_lengths[k]);
+diff --git a/src/lsl_inlet_c.cpp b/src/lsl_inlet_c.cpp
+index 48289c2d..89315989 100644
+--- a/src/lsl_inlet_c.cpp
++++ b/src/lsl_inlet_c.cpp
+@@ -178,51 +178,51 @@ LIBLSL_C_API double lsl_pull_sample_v(
+ 	return 0.0;
+ }
+ 
+-LIBLSL_C_API unsigned long lsl_pull_chunk_f(lsl_inlet in, float *data_buffer,
+-	double *timestamp_buffer, unsigned long data_buffer_elements,
+-	unsigned long timestamp_buffer_elements, double timeout, int32_t *ec) {
++LIBLSL_C_API size_t lsl_pull_chunk_f(lsl_inlet in, float *data_buffer,
++	double *timestamp_buffer, size_t data_buffer_elements,
++	size_t timestamp_buffer_elements, double timeout, int32_t *ec) {
+ 	return in->pull_chunk_multiplexed_noexcept(data_buffer, timestamp_buffer, data_buffer_elements,
+ 		timestamp_buffer_elements, timeout, (lsl_error_code_t *)ec);
+ }
+ 
+-LIBLSL_C_API unsigned long lsl_pull_chunk_d(lsl_inlet in, double *data_buffer,
+-	double *timestamp_buffer, unsigned long data_buffer_elements,
+-	unsigned long timestamp_buffer_elements, double timeout, int32_t *ec) {
++LIBLSL_C_API size_t lsl_pull_chunk_d(lsl_inlet in, double *data_buffer,
++	double *timestamp_buffer, size_t data_buffer_elements,
++	size_t timestamp_buffer_elements, double timeout, int32_t *ec) {
+ 	return in->pull_chunk_multiplexed_noexcept(data_buffer, timestamp_buffer, data_buffer_elements,
+ 		timestamp_buffer_elements, timeout, (lsl_error_code_t *)ec);
+ }
+ 
+-LIBLSL_C_API unsigned long lsl_pull_chunk_l(lsl_inlet in, int64_t *data_buffer,
+-	double *timestamp_buffer, unsigned long data_buffer_elements,
+-	unsigned long timestamp_buffer_elements, double timeout, int32_t *ec) {
++LIBLSL_C_API size_t lsl_pull_chunk_l(lsl_inlet in, int64_t *data_buffer,
++	double *timestamp_buffer, size_t data_buffer_elements,
++	size_t timestamp_buffer_elements, double timeout, int32_t *ec) {
+ 	return in->pull_chunk_multiplexed_noexcept(data_buffer, timestamp_buffer, data_buffer_elements,
+ 		timestamp_buffer_elements, timeout, (lsl_error_code_t *)ec);
+ }
+ 
+-LIBLSL_C_API unsigned long lsl_pull_chunk_i(lsl_inlet in, int32_t *data_buffer,
+-	double *timestamp_buffer, unsigned long data_buffer_elements,
+-	unsigned long timestamp_buffer_elements, double timeout, int32_t *ec) {
++LIBLSL_C_API size_t lsl_pull_chunk_i(lsl_inlet in, int32_t *data_buffer,
++	double *timestamp_buffer, size_t data_buffer_elements,
++	size_t timestamp_buffer_elements, double timeout, int32_t *ec) {
+ 	return in->pull_chunk_multiplexed_noexcept(data_buffer, timestamp_buffer, data_buffer_elements,
+ 		timestamp_buffer_elements, timeout, (lsl_error_code_t *)ec);
+ }
+ 
+-LIBLSL_C_API unsigned long lsl_pull_chunk_s(lsl_inlet in, int16_t *data_buffer,
+-	double *timestamp_buffer, unsigned long data_buffer_elements,
+-	unsigned long timestamp_buffer_elements, double timeout, int32_t *ec) {
++LIBLSL_C_API size_t lsl_pull_chunk_s(lsl_inlet in, int16_t *data_buffer,
++	double *timestamp_buffer, size_t data_buffer_elements,
++	size_t timestamp_buffer_elements, double timeout, int32_t *ec) {
+ 	return in->pull_chunk_multiplexed_noexcept(data_buffer, timestamp_buffer, data_buffer_elements,
+ 		timestamp_buffer_elements, timeout, (lsl_error_code_t *)ec);
+ }
+ 
+-LIBLSL_C_API unsigned long lsl_pull_chunk_c(lsl_inlet in, int8_t *data_buffer,
+-	double *timestamp_buffer, unsigned long data_buffer_elements,
+-	unsigned long timestamp_buffer_elements, double timeout, int32_t *ec) {
++LIBLSL_C_API size_t lsl_pull_chunk_c(lsl_inlet in, int8_t *data_buffer,
++	double *timestamp_buffer, size_t data_buffer_elements,
++	size_t timestamp_buffer_elements, double timeout, int32_t *ec) {
+ 	return in->pull_chunk_multiplexed_noexcept(data_buffer, timestamp_buffer, data_buffer_elements,
+ 		timestamp_buffer_elements, timeout, (lsl_error_code_t *)ec);
+ }
+ 
+-LIBLSL_C_API unsigned long lsl_pull_chunk_str(lsl_inlet in, char **data_buffer,
+-	double *timestamp_buffer, unsigned long data_buffer_elements,
+-	unsigned long timestamp_buffer_elements, double timeout, int32_t *ec) {
++LIBLSL_C_API size_t lsl_pull_chunk_str(lsl_inlet in, char **data_buffer,
++	double *timestamp_buffer, size_t data_buffer_elements,
++	size_t timestamp_buffer_elements, double timeout, int32_t *ec) {
+ 	if (ec) *ec = lsl_no_error;
+ 	try {
+ 		// capture output in a temporary string buffer
+@@ -249,9 +249,9 @@ LIBLSL_C_API unsigned long lsl_pull_chunk_str(lsl_inlet in, char **data_buffer,
+ 	return 0;
+ }
+ 
+-LIBLSL_C_API unsigned long lsl_pull_chunk_buf(lsl_inlet in, char **data_buffer,
+-	uint32_t *lengths_buffer, double *timestamp_buffer, unsigned long data_buffer_elements,
+-	unsigned long timestamp_buffer_elements, double timeout, int32_t *ec) {
++LIBLSL_C_API size_t lsl_pull_chunk_buf(lsl_inlet in, char **data_buffer,
++	uint32_t *lengths_buffer, double *timestamp_buffer, size_t data_buffer_elements,
++	size_t timestamp_buffer_elements, double timeout, int32_t *ec) {
+ 	if (ec) *ec = lsl_no_error;
+ 	try {
+ 		// capture output in a temporary string buffer
+diff --git a/src/lsl_outlet_c.cpp b/src/lsl_outlet_c.cpp
+index b79682ed..f2a55254 100644
+--- a/src/lsl_outlet_c.cpp
++++ b/src/lsl_outlet_c.cpp
+@@ -173,170 +173,170 @@ LIBLSL_C_API int32_t lsl_push_sample_buftp(lsl_outlet out, const char **data,
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_f(
+-	lsl_outlet out, const float *data, unsigned long data_elements) {
++	lsl_outlet out, const float *data, size_t data_elements) {
+ 	return out->push_chunk_multiplexed_noexcept(data, data_elements);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_d(
+-	lsl_outlet out, const double *data, unsigned long data_elements) {
++	lsl_outlet out, const double *data, size_t data_elements) {
+ 	return out->push_chunk_multiplexed_noexcept(data, data_elements);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_l(
+-	lsl_outlet out, const int64_t *data, unsigned long data_elements) {
++	lsl_outlet out, const int64_t *data, size_t data_elements) {
+ 	return out->push_chunk_multiplexed_noexcept(data, data_elements);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_i(
+-	lsl_outlet out, const int32_t *data, unsigned long data_elements) {
++	lsl_outlet out, const int32_t *data, size_t data_elements) {
+ 	return out->push_chunk_multiplexed_noexcept(data, data_elements);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_s(
+-	lsl_outlet out, const int16_t *data, unsigned long data_elements) {
++	lsl_outlet out, const int16_t *data, size_t data_elements) {
+ 	return out->push_chunk_multiplexed_noexcept(data, data_elements);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_c(
+-	lsl_outlet out, const int8_t *data, unsigned long data_elements) {
++	lsl_outlet out, const int8_t *data, size_t data_elements) {
+ 	return out->push_chunk_multiplexed_noexcept(data, data_elements);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_ft(
+-	lsl_outlet out, const float *data, unsigned long data_elements, double timestamp) {
++	lsl_outlet out, const float *data, size_t data_elements, double timestamp) {
+ 	return out->push_chunk_multiplexed_noexcept(data, data_elements, timestamp);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_dt(
+-	lsl_outlet out, const double *data, unsigned long data_elements, double timestamp) {
++	lsl_outlet out, const double *data, size_t data_elements, double timestamp) {
+ 	return out->push_chunk_multiplexed_noexcept(data, data_elements, timestamp);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_lt(
+-	lsl_outlet out, const int64_t *data, unsigned long data_elements, double timestamp) {
++	lsl_outlet out, const int64_t *data, size_t data_elements, double timestamp) {
+ 	return out->push_chunk_multiplexed_noexcept(data, data_elements, timestamp);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_it(
+-	lsl_outlet out, const int32_t *data, unsigned long data_elements, double timestamp) {
++	lsl_outlet out, const int32_t *data, size_t data_elements, double timestamp) {
+ 	return out->push_chunk_multiplexed_noexcept(data, data_elements, timestamp);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_st(
+-	lsl_outlet out, const int16_t *data, unsigned long data_elements, double timestamp) {
++	lsl_outlet out, const int16_t *data, size_t data_elements, double timestamp) {
+ 	return out->push_chunk_multiplexed_noexcept(data, data_elements, timestamp);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_ct(
+-	lsl_outlet out, const int8_t *data, unsigned long data_elements, double timestamp) {
++	lsl_outlet out, const int8_t *data, size_t data_elements, double timestamp) {
+ 	return out->push_chunk_multiplexed_noexcept(data, data_elements, timestamp);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_ftp(lsl_outlet out, const float *data,
+-	unsigned long data_elements, double timestamp, int32_t pushthrough) {
++	size_t data_elements, double timestamp, int32_t pushthrough) {
+ 	return out->push_chunk_multiplexed_noexcept(data, data_elements, timestamp, pushthrough);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_dtp(lsl_outlet out, const double *data,
+-	unsigned long data_elements, double timestamp, int32_t pushthrough) {
++	size_t data_elements, double timestamp, int32_t pushthrough) {
+ 	return out->push_chunk_multiplexed_noexcept(data, data_elements, timestamp, pushthrough);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_ltp(lsl_outlet out, const int64_t *data,
+-	unsigned long data_elements, double timestamp, int32_t pushthrough) {
++	size_t data_elements, double timestamp, int32_t pushthrough) {
+ 	return out->push_chunk_multiplexed_noexcept(data, data_elements, timestamp, pushthrough);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_itp(lsl_outlet out, const int32_t *data,
+-	unsigned long data_elements, double timestamp, int32_t pushthrough) {
++	size_t data_elements, double timestamp, int32_t pushthrough) {
+ 	return out->push_chunk_multiplexed_noexcept(data, data_elements, timestamp, pushthrough);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_stp(lsl_outlet out, const int16_t *data,
+-	unsigned long data_elements, double timestamp, int32_t pushthrough) {
++	size_t data_elements, double timestamp, int32_t pushthrough) {
+ 	return out->push_chunk_multiplexed_noexcept(data, data_elements, timestamp, pushthrough);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_ctp(lsl_outlet out, const int8_t *data,
+-	unsigned long data_elements, double timestamp, int32_t pushthrough) {
++	size_t data_elements, double timestamp, int32_t pushthrough) {
+ 	return out->push_chunk_multiplexed_noexcept(data, data_elements, timestamp, pushthrough);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_ftn(
+-	lsl_outlet out, const float *data, unsigned long data_elements, const double *timestamps) {
++	lsl_outlet out, const float *data, size_t data_elements, const double *timestamps) {
+ 	return out->push_chunk_multiplexed_noexcept(data, timestamps, data_elements);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_dtn(
+-	lsl_outlet out, const double *data, unsigned long data_elements, const double *timestamps) {
++	lsl_outlet out, const double *data, size_t data_elements, const double *timestamps) {
+ 	return out->push_chunk_multiplexed_noexcept(data, timestamps, data_elements);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_ltn(
+-	lsl_outlet out, const int64_t *data, unsigned long data_elements, const double *timestamps) {
++	lsl_outlet out, const int64_t *data, size_t data_elements, const double *timestamps) {
+ 	return out->push_chunk_multiplexed_noexcept(data, timestamps, data_elements);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_itn(
+-	lsl_outlet out, const int32_t *data, unsigned long data_elements, const double *timestamps) {
++	lsl_outlet out, const int32_t *data, size_t data_elements, const double *timestamps) {
+ 	return out->push_chunk_multiplexed_noexcept(data, timestamps, data_elements);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_stn(
+-	lsl_outlet out, const int16_t *data, unsigned long data_elements, const double *timestamps) {
++	lsl_outlet out, const int16_t *data, size_t data_elements, const double *timestamps) {
+ 	return out->push_chunk_multiplexed_noexcept(data, timestamps, data_elements);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_ctn(
+-	lsl_outlet out, const int8_t *data, unsigned long data_elements, const double *timestamps) {
++	lsl_outlet out, const int8_t *data, size_t data_elements, const double *timestamps) {
+ 	return out->push_chunk_multiplexed_noexcept(data, timestamps, data_elements);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_ftnp(lsl_outlet out, const float *data,
+-	unsigned long data_elements, const double *timestamps, int32_t pushthrough) {
++	size_t data_elements, const double *timestamps, int32_t pushthrough) {
+ 	return out->push_chunk_multiplexed_noexcept(data, timestamps, data_elements, pushthrough);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_dtnp(lsl_outlet out, const double *data,
+-	unsigned long data_elements, const double *timestamps, int32_t pushthrough) {
++	size_t data_elements, const double *timestamps, int32_t pushthrough) {
+ 	return out->push_chunk_multiplexed_noexcept(data, timestamps, data_elements, pushthrough);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_ltnp(lsl_outlet out, const int64_t *data,
+-	unsigned long data_elements, const double *timestamps, int32_t pushthrough) {
++	size_t data_elements, const double *timestamps, int32_t pushthrough) {
+ 	return out->push_chunk_multiplexed_noexcept(data, timestamps, data_elements, pushthrough);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_itnp(lsl_outlet out, const int32_t *data,
+-	unsigned long data_elements, const double *timestamps, int32_t pushthrough) {
++	size_t data_elements, const double *timestamps, int32_t pushthrough) {
+ 	return out->push_chunk_multiplexed_noexcept(data, timestamps, data_elements, pushthrough);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_stnp(lsl_outlet out, const int16_t *data,
+-	unsigned long data_elements, const double *timestamps, int32_t pushthrough) {
++	size_t data_elements, const double *timestamps, int32_t pushthrough) {
+ 	return out->push_chunk_multiplexed_noexcept(data, timestamps, data_elements, pushthrough);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_ctnp(lsl_outlet out, const int8_t *data,
+-	unsigned long data_elements, const double *timestamps, int32_t pushthrough) {
++	size_t data_elements, const double *timestamps, int32_t pushthrough) {
+ 	return out->push_chunk_multiplexed_noexcept(data, timestamps, data_elements, pushthrough);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_str(
+-	lsl_outlet out, const char **data, unsigned long data_elements) {
++	lsl_outlet out, const char **data, size_t data_elements) {
+ 	return lsl_push_chunk_strtp(out, data, data_elements, 0.0, true);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_strt(
+-	lsl_outlet out, const char **data, unsigned long data_elements, double timestamp) {
++	lsl_outlet out, const char **data, size_t data_elements, double timestamp) {
+ 	return lsl_push_chunk_strtp(out, data, data_elements, timestamp, true);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_strtp(lsl_outlet out, const char **data,
+-	unsigned long data_elements, double timestamp, int32_t pushthrough) {
++	size_t data_elements, double timestamp, int32_t pushthrough) {
+ 	try {
+ 		std::vector<std::string> tmp;
+-		for (unsigned long k = 0; k < data_elements; k++) tmp.emplace_back(data[k]);
++		for (size_t k = 0; k < data_elements; k++) tmp.emplace_back(data[k]);
+ 		if (data_elements)
+ 			out->push_chunk_multiplexed(tmp.data(), tmp.size(), timestamp, pushthrough);
+ 	}
+@@ -344,16 +344,16 @@ LIBLSL_C_API int32_t lsl_push_chunk_strtp(lsl_outlet out, const char **data,
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_strtn(
+-	lsl_outlet out, const char **data, unsigned long data_elements, const double *timestamps) {
++	lsl_outlet out, const char **data, size_t data_elements, const double *timestamps) {
+ 	return lsl_push_chunk_strtnp(out, data, data_elements, timestamps, true);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_strtnp(lsl_outlet out, const char **data,
+-	unsigned long data_elements, const double *timestamps, int32_t pushthrough) {
++	size_t data_elements, const double *timestamps, int32_t pushthrough) {
+ 	try {
+ 		if (data_elements) {
+ 			std::vector<std::string> tmp;
+-			for (unsigned long k = 0; k < data_elements; k++) tmp.emplace_back(data[k]);
++			for (size_t k = 0; k < data_elements; k++) tmp.emplace_back(data[k]);
+ 			out->push_chunk_multiplexed_noexcept(
+ 				tmp.data(), timestamps, data_elements, pushthrough);
+ 		}
+@@ -362,20 +362,20 @@ LIBLSL_C_API int32_t lsl_push_chunk_strtnp(lsl_outlet out, const char **data,
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_buf(
+-	lsl_outlet out, const char **data, const uint32_t *lengths, unsigned long data_elements) {
++	lsl_outlet out, const char **data, const uint32_t *lengths, size_t data_elements) {
+ 	return lsl_push_chunk_buftp(out, data, lengths, data_elements, 0.0, true);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_buft(lsl_outlet out, const char **data, const uint32_t *lengths,
+-	unsigned long data_elements, double timestamp) {
++	size_t data_elements, double timestamp) {
+ 	return lsl_push_chunk_buftp(out, data, lengths, data_elements, timestamp, true);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_buftp(lsl_outlet out, const char **data,
+-	const uint32_t *lengths, unsigned long data_elements, double timestamp, int32_t pushthrough) {
++	const uint32_t *lengths, size_t data_elements, double timestamp, int32_t pushthrough) {
+ 	try {
+ 		std::vector<std::string> tmp;
+-		for (unsigned long k = 0; k < data_elements; k++) tmp.emplace_back(data[k], lengths[k]);
++		for (size_t k = 0; k < data_elements; k++) tmp.emplace_back(data[k], lengths[k]);
+ 		if (data_elements)
+ 			out->push_chunk_multiplexed(tmp.data(), tmp.size(), timestamp, pushthrough);
+ 	}
+@@ -383,17 +383,17 @@ LIBLSL_C_API int32_t lsl_push_chunk_buftp(lsl_outlet out, const char **data,
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_buftn(lsl_outlet out, const char **data,
+-	const uint32_t *lengths, unsigned long data_elements, const double *timestamps) {
++	const uint32_t *lengths, size_t data_elements, const double *timestamps) {
+ 	return lsl_push_chunk_buftnp(out, data, lengths, data_elements, timestamps, true);
+ }
+ 
+ LIBLSL_C_API int32_t lsl_push_chunk_buftnp(lsl_outlet out, const char **data,
+-	const uint32_t *lengths, unsigned long data_elements, const double *timestamps,
++	const uint32_t *lengths, size_t data_elements, const double *timestamps,
+ 	int32_t pushthrough) {
+ 	try {
+ 		if (data_elements) {
+ 			std::vector<std::string> tmp;
+-			for (unsigned long k = 0; k < data_elements; k++) tmp.emplace_back(data[k], lengths[k]);
++			for (size_t k = 0; k < data_elements; k++) tmp.emplace_back(data[k], lengths[k]);
+ 			out->push_chunk_multiplexed(
+ 				tmp.data(), timestamps, (std::size_t)data_elements, pushthrough);
+ 		}

--- a/pkgs/by-name/li/liblsl/0004-use-int32_t-in-three-specific-spots.patch
+++ b/pkgs/by-name/li/liblsl/0004-use-int32_t-in-three-specific-spots.patch
@@ -1,0 +1,59 @@
+From f517b8419c90927250225dc83a79b53742981b97 Mon Sep 17 00:00:00 2001
+From: Gavin John <gavinnjohn@gmail.com>
+Date: Mon, 29 Jun 2026 14:37:26 -0400
+Subject: [PATCH] fix(lsl_cpp.h): use explicit int32_t rather than int
+
+This one's just for correctness; AFAIK this doesn't actually cause any issues on any platforms.
+---
+ include/lsl_cpp.h | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/include/lsl_cpp.h b/include/lsl_cpp.h
+index 41d64d79..e28cf1c2 100644
+--- a/include/lsl_cpp.h
++++ b/include/lsl_cpp.h
+@@ -846,7 +846,7 @@ class stream_outlet {
+  */
+ inline std::vector<stream_info> resolve_streams(double wait_time = 1.0) {
+ 	lsl_streaminfo buffer[1024];
+-	int nres = check_error(lsl_resolve_all(buffer, sizeof(buffer) / sizeof(lsl_streaminfo), wait_time));
++	int32_t nres = check_error(lsl_resolve_all(buffer, sizeof(buffer) / sizeof(lsl_streaminfo), wait_time));
+ 	return std::vector<stream_info>(&buffer[0], &buffer[nres]);
+ }
+ 
+@@ -866,7 +866,7 @@ inline std::vector<stream_info> resolve_streams(double wait_time = 1.0) {
+ inline std::vector<stream_info> resolve_stream(const std::string &prop, const std::string &value,
+ 	int32_t minimum = 1, double timeout = FOREVER) {
+ 	lsl_streaminfo buffer[1024];
+-	int nres = check_error(
++	int32_t nres = check_error(
+ 		lsl_resolve_byprop(buffer, sizeof(buffer) / sizeof(lsl_streaminfo), prop.c_str(), value.c_str(), minimum, timeout));
+ 	return std::vector<stream_info>(&buffer[0], &buffer[nres]);
+ }
+@@ -888,7 +888,7 @@ inline std::vector<stream_info> resolve_stream(const std::string &prop, const st
+ inline std::vector<stream_info> resolve_stream(
+ 	const std::string &pred, int32_t minimum = 1, double timeout = FOREVER) {
+ 	lsl_streaminfo buffer[1024];
+-	int nres =
++	int32_t nres =
+ 		check_error(lsl_resolve_bypred(buffer, sizeof(buffer) / sizeof(lsl_streaminfo), pred.c_str(), minimum, timeout));
+ 	return std::vector<stream_info>(&buffer[0], &buffer[nres]);
+ }
+@@ -1048,7 +1048,7 @@ class stream_inlet {
+ 	 * .time_correction() to it.
+ 	 * @throws lost_error (if the stream source has been lost).
+ 	 */
+-	template <class T, int N> double pull_sample(T sample[N], double timeout = FOREVER) {
++	template <class T, int32_t N> double pull_sample(T sample[N], double timeout = FOREVER) {
+ 		return pull_sample(&sample[0], N, timeout);
+ 	}
+ 
+@@ -1506,7 +1506,7 @@ class stream_inlet {
+ 	 */
+ 	void smoothing_halftime(float value) { check_error(lsl_smoothing_halftime(obj.get(), value)); }
+ 
+-	int get_channel_count() const { return channel_count; }
++	int32_t get_channel_count() const { return channel_count; }
+ 
+ private:
+ 	// The inlet is a non-copyable object.

--- a/pkgs/by-name/li/liblsl/package.nix
+++ b/pkgs/by-name/li/liblsl/package.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "LSL_FRAMEWORK" false)
     (lib.cmakeBool "LSL_BUNDLED_BOOST" false)
     (lib.cmakeBool "LSL_BUNDLED_PUGIXML" false)
+    (lib.cmakeBool "LSL_BUILD_STATIC" stdenv.targetPlatform.isStatic)
   ];
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/li/liblsl/package.nix
+++ b/pkgs/by-name/li/liblsl/package.nix
@@ -1,9 +1,11 @@
 {
   cmake,
   stdenv,
+  runCommand,
   lib,
   fetchFromGitHub,
   boost,
+  catch2_3,
   pugixml,
   nix-update-script,
 }:
@@ -26,6 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     boost
     pugixml
+    catch2_3
   ];
 
   cmakeFlags = [
@@ -33,10 +36,27 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "LSL_FRAMEWORK" false)
     (lib.cmakeBool "LSL_BUNDLED_BOOST" false)
     (lib.cmakeBool "LSL_FETCH_PUGIXML" false)
+    (lib.cmakeBool "LSL_TESTS_PREFER_SYSTEM_CATCH2" true)
     (lib.cmakeBool "LSL_BUILD_STATIC" stdenv.targetPlatform.isStatic)
+    (lib.cmakeBool "LSL_TOOLS" true)
+    (lib.cmakeBool "LSL_UNITTESTS" true)
   ];
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = {
+      # TODO(@Pandapip1): currently fails, investigate why
+      # exported = runCommand "lsl_test_exported" {
+      #   nativeBuildInputs = [ finalAttrs.finalPackage ];
+      # } "lsl_test_exported && touch $out";
+      internal = runCommand "lsl_test_internal" {
+        nativeBuildInputs = [ finalAttrs.finalPackage ];
+      } "lsl_test_internal && touch $out";
+      runtime_config = runCommand "lsl_test_runtime_config" {
+        nativeBuildInputs = [ finalAttrs.finalPackage ];
+      } "lsl_test_runtime_config && touch $out";
+    };
+  };
 
   meta = {
     description = "C++ lsl library for multi-modal time-synched data transmission over the local network";

--- a/pkgs/by-name/li/liblsl/package.nix
+++ b/pkgs/by-name/li/liblsl/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   runCommand,
   lib,
+  testers,
   fetchFromGitHub,
   boost,
   catch2_3,
@@ -20,6 +21,10 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "e651023ca67996a05a028fd88a28603297120294";
     hash = "sha256-hYG+sWnvY6NcapT3d+Kdf5nAXUBoDbiJRTGs/3sJV2k=";
   };
+
+  patches = [
+    ./0001-pkg-config.patch
+  ];
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -49,6 +54,9 @@ stdenv.mkDerivation (finalAttrs: {
       # exported = runCommand "lsl_test_exported" {
       #   nativeBuildInputs = [ finalAttrs.finalPackage ];
       # } "lsl_test_exported && touch $out";
+      pkg-config = testers.hasPkgConfigModules {
+        package = finalAttrs.finalPackage;
+      };
       internal = runCommand "lsl_test_internal" {
         nativeBuildInputs = [ finalAttrs.finalPackage ];
       } "lsl_test_internal && touch $out";
@@ -63,6 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/sccn/liblsl";
     changelog = "https://github.com/sccn/liblsl/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
+    pkgConfigModules = [ "lsl" ];
     maintainers = with lib.maintainers; [
       abcsds
       pandapip1

--- a/pkgs/by-name/li/liblsl/package.nix
+++ b/pkgs/by-name/li/liblsl/package.nix
@@ -18,6 +18,9 @@ stdenv.mkDerivation (finalAttrs: {
   };
   passthru.updateScript = nix-update-script { };
 
+  __structuredAttrs = true;
+  strictDeps = true;
+  separateDebugInfo = true;
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [ "-DLSL_UNIXFOLDERS=ON" ];

--- a/pkgs/by-name/li/liblsl/package.nix
+++ b/pkgs/by-name/li/liblsl/package.nix
@@ -24,6 +24,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./0001-pkg-config.patch
+    ./0002-use-i8-for-i8-channels.patch
+    ./0003-use-sizet-for-message-count.patch
+    ./0004-use-int32_t-in-three-specific-spots.patch
   ];
 
   __structuredAttrs = true;

--- a/pkgs/by-name/li/liblsl/package.nix
+++ b/pkgs/by-name/li/liblsl/package.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "LSL_UNIXFOLDERS" true)
+    (lib.cmakeBool "LSL_FRAMEWORK" false)
   ];
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/li/liblsl/package.nix
+++ b/pkgs/by-name/li/liblsl/package.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "liblsl";
-  version = "1.17.5";
+  version = "1.17.7-unstable-2026-06-17";
 
   src = fetchFromGitHub {
     owner = "sccn";
     repo = "liblsl";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-Xu/Bdv+aA+XG/fPBNDPcHELem17vaV86e6F8zfVI//o=";
+    rev = "e651023ca67996a05a028fd88a28603297120294";
+    hash = "sha256-hYG+sWnvY6NcapT3d+Kdf5nAXUBoDbiJRTGs/3sJV2k=";
   };
 
   __structuredAttrs = true;
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "LSL_UNIXFOLDERS" true)
     (lib.cmakeBool "LSL_FRAMEWORK" false)
     (lib.cmakeBool "LSL_BUNDLED_BOOST" false)
-    (lib.cmakeBool "LSL_BUNDLED_PUGIXML" false)
+    (lib.cmakeBool "LSL_FETCH_PUGIXML" false)
     (lib.cmakeBool "LSL_BUILD_STATIC" stdenv.targetPlatform.isStatic)
   ];
 

--- a/pkgs/by-name/li/liblsl/package.nix
+++ b/pkgs/by-name/li/liblsl/package.nix
@@ -16,14 +16,17 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-Xu/Bdv+aA+XG/fPBNDPcHELem17vaV86e6F8zfVI//o=";
   };
-  passthru.updateScript = nix-update-script { };
 
   __structuredAttrs = true;
   strictDeps = true;
   separateDebugInfo = true;
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = [ "-DLSL_UNIXFOLDERS=ON" ];
+  cmakeFlags = [
+    (lib.cmakeBool "LSL_UNIXFOLDERS" true)
+  ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "C++ lsl library for multi-modal time-synched data transmission over the local network";

--- a/pkgs/by-name/li/liblsl/package.nix
+++ b/pkgs/by-name/li/liblsl/package.nix
@@ -27,7 +27,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/sccn/liblsl";
     changelog = "https://github.com/sccn/liblsl/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ abcsds ];
+    maintainers = with lib.maintainers; [
+      abcsds
+      pandapip1
+    ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/li/liblsl/package.nix
+++ b/pkgs/by-name/li/liblsl/package.nix
@@ -3,6 +3,8 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  boost,
+  pugixml,
   nix-update-script,
 }:
 
@@ -21,10 +23,16 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
   separateDebugInfo = true;
   nativeBuildInputs = [ cmake ];
+  buildInputs = [
+    boost
+    pugixml
+  ];
 
   cmakeFlags = [
     (lib.cmakeBool "LSL_UNIXFOLDERS" true)
     (lib.cmakeBool "LSL_FRAMEWORK" false)
+    (lib.cmakeBool "LSL_BUNDLED_BOOST" false)
+    (lib.cmakeBool "LSL_BUNDLED_PUGIXML" false)
   ];
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
