### PR TITLE
ctranslate2: don't set default nvcc arch flags

### DIFF
--- a/pkgs/by-name/ct/ctranslate2/package.nix
+++ b/pkgs/by-name/ct/ctranslate2/package.nix
@@ -51,6 +51,13 @@ stdenv'.mkDerivation (finalAttrs: {
         'CMAKE_MINIMUM_REQUIRED(VERSION 3.10 FATAL_ERROR)'
 
     sed -e '1i #include <cstdint>' -i third_party/cxxopts/include/cxxopts.hpp
+
+    # Prevent setting the default nvcc arch flags, which can be
+    # ones that don't work with the current CUDA version
+    substituteInPlace CMakeLists.txt \
+      --replace-fail \
+        'list(APPEND CUDA_NVCC_FLAGS ''${ARCH_FLAGS})' \
+        ""
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
This fixes a build failure when using cudaPackages_13:

> Unsupported gpu architecture 'compute_53'

Build failure originally reproduced with:
```
nix build -f =(echo 'with (import (builtins.getFlake "nixpkgs/nixos-unstable")  { config = { cudaSupport = true; allowUnfree=true; }; }).extend (final: prev: { cudaPackages = final.cudaPackages_13; }); ctranslate2' )
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
