### PR TITLE
maintainers: remove ftrvxmtrx

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9542,12 +9542,6 @@
     name = "Fritz Stracke";
     keys = [ { fingerprint = "7A9D 6DB2 0C5A AA55 7838  EEE6 B8CA 2D9A D8F0 506F"; } ];
   };
-  ftrvxmtrx = {
-    email = "ftrvxmtrx@gmail.com";
-    github = "ftrvxmtrx";
-    githubId = 248148;
-    name = "Sigrid Solveig Haflínudóttir";
-  };
   ftsimas = {
     name = "Filippos Tsimas";
     email = "filippos.tsimas@outlook.com";

--- a/pkgs/applications/audio/mpg123/default.nix
+++ b/pkgs/applications/audio/mpg123/default.nix
@@ -96,7 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Fast console MPEG Audio Player and decoder library";
     homepage = "https://mpg123.org";
     license = lib.licenses.lgpl21Only;
-    maintainers = with lib.maintainers; [ ftrvxmtrx ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/al/alock/package.nix
+++ b/pkgs/by-name/al/alock/package.nix
@@ -64,7 +64,6 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
-      ftrvxmtrx
       chris-martin
     ];
     license = lib.licenses.mit;

--- a/pkgs/by-name/fl/fldigi/package.nix
+++ b/pkgs/by-name/fl/fldigi/package.nix
@@ -62,7 +62,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       relrod
-      ftrvxmtrx
     ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/op/openal-soft/package.nix
+++ b/pkgs/by-name/op/openal-soft/package.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/kcat/openal-soft/blob/master/ChangeLog";
     license = lib.licenses.lgpl2;
     pkgConfigModules = [ "openal" ];
-    maintainers = with lib.maintainers; [ ftrvxmtrx ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/pc/pcalc/package.nix
+++ b/pkgs/by-name/pc/pcalc/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation {
     description = "Programmer's calculator";
     mainProgram = "pcalc";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ ftrvxmtrx ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/sc/schismtracker/package.nix
+++ b/pkgs/by-name/sc/schismtracker/package.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://schismtracker.org/";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ ftrvxmtrx ];
+    maintainers = [ ];
     mainProgram = "schismtracker";
   };
 })

--- a/pkgs/by-name/sp/spotify/linux.nix
+++ b/pkgs/by-name/sp/spotify/linux.nix
@@ -249,7 +249,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = meta // {
     maintainers = with lib.maintainers; [
-      ftrvxmtrx
       timokau
       ma27
     ];

--- a/pkgs/by-name/un/uni-vga/package.nix
+++ b/pkgs/by-name/un/uni-vga/package.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Unicode VGA font";
-    maintainers = [ lib.maintainers.ftrvxmtrx ];
+    maintainers = [ ];
     homepage = "http://www.inp.nsk.su/~bolkhov/files/fonts/univga/";
     license = lib.licenses.mit;
   };

--- a/pkgs/by-name/ut/utf8proc/package.nix
+++ b/pkgs/by-name/ut/utf8proc/package.nix
@@ -40,7 +40,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
     maintainers = [
-      lib.maintainers.ftrvxmtrx
       lib.maintainers.sternenseemann
     ];
   };

--- a/pkgs/desktops/enlightenment/econnman/default.nix
+++ b/pkgs/desktops/enlightenment/econnman/default.nix
@@ -50,7 +50,6 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
       matejc
-      ftrvxmtrx
     ];
     teams = [ lib.teams.enlightenment ];
   };

--- a/pkgs/desktops/enlightenment/efl/default.nix
+++ b/pkgs/desktops/enlightenment/efl/default.nix
@@ -247,7 +247,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
       matejc
-      ftrvxmtrx
     ];
     teams = [ lib.teams.enlightenment ];
   };

--- a/pkgs/desktops/enlightenment/enlightenment/default.nix
+++ b/pkgs/desktops/enlightenment/enlightenment/default.nix
@@ -88,7 +88,6 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
       matejc
-      ftrvxmtrx
     ];
     teams = [ lib.teams.enlightenment ];
   };

--- a/pkgs/desktops/enlightenment/rage/default.nix
+++ b/pkgs/desktops/enlightenment/rage/default.nix
@@ -46,7 +46,6 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
       matejc
-      ftrvxmtrx
     ];
     teams = [ lib.teams.enlightenment ];
   };

--- a/pkgs/desktops/enlightenment/terminology/default.nix
+++ b/pkgs/desktops/enlightenment/terminology/default.nix
@@ -46,7 +46,6 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
       matejc
-      ftrvxmtrx
     ];
     teams = [ lib.teams.enlightenment ];
   };

--- a/pkgs/development/python-modules/python-efl/default.nix
+++ b/pkgs/development/python-modules/python-efl/default.nix
@@ -87,7 +87,6 @@ buildPythonPackage rec {
     ];
     maintainers = with lib.maintainers; [
       matejc
-      ftrvxmtrx
     ];
     teams = [ lib.teams.enlightenment ];
   };

--- a/pkgs/tools/system/plan9port/default.nix
+++ b/pkgs/tools/system/plan9port/default.nix
@@ -135,7 +135,6 @@ stdenv.mkDerivation {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       bbarker
-      ftrvxmtrx
       kovirobi
       matthewdargan
       ylh


### PR DESCRIPTION
## Reasons

- Last commented in [January 2022](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Aftrvxmtrx)
- Hasn't created any PRs / Issues since [August 2023](https://github.com/NixOS/nixpkgs/issues?q=author%3Aftrvxmtrx)
- About 120 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Aftrvxmtrx%20-commenter%3Aftrvxmtrx%20-author%3Aftrvxmtrx%20-reviewed-by%3Aftrvxmtrx%20created%3A%3E2024-01-01) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] mpg123
- [ ] openal-soft
- [ ] pcalc
- [ ] schismtracker
- [ ] uni-vga