### PR TITLE
codebase-memory-mcp: disable updater and install/uninstall

### DIFF
--- a/pkgs/by-name/co/codebase-memory-mcp/package.nix
+++ b/pkgs/by-name/co/codebase-memory-mcp/package.nix
@@ -8,12 +8,17 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "codebase-memory-mcp";
   version = "0.8.1";
+
   src = fetchFromGitHub {
     owner = "DeusData";
     repo = "codebase-memory-mcp";
     rev = "v${finalAttrs.version}";
     hash = "sha256-H0l8H2JhPT1Rs0p+CJC1a1qYtnZNgLGe6n7PmM+WvE4=";
   };
+
+  patches = [
+    ./remove-install-update.diff
+  ];
 
   nativeBuildInputs = [ gnumake ];
 

--- a/pkgs/by-name/co/codebase-memory-mcp/remove-install-update.diff
+++ b/pkgs/by-name/co/codebase-memory-mcp/remove-install-update.diff
@@ -1,0 +1,30 @@
+diff --git a/src/main.c b/src/main.c
+index f2b72cb..1663138 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -284,9 +284,6 @@ static void print_help(void) {
+     printf("Usage:\n");
+     printf("  codebase-memory-mcp              Run MCP server on stdio\n");
+     printf("  codebase-memory-mcp cli <tool> [json]  Run a single tool\n");
+-    printf("  codebase-memory-mcp install [-y|-n] [--force] [--dry-run]\n");
+-    printf("  codebase-memory-mcp uninstall [-y|-n] [--dry-run]\n");
+-    printf("  codebase-memory-mcp update [-y|-n]\n");
+     printf("  codebase-memory-mcp config <list|get|set|reset>\n");
+     printf("  codebase-memory-mcp --version    Print version\n");
+     printf("  codebase-memory-mcp --help       Print this help\n");
+@@ -331,15 +328,6 @@ static int handle_subcommand(int argc, char **argv) {
+             cbm_mem_init(MAIN_RAM_FRACTION);
+             return cbm_cmd_hook_augment();
+         }
+-        if (strcmp(argv[i], "install") == 0) {
+-            return cbm_cmd_install(argc - i - SKIP_ONE, argv + i + SKIP_ONE);
+-        }
+-        if (strcmp(argv[i], "uninstall") == 0) {
+-            return cbm_cmd_uninstall(argc - i - SKIP_ONE, argv + i + SKIP_ONE);
+-        }
+-        if (strcmp(argv[i], "update") == 0) {
+-            return cbm_cmd_update(argc - i - SKIP_ONE, argv + i + SKIP_ONE);
+-        }
+         if (strcmp(argv[i], "config") == 0) {
+             return cbm_cmd_config(argc - i - SKIP_ONE, argv + i + SKIP_ONE);
+         }


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
