### PR TITLE
python3Packages.ocrmypdf: 17.7.0 -> 17.7.1

### DIFF
--- a/pkgs/development/python-modules/ocrmypdf/default.nix
+++ b/pkgs/development/python-modules/ocrmypdf/default.nix
@@ -32,7 +32,7 @@
 
 buildPythonPackage rec {
   pname = "ocrmypdf";
-  version = "17.7.0";
+  version = "17.7.1";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     postFetch = ''
       rm "$out/.git_archival.txt"
     '';
-    hash = "sha256-3WBqXrt1u7Xl1JJAKUHC3C5arCfCEsrYglIOfMrUx9g=";
+    hash = "sha256-LHNaWpnx11EGKvmudicMFCQJzTQMB2+Rz5JgHJN7lFk=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/ocrmypdf/use-pillow-heif.patch
+++ b/pkgs/development/python-modules/ocrmypdf/use-pillow-heif.patch
@@ -1,22 +1,22 @@
 diff --git a/pyproject.toml b/pyproject.toml
-index 2caa0e75..f6fcf60a 100644
+index 7be62275..0b70ad88 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
-@@ -16,7 +16,7 @@ dependencies = [
+@@ -17,7 +17,7 @@ dependencies = [
    "img2pdf>=0.5",
    "packaging>=20",
-   "pdfminer.six>=20220319",
+   "pdfminer.six>=20260107",  # fixes parsing of tokens split across the read buffer/streams (gh #1361)
 -  "pi-heif",                # Heif image format - maintainers: if this is removed, it will NOT break
 +  "pillow-heif",                # Heif image format - maintainers: if this is removed, it will NOT break
    "pikepdf>=10",
    "Pillow>=10.0.1",
    "pluggy>=1",
 diff --git a/src/ocrmypdf/_pipeline.py b/src/ocrmypdf/_pipeline.py
-index 90524d58..0be5a0f8 100644
+index 161d77df..1ec03a12 100644
 --- a/src/ocrmypdf/_pipeline.py
 +++ b/src/ocrmypdf/_pipeline.py
-@@ -42,7 +42,7 @@ from ocrmypdf.pdfinfo import Colorspace, Encoding, PageInfo, PdfInfo
- from ocrmypdf.pluginspec import OrientationConfidence
+@@ -49,7 +49,7 @@ from ocrmypdf.pdfinfo import Colorspace, Encoding, FloatRect, Ink, PageInfo, Pdf
+ from ocrmypdf.pluginspec import GhostscriptRasterDevice, OrientationConfidence
  
  try:
 -    from pi_heif import register_heif_opener


### PR DESCRIPTION
Diff: https://github.com/ocrmypdf/OCRmyPDF/compare/v17.7.0...v17.7.1

Changelog: https://github.com/ocrmypdf/OCRmyPDF/blob/v17.7.1/docs/releasenotes/version17.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
