### PR TITLE
[Backport release-26.05] pgrok: 1.5.0 -> 1.7.0, use pnpm 11 

### DIFF
--- a/pkgs/by-name/pg/pgrok/package.nix
+++ b/pkgs/by-name/pg/pgrok/package.nix
@@ -4,24 +4,21 @@
   fetchFromGitHub,
   nix-update-script,
   nodejs,
-  pnpm_9,
+  pnpm_11,
   fetchPnpmDeps,
   pnpmConfigHook,
 }:
 
-let
+buildGoModule (finalAttrs: {
   pname = "pgrok";
   version = "1.7.0";
+
   src = fetchFromGitHub {
     owner = "pgrok";
     repo = "pgrok";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-uMHeVxAGmAEIOfCK9SEFsL7GZZIUNMYdoV8XeHjXmWc=";
   };
-in
-
-buildGoModule {
-  inherit pname version src;
 
   outputs = [
     "out"
@@ -31,7 +28,7 @@ buildGoModule {
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
-    pnpm_9
+    pnpm_11
   ];
 
   postPatch = ''
@@ -47,14 +44,14 @@ buildGoModule {
   '';
 
   env.pnpmDeps = fetchPnpmDeps {
-    inherit
+    inherit (finalAttrs)
       pname
       version
       src
       ;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-O3bDxnxeRO20FsRNpgXfz4UweYJmeU6zgrrPJ05fgWo=";
+    pnpm = pnpm_11;
+    fetcherVersion = 4;
+    hash = "sha256-8CLAtxqNgcVIUw4RKAy6jKlErmkgZYyVYFdrD+jyfAA=";
   };
 
   vendorHash = "sha256-fhyyyXHUJsIWiCZbqtLZZRuIG9hb0LAkSo7lKW0i8Sk";
@@ -62,7 +59,7 @@ buildGoModule {
   ldflags = [
     "-s"
     "-w"
-    "-X main.version=${version}"
+    "-X main.version=${finalAttrs.version}"
     "-X main.commit=unknown"
     "-X main.date=unknown"
   ];
@@ -93,4 +90,4 @@ buildGoModule {
     maintainers = with lib.maintainers; [ marie ];
     mainProgram = "pgrok";
   };
-}
+})

--- a/pkgs/by-name/pg/pgrok/package.nix
+++ b/pkgs/by-name/pg/pgrok/package.nix
@@ -11,12 +11,12 @@
 
 let
   pname = "pgrok";
-  version = "1.5.0";
+  version = "1.7.0";
   src = fetchFromGitHub {
     owner = "pgrok";
     repo = "pgrok";
     tag = "v${version}";
-    hash = "sha256-arPFccclBie3XOBt0q6UC96fPaPc7NmgQDMsd2H2bhI=";
+    hash = "sha256-uMHeVxAGmAEIOfCK9SEFsL7GZZIUNMYdoV8XeHjXmWc=";
   };
 in
 
@@ -34,6 +34,18 @@ buildGoModule {
     pnpm_9
   ];
 
+  postPatch = ''
+    # Rename directories to avoid binary naming conflicts (both would be named "cli")
+    mv pgrok/cli pgrok/pgrok
+    mv pgrokd/cli pgrokd/pgrokd
+
+    # Update references in Go code and web app package.json to match renamed directory
+    substituteInPlace pgrokd/pgrokd/main.go \
+      --replace-fail "github.com/pgrok/pgrok/pgrokd/cli/internal/web" "github.com/pgrok/pgrok/pgrokd/pgrokd/internal/web"
+    substituteInPlace pgrokd/web/package.json \
+      --replace-fail "../cli/internal/web/dist" "../pgrokd/internal/web/dist"
+  '';
+
   env.pnpmDeps = fetchPnpmDeps {
     inherit
       pname
@@ -42,10 +54,10 @@ buildGoModule {
       ;
     pnpm = pnpm_9;
     fetcherVersion = 3;
-    hash = "sha256-D8UZoN0ZnjB8CXQiHmBZwBEt57XGb5SDLg61xxSqNus=";
+    hash = "sha256-O3bDxnxeRO20FsRNpgXfz4UweYJmeU6zgrrPJ05fgWo=";
   };
 
-  vendorHash = "sha256-ob8s1jYL2+JGaqjCsM10jgirPiEyTY4U3IVVlHVdoGQ=";
+  vendorHash = "sha256-fhyyyXHUJsIWiCZbqtLZZRuIG9hb0LAkSo7lKW0i8Sk";
 
   ldflags = [
     "-s"
@@ -66,10 +78,6 @@ buildGoModule {
     pnpm run build
 
     popd
-
-    # rename packages due to naming conflict
-    mv pgrok/cli/ pgrok/pgrok/
-    mv pgrokd/cli/ pgrokd/pgrokd/
   '';
 
   postInstall = ''


### PR DESCRIPTION
Backport PR of #535933 and #534156

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
