### PR TITLE
amaranth-stubs: init at 0.5.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3554,6 +3554,11 @@
     githubId = 28444296;
     name = "Benjamin Hougland";
   };
+  bigflipbot = {
+    name = "bigflipbot";
+    github = "bigflipbot";
+    githubId = 57315276;
+  };
   billewanick = {
     email = "bill@ewanick.com";
     github = "billewanick";

--- a/pkgs/development/python-modules/amaranth-stubs/default.nix
+++ b/pkgs/development/python-modules/amaranth-stubs/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchPypi,
+
+  amaranth,
+
+  setuptools,
+  setuptools-scm,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "amaranth_stubs";
+  version = "0.5.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "kuznia-rdzeni";
+    repo = "amaranth-stubs";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-tpZH1Wrl+03AheS3OA8m3NpWQygfqn1GMIfmwkpdyos=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    amaranth
+  ];
+
+  # doCheck = false;
+
+  meta = {
+    description = "Typing stubs for Amaranth HDL, intended for use with Pyright";
+    homepage = "https://github.com/kuznia-rdzeni/amaranth-stubs/";
+    downloadPage = "https://pypi.org/project/amaranth-stubs/#amaranth_stubs-0.5.0.0.tar.gz";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ bigflipbot ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -790,6 +790,8 @@ self: super: with self; {
 
   amaranth-soc = callPackage ../development/python-modules/amaranth-soc { };
 
+  amaranth-stubs = callPackage ../development/python-modules/amaranth-stubs { };
+
   amarna = callPackage ../development/python-modules/amarna { };
 
   amazon-ion = callPackage ../development/python-modules/amazon-ion { inherit (pkgs) cmake; };


### PR DESCRIPTION
Typing stubs for Amaranth HDL, intended for use with Pyright.

adding package and also myself to maintainer list
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
