### PR TITLE
nixos/autoUpgrade: add option for rebooting using kexec

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -200,6 +200,8 @@
 
 - `boot.supportedFilesystems.ntfs` installs `ntfsprogs-plus` instead of `ntfs3g` on kernel version 7.1 and later, unless `boot.supportedFilesystems.ntfs-3g` is explicitly enabled.
 
+- `system.autoUpgrade.kexecReboot` added to allow for faster reboots using kexec.
+
 - The `programs.fuse` module, which provides the `fusermount3` executable and the `/etc/fuse.conf` config file, is now opt-in. The obligation to enable it has been shifted to its various consumers (e.g. gvfs, flatpak, appimage, sshfs). This can break fuse consumers at runtime, that don't explicitly declare that dependency with a module, e.g the mounting functionality in various backup tools (borg, restic, rclone, ...).
 
 - `services.plausible` can now again seed an initial admin user declaratively via [`services.plausible.adminUser.email`](#opt-services.plausible.adminUser.email).

--- a/nixos/modules/tasks/auto-upgrade.nix
+++ b/nixos/modules/tasks/auto-upgrade.nix
@@ -114,6 +114,19 @@ in
         '';
       };
 
+      kexecReboot = lib.mkOption {
+        default = false;
+        type = lib.types.bool;
+        description = ''
+          Reboot the system using kexec. This can reduce reboot times by skipping
+          firmware (BIOS/UEFI).
+          ::: {.note}
+          Kexec might not work correctly on some hardware (like PCIe devices e.g. GPUs).
+          If in doubt test if the machine reboots correctly by running {command}`systemctl start kexec.target --job-mode=replace-irreversibly --no-block`.
+          :::
+        '';
+      };
+
       randomizedDelaySec = lib.mkOption {
         default = "0";
         type = lib.types.str;
@@ -212,6 +225,12 @@ in
           The option 'system.autoUpgrade.runGarbageCollection = true' requires 'nix.enable = true'.
         '';
       }
+      {
+        assertion = cfg.kexecReboot -> cfg.allowReboot;
+        message = ''
+          The option 'system.autoUpgrade.kexecReboot = true' requires 'system.autoUpgrade.allowReboot = true'.
+        '';
+      }
     ];
 
     system.autoUpgrade.flags = (
@@ -263,6 +282,14 @@ in
           date = "${pkgs.coreutils}/bin/date";
           readlink = "${pkgs.coreutils}/bin/readlink";
           shutdown = "${config.systemd.package}/bin/shutdown";
+          reboot =
+            if cfg.kexecReboot then
+              # see man systemctl(5) kexec. using systemctl kexec won't work for systems that use UKIs
+              # as systemd won't find the kernel image, which gets loaded by `prepare-kexec.service`,
+              # which is a dependency of kexec.target
+              "${config.systemd.package}/bin/systemctl start kexec.target --job-mode=replace-irreversibly --no-block"
+            else
+              "${shutdown} -r +1";
           upgradeFlag = lib.optional (cfg.channel == null && cfg.upgrade) "--upgrade";
         in
         if cfg.allowReboot then
@@ -303,7 +330,7 @@ in
                 echo "Outside of configured reboot window, skipping."
             ''}
             else
-              ${shutdown} -r +1
+               ${reboot}
             fi
           ''
         else


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This should especially reduce the downtime of servers a lot which often need multiple minutes for memory training. Might also cause issues/not work for certain PCIe devices due to not fully re-initializing (example: my amdgpu doesn't display anything after a kexec).

I also wonder what purpose the fixed one minute reboot delay serves as its mentioned nowhere and is not configurable. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
