### PR TITLE
python3Packages.wgpu-py: 0.31.0 -> 0.31.1, python3Packages.rendercanvas: 2.5.2 -> 2.6.3

### DIFF
--- a/pkgs/development/python-modules/rendercanvas/default.nix
+++ b/pkgs/development/python-modules/rendercanvas/default.nix
@@ -16,14 +16,14 @@
 }:
 buildPythonPackage rec {
   pname = "rendercanvas";
-  version = "2.5.2";
+  version = "2.6.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pygfx";
     repo = "rendercanvas";
     tag = "v${version}";
-    hash = "sha256-fOjiGNxEUVI+jddrwqrlBYT+CAMDQCIPNHwGonBH4Hk=";
+    hash = "sha256-gJyNj/FYT0NVyGiTnG++9uKZ/66n9mjNLBicvhazPqg=";
   };
 
   postPatch = ''
@@ -36,6 +36,8 @@ buildPythonPackage rec {
   };
 
   build-system = [ flit-core ];
+
+  dependencies = [ numpy ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/wgpu-py/default.nix
+++ b/pkgs/development/python-modules/wgpu-py/default.nix
@@ -39,14 +39,14 @@
 }:
 buildPythonPackage (finalAttrs: {
   pname = "wgpu-py";
-  version = "0.31.0";
+  version = "0.31.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pygfx";
     repo = "wgpu-py";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-qy5tBlmA9mwEkk87WhIa5UxbXYNVFct6CrUWKm3Fy5s=";
+    hash = "sha256-K3GOsAOJ5tGaX/e3Ze/GA0991pFluYuGC2OgTKL64zE=";
   };
 
   postPatch =


### PR DESCRIPTION
Supersedes #536268, no script for now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
