### PR TITLE
i3pystatus: 3.35-unstable-2025-06-24 -> 3.35-unstable-2026-04-21

### DIFF
--- a/pkgs/by-name/i3/i3pystatus/package.nix
+++ b/pkgs/by-name/i3/i3pystatus/package.nix
@@ -14,7 +14,7 @@
 python3Packages.buildPythonApplication rec {
   # i3pystatus moved to rolling release:
   # https://github.com/enkore/i3pystatus/issues/584
-  version = "3.35-unstable-2025-06-24";
+  version = "3.35-unstable-2026-04-21";
   pname = "i3pystatus";
   pyproject = true;
   build-system = [ python3Packages.setuptools ];
@@ -22,8 +22,8 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "enkore";
     repo = "i3pystatus";
-    rev = "e8e03934d95658c85fa9f594987dac0481ca26c9";
-    hash = "sha256-uAt6jxNAUR9txyPtHS4BRtu8Z5QaP6uqFg0sROf356c=";
+    rev = "045d5f09220ccec1146a220619ff80b1077206a4";
+    hash = "sha256-K6sCII8qw0JLcMw5QVCY0RCu0O55MlEKFQXDY96V3NM=";
   };
 
   patches = [
@@ -44,12 +44,20 @@ python3Packages.buildPythonApplication rec {
 
   nativeCheckInputs = [
     python3Packages.pytestCheckHook
+    python3Packages.mock
     writableTmpDirAsHomeHook
   ];
 
-  checkInputs = [ python3Packages.requests ];
+  # Upstream tests construct ElementCall via __new__ without Module.__init__, so
+  # output/_output is never set (AttributeError on .output after run()).
+  disabledTests = [
+    "test_active_output"
+    "test_empty_output"
+    "test_error_output"
+    "test_format_includes_room_alias"
+  ];
 
-  propagatedBuildInputs =
+  dependencies =
     with python3Packages;
     [
       keyring
@@ -58,6 +66,8 @@ python3Packages.buildPythonApplication rec {
       psutil
       basiciw
       pygobject3
+      requests
+      dbus-python
     ]
     ++ extraLibs;
 


### PR DESCRIPTION
Bump `i3pystatus` to fix the [nixpkgs-update build failure](https://nixpkgs-update-logs.nix-community.org/i3pystatus/2026-06-22.log) (pytest collection errors for new hassio/kdeconnect tests).

- Update to `3.35-unstable-2026-04-21` (`045d5f0`)
- Propagate `requests` and `dbus-python` so hassio / element_call / kdeconnect modules work out of the box (not only in the check phase)
- Add `mock` to `nativeCheckInputs` (`tests/test_hassio.py` uses `from mock import patch`)
- Drop redundant `checkInputs` for `requests` (now propagated)
- Disable four `element_call` tests that hit `AttributeError` on `.output` because upstream builds `ElementCall` via `__new__` without `Module.__init__`

Assisted with Grok Build (xAI Grok 4.3). Verified with `nix-build -A i3pystatus` on x86_64-linux (182 tests passed, 4 deselected).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
