### PR TITLE
stellar-core: 27.0.0 -> 27.1.0

### DIFF
--- a/pkgs/by-name/st/stellar-core/package.nix
+++ b/pkgs/by-name/st/stellar-core/package.nix
@@ -48,13 +48,13 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "stellar-core";
-  version = "27.0.0";
+  version = "27.1.0";
 
   src = fetchFromGitHub {
     owner = "stellar";
     repo = "stellar-core";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ikTkp/r24xTJ+RDMlu5q8PmFvGUeLz/sejeIjOSmd5M=";
+    hash = "sha256-EXtfkjNOl3Loml7GXWYE8hh/IqItqA677YEh0Ve6dOI=";
     fetchSubmodules = true;
   };
 
@@ -69,16 +69,11 @@ stdenv.mkDerivation (finalAttrs: {
         p26 = "sha256-OxkiWTzNtmYxB64OtLUwghAkcT//SnMZVfUXynFg2Bg=";
         p27 = "sha256-KcsyPBJLUOwRAtp95IYFiZZNMi1xWmYW7XXG+bMucmY=";
       };
-    in
-    symlinkJoin {
-      name = "stellar-core-${finalAttrs.version}-cargo-vendor-dir";
-      paths = [
-        (rustPlatform.fetchCargoVendor {
-          inherit (finalAttrs) src;
-          hash = "sha256-e7WGYm5RLmg9vjcMjy98RBW0QqjGTd8cPPeilhYbZ2I=";
-        })
-      ]
-      ++ lib.mapAttrsToList (
+      mainCargoDeps = rustPlatform.fetchCargoVendor {
+        inherit (finalAttrs) src;
+        hash = "sha256-8seehYc2W0lvW9WPewPHC3cLR9Lgj2qCib/EXK0gwVA=";
+      };
+      sorobanCargoDeps = lib.mapAttrs (
         protocol: hash:
         rustPlatform.fetchCargoVendor {
           pname = "stellar-core-${protocol}";
@@ -87,6 +82,13 @@ stdenv.mkDerivation (finalAttrs: {
           inherit hash;
         }
       ) sorobanProtocolHashes;
+    in
+    symlinkJoin {
+      name = "stellar-core-${finalAttrs.version}-cargo-vendor-dir";
+      paths = [ mainCargoDeps ] ++ lib.attrValues sorobanCargoDeps;
+      passthru = {
+        inherit sorobanProtocolHashes mainCargoDeps sorobanCargoDeps;
+      };
       postBuild = ''
         # `soroban-synth-wasm` resolves this path relative to the vendored git
         # source root, but cargo vendors the workspace crates with versioned
@@ -159,6 +161,10 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postCheck
   '';
+
+  passthru = {
+    updateScript = ./update.sh;
+  };
 
   meta = {
     description = "Reference peer-to-peer agent that manages the Stellar network";

--- a/pkgs/by-name/st/stellar-core/update.sh
+++ b/pkgs/by-name/st/stellar-core/update.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bash common-updater-scripts coreutils curl jq nix perl
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+nixpkgs="$(cd "$script_dir/../../../.." >/dev/null 2>&1 && pwd)"
+nix_file="$script_dir/package.nix"
+attr="stellar-core"
+github_repo="stellar/stellar-core"
+
+cd "$nixpkgs"
+
+old_version="$(nix-instantiate --eval --raw -A "$attr.version")"
+latest_tag="$(curl -fsS ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "https://api.github.com/repos/$github_repo/releases/latest" | jq -r '.tag_name')"
+latest_version="${latest_tag#v}"
+fake_hash="$(nix-instantiate --eval --raw -A lib.fakeHash)"
+
+soroban_revs() {
+  local version_tag="$1"
+
+  curl -fsS ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "https://api.github.com/repos/$github_repo/git/trees/$version_tag?recursive=1" \
+    | jq '
+        reduce (
+          .tree[]
+          | select(.mode == "160000" and (.path | test("^src/rust/soroban/p[0-9]+$")))
+        ) as $submodule ({};
+          .[$submodule.path | sub("^src/rust/soroban/"; "")] = $submodule.sha
+        )
+      '
+}
+
+current_soroban_hashes="$(nix-instantiate --eval --json -A "$attr.cargoDeps.sorobanProtocolHashes")"
+old_soroban_revs="{}"
+new_soroban_revs="$(soroban_revs "$latest_tag")"
+
+if [[ "$(jq length <<< "$new_soroban_revs")" -eq 0 ]]; then
+  echo "Could not find Soroban protocol submodules in $latest_tag" >&2
+  exit 1
+fi
+
+if [[ "$old_version" != "$latest_version" ]]; then
+  old_soroban_revs="$(soroban_revs "v$old_version")"
+fi
+
+protocols="$(
+  jq --compact-output \
+    --arg fake_hash "$fake_hash" \
+    --argjson hashes "$current_soroban_hashes" \
+    --argjson old "$old_soroban_revs" \
+    '
+      . as $new
+      | keys
+      | sort_by(ltrimstr("p") | tonumber)
+      | map({
+          protocol: .,
+          hash: ($hashes[.] // $fake_hash),
+          needsUpdate: ($hashes[.] == null or ($old[.] != null and $old[.] != $new[.]))
+        })
+    ' <<< "$new_soroban_revs"
+)"
+soroban_hash_lines="$(jq -r '.[] | "        \(.protocol) = \"\(.hash)\";"' <<< "$protocols")"
+mapfile -t soroban_protocols_to_update < <(jq -r '.[] | select(.needsUpdate).protocol' <<< "$protocols")
+
+update-source-version "$attr" "$latest_version"
+
+SOROBAN_HASH_LINES="$soroban_hash_lines" \
+perl -0pi -e '
+  s/(sorobanProtocolHashes = \{\n).*?(\n[[:space:]]+\};)/$1$ENV{SOROBAN_HASH_LINES}$2/s;
+' "$nix_file"
+
+update-source-version "$attr" \
+  --ignore-same-version \
+  --source-key=cargoDeps.mainCargoDeps.vendorStaging
+
+for protocol in "${soroban_protocols_to_update[@]}"; do
+  update-source-version "$attr" \
+    --ignore-same-version \
+    --source-key="cargoDeps.sorobanCargoDeps.$protocol.vendorStaging"
+done


### PR DESCRIPTION
Changelog https://github.com/stellar/stellar-core/releases/tag/v27.1.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
