### PR TITLE
undocker: fix upstream URLs

### DIFF
--- a/pkgs/by-name/un/undocker/package.nix
+++ b/pkgs/by-name/un/undocker/package.nix
@@ -1,18 +1,15 @@
 {
   lib,
   buildGoModule,
-  fetchFromGitea,
+  fetchgit,
   gnumake,
 }:
 let
   version = "1.2.3";
-  hash = "sha256-hyP85pYtXxucAliilUt9Y2qnrfPeSjeGsYEFJndJWyA=";
-  src = fetchFromGitea {
-    domain = "git.jakstys.lt";
-    owner = "motiejus";
-    repo = "undocker";
+  src = fetchgit {
+    url = "https://git.jakstys.lt/motiejus/undocker.git";
     rev = "v${version}";
-    hash = hash;
+    hash = "sha256-hyP85pYtXxucAliilUt9Y2qnrfPeSjeGsYEFJndJWyA=";
   };
 in
 buildGoModule {
@@ -21,7 +18,7 @@ buildGoModule {
 
   nativeBuildInputs = [ gnumake ];
 
-  buildPhase = "make VSN=v${version} VSNHASH=${hash} undocker";
+  buildPhase = "make VSN=v${version} VSNHASH=${src.rev} undocker";
 
   installPhase = "install -D undocker $out/bin/undocker";
 


### PR DESCRIPTION
I have moved from `gitea` to `stagit`, paths have changed. Converting `fetchFromGitea` to `fetchgit`.

Context: https://m.jakstys.lt/2026/git-hosting/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
