### PR TITLE
nixos/journald: migrate to RFC 42-style settings

### DIFF
--- a/nixos/doc/manual/administration/systemd-state.section.md
+++ b/nixos/doc/manual/administration/systemd-state.section.md
@@ -47,6 +47,6 @@ form to `/var/log/journal/{machine-id}`; if (locally) persisting the entire log
 is desired, it is recommended to make all of `/var/log/journal` persistent.
 
 If not, one can set `Storage=volatile` in {manpage}`journald.conf(5)`
-([`services.journald.storage = "volatile";`](#opt-services.journald.storage)),
+([`services.journald.settings.Journal.Storage = "volatile";`](#opt-services.journald.settings.Journal)),
 which disables journal persistence and causes it to be written to
 `/run/log/journal`.

--- a/nixos/modules/services/logging/rsyslogd.nix
+++ b/nixos/modules/services/logging/rsyslogd.nix
@@ -84,6 +84,8 @@ in
 
   config = lib.mkIf cfg.enable {
 
+    services.journald.settings.Journal.ForwardToSyslog = lib.mkOptionDefault true;
+
     environment.systemPackages = [ pkgs.rsyslog ];
 
     systemd.services.syslog = {

--- a/nixos/modules/services/logging/syslog-ng.nix
+++ b/nixos/modules/services/logging/syslog-ng.nix
@@ -77,6 +77,8 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    services.journald.settings.Journal.ForwardToSyslog = lib.mkOptionDefault true;
+
     systemd.services.syslog-ng = {
       description = "syslog-ng daemon";
       wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/system/boot/systemd/journald.nix
+++ b/nixos/modules/system/boot/systemd/journald.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  pkgs,
   utils,
   ...
 }:
@@ -10,111 +9,65 @@ let
 in
 {
   imports = [
+    (lib.mkRenamedOptionModule
+      [ "services" "journald" "storage" ]
+      [ "services" "journald" "settings" "Journal" "Storage" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "journald" "rateLimitInterval" ]
+      [ "services" "journald" "settings" "Journal" "RateLimitIntervalSec" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "journald" "rateLimitBurst" ]
+      [ "services" "journald" "settings" "Journal" "RateLimitBurst" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "journald" "forwardToSyslog" ]
+      [ "services" "journald" "settings" "Journal" "ForwardToSyslog" ]
+    )
+    (lib.mkRemovedOptionModule
+      [
+        "services"
+        "journald"
+        "console"
+      ]
+      "Use services.journald.settings.Journal.ForwardToConsole and services.journald.settings.Journal.TTYPath instead."
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "journald" "audit" ]
+      [ "services" "journald" "settings" "Journal" "Audit" ]
+    )
+    (lib.mkRemovedOptionModule [
+      "services"
+      "journald"
+      "extraConfig"
+    ] "Use services.journald.settings.Journal instead.")
   ];
 
   options = {
-    services.journald.console = lib.mkOption {
-      default = "";
-      type = lib.types.str;
-      description = "If non-empty, write log messages to the specified TTY device.";
-    };
-
-    services.journald.rateLimitInterval = lib.mkOption {
-      default = "30s";
-      type = lib.types.str;
+    services.journald.settings.Journal = lib.mkOption {
+      default = { };
+      example = {
+        Storage = "volatile";
+        ForwardToConsole = true;
+        TTYPath = "/dev/tty12";
+      };
       description = ''
-        Configures the rate limiting interval that is applied to all
-        messages generated on the system. This rate limiting is applied
-        per-service, so that two services which log do not interfere with
-        each other's limit. The value may be specified in the following
-        units: s, min, h, ms, us. To turn off any kind of rate limiting,
-        set either value to 0.
-
-        See {option}`services.journald.rateLimitBurst` for important
-        considerations when setting this value.
+        Options for the systemd journal service. See {manpage}`journald.conf(5)`
+        man page for available options.
       '';
-    };
-
-    services.journald.storage = lib.mkOption {
-      default = "persistent";
-      type = lib.types.enum [
-        "persistent"
-        "volatile"
-        "auto"
-        "none"
-      ];
-      description = ''
-        Controls where to store journal data. See
-        {manpage}`journald.conf(5)` for further information.
-      '';
-    };
-
-    services.journald.rateLimitBurst = lib.mkOption {
-      default = 10000;
-      type = lib.types.int;
-      description = ''
-        Configures the rate limiting burst limit (number of messages per
-        interval) that is applied to all messages generated on the system.
-        This rate limiting is applied per-service, so that two services
-        which log do not interfere with each other's limit.
-
-        Note that the effective rate limit is multiplied by a factor derived
-        from the available free disk space for the journal as described on
-        {manpage}`journald.conf(5)`.
-
-        Note that the total amount of logs stored is limited by journald settings
-        such as `SystemMaxUse`, which defaults to 10% the file system size
-        (capped at max 4GB), and `SystemKeepFree`, which defaults to 15% of the
-        file system size.
-
-        It is thus recommended to compute what period of time that you will be
-        able to store logs for when an application logs at full burst rate.
-        With default settings for log lines that are 100 Bytes long, this can
-        amount to just a few hours.
-      '';
-    };
-
-    services.journald.audit = lib.mkOption {
-      default = "keep";
-      type = lib.types.oneOf [
-        lib.types.bool
-        (lib.types.enum [ "keep" ])
-      ];
-      description = ''
-        If enabled systemd-journald will turn on auditing on start-up.
-        If disabled it will turn it off. If unset it will neither enable nor disable it, leaving the previous state unchanged.
-
-        NixOS defaults to leaving this unset as enabling audit without auditd running leads to spamming /dev/kmesg with random messages
-        and if you enable auditd then auditd is responsible for turning auditing on.
-
-        If you want to have audit logs in journald and do not mind audit logs also ending up in /dev/kmesg you can set this option to true.
-
-        If you want to for some ununderstandable reason disable auditing if auditd enabled it then you can set this option to false.
-        It is of NixOS' opinion that setting this to false is definitely the wrong thing to do - but it's an option.
-      '';
-    };
-
-    services.journald.extraConfig = lib.mkOption {
-      default = "";
-      type = lib.types.lines;
-      example = "Storage=volatile";
-      description = ''
-        Extra config options for systemd-journald. See {manpage}`journald.conf(5)`
-        for available options.
-      '';
-    };
-
-    services.journald.forwardToSyslog = lib.mkOption {
-      default = config.services.rsyslogd.enable || config.services.syslog-ng.enable;
-      defaultText = lib.literalExpression "services.rsyslogd.enable || services.syslog-ng.enable";
-      type = lib.types.bool;
-      description = ''
-        Whether to forward log messages to syslog.
-      '';
+      type = lib.types.submodule {
+        freeformType = lib.types.attrsOf utils.systemdUtils.unitOptions.unitOption;
+      };
     };
   };
 
   config = {
+    services.journald.settings.Journal = {
+      # "keep" isn't systemd's default since v258, so set it explicitly.
+      Audit = lib.mkOptionDefault "keep";
+    };
+
     systemd.additionalUpstreamSystemUnits = [
       "systemd-journald.socket"
       "systemd-journald@.socket"
@@ -136,23 +89,8 @@ in
       "sockets.target"
     ];
 
-    environment.etc = {
-      "systemd/journald.conf".text = ''
-        [Journal]
-        Storage=${cfg.storage}
-        RateLimitInterval=${cfg.rateLimitInterval}
-        RateLimitBurst=${toString cfg.rateLimitBurst}
-        ${lib.optionalString (cfg.console != "") ''
-          ForwardToConsole=yes
-          TTYPath=${cfg.console}
-        ''}
-        ${lib.optionalString (cfg.forwardToSyslog) ''
-          ForwardToSyslog=yes
-        ''}
-        Audit=${utils.systemdUtils.lib.toOption cfg.audit}
-        ${cfg.extraConfig}
-      '';
-    };
+    environment.etc."systemd/journald.conf".text =
+      utils.systemdUtils.lib.settingsToSections cfg.settings;
 
     users.groups.systemd-journal.gid = config.ids.gids.systemd-journal;
 

--- a/nixos/modules/testing/test-instrumentation.nix
+++ b/nixos/modules/testing/test-instrumentation.nix
@@ -233,11 +233,11 @@ in
     environment.systemPackages = [ pkgs.xwininfo ];
 
     # Log everything to the serial console.
-    services.journald.extraConfig = ''
-      ForwardToConsole=yes
-      TTYPath=/dev/${qemu-common.qemuSerialDevice}
-      MaxLevelConsole=debug
-    '';
+    services.journald.settings.Journal = {
+      ForwardToConsole = true;
+      TTYPath = "/dev/${qemu-common.qemuSerialDevice}";
+      MaxLevelConsole = "debug";
+    };
 
     systemd.settings.Manager = managerSettings;
     systemd.user.settings.Manager = {

--- a/nixos/tests/rsyslogd.nix
+++ b/nixos/tests/rsyslogd.nix
@@ -13,10 +13,11 @@ with pkgs.lib;
     meta.maintainers = [ pkgs.lib.maintainers.aanderse ];
 
     nodes.machine =
-      { config, pkgs, ... }:
+      { lib, ... }:
       {
         services.rsyslogd.enable = true;
-        services.journald.forwardToSyslog = false;
+        # Verify that the module's option default remains overridable by downstream defaults.
+        services.journald.settings.Journal.ForwardToSyslog = lib.mkDefault false;
       };
 
     # ensure rsyslogd isn't receiving messages from journald if explicitly disabled
@@ -31,7 +32,7 @@ with pkgs.lib;
     meta.maintainers = [ pkgs.lib.maintainers.aanderse ];
 
     nodes.machine =
-      { config, pkgs, ... }:
+      { ... }:
       {
         services.rsyslogd.enable = true;
       };

--- a/nixos/tests/systemd-journal.nix
+++ b/nixos/tests/systemd-journal.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ lib, pkgs, ... }:
 
 {
   name = "systemd-journal";
@@ -14,7 +14,8 @@
     security.audit.enable = true;
   };
   nodes.journaldAudit = {
-    services.journald.audit = true;
+    # Verify that the module's option default remains overridable by downstream defaults.
+    services.journald.settings.Journal.Audit = lib.mkDefault true;
     security.audit.enable = true;
   };
   nodes.containerCheck = {
@@ -45,6 +46,7 @@
 
     with subtest("journald audit"):
       journaldAudit.wait_for_unit("multi-user.target")
+      journaldAudit.succeed("grep -Fx 'Audit=true' /etc/systemd/journald.conf")
 
       # logs should end up in the journald
       journaldAudit.succeed("journalctl _TRANSPORT=audit --grep 'unit=systemd-journald'")

--- a/nixos/tests/systemd.nix
+++ b/nixos/tests/systemd.nix
@@ -35,7 +35,7 @@
         KExecWatchdogSec = "5min";
       };
       systemd.user.settings.Manager.DefaultEnvironment = "\"XXX_USER=bar\"";
-      services.journald.extraConfig = "Storage=volatile";
+      services.journald.settings.Journal.Storage = "volatile";
       test-support.displayManager.auto.user = "alice";
 
       systemd.shutdownRamfs.contents."/etc/systemd/system-shutdown/test".source =


### PR DESCRIPTION
Continues #455499. Adds `services.journald.settings.Journal`, renames the old options into it, and drops `extraConfig`/`console`/`audit`. Co-authored by @LordGrimmauld.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
