### PR TITLE
buildDubPackage: remove references to std headers

### DIFF
--- a/pkgs/build-support/dlang/builddubpackage/default.nix
+++ b/pkgs/build-support/dlang/builddubpackage/default.nix
@@ -58,10 +58,12 @@ lib.extendMkDerivation {
       preFixup = ''
         ${args.preFixup or ""}
 
-        find "$out" -type f -exec remove-references-to -t ${compiler} '{}' +
+        find "$out" -type f -exec remove-references-to ${
+          lib.concatMapStringsSep " " (output: "-t ${output}") compiler.all
+        } '{}' +
       '';
 
-      disallowedReferences = args.disallowedReferences or [ compiler ];
+      disallowedReferences = args.disallowedReferences or compiler.all;
 
       meta = {
         platforms = dub.meta.platforms;

--- a/pkgs/build-support/dlang/builddubpackage/default.nix
+++ b/pkgs/build-support/dlang/builddubpackage/default.nix
@@ -35,6 +35,7 @@ lib.extendMkDerivation {
       };
 
       strictDeps = args.strictDeps or true;
+      __structuredAttrs = args.__structuredAttrs or true;
 
       nativeBuildInputs = args.nativeBuildInputs or [ ] ++ [
         dubSetupHook


### PR DESCRIPTION
While looking for potential candidates for 
- https://github.com/NixOS/nixpkgs/issues/515268

in my NixOS closure, I've noticed that `18.83/92.73 MiB` for `btdu` closure were due to `ldc-1.41.0-include`, which seemingly only ever used for backtraces.

---

While we're at it, also let's set `__structuredAttrs`.
cc:
- https://github.com/NixOS/nixpkgs/issues/205690

---

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
