### PR TITLE
 codebase-memory-mcp: use makeFlags and makefile 

### DIFF
--- a/pkgs/by-name/co/codebase-memory-mcp/package.nix
+++ b/pkgs/by-name/co/codebase-memory-mcp/package.nix
@@ -22,13 +22,14 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
   __structuredAttrs = true;
 
+  makefile = "Makefile.cbm";
+
   # scripts/build.sh verifies CC via `file`, which fails on Nix's compiler wrapper.
   # Call make directly — mirrors upstream flake.nix.
-  buildPhase = ''
-    runHook preBuild
-    make -j$NIX_BUILD_CORES -f Makefile.cbm cbm CFLAGS_EXTRA='-DCBM_VERSION=\"${finalAttrs.version}\"'
-    runHook postBuild
-  '';
+  makeFlags = [
+    "cbm"
+    "CFLAGS_EXTRA='-DCBM_VERSION=\"${finalAttrs.version}\"'"
+  ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/co/codebase-memory-mcp/package.nix
+++ b/pkgs/by-name/co/codebase-memory-mcp/package.nix
@@ -14,10 +14,14 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "v${finalAttrs.version}";
     hash = "sha256-H0l8H2JhPT1Rs0p+CJC1a1qYtnZNgLGe6n7PmM+WvE4=";
   };
+
   nativeBuildInputs = [ gnumake ];
+
   buildInputs = [ zlib ];
+
   strictDeps = true;
   __structuredAttrs = true;
+
   # scripts/build.sh verifies CC via `file`, which fails on Nix's compiler wrapper.
   # Call make directly — mirrors upstream flake.nix.
   buildPhase = ''
@@ -25,11 +29,13 @@ stdenv.mkDerivation (finalAttrs: {
     make -j$NIX_BUILD_CORES -f Makefile.cbm cbm CFLAGS_EXTRA='-DCBM_VERSION=\"${finalAttrs.version}\"'
     runHook postBuild
   '';
+
   installPhase = ''
     runHook preInstall
     install -Dm755 build/c/codebase-memory-mcp $out/bin/codebase-memory-mcp
     runHook postInstall
   '';
+
   meta = {
     homepage = "https://github.com/DeusData/codebase-memory-mcp";
     description = "High-performance C11 MCP server that indexes codebases into a persistent knowledge graph";


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
