### PR TITLE
thorium-reader: add `.app` bundle on macOS

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -814,6 +814,12 @@
     github = "aftix";
     githubId = 4008299;
   };
+  agarmu = {
+    name = "Mukul Agarwal";
+    email = "vcs@agarmu.com";
+    github = "agarmu";
+    githubId = 55563106;
+  };
   agbrooks = {
     email = "andrewgrantbrooks@gmail.com";
     github = "agbrooks";

--- a/pkgs/by-name/th/thorium-reader/package.nix
+++ b/pkgs/by-name/th/thorium-reader/package.nix
@@ -27,10 +27,9 @@ buildNpmPackage (finalAttrs: {
   };
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
-  # makeBinaryWrapper is preferred on Darwin since the OS may confuse itself
+  # makeBinaryWrapper is required on Darwin since MacOS is confuses itself
   # into thinking it needs Rosetta 2 if it encounters a non-MachO executable
-  # in a .app bundle
-
+  # in a .app bundle.
   # Simultaneously, we need makeShellWrapper on linux platforms to pass
   # electron-specific flags.
   nativeBuildInputs = [

--- a/pkgs/by-name/th/thorium-reader/package.nix
+++ b/pkgs/by-name/th/thorium-reader/package.nix
@@ -1,12 +1,15 @@
 {
   lib,
+  stdenv,
   buildNpmPackage,
   fetchFromGitHub,
   nodejs_24,
-  makeWrapper,
+  makeShellWrapper,
+  makeBinaryWrapper,
   electron,
   copyDesktopItems,
   makeDesktopItem,
+  desktopToDarwinBundle,
 }:
 
 buildNpmPackage (finalAttrs: {
@@ -24,23 +27,40 @@ buildNpmPackage (finalAttrs: {
   };
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+  # makeBinaryWrapper is preferred on Darwin since the OS may confuse itself
+  # into thinking it needs Rosetta 2 if it encounters a non-MachO executable
+  # in a .app bundle
 
+  # Simultaneously, we need makeShellWrapper on linux platforms to pass
+  # electron-specific flags.
   nativeBuildInputs = [
-    makeWrapper
     copyDesktopItems
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    makeShellWrapper
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    makeBinaryWrapper
+    desktopToDarwinBundle
   ];
 
-  postInstall = ''
-    install -Dpm644 resources/icon.png $out/share/icons/thorium-reader.png
+  postInstall =
+    let
+      ozoneFlags = lib.optionalString stdenv.hostPlatform.isLinux ''--add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"'';
+    in
+    ''
+      install -Dpm644 resources/icon.png $out/share/icons/thorium-reader.png
 
-    cp -r dist/* $out/lib/node_modules/EDRLab.ThoriumReader/
+      cp -r dist/* $out/lib/node_modules/EDRLab.ThoriumReader/
 
-    makeWrapper '${lib.getExe electron}' "$out/bin/thorium-reader" \
-      --add-flags $out/lib/node_modules/EDRLab.ThoriumReader \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
-      --set-default ELECTRON_IS_DEV 0 \
-      --inherit-argv0
-  '';
+      ${
+        if stdenv.hostPlatform.isDarwin then "makeBinaryWrapper" else "makeWrapper"
+      } '${lib.getExe electron}' "$out/bin/thorium-reader" \
+        --add-flags $out/lib/node_modules/EDRLab.ThoriumReader \
+        ${ozoneFlags} \
+        --set-default ELECTRON_IS_DEV 0 \
+        --inherit-argv0
+    '';
 
   desktopItems = [
     (makeDesktopItem {

--- a/pkgs/by-name/th/thorium-reader/package.nix
+++ b/pkgs/by-name/th/thorium-reader/package.nix
@@ -91,7 +91,10 @@ buildNpmPackage (finalAttrs: {
     description = "EPUB reader";
     homepage = "https://www.edrlab.org/software/thorium-reader/";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ YodaDaCoda ];
+    maintainers = with lib.maintainers; [
+      YodaDaCoda
+      agarmu
+    ];
     platforms = lib.platforms.all;
     mainProgram = "thorium-reader";
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
In this commit, I:
- added a `Thorium.app` bundle for macOS.  The bundle is auto-generated from the existing desktop entry by an existing nixpkgs helper, `desktopToDarwinBundle`
- changed the `makeWrapper` to a `makeBinaryWrapper` in the thorium-reader derivation, to help compatibility on Darwin. I tested without changing the makeWrapper to makeBinaryWrapper and did indeed run into the issue i describe in the comment.
- added myself (agarmu) as a maintainer; I can remove myself if the existing maintainers would prefer.

There is one minor issue regarding the generated macOS bundle not containing a proper icon, which is fixed in a separate PR (#536162).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
