### PR TITLE
buildOpenSCADPackage: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -30360,6 +30360,12 @@
     githubId = 3028542;
     name = "Guillermo NWDD";
   };
+  xoconoch = {
+    email = "github@cordovault.com";
+    github = "xoconoch";
+    githubId = 93692082;
+    name = "Xoconoch";
+  };
   xokdvium = {
     email = "sergei@zimmerman.foo";
     github = "xokdvium";

--- a/pkgs/build-support/build-openscad-package/default.nix
+++ b/pkgs/build-support/build-openscad-package/default.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  stdenvNoCC,
+  buildPackages,
+}:
+
+lib.extendMkDerivation {
+  constructDrv = stdenvNoCC.mkDerivation;
+  extendDrvArgs =
+    finalAttrs:
+    {
+      pname,
+      version,
+      libName ? pname,
+      installTargets ? [ "." ],
+
+      ...
+    }@args:
+
+    {
+      inherit
+        pname
+        version
+        libName
+        installTargets
+        ;
+
+      __structuredAttrs = true;
+      name = "openscad-package-${finalAttrs.pname}-${finalAttrs.version}";
+
+      strictDeps = true;
+
+      # Use the interactive Bash shell (with readline support) for the compgen shell built-in.
+      realBuilder = lib.getExe buildPackages.bash;
+
+      installPhase =
+        args.installPhase or ''
+          runHook preInstall
+
+          installDir="$out/share/openscad/libraries/$libName"
+          mkdir -p "$installDir"
+
+          for _target in "''${installTargets[@]}"; do
+            _targetDirName="$(dirname "$_target")"
+            _targetBaseName="$(basename "$_target")"
+            # Support globs using Bash's compgen built-in.
+            (
+              if [[ "$_targetDirName" != "." ]]; then
+                if ! cd "$_targetDirName"; then
+                  echo "ERROR: $name: Fails to switch to the dirname of $_target -- $_targetDirName" >&2
+                  exit 1
+                fi
+              fi
+              if [[ "$_targetBaseName" == "." ]]; then
+                echo "$_targetBaseName"
+              else
+                if ! compgen -G "$_targetBaseName"; then
+                  echo "ERROR: $name: Glob $_target does not match any files or directories." >&2
+                  exit 1
+                fi
+              fi
+            # Keep the number of input files per batch under Bash's command length limitation.
+            ) | while read -r _line; do
+              printf "%s/%s\0" "$_targetDirName" "$_line"
+            done | xargs -0 cp -r -t "$installDir"
+          done
+
+          runHook postInstall
+        '';
+    };
+}

--- a/pkgs/build-support/openscad/tests/default.nix
+++ b/pkgs/build-support/openscad/tests/default.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  stdenv,
+  runCommand,
+  openscad,
+  openscadPackages,
+}:
+
+let
+  # We may add more libraries as they get added
+  dummySrc = runCommand "mock-chaotic-repo" { } ''
+    mkdir -p $out/modules \
+             $out/unwanted-clutter \
+             $out/utils \
+             $out/"folder with spaces" \
+             $out/empty-dir \
+             $out/glob-char-\* \
+             $out/dot-files
+
+    echo "module main_core() { sphere(10); }" > $out/core.scad
+    echo "module main_utils() { cube(5); }" > $out/utils.scad
+    echo "module nested_mod() { cylinder(10); }" > $out/modules/shapes.scad
+    echo "module math_helpers() { cube(2); }" > $out/utils/math.scad
+
+    echo "module spaced() { sphere(1); }" > $out/"my file.scad"
+
+    echo "module weird() { echo(\"weird\"); }" > $out/glob-char-\*/actual.scad
+
+    echo "secret config" > $out/modules/.hidden-config
+
+    echo "print('broken script')" > $out/unwanted-clutter/dont_copy_me.py
+    echo "unwanted markdown" > $out/README.md
+  '';
+
+  openscadPackagesOverridden = openscadPackages.overrideScope (
+    openscadFinal: openscadPrev: {
+      dummylib = openscadFinal.buildOpenSCADPackage {
+        pname = "dummylib";
+        version = "1.0.0";
+        libName = "dummylib";
+        src = dummySrc;
+        installTargets = [
+          "core.scad"
+          "modules"
+          "my file.scad"
+          "glob-char-*"
+          "utils/*.scad"
+        ];
+      };
+    }
+  );
+
+  wrappedOpenscad = openscad.override {
+    openscadPackages = openscadPackagesOverridden;
+  };
+in
+lib.optionalAttrs (!stdenv.hostPlatform.isDarwin) {
+  withPackages-glob-test =
+    runCommand "openscad-withPackages-glob-test"
+      {
+        nativeBuildInputs = [
+          (wrappedOpenscad.withPackages (ps: [ ps.dummylib ]))
+        ];
+      }
+      ''
+        openscad -o test.3mf - <<EOF
+        use <dummylib/core.scad>
+        use <dummylib/modules/shapes.scad>
+        use <dummylib/my file.scad>
+        use <dummylib/glob-char-*/actual.scad>
+        use <dummylib/math.scad>
+
+        main_core();
+        nested_mod();
+        spaced();
+        weird();
+        math_helpers();
+        EOF
+        touch $out
+      '';
+}

--- a/pkgs/by-name/op/openscad/package.nix
+++ b/pkgs/by-name/op/openscad/package.nix
@@ -207,6 +207,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       bjornfor
       raskin
+      xoconoch
     ];
     mainProgram = "openscad";
   };

--- a/pkgs/by-name/op/openscad/package.nix
+++ b/pkgs/by-name/op/openscad/package.nix
@@ -30,9 +30,11 @@
   wayland-protocols,
   wrapGAppsHook3,
   cairo,
+  callPackage,
   openscad,
   runCommand,
   versionCheckHook,
+  openscadPackages,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -209,16 +211,22 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "openscad";
   };
 
-  passthru.tests = {
-    lib3mf_support =
-      runCommand "${finalAttrs.pname}-lib3mf-support-test"
-        {
-          nativeBuildInputs = [ finalAttrs.finalPackage ];
-        }
-        ''
-          echo "cube([1, 1, 1]);" | openscad -o cube.3mf -
-          echo "import(\"cube.3mf\");" | openscad -o cube-import.3mf -
-          mv cube-import.3mf $out
-        '';
+  passthru = {
+    tests = lib.optionalAttrs (!stdenv.hostPlatform.isDarwin) {
+      lib3mf_support =
+        runCommand "${finalAttrs.pname}-lib3mf-support-test"
+          {
+            nativeBuildInputs = [ finalAttrs.finalPackage ];
+          }
+          ''
+            echo "cube([1, 1, 1]);" | openscad -o cube.3mf -
+            echo "import(\"cube.3mf\");" | openscad -o cube-import.3mf -
+            mv cube-import.3mf $out
+          '';
+    };
+    withPackages = callPackage ./wrapper.nix {
+      openscad = finalAttrs.finalPackage;
+      inherit openscadPackages;
+    };
   };
 })

--- a/pkgs/by-name/op/openscad/wrapper.nix
+++ b/pkgs/by-name/op/openscad/wrapper.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  makeWrapper,
+  symlinkJoin,
+  buildEnv,
+  openscad,
+  openscadPackages,
+}:
+
+f:
+
+assert lib.assertMsg (lib.isFunction f)
+  "openscad.withPackages: Expected `f` to be callable (e.g., 'ps: [ ps.bosl2 ]'), but received a ${lib.typeOf f}.";
+
+let
+  selectedPackages = f openscadPackages;
+in
+
+symlinkJoin {
+  name = "${openscad.pname}-with-packages-${openscad.version}";
+  paths = [ openscad ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postBuild = ''
+    rm $out/bin/openscad
+
+    # Add the OPENSCADPATH environment variable
+    makeWrapper ${openscad}/bin/openscad $out/bin/openscad \
+      --set OPENSCADPATH ${lib.makeSearchPath "share/openscad/libraries" selectedPackages}
+  '';
+
+  passthru = {
+    unwrapped = openscad;
+    withPackages = openscad.withPackages;
+  };
+}

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -271,4 +271,6 @@ in
   );
 
   home-assistant-components = recurseIntoAttrs pkgs.home-assistant.tests.components;
+
+  openscad = recurseIntoAttrs (callPackage ../build-support/openscad/tests { });
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2670,6 +2670,8 @@ with pkgs;
     openrgb-plugin-hardwaresync
   ];
 
+  openscadPackages = lib.recurseIntoAttrs (callPackage ../top-level/openscad-packages.nix { });
+
   opensshPackages = dontRecurseIntoAttrs (callPackage ../tools/networking/openssh { });
 
   openssh = opensshPackages.openssh.override {

--- a/pkgs/top-level/openscad-packages.nix
+++ b/pkgs/top-level/openscad-packages.nix
@@ -1,0 +1,16 @@
+{
+  lib,
+  newScope,
+  openscad,
+}:
+
+let
+  openscadOrig = openscad;
+in
+lib.makeScope newScope (
+  self:
+  lib.recurseIntoAttrs {
+    buildOpenSCADPackage = self.callPackage ../build-support/build-openscad-package { };
+    openscad = openscadOrig.override { openscadPackages = self; };
+  }
+)


### PR DESCRIPTION
## Things done

This PR adds a new builder called `buildOpenSCADPackage` and a new wrapper around the Openscad package called openscad.withPackages which takes a function list of openscad packages (or a function which returns a list of openscad packages) and wraps the openscad executable with the necessary paths to access the specified libraries.

I am fairly a beginner in Openscad so this builder assumes that all of its libraries are just .scad files packed up in their own directories, which is what I have seen during my short time using the tool. Considering that possibly the biggest library (BOSL2) works that way, I feel confident that is, indeed, the whole picture, but please somebody correct me if I'm wrong.

If this gets merged, I would like to further go and package libraries like BOSL2, dotSCAD, UB.scad, etc. A full list can be found on https://openscad.org/libraries.html

## How to test
I just dropped this dirty shell in the root of my nixpkgs fork, ran `nix-shell openscad_test.nix` and then opened Openscad. Finally, I typed `include <dummylib/dummy.scad>` in the editor and it successfully rendered the sphere specified in the dummylib file, which  means that the wrapped openscad was indeed able to see said file.

```nix
let
  pkgs = import ./default.nix { };

  dummySrc = pkgs.writeTextDir "dummy.scad" "sphere(r=100);";

  dummylib = pkgs.buildOpenSCADPackage {
    pname = "dummylib";
    version = "1.0.0";
    libraryName = "dummylib";
    src = dummySrc;
  };

  openscadWrapped = pkgs.openscad.withPackages (ps: [ dummylib ]);
in
pkgs.mkShell {
  buildInputs = [ openscadWrapped ];

}
```

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
