### PR TITLE
buildFishPlugin: allow `finalAttrs` pattern

### DIFF
--- a/pkgs/shells/fish/plugins/build-fish-plugin.nix
+++ b/pkgs/shells/fish/plugins/build-fish-plugin.nix
@@ -3,6 +3,7 @@
   lib,
   writeScript,
   wrapFish,
+  writableTmpDirAsHomeHook,
 }:
 lib.extendMkDerivation {
   constructDrv = stdenv.mkDerivation;
@@ -60,6 +61,7 @@ lib.extendMkDerivation {
       inherit doCheck;
 
       nativeCheckInputs = [
+        writableTmpDirAsHomeHook
         (wrapFish {
           pluginPkgs = checkPlugins;
           functionDirs = checkFunctionDirs;
@@ -68,7 +70,6 @@ lib.extendMkDerivation {
       ++ nativeCheckInputs;
 
       checkPhase = ''
-        export HOME=$(mktemp -d)  # fish wants a writable home
         fish "${writeScript "${finalAttrs.name}-test" checkPhase}"
       '';
     };

--- a/pkgs/shells/fish/plugins/build-fish-plugin.nix
+++ b/pkgs/shells/fish/plugins/build-fish-plugin.nix
@@ -4,83 +4,72 @@
   writeScript,
   wrapFish,
 }:
-
-attrs@{
-  pname,
-  version,
-  src,
-
-  name ? "fishplugin-${pname}-${version}",
-  unpackPhase ? "",
-  configurePhase ? ":",
-  buildPhase ? ":",
-  preInstall ? "",
-  postInstall ? "",
-
-  nativeCheckInputs ? [ ],
-  # plugin packages to add to the vendor paths of the test fish shell
-  checkPlugins ? [ ],
-  # vendor directories to add to the function path of the test fish shell
-  checkFunctionDirs ? [ ],
-  # test script to be executed in a fish shell
-  checkPhase ? "",
-  doCheck ? checkPhase != "",
-
-  ...
-}:
-
-let
-  # Do not pass attributes that are only relevant to buildFishPlugin to mkDerivation.
-  drvAttrs = removeAttrs attrs [
+lib.extendMkDerivation {
+  constructDrv = stdenv.mkDerivation;
+  excludeDrvArgNames = [
     "checkPlugins"
     "checkFunctionDirs"
   ];
-in
+  extendDrvArgs =
+    finalAttrs:
+    {
+      name ? "fishplugin-${finalAttrs.pname}-${finalAttrs.version}",
+      unpackPhase ? "",
+      configurePhase ? ":",
+      buildPhase ? ":",
 
-stdenv.mkDerivation (
-  drvAttrs
-  // {
-    inherit name;
-    inherit unpackPhase configurePhase buildPhase;
+      nativeCheckInputs ? [ ],
+      # plugin packages to add to the vendor paths of the test fish shell
+      checkPlugins ? [ ],
+      # vendor directories to add to the function path of the test fish shell
+      checkFunctionDirs ? [ ],
+      # test script to be executed in a fish shell
+      checkPhase ? "",
+      doCheck ? checkPhase != "",
 
-    inherit preInstall postInstall;
-    installPhase = ''
-      runHook preInstall
+      ...
+    }:
+    {
+      inherit name;
+      inherit unpackPhase configurePhase buildPhase;
 
-      (
-        install_vendor_files() {
-          source="$1"
-          target="$out/share/fish/vendor_$2.d"
+      installPhase = ''
+        runHook preInstall
 
-          # Check if any .fish file exists in $source
-          [ -n "$(shopt -s nullglob; echo $source/*.fish)" ] || return 0
+        (
+          install_vendor_files() {
+            source="$1"
+            target="$out/share/fish/vendor_$2.d"
 
-          mkdir -p $target
-          cp $source/*.fish "$target/"
-        }
+            # Check if any .fish file exists in $source
+            [ -n "$(shopt -s nullglob; echo $source/*.fish)" ] || return 0
 
-        install_vendor_files completions completions
-        install_vendor_files functions functions
-        install_vendor_files conf conf
-        install_vendor_files conf.d conf
-      )
+            mkdir -p $target
+            cp $source/*.fish "$target/"
+          }
 
-      runHook postInstall
-    '';
+          install_vendor_files completions completions
+          install_vendor_files functions functions
+          install_vendor_files conf conf
+          install_vendor_files conf.d conf
+        )
 
-    inherit doCheck;
+        runHook postInstall
+      '';
 
-    nativeCheckInputs = [
-      (wrapFish {
-        pluginPkgs = checkPlugins;
-        functionDirs = checkFunctionDirs;
-      })
-    ]
-    ++ nativeCheckInputs;
+      inherit doCheck;
 
-    checkPhase = ''
-      export HOME=$(mktemp -d)  # fish wants a writable home
-      fish "${writeScript "${name}-test" checkPhase}"
-    '';
-  }
-)
+      nativeCheckInputs = [
+        (wrapFish {
+          pluginPkgs = checkPlugins;
+          functionDirs = checkFunctionDirs;
+        })
+      ]
+      ++ nativeCheckInputs;
+
+      checkPhase = ''
+        export HOME=$(mktemp -d)  # fish wants a writable home
+        fish "${writeScript "${finalAttrs.name}-test" checkPhase}"
+      '';
+    };
+}

--- a/pkgs/shells/fish/plugins/done.nix
+++ b/pkgs/shells/fish/plugins/done.nix
@@ -5,15 +5,14 @@
   fishtape,
   jq,
 }:
-
-buildFishPlugin rec {
+buildFishPlugin (finalAttrs: {
   pname = "done";
   version = "1.21.1";
 
   src = fetchFromGitHub {
     owner = "franciscolourenco";
     repo = "done";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-GZ1ZpcaEfbcex6XvxOFJDJqoD9C5out0W4bkkn768r0=";
   };
 
@@ -37,4 +36,4 @@ buildFishPlugin rec {
       rexies
     ];
   };
-}
+})

--- a/pkgs/shells/fish/plugins/pisces.nix
+++ b/pkgs/shells/fish/plugins/pisces.nix
@@ -3,15 +3,14 @@
   buildFishPlugin,
   fetchFromGitHub,
 }:
-
-buildFishPlugin rec {
+buildFishPlugin (finalAttrs: {
   pname = "pisces";
   version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "laughedelic";
     repo = "pisces";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Oou2IeNNAqR00ZT3bss/DbhrJjGeMsn9dBBYhgdafBw=";
   };
 
@@ -21,4 +20,4 @@ buildFishPlugin rec {
     license = lib.licenses.lgpl3;
     maintainers = with lib.maintainers; [ vanilla ];
   };
-}
+})

--- a/pkgs/shells/fish/plugins/pure.nix
+++ b/pkgs/shells/fish/plugins/pure.nix
@@ -5,15 +5,14 @@
   git,
   fishtape_3,
 }:
-
-buildFishPlugin rec {
+buildFishPlugin (finalAttrs: {
   pname = "pure";
   version = "4.15.0";
 
   src = fetchFromGitHub {
     owner = "pure-fish";
     repo = "pure";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-fqcIfst9YnkOi50pIUMoJJQ7s1w1Vr6hRdEFo+FWIZY=";
   };
 
@@ -32,4 +31,4 @@ buildFishPlugin rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ euxane ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update the `buildFishPlugin` helper to allow for the `finalAttrs` pattern. Also migrated some plugins to test the new upgraded version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
