### PR TITLE
nixos/containers: fix IPv4-mapped addresses

### DIFF
--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -524,8 +524,8 @@ let
     tmpfs = null;
   };
 
-  # Parses an IPv4 address with an optional prefix
-  ipv4FromString =
+  # Parses an IP address with an optional prefix
+  ipFromString =
     str:
     let
       segments = lib.splitString "/" str;
@@ -610,10 +610,10 @@ in
                                 networking.interfaces = lib.mkIf config.privateNetwork (
                                   lib.mkMerge [
                                     (lib.mkIf (config.localAddress != null) {
-                                      eth0.ipv4.addresses = [ (ipv4FromString config.localAddress) ];
+                                      eth0.ipv4.addresses = [ (ipFromString config.localAddress) ];
                                     })
                                     (lib.mkIf (config.localAddress6 != null) {
-                                      eth0.ipv6.addresses = [ (lib.network.ipv6.fromString config.localAddress6) ];
+                                      eth0.ipv6.addresses = [ (ipFromString config.localAddress6) ];
                                     })
                                   ]
                                 );


### PR DESCRIPTION
lib.network.ipv6.fromString tries to parse the address and fails with IPv4-mapped addresses, but we actually just want to extract the prefix, so do this using string operations, as for IPv4.

Fixes issue #530543.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests] (`nixosTests.containers-gateway`, `nixosTests.containers-restart_networking`).
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
