### PR TITLE
kulala-core: improve description

### DIFF
--- a/pkgs/by-name/ku/kulala-core/package.nix
+++ b/pkgs/by-name/ku/kulala-core/package.nix
@@ -116,7 +116,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "Core parser and runner for kulala.nvim";
+    description = "HTTP client library powering the Kulala toolchain";
     homepage = "https://github.com/mistweaverco/kulala-core";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ khaneliman ];


### PR DESCRIPTION
   Update the `kulala-core` package description to reflect that it powers the broader Kulala
 toolchain, not only `kulala.nvim`.

   Closes #536011.

   Assisted-by: pi coding agent / Mika (OpenAI GPT-5.5)

   ## Things done

   <!-- Please check what applies. Note that these are not hard requirements but merely
 serve as information for reviewers. -->

   - Built on platform:
     - [ ] x86_64-linux
     - [ ] aarch64-linux
     - [ ] aarch64-darwin
   - Tested, as applicable:
     - [ ] [NixOS tests] in [nixos/tests].
     - [ ] [Package tests] at `passthru.tests`.
     - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
   - [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
   - [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
   - Nixpkgs Release Notes
     - [ ] Package update: when the change is major or breaking.
   - NixOS Release Notes
     - [ ] Module addition: when adding a new NixOS module.
     - [ ] Module update: when the change is significant.
   - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other
 READMEs.
   - [x] Follows the [automation/AI policy].

   [NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
   [Package tests]:
 https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
   [nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

   [CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
   [automation/AI policy]:
 https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
   [lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
   [maintainers/README.md]:
 https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
   [nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
   [pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
   [pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test