### PR TITLE
bitwarden-desktop: 2026.5.0 -> 2026.6.0

### DIFF
--- a/pkgs/by-name/bi/bitwarden-desktop/package.nix
+++ b/pkgs/by-name/bi/bitwarden-desktop/package.nix
@@ -27,13 +27,13 @@ let
 in
 buildNpmPackage rec {
   pname = "bitwarden-desktop";
-  version = "2026.5.0";
+  version = "2026.6.0";
 
   src = fetchFromGitHub {
     owner = "bitwarden";
     repo = "clients";
     rev = "desktop-v${version}";
-    hash = "sha256-R00wt5W4kKmFIODEaGoUqDwfGyHH/2PpiRaC8Gq3d88=";
+    hash = "sha256-JIIis3wW0cU33ovRQfJi3HlB2YdLZ5IPvueq1dGFbas=";
   };
 
   patches = [
@@ -49,10 +49,6 @@ buildNpmPackage rec {
   ];
 
   postPatch = ''
-    # https://github.com/bitwarden/clients/pull/20480
-    substituteInPlace package-lock.json apps/desktop/desktop_native/napi/package.json \
-      --replace-fail '"@napi-rs/cli": "3.5.1"' '"@napi-rs/cli": "3.2.0"'
-
     # remove code under unfree license
     rm -r bitwarden_license
 
@@ -79,7 +75,7 @@ buildNpmPackage rec {
 
   npmWorkspace = "apps/desktop";
   npmDepsFetcherVersion = 2;
-  npmDepsHash = "sha256-xmb3zwE8/nWpRlUOgTz2UhNRaUA8KW9sHQHA97pjjfg=";
+  npmDepsHash = "sha256-sXFSjQw9iM5Ye03BX+ZzpDfeAyLTJoG/k46NiI3O8+A=";
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit
@@ -89,7 +85,7 @@ buildNpmPackage rec {
       cargoRoot
       patches
       ;
-    hash = "sha256-phvk4t1JKfSYGzm/vm1rT8A0fACHJF/C0WiZ2Lk3cV0=";
+    hash = "sha256-xyK3+z2yfCG9K5XAB6LNEeyqMRknONi6ZfY/3oko7Z8=";
   };
   cargoRoot = "apps/desktop/desktop_native";
 
@@ -244,7 +240,10 @@ buildNpmPackage rec {
     inherit description;
     homepage = "https://bitwarden.com";
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ amarshall ];
+    maintainers = with lib.maintainers; [
+      amarshall
+      damidoug
+    ];
     platforms = [
       "x86_64-linux"
       "aarch64-linux"


### PR DESCRIPTION
## Description

Version bump: `bitwarden-desktop` 2026.5.0 → 2026.6.0

Changes:
- Updated `src.hash`
- Updated `npmDepsHash` (removed `@napi-rs/cli` 3.5.1→3.2.0 downgrade from `postPatch` — no longer needed in 2026.6.0)
- Updated `cargoDeps.hash`

Changelog: https://github.com/bitwarden/clients/releases/tag/desktop-v2026.6.0

---

**Note on `electron-39.8.10`:** bitwarden-desktop still pins electron 39, which nixpkgs
now marks as insecure/EOL. This is an upstream constraint — the build enforces a strict
electron major version match (`preBuild` check in `package.nix`). Users will need to add
`"electron-39.8.10"` to `nixpkgs.config.permittedInsecurePackages` until bitwarden
migrates to a newer electron version upstream.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
