### PR TITLE
zed-editor: add nix-shell update script using nix-update

### DIFF
--- a/pkgs/by-name/ze/zed-editor/package.nix
+++ b/pkgs/by-name/ze/zed-editor/package.nix
@@ -19,7 +19,6 @@
   stdenv,
   vulkan-loader,
   envsubst,
-  nix-update-script,
   cargo-about,
   versionCheckHook,
   buildFHSEnv,
@@ -292,17 +291,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   doInstallCheck = true;
 
   passthru = {
-    updateScript = nix-update-script {
-      extraArgs = [
-        "--version-regex"
-        "^v(?!.*(?:-pre|0\\.999999\\.0|0\\.9999-temporary)$)(.+)$"
-
-        # use github releases instead of git tags
-        # zed sometimes moves git tags, making them unreliable
-        # see: https://github.com/NixOS/nixpkgs/pull/439893#issuecomment-3250497178
-        "--use-github-releases"
-      ];
-    };
+    updateScript = ./update.sh;
     fhs = fhs { zed-editor = finalAttrs.finalPackage; };
     fhsWithPackages =
       f:

--- a/pkgs/by-name/ze/zed-editor/update.sh
+++ b/pkgs/by-name/ze/zed-editor/update.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bash nix-update
+
+set -euo pipefail
+
+exec nix-update zed-editor \
+  --version-regex '^v(?!.*(?:-pre|0\.999999\.0|0\.9999-temporary)$)(.+)$' \
+  --use-github-releases


### PR DESCRIPTION
Replaces the nix-update-script derivation with an explicit update.sh using the standard #!/usr/bin/env nix-shell shebang recognised by the nixpkgs-update bot. Functionally identical — still calls nix-update with the same version-regex and
--use-github-releases flags — but the nix-shell format is more reliably picked up by automation.

Tested: ran the script locally, correctly updated 1.7.2 → 1.8.2 including
cargoHash.

Tested: ran the script locally, correctly updated 1.7.2 → 1.8.2 including
cargoHash.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
