### PR TITLE
backgroundremover: 0.3.4 -> 0.4.4

### DIFF
--- a/pkgs/by-name/ba/backgroundremover/package.nix
+++ b/pkgs/by-name/ba/backgroundremover/package.nix
@@ -12,7 +12,7 @@ let
   p = python3.pkgs;
   self = p.buildPythonApplication rec {
     pname = "backgroundremover";
-    version = "0.3.4";
+    version = "0.4.4";
     pyproject = true;
 
     build-system = [
@@ -23,7 +23,7 @@ let
       owner = "nadermx";
       repo = "backgroundremover";
       tag = "v${version}";
-      hash = "sha256-7C31wlokX3M4csZ4ZbOqxowQvh8DMQJJcENKgQWNTa8=";
+      hash = "sha256-S6irFkNw+5HHr3ziMRxaeg3QoXWe1qqf10CGTTHKpb4=";
     };
 
     models = runCommand "background-remover-models" { } ''
@@ -51,12 +51,14 @@ let
       p.ffmpeg-python
       p.filelock
       p.filetype
+      p.flask
       p.hsh
       p.idna
       p.more-itertools
       p.moviepy
       p.numpy
       p.pillow
+      p.pillow-heif
       p.pymatting
       p.pysocks
       p.requests


### PR DESCRIPTION
Bump backgroundremover to 0.4.4 and declare new upstream runtime deps
(`flask`, `pillow-heif`) so the package builds again after the
[nixpkgs-update failure](https://nixpkgs-update-logs.nix-community.org/backgroundremover/2026-06-28.log).

Release: https://github.com/nadermx/backgroundremover/releases/tag/v0.4.4

Assisted with Grok Build (Grok 4.3, xAI); I reviewed the diff and verified the build. Commit uses an `Assisted-by:` trailer per the automation/AI policy. [nixpkgs-review on x86_64-linux via lucasew/nixcfg](https://github.com/lucasew/nixcfg/actions/runs/28325398028) built `backgroundremover`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test