### PR TITLE
scantpaper: add desktop entry

### DIFF
--- a/pkgs/by-name/sc/scantpaper/package.nix
+++ b/pkgs/by-name/sc/scantpaper/package.nix
@@ -104,6 +104,16 @@ python3.pkgs.buildPythonApplication rec {
     (lib.makeBinPath runtimeExecDeps)
   ];
 
+  postInstall = ''
+    install -Dm644 \
+      icons/hicolor/scalable/apps/scantpaper.svg \
+      $out/share/icons/hicolor/scalable/apps/scantpaper.svg
+
+    install -Dm444 \
+      org.scantpaper.desktop \
+      $out/share/applications/org.scantpaper.desktop
+  '';
+
   meta = with lib; {
     changelog = "https://github.com/carygravel/scantpaper/blob/${src.tag}/changelog.md";
     description = "GUI to produce PDFs or DjVus from scanned documents";


### PR DESCRIPTION
Add desktop entry.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
