### PR TITLE
calendar-cli: 1.0.2 -> 1.0.3

### DIFF
--- a/pkgs/by-name/ca/calendar-cli/package.nix
+++ b/pkgs/by-name/ca/calendar-cli/package.nix
@@ -12,29 +12,25 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "calendar-cli";
-  version = "1.0.2";
+  version = "1.0.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pycalendar";
     repo = "calendar-cli";
-    # https://github.com/pycalendar/calendar-cli/pull/113#issuecomment-3977892432
-    tag = "v0.15.0";
-    hash = "sha256-P6ClvX6C5VargAvudgSvBwObIUouTRg7SQ62KxhcKiE=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-5qPBHwOPW/HsmO/jBMyq6ROb23JYfJ/XLWmHwgb5kPY=";
   };
 
   postPatch = ''
-    substituteInPlace calendar_cli/metadata.py \
-      --replace-fail '"version": "1.0.1"' '"version": "${finalAttrs.version}"'
-
     patchShebangs tests
     substituteInPlace tests/test_calendar-cli.sh \
-      --replace-fail "../bin/calendar-cli.py" "$out/bin/calendar-cli" \
-      --replace-fail "../bin/calendar-cli" "$out/bin/calendar-cli"
+      --replace-fail "../bin/calendar-cli.py" "$out/bin/calendar-cli"
   '';
 
   build-system = with python3.pkgs; [
-    setuptools
+    hatch-vcs
+    hatchling
   ];
 
   dependencies = with python3.pkgs; [
@@ -45,7 +41,6 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     tzlocal
     click
     six
-    urllib3
     vobject
   ];
 


### PR DESCRIPTION
Diff: https://github.com/pycalendar/calendar-cli/compare/v1.0.2...v1.0.3

Changelog: https://github.com/pycalendar/calendar-cli/releases/tag/v1.0.3


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
