### PR TITLE
python3Packages.oxitest: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26043,6 +26043,11 @@
     github = "snpschaaf";
     githubId = 105843013;
   };
+  snregales = {
+    github = "snregales";
+    githubId = 31469087;
+    name = "Stephan N. Regales";
+  };
   snu = {
     email = "kabelfrickler@gmail.com";
     github = "snue";

--- a/pkgs/development/python-modules/oxitest/default.nix
+++ b/pkgs/development/python-modules/oxitest/default.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  cargo,
+  rustPlatform,
+  rustc,
+  writeText,
+  runCommand,
+}:
+
+let
+  oxitest = buildPythonPackage rec {
+    pname = "oxitest";
+    version = "1.0.0";
+    pyproject = true;
+
+    src = fetchFromGitHub {
+      owner = "kalonji-tools";
+      repo = "oxitest";
+      tag = "v${version}";
+      hash = "sha256-X4xRXqXXsc8bGydHGk3w2j/klL/TXa7tEKt42kHTQGk=";
+    };
+
+    cargoDeps = rustPlatform.fetchCargoVendor {
+      inherit pname version src;
+      hash = "sha256-nBEmgsU7WDIsy32UclzwqHz10KAMlQ5htZ3+jgPsUnc=";
+    };
+
+    nativeBuildInputs = [
+      cargo
+      rustPlatform.cargoSetupHook
+      rustPlatform.maturinBuildHook
+      rustc
+    ];
+
+    doCheck = false;
+
+    pythonImportsCheck = [ "oxitest" ];
+
+    passthru.tests = {
+      version = runCommand "${pname}-version-test" { } ''
+        ${lib.getExe oxitest} --version | grep -q "${version}"
+        touch $out
+      '';
+      smoke = runCommand "${pname}-smoke-test" { } ''
+        ${lib.getExe oxitest} ${writeText "test_smoke.py" ''
+          def test_smoke():
+              assert 1 + 1 == 2, "basic arithmetic should work"
+        ''}
+        touch $out
+      '';
+    };
+
+    meta = {
+      description = "A fast Python test runner written in Rust";
+      homepage = "https://github.com/kalonji-tools/oxitest";
+      changelog = "https://github.com/kalonji-tools/oxitest/blob/v${version}/CHANGELOG.md";
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [ snregales ];
+      mainProgram = "oxitest";
+    };
+  };
+in
+oxitest

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12364,6 +12364,8 @@ self: super: with self; {
 
   owslib = callPackage ../development/python-modules/owslib { };
 
+  oxitest = callPackage ../development/python-modules/oxitest { };
+
   oyaml = callPackage ../development/python-modules/oyaml { };
 
   p1monitor = callPackage ../development/python-modules/p1monitor { };


### PR DESCRIPTION
## Description

Add [oxitest](https://github.com/kalonji-tools/oxitest), a fast Python test runner written in Rust.

oxitest rewrites the slow parts of test infrastructure (collection, scheduling, parallelism, caching, reporting) in Rust while keeping test code in pure Python. It uses PyO3/maturin for the Rust-Python bridge.

- **Homepage**: https://github.com/kalonji-tools/oxitest
- **Documentation**: https://kalonji-tools.github.io/oxitest/
- **License**: MIT
- **PyPI**: https://pypi.org/project/oxitest/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - [x] `pythonImportsCheck` passes
  - [x] `passthru.tests` (version check + smoke test) verified manually
- [x] Verified evaluation: `nix-instantiate --eval -E '(import ./. {}).python3Packages.oxitest.pname'` → `"oxitest"`
- [x] Added myself to `maintainers/maintainer-list.nix` (first contribution)
- [x] Added to `pkgs/top-level/python-packages.nix`

## Build details

Uses `buildPythonPackage` with `cargoSetupHook` + `maturinBuildHook` + `fetchCargoVendor`, following the same pattern as `pydantic-core`, `polars`, `cryptography`, and `orjson`.