### PR TITLE
haskellPackages.servant-{auth-client,auth-docs,auth-server,swagger}: jailbreak

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1541,6 +1541,16 @@ with haskellLib;
   # https://github.com/haskellari/binary-instances/pull/34/changes#r3257818178
   binary-instances = doJailbreak super.binary-instances;
 
+  # 2026-06-28: allow QuickCheck 2.16 (upstream currently bound to 2.18)
+  # https://github.com/haskell-servant/servant/pull/1875 # krank:ignore-line
+  servant-auth-client = doJailbreak super.servant-auth-client;
+  servant-auth-server = doJailbreak super.servant-auth-server;
+
+  # 2026-06-28: allow doctest 0.25
+  # https://github.com/haskell-servant/servant/issues/1890
+  servant-auth-docs = doJailbreak super.servant-auth-docs;
+  servant-swagger = doJailbreak super.servant-swagger;
+
   # chell-quickcheck doesn't work with QuickCheck >= 2.15 with no known fix yet
   # https://github.com/typeclasses/chell/issues/5
   system-filepath = dontCheck super.system-filepath;


### PR DESCRIPTION


## Things done

- Built on platform:
  - [x] x86_64-linux
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
