### PR TITLE
iio-oscilliscope: 0.17 -> 0.18 and add darwin support

### DIFF
--- a/pkgs/by-name/ii/iio-oscilloscope/package.nix
+++ b/pkgs/by-name/ii/iio-oscilloscope/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   pkg-config,
   wrapGAppsHook3,
@@ -23,22 +22,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "iio-oscilloscope";
-  version = "0.17";
+  version = "0.18";
 
   src = fetchFromGitHub {
     owner = "analogdevicesinc";
     repo = "iio-oscilloscope";
-    rev = "v${finalAttrs.version}-master";
-    hash = "sha256-wCeOLAkrytrBaXzUbNu8z2Ayz44M+b+mbyaRoWHpZYU=";
+    rev = "v${finalAttrs.version}-main";
+    hash = "sha256-lAP8rI1YnBMmwWBDxfQOV5W8NYscQbb7lh/ZhG893p0=";
   };
-
-  patches = [
-    # make sure the sizeof argument to calloc is the second argument.
-    (fetchpatch {
-      url = "https://github.com/analogdevicesinc/iio-oscilloscope/commit/565cade20566d50adec7be191a6dd7b21217f878.patch";
-      hash = "sha256-JeRve3xtWi+EcZR+qZlek+YwAbPB56OYxkFVd8MmIb0=";
-    })
-  ];
 
   postPatch = ''
     # error: 'idx' may be used uninitialized

--- a/pkgs/by-name/ii/iio-oscilloscope/package.nix
+++ b/pkgs/by-name/ii/iio-oscilloscope/package.nix
@@ -5,6 +5,7 @@
   cmake,
   pkg-config,
   wrapGAppsHook3,
+  desktopToDarwinBundle,
   libiio,
   glib,
   gtk3,
@@ -34,12 +35,21 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     # error: 'idx' may be used uninitialized
     substituteInPlace plugins/lidar.c --replace-fail "int i, j, idx;" "int i, j, idx = 0;"
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace oscmain.c --replace-fail '#include "osc.h"${"\n"}#include "backtrace.h"' '#include "backtrace.h"${"\n"}#include "osc.h"'
+    substituteInPlace CMakeLists.txt \
+      --replace-fail '-D_GNU_SOURCE' '-D_DARWIN_C_SOURCE' \
+      --replace-fail '${"\${CMAKE_SYSTEM_NAME} MATCHES \"Linux\""}' 'TRUE'
   '';
 
   nativeBuildInputs = [
     cmake
     pkg-config
     wrapGAppsHook3
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    desktopToDarwinBundle
   ];
 
   buildInputs = [
@@ -59,6 +69,20 @@ stdenv.mkDerivation (finalAttrs: {
     "-DCMAKE_POLKIT_PREFIX=${placeholder "out"}"
   ];
 
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-Wno-error=unused-variable"
+  ];
+
+  preInstall = ''
+    sed -e 's/Exec=.*/Exec=osc/' \
+        -e 's/Icon=.*/Icon=osc/' \
+        -i adi-osc.desktop
+  '';
+
+  postInstall = ''
+    ln -s $out/share/osc/icons/osc.svg $out/share/icons/hicolor/scalable/apps/
+  '';
+
   meta = {
     description = "GTK+ based oscilloscope application for interfacing with various IIO devices";
     homepage = "https://wiki.analog.com/resources/tools-software/linux-software/iio_oscilloscope";
@@ -66,6 +90,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl2Only;
     changelog = "https://github.com/analogdevicesinc/iio-oscilloscope/releases/tag/v${finalAttrs.version}-master";
     maintainers = with lib.maintainers; [ chuangzhu ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
FFIW I could not get version 0.17 working on my `aarch64-darwin` system, so the version bump is not an arbitrary extra change.

Unfortunately there are some rather inelegant hacks in `preInstall` and `postInstall` to massage the output into something `desktopToDarwinBundle` will accept, although I believe these are technically issues in how the upstream project writes their .desktop file.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

<!-- Message of single commit: -->