### PR TITLE
regclient: 0.11.3 -> 0.11.5

### DIFF
--- a/pkgs/by-name/re/regclient/package.nix
+++ b/pkgs/by-name/re/regclient/package.nix
@@ -19,15 +19,15 @@ in
 
 buildGoModule (finalAttrs: {
   pname = "regclient";
-  version = "0.11.3";
+  version = "0.11.5";
 
   src = fetchFromGitHub {
     owner = "regclient";
     repo = "regclient";
     tag = "v${finalAttrs.version}";
-    sha256 = "sha256-/gKvjyFOzyTsgMuqCqZaWl2yun7f+eboQ0iLuXHh4lI=";
+    sha256 = "sha256-tJBnNtuN9BIlGvHekrvziyBu5gFPzbID/09eAoM5VUc=";
   };
-  vendorHash = "sha256-P9ayAWvQY4WgmFTWzk2ZLQ5uwMvIsSfL73C99ROmze8=";
+  vendorHash = "sha256-jpXy3ZWj+JoDKU2r7FanKR8nQGIQPAL9GW4g//e5xZs=";
 
   outputs = [ "out" ] ++ bins;
 
@@ -66,10 +66,22 @@ buildGoModule (finalAttrs: {
     ''
   ) bins;
 
-  checkFlags = [
-    # touches network
-    "-skip=^ExampleNew$"
-  ];
+  checkFlags =
+    let
+      skip = [
+        # touch network
+        "^ExampleNew$"
+        "^TestIsLocal/regclient\\.org$"
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isLinux [
+        # The Nix sandbox does not have the /etc/nsswitch.conf file (`hosts: files dns`),
+        # so Go defaults to a DNS lookup instead of using the /etc/hosts file.
+        "^TestIsLocal/localhost\\.$"
+      ];
+    in
+    [
+      "-skip=${builtins.concatStringsSep "|" skip}"
+    ];
 
   passthru.tests = lib.mergeAttrsList (
     map (bin: {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* [Release on GitHub](https://github.com/regclient/regclient/releases/tag/v0.11.5)
* [Compare changes on GitHub](https://github.com/regclient/regclient/compare/v0.11.3...v0.11.5)

Fix failing tests:

```
--- FAIL: TestIsLocal (0.00s)
    --- FAIL: TestIsLocal/localhost. (0.00s)
        regnet_test.go:97: expected true, received false
FAIL
FAIL	github.com/regclient/regclient/internal/regnet	0.013s
FAIL
```

https://nixpkgs-update-logs.nix-community.org/regclient/2026-06-24.log

The darwin check phase failure with sandbox seems to be unrelated to the changes in `regclient` (appears to be some kind of network deadlock), v0.11.3 also fails. I believe Hydra builds with sandbox disabled, so it is not visible there. Even the last version recorded/reported as working (v0.5.7, March 2024, ef0ed76841855b401ab67a81d7dd4f6e1f2fd705) does not pass it. It could be caused by changes in Nix/nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
