### PR TITLE
kermit: fix build with GCC 14+

### DIFF
--- a/pkgs/by-name/ke/kermit/package.nix
+++ b/pkgs/by-name/ke/kermit/package.nix
@@ -39,7 +39,8 @@ stdenv.mkDerivation {
     make -f makefile install
   '';
 
-  env.NIX_CFLAGS_COMPILE = "-Wno-implicit-function-declaration -Wno-implicit-int";
+  # Old K&R C sources fail under GCC 14+ default C standard (e.g. dosexp prototypes).
+  env.NIX_CFLAGS_COMPILE = "-std=gnu89 -Wno-implicit-function-declaration -Wno-implicit-int";
 
   meta = {
     homepage = "https://www.kermitproject.org/ck90.html";


### PR DESCRIPTION
`kermit` fails to build on current master with GCC 14+ (seen on [nfd.1l.is](https://nfd.1l.is) as `c-compile-error`), e.g.:

```
ckuusr.c:8275:22: error: too many arguments to function 'dosexp'; expected 0, have 1
```

The tree is old K&R C. Declarations like `char *dosexp()` are treated as zero-argument prototypes under newer defaults, so the existing `-Wno-implicit-*` flags are not enough. Compile with `-std=gnu89` (same approach as other legacy packages such as `magic-vlsi` / `bftpd`).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

AI assistance: implementation and PR text drafted with Grok; human reviewed and verified the local build and `kermit -h` on x86_64-linux. Commit includes `Assisted-by: Grok (Grok 4.3)`.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test