### PR TITLE
treewide: Fix malformed input hashes

### DIFF
--- a/pkgs/by-name/gu/guake/package.nix
+++ b/pkgs/by-name/gu/guake/package.nix
@@ -46,7 +46,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     # Note: This is not a long-term solution, setup.py is deprecated.
     (fetchpatch {
       url = "https://github.com/Guake/guake/commit/14abaa0c69cfab64fe3467fbbea211d830042de8.patch";
-      hash = "sha256-RjGRFJDTQX2meAaw3UZi/3OxAtIHbRZVpXTbcJk/scY= ";
+      hash = "sha256-RjGRFJDTQX2meAaw3UZi/3OxAtIHbRZVpXTbcJk/scY=";
       revert = true;
     })
 

--- a/pkgs/by-name/hy/hyperssh/package.nix
+++ b/pkgs/by-name/hy/hyperssh/package.nix
@@ -20,7 +20,7 @@ buildNpmPackage {
     owner = "mafintosh";
     repo = "hyperssh";
     rev = "v5.0.3";
-    hash = "sha256-vjPSNcQRsqu0ee0hownEE9y8dFf9dqaL7alGRc9WjcI=2";
+    hash = "sha256-vjPSNcQRsqu0ee0hownEE9y8dFf9dqaL7alGRc9WjcI=";
   };
 
   patches = [

--- a/pkgs/by-name/ja/jameica/package.nix
+++ b/pkgs/by-name/ja/jameica/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     owner = "willuhn";
     repo = "jameica";
     tag = version;
-    hash = "sha256-7KpQas8ttL2DP+gFH87uLQyx4PMwVQ+FaqXpZBPWV5U=i";
+    hash = "sha256-7KpQas8ttL2DP+gFH87uLQyx4PMwVQ+FaqXpZBPWV5U=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ow/owncast/package.nix
+++ b/pkgs/by-name/ow/owncast/package.nix
@@ -22,7 +22,7 @@ buildGoModule {
     hash = "sha256-REgo9RC1izb9vJ6ae66Wti9yfP8DrCGetf6O4rX3DPY=";
   };
 
-  vendorHash = "sha256-T4nr4lNUEq6grZ21qumaOjIDIDoJK7Ql8j8WbCy2u3g=n";
+  vendorHash = "sha256-T4nr4lNUEq6grZ21qumaOjIDIDoJK7Ql8j8WbCy2u3g=";
 
   subPackages = [ "." ];
 

--- a/pkgs/by-name/qu/quintom-cursor-theme/package.nix
+++ b/pkgs/by-name/qu/quintom-cursor-theme/package.nix
@@ -12,7 +12,7 @@ stdenvNoCC.mkDerivation {
     owner = "Burning_Cube";
     repo = "quintom-cursor-theme";
     rev = "d23e57333e816033cf20481bdb47bb1245ed5d4d";
-    hash = "sha256-Sec2DSnWYal6wzYzP9W+DDuTKHsFHWdRYyMzliMU5bU=A";
+    hash = "sha256-Sec2DSnWYal6wzYzP9W+DDuTKHsFHWdRYyMzliMU5bU=";
   };
 
   installPhase = ''

--- a/pkgs/by-name/tr/trucky/package.nix
+++ b/pkgs/by-name/tr/trucky/package.nix
@@ -10,7 +10,7 @@ let
 
   src = fetchurl {
     url = "https://web.archive.org/web/20260328182310/https://client-download.truckyapp.com/linux/latest/Trucky.AppImage";
-    hash = "sha256-8F6tIyooqzjgH2+qHsaoFwJkFzzW07fjqK9znDW/AyA=3";
+    hash = "sha256-8F6tIyooqzjgH2+qHsaoFwJkFzzW07fjqK9znDW/AyA=";
   };
 
   appimageContents = appimageTools.extract { inherit pname version src; };

--- a/pkgs/development/ocaml-modules/janestreet/0.17.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.17.nix
@@ -1577,7 +1577,7 @@ with self;
       if lib.versionAtLeast ppxlib.version "0.36" then
         {
           version = "0.17.1";
-          hash = "sha256-O3FtpXrFoyMI3iPL3BUwquREy+8TygOlyaTUGBUPk4Q=$";
+          hash = "sha256-O3FtpXrFoyMI3iPL3BUwquREy+8TygOlyaTUGBUPk4Q=";
         }
       else
         {

--- a/pkgs/games/cataclysm-dda/stable.nix
+++ b/pkgs/games/cataclysm-dda/stable.nix
@@ -24,7 +24,7 @@ let
       repo = "Cataclysm-DDA";
       # Head of 0.H-branch
       tag = "cdda-${version}";
-      sha256 = "sha256-r4cl8cij68WmQRfg+DHQIeDBIwhgwSre6kAUYZaCPR8=n";
+      sha256 = "sha256-r4cl8cij68WmQRfg+DHQIeDBIwhgwSre6kAUYZaCPR8=";
     };
 
     patches = [


### PR DESCRIPTION
Nixcpp implementation of base64 decoder ignores everything that comes after the first "=" symbol. Clean up the existing nixpkgs code so the decoder can be made strict one day.

https://github.com/NixOS/nix/blob/master/src/libutil/base-n.cc#L94


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
