### PR TITLE
invidious: 2.20260207.0 -> 2.20260626.0

### DIFF
--- a/pkgs/by-name/in/invidious/package.nix
+++ b/pkgs/by-name/in/invidious/package.nix
@@ -31,6 +31,7 @@ in
 crystal.buildCrystalPackage rec {
   pname = "invidious";
   inherit (versions.invidious) version;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "iv-org";

--- a/pkgs/by-name/in/invidious/update.sh
+++ b/pkgs/by-name/in/invidious/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl crystal crystal2nix jq git moreutils nix nix-prefetch pkg-config pcre gnugrep
+#!nix-shell -i bash -p curl crystal crystal2nix jq git moreutils nix nurl pkg-config pcre gnugrep
 git_url='https://github.com/iv-org/invidious.git'
 git_branch='master'
 git_dir='/var/tmp/invidious.git'
@@ -51,7 +51,7 @@ json_set '.invidious.date' "$date"
 json_set '.invidious.commit' "$commit"
 json_set '.invidious.version' "$new_version"
 
-new_hash=$(nix-prefetch -I 'nixpkgs=../../../..' "$pkg")
+new_hash=$(nurl --submodules --hash "$git_url" "$new_tag")
 json_set '.invidious.hash' "$new_hash"
 
 # fetch video.js dependencies

--- a/pkgs/by-name/in/invidious/versions.json
+++ b/pkgs/by-name/in/invidious/versions.json
@@ -1,9 +1,9 @@
 {
   "invidious": {
-    "hash": "sha256-tACx4+HqouftDalZlrurS75gYvS02qnmxQoL91YfTjg=",
-    "version": "2.20260207.0",
-    "date": "2026.02.07",
-    "commit": "118d6356"
+    "hash": "sha256-xJZjEnSeMnDo37ohtSAI2ucaPPv+nBYdrslHUCL/Pd8=",
+    "version": "2.20260626.0",
+    "date": "2026.06.27",
+    "commit": "ad0bd928"
   },
   "videojs": {
     "hash": "sha256-jED3zsDkPN8i6GhBBJwnsHujbuwlHdsVpVqa1/pzSH4="


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **invidious: fix update script**
- **invidious: 2.20260207.0 -> 2.20260626.0**
- **invidious: enable __structuredAttrs**

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
