### PR TITLE
hare: modified hook: added support for tools; hare-update: init at 0.26.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26038,6 +26038,12 @@
     githubId = 57048005;
     name = "snicket2100";
   };
+  snifexx = {
+    name = "Matteo Bonesoli";
+    email = "snifex@phnxdev.eu";
+    githubId = 71451061;
+    github = "snifexx";
+  };
   sno2wman = {
     name = "SnO2WMaN";
     email = "me@sno2wman.net";

--- a/pkgs/by-name/ha/hare-update/package.nix
+++ b/pkgs/by-name/ha/hare-update/package.nix
@@ -1,0 +1,46 @@
+{
+  fetchFromSourcehut,
+  hareHook,
+  lib,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hare-update";
+  version = "0.26.0.0";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromSourcehut {
+    owner = "~sircmpwn";
+    repo = "hare-update";
+    tag = finalAttrs.version;
+    hash = "sha256-E6N9UMYdNTgy0tppBgOwT14WUXvjliSh/ps16fPDFN8=";
+  };
+
+  nativeBuildInputs = [
+    hareHook
+  ];
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  meta = {
+    description = "Tool for assisting in updating Hare codebases affected by breaking changes";
+    longDescription = ''
+      hare-update is a Hare add-on which assists in migrating a Hare codebases
+      to a newer release of Hare by scanning your code, identifying areas
+      impacted by breaking changes, and suggesting the appropriate fix.
+    '';
+    homepage = "https://git.sr.ht/~sircmpwn/hare-update";
+    license = lib.licenses.eupl12;
+    maintainers = with lib.maintainers; [ snifexx ];
+    # Same as the harec package except with added netbsd. harec also supports netbsd, so...
+    platforms =
+      with lib.platforms;
+      lib.intersectLists (netbsd ++ freebsd ++ openbsd ++ linux) (aarch64 ++ x86_64 ++ riscv64);
+    # Same as the harec package. The harec developers do not explicitly supprt
+    # MacOS, even if ports exists
+    badPlatforms = lib.platforms.darwin;
+  };
+})

--- a/pkgs/by-name/ha/hare/package.nix
+++ b/pkgs/by-name/ha/hare/package.nix
@@ -175,7 +175,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://harelang.org/";
     description = "Systems programming language designed to be simple, stable, and robust";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ sikmir ];
+    maintainers = with lib.maintainers; [
+      sikmir
+      snifexx
+    ];
     mainProgram = "hare";
     inherit (harec.meta) platforms badPlatforms;
   };

--- a/pkgs/by-name/ha/hare/setup-hook.sh
+++ b/pkgs/by-name/ha/hare/setup-hook.sh
@@ -7,6 +7,13 @@ addHarepath() {
     fi
 }
 
+addHareToolpath() {
+  local -r toolpath="${1-}/libexec/hare"
+  if [[ -d "$toolpath" ]]; then
+    addToSearchPath HARE_TOOLPATH "$toolpath"
+  fi
+}
+
 # Hare's stdlib should come after its third party libs, since the latter may
 # expand or shadow the former.
 readonly hareSetStdlibPhase='
@@ -34,3 +41,4 @@ HARECACHE="$(mktemp -d)"
 export HARECACHE
 
 addEnvHooks "$hostOffset" addHarepath
+addEnvHooks "$hostOffset" addHareToolpath


### PR DESCRIPTION
Added hareToolsHook, a hook for packages distributing [hare-tools] executables.

Added hareTools.[hare-update] an [Hare] tool for aiding in refactoring hare source code from old version to newer, when breaking changes in the [harec] compiler happen.

Added myself (snifexx <snifex@phnxdev.eu>) as maintainer
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


[hare-tools]: https://man.archlinux.org/man/hare-tool.1.en
[hare-update]: https://git.sr.ht/~sircmpwn/hare-update/
[Hare]: https://harelang.org/
[harec]: https://git.sr.ht/~sircmpwn/harec/