### PR TITLE
stylelint-lsp: remove pnpm_9's knownVulnerabilities, refactor

### DIFF
--- a/pkgs/by-name/st/stylelint-lsp/package.nix
+++ b/pkgs/by-name/st/stylelint-lsp/package.nix
@@ -1,7 +1,7 @@
 {
   fetchFromGitHub,
   lib,
-  nodejs,
+  nodejs-slim,
   pnpm_9,
   fetchPnpmDeps,
   pnpmConfigHook,
@@ -22,11 +22,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     hash = "sha256-LUX/H7yY8Dl44vgpf7vOgtMdY7h//m5BAfrK5RRH9DM=";
   };
 
-  buildInputs = [
-    nodejs
-  ];
-
   nativeBuildInputs = [
+    nodejs-slim
     pnpmConfigHook
     pnpmBuildHook
     pnpm_9
@@ -53,7 +50,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     mkdir -p $out/{bin,lib/stylelint-lsp}
     mv {dist,node_modules} $out/lib/stylelint-lsp
+
     chmod a+x $out/lib/stylelint-lsp/dist/index.js
+    patchShebangs $out/lib/stylelint-lsp/dist/index.js
     ln -s $out/lib/stylelint-lsp/dist/index.js $out/bin/stylelint-lsp
 
     runHook postInstall

--- a/pkgs/by-name/st/stylelint-lsp/package.nix
+++ b/pkgs/by-name/st/stylelint-lsp/package.nix
@@ -5,6 +5,7 @@
   pnpm_9,
   fetchPnpmDeps,
   pnpmConfigHook,
+  pnpmBuildHook,
   stdenvNoCC,
   nix-update-script,
 }:
@@ -25,6 +26,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     pnpmConfigHook
+    pnpmBuildHook
     pnpm_9
   ];
 
@@ -34,14 +36,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     fetcherVersion = 3;
     hash = "sha256-qzUvA00ujnIibQAONOPlp5BsXcwQb/gQvOPp83hMT5A=";
   };
-
-  buildPhase = ''
-    runHook preBuild
-
-    pnpm build
-
-    runHook postBuild
-  '';
 
   preInstall = ''
     # remove unnecessary files

--- a/pkgs/by-name/st/stylelint-lsp/package.nix
+++ b/pkgs/by-name/st/stylelint-lsp/package.nix
@@ -11,6 +11,13 @@
   runCommand,
   stylelint-lsp,
 }:
+let
+  pnpm = pnpm_9.overrideAttrs (old: {
+    meta = old.meta // {
+      knownVulnerabilities = [ ];
+    };
+  });
+in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "stylelint-lsp";
   version = "2.0.1";
@@ -26,12 +33,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     nodejs-slim
     pnpmConfigHook
     pnpmBuildHook
-    pnpm_9
+    pnpm
   ];
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_9;
+    inherit pnpm;
     fetcherVersion = 3;
     hash = "sha256-qzUvA00ujnIibQAONOPlp5BsXcwQb/gQvOPp83hMT5A=";
   };

--- a/pkgs/by-name/st/stylelint-lsp/package.nix
+++ b/pkgs/by-name/st/stylelint-lsp/package.nix
@@ -8,6 +8,8 @@
   pnpmBuildHook,
   stdenvNoCC,
   nix-update-script,
+  runCommand,
+  stylelint-lsp,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "stylelint-lsp";
@@ -57,7 +59,24 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+
+    tests.smoke = runCommand "stylelint-lsp-smoke-test" { } ''
+      INIT_REQUEST='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":null,"rootUri":"file:///tmp","workspaceFolders":[{"uri":"file:///tmp","name":"test"}],"capabilities":{}}}'
+      CONTENT_LENGTH=''${#INIT_REQUEST}
+
+      RESPONSE=$(
+        {
+          printf "Content-Length: %d\r\n\r\n%s" "$CONTENT_LENGTH" "$INIT_REQUEST"
+          sleep 1
+        } | timeout 3  ${lib.getExe stylelint-lsp} --stdio 2>&1 | head -c 1000
+      ) || true
+
+      echo "$RESPONSE" | grep -q '"capabilities"'
+      touch $out
+    '';
+  };
 
   meta = {
     description = "Stylelint Language Server";


### PR DESCRIPTION
This is maintained in nixpkgs, but not upstream. To keep this building without security warnings that likely don't affect end users, I used the suggestion from https://github.com/NixOS/nixpkgs/pull/535905 to remove `meta.knownVulneraibilities`.

Alternative (bad) solution: https://github.com/NixOS/nixpkgs/pull/530554.
Since this package still works as it should and is useful for me, for the long term solution, I'm planning to fork this package and keep the dependencies updated. Are there any requirements for accepting such forks into nixpkgs?
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
