### PR TITLE
tree-sitter: restore extraGrammars

### DIFF
--- a/pkgs/by-name/tr/tree-sitter/grammars/README.md
+++ b/pkgs/by-name/tr/tree-sitter/grammars/README.md
@@ -46,6 +46,31 @@ Attempt to build the new grammar: `nix-build -A tree-sitter-grammars.tree-sitter
 This will fail due to the invalid hash.
 Review the downloaded source, then update the source definition with the printed source `hash`.
 
+## Extending Grammars
+
+Overlays may extend the grammar set without modifying nixpkgs by overriding `tree-sitter` with `extraGrammars`.
+Extra grammars use the expanded `pkgs.tree-sitter.grammars` form: each key is the final `tree-sitter-*` attribute name, and each value provides `language`, `version`, and `src`.
+When added through an overlay, extra grammars are also available through `pkgs.tree-sitter.builtGrammars`, `pkgs.tree-sitter-grammars`, and `pkgs.tree-sitter.withPlugins`.
+
+```nix
+final: prev: {
+  tree-sitter = prev.tree-sitter.override {
+    extraGrammars = {
+      tree-sitter-foolang = {
+        language = "foolang";
+        version = "0.42.0";
+        src = final.fetchFromGitHub {
+          owner = "example";
+          repo = "tree-sitter-foolang";
+          tag = "v0.42.0";
+          hash = "";
+        };
+      };
+    };
+  };
+}
+```
+
 ## Pinning Grammar Sources
 
 To pin to a specific ref, append this to the source `url` to override the default version tag.

--- a/pkgs/by-name/tr/tree-sitter/package.nix
+++ b/pkgs/by-name/tr/tree-sitter/package.nix
@@ -25,6 +25,7 @@
   enableStatic ? stdenv.hostPlatform.isStatic,
   wasmSupport ? false,
   webUISupport ? false,
+  extraGrammars ? { },
 }:
 
 let
@@ -52,18 +53,20 @@ let
 
     Use pkgs.tree-sitter.grammars.<name> to access.
   */
-  grammars = import ./grammars {
-    inherit
-      lib
-      nix-update-script
-      fetchFromGitHub
-      fetchFromGitLab
-      fetchFromSourcehut
-      fetchFromCodeberg
-      fetchpatch
-      stdenv
-      ;
-  };
+  grammars =
+    import ./grammars {
+      inherit
+        lib
+        nix-update-script
+        fetchFromGitHub
+        fetchFromGitLab
+        fetchFromSourcehut
+        fetchFromCodeberg
+        fetchpatch
+        stdenv
+        ;
+    }
+    // extraGrammars;
 
   /**
     Attrset of compiled grammars.


### PR DESCRIPTION
The grammar source refactor removed the hook overlays used to add grammars before builtGrammars is computed. Add it back so custom grammar sources populate tree-sitter.grammars, tree-sitter.builtGrammars, tree-sitter-grammars, and withPlugins from one override.

Follow up to https://github.com/NixOS/nixpkgs/pull/408414 to restore the `extraGrammars` arg that makes it easy to extend the set.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
