### PR TITLE
coreboot-toolchain: 26.03 -> 26.06

### DIFF
--- a/pkgs/development/tools/misc/coreboot-toolchain/default.nix
+++ b/pkgs/development/tools/misc/coreboot-toolchain/default.nix
@@ -26,12 +26,12 @@ let
 
       stdenvNoCC.mkDerivation (finalAttrs: {
         pname = "coreboot-toolchain-${arch}";
-        version = "26.03";
+        version = "26.06";
 
         src = fetchgit {
           url = "https://review.coreboot.org/coreboot";
           rev = finalAttrs.version;
-          hash = "sha256-9ollzu6vtU+uHibvV/B5N70ZVl701kuI/orWlFZLjIU=";
+          hash = "sha256-MESai+UGo/Ref5t1VcgCrgQk+2ZeZW4Vh0xk3Z5v8ZE=";
           fetchSubmodules = false;
           leaveDotGit = true;
           postFetch = ''

--- a/pkgs/development/tools/misc/coreboot-toolchain/stable.nix
+++ b/pkgs/development/tools/misc/coreboot-toolchain/stable.nix
@@ -22,31 +22,38 @@
     };
   }
   {
-    name = "gcc-14.2.0.tar.xz";
+    name = "gcc-15.2.0.tar.xz";
     archive = fetchurl {
-      sha256 = "1j9wdznsp772q15w1kl5ip0gf0bh8wkanq2sdj12b7mzkk39pcx7";
-      url = "mirror://gnu/gcc/gcc-14.2.0/gcc-14.2.0.tar.xz";
+      sha256 = "0knj4ph6y7r7yhnp1v4339af7mki5nkh7ni9b948433bhabdk3s3";
+      url = "mirror://gnu/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz";
     };
   }
   {
-    name = "binutils-2.45.tar.xz";
+    name = "binutils-2.45.1.tar.xz";
     archive = fetchurl {
-      sha256 = "1lpmpszs3lk9mcg7yn0m312745kbc8vlazn95h79i25ikizhw365";
-      url = "mirror://gnu/binutils/binutils-2.45.tar.xz";
+      sha256 = "199sa5igipbvz2zg0j1zgvrybphgcznq2bcnjpngs64xzvk03qaz";
+      url = "mirror://gnu/binutils/binutils-2.45.1.tar.xz";
     };
   }
   {
-    name = "acpica-unix-20250807.tar.gz";
+    name = "acpica-unix-20251212.tar.gz";
     archive = fetchurl {
-      sha256 = "0cwfm7i5a2fqq35hznnal38pgxgmnkm0v2xkb82jm1yv9014rjpa";
-      url = "https://downloadmirror.intel.com/864114/acpica-unix-20250807.tar.gz";
+      sha256 = "06azmpymppycmri6wf64pgf100k7gl2sxaddnl5xsm41bwj26r28";
+      url = "https://github.com/acpica/acpica/releases/download/20251212/acpica-unix-20251212.tar.gz";
     };
   }
   {
-    name = "nasm-2.16.03.tar.bz2";
+    name = "cmake-4.0.3.tar.gz";
     archive = fetchurl {
-      sha256 = "0mwynbnn7c4ay4rpcsyp99j49sa6j3p8gk5pigwssqfdkcaxxwxy";
-      url = "https://www.nasm.us/pub/nasm/releasebuilds/2.16.03/nasm-2.16.03.tar.bz2";
+      sha256 = "1yrzkwkr2nxl8hcjkk333l9ycbw9prkg363k4km609kknyvkfdcd";
+      url = "https://cmake.org/files/v4.0/cmake-4.0.3.tar.gz";
+    };
+  }
+  {
+    name = "nasm-3.01.tar.bz2";
+    archive = fetchurl {
+      sha256 = "1cf08p8ak15sksbzfyjxaiqggkjwc35f9yzjc9w29wzfn3riyyvs";
+      url = "https://www.nasm.us/pub/nasm/releasebuilds/3.01/nasm-3.01.tar.bz2";
     };
   }
 ]


### PR DESCRIPTION
What I did was run `pkgs/development/tools/misc/coreboot-toolchain/update.sh` and then remove the LLVM additions (see https://github.com/NixOS/nixpkgs/pull/521765).

I was able to build Framework marigold platform with the new toolchain on the coreboot 26.06 tag.
I built all the other toolchains but did not use them, only i386.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
