### PR TITLE
agents/nixpkgs: add nixpkgs agent skill

### DIFF
--- a/.agents/skills/nixpkgs/SKILL.md
+++ b/.agents/skills/nixpkgs/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: nixpkgs
+description: >
+  AI entrypoint for NixOS/nixpkgs in this checkout: route to live contributor
+  docs, enforce non-negotiable guidelines (Automation/AI policy, Assisted-by,
+  PR Things done honesty), reduce reviewer noise, and verify with
+  nixpkgs-review (use nixpkgs-review skill if present, else default wip/rev/pr).
+  Use for package bumps/fixes/inits, hashes, branches, commits, draft PRs,
+  CI follow-up, modules, maintainers—not unattended mass AI spam.
+---
+
+# nixpkgs (agent entrypoint)
+
+Nixpkgs is **high-scrutiny** for AI output. Unattended or low-quality LLM PRs are **reviewer noise** and may violate the [Automation/AI policy](../../../CONTRIBUTING.md#automationai-policy). This skill is **not** a copy of the docs: it routes you to **where to look** and states **non‑negotiables** so contributions stay small, disclosed, verified, and mergeable.
+
+**On conflict: live in-tree docs win.** Fix the skill later; do not invent policy.
+
+## Always / Ask / Never
+
+### Always
+
+- Optimize for **reviewer trust**: human-in-the-loop understanding, minimal scope, honest claims.
+- Open the **live file** for the topic (see [references/docs-map.md](references/docs-map.md)); do not guess guidelines.
+- Package commits: subject format from [`pkgs/README.md` § Commit conventions](../../../pkgs/README.md#commit-conventions) — **open it**.
+- LLM-influenced commits: accountable human review + trailer  
+  `Assisted-by: <tool> (<primary model name and version>)`  
+  Full rules: [`CONTRIBUTING.md` § Automation/AI policy](../../../CONTRIBUTING.md#automationai-policy).  
+  `Co-authored-by` **alone does not satisfy** the policy. Disclose AI in PR body / review comments separately when those are AI-assisted.
+- PR [Things done](../../../.github/PULL_REQUEST_TEMPLATE.md): check **only** what was actually done (platforms, `nixpkgs-review`, binaries, tests, AI policy).
+- New top-level packages: prefer [`pkgs/by-name`](../../../pkgs/by-name/README.md) (see [`pkgs/README.md`](../../../pkgs/README.md)).
+- Package-affecting changes: run the **active review strategy** (below) for real—not checkbox fiction. Prefer real `nixpkgs-review` runs over waiting on remote CI alone.
+- Match nearby expressions; for language lock hashes (`cargoHash`, `vendorHash`, `npmDepsHash`, …) update the attr the expression **already uses**. Open `doc/languages-frameworks/<lang>.section.md` when unsure.
+
+### Ask first
+
+- Branch target unclear (`staging`, `staging-nixos`, `release-*`) — open [`CONTRIBUTING.md` § Branch conventions](../../../CONTRIBUTING.md#branch-conventions) with the user if rebuild impact is uncertain. Large CI `rebuild` labels ⇒ read that section before targeting `master`.
+- New packages that may fail the “should this be in nixpkgs?” gates in [`pkgs/README.md`](../../../pkgs/README.md) (Quick Start).
+- Force-push / history rewrite on branches others may use.
+- **Worktree** or extra clone — **opt-in only** (user asked, or the optional `nixpkgs-review` skill requires it).
+- Scope expansion / drive-by refactors (noise).
+
+### Never
+
+- Tick PR template boxes without evidence (including review and AI policy).
+- Submit unreviewed LLM output for inclusion (“vibe coding”) — [AI policy](../../../CONTRIBUTING.md#automationai-policy).
+- Skip or **fake** review while claiming it was done — use the real active strategy.
+- Short ambiguous GitHub `rev`s in fetchers when docs require full commit hashes — [`pkgs/README.md` § Sources](../../../pkgs/README.md#sources).
+- Invent policy; contradict in-tree docs.
+- Sprawl: multi-topic PRs, unsolicited cleanups, agent “helpfulness” that increases review burden.
+
+## Where to look
+
+**MANDATORY when unsure of procedure or policy:** read [references/docs-map.md](references/docs-map.md), then open the **live** path listed there. Do **not** load a skill reference that restates CONTRIBUTING—there isn’t one; only the map and the default review card.
+
+| Task class | Start here (then docs-map for more) |
+|------------|-------------------------------------|
+| Any contrib / PR process | [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) |
+| Package edit / init / tests / sources | [`pkgs/README.md`](../../../pkgs/README.md), [`pkgs/by-name/README.md`](../../../pkgs/by-name/README.md) |
+| PR checkboxes | [`.github/PULL_REQUEST_TEMPLATE.md`](../../../.github/PULL_REQUEST_TEMPLATE.md) |
+| AI / automation disclosure | [`CONTRIBUTING.md` § Automation/AI policy](../../../CONTRIBUTING.md#automationai-policy) |
+| Branch / staging / mass rebuild | [`CONTRIBUTING.md` § Branch conventions](../../../CONTRIBUTING.md#branch-conventions) |
+| NixOS modules / tests | [`nixos/README.md`](../../../nixos/README.md), NixOS manual tests section (linked from PR template) |
+| `lib` | [`lib/README.md`](../../../lib/README.md) |
+| Manual / `doc` | [`doc/README.md`](../../../doc/README.md) |
+| Maintainers list | [`maintainers/README.md`](../../../maintainers/README.md) |
+| Language-specific build | `doc/languages-frameworks/<lang>.section.md` |
+| `nixpkgs-review` flags / behavior | [Mic92/nixpkgs-review](https://github.com/Mic92/nixpkgs-review#usage) (also linked from CONTRIBUTING / PR template) |
+
+**Landmine (one line):** PR **title** `WIP:` / `[WIP]` affects automatic package builds; **draft** status alone does not — see [`pkgs/README.md` § Commit conventions](../../../pkgs/README.md#commit-conventions).
+
+## Review strategy
+
+Resolve **once** per task; follow **one** procedure wholly (do not invent a hybrid):
+
+1. **User said how to review** in this session → that instruction wins for this run.
+2. Else if a skill named **`nixpkgs-review`** is installed (user or project, e.g. `~/.agents/skills/nixpkgs-review/SKILL.md` or `.agents/skills/nixpkgs-review/SKILL.md`) → **read that skill completely** and use it as the full review procedure (nonstandard setups belong there).
+3. Else → **default strategy**: open [references/review-default.md](references/review-default.md) and run those commands from the nixpkgs checkout.
+
+To customize review long-term, add a **`nixpkgs-review`** skill; otherwise defaults apply. See [references/nixpkgs-review-skill.example.md](references/nixpkgs-review-skill.example.md) (example only—do not load unless creating that skill).
+
+After builds: exercise relevant binaries (often under `./result/bin/`), run applicable `passthru.tests` / NixOS tests; claim only platforms you used. Checkbox meaning → PR template + CONTRIBUTING PR template section.
+
+## Worktree (opt-in)
+
+Default: edit and build in the **current** checkout.
+
+Only if the user asks (e.g. “work on this in a worktree”) or the active `nixpkgs-review` skill requires it: `git fetch` the base, `git worktree add <path> <base>`, work there with the **same** guidelines. Do not create worktrees proactively.
+
+## Phase checklist (router)
+
+1. **Classify** — bump / init / fix / module / lib / docs / review-only PR.  
+2. **Open docs-map** rows for that class; read live files.  
+3. **Branch** — [`CONTRIBUTING.md` § Branch conventions](../../../CONTRIBUTING.md#branch-conventions) (no skill-side staging/Hydra tutorial).  
+4. **Edit** — nearest similar package + area README / language doc.  
+5. **Build / hashes** — expression + [`pkgs/README.md` § Sources](../../../pkgs/README.md#sources); language section if needed.  
+6. **Verify** — active review strategy (above); binaries/tests per PR template.  
+7. **Commit / PR** — commit conventions (area README + CONTRIBUTING); AI trailer if applicable; honest Things done; push and open PR per CONTRIBUTING “How to create pull requests”.  
+8. **CI / feedback** — ofborg and format (`nix fmt` / `treefmt` per [CONTRIBUTING code conventions](../../../CONTRIBUTING.md#code-conventions)); rebase/update per CONTRIBUTING PR section (`--force-with-lease` when rewriting).  
+9. **Worktree** — only if requested; then continue from step 3 in that tree.
+
+## Do not
+
+- Rehost or paraphrase multi-page policy into new skill files.  
+- Skip real verification; use **local builds + the active `nixpkgs-review` strategy** (custom skill or default card).  
+- Load obsolete personal playbooks from older skill versions—this skill is the entrypoint.

--- a/.agents/skills/nixpkgs/references/docs-map.md
+++ b/.agents/skills/nixpkgs/references/docs-map.md
@@ -1,0 +1,43 @@
+# Docs map (open live files — do not treat this table as policy text)
+
+Paths are relative to the **nixpkgs repository root**. Read the target when the topic applies. Prefer the file over memory.
+
+| Topic | Open |
+|-------|------|
+| Contributing overview, PR how-to, rebase, backport, review/merge culture | `CONTRIBUTING.md` |
+| Pull request template / Things done checkboxes | `.github/PULL_REQUEST_TEMPLATE.md` |
+| Branch choice (`master`, `staging`, `staging-nixos`, `release-*`), mass rebuilds | `CONTRIBUTING.md` → Branch conventions |
+| Staging workflow / Hydra batching (only if you need merge-flow context) | `CONTRIBUTING.md` → Staging |
+| Commit conventions (repo-wide) | `CONTRIBUTING.md` → Commit conventions |
+| Code conventions, formatting (`nix fmt` / `treefmt`), editorconfig | `CONTRIBUTING.md` → Code conventions |
+| Automation / AI policy (`Assisted-by`, accountability, exemptions) | `CONTRIBUTING.md` → Automation/AI policy |
+| Packages: layout, init gates, naming, versioning, meta | `pkgs/README.md` |
+| Package commit subject (`attr: old -> new`, `init at`, CI build prefixes) | `pkgs/README.md` → Commit conventions |
+| Sources, hashes, GitHub full `rev`, patches | `pkgs/README.md` → Sources (and Patches) |
+| Package tests, `passthru.tests`, linking NixOS tests | `pkgs/README.md` → Package tests |
+| Automatic updates / `passthru.updateScript` | `pkgs/README.md` → Automatic package updates |
+| Reviewing package PRs (human reviewer notes) | `pkgs/README.md` → Reviewing contributions |
+| `pkgs/by-name` layout and rules | `pkgs/by-name/README.md` |
+| Language / framework builders | `doc/languages-frameworks/<lang>.section.md` |
+| Fetchers (manual) | Nixpkgs manual § fetchers (from `pkgs/README.md` Sources links) |
+| NixOS modules and tests in-tree | `nixos/README.md`; tests also linked from PR template |
+| `lib` contributions | `lib/README.md` |
+| Nixpkgs manual / `doc` | `doc/README.md` |
+| Maintainers list, becoming a maintainer | `maintainers/README.md` |
+| ofborg behavior | https://github.com/NixOS/ofborg#readme (linked from CONTRIBUTING) |
+| `nixpkgs-review` usage and flags | https://github.com/Mic92/nixpkgs-review#usage — also `CONTRIBUTING.md` PR template section; default commands in [review-default.md](review-default.md) |
+| Custom review setups (optional agent skill) | User/project skill named `nixpkgs-review` |
+
+## Task → first opens
+
+| Task | Open first |
+|------|------------|
+| Version bump / package fix | Package expression; `pkgs/README.md` (Sources, commit conventions); then review strategy |
+| New package | `pkgs/README.md` Quick Start + gates; `pkgs/by-name/README.md`; similar packages |
+| Mass-rebuild / stdenv / widely used dep | `CONTRIBUTING.md` Branch conventions **before** large commits to `master` |
+| NixOS module | `nixos/README.md`; related module tests |
+| `lib` change | `lib/README.md` |
+| Docs-only | `doc/README.md` |
+| Add maintainer entry | `maintainers/README.md` (separate commit message convention in CONTRIBUTING) |
+| Backport | `CONTRIBUTING.md` → How to backport pull requests |
+| Review someone else’s PR | `CONTRIBUTING.md` → How to review; optional `nixpkgs-review` skill or [review-default.md](review-default.md) `pr` |

--- a/.agents/skills/nixpkgs/references/review-default.md
+++ b/.agents/skills/nixpkgs/references/review-default.md
@@ -1,0 +1,33 @@
+# Default review strategy (`nixpkgs-review`)
+
+Use this file **only** when no user instruction overrides review **and** no skill named `nixpkgs-review` is installed.
+
+Canonical mentions: [`CONTRIBUTING.md`](../../../../CONTRIBUTING.md) (PR template / Things done section), [Mic92/nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage).
+
+Run from the **nixpkgs git checkout** (not a random subdirectory outside the tree). Prefer a full clone; shallow clones can break merges (upstream README).
+
+## Commands
+
+| Situation | Command |
+|-----------|---------|
+| Uncommitted changes | `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` |
+| Staged only | `nix-shell -p nixpkgs-review --run "nixpkgs-review wip --staged"` |
+| Local commit(s) | `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` |
+| GitHub PR by number or URL | `nix run nixpkgs#nixpkgs-review -- pr <N-or-URL>` |
+| Post markdown result on PR (reviewer) | `nixpkgs-review pr <N> --post-result` (optional `--no-logs`) |
+| Non-interactive / agent | add `--no-shell` where supported; see Mic92 README for current flags |
+
+Flake-style equivalents of the shell form are fine, e.g. `nix run nixpkgs#nixpkgs-review -- wip`.
+
+## After a successful build
+
+- Exercise relevant binaries (often `./result/bin/` or paths from the review environment).
+- Run applicable package tests (`passthru.tests`) and NixOS tests if the change warrants it — see PR template links and `pkgs/README.md` § Package tests.
+- Record **only** platforms you actually built on in Things done.
+- Do **not** claim `nixpkgs-review` in the PR unless you ran it (or the active custom skill’s equivalent).
+
+## Flags and advanced behavior
+
+Do not invent flags. Open [Mic92/nixpkgs-review](https://github.com/Mic92/nixpkgs-review#usage) for `--systems`, package filters, `--post-result`, tokens, etc.
+
+Optional tools (`nom`, `glow`, `delta`, remote builders) are **not** required by this default strategy. Put personal stacks in a **`nixpkgs-review`** skill.


### PR DESCRIPTION



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
