### PR TITLE
nixos/oci-containers: assert user's membership in podman

### DIFF
--- a/nixos/modules/virtualisation/oci-containers.nix
+++ b/nixos/modules/virtualisation/oci-containers.nix
@@ -299,7 +299,11 @@ let
                   default = "root";
                   type = types.str;
                   description = ''
-                    The user under which the container should run.
+                    The user under which the container should run. It must met the following conditions:
+
+                     * The home directory must be created and be non empty.
+                     * The user must have configured sub UID and GID ranges. E.g. set the
+                       autoSubUidGidRange option to true for this user.
                   '';
                 };
               };
@@ -599,6 +603,13 @@ in
                 podman,
                 ...
               }:
+              let
+                podmanUserIsNotRoot = cfg.backend == "podman" && podman.user != "root";
+                podmanUserConfig = config.users.users.${podman.user};
+                podmanUserHasSubUidGidRanges =
+                  (podmanUserConfig.subUidRanges != [ ] && podmanUserConfig.subGidRanges != [ ])
+                  || podmanUserConfig.autoSubUidGidRange;
+              in
               [
                 {
                   assertion = imageFile == null || imageStream == null;
@@ -611,11 +622,25 @@ in
                 }
                 {
                   assertion =
-                    cfg.backend == "podman" && podman.sdnotify == "healthy" && podman.user != "root"
-                    -> config.users.users.${podman.user}.uid != null;
+                    podmanUserIsNotRoot -> podmanUserConfig.createHome && podmanUserConfig.home != "/var/empty";
+                  message = ''
+                    Starting the podman container ${name} as non "root", requires its running user
+                    ${podman.user} has a home directory.
+                  '';
+                }
+                {
+                  assertion = podmanUserIsNotRoot && podman.sdnotify == "healthy" -> podmanUserConfig.uid != null;
                   message = ''
                     Rootless container ${name} (with podman and sdnotify=healthy)
                     requires that its running user ${podman.user} has a statically specified uid.
+                  '';
+                }
+                {
+                  assertion = podmanUserIsNotRoot -> podmanUserHasSubUidGidRanges;
+                  message = ''
+                    Rootless container ${name} (with podman) requires that its running user
+                    ${podman.user} has configured sub UID and GID ranges. E.g. set
+                    users.users.${podman.user}.autoSubUidGidRange to true.
                   '';
                 }
               ];


### PR DESCRIPTION
nixos/oci-containers: assert podman user's suitability

While technically one can create a podman oci-container for all users,
starting this container might fail with a more or less cryptic error
message. By asserting these, the user gets an early failure with a
readable error message.

In addition document this in the option description.

This would have saved me some time debugging my setup.

## Things done

Tested:

 * The assertion is triggered, if the podman user is not part of the podman group.
 * The assertion succeeds, if the podman user is part of the podman group.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
