### PR TITLE
nixos/pam/u2f: add settings.{,cue_}prompt option

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -2250,6 +2250,30 @@ in
               '';
             };
 
+            prompt = lib.mkOption {
+              default = null;
+              type = with lib.types; nullOr str;
+              description = ''
+                Set individual prompt message for interactive mode.
+                By setting this option, you can set a message to be shown by the
+                {option}`security.pam.u2f.settings.interactive` option.
+
+                Requires {option}`security.pam.u2f.settings.interactive` to be set to `true`.
+              '';
+            };
+
+            cue_prompt = lib.mkOption {
+              default = null;
+              type = with lib.types; nullOr str;
+              description = ''
+                Set individual prompt message for cue mode.
+                By setting this option, you can set a message to be shown by the
+                {option}`security.pam.u2f.settings.cue` option.
+
+                Requires {option}`security.pam.u2f.settings.cue` to be set to `true`.
+              '';
+            };
+
             cue = lib.mkOption {
               default = false;
               type = lib.types.bool;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add `prompt` and `cue_prompt` to `security.pam.u2f.settings` so they have docs.
 
Closes #170260 (most changes there are not required at all since #276106)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
