### PR TITLE
[26.05] signal-desktop: 8.13.0 -> 8.15.0

### DIFF
--- a/pkgs/by-name/si/signal-desktop/chromium-147-llvm-22.patch
+++ b/pkgs/by-name/si/signal-desktop/chromium-147-llvm-22.patch
@@ -1,0 +1,13 @@
+diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
+index c092446fa0715351f72913fd449c8dddb855a10f..83670b496575a85ecb02a4671c0287fd0e052c5a 100644
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -616,7 +616,7 @@ config("compiler") {
+     # The performance improvement does not seem worth the risk. See
+     # https://crbug.com/484082200 for background and https://crrev.com/c/7593035
+     # for discussion.
+-    if (!is_wasm) {
++    if (false) {
+       cflags += [ "-fno-lifetime-dse" ]
+     }
+ 

--- a/pkgs/by-name/si/signal-desktop/libsignal-node.nix
+++ b/pkgs/by-name/si/signal-desktop/libsignal-node.nix
@@ -15,23 +15,23 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "libsignal-node";
-  version = "0.94.4";
+  version = "0.95.0";
 
   src = fetchFromGitHub {
     owner = "signalapp";
     repo = "libsignal";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Uh/j8cXUWgWgSo9UBfYOFuC8i+2YdMwGHcXf55PkGgU=";
+    hash = "sha256-stxakRw9CJQetkBcF2BfQh1EvEGurccP5/QLNLyEJz0=";
   };
 
-  cargoHash = "sha256-st6zTKvxSsyMce22E8nFsJMGjQkk9sEAzSCmyZP8x20=";
+  cargoHash = "sha256-bbOsE6vcFQpplzXAupcvp2oEoIFT3nk8Ug9QWbCe2yc=";
 
   npmRoot = "node";
   npmDeps = fetchNpmDeps {
     name = "${finalAttrs.pname}-npm-deps";
     inherit (finalAttrs) version src;
     sourceRoot = "${finalAttrs.src.name}/${finalAttrs.npmRoot}";
-    hash = "sha256-A/RTWBHnI9eBrguXezOb5qSkGzIyVl66ATAA/ZUtk3Y=";
+    hash = "sha256-lCLM0qI11Ce9w2NNgXHalxa8Ks628nvTjZhy26PvNbM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/si/signal-desktop/libsignal-node.nix
+++ b/pkgs/by-name/si/signal-desktop/libsignal-node.nix
@@ -15,23 +15,23 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "libsignal-node";
-  version = "0.94.1";
+  version = "0.94.4";
 
   src = fetchFromGitHub {
     owner = "signalapp";
     repo = "libsignal";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-re9IAC0R2QOIjyOLUjdaJw/TgDA4JT1nhtOskE5A0FQ=";
+    hash = "sha256-Uh/j8cXUWgWgSo9UBfYOFuC8i+2YdMwGHcXf55PkGgU=";
   };
 
-  cargoHash = "sha256-EVwIRUJ8SmajjocZj3dAHkTiR7Q78m/lf+4qls/oZAM=";
+  cargoHash = "sha256-st6zTKvxSsyMce22E8nFsJMGjQkk9sEAzSCmyZP8x20=";
 
   npmRoot = "node";
   npmDeps = fetchNpmDeps {
     name = "${finalAttrs.pname}-npm-deps";
     inherit (finalAttrs) version src;
     sourceRoot = "${finalAttrs.src.name}/${finalAttrs.npmRoot}";
-    hash = "sha256-bEQb+36IB+kXSbIkAFDpeIXWeHoQoIIiHo9q5AbaTio=";
+    hash = "sha256-A/RTWBHnI9eBrguXezOb5qSkGzIyVl66ATAA/ZUtk3Y=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/si/signal-desktop/package.nix
+++ b/pkgs/by-name/si/signal-desktop/package.nix
@@ -6,12 +6,12 @@
   node-gyp,
   fetchPnpmDeps,
   pnpmConfigHook,
-  electron_41,
+  pnpmBuildHook,
+  electron_42,
   python3,
   makeWrapper,
   callPackage,
   fetchFromGitHub,
-  fetchpatch,
   fetchurl,
   jq,
   makeDesktopItem,
@@ -32,7 +32,7 @@ assert lib.warnIf (commandLineArgs != "")
 let
   nodejs = nodejs_24;
   pnpm = pnpm_10_29_2;
-  electron = electron_41;
+  electron = electron_42;
 
   libsignal-node = callPackage ./libsignal-node.nix { inherit nodejs; };
   signal-sqlcipher = callPackage ./signal-sqlcipher.nix { inherit pnpm nodejs; };
@@ -40,13 +40,13 @@ let
   webrtc = callPackage ./webrtc.nix { };
   ringrtc = callPackage ./ringrtc.nix { inherit webrtc; };
 
-  version = "8.13.0";
+  version = "8.14.0";
 
   src = fetchFromGitHub {
     owner = "signalapp";
     repo = "Signal-Desktop";
     tag = "v${version}";
-    hash = "sha256-gOYnjNCjI1eNVzcb7sx0XDXbhrAdvlgsZQaRuyBXpwI=";
+    hash = "sha256-U5xJumoKWc1hGZ7OML05U7U3DFdrnRHUlfIU3qYph6w=";
     # Emoji font files will be added in `postFetch` if `withAppleEmojis` is enabled. They
     # are fetched separately below.
     postFetch = ''
@@ -68,22 +68,17 @@ let
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname src version;
       inherit pnpm;
-      fetcherVersion = 3;
-      hash = "sha256-CPZkybD/rCBMBK9qUSweBdLr9hXu0Ztn8fekqrRzUR4=";
+      fetcherVersion = 4;
+      hash = "sha256-WmDSa4PrASaqs8X68LYaPBeE+i+Jh3FfWF30SseN74Y=";
     };
 
     strictDeps = true;
     nativeBuildInputs = [
       nodejs
       pnpmConfigHook
+      pnpmBuildHook
       pnpm
     ];
-
-    buildPhase = ''
-      runHook preBuild
-      pnpm run build
-      runHook postBuild
-    '';
 
     installPhase = ''
       runHook preInstall
@@ -101,6 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
     node-gyp
     nodejs
     pnpmConfigHook
+    pnpmBuildHook
     pnpm
     makeWrapper
     python3
@@ -173,14 +169,14 @@ stdenv.mkDerivation (finalAttrs: {
       patches
       ;
     inherit pnpm;
-    fetcherVersion = 3;
-    hash = "sha256-3EEeHmtOAdcm2Q3eNUEl2RbTFRB4YBKcZLFtEmwbVOk=";
+    fetcherVersion = 4;
+    hash = "sha256-YQY+ohfLcaR2jzB9bzWpNQImuLja2DQ9iwDKhoH8kiU=";
   };
 
   env = {
     ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
     SIGNAL_ENV = "production";
-    SOURCE_DATE_EPOCH = 1780508208;
+    SOURCE_DATE_EPOCH = 1781124627;
   };
 
   preBuild = ''
@@ -234,17 +230,15 @@ stdenv.mkDerivation (finalAttrs: {
     node-gyp rebuild
     popd
     test -f node_modules/fs-xattr/build/Release/xattr.node
-  '';
 
-  buildPhase = ''
-    runHook preBuild
-
-    export npm_config_nodedir=${electron.headers}
     cp -r ${electron.dist} electron-dist
     chmod -R u+w electron-dist
     cp -r ${sticker-creator} sticker-creator/dist
+  '';
 
-    pnpm run generate
+  pnpmBuildScript = "generate";
+
+  postBuild = ''
     pnpm exec electron-builder \
       ${
         if stdenv.hostPlatform.isDarwin then "--mac" else "--linux"
@@ -254,8 +248,6 @@ stdenv.mkDerivation (finalAttrs: {
       -c.electronVersion=${electron.version} \
       -c.npmRebuild=false \
       ${lib.optionalString stdenv.hostPlatform.isDarwin "-c.mac.identity=null"}
-
-    runHook postBuild
   '';
 
   installPhase = ''

--- a/pkgs/by-name/si/signal-desktop/package.nix
+++ b/pkgs/by-name/si/signal-desktop/package.nix
@@ -40,13 +40,13 @@ let
   webrtc = callPackage ./webrtc.nix { };
   ringrtc = callPackage ./ringrtc.nix { inherit webrtc; };
 
-  version = "8.14.0";
+  version = "8.15.0";
 
   src = fetchFromGitHub {
     owner = "signalapp";
     repo = "Signal-Desktop";
     tag = "v${version}";
-    hash = "sha256-U5xJumoKWc1hGZ7OML05U7U3DFdrnRHUlfIU3qYph6w=";
+    hash = "sha256-SiOgNUll6J+EZNlmM6yhXakOc5qFCFRE/GczhaH57Vo=";
     # Emoji font files will be added in `postFetch` if `withAppleEmojis` is enabled. They
     # are fetched separately below.
     postFetch = ''
@@ -170,13 +170,13 @@ stdenv.mkDerivation (finalAttrs: {
       ;
     inherit pnpm;
     fetcherVersion = 4;
-    hash = "sha256-YQY+ohfLcaR2jzB9bzWpNQImuLja2DQ9iwDKhoH8kiU=";
+    hash = "sha256-/z+P9mb7Cm3FzzMpV6Da6THcHd73JgPuuB0Gx8KwKcc=";
   };
 
   env = {
     ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
     SIGNAL_ENV = "production";
-    SOURCE_DATE_EPOCH = 1781124627;
+    SOURCE_DATE_EPOCH = 1781737260;
   };
 
   preBuild = ''

--- a/pkgs/by-name/si/signal-desktop/package.nix
+++ b/pkgs/by-name/si/signal-desktop/package.nix
@@ -1,4 +1,5 @@
 {
+  actool,
   stdenv,
   lib,
   nodejs_24,
@@ -93,6 +94,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
   nativeBuildInputs = [
+    actool
     node-gyp
     nodejs
     pnpmConfigHook

--- a/pkgs/by-name/si/signal-desktop/package.nix
+++ b/pkgs/by-name/si/signal-desktop/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   lib,
   nodejs_24,
-  pnpm_10_29_2,
+  pnpm_10,
   node-gyp,
   fetchPnpmDeps,
   pnpmConfigHook,
@@ -32,7 +32,7 @@ assert lib.warnIf (commandLineArgs != "")
   true;
 let
   nodejs = nodejs_24;
-  pnpm = pnpm_10_29_2;
+  pnpm = pnpm_10;
   electron = electron_42;
 
   libsignal-node = callPackage ./libsignal-node.nix { inherit nodejs; };

--- a/pkgs/by-name/si/signal-desktop/ringrtc.nix
+++ b/pkgs/by-name/si/signal-desktop/ringrtc.nix
@@ -19,16 +19,16 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ringrtc";
-  version = "2.69.1";
+  version = "2.69.3";
 
   src = fetchFromGitHub {
     owner = "signalapp";
     repo = "ringrtc";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-XKzZ9AUGunOTs4vchWNlBYDIln25kRfxyQ2RZCr29Bs=";
+    hash = "sha256-ekSXEaAyVzd5957qoFakD33UYrUmvxZL19M6uflPR5U=";
   };
 
-  cargoHash = "sha256-U1Zf7fCNoJNBYyIN/IRI41Gj6sK+iiUwGbAfYEo+a/0=";
+  cargoHash = "sha256-oNHT2owg3Ob2z8JxdYnICRdogK+XaasVgbF5RYYBJas=";
 
   preConfigure = ''
     # Check for matching webrtc version

--- a/pkgs/by-name/si/signal-desktop/ringrtc.nix
+++ b/pkgs/by-name/si/signal-desktop/ringrtc.nix
@@ -19,16 +19,16 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ringrtc";
-  version = "2.69.0";
+  version = "2.69.1";
 
   src = fetchFromGitHub {
     owner = "signalapp";
     repo = "ringrtc";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-KQ/zAyj9caArZvl8SwMFfRcye1IzPoChjnYA0A8GcWw=";
+    hash = "sha256-XKzZ9AUGunOTs4vchWNlBYDIln25kRfxyQ2RZCr29Bs=";
   };
 
-  cargoHash = "sha256-DlRAPFluKdfU1YutDNQbAEF95aydd+duc6T2hqYWwGQ=";
+  cargoHash = "sha256-U1Zf7fCNoJNBYyIN/IRI41Gj6sK+iiUwGbAfYEo+a/0=";
 
   preConfigure = ''
     # Check for matching webrtc version

--- a/pkgs/by-name/si/signal-desktop/signal-sqlcipher.nix
+++ b/pkgs/by-name/si/signal-desktop/signal-sqlcipher.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   fetchPnpmDeps,
   pnpmConfigHook,
+  pnpmBuildHook,
   nodejs,
   rustPlatform,
   cargo,
@@ -27,8 +28,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     inherit pnpm; # may be different than top-level pnpm
-    fetcherVersion = 3;
-    hash = "sha256-/EcPuqTXXGw1dEN6l1x84cUGyx890/rujjT+zJouIvM=";
+    fetcherVersion = 4;
+    hash = "sha256-HK3AetwGqFq/dhxX+aWgUww6eLCeQEkZIVsmmnYqdmM=";
   };
 
   cargoRoot = "deps/extension";
@@ -42,6 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
+    pnpmBuildHook
     pnpm
     rustPlatform.cargoSetupHook
     cargo
@@ -53,15 +55,13 @@ stdenv.mkDerivation (finalAttrs: {
     cctools.libtool
   ];
 
-  buildPhase = ''
-    runHook preBuild
-
+  preBuild = ''
     export npm_config_nodedir=${nodejs}
-    pnpm run prebuildify --strip false --arch "${stdenv.hostPlatform.node.arch}" --platform "${stdenv.hostPlatform.node.platform}"
-    pnpm run build
 
-    runHook postBuild
+    pnpm run prebuildify --strip false --arch "${stdenv.hostPlatform.node.arch}" --platform "${stdenv.hostPlatform.node.platform}"
   '';
+
+  pnpmBuildScript = "build";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/si/signal-desktop/webrtc-sources.json
+++ b/pkgs/by-name/si/signal-desktop/webrtc-sources.json
@@ -1,25 +1,25 @@
 {
     "src": {
         "args": {
-            "hash": "sha256-TsVGiR9qXq6AmvPETkCQP7BGgO21/SUwZJZrSXlj7p8=",
+            "hash": "sha256-T3zxuDqTiThU9Tv3cmJASK6cMo2W/crYYPyshVeV6LM=",
             "owner": "signalapp",
             "repo": "webrtc",
-            "tag": "7680g"
+            "tag": "7778b"
         },
         "fetcher": "fetchFromGitHub"
     },
     "src/build": {
         "args": {
-            "hash": "sha256-ZPEL0Oy07aAd/qtboCcbD7t55f4EzHiOnE3fiVkZE3Q=",
-            "rev": "a37e61dc22fd633ab32146e7000068a57a2864ff",
+            "hash": "sha256-XmuuR4mLcaoAPCr82ka6ldtE4OmYFmXlWjNaP/wM2BQ=",
+            "rev": "dd54dd5186566a13bda647123c22540666b12ace",
             "url": "https://chromium.googlesource.com/chromium/src/build"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/buildtools": {
         "args": {
-            "hash": "sha256-wR2qwqxiRmInKzQiVIiZ13SNKuY5k+aJ+dxKAWV1zdo=",
-            "rev": "6a18683f555b4ac8b05ac8395c29c84483ac9588",
+            "hash": "sha256-BvGCdJ3EgUZX6MC3jf86YNl4LzUxpxiptCEBv3bqBIo=",
+            "rev": "95ed44cf5f06dbb5861030b91c9db9ccb4316762",
             "url": "https://chromium.googlesource.com/chromium/src/buildtools"
         },
         "fetcher": "fetchFromGitiles"
@@ -35,40 +35,40 @@
     },
     "src/testing": {
         "args": {
-            "hash": "sha256-cE8uCDkhkzFjrEJ3ccXq5H45WJ3wvmirLeeSymnR8bk=",
-            "rev": "b887106bc278bb2a49e21f3a0ab2019574e7e47a",
+            "hash": "sha256-tUh/eOrf71OjndY6p6IOJ5MFJUnuisDGWXJzsHHyrHs=",
+            "rev": "629b7bb6055714e23d8125bf790cfc8d94a94159",
             "url": "https://chromium.googlesource.com/chromium/src/testing"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party": {
         "args": {
-            "hash": "sha256-fSsA88V0cv/hAJEZJ7p+RnrnkceLMZCa+XaP+1awo9M=",
-            "rev": "e43b96b7a65dd3f45f066983061e6f8b2f3a112d",
+            "hash": "sha256-sLMCkUCadVZIX5bTVovDd5tPn0ZB/CH/d0tQic8lEQg=",
+            "rev": "4923971b35e39f6bd9be8bc19c4680785a15c80d",
             "url": "https://chromium.googlesource.com/chromium/src/third_party"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/boringssl/src": {
         "args": {
-            "hash": "sha256-4eCoRVe47hZ6hc3gXgBS1gY64d+sPqeI08hNMh6JkUY=",
-            "rev": "305bcfce00b189f2297f53365b0454f96009927d",
+            "hash": "sha256-OIaU7GoHYKq1ZyPaW/gLSKNq1ipw5nAgjqcPIFXtGwE=",
+            "rev": "8dce4fd20ab7e768c0a5103edc1d8cb7e54366ba",
             "url": "https://boringssl.googlesource.com/boringssl.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/breakpad/breakpad": {
         "args": {
-            "hash": "sha256-dtuBGcYwwaqSKiW7ASFveAeJqcdnFLeU97ip8D786/Q=",
-            "rev": "79099fdf668ae097c9eca7052fd5c4c5de6c9098",
+            "hash": "sha256-igcX5XwacIwoGbqIcZKwlJYpRWl9Uc32WdpXyHO7UVA=",
+            "rev": "8be0e3114685fcc1589561067282edf75ea1259a",
             "url": "https://chromium.googlesource.com/breakpad/breakpad.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/catapult": {
         "args": {
-            "hash": "sha256-Buh+Ixx8CTqBb0vuu/Fnv6fx15lPMOatYGPAgQ0aWEI=",
-            "rev": "39805a224bb6c6e80e403a4ebe9a150c7ca0b4d1",
+            "hash": "sha256-f57wYazKyGrjfzcQ7EVqwIG8p+bHLGK0Qb/tZERxwY8=",
+            "rev": "5a34891efa6e41c8aca8842386b8ee528963ffdf",
             "url": "https://chromium.googlesource.com/catapult.git"
         },
         "fetcher": "fetchFromGitiles"
@@ -99,16 +99,16 @@
     },
     "src/third_party/compiler-rt/src": {
         "args": {
-            "hash": "sha256-7Jnb0tzi0SkS9vL7VurdTk6Igz5I8ol4H4nRqcZ2+O0=",
-            "rev": "d606e955eec3d4fb0bf831dea336c3b24cba2f27",
+            "hash": "sha256-ay0gzhNjAah27LQd/i0ex6EcHEdqpsWBT9Tw510coRM=",
+            "rev": "bb7645f5e11c9c1d719a890fcb09ccfaaa14580f",
             "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/compiler-rt.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/cpuinfo/src": {
         "args": {
-            "hash": "sha256-eXrfeFK0ADKAYoy/vESv7nQnH0oGpeZKlX8XEqPQspo=",
-            "rev": "84818a41e074779dbb00521a4731d3e14160ff15",
+            "hash": "sha256-LnLtCMMRg+DwB7MijBdt/tmCKD/zN5y2oTgXlYw3hTg=",
+            "rev": "7607ca500436b37ad23fb8d18614bec7796b68a7",
             "url": "https://chromium.googlesource.com/external/github.com/pytorch/cpuinfo.git"
         },
         "fetcher": "fetchFromGitiles"
@@ -123,24 +123,24 @@
     },
     "src/third_party/dav1d/libdav1d": {
         "args": {
-            "hash": "sha256-E3da/LJ8HNy1osExmupovqnL8JHgVNzPUCG5F8TJKXQ=",
-            "rev": "b546257f770768b2c88258c533da38b91a06f737",
+            "hash": "sha256-iKq6TYscIBK4ydv+0msNV3tcs82Ljk5ZNr954Qv2lII=",
+            "rev": "d69235dd804b24c04ed05639cffcc912cd6cfd75",
             "url": "https://chromium.googlesource.com/external/github.com/videolan/dav1d.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/depot_tools": {
         "args": {
-            "hash": "sha256-RsmH8kxnmzOKsrfmDqULDeQsvRr1l+p8ZE1a4bPLVLs=",
-            "rev": "9fd48a305e18b9bbaf61734557ce2c46497192b3",
+            "hash": "sha256-r/mmibfbCBpV9reVbHc/S7FKffrtE729y2Mot/JsHgc=",
+            "rev": "ce1ebad2c35c9387186f01d77edeea28a254c955",
             "url": "https://chromium.googlesource.com/chromium/tools/depot_tools.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/eigen3/src": {
         "args": {
-            "hash": "sha256-GpuSoq887Z1qGKsc4+Vz8X+Sx40P6UnWhaQgrmigkdQ=",
-            "rev": "afb43805349cf1cbec0083d94256bb8f72cbc53b",
+            "hash": "sha256-/nzzcoJ87L7EVsRfAeok3UbxNKQeAWOFjmwZ3TYmGmI=",
+            "rev": "002229ce470065878afb7c2f6f96d22c9a9b7ba0",
             "url": "https://chromium.googlesource.com/external/gitlab.com/libeigen/eigen.git"
         },
         "fetcher": "fetchFromGitiles"
@@ -155,8 +155,8 @@
     },
     "src/third_party/ffmpeg": {
         "args": {
-            "hash": "sha256-LphjwzqsrvAOzd+O+lJ/gGfaWuX4h2/UrRC694ftwSs=",
-            "rev": "9e588ab02e16326026aa61cc3b6515da20520cec",
+            "hash": "sha256-JHAicFKBvtkwmZPRBKYPT6JVqYqF8hyXxU0H7kfgCBs=",
+            "rev": "b5e18fb9da84e26ceef30d4e4886696bf59337c0",
             "url": "https://chromium.googlesource.com/chromium/third_party/ffmpeg.git"
         },
         "fetcher": "fetchFromGitiles"
@@ -187,16 +187,16 @@
     },
     "src/third_party/freetype/src": {
         "args": {
-            "hash": "sha256-CorCyTiS2fumIF0jhqQgw7VjGkjGXNVD8efdmfZ2wUo=",
-            "rev": "e3a0652b6d706ee1ce77d4dda606b6597dd8b5c4",
+            "hash": "sha256-H5RzBFYWIp/QYKyeBM2wfuX7FvXHPbhCAp7qne5Zvhw=",
+            "rev": "99b479dc34728936b006679a31e12b8cf432fc55",
             "url": "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/fuzztest/src": {
         "args": {
-            "hash": "sha256-CqJJ1hj9nQkGONB+5tJgafg1xvrPgTuE3tM8RjO2RY0=",
-            "rev": "54dfec04d5c9ad1f22b08002ab6a5e2d0de77671",
+            "hash": "sha256-0Fk2W4rS1xB6YcXsDbrMfmZUfMxNlGz29xRcBHZbijA=",
+            "rev": "dc327134097700121e4ecd6e1d54d1d0a832a18d",
             "url": "https://chromium.googlesource.com/external/github.com/google/fuzztest.git"
         },
         "fetcher": "fetchFromGitiles"
@@ -235,8 +235,8 @@
     },
     "src/third_party/grpc/src": {
         "args": {
-            "hash": "sha256-GvzPndJkPZsVCp0LtaQ29rnORQ7xSZ76if/feEIhvkI=",
-            "rev": "f394c3f07b4c685b9f6948b36d65ca10a629f4fa",
+            "hash": "sha256-LQrig9/ceXS1LclfN9b9DoAvwltIA1R5fSpmHTmaN8s=",
+            "rev": "5e9fb9cbfb12a10ff9c16fbc360328d224b838d6",
             "url": "https://chromium.googlesource.com/external/github.com/grpc/grpc.git"
         },
         "fetcher": "fetchFromGitiles"
@@ -251,16 +251,16 @@
     },
     "src/third_party/harfbuzz-ng/src": {
         "args": {
-            "hash": "sha256-pXAQYEotsqZmfaJSQFaJmZAQVzUiNrHw52z0vmbxQRQ=",
-            "rev": "fa2908bf16d2ccd6623f4d575455fea72a1a722b",
+            "hash": "sha256-jQZElINbJgiVj1IHhkrtBCL5jGYzZrjJkO7gt+bgMA4=",
+            "rev": "6f4c5cec306d31e6822303f5ba248a14293d588e",
             "url": "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/icu": {
         "args": {
-            "hash": "sha256-zFxeAY6lEFRGNbCOOJij0CFjp3512WkyaN1Ld0+WADs=",
-            "rev": "a86a32e67b8d1384b33f8fa48c83a6079b86f8cd",
+            "hash": "sha256-hKIzBQVs4C/QJ4BdP3DTm6au9hq8BE0kG1VphtbtHVE=",
+            "rev": "b4aae6832c06df9d538d41b249403cf0678f16b4",
             "url": "https://chromium.googlesource.com/chromium/deps/icu.git"
         },
         "fetcher": "fetchFromGitiles"
@@ -291,8 +291,8 @@
     },
     "src/third_party/libaom/source/libaom": {
         "args": {
-            "hash": "sha256-SE9nevzv+e2pVvRECQM0bg3dU1l7rE/4bLPuZDHFi18=",
-            "rev": "557586fde2fdc09dff9c3edf6943d6d54aa8914c",
+            "hash": "sha256-uO+zjmt0g5m780WR823UJ0AmQA+dfVFOjPChTLAciTM=",
+            "rev": "f3dddebddd0dba76fbfb97b96b6336bcf1d3a30c",
             "url": "https://aomedia.googlesource.com/aom.git"
         },
         "fetcher": "fetchFromGitiles"
@@ -323,56 +323,56 @@
     },
     "src/third_party/libjpeg_turbo": {
         "args": {
-            "hash": "sha256-FeSS7D3NietL34KgpaDFenBf/GcvapGSpkiKwgIOOHs=",
-            "rev": "6bb85251a8382b5e07f635a981ac685cc5ab5053",
+            "hash": "sha256-KGeB/lTjhm8DQBDZVSPENvZEGSHeLTkviJrYsFh5vEM=",
+            "rev": "d1f5f2393e0d51f840207342ae86e55a86443288",
             "url": "https://chromium.googlesource.com/chromium/deps/libjpeg_turbo.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/libpfm4/src": {
         "args": {
-            "hash": "sha256-awpZ22rovLZWQkX/qog93vL4u2gJ+F3w5IGFNlZ0heQ=",
-            "rev": "964baf9d35d5f88d8422f96d8a82c672042e7064",
+            "hash": "sha256-6YaPJcI6Qk0F1Dv5evfFq3MVSsBpsQ7sIreSuHZmOUo=",
+            "rev": "41878eab48c50bb9ec5f741a013e971bb5a9dff2",
             "url": "https://chromium.googlesource.com/external/git.code.sf.net/p/perfmon2/libpfm4.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/libsrtp": {
         "args": {
-            "hash": "sha256-bkG1+ss+1a2rCHGwZjhvf5UaNVbPPZJt9HZSIPBKGwM=",
-            "rev": "a52756acb1c5e133089c798736dd171567df11f5",
+            "hash": "sha256-xC//VEFrI94nCkyLnRa6uQ+hJQqe41v0Qjm4LJ7K84I=",
+            "rev": "e8383771af8aa4096f5bcfe3743a5ea128f88a9a",
             "url": "https://chromium.googlesource.com/chromium/deps/libsrtp.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/libunwind/src": {
         "args": {
-            "hash": "sha256-iRfpzVN+QEpN6okwVs5oEtZqIJYzFGxsUO/IJY1c/W8=",
-            "rev": "ba19d93d6d4f467fba11ff20fe2fc7c056f79345",
+            "hash": "sha256-miwz3+/fq+7Ohsn8J6xrLsQn/VqyezS9vZO9XzEuZZA=",
+            "rev": "db838d918570d4e381ecf9f5cc70a0098c9c2cd6",
             "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libunwind.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/libvpx/source/libvpx": {
         "args": {
-            "hash": "sha256-/FtYzbcOgOlaaWCoJfYns5oye7DoRZx1/xew3lN7tAM=",
-            "rev": "e83e25f791932202256479052f18bdd03a091147",
+            "hash": "sha256-8vej9g9+L73eOIuXZNfOWe6pV/cNr4JZOihZUtRxbFA=",
+            "rev": "3fce57ecc905d95a4619f33d09851d68c5a88663",
             "url": "https://chromium.googlesource.com/webm/libvpx.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/libyuv": {
         "args": {
-            "hash": "sha256-2lnobd22L9u+h6JGWJoWT/0gjhI5JImDsEjn+RRYzJg=",
-            "rev": "917276084a49be726c90292ff0a6b0a3d571a6af",
+            "hash": "sha256-DW7PuRqA1x0K8/uJbxBJ4Cn9YEPFhZ9vhuGVVyGKK98=",
+            "rev": "30809ff64a9ca5e45f86439c0d474c2d3eef3d05",
             "url": "https://chromium.googlesource.com/libyuv/libyuv.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/llvm-libc/src": {
         "args": {
-            "hash": "sha256-ZPsVBO+5v1xR9lvzHi616unK4HEak07Sy/reMSYwiok=",
-            "rev": "d99c56d4b9f6663bff528c4fac5313bceb32e762",
+            "hash": "sha256-nrd+E7LRTclF/Qa3wBvlutJ/wbLQKr73LOBk9k0qFOI=",
+            "rev": "adccc443070c58badd6414fd9a4380ca8c78e7c4",
             "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libc.git"
         },
         "fetcher": "fetchFromGitiles"
@@ -387,8 +387,8 @@
     },
     "src/third_party/nasm": {
         "args": {
-            "hash": "sha256-vH3OUzfLZbaPY4DMAvSW0jKYRJmOa7aE8EfIJtZ1/Xs=",
-            "rev": "af5eeeb054bebadfbb79c7bcd100a95e2ad4525f",
+            "hash": "sha256-0KsHYi76IaVNwk0dBhem2AnUXd9PpeS+jUsY+zPmeJ8=",
+            "rev": "45252858722aad12e545819b2d0f370eb865431b",
             "url": "https://chromium.googlesource.com/chromium/deps/nasm.git"
         },
         "fetcher": "fetchFromGitiles"
@@ -411,8 +411,8 @@
     },
     "src/third_party/perfetto": {
         "args": {
-            "hash": "sha256-xOFm5u6uwzktkHCLuLmy3ryiuVN8B8Fo+ltHbFmilOY=",
-            "rev": "2074b65d22dd04b65c2688647b9386a63338f0b9",
+            "hash": "sha256-ZDQsBVFq9TgGGf5r2vv8nsHvFy03NM+SkbaXPoa345Q=",
+            "rev": "40b1342aa7bd47d9c963c3617fd98ec1551528f9",
             "url": "https://chromium.googlesource.com/external/github.com/google/perfetto.git"
         },
         "fetcher": "fetchFromGitiles"
@@ -443,32 +443,32 @@
     },
     "src/third_party/ruy/src": {
         "args": {
-            "hash": "sha256-zJ7EYxIoZvN2uOfPscKzWycBO057g4bMnTys2sUrp2M=",
-            "rev": "576e020f06334118994496b45f9796ed7fda3280",
+            "hash": "sha256-4To1BMUgzj2/sV7USN9W0CgHnpRmaktEspfhwWWeVBc=",
+            "rev": "2af88863614a8298689cc52b1a47b3fcad7be835",
             "url": "https://chromium.googlesource.com/external/github.com/google/ruy.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/tflite/src": {
         "args": {
-            "hash": "sha256-pIhOSb9eLzel5oDPCpxCvI2XJ2jGLdLURCRkd1BbMkk=",
-            "rev": "01e030d23d3b904d98cbf908da74d63b3c186949",
+            "hash": "sha256-nvU3p6TzEqBkDtZEoxCZGPsQA0oZNJID8raqHBDS0ko=",
+            "rev": "8fd527849069a358ad6c2980b9a9b34a53c53717",
             "url": "https://chromium.googlesource.com/external/github.com/tensorflow/tensorflow.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/xnnpack/src": {
         "args": {
-            "hash": "sha256-OdrwYAazY0E3han/fpFjlAiguY4M/xnCMJjL3KAIhvw=",
-            "rev": "4574c4d9b00703c15f2218634ddf101597b22b18",
+            "hash": "sha256-vOUwMXZJbYxTGPpdD5uc9ATfPIpThCDHV/YTlWN0ajw=",
+            "rev": "97f3177fd836fff03b48a886bb130591866ad7ca",
             "url": "https://chromium.googlesource.com/external/github.com/google/XNNPACK.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/tools": {
         "args": {
-            "hash": "sha256-QKFYNmNwVcm7aAP3aeuSrY2ScbgMPs4/odf62dI0WJg=",
-            "rev": "f8f65faf07b1132c9d01932ef95846e9a82b8d54",
+            "hash": "sha256-PDjcHq8BTDLD6OsYFfvjw8ffmam/4YSx8SF0G/NvebY=",
+            "rev": "f363a79871a91f36322e845e3134e2f04e1fc18a",
             "url": "https://chromium.googlesource.com/chromium/src/tools"
         },
         "fetcher": "fetchFromGitiles"

--- a/pkgs/by-name/si/signal-desktop/webrtc-sources.json
+++ b/pkgs/by-name/si/signal-desktop/webrtc-sources.json
@@ -1,10 +1,10 @@
 {
     "src": {
         "args": {
-            "hash": "sha256-T3zxuDqTiThU9Tv3cmJASK6cMo2W/crYYPyshVeV6LM=",
+            "hash": "sha256-kdRUqYFKsEbAR0u4btQc995vtbN+FVcei19PgTf1DyA=",
             "owner": "signalapp",
             "repo": "webrtc",
-            "tag": "7778b"
+            "tag": "7778c"
         },
         "fetcher": "fetchFromGitHub"
     },

--- a/pkgs/by-name/si/signal-desktop/webrtc.nix
+++ b/pkgs/by-name/si/signal-desktop/webrtc.nix
@@ -97,6 +97,32 @@ stdenv.mkDerivation (finalAttrs: {
       revert = true;
       hash = "sha256-WZsN2qm6lX121bDf7SoN75flXtCTmPPpwtHK0ayjkPc=";
     })
+
+    # https://github.com/NixOS/nixpkgs/blob/8e689a91c5b4e47b57dee488dd7e319cc704eb9d/pkgs/applications/networking/browsers/chromium/common.nix#L620-L623
+    # clang++: error: unknown argument: '-fno-lifetime-dse'
+    ./chromium-147-llvm-22.patch
+
+    # https://github.com/NixOS/nixpkgs/blob/8e689a91c5b4e47b57dee488dd7e319cc704eb9d/pkgs/applications/networking/browsers/chromium/common.nix#L624-L644
+    # clang++: error: unknown argument: '-fsanitize-ignore-for-ubsan-feature=return'
+    (fetchpatch {
+      name = "chromium-148-revert-build-Add--fsanitizer=return-config.patch";
+      # https://chromium-review.googlesource.com/c/chromium/src/+/7629257
+      url = "https://chromium.googlesource.com/chromium/src/+/99ba1f5302f9433efdb4df302cb7b7de56c72e4c^!?format=TEXT";
+      decode = "base64 -d";
+      revert = true;
+      hash = "sha256-/qzzxwTdPMwIdsqD/G02S7kKHCj3QxECL+g1WYEaWmU=";
+    })
+    # ERROR Unresolved dependencies.
+    # //apps:apps(//build/toolchain/linux/unbundle:default)
+    #   needs //build/config/compiler:sanitize_return(//build/toolchain/linux/unbundle:default)
+    (fetchpatch {
+      name = "chromium-148-revert-build-Enable--fsanitizer=return-config.patch";
+      # https://chromium-review.googlesource.com/c/chromium/src/+/7629258
+      url = "https://chromium.googlesource.com/chromium/src/+/9357bfbea03753fe52264c9ec36abe74f48cfef5^!?format=TEXT";
+      decode = "base64 -d";
+      revert = true;
+      hash = "sha256-14fTHNh3vGsf4KgeH8uLX+aK3lrjK0VKd1dfK1g7r0I=";
+    })
   ];
 
   postPatch = ''
@@ -196,7 +222,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "WebRTC library used by Signal";
     homepage = "https://github.com/SignalApp/webrtc";
     license = lib.licenses.bsd3;
-    maintainers = [ ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/531481, https://github.com/NixOS/nixpkgs/pull/534350 (closes https://github.com/NixOS/nixpkgs/pull/532457) and https://github.com/NixOS/nixpkgs/pull/535818

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
