### PR TITLE
python3Packages.colcon-ros-domain-id-coordinator: fetch correct tag

### DIFF
--- a/pkgs/development/python-modules/colcon-ros-domain-id-coordinator/default.nix
+++ b/pkgs/development/python-modules/colcon-ros-domain-id-coordinator/default.nix
@@ -11,7 +11,7 @@
   setuptools,
   writableTmpDirAsHomeHook,
 }:
-buildPythonPackage {
+buildPythonPackage (finalAttrs: {
   pname = "colcon-ros-domain-id-coordinator";
   version = "0.2.4";
   pyproject = true;
@@ -19,8 +19,8 @@ buildPythonPackage {
   src = fetchFromGitHub {
     owner = "colcon";
     repo = "colcon-ros-domain-id-coordinator";
-    tag = "0.2.1";
-    hash = "sha256-8DTpixa5ZGuSOpmwoeJgxLQI+17XheLxPWcJymE0GqM=";
+    tag = finalAttrs.version;
+    hash = "sha256-B7BBBng/fODqVtneVgjoPgU6Cyon66PQa2QcGuRLfFU=";
   };
   build-system = [ setuptools ];
 
@@ -51,4 +51,4 @@ buildPythonPackage {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ guelakais ];
   };
-}
+})


### PR DESCRIPTION
discovered in #532778 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
