### PR TITLE
isa-l: mark unbroken for aarch64-darwin and i686-linux

### DIFF
--- a/pkgs/by-name/is/isa-l/package.nix
+++ b/pkgs/by-name/is/isa-l/package.nix
@@ -97,9 +97,6 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [ jbedo ];
     platforms = lib.platforms.all;
     badPlatforms = [
-      # <instantiation>:4:26: error: unexpected token in argument list
-      #  movk x7, p4_low_b1, lsl 16
-      "aarch64-darwin"
       # https://github.com/intel/isa-l/issues/188
       "i686-linux"
     ];

--- a/pkgs/by-name/is/isa-l/package.nix
+++ b/pkgs/by-name/is/isa-l/package.nix
@@ -96,9 +96,5 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/intel/isa-l/releases/tag/v${finalAttrs.version}";
     maintainers = with lib.maintainers; [ jbedo ];
     platforms = lib.platforms.all;
-    badPlatforms = [
-      # https://github.com/intel/isa-l/issues/188
-      "i686-linux"
-    ];
   };
 })

--- a/pkgs/development/python-modules/aiohttp/default.nix
+++ b/pkgs/development/python-modules/aiohttp/default.nix
@@ -3,7 +3,6 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  replaceVars,
   isPyPy,
   pythonOlder,
 
@@ -18,7 +17,6 @@
   # dependencies
   aiohappyeyeballs,
   aiosignal,
-  async-timeout,
   attrs,
   backports-zstd,
   frozenlist,

--- a/pkgs/development/python-modules/aiohttp/default.nix
+++ b/pkgs/development/python-modules/aiohttp/default.nix
@@ -33,7 +33,6 @@
   blockbuster,
   freezegun,
   gunicorn,
-  isa-l,
   isal,
   proxy-py,
   pytest-codspeed,
@@ -107,8 +106,7 @@ buildPythonPackage rec {
     blockbuster
     freezegun
     gunicorn
-    # broken on aarch64-darwin
-    (if lib.meta.availableOn stdenv.hostPlatform isa-l then isal else null)
+    isal
     proxy-py
     pytest-codspeed
     pytest-cov-stub


### PR DESCRIPTION
Tested with a gzip encoded test file and works without errors.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
