### PR TITLE
python3Packages.mpl-typst: 0.2.1 -> 0.3.1

### DIFF
--- a/pkgs/development/python-modules/mpl-typst/default.nix
+++ b/pkgs/development/python-modules/mpl-typst/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "mpl-typst";
-  version = "0.2.1";
+  version = "0.3.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "daskol";
     repo = "mpl-typst";
     tag = "v${version}";
-    hash = "sha256-lkO4BTo3duNAsppTjteeBuzgSJL/UnKVW2QXgrfVrqM=";
+    hash = "sha256-RVzovICoDqEnjq0HngSe4vLlPszSgkq1FF0/Jrnw34Y=";
   };
 
   postPatch = ''
@@ -53,14 +53,21 @@ buildPythonPackage rec {
     "mpl_typst.as_default"
   ];
 
-  disabledTests = [
-    # runs typst and gets "error: failed to download package"
-    "test_draw_path"
-    "test_draw_image_lenna"
-    "test_draw_image_spy"
-  ];
-
-  disabledTestPaths = lib.optional stdenv.hostPlatform.isDarwin [
+  disabledTestPaths = [
+    # These render generated Typst through the typst binary. The prologue
+    # imports @preview/based, so Typst attempts to download a package in the
+    # Nix sandbox.
+    "mpl_typst/backend_test.py::TestTypstRenderer::test_draw_path"
+    "mpl_typst/backend_test.py::TestTypstRenderer::test_draw_path_clips_to_bbox"
+    "mpl_typst/backend_test.py::TestTypstRenderer::test_draw_path_bbox_pixels"
+    "mpl_typst/backend_test.py::TestTypstRenderer::test_draw_path_hatched_rect_pixels"
+    "mpl_typst/backend_test.py::TestTypstRenderer::test_draw_path_hatched_rect_pixels_golden"
+    "mpl_typst/backend_test.py::TestTypstRenderer::test_draw_text_colored"
+    "mpl_typst/backend_test.py::TestTypstRenderer::test_draw_image_lenna"
+    "mpl_typst/backend_test.py::TestTypstRenderer::test_draw_image_spy"
+    "tests/regression/issue32_test.py::TestIssue32::test_reference"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # fatal error when matplotlib creates a canvas
     "mpl_typst/backend_test.py"
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Package `mpl-typst` has been updated with compatibility to newer Typst versions ([v0.3.0][0.3.0] and [v0.3.1][0.3.1]).

[0.3.0]: https://github.com/daskol/mpl-typst/releases/tag/v0.3.0
[0.3.1]: https://github.com/daskol/mpl-typst/releases/tag/v0.3.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


@genga898 Take a look at this PR, please.