### PR TITLE
wildcard: 0.3.3 -> 0.3.5

### DIFF
--- a/pkgs/by-name/wi/wildcard/package.nix
+++ b/pkgs/by-name/wi/wildcard/package.nix
@@ -16,21 +16,21 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wildcard";
-  version = "0.3.3";
+  version = "0.3.5";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "Wildcard";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-jOv0l1vnfDePWF7SAbsBFipPAONliPdc47xj79BJ+rc=";
+    hash = "sha256-8e3UWJ6PGhwvo/AB89VgkBfgsaNVa4g6hT9vBTmKlZQ=";
   };
 
   strictDeps = true;
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
-    hash = "sha256-eUT3K7DJk0U4GZ/oqvMAGUjTctcDMaRdsjq1sD+fitg=";
+    hash = "sha256-hoJsXoPmp0A6oIV1Rm7eXI2U2OIGrStmKzDdPQtI41A=";
     name = "wildcard-${finalAttrs.version}";
   };
 


### PR DESCRIPTION
diff: https://gitlab.gnome.org/World/Wildcard/-/compare/v0.3.3...v0.3.5

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
