### PR TITLE
calamares-nixos-extensions: clean up config generation

### DIFF
--- a/pkgs/by-name/ca/calamares-nixos-extensions/src/modules/nixos/main.py
+++ b/pkgs/by-name/ca/calamares-nixos-extensions/src/modules/nixos/main.py
@@ -234,9 +234,8 @@ cfgmisc = """  # Enable CUPS to print documents.
     # If you want to use JACK applications, uncomment this
     #jack.enable = true;
 
-    # use the example session manager (no others are packaged yet so this is enabled by default,
-    # no need to redefine it in your config for now)
-    #media-session.enable = true;
+    # Use the WirePlumber session manager
+    #wireplumber.enable = true;
   };
 
   # Enable touchpad support (enabled default in most desktopManager).

--- a/pkgs/by-name/ca/calamares-nixos-extensions/src/modules/nixos/main.py
+++ b/pkgs/by-name/ca/calamares-nixos-extensions/src/modules/nixos/main.py
@@ -117,10 +117,7 @@ cfglocaleextra = """  i18n.extraLocaleSettings = {
 
 """
 
-cfggnome = """  # Enable the X11 windowing system.
-  services.xserver.enable = true;
-
-  # Enable the GNOME Desktop Environment.
+cfggnome = """  # Enable the GNOME Desktop Environment.
   services.xserver.displayManager.gdm.enable = true;
   services.xserver.desktopManager.gnome.enable = true;
 

--- a/pkgs/by-name/ca/calamares-nixos-extensions/src/modules/nixos/main.py
+++ b/pkgs/by-name/ca/calamares-nixos-extensions/src/modules/nixos/main.py
@@ -22,8 +22,8 @@ _ = gettext.translation(
 
 cfghead = """\
 # Edit this configuration file to define what should be installed on
-# your system.  Help is available in the configuration.nix(5) man page
-# and in the NixOS manual (accessible by running ‘nixos-help’).
+# your system. Help is available in the configuration.nix(5) man page, on
+# https://search.nixos.org/options and in the NixOS manual (`nixos-help`).
 
 { config, pkgs, ... }:
 
@@ -35,14 +35,14 @@ cfghead = """\
 
 """
 cfgbootefi = """\
-  # Bootloader.
+  # Use the systemd-boot EFI boot loader.
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
 
 """
 
 cfgbootbios = """\
-  # Bootloader.
+  # Use the GRUB 2 boot loader.
   boot.loader.grub.enable = true;
   boot.loader.grub.device = "@@bootdev@@";
   boot.loader.grub.useOSProber = true;
@@ -50,7 +50,7 @@ cfgbootbios = """\
 """
 
 cfgbootbiosbtrfs = """\
-  # Bootloader.
+  # Use the GRUB 2 boot loader.
   boot.loader.grub.enable = true;
   boot.loader.grub.device = "@@bootdev@@";
   boot.loader.grub.useOSProber = true;
@@ -305,12 +305,12 @@ cfgunfree = """\
 """
 
 cfgpkgs = """\
-  # List packages installed in system profile. To search, run:
-  # $ nix search wget
-  environment.systemPackages = with pkgs; [
-  #  vim # Do not forget to add an editor to edit configuration.nix! The Nano editor is also installed by default.
-  #  wget
-  ];
+  # List packages installed in system profile.
+  # You can use https://search.nixos.org/ to find more packages (and options).
+  # environment.systemPackages = with pkgs; [
+  #   vim # Do not forget to add an editor to edit configuration.nix! The Nano editor is also installed by default.
+  #   wget
+  # ];
 
 """
 
@@ -334,12 +334,28 @@ cfgtail = """\
   # Or disable the firewall altogether.
   # networking.firewall.enable = false;
 
-  # This value determines the NixOS release from which the default
-  # settings for stateful data, like file locations and database versions
-  # on your system were taken. It‘s perfectly fine and recommended to leave
-  # this value at the release version of the first install of this system.
-  # Before changing this value read the documentation for this option
-  # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
+  # Copy the NixOS configuration file and link it from the resulting system
+  # (/run/current-system/configuration.nix). This is useful in case you
+  # accidentally delete configuration.nix.
+  # system.copySystemConfiguration = true;
+
+  # This option defines the first version of NixOS you have installed on this particular machine,
+  # and is used to maintain compatibility with application data (e.g. databases) created on older NixOS versions.
+  #
+  # Most users should NEVER change this value after the initial install, for any reason,
+  # even if you've upgraded your system to a new NixOS release.
+  #
+  # This value does NOT affect the Nixpkgs version your packages and OS are pulled from,
+  # so changing it will NOT upgrade your system - see https://nixos.org/manual/nixos/stable/#sec-upgrading for how
+  # to actually do that.
+  #
+  # This value being lower than the current NixOS release does NOT mean your system is
+  # out of date, out of support, or vulnerable.
+  #
+  # Do NOT change this value unless you have manually inspected all the changes it would make to your configuration,
+  # and migrated your data accordingly.
+  #
+  # For more information, see `man configuration.nix` or https://nixos.org/manual/nixos/stable/options#opt-system.stateVersion .
   system.stateVersion = "@@nixosversion@@"; # Did you read the comment?
 
 }

--- a/pkgs/by-name/ca/calamares-nixos-extensions/src/modules/nixos/main.py
+++ b/pkgs/by-name/ca/calamares-nixos-extensions/src/modules/nixos/main.py
@@ -239,7 +239,7 @@ cfgmisc = """  # Enable CUPS to print documents.
   };
 
   # Enable touchpad support (enabled default in most desktopManager).
-  # services.xserver.libinput.enable = true;
+  # services.libinput.enable = true;
 
 """
 cfgusers = """  # Define a user account. Don't forget to set a password with ‘passwd’.

--- a/pkgs/by-name/ca/calamares-nixos-extensions/src/modules/nixos/main.py
+++ b/pkgs/by-name/ca/calamares-nixos-extensions/src/modules/nixos/main.py
@@ -263,12 +263,6 @@ cfgautologin = """  # Enable automatic login for the user.
 
 """
 
-cfgautologingdm = """  # Workaround for GNOME autologin: https://github.com/NixOS/nixpkgs/issues/103746#issuecomment-945091229
-  systemd.services."getty@tty1".enable = false;
-  systemd.services."autovt@tty1".enable = false;
-
-"""
-
 cfgautologintty = """  # Enable automatic login for the user.
   services.getty.autologinUser = "@@username@@";
 
@@ -876,8 +870,6 @@ def run():
             and gs.value("packagechooser_packagechooser") != ""
         ):
             cfg += cfgautologin
-            if gs.value("packagechooser_packagechooser") == "gnome":
-                cfg += cfgautologingdm
         elif gs.value("autoLoginUser") is not None:
             cfg += cfgautologintty
 

--- a/pkgs/by-name/ca/calamares-nixos-extensions/src/modules/nixos/main.py
+++ b/pkgs/by-name/ca/calamares-nixos-extensions/src/modules/nixos/main.py
@@ -118,8 +118,8 @@ cfglocaleextra = """  i18n.extraLocaleSettings = {
 """
 
 cfggnome = """  # Enable the GNOME Desktop Environment.
-  services.xserver.displayManager.gdm.enable = true;
-  services.xserver.desktopManager.gnome.enable = true;
+  services.displayManager.gdm.enable = true;
+  services.desktopManager.gnome.enable = true;
 
 """
 

--- a/pkgs/by-name/ca/calamares-nixos-extensions/src/modules/nixos/main.py
+++ b/pkgs/by-name/ca/calamares-nixos-extensions/src/modules/nixos/main.py
@@ -20,7 +20,8 @@ _ = gettext.translation(
 # The following strings contain pieces of a nix-configuration file.
 # They are adapted from the default config generated from the nixos-generate-config command.
 
-cfghead = """# Edit this configuration file to define what should be installed on
+cfghead = """\
+# Edit this configuration file to define what should be installed on
 # your system.  Help is available in the configuration.nix(5) man page
 # and in the NixOS manual (accessible by running ‘nixos-help’).
 
@@ -33,20 +34,23 @@ cfghead = """# Edit this configuration file to define what should be installed o
     ];
 
 """
-cfgbootefi = """  # Bootloader.
+cfgbootefi = """\
+  # Bootloader.
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
 
 """
 
-cfgbootbios = """  # Bootloader.
+cfgbootbios = """\
+  # Bootloader.
   boot.loader.grub.enable = true;
   boot.loader.grub.device = "@@bootdev@@";
   boot.loader.grub.useOSProber = true;
 
 """
 
-cfgbootbiosbtrfs = """  # Bootloader.
+cfgbootbiosbtrfs = """\
+  # Bootloader.
   boot.loader.grub.enable = true;
   boot.loader.grub.device = "@@bootdev@@";
   boot.loader.grub.useOSProber = true;
@@ -55,12 +59,14 @@ cfgbootbiosbtrfs = """  # Bootloader.
 
 """
 
-cfgbootnone = """  # Disable bootloader.
+cfgbootnone = """\
+  # Disable bootloader.
   boot.loader.grub.enable = false;
 
 """
 
-cfgbootgrubcrypt = """  # Setup keyfile
+cfgbootgrubcrypt = """\
+  # Setup keyfile
   boot.initrd.secrets = {
     "/boot/crypto_keyfile.bin" = null;
   };
@@ -69,7 +75,8 @@ cfgbootgrubcrypt = """  # Setup keyfile
 
 """
 
-cfgnetwork = """  networking.hostName = "@@hostname@@"; # Define your hostname.
+cfgnetwork = """\
+  networking.hostName = "@@hostname@@"; # Define your hostname.
   # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
 
   # Configure network proxy if necessary
@@ -78,32 +85,38 @@ cfgnetwork = """  networking.hostName = "@@hostname@@"; # Define your hostname.
 
 """
 
-cfgnetworkmanager = """  # Enable networking
+cfgnetworkmanager = """\
+  # Enable networking
   networking.networkmanager.enable = true;
 
 """
 
-cfgconnman = """  # Enable networking
+cfgconnman = """\
+  # Enable networking
   services.connman.enable = true;
 
 """
 
-cfgnmapplet = """  # Enable network manager applet
+cfgnmapplet = """\
+  # Enable network manager applet
   programs.nm-applet.enable = true;
 
 """
 
-cfgtime = """  # Set your time zone.
+cfgtime = """\
+  # Set your time zone.
   time.timeZone = "@@timezone@@";
 
 """
 
-cfglocale = """  # Select internationalisation properties.
+cfglocale = """\
+  # Select internationalisation properties.
   i18n.defaultLocale = "@@LANG@@";
 
 """
 
-cfglocaleextra = """  i18n.extraLocaleSettings = {
+cfglocaleextra = """\
+  i18n.extraLocaleSettings = {
     LC_ADDRESS = "@@LC_ADDRESS@@";
     LC_IDENTIFICATION = "@@LC_IDENTIFICATION@@";
     LC_MEASUREMENT = "@@LC_MEASUREMENT@@";
@@ -117,13 +130,15 @@ cfglocaleextra = """  i18n.extraLocaleSettings = {
 
 """
 
-cfggnome = """  # Enable the GNOME Desktop Environment.
+cfggnome = """\
+  # Enable the GNOME Desktop Environment.
   services.displayManager.gdm.enable = true;
   services.desktopManager.gnome.enable = true;
 
 """
 
-cfgplasma6 = """  # Enable the X11 windowing system.
+cfgplasma6 = """\
+  # Enable the X11 windowing system.
   # You can disable this if you're only using the Wayland session.
   services.xserver.enable = true;
 
@@ -133,7 +148,8 @@ cfgplasma6 = """  # Enable the X11 windowing system.
 
 """
 
-cfgxfce = """  # Enable the X11 windowing system.
+cfgxfce = """\
+  # Enable the X11 windowing system.
   services.xserver.enable = true;
 
   # Enable the XFCE Desktop Environment.
@@ -142,7 +158,8 @@ cfgxfce = """  # Enable the X11 windowing system.
 
 """
 
-cfgpantheon = """  # Enable the X11 windowing system.
+cfgpantheon = """\
+  # Enable the X11 windowing system.
   services.xserver.enable = true;
 
   # Enable the Pantheon Desktop Environment.
@@ -151,7 +168,8 @@ cfgpantheon = """  # Enable the X11 windowing system.
 
 """
 
-cfgcinnamon = """  # Enable the X11 windowing system.
+cfgcinnamon = """\
+  # Enable the X11 windowing system.
   services.xserver.enable = true;
 
   # Enable the Cinnamon Desktop Environment.
@@ -160,7 +178,8 @@ cfgcinnamon = """  # Enable the X11 windowing system.
 
 """
 
-cfgmate = """  # Enable the X11 windowing system.
+cfgmate = """\
+  # Enable the X11 windowing system.
   services.xserver.enable = true;
 
   # Enable the MATE Desktop Environment.
@@ -169,7 +188,8 @@ cfgmate = """  # Enable the X11 windowing system.
 
 """
 
-cfgenlightenment = """  # Enable the X11 windowing system.
+cfgenlightenment = """\
+  # Enable the X11 windowing system.
   services.xserver.enable = true;
 
   # Enable the Enlightenment Desktop Environment.
@@ -181,7 +201,8 @@ cfgenlightenment = """  # Enable the X11 windowing system.
 
 """
 
-cfglxqt = """  # Enable the X11 windowing system.
+cfglxqt = """\
+  # Enable the X11 windowing system.
   services.xserver.enable = true;
 
   # Enable the LXQT Desktop Environment.
@@ -190,7 +211,8 @@ cfglxqt = """  # Enable the X11 windowing system.
 
 """
 
-cfglumina = """  # Enable the X11 windowing system.
+cfglumina = """\
+  # Enable the X11 windowing system.
   services.xserver.enable = true;
 
   # Enable the Lumina Desktop Environment.
@@ -199,7 +221,8 @@ cfglumina = """  # Enable the X11 windowing system.
 
 """
 
-cfgbudgie = """  # Enable the X11 windowing system.
+cfgbudgie = """\
+  # Enable the X11 windowing system.
   services.xserver.enable = true;
 
   # Enable the Budgie Desktop environment.
@@ -208,19 +231,22 @@ cfgbudgie = """  # Enable the X11 windowing system.
 
 """
 
-cfgkeymap = """  # Configure keymap in X11
+cfgkeymap = """\
+  # Configure keymap in X11
   services.xserver.xkb = {
     layout = "@@kblayout@@";
     variant = "@@kbvariant@@";
   };
 
 """
-cfgconsole = """  # Configure console keymap
+cfgconsole = """\
+  # Configure console keymap
   console.keyMap = "@@vconsole@@";
 
 """
 
-cfgmisc = """  # Enable CUPS to print documents.
+cfgmisc = """\
+  # Enable CUPS to print documents.
   services.printing.enable = true;
 
   # Enable sound with pipewire.
@@ -242,7 +268,8 @@ cfgmisc = """  # Enable CUPS to print documents.
   # services.libinput.enable = true;
 
 """
-cfgusers = """  # Define a user account. Don't forget to set a password with ‘passwd’.
+cfgusers = """\
+  # Define a user account. Don't forget to set a password with ‘passwd’.
   users.users."@@username@@" = {
     isNormalUser = true;
     description = "@@fullname@@";
@@ -252,28 +279,33 @@ cfgusers = """  # Define a user account. Don't forget to set a password with ‘
 
 """
 
-cfgfirefox = """  # Install firefox.
+cfgfirefox = """\
+  # Install firefox.
   programs.firefox.enable = true;
 
 """
 
-cfgautologin = """  # Enable automatic login for the user.
+cfgautologin = """\
+  # Enable automatic login for the user.
   services.displayManager.autoLogin.enable = true;
   services.displayManager.autoLogin.user = "@@username@@";
 
 """
 
-cfgautologintty = """  # Enable automatic login for the user.
+cfgautologintty = """\
+  # Enable automatic login for the user.
   services.getty.autologinUser = "@@username@@";
 
 """
 
-cfgunfree = """  # Allow unfree packages
+cfgunfree = """\
+  # Allow unfree packages
   nixpkgs.config.allowUnfree = true;
 
 """
 
-cfgpkgs = """  # List packages installed in system profile. To search, run:
+cfgpkgs = """\
+  # List packages installed in system profile. To search, run:
   # $ nix search wget
   environment.systemPackages = with pkgs; [
   #  vim # Do not forget to add an editor to edit configuration.nix! The Nano editor is also installed by default.
@@ -282,7 +314,8 @@ cfgpkgs = """  # List packages installed in system profile. To search, run:
 
 """
 
-cfgtail = """  # Some programs need SUID wrappers, can be configured further or are
+cfgtail = """\
+  # Some programs need SUID wrappers, can be configured further or are
   # started in user sessions.
   # programs.mtr.enable = true;
   # programs.gnupg.agent = {
@@ -312,7 +345,8 @@ cfgtail = """  # Some programs need SUID wrappers, can be configured further or 
 }
 """
 
-cfglatestkernel = """  # Use latest kernel.
+cfglatestkernel = """\
+  # Use latest kernel.
   boot.kernelPackages = pkgs.linuxPackages_latest;
 
 """


### PR DESCRIPTION
It's probably easiest to review commit by commit, but here's a rough summary:

- Handle a few renamed/removed options
- Don't enable X11 for GNOME
- Remove redundant GNOME autologin workaround
- Sync some config snippets from nixos-generate-config
- Improve readability of `main.py` by using `"""\` at the start of config snippets

Tested by building and running the calamares installer for GNOME, basically following the full installation process on `x86_64-linux`. ISO generated via:

```
nix-build -A config.system.build.isoImage -I nixos-config=nixos/modules/installer/cd-dvd/installation-cd-graphical-calamares-gnome.nix nixos/default.nix
```

Also verified that auto-login on GNOME still works without the workaround.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — Plus ISO image, see command above
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
