### PR TITLE
onnxruntime: fix CUDAExecutionProvider loading error

### DIFF
--- a/pkgs/by-name/on/onnxruntime/nvrtc-link.patch
+++ b/pkgs/by-name/on/onnxruntime/nvrtc-link.patch
@@ -1,0 +1,26 @@
+diff --git a/cmake/onnxruntime_providers_cuda.cmake b/cmake/onnxruntime_providers_cuda.cmake
+index 624057dd43..64de9a0860 100644
+--- a/cmake/onnxruntime_providers_cuda.cmake
++++ b/cmake/onnxruntime_providers_cuda.cmake
+@@ -310,7 +310,7 @@
+           message( WARNING "To compile with NHWC ops enabled please compile against cuDNN 9 or newer." )
+         endif()
+       endif()
+-      target_link_libraries(${target} PRIVATE CUDA::cublasLt CUDA::cublas CUDNN::cudnn_all cudnn_frontend CUDA::curand CUDA::cufft CUDA::cudart
++      target_link_libraries(${target} PRIVATE CUDA::cublasLt CUDA::cublas CUDNN::cudnn_all cudnn_frontend CUDA::curand CUDA::cufft CUDA::cudart CUDA::nvrtc CUDA::cuda_driver
+               ${ABSEIL_LIBS} ${ONNXRUNTIME_PROVIDERS_SHARED} Boost::mp11 safeint_interface)
+     endif()
+ 
+diff --git a/cmake/onnxruntime_providers_cuda_plugin.cmake b/cmake/onnxruntime_providers_cuda_plugin.cmake
+index e345c944dc..82742df359 100644
+--- a/cmake/onnxruntime_providers_cuda_plugin.cmake
++++ b/cmake/onnxruntime_providers_cuda_plugin.cmake
+@@ -250,6 +250,8 @@ target_link_libraries(onnxruntime_providers_cuda_plugin PRIVATE
+     CUDA::cublas
+     CUDA::cublasLt
+     CUDA::cufft
++    CUDA::nvrtc
++    CUDA::cuda_driver
+     CUDNN::cudnn_all
+     cudnn_frontend
+     Boost::mp11

--- a/pkgs/by-name/on/onnxruntime/package.nix
+++ b/pkgs/by-name/on/onnxruntime/package.nix
@@ -132,6 +132,12 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     # https://github.com/microsoft/onnxruntime/issues/9155
     # Patch adapted from https://gitlab.alpinelinux.org/alpine/aports/-/raw/462dfe0eb4b66948fe48de44545cc22bb64fdf9f/community/onnxruntime/0001-Remove-MATH_NO_EXCEPT-macro.patch
     ./remove-MATH_NO_EXCEPT-macro.patch
+  ]
+  # Include additional target_link_libraries needed for cudnn-frontend >= 2.19
+  # See: https://github.com/microsoft/onnxruntime/pull/28849
+  # These changes are included in 548ab6e and fc7a9f0 upstream
+  ++ lib.optionals cudaSupport [
+    ./nvrtc-link.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
onnxruntime fails to load the CUDAExecutionProvider with an `libonnxruntime_providers_cuda.so: undefined symbol: nvrtcGetProgramLogSize` error.

cudnn-frontend >=1.19.0 now includes symbols provided by nvrtc but does not ensure it is linked against it. Recent commits to onnxruntime add the CUDA::nvrtc link target to resolve the issue. This adds the same change here.

Fixes https://github.com/NixOS/nixpkgs/issues/536183.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
