### PR TITLE
rift-wm: init at 0.4.3

### DIFF
--- a/pkgs/by-name/ri/rift-wm/package.nix
+++ b/pkgs/by-name/ri/rift-wm/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  apple-sdk,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rift-wm";
+  version = "0.4.3";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "acsandmann";
+    repo = "rift";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-oOVNq4/hdiRcCbc9kaMxynnq2gXVezviQRTvjrdkfPs=";
+  };
+
+  nativeBuildInputs = [
+    apple-sdk
+  ];
+
+  cargoHash = "sha256-eb3Z5NIUusJApQWa6sDMRP//Y0BOToQsEIhQqqR728o=";
+
+  meta = {
+    description = "Tiling window manager for macos";
+    homepage = "https://github.com/acsandmann/rift";
+    changelog = "https://github.com/acsandmann/rift/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ eveeifyeve ];
+    mainProgram = "rift";
+    platforms = lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
Adds https://github.com/acsandmann/rift (the macos tiling window manager) as a package.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
