### PR TITLE
Enforce alphabetical order in `pkgs/top-level/octave-packages.nix`

### DIFF
--- a/pkgs/top-level/octave-packages.nix
+++ b/pkgs/top-level/octave-packages.nix
@@ -62,6 +62,8 @@ makeScope newScope (
       writeRequiredOctavePackagesHook
       ;
 
+    # keep-sorted start block=yes newline_separated=yes case=no numeric=yes skip_lines=1
+
     arduino = callPackage ../development/octave-modules/arduino {
       inherit (pkgs) arduino-core-unwrapped;
     };
@@ -94,9 +96,9 @@ makeScope newScope (
 
     econometrics = callPackage ../development/octave-modules/econometrics { };
 
-    fits = callPackage ../development/octave-modules/fits { };
-
     financial = callPackage ../development/octave-modules/financial { };
+
+    fits = callPackage ../development/octave-modules/fits { };
 
     fpl = callPackage ../development/octave-modules/fpl { };
 
@@ -128,11 +130,11 @@ makeScope newScope (
 
     instrument-control = callPackage ../development/octave-modules/instrument-control { };
 
+    interval = callPackage ../development/octave-modules/interval { };
+
     io = callPackage ../development/octave-modules/io {
       inherit (octave) enableJava;
     };
-
-    interval = callPackage ../development/octave-modules/interval { };
 
     linear-algebra = callPackage ../development/octave-modules/linear-algebra { };
 
@@ -191,11 +193,11 @@ makeScope newScope (
 
     sockets = callPackage ../development/octave-modules/sockets { };
 
-    stk = callPackage ../development/octave-modules/stk { };
-
     splines = callPackage ../development/octave-modules/splines { };
 
     statistics = callPackage ../development/octave-modules/statistics { };
+
+    stk = callPackage ../development/octave-modules/stk { };
 
     strings = callPackage ../development/octave-modules/strings { };
 
@@ -215,6 +217,7 @@ makeScope newScope (
       inherit (pkgs) zeromq autoreconfHook;
     };
 
+    # keep-sorted end
   }
   // lib.optionalAttrs config.allowAliases {
     fem-fenics = throw "octavePackages.fem-fenics has been removed due to being broken for more than a year; see RFC 180"; # Added 2026-02-05


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I have added `keep-sorted` comments to  `pkgs/top-level/octave-packages.nix` to help `nix fmt` to sort the octave packages in alphabetical order.
This was almost the case, but now it is a requirement.

Is this a good change @ravenjoad?

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
