### PR TITLE
pyadi-iio: init at 0.0.21

### DIFF
--- a/pkgs/development/python-modules/pyadi-iio/default.nix
+++ b/pkgs/development/python-modules/pyadi-iio/default.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  numpy,
+  libiio,
+  scipy,
+  plotly,
+  pytestCheckHook,
+  pytest-cov-stub,
+  pytest-html,
+  hatchling,
+  pytest,
+  pyyaml,
+  lxml,
+  click,
+  pytest-xdist,
+}:
+
+let
+  pytest-libiio = buildPythonPackage (finalAttrs: {
+    pname = "pytest-libiio";
+    version = "0.2.0";
+    pyproject = true;
+
+    src = fetchFromGitHub {
+      owner = "tfcollins";
+      repo = "pytest-libiio";
+      rev = "v${finalAttrs.version}";
+      hash = "sha256-3bCKDaKJXQIX+tbR5XHXhPAm+jc5UpYK0lZxv50kj5c=";
+    };
+
+    build-system = [ hatchling ];
+
+    dependencies = [
+      pytest
+      libiio
+      pyyaml
+      lxml
+      click
+      pytest-xdist
+    ];
+  });
+in
+
+buildPythonPackage (finalAttrs: {
+  pname = "adi";
+  version = "0.0.21";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "analogdevicesinc";
+    repo = "pyadi-iio";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-xYeCzQExnFvgxqD91L+Ncmo4XfXhK1hRlTGexNvvyp4=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    numpy
+    libiio
+  ];
+
+  # required for test suite
+  __darwinAllowLocalNetworking = true;
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+    pytest-html
+    pytest-libiio
+    scipy
+    plotly
+  ];
+
+  pythonImportsCheck = [ "adi" ];
+
+  meta = {
+    description = "Analog Devices python interfaces for hardware with Industrial I/O drivers";
+    homepage = "https://github.com/analogdevicesinc/pyadi-iio";
+    # BSD-like license with restrictions on usage
+    license = lib.licenses.unfreeRedistributable;
+    maintainers = with lib.maintainers; [ feyorsh ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13692,6 +13692,8 @@ self: super: with self; {
 
   pyacoustid = callPackage ../development/python-modules/pyacoustid { };
 
+  pyadi-iio = callPackage ../development/python-modules/pyadi-iio { };
+
   pyadjoint-ad = callPackage ../development/python-modules/pyadjoint-ad { };
 
   pyads = callPackage ../development/python-modules/pyads { };


### PR DESCRIPTION
Analog Device's Python API for interacting with some of their devices, e.g. the [ADALM-PLUTO](https://wiki.analog.com/university/tools/pluto) SDR.

#### Notes
- The tests require an auxiliary package; I do think it makes sense to include this so tests can run, but I do not think this auxiliary package should be exposed in nixpkgs (it can be refactored later if the need arises).
  - On a related note, almost all of the tests are skipped---it's unclear to me if the tests being skipped are important or are specific to certain configurations. Their test suite is designed in such a way that not all tests will run in one go.
- Unlike some of Analog Device's other packages, this package uses a custom unfree license ("ADI BSD"):
> Use of the software either in source or binary form or filter designs resulting from the use of this software, must be connected to, run on or loaded to an Analog Devices Inc. component.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

<!-- Message of single commit: -->