### PR TITLE
far2l: Enable plugins

### DIFF
--- a/pkgs/by-name/_7/_7zz/package.nix
+++ b/pkgs/by-name/_7/_7zz/package.nix
@@ -120,6 +120,7 @@ stdenv.mkDerivation (finalAttrs: {
   outputs = [
     "out"
     "doc"
+    "lib"
   ];
 
   setupHook = ./setup-hook.sh;
@@ -128,11 +129,18 @@ stdenv.mkDerivation (finalAttrs: {
 
   preBuild = "cd CPP/7zip/Bundles/Alone2";
 
+  postBuild = ''
+    make $makeFlags -j $NIX_BUILD_CORES -C ../Format7zF -f ../../cmpl_gcc.mak
+  '';
+
   installPhase = ''
     runHook preInstall
 
     install -Dm555 -t $out/bin b/*/7zz${stdenv.hostPlatform.extensions.executable}
     install -Dm444 -t $out/share/doc/7zz ../../../../DOC/*.txt
+
+    mkdir -p $lib/lib
+    install -Dm555 -t $lib/lib ../Format7zF/b/g/*
 
     runHook postInstall
   '';

--- a/pkgs/by-name/fa/far2l/package.nix
+++ b/pkgs/by-name/fa/far2l/package.nix
@@ -7,7 +7,6 @@
   cmake,
   ninja,
   pkg-config,
-  m4,
   perl,
   bash,
   xdg-utils,
@@ -16,28 +15,69 @@
   gzip,
   bzip2,
   gnutar,
-  p7zip,
   xz,
+
+  # Backend options
   withTTYX ? true,
   libx11,
   withGUI ? true,
   wxwidgets_3_2,
+  withSDL ? false, # SDL GUI (testing), disabled by default
+  SDL2,
+  harfbuzz,
+  fontconfig,
+  libxft,
   withUCD ? true,
   libuchardet,
 
-  # Plugins
+  # Plugins (all are enabled by default)
   withColorer ? true,
   spdlog,
   libxml2,
   withMultiArc ? true,
   libarchive,
-  pcre,
+
   withNetRocks ? true,
   openssl,
   libssh,
   samba,
   libnfs,
   neon,
+  gnutls,
+  libtasn1,
+  p11-kit,
+
+  withAWS ? true,
+  aws-sdk-cpp,
+  withImageViewer ? true,
+  imagemagick,
+  ffmpeg,
+  withADB ? true,
+  android-tools,
+  withMTP ? true,
+  libmtp,
+  libusb1,
+  withArclite ? true, # Archive support with custom 7z plugin
+  _7zz, # 7zip plugin (only used if withArclite is true)
+  withAlign ? true, # Align plugin
+  withAutowrap ? true, # Autowrap plugin
+  withTruncate ? true, # Truncate plugin
+  withCalc ? true, # Calculator plugin
+  withCompare ? true, # Compare files plugin
+  withDrawline ? true, # Draw line plugin
+  withEditcase ? true, # Change case plugin
+  withEditorcomp ? true, # Editor completion plugin
+  withFarftp ? true, # FTP client plugin
+  withFilecase ? true, # File case plugin
+  withIncsrch ? true, # Incremental search plugin
+  withInside ? true, # Inside plugin
+  withSimpleindent ? true, # Simple indent plugin
+  withTmppanel ? true, # Temporary panel plugin
+  withHexitor ? true, # Hex editor plugin
+  withOpenwith ? true, # Open with plugin
+  withEdsort ? true, # Editor sort plugin
+  withMemo ? true, # Memo plugin
+
   withPython ? false,
   python3Packages,
 }:
@@ -53,57 +93,125 @@ stdenv.mkDerivation rec {
     hash = "sha256-LP+agJrYxjH6vLAg6cJTU4/9jYGF9iaZzxA7hozDKNY=";
   };
 
+  patches = [
+    # Fix sudo helper stealing TTY input in mortal mode, see https://github.com/elfmz/far2l/issues/3425
+    (fetchpatch {
+      url = "https://github.com/elfmz/far2l/commit/d9f96544adf36d93de813f2f918b78a6f37c61e4.patch";
+      sha256 = "sha256-hkFunNxey7A47va8Rm0ZOknM0jPuuT9AL5nfXdssE8s=";
+    })
+  ];
+
+  postPatch = ''
+    chmod +x far2l/bootstrap/*.sh
+    patchShebangs far2l/bootstrap/view.sh
+  '';
+
   nativeBuildInputs = [
     cmake
     ninja
     pkg-config
-    m4
     perl
     makeWrapper
   ];
 
   buildInputs =
-    lib.optional withTTYX libx11
+    lib.optionals withSDL [
+      SDL2
+      harfbuzz
+      fontconfig
+      libxft
+    ]
+    # TTYX backend
+    ++ lib.optional withTTYX libx11
+    # WxWidgets backend
     ++ lib.optional withGUI wxwidgets_3_2
+    # UCD plugin
     ++ lib.optional withUCD libuchardet
+    # Colorer plugin
     ++ lib.optionals withColorer [
       spdlog
       libxml2
     ]
+    # MultiArc plugin
     ++ lib.optionals withMultiArc [
       libarchive
-      pcre
     ]
+    # NetRocks plugin
     ++ lib.optionals withNetRocks [
       openssl
       libssh
       libnfs
       neon
+      gnutls
+      libtasn1
+      p11-kit
     ]
-    ++ lib.optional (withNetRocks && !stdenv.hostPlatform.isDarwin) samba # broken on darwin
+    ++ lib.optional (withNetRocks && withAWS) aws-sdk-cpp
+    # Samba support for NetRocks (broken on darwin)
+    ++ lib.optional (withNetRocks && !stdenv.hostPlatform.isDarwin) samba
+    # ImageViewer plugin
+    ++ lib.optionals withImageViewer [
+      imagemagick
+      ffmpeg
+    ]
+    # ADB plugin
+    ++ lib.optional withADB android-tools
+    #  MTP plugin
+    ++ lib.optionals withMTP [
+      libmtp
+      libusb1
+    ]
+    # Python plugins support
     ++ lib.optionals withPython (
       with python3Packages;
       [
         python
         cffi
-        debugpy
         pcpp
       ]
     );
 
-  postPatch = ''
-    patchShebangs python/src/prebuild.sh
-    patchShebangs far2l/bootstrap/view.sh
-  '';
-
   cmakeFlags = [
-    (lib.cmakeBool "TTYX" withTTYX)
-    (lib.cmakeBool "USEWX" withGUI)
+    # Basic plugins (always enabled by default, but can be disabled)
+    (lib.cmakeBool "ALIGN" withAlign)
+    (lib.cmakeBool "AUTOWRAP" withAutowrap)
+    (lib.cmakeBool "TRUNCATE" withTruncate)
+    (lib.cmakeBool "CALC" withCalc)
+    (lib.cmakeBool "COMPARE" withCompare)
+    (lib.cmakeBool "DRAWLINE" withDrawline)
+    (lib.cmakeBool "EDITCASE" withEditcase)
+    (lib.cmakeBool "EDITORCOMP" withEditorcomp)
+    (lib.cmakeBool "FARFTP" withFarftp)
+    (lib.cmakeBool "FILECASE" withFilecase)
+    (lib.cmakeBool "INCSRCH" withIncsrch)
+    (lib.cmakeBool "INSIDE" withInside)
+    (lib.cmakeBool "SIMPLEINDENT" withSimpleindent)
+    (lib.cmakeBool "TMPPANEL" withTmppanel)
+    (lib.cmakeBool "HEXITOR" withHexitor)
+    (lib.cmakeBool "OPENWITH" withOpenwith)
+    (lib.cmakeBool "EDSORT" withEdsort)
+    (lib.cmakeBool "MEMO" withMemo)
+
+    # Additional plugins
     (lib.cmakeBool "USEUCD" withUCD)
     (lib.cmakeBool "COLORER" withColorer)
     (lib.cmakeBool "MULTIARC" withMultiArc)
     (lib.cmakeBool "NETROCKS" withNetRocks)
+    (lib.cmakeBool "AWS_S3" (withNetRocks && withAWS))
+    (lib.cmakeBool "IMAGEVIEWER" withImageViewer)
+    (lib.cmakeBool "ADB" withADB)
+    (lib.cmakeBool "MTP" withMTP)
     (lib.cmakeBool "PYTHON" withPython)
+    (lib.cmakeBool "ARCLITE" withArclite)
+
+    # Backend setup
+    (lib.cmakeBool "USESDL" withSDL)
+    (lib.cmakeBool "TTYX" withTTYX)
+    (lib.cmakeBool "USEWX" withGUI)
+  ]
+  ++ lib.optionals withMTP [
+    (lib.cmakeBool "MTP_SYSTEM_LIBUSB" true)
+    (lib.cmakeBool "MTP_SYSTEM_LIBMTP" true)
   ]
   ++ lib.optionals withPython [
     (lib.cmakeFeature "VIRTUAL_PYTHON" "python")
@@ -113,21 +221,31 @@ stdenv.mkDerivation rec {
   runtimeDeps = [
     unzip
     zip
-    p7zip
     xz
     gzip
     bzip2
     gnutar
-  ];
+  ]
+  # Tools for ADB plugin
+  ++ lib.optional withADB android-tools;
 
   postInstall = ''
     wrapProgram $out/bin/far2l \
       --prefix PATH : ${lib.makeBinPath runtimeDeps} \
       --suffix PATH : ${lib.makeBinPath [ xdg-utils ]}
+  ''
+  # Link 7z plugin if Arclite is enabled
+  + lib.optionalString withArclite ''
+    # Link 7z plugin
+    echo "Linking 7z libraries..."
+    mkdir -p $out/lib/far2l/Plugins/arclite/plug/
+    for file in ${_7zz.lib}/lib/*; do
+      ln -sf "$file" "$out/lib/far2l/Plugins/arclite/plug/"
+    done
   '';
 
   meta = {
-    description = "Linux port of FAR Manager v2, a program for managing files and archives in Windows operating systems";
+    description = "Linux port of FAR Manager v2 with enhanced plugin support";
     homepage = "https://github.com/elfmz/far2l";
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [ smakarov ];

--- a/pkgs/by-name/fa/far2l/package.nix
+++ b/pkgs/by-name/fa/far2l/package.nix
@@ -16,6 +16,7 @@
   bzip2,
   gnutar,
   xz,
+  nix-update-script,
 
   # Backend options
   withTTYX ? true,
@@ -84,22 +85,14 @@
 
 stdenv.mkDerivation rec {
   pname = "far2l";
-  version = "2.8.0";
+  version = "2.8.0-unstable-12-07-2026";
 
   src = fetchFromGitHub {
     owner = "elfmz";
     repo = "far2l";
-    tag = "v_${version}";
-    hash = "sha256-LP+agJrYxjH6vLAg6cJTU4/9jYGF9iaZzxA7hozDKNY=";
+    rev = "bcfe026fe1d0631a59631bca9d48da38ee23f222";
+    hash = "sha256-x0XblY613XrGDUz/HZ7bWGp8ZJ/HYr8vmZKDhGAFNfE=";
   };
-
-  patches = [
-    # Fix sudo helper stealing TTY input in mortal mode, see https://github.com/elfmz/far2l/issues/3425
-    (fetchpatch {
-      url = "https://github.com/elfmz/far2l/commit/d9f96544adf36d93de813f2f918b78a6f37c61e4.patch";
-      sha256 = "sha256-hkFunNxey7A47va8Rm0ZOknM0jPuuT9AL5nfXdssE8s=";
-    })
-  ];
 
   postPatch = ''
     chmod +x far2l/bootstrap/*.sh
@@ -243,6 +236,8 @@ stdenv.mkDerivation rec {
       ln -sf "$file" "$out/lib/far2l/Plugins/arclite/plug/"
     done
   '';
+
+  passthru.updateScript = nix-update-script { extraArgs = "--version=branch=master"; };
 
   meta = {
     description = "Linux port of FAR Manager v2 with enhanced plugin support";

--- a/pkgs/by-name/fa/far2l/package.nix
+++ b/pkgs/by-name/fa/far2l/package.nix
@@ -58,6 +58,8 @@
   withMTP ? true,
   libmtp,
   libusb1,
+  withGitGutter ? true,
+  git,
   withArclite ? true, # Archive support with custom 7z plugin
   _7zz, # 7zip plugin (only used if withArclite is true)
   withAlign ? true, # Align plugin
@@ -149,6 +151,8 @@ stdenv.mkDerivation rec {
     ]
     # ADB plugin
     ++ lib.optional withADB android-tools
+    #  GitGutter plugin
+    ++ lib.optional withGitGutter git
     #  MTP plugin
     ++ lib.optionals withMTP [
       libmtp
@@ -194,6 +198,7 @@ stdenv.mkDerivation rec {
     (lib.cmakeBool "IMAGEVIEWER" withImageViewer)
     (lib.cmakeBool "ADB" withADB)
     (lib.cmakeBool "MTP" withMTP)
+    (lib.cmakeBool "GITGUTTER" withGitGutter)
     (lib.cmakeBool "PYTHON" withPython)
     (lib.cmakeBool "ARCLITE" withArclite)
 
@@ -219,6 +224,8 @@ stdenv.mkDerivation rec {
     bzip2
     gnutar
   ]
+  # Git for GitGutter plugin
+  ++ lib.optional withGitGutter git
   # Tools for ADB plugin
   ++ lib.optional withADB android-tools;
 


### PR DESCRIPTION
Enable far2l plugins brought with recent updates. Export library required for far2l Arclite plugin from _7zz package.

PR is based on #519180.

Closes #447724.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
