### PR TITLE
git: fix riscv64-linux build

### DIFF
--- a/pkgs/by-name/gi/git/package.nix
+++ b/pkgs/by-name/gi/git/package.nix
@@ -583,6 +583,10 @@ stdenv.mkDerivation (finalAttrs: {
     # Tested to fail: 2.18.0
     disable_test t0028-working-tree-encoding
   ''
+  + lib.optionalString stdenv.hostPlatform.isRiscV64 ''
+    # Tests 2-5 fail on riscv64.
+    disable_test t0213-trace2-ancestry
+  ''
   + lib.optionalString stdenv.hostPlatform.isFreeBSD ''
     # Time zones are not available in the build sandbox.
     # This can be fixed if/when we decide on how the hardcoded libc paths should look


### PR DESCRIPTION
fix git issue :

```
git-riscv64-linux> Test Summary Report
git-riscv64-linux> -------------------
git-riscv64-linux> t0213-trace2-ancestry.sh                         (Wstat: 256 (exited 1) Tests: 5 Failed: 4)
git-riscv64-linux>   Failed tests:  2-5
git-riscv64-linux>   Non-zero exit status: 1
git-riscv64-linux> Files=1028, Tests=29512, 1604 wallclock secs (41.52 usr  2.33 sys + 15862.29 cusr 1850.84 csys = 17756.98 CPU)
git-riscv64-linux> Result: FAIL
git-riscv64-linux> make[1]: *** [Makefile:78: prove] Error 1
git-riscv64-linux> make[1]: Leaving directory '/build/git-2.54.0/t'
git-riscv64-linux> make: *** [Makefile:3391: test] Error 2
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
  - [ ] riscv64-linux
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
