### PR TITLE
pear-desktop: 3.11.0 -> 3.12.0

### DIFF
--- a/pkgs/by-name/pe/pear-desktop/fix-mpris-desktop-entry.patch
+++ b/pkgs/by-name/pe/pear-desktop/fix-mpris-desktop-entry.patch
@@ -1,13 +1,13 @@
 diff --git a/src/plugins/shortcuts/mpris.ts b/src/plugins/shortcuts/mpris.ts
-index 93cb40f9..ad0bede3 100644
+index 064a1187..6b9ef7d8 100644
 --- a/src/plugins/shortcuts/mpris.ts
 +++ b/src/plugins/shortcuts/mpris.ts
-@@ -79,7 +79,7 @@ function setupMPRIS() {
-   instance.canQuit = false;
+@@ -74,7 +74,7 @@ function setupMPRIS() {
    instance.canUsePlayerControls = true;
    instance.supportedUriSchemes = ['http', 'https'];
--  instance.desktopEntry = 'youtube-music';
-+  instance.desktopEntry = 'com.github.th_ch.youtube_music';
+   instance.desktopEntry =
+-    '\u0079\u006f\u0075\u0074\u0075\u0062\u0065\u002d\u006d\u0075\u0073\u0069\u0063';
++    'com.github.th-ch.\u0079\u006f\u0075\u0074\u0075\u0062\u0065\u002d\u006d\u0075\u0073\u0069\u0063';
    return instance;
  }
  

--- a/pkgs/by-name/pe/pear-desktop/package.nix
+++ b/pkgs/by-name/pe/pear-desktop/package.nix
@@ -4,11 +4,11 @@
   fetchFromGitHub,
   makeWrapper,
   actool,
-  electron,
+  electron_42,
   python3,
   copyDesktopItems,
   nodejs,
-  pnpm_10,
+  pnpm_11,
   fetchPnpmDeps,
   pnpmConfigHook,
   makeDesktopItem,
@@ -16,13 +16,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "pear-desktop";
-  version = "3.11.0";
+  version = "3.12.0";
 
   src = fetchFromGitHub {
     owner = "pear-devs";
     repo = "pear-desktop";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-M8YFpeauM55fpNyHSGQm8iZieV0oWqOieVThhglKKPE=";
+    hash = "sha256-RSQPwsED3YK5VScVAXH3f8Lz74v1b2448gro1Vo22hg=";
   };
 
   patches = [
@@ -32,9 +32,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_10;
+    pnpm = pnpm_11;
     fetcherVersion = 4;
-    hash = "sha256-BNvAGM9ECtptDwxWsmJVq82Bky1AxslYt51FyvOBEvs=";
+    hash = "sha256-y4eLjikf9X/682RdK0ZvW7+GR1Ei82UJ5SVop09B9wg=";
   };
 
   nativeBuildInputs = [
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     python3
     nodejs
     pnpmConfigHook
-    pnpm_10
+    pnpm_11
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ actool ]
   ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [ copyDesktopItems ];
@@ -52,22 +52,22 @@ stdenv.mkDerivation (finalAttrs: {
   postBuild = ''
     pnpm build
 
-    cp -r ${electron.dist} electron-dist
+    cp -r ${electron_42.dist} electron-dist
     chmod -R u+w electron-dist
 
     ./node_modules/.bin/electron-builder \
       --dir \
       -c.electronDist=electron-dist \
-      -c.electronVersion=${electron.version}
+      -c.electronVersion=${electron_42.version}
   '';
 
   desktopItems = [
     (makeDesktopItem {
-      name = "com.github.th_ch.youtube_music";
+      name = "com.github.th-ch.youtube-music";
       exec = "pear-desktop %u";
       icon = "pear-desktop";
       desktopName = "Pear Desktop";
-      startupWMClass = "com.github.th_ch.youtube_music";
+      startupWMClass = "com.github.th-ch.youtube-music";
       categories = [ "AudioVideo" ];
     })
   ];
@@ -97,7 +97,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   postFixup = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
-    makeWrapper ${electron}/bin/electron $out/bin/pear-desktop \
+    makeWrapper ${electron_42}/bin/electron $out/bin/pear-desktop \
       --add-flags $out/share/pear-desktop/resources/app.asar \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true --wayland-text-input-version=3}}" \
       --set-default ELECTRON_FORCE_IS_PACKAGED 1 \


### PR DESCRIPTION
Diff: https://github.com/pear-devs/pear-desktop/compare/v3.11.0...v3.12.0

Changelog: https://github.com/pear-devs/pear-desktop/blob/master/changelog.md#v3120

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
