### PR TITLE
qmplay2: 25.09.11 -> 26.06.27

### DIFF
--- a/pkgs/by-name/qm/qmplay2/package.nix
+++ b/pkgs/by-name/qm/qmplay2/package.nix
@@ -18,13 +18,21 @@
   libxcb,
   ninja,
   pkg-config,
+  shaderc,
   qt5,
   qt6,
   taglib,
   vulkan-headers,
   vulkan-tools,
-  rubberband,
   deno,
+  expat,
+  libmpg123,
+  libogg,
+  libopenmpt,
+  libsysprof-capture,
+  libvorbis,
+  pipewire,
+  rubberband,
   # Configurable options
   qtVersion ? "6", # Can be 5 or 6
 }:
@@ -54,6 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     ninja
     pkg-config
+    shaderc
   ]
   ++ lib.optionals (qtVersion == "6") [ qt6.wrapQtAppsHook ]
   ++ lib.optionals (qtVersion == "5") [ qt5.wrapQtAppsHook ];
@@ -76,6 +85,13 @@ stdenv.mkDerivation (finalAttrs: {
     vulkan-headers-qmplay2
     vulkan-tools
     deno
+    expat
+    libmpg123
+    libogg
+    libopenmpt
+    libsysprof-capture
+    libvorbis
+    pipewire
   ]
   ++ lib.optionals (qtVersion == "6") [
     rubberband

--- a/pkgs/by-name/qm/qmplay2/package.nix
+++ b/pkgs/by-name/qm/qmplay2/package.nix
@@ -105,6 +105,10 @@ stdenv.mkDerivation (finalAttrs: {
     qt5.qttools
   ];
 
+  cmakeFlags = lib.optionals (qtVersion == "5") [
+    (lib.cmakeBool "BUILD_WITH_QT6" false)
+  ];
+
   strictDeps = true;
 
   # Because we think it is better to use only lowercase letters!

--- a/pkgs/by-name/qm/qmplay2/sources.nix
+++ b/pkgs/by-name/qm/qmplay2/sources.nix
@@ -5,13 +5,13 @@
     let
       self = {
         pname = "qmplay2";
-        version = "25.09.11";
+        version = "26.06.27";
 
         src = fetchFromGitHub {
           owner = "zaps166";
           repo = "QMPlay2";
           tag = self.version;
-          hash = "sha256-1F6VOTMJZ64PlIVSWoYzNz4LVmn5pEcUq+IfstYDwYo=";
+          hash = "sha256-8PY6s74unLgwDFlyiHHCWrsatdI05obbREOICZoI+lU=";
         };
       };
     in
@@ -21,13 +21,13 @@
     let
       self = {
         pname = "vulkan-headers";
-        version = "1.4.317";
+        version = "1.4.350";
 
         src = fetchFromGitHub {
           owner = "KhronosGroup";
           repo = "Vulkan-Headers";
           tag = "v${self.version}";
-          hash = "sha256-ezNthwKsnXehQfrQh0zTk6Zrz3JgdqjYu68abYUWIik=";
+          hash = "sha256-RcUVurC+Rc0MyWpQLaLVmdn7FZO1GWWzTZZAOwvKwb4=";
         };
       };
     in
@@ -35,13 +35,13 @@
 
   qmvk = {
     pname = "qmvk";
-    version = "0-unstable-2025-09-02";
+    version = "0-unstable-2026-06-21";
 
     src = fetchFromGitHub {
       owner = "zaps166";
       repo = "QmVk";
-      rev = "0225dc851afaf39be2b92f91d4316e866f4b6133";
-      hash = "sha256-W2102+X+gE/9ghdAwWBeWYmSkSdp6lLPx4IKaQpLANI=";
+      rev = "26ef419a3b91bc11856c714b3b932c62db098bf9";
+      hash = "sha256-EaOGXYjon1brDQx+l7C2jvUkYgkW+D1qP52JPiMr3H0=";
     };
   };
 }


### PR DESCRIPTION
https://github.com/zaps166/QMPlay2/releases/tag/26.06.27
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
