### PR TITLE
nixos/printers: fix empty value handling in ensurePrinters

### DIFF
--- a/nixos/modules/hardware/printers.nix
+++ b/nixos/modules/hardware/printers.nix
@@ -10,22 +10,30 @@ let
   ensurePrinter =
     p:
     let
-      args = lib.cli.toCommandLineShellGNU { } (
-        {
-          p = p.name;
-          v = p.deviceUri;
-          m = p.model;
-        }
-        // lib.optionalAttrs (p.location != null) {
-          L = p.location;
-        }
-        // lib.optionalAttrs (p.description != null) {
-          D = p.description;
-        }
-        // lib.optionalAttrs (p.ppdOptions != { }) {
-          o = lib.mapAttrsToList (name: value: "${name}=${value}") p.ppdOptions;
-        }
-      );
+      args =
+        # Not using toCommandLineShellGNU since it omits empty strings for short options.
+        lib.cli.toCommandLineShell
+          (optionName: {
+            option = "-${optionName}";
+            sep = null;
+            explicitBool = false;
+          })
+          (
+            {
+              p = p.name;
+              v = p.deviceUri;
+              m = p.model;
+            }
+            // lib.optionalAttrs (p.location != null) {
+              L = p.location;
+            }
+            // lib.optionalAttrs (p.description != null) {
+              D = p.description;
+            }
+            // lib.optionalAttrs (p.ppdOptions != { }) {
+              o = lib.mapAttrsToList (name: value: "${name}=${value}") p.ppdOptions;
+            }
+          );
     in
     ''
       # shellcheck disable=SC2016


### PR DESCRIPTION
E.g. this configuration:

    hardware.printers.ensurePrinters = [
      {
        name = "test";
        deviceUri = "ipp://somewhere";
        location = "";
        model = "everywhere";
      }
    ];

Resulted in the following command being generated:

    /nix/store/...-cups-2.4.19/bin/lpadmin -L -meverywhere -ptest -vipp://somewhere -E

Note the missing '' after -L which then caused /etc/cups/printers.conf to contain:

    Info test
    Location -meverywhere
    DeviceURI ipp://somewhere

This bug was introduced in 1f4c50ab8116b151fb9a007b2dbf46decd7a1483 with the change from the (now deprecated) toGNUCommandLineShell to toCommandLineShellGNU.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
