### PR TITLE
kellnr: init at 6.5.0

### DIFF
--- a/pkgs/by-name/ke/kellnr/package.nix
+++ b/pkgs/by-name/ke/kellnr/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  stdenv,
+  cmake,
+  pkg-config,
+  openssl,
+  libiconv,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "kellnr";
+  version = "6.5.0";
+
+  src = fetchFromGitHub {
+    owner = "kellnr";
+    repo = "kellnr";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-aBPLEZBRJ1DkmpBmqhhk7lAyfx9dN5vtwNcRhCtJEZg=";
+  };
+
+  cargoHash = "sha256-+41c4g5Ua7kLvO0Tv02W4C1wrqvbgy+D0Dppczw6ONk=";
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    openssl.dev
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    libiconv
+  ];
+
+  OPENSSL_DIR = "${openssl.dev}";
+  OPENSSL_INCLUDE_DIR = "${openssl.dev}/include";
+  OPENSSL_LIB_DIR = "${openssl.out}/lib";
+  OPENSSL_NO_VENDOR = true;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--url=https://github.com/kellnr/kellnr" ];
+  };
+
+  meta = {
+    description = "Open-source Rust registry for crates";
+    longDescription = ''
+      Host your private Rust crates on your own infrastructure.
+      Full control. Complete privacy. Zero dependencies on external services.
+    '';
+    homepage = "https://kellnr.io";
+    changelog = "https://github.com/kellnr/kellnr/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [
+      mit # or
+      asl20
+    ];
+    maintainers = with lib.maintainers; [ Br1ght0ne ];
+    mainProgram = "kellnr";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Replaces #494291.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
