### PR TITLE
claude-code: use nix-shell shebang and npm registry in update script

### DIFF
--- a/pkgs/by-name/cl/claude-code/update.sh
+++ b/pkgs/by-name/cl/claude-code/update.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/env nix
-#!nix shell --ignore-environment .#cacert .#coreutils .#curl .#bash --command bash
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bash curl jq
 
 set -euo pipefail
 
@@ -7,6 +7,6 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 BASE_URL="https://downloads.claude.ai/claude-code-releases"
 
-VERSION="${1:-$(curl -fsSL "$BASE_URL/latest")}"
+VERSION="${1:-$(curl -fsSL "https://registry.npmjs.org/@anthropic-ai/claude-code/latest" | jq -r '.version')}"
 
 curl -fsSL "$BASE_URL/$VERSION/manifest.json" --output manifest.json


### PR DESCRIPTION
The existing update script uses #!/usr/bin/env nix (flakes syntax) which is not compatible with the nixpkgs-update bot. Replace with the standard nix-shell shebang pattern. Also replace the private CDN /latest endpoint with the npm registry, which is the canonical public source for the latest version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
