### PR TITLE
codebase-memory-mcp: build web ui

### DIFF
--- a/pkgs/by-name/co/codebase-memory-mcp/package.nix
+++ b/pkgs/by-name/co/codebase-memory-mcp/package.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
   __structuredAttrs = true;
 
+  enableParallelBuilding = true;
+
   makefile = "Makefile.cbm";
 
   # scripts/build.sh verifies CC via `file`, which fails on Nix's compiler wrapper.

--- a/pkgs/by-name/co/codebase-memory-mcp/package.nix
+++ b/pkgs/by-name/co/codebase-memory-mcp/package.nix
@@ -1,8 +1,11 @@
 {
   lib,
-  stdenv,
+  bash,
   fetchFromGitHub,
-  gnumake,
+  fetchNpmDeps,
+  nodejs,
+  npmHooks,
+  stdenv,
   zlib,
 }:
 stdenv.mkDerivation (finalAttrs: {
@@ -20,9 +23,31 @@ stdenv.mkDerivation (finalAttrs: {
     ./remove-install-update.diff
   ];
 
-  nativeBuildInputs = [ gnumake ];
+  postPatch = ''
+    substituteInPlace Makefile.cbm \
+      --replace-fail "npm ci &&" ""
 
-  buildInputs = [ zlib ];
+    substituteInPlace scripts/embed-frontend.sh \
+      --replace-fail "/bin/bash" "${bash}/bin/bash"
+  '';
+
+  npmDeps = fetchNpmDeps {
+    inherit (finalAttrs) src;
+    sourceRoot = "${finalAttrs.src.name}/${finalAttrs.npmRoot}";
+    hash = "sha256-feoZNsZfrPgoLdjlnnh3w3vTxR6AwPdUkPubaR93TAk=";
+  };
+
+  npmRoot = "graph-ui";
+
+  nativeBuildInputs = [
+    nodejs
+    npmHooks.npmConfigHook
+  ];
+
+  buildInputs = [
+    bash
+    zlib
+  ];
 
   strictDeps = true;
   __structuredAttrs = true;
@@ -34,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
   # scripts/build.sh verifies CC via `file`, which fails on Nix's compiler wrapper.
   # Call make directly — mirrors upstream flake.nix.
   makeFlags = [
-    "cbm"
+    "cbm-with-ui"
     "CFLAGS_EXTRA='-DCBM_VERSION=\"${finalAttrs.version}\"'"
   ];
 


### PR DESCRIPTION
Last PR for today :) and the webui now works

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
