### PR TITLE
cosmic-ext-fido2-manager: init at 0-unstable-2026-06-08

### DIFF
--- a/pkgs/by-name/co/cosmic-ext-fido2-manager/package.nix
+++ b/pkgs/by-name/co/cosmic-ext-fido2-manager/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromCodeberg,
+  libcosmicAppHook,
+  pkg-config,
+  udev,
+  libsodium,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cosmic-ext-fido2-manager";
+  version = "0-unstable-2026-06-08";
+
+  src = fetchFromCodeberg {
+    owner = "Pandapip1";
+    repo = "cosmic-ext-fido2-manager";
+    rev = "19650d90adcece13c98a566c76880bdfdae6f5a5";
+    hash = "sha256-PE4ukwBw8eIc2k8ci9TCojJRhiZfP18CzFaIrz1uiJY=";
+  };
+
+  cargoHash = "sha256-l2He1e/d9raLHRlEnZUbnclW1ivtuo2dfAmWQtWMCgY=";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+  separateDebugInfo = true;
+
+  nativeBuildInputs = [
+    libcosmicAppHook
+    pkg-config
+  ];
+  buildInputs = [
+    udev
+    libsodium
+  ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    description = "Third-party COSMIC passkey manager";
+    homepage = "https://codeberg.org/Pandapip1/cosmic-ext-fido2-manager";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "cosmic-ext-fido2-manager";
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ pandapip1 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
