### PR TITLE
ntpd-rs: skip more tests on darwin

### DIFF
--- a/pkgs/by-name/nt/ntpd-rs/package.nix
+++ b/pkgs/by-name/nt/ntpd-rs/package.nix
@@ -33,13 +33,26 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   # These fail based on timestamp issues with bundled certificates
   # See https://github.com/NixOS/nixpkgs/issues/497682 & https://github.com/pendulum-project/ntpd-rs/pull/2133
-  checkFlags = [
-    "--skip=daemon::keyexchange::tests::key_exchange_connection_limiter"
-    "--skip=daemon::keyexchange::tests::key_exchange_roundtrip_with_port_server"
-    "--skip=daemon::ntp_source::tests::test_deny_stops_poll"
-    "--skip=daemon::ntp_source::tests::test_timeroundtrip"
-    "--skip=daemon::server::tests::test_server_serves"
-    "--skip=daemon::spawn::nts::tests::allow_srv_direct_name_resolution"
+  checkFlags = map (t: "--skip=${t}") [
+    "daemon::keyexchange::tests::key_exchange_connection_limiter"
+    "daemon::keyexchange::tests::key_exchange_roundtrip_with_port_server"
+    "daemon::ntp_source::tests::test_deny_stops_poll"
+    "daemon::ntp_source::tests::test_timeroundtrip"
+    "daemon::server::tests::test_server_serves"
+    "daemon::spawn::nts::tests::allow_srv_direct_name_resolution"
+    "daemon::spawn::standard::tests::reresolves_on_unreachable"
+    "nts::tests::test_key_exchange_roundtrip_no_cookies"
+    "nts::tests::test_keyexchange_fixed_key_no_permission"
+    "nts::tests::test_keyexchange_roundtrip_fixed_key"
+    "nts::tests::test_keyexchange_roundtrip_fixed_key_keep_alive"
+    "nts::tests::test_keyexchange_roundtrip_fixed_key_no_permit"
+    "nts::tests::test_keyexchange_roundtrip_no_proto_overlap"
+    "nts::tests::test_keyexchange_roundtrip_no_upgrade_possible"
+    "nts::tests::test_keyexchange_roundtrip_supports"
+    "nts::tests::test_keyexchange_roundtrip_upgrading"
+    "nts::tests::test_keyexchange_roundtrip_v4"
+    "nts::tests::test_keyexchange_roundtrip_v5"
+    "nts::tests::test_keyexchange_supports_no_permission"
   ];
 
   postPatch = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
