### PR TITLE
onnxruntime: add cuda_nvrtc to buildInputs for CUDA

### DIFF
--- a/pkgs/by-name/on/onnxruntime/package.nix
+++ b/pkgs/by-name/on/onnxruntime/package.nix
@@ -219,6 +219,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
       cudnn # cudnn.h
       cudnn-frontend
       cuda_cudart
+      cuda_nvrtc
     ]
     ++ lib.optionals ncclSupport [ nccl ]
   )


### PR DESCRIPTION
`cudnn-frontend` 1.19.0 introduced `nvrtc_shim.h` which pulls in `nvrtc` symbols via the `CUDNN::cudnn_all target`. Since we patch `onnxruntime` to use the system `cudnn-frontend`, `libonnxruntime_providers_cuda.so` ends up with unresolved symbols and fails to load. Adding `cuda_nvrtc` to buildInputs fixes it.

Resolves https://github.com/NixOS/nixpkgs/issues/536183

  ## Things done
  
  <!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
  
  - Built on platform:
    - [ ] x86_64-linux
    - [ ] aarch64-linux
    - [ ] aarch64-darwin
  - Tested, as applicable:
    - [ ] [NixOS tests] in [nixos/tests].
    - [ ] [Package tests] at `passthru.tests`.
    - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Nixpkgs Release Notes
    - [ ] Package update: when the change is major or breaking.
  - NixOS Release Notes
    - [ ] Module addition: when adding a new NixOS module.
    - [ ] Module update: when the change is significant.
  - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
  - [x] Follows the [automation/AI policy].
  
  [NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
  [Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
  [nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
  
  [CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
  [automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
  [lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
  [maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
  [nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
  [pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
  [pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
