### PR TITLE
kdrive: init at 3.8.5

### DIFF
--- a/pkgs/by-name/kd/kdrive/CMakeLists.txt.patch
+++ b/pkgs/by-name/kd/kdrive/CMakeLists.txt.patch
@@ -1,0 +1,23 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8f0ac5c47..e2fa70454 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -317,11 +317,13 @@ elseif(BUILD_CLIENT)
+         message(STATUS "CMAKE_SYSTEM_PROCESSOR=${CMAKE_SYSTEM_PROCESSOR}")
+         if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+             find_program(CRASHPAD_HANDLER_PROGRAM NAMES crashpad_handler NO_CACHE)
+-            message(STATUS "crashpad_handler found in ${CRASHPAD_HANDLER_PROGRAM}")
+-            if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+-                file(COPY ${CRASHPAD_HANDLER_PROGRAM} DESTINATION ${BIN_OUTPUT_DIRECTORY})
+-            else()
+-                install(PROGRAMS ${CRASHPAD_HANDLER_PROGRAM} DESTINATION ${CMAKE_INSTALL_BINDIR})
++            if(CRASHPAD_HANDLER_PROGRAM)
++                message(STATUS "crashpad_handler found in ${CRASHPAD_HANDLER_PROGRAM}")
++                if(CMAKE_BUILD_TYPE STREQUAL "Debug")
++                    file(COPY ${CRASHPAD_HANDLER_PROGRAM} DESTINATION ${BIN_OUTPUT_DIRECTORY})
++                else()
++                    install(PROGRAMS ${CRASHPAD_HANDLER_PROGRAM} DESTINATION ${CMAKE_INSTALL_BINDIR})
++                endif()
+             endif()
+         endif()
+     endif()

--- a/pkgs/by-name/kd/kdrive/package.nix
+++ b/pkgs/by-name/kd/kdrive/package.nix
@@ -1,0 +1,143 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  cups,
+  desktop-file-utils,
+  libGL,
+  libgcrypt,
+  libgpg-error,
+  libsecret,
+  libsysprof-capture,
+  libzip,
+  log4cplus,
+  kdePackages,
+  openssl,
+  pkg-config,
+  poco,
+  qt6,
+  sentry-native,
+  shared-mime-info,
+  sqlite,
+  xdg-utils,
+  xxhash,
+  zlib,
+}:
+
+let
+  # This is required because kdrive needs the log4cplusConfig.cmake file, which is only generated when built with cmake.
+  # Since log4cplus is built with make in nixpkgs, we rebuild it with cmake.
+  log4cplus-cmake = log4cplus.overrideAttrs (old: {
+    pname = "log4cplus-cmake";
+
+    nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ cmake ];
+
+    cmakeFlags = [
+      # kDrive uses the unicode version of log4cplus.
+      "-DUNICODE=ON"
+      # Disable decorated library name so that kDrive can find log4cplus::log4cplus. This avoid having to patch kDrive
+      # code to match the decorated name log4cplus::log4cplusU when unicode is enabled.
+      "-DLOG4CPLUS_ENABLE_DECORATED_LIBRARY_NAME=OFF"
+      # See https://github.com/NixOS/nixpkgs/issues/144170 for why this is needed.
+      "-DCMAKE_INSTALL_INCLUDEDIR=include"
+      "-DCMAKE_INSTALL_LIBDIR=lib"
+    ];
+  });
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "kdrive";
+  version = "3.8.5";
+
+  src = fetchFromGitHub {
+    owner = "Infomaniak";
+    repo = "desktop-kDrive";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-sg2lN08T41Gxloh/rozIwcDWI7r5B9pJq7Bai2vJ+ZQ=";
+    fetchSubmodules = true;
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    cmake
+    kdePackages.extra-cmake-modules
+    libsysprof-capture
+    pkg-config
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    cups
+    desktop-file-utils
+    libGL
+    libgcrypt
+    libgpg-error
+    libsecret
+    libzip
+    log4cplus-cmake
+    openssl
+    poco
+    qt6.qt5compat
+    qt6.qtbase
+    qt6.qtnetworkauth
+    qt6.qtsvg
+    qt6.qttools
+    qt6.qtwebchannel
+    qt6.qtwebengine
+    qt6.qtwebsockets
+    sentry-native
+    shared-mime-info
+    sqlite
+    xdg-utils
+    xxhash
+    zlib
+  ];
+
+  patches = [
+    # Patch to disable Sentry's crashpad handler. Nixpkgs' sentry-native uses breakpad handler (which should be fine).
+    ./CMakeLists.txt.patch
+  ];
+
+  # "Hack" to have SYSCONFDIR point to the Nix store path thanks to ${outputBin}. This is needed because kDrive
+  # installs sentry's shared library and sync-exclude.lst at this location. If unset, cmake will attempt to install
+  # those at fs root, which is not permitted.
+  preConfigure = ''
+    prependToVar cmakeFlags "-DSYSCONFDIR=''${!outputBin}"
+  '';
+
+  cmakeFlags = [
+    # Prevent dev warnings from ECM.
+    "-Wno-dev"
+    # Original options from upstream.
+    # NOTE: we explicitly don't set CMAKE_BUILD_TYPE nor CMAKE_INSTALL_PREFIX here since they are already added by
+    #       nixpkgs' cmake build environment.
+    "-DQT_FEATURE_neon=OFF"
+    "-DKDRIVE_THEME_DIR=${finalAttrs.src}/infomaniak"
+    # Disables unit tests. Requires cppunit.
+    # TODO: enable?
+    "-DBUILD_UNIT_TESTS=0"
+  ];
+
+  # Prevent compilation error of keychain submodule.
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=uninitialized";
+
+  # Move sync-exclude.lst to the bin directory since kDrive fails to start without it at this location.
+  postInstall = ''
+    mv $out/kDrive/sync-exclude.lst $out/bin
+    rm -rf $out/kDrive
+  '';
+
+  meta = {
+    mainProgram = "kdrive";
+    description = "Desktop syncing client for kDrive";
+    homepage = "https://github.com/Infomaniak/desktop-kDrive";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      nicolas-goudry
+      FelixLusseau
+    ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/kd/kdrive/package.nix
+++ b/pkgs/by-name/kd/kdrive/package.nix
@@ -1,0 +1,142 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  cups,
+  desktop-file-utils,
+  libGL,
+  libgcrypt,
+  libgpg-error,
+  libsecret,
+  libsysprof-capture,
+  libzip,
+  log4cplus,
+  kdePackages,
+  openssl,
+  pkg-config,
+  poco,
+  qt6,
+  sentry-native,
+  shared-mime-info,
+  sqlite,
+  xdg-utils,
+  xxhash,
+  zlib,
+}:
+
+let
+  # This is required because kdrive needs the log4cplusConfig.cmake file, which is only generated when built with cmake.
+  # Since log4cplus is built with make in nixpkgs, we rebuild it with cmake.
+  log4cplus-cmake = log4cplus.overrideAttrs (old: {
+    pname = "log4cplus-cmake";
+
+    nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ cmake ];
+
+    cmakeFlags = [
+      # kDrive uses the unicode version of log4cplus.
+      "-DUNICODE=ON"
+      # Disable decorated library name so that kDrive can find log4cplus::log4cplus. This avoid having to patch kDrive
+      # code to match the decorated name log4cplus::log4cplusU when unicode is enabled.
+      "-DLOG4CPLUS_ENABLE_DECORATED_LIBRARY_NAME=OFF"
+      # See https://github.com/NixOS/nixpkgs/issues/144170 for why this is needed.
+      "-DCMAKE_INSTALL_INCLUDEDIR=include"
+      "-DCMAKE_INSTALL_LIBDIR=lib"
+    ];
+  });
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "kdrive";
+  version = "3.8.5";
+
+  src = fetchFromGitHub {
+    owner = "Infomaniak";
+    repo = "desktop-kDrive";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-sg2lN08T41Gxloh/rozIwcDWI7r5B9pJq7Bai2vJ+ZQ=";
+    fetchSubmodules = true;
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    cmake
+    kdePackages.extra-cmake-modules
+    libsysprof-capture
+    pkg-config
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    cups
+    desktop-file-utils
+    libGL
+    libgcrypt
+    libgpg-error
+    libsecret
+    libzip
+    log4cplus-cmake
+    openssl
+    poco
+    qt6.qt5compat
+    qt6.qtbase
+    qt6.qtnetworkauth
+    qt6.qtsvg
+    qt6.qttools
+    qt6.qtwebchannel
+    qt6.qtwebengine
+    qt6.qtwebsockets
+    sentry-native
+    shared-mime-info
+    sqlite
+    xdg-utils
+    xxhash
+    zlib
+  ];
+
+  patches = [
+    # Patch to disable Sentry's crashpad handler. Nixpkgs' sentry-native uses breakpad handler (which should be fine).
+    ./CMakeLists.txt.patch
+  ];
+
+  # "Hack" to have SYSCONFDIR point to the Nix store path thanks to ${outputBin}. This is needed because kDrive
+  # installs sentry's shared library and sync-exclude.lst at this location. If unset, cmake will attempt to install
+  # those at fs root, which is not permitted.
+  preConfigure = ''
+    prependToVar cmakeFlags "-DSYSCONFDIR=''${!outputBin}"
+  '';
+
+  cmakeFlags = [
+    # Prevent dev warnings from ECM.
+    "-Wno-dev"
+    # Original options from upstream.
+    # NOTE: we explicitly don't set CMAKE_BUILD_TYPE nor CMAKE_INSTALL_PREFIX here since they are already added by
+    #       nixpkgs' cmake build environment.
+    "-DQT_FEATURE_neon=OFF"
+    "-DKDRIVE_THEME_DIR=${finalAttrs.src}/infomaniak"
+    # Disables unit tests because they rely on the network. This is not compatible with Nix sandboxing.
+    "-DBUILD_UNIT_TESTS=0"
+  ];
+
+  # Prevent compilation error of keychain submodule.
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=uninitialized";
+
+  # Move sync-exclude.lst to the bin directory since kDrive fails to start without it at this location.
+  postInstall = ''
+    mv $out/kDrive/sync-exclude.lst $out/bin
+    rm -rf $out/kDrive
+  '';
+
+  meta = {
+    mainProgram = "kdrive";
+    description = "Desktop syncing client for kDrive";
+    homepage = "https://github.com/Infomaniak/desktop-kDrive";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      nicolas-goudry
+      FelixLusseau
+    ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
The Desktop application for kDrive by Infomaniak  
Synchronise, share, collaborate. The Swiss cloud that’s 100% secure.

https://github.com/Infomaniak/desktop-kDrive

This PR is opened in collaboration with @nicolas-goudry from https://github.com/NixOS/nixpkgs/issues/380995 to add kDrive to Nixpkgs.

It is also an improvement / replacement of https://github.com/NixOS/nixpkgs/pull/483592 that is built from source instead of AppImage.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
