### PR TITLE
gamemac: init at 0.8.328

### DIFF
--- a/pkgs/by-name/ga/gamemac/package.nix
+++ b/pkgs/by-name/ga/gamemac/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  undmg,
+  makeWrapper,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "gamemac";
+  version = "0.8.328";
+
+  src = fetchurl {
+    name = "GameHub_en_${finalAttrs.version}.dmg";
+    url = "https://gamehub-cdn.masnet.cn/uploads/upgrade/20260618/b616a96780c249a789d95f7b897333cb.dmg";
+    hash = "sha256-uo/kr9PAFREfbkXX9hpJJNT6OZDv3jnOuZgc2fwtSyM=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    undmg
+    makeWrapper
+  ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications" "$out/bin"
+    mv GameHub.app "$out/Applications/"
+    makeWrapper "$out/Applications/GameHub.app/Contents/MacOS/GameHub" "$out/bin/GameHub"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Play mobile games natively on macOS";
+    homepage = "https://www.gamemac.com/en/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ damidoug ];
+    mainProgram = "GameHub";
+    platforms = lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/ga/gamemac/update.sh
+++ b/pkgs/by-name/ga/gamemac/update.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bash curl gnused nix
+
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+ROLLING_URL="https://api-international-gamehub.xiaoji.com/game/download/mac/en"
+UA="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+
+# Resolve rolling URL to stable CDN URL (strip query string)
+DIRECT_URL=$(curl -fsSL -A "$UA" -w "%{url_effective}" -o /dev/null "$ROLLING_URL")
+CDN_URL="${DIRECT_URL%%\?*}"
+
+# Extract version from CDN filename (e.g. .../GameHub_en_0.8.328.dmg)
+VERSION=$(basename "$CDN_URL" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+
+CURRENT=$(grep 'version = ' package.nix | head -1 | grep -oE '"[0-9.]+"' | tr -d '"')
+if [ "$VERSION" = "$CURRENT" ]; then
+  echo "Already at $VERSION"
+  exit 0
+fi
+
+HASH=$(nix-prefetch-url --name "GameHub_en_${VERSION}.dmg" --type sha256 "$CDN_URL")
+SRI=$(nix-hash --to-sri --type sha256 "$HASH")
+
+sed -i \
+  -e "s|version = \"[^\"]*\"|version = \"$VERSION\"|" \
+  -e "s|https://gamehub-cdn\.masnet\.cn/uploads/upgrade/[^\"]*|$CDN_URL|" \
+  -e "s|hash = \"sha256-[^\"]*\"|hash = \"$SRI\"|" \
+  package.nix
+
+echo "Updated $CURRENT -> $VERSION"


### PR DESCRIPTION
GameHub (branded as GameMac) is a macOS application that lets you play Android mobile games natively on your Mac via virtualization. Homepage: https://www.gamemac.com/en/

- Darwin-only binary package using `undmg` to extract the DMG
- Unfree license declared with `sourceProvenance = [ binaryNativeCode ]`
- Install checks verify the wrapper and `.app` bundle are present
- `update.sh` resolves the rolling download URL to a stable CDN URL for reproducible fetching

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
