### PR TITLE
texlive: make overlaying texlive.pkgs possible

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
+++ b/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
@@ -1,6 +1,6 @@
 {
   # texlive package set
-  tl,
+  pkgs,
 
   tlpdbVersion,
 
@@ -55,7 +55,7 @@ lib.fix (
         # resolve dependencies of the packages that affect the runtime
         all =
           let
-            packages = ensurePkgSets (finalAttrs.passthru.requiredTeXPackages tl);
+            packages = ensurePkgSets (finalAttrs.passthru.requiredTeXPackages pkgs);
             runtime = builtins.partition (
               p:
               p.outputSpecified or false
@@ -72,7 +72,7 @@ lib.fix (
               inherit p;
               tlDeps =
                 if p ? tlDeps then
-                  (if builtins.isFunction p.tlDeps then p.tlDeps tl else ensurePkgSets p.tlDeps)
+                  (if builtins.isFunction p.tlDeps then p.tlDeps pkgs else ensurePkgSets p.tlDeps)
                 else
                   [ ];
             };
@@ -214,13 +214,13 @@ lib.fix (
 
         # mktexlsr
         nativeBuildInputs = [
-          tl.texlive-scripts # for mktexlsr.pl with --sort support
+          pkgs.texlive-scripts # for mktexlsr.pl with --sort support
           perl
         ];
 
         postBuild = # generate ls-R database
           ''
-            perl ${tl.texlive-scripts.tex}/scripts/texlive/mktexlsr.pl --sort "$out"
+            perl ${pkgs.texlive-scripts.tex}/scripts/texlive/mktexlsr.pl --sort "$out"
           '';
       };
 
@@ -269,7 +269,7 @@ lib.fix (
           + lib.concatMapStringsSep "\n - " (
             p:
             p.pname + (lib.optionalString (p.outputSpecified or false) " (${p.tlOutputName or p.outputName})")
-          ) (finalAttrs.passthru.requiredTeXPackages tl);
+          ) (finalAttrs.passthru.requiredTeXPackages pkgs);
       };
 
       # other outputs
@@ -479,9 +479,9 @@ lib.fix (
         nativeBuildInputs = [
           makeWrapper
           libfaketime
-          tl."texlive.infra" # mktexlsr
-          tl.texlive-scripts # fmtutil, updmap
-          tl.texlive-scripts-extra # texlinks
+          pkgs."texlive.infra" # mktexlsr
+          pkgs.texlive-scripts # fmtutil, updmap
+          pkgs.texlive-scripts-extra # texlinks
           perl
         ];
 

--- a/pkgs/tools/typesetting/tex/texlive/combine-wrapper.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine-wrapper.nix
@@ -2,7 +2,7 @@
 {
   lib,
   toTLPkgList,
-  tl,
+  pkgs,
   buildTeXEnv,
 }:
 args@{
@@ -49,7 +49,7 @@ let
         operator =
           { pkg, ... }:
           pkgListToSets (
-            if pkg ? tlDeps then if builtins.isFunction pkg.tlDeps then pkg.tlDeps tl else pkg.tlDeps else [ ]
+            if pkg ? tlDeps then if builtins.isFunction pkg.tlDeps then pkg.tlDeps pkgs else pkg.tlDeps else [ ]
           );
       }
     );

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -46,6 +46,7 @@
   nixfmt,
   luajit,
   texinfo,
+  texlive,
   # for bin.nix
   gnum4,
   jdk_headless,
@@ -73,7 +74,6 @@
   unzip,
   fetchFromGitHub,
   buildPackages,
-  texlive,
   zlib,
   libiconv,
   libpng,
@@ -99,6 +99,7 @@ let
   overriddenTlpdb =
     let
       overrides = import ./tlpdb-overrides.nix {
+        inherit (texlive) pkgs;
         inherit
           stdenv
           lib
@@ -106,7 +107,6 @@ let
           bin
           tlpdb
           tlpdbxz
-          tl
           installShellFiles
           coreutils
           findutils
@@ -226,13 +226,15 @@ let
         inherit mirrors pname;
         fixedHashes = fixedHashes."${pname}-${toString revision}${extraRevision}" or { };
       }
-      // lib.optionalAttrs (args ? deps) { deps = map (n: tl.${n} or bin.${n}) (args.deps or [ ]); }
+      // lib.optionalAttrs (args ? deps) {
+        deps = map (n: texlive.pkgs.${n} or bin.${n}) (args.deps or [ ]);
+      }
     )
   ) overriddenTlpdb;
 
   # function for creating a working environment
   buildTeXEnv = import ./build-tex-env.nix {
-    inherit tl;
+    inherit (texlive) pkgs;
     inherit tlpdbVersion;
     ghostscript = ghostscript_headless;
     inherit
@@ -260,7 +262,7 @@ let
       drvWithoutDeps = removeAttrs drv [ "tlDeps" ];
       drvWithDeps =
         if (drv ? tlDeps) then
-          drv // { tlDeps = if builtins.isFunction drv.tlDeps then drv.tlDeps tl else drv.tlDeps; }
+          drv // { tlDeps = if builtins.isFunction drv.tlDeps then drv.tlDeps texlive.pkgs else drv.tlDeps; }
         else
           drv;
     in
@@ -320,10 +322,10 @@ let
   # function for creating a working environment from a set of TL packages
   # now a legacy wrapper around buildTeXEnv
   combine = import ./combine-wrapper.nix {
+    inherit (texlive) pkgs;
     inherit
       buildTeXEnv
       lib
-      tl
       toTLPkgList
       ;
   };
@@ -667,7 +669,7 @@ allPkgLists
     bin
     // {
       # for backward compatibility
-      latexindent = tl.latexindent;
+      latexindent = texlive.pkgs.latexindent;
     };
 
   combine =

--- a/pkgs/tools/typesetting/tex/texlive/tlpdb-overrides.nix
+++ b/pkgs/tools/typesetting/tex/texlive/tlpdb-overrides.nix
@@ -5,7 +5,7 @@
   tlpdb,
   bin,
   tlpdbxz,
-  tl,
+  pkgs,
   installShellFiles,
   coreutils,
   findutils,
@@ -253,9 +253,9 @@ lib.recursiveUpdate orig rec {
 
   context.binlinks = {
     context = "luametatex";
-    "context.lua" = tl.context.tex + "/scripts/context/lua/context.lua";
+    "context.lua" = pkgs.context.tex + "/scripts/context/lua/context.lua";
     mtxrun = "luametatex";
-    "mtxrun.lua" = tl.context.tex + "/scripts/context/lua/mtxrun.lua";
+    "mtxrun.lua" = pkgs.context.tex + "/scripts/context/lua/mtxrun.lua";
   };
 
   dvipdfmx.binlinks = {
@@ -269,10 +269,10 @@ lib.recursiveUpdate orig rec {
 
   # TODO: handle symlinks in bin.core
   ptex.binlinks = {
-    pbibtex = tl.uptex.out + "/bin/upbibtex";
-    pdvitype = tl.uptex.out + "/bin/updvitype";
-    ppltotf = tl.uptex.out + "/bin/uppltotf";
-    ptftopl = tl.uptex.out + "/bin/uptftopl";
+    pbibtex = pkgs.uptex.out + "/bin/upbibtex";
+    pdvitype = pkgs.uptex.out + "/bin/updvitype";
+    ppltotf = pkgs.uptex.out + "/bin/uppltotf";
+    ptftopl = pkgs.uptex.out + "/bin/uptftopl";
   };
 
   texdef.binlinks = {
@@ -281,7 +281,7 @@ lib.recursiveUpdate orig rec {
 
   texlive-scripts.binlinks = {
     mktexfmt = "fmtutil";
-    texhash = tl."texlive.infra".out + "/bin/mktexlsr";
+    texhash = pkgs."texlive.infra".out + "/bin/mktexlsr";
   };
 
   texlive-scripts-extra.binlinks = {
@@ -309,7 +309,7 @@ lib.recursiveUpdate orig rec {
   '';
 
   context-legacy.postFixup = ''
-    sed -i 's!File.dirname(\$0)!'"'"'${tl.context-legacy.tex}/scripts/context/ruby'"'"'!' "$out"/bin/*
+    sed -i 's!File.dirname(\$0)!'"'"'${pkgs.context-legacy.tex}/scripts/context/ruby'"'"'!' "$out"/bin/*
   '';
 
   cyrillic-bin.postFixup = ''
@@ -476,7 +476,7 @@ lib.recursiveUpdate orig rec {
 
   # find files in source container, fix incompatibilities with snobol4
   texaccents.postFixup = ''
-    sed -i '1s!$! -I${tl.texaccents.texsource}/source/support/texaccents!' "$out"/bin/*
+    sed -i '1s!$! -I${pkgs.texaccents.texsource}/source/support/texaccents!' "$out"/bin/*
   '';
   texaccents.postUnpack = ''
     if [[ -f "$out"/source/support/texaccents/grepl.inc ]] ; then
@@ -586,7 +586,7 @@ lib.recursiveUpdate orig rec {
         mkdir -p support/texdoc
         touch support/texdoc/NEWS
 
-        TEXMFCNF="${tl.kpathsea.tex}/web2c" TEXMF="$out" TEXDOCS=. TEXMFVAR=. \
+        TEXMFCNF="${pkgs.kpathsea.tex}/web2c" TEXMF="$out" TEXDOCS=. TEXMFVAR=. \
           "${bin.luatex}"/bin/texlua "$out"/scripts/texdoc/texdoc.tlu \
           -c texlive_tlpdb=texlive.tlpdb -lM texdoc
 
@@ -596,7 +596,7 @@ lib.recursiveUpdate orig rec {
 
     # install zsh completion
     postFixup = ''
-      TEXMFCNF="${tl.kpathsea.tex}"/web2c TEXMF="$scriptsFolder/../.." \
+      TEXMFCNF="${pkgs.kpathsea.tex}"/web2c TEXMF="$scriptsFolder/../.." \
         texlua "$out"/bin/texdoc --print-completion zsh > "$TMPDIR"/_texdoc
       installShellCompletion --zsh "$TMPDIR"/_texdoc
     '';
@@ -618,7 +618,7 @@ lib.recursiveUpdate orig rec {
       coreutils
       gnused
       gnupg
-      tl.kpathsea
+      pkgs.kpathsea
       (perl.withPackages (ps: with ps; [ Tk ]))
     ];
 
@@ -631,7 +631,7 @@ lib.recursiveUpdate orig rec {
         lib.makeBinPath [
           coreutils
           gnused
-          tl.kpathsea
+          pkgs.kpathsea
         ]
       }''${PATH:+:$PATH}"' "$out"/bin/mktexlsr
     '';


### PR DESCRIPTION
Change the TeX Live package set slightly so that it is theoretically possible to overlay packages in `texlive.pkgs`.

We shouldn't document this, because it does not support `texlive.combine` for annoying reasons, and it's not very idiomatic: one would expect that overlays go to `texlivePackages`, but that package set exists virtually only for search, and there are deep reasons why you can't have search and overlays in the same place (coming from a mismatch between multioutput derivations, which is how we want search to view the packages, and fixed outputs, which is how we actually build them).

Cc'ing some people who might be able to test this and/or have opinions about it: @nacno-toporiame @mkouhia @mightyiam and of course @veprbl 

## Things done

Ideally, this should be a no-op evaluation wise. I haven't tested that overlays actually work.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
