### PR TITLE
nixos/gnome: don't restart gnome-session-monitor.service on switch

### DIFF
--- a/nixos/modules/services/desktop-managers/gnome.nix
+++ b/nixos/modules/services/desktop-managers/gnome.nix
@@ -400,6 +400,15 @@ in
         pkgs.xdg-user-dirs-gtk # Used to create the default bookmarks
       ];
 
+      # Restarting this unit terminates the active GNOME session.
+      systemd.user.services.gnome-session-monitor = {
+        restartIfChanged = false;
+        overrideStrategy = "asDropin";
+        # No need to add the NixOS default Environment="Path=coreutils:...",
+        # to the gnome-session-monitor service.
+        enableDefaultPath = false;
+      };
+
       services.udev.packages = [
         # Force enable KMS modifiers for devices that require them.
         # https://gitlab.gnome.org/GNOME/pkgs.mutter/-/merge_requests/1443


### PR DESCRIPTION
Sets `restartIfChanged = false;` for `gnome-session-monitor.service`.

The current behavior makes it so that if `gnome-session-monitor.service` changes for whatever reason, it is restarted by `nixos-rebuild switch`, which then causes the GNOME session to be stopped (easily verifiable with `systemctl --user restart gnome-session-monitor.service`).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
