### PR TITLE
lib.strings: init toShellVar' and toShellVars'

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -101,5 +101,5 @@
 
 ### Additions and Improvements {#sec-nixpkgs-release-26.11-lib-additions-improvements}
 
-- Create the first release note entry in this section!
+- `lib.strings.toShellVar'` and `lib.strings.toShellVars'` have been added. They are similar to `lib.strings.toShellVar` and `lib.strings.toShellVars`, but with an additional feature: they allow you to easily make all of the variables that you create exported variables, read-only variables or both.
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -353,6 +353,7 @@ let
         isStringLike
         isValidPosixName
         toShellVar
+        toShellVar'
         toShellVars
         trim
         trimWith

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -355,6 +355,7 @@ let
         toShellVar
         toShellVar'
         toShellVars
+        toShellVars'
         trim
         trimWith
         escapeRegex

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -1335,6 +1335,72 @@ rec {
         "${name}=${escapeShellArg value}";
 
   /**
+    Translate a Nix value into a shell variable declaration, with proper escaping.
+
+    This function is the same as `toShellVar`, but it takes an attribute set as
+    its argument and has additional options.
+
+    # Inputs
+
+    `name` (String)
+
+    : The name of the resulting shell variable.
+
+    `value` (String, list of strings or attribute set where every value is a string)
+
+    : The value of the resulting shell variable. See the description for
+    `lib.strings.toShellVar` for more information about the different types of
+    values that can be used.
+
+    `export` (Boolean; _optional_)
+
+    : If `true`, then the generated shell variable will be exported using [the
+    POSIX {command}`export` command](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/V3_chap02.html#tag_19_23).
+
+      _Default:_ `false`
+
+    `readonly` (Boolean; _optional_)
+
+    : If `true`, then the generated shell variable will be made read-only using
+    [the POSIX {command}`readonly` command](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/V3_chap02.html#tag_19_24).
+
+      _Default:_ `false`
+
+    # Type
+
+    ```
+    toShellVar' :: AttrSet -> String
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.strings.toShellVar'` usage example
+
+    ```nix
+    ''
+      ${toShellVar' {
+        name = "DOOMWADDIR";
+        value = "${pkgs.freedoom}/share/games/doom";
+        export = true;
+      }}
+      crispy-doom -iwad freedoom2.wad
+    ''
+    ```
+
+    :::
+  */
+  toShellVar' =
+    {
+      name,
+      value,
+      export ? false,
+      readonly ? false,
+    }:
+    (toShellVar name value)
+    + (optionalString export "\nexport ${escapeShellArg name}")
+    + (optionalString readonly "\nreadonly ${escapeShellArg name}");
+
+  /**
     Translate an attribute set `vars` into corresponding shell variable declarations
     using `toShellVar`.
 

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -1436,6 +1436,86 @@ rec {
   toShellVars = vars: concatStringsSep "\n" (lib.mapAttrsToList toShellVar vars);
 
   /**
+    Translate an attribute set `vars` into corresponding shell variable
+    declarations using `toShellVar'`.
+
+    This function is similar to `lib.strings.toShellVars` but it has additional
+    options.
+
+    # Inputs
+
+    `vars` (Attribute set where each value is a string, a list of strings or an attribute set where every value is a string)
+
+    : The names and values of the resulting shell variables. See the
+    description for `lib.strings.toShellVar` for more information about the
+    different types of values that can be used.
+
+    `export` (Boolean; _optional_)
+
+    : If `true`, then all of the generated shell variables will be exported using
+    [the POSIX {command}`export` command](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/V3_chap02.html#tag_19_23).
+
+      _Default:_ `false`
+
+    `readonly` (Boolean; _optional_)
+
+    : If `true`, then all of the generated shell variables will be made read-only using
+    [the POSIX {command}`readonly` command](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/V3_chap02.html#tag_19_24).
+
+      _Default:_ `false`
+
+    # Type
+
+    ```
+    toShellVars' :: AttrSet -> String
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.strings.toShellVars'` usage example
+
+    ```nix
+    ''
+      # Set a bunch of variables that will get used by the Linux man-pages
+      # project’s make file.
+      ${toShellVars' {
+        vars = {
+          TINOS_PFB = "${pkgs.texlivePackages.tinos}/fonts/type1/google/tinos/Tinos.pfb";
+          TINOSR_TTF = "${pkgs.texlivePackages.tinos}/fonts/truetype/google/tinos/Tinos-Regular.ttf";
+          PDF_TEXT_ENC = "${pkgs.groff}/share/groff/current/font/devpdf/enc/text.enc";
+          PDF_TEXT_MAP = "${pkgs.groff}/share/groff/current/font/devpdf/map/text.map";
+        };
+        # Export the variables so that they can be seen by commands that the
+        # user runs.
+        export = true;
+      }}
+      # Drop the user into an interactive shell so that they can start
+      # contributing to the Linux man-pages project.
+      bash
+    ''
+    ```
+
+    :::
+  */
+  toShellVars' =
+    {
+      vars,
+      export ? false,
+      readonly ? false,
+    }:
+    concatMapAttrsStringSep "\n" (
+      name: value:
+      lib.toShellVar' {
+        inherit
+          name
+          value
+          export
+          readonly
+          ;
+      }
+    ) vars;
+
+  /**
     Turn a string `s` into a Nix expression representing that string
 
     # Inputs

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -114,6 +114,7 @@ let
     fromHexString
     toInt
     toIntBase10
+    toShellVar'
     toShellVars
     types
     uniqueStrings
@@ -970,6 +971,135 @@ runTests {
   testEscapeXML = {
     expr = escapeXML ''"test" 'test' < & >'';
     expected = "&quot;test&quot; &apos;test&apos; &lt; &amp; &gt;";
+  };
+
+  testToShellVar' = {
+    expr = ''
+      ${toShellVar' {
+        name = "string";
+        value = "Example value";
+      }}
+      ${toShellVar' {
+        name = "list";
+        value = [
+          "List item 1"
+          "List item 2"
+          "List item 3"
+        ];
+      }}
+      ${toShellVar' {
+        name = "attrs";
+        value = {
+          "First attr" = "First value";
+          "Second attr" = "Second value";
+          "Third attr" = "Third value";
+        };
+      }}
+
+      ${toShellVar' {
+        name = "exportedString";
+        value = "Example exported value";
+        export = true;
+      }}
+      ${toShellVar' {
+        name = "exportedList";
+        value = [
+          "Exported list item 1"
+          "Exported list item 2"
+          "Exported list item 3"
+        ];
+        export = true;
+      }}
+      ${toShellVar' {
+        name = "exportedAttrs";
+        value = {
+          "First exported attr" = "First exported value";
+          "Second exported attr" = "Second exported value";
+          "Third exported attr" = "Third exported value";
+        };
+        export = true;
+      }}
+
+      ${toShellVar' {
+        name = "readonlyString";
+        value = "Example read-only value";
+        readonly = true;
+      }}
+      ${toShellVar' {
+        name = "readonlyList";
+        value = [
+          "Read-only list item 1"
+          "Read-only list item 2"
+          "Read-only list item 3"
+        ];
+        readonly = true;
+      }}
+      ${toShellVar' {
+        name = "readonlyAttrs";
+        value = {
+          "First read-only attr" = "First read-only value";
+          "Second read-only attr" = "Second read-only value";
+          "Third read-only attr" = "Third read-only value";
+        };
+        readonly = true;
+      }}
+
+      ${toShellVar' {
+        name = "exportedReadonlyString";
+        value = "Example exported read-only value";
+        export = true;
+        readonly = true;
+      }}
+      ${toShellVar' {
+        name = "exportedReadonlyList";
+        value = [
+          "Exported read-only list item 1"
+          "Exported read-only list item 2"
+          "Exported read-only list item 3"
+        ];
+        export = true;
+        readonly = true;
+      }}
+      ${toShellVar' {
+        name = "exportedReadonlyAttrs";
+        value = {
+          "First exported read-only attr" = "First exported read-only value";
+          "Second exported read-only attr" = "Second exported read-only value";
+          "Third exported read-only attr" = "Third exported read-only value";
+        };
+        export = true;
+        readonly = true;
+      }}
+    '';
+    expected = ''
+      string='Example value'
+      declare -a list=('List item 1' 'List item 2' 'List item 3')
+      declare -A attrs=(['First attr']='First value' ['Second attr']='Second value' ['Third attr']='Third value')
+
+      exportedString='Example exported value'
+      export exportedString
+      declare -a exportedList=('Exported list item 1' 'Exported list item 2' 'Exported list item 3')
+      export exportedList
+      declare -A exportedAttrs=(['First exported attr']='First exported value' ['Second exported attr']='Second exported value' ['Third exported attr']='Third exported value')
+      export exportedAttrs
+
+      readonlyString='Example read-only value'
+      readonly readonlyString
+      declare -a readonlyList=('Read-only list item 1' 'Read-only list item 2' 'Read-only list item 3')
+      readonly readonlyList
+      declare -A readonlyAttrs=(['First read-only attr']='First read-only value' ['Second read-only attr']='Second read-only value' ['Third read-only attr']='Third read-only value')
+      readonly readonlyAttrs
+
+      exportedReadonlyString='Example exported read-only value'
+      export exportedReadonlyString
+      readonly exportedReadonlyString
+      declare -a exportedReadonlyList=('Exported read-only list item 1' 'Exported read-only list item 2' 'Exported read-only list item 3')
+      export exportedReadonlyList
+      readonly exportedReadonlyList
+      declare -A exportedReadonlyAttrs=(['First exported read-only attr']='First exported read-only value' ['Second exported read-only attr']='Second exported read-only value' ['Third exported read-only attr']='Third exported read-only value')
+      export exportedReadonlyAttrs
+      readonly exportedReadonlyAttrs
+    '';
   };
 
   testToShellVars = {

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -116,6 +116,7 @@ let
     toIntBase10
     toShellVar'
     toShellVars
+    toShellVars'
     types
     uniqueStrings
     updateManyAttrsByPath
@@ -1134,6 +1135,107 @@ runTests {
       drv=/drv
       path=/path
       stringable='hello toString'
+    '';
+  };
+
+  testToShellVars' = {
+    expr = ''
+      ${toShellVars' {
+        vars = {
+          string = "Example value";
+          list = [
+            "List item 1"
+            "List item 2"
+            "List item 3"
+          ];
+          attrs = {
+            "First attr" = "First value";
+            "Second attr" = "Second value";
+            "Third attr" = "Third value";
+          };
+        };
+      }}
+
+      ${toShellVars' {
+        vars = {
+          exportedString = "Example exported value";
+          exportedList = [
+            "Exported list item 1"
+            "Exported list item 2"
+            "Exported list item 3"
+          ];
+          exportedAttrs = {
+            "First exported attr" = "First exported value";
+            "Second exported attr" = "Second exported value";
+            "Third exported attr" = "Third exported value";
+          };
+        };
+        export = true;
+      }}
+
+      ${toShellVars' {
+        vars = {
+          readonlyString = "Example read-only value";
+          readonlyList = [
+            "Exported read-only list item 1"
+            "Exported read-only list item 2"
+            "Exported read-only list item 3"
+          ];
+          readonlyAttrs = {
+            "First read-only attr" = "First read-only value";
+            "Second read-only attr" = "Second read-only value";
+            "Third read-only attr" = "Third read-only value";
+          };
+        };
+        readonly = true;
+      }}
+
+      ${toShellVars' {
+        vars = {
+          exportedReadonlyString = "Example exported read-only value";
+          exportedReadonlyList = [
+            "Read-only list item 1"
+            "Read-only list item 2"
+            "Read-only list item 3"
+          ];
+          exportedReadonlyAttrs = {
+            "First exported read-only attr" = "First exported read-only value";
+            "Second exported read-only attr" = "Second exported read-only value";
+            "Third exported read-only attr" = "Third exported read-only value";
+          };
+        };
+        export = true;
+        readonly = true;
+      }}
+    '';
+    expected = ''
+      declare -A attrs=(['First attr']='First value' ['Second attr']='Second value' ['Third attr']='Third value')
+      declare -a list=('List item 1' 'List item 2' 'List item 3')
+      string='Example value'
+
+      declare -A exportedAttrs=(['First exported attr']='First exported value' ['Second exported attr']='Second exported value' ['Third exported attr']='Third exported value')
+      export exportedAttrs
+      declare -a exportedList=('Exported list item 1' 'Exported list item 2' 'Exported list item 3')
+      export exportedList
+      exportedString='Example exported value'
+      export exportedString
+
+      declare -A readonlyAttrs=(['First read-only attr']='First read-only value' ['Second read-only attr']='Second read-only value' ['Third read-only attr']='Third read-only value')
+      readonly readonlyAttrs
+      declare -a readonlyList=('Exported read-only list item 1' 'Exported read-only list item 2' 'Exported read-only list item 3')
+      readonly readonlyList
+      readonlyString='Example read-only value'
+      readonly readonlyString
+
+      declare -A exportedReadonlyAttrs=(['First exported read-only attr']='First exported read-only value' ['Second exported read-only attr']='Second exported read-only value' ['Third exported read-only attr']='Third exported read-only value')
+      export exportedReadonlyAttrs
+      readonly exportedReadonlyAttrs
+      declare -a exportedReadonlyList=('Read-only list item 1' 'Read-only list item 2' 'Read-only list item 3')
+      export exportedReadonlyList
+      readonly exportedReadonlyList
+      exportedReadonlyString='Example exported read-only value'
+      export exportedReadonlyString
+      readonly exportedReadonlyString
     '';
   };
 


### PR DESCRIPTION
This pull request adds a new `lib.strings.toShellVars'` function. This new function is similar to `lib.strings.toShellVars`, but it allows you to easily make every single variable that you are creating exported, read-only or both.

Here’s an example of how you would do things at the moment:

```nix
''
  ${pkgsForTargetPkgs.lib.strings.toShellVars {
    TINOS_PFB = "${pkgsForTargetPkgs.texlivePackages.tinos}/fonts/type1/google/tinos/Tinos.pfb";
    TINOSR_TTF = "${pkgsForTargetPkgs.texlivePackages.tinos}/fonts/truetype/google/tinos/Tinos-Regular.ttf";
    PDF_TEXT_ENC = "${pkgsForTargetPkgs.groff}/share/groff/current/font/devpdf/enc/text.enc";
    PDF_TEXT_MAP = "${pkgsForTargetPkgs.groff}/share/groff/current/font/devpdf/map/text.map";
  }}
  # TODO: Make sure that this matches the above list of names.
  export TINOS_PFB TINOSR_TTF PDF_TEXT_ENC PDF_TEXT_MAP
''
```
[(This example comes from some code that I’ve been working on here).](https://codeberg.org/JasonYundt/flake-for-working-on-man-pages/commit/10b6f0af3507013e4e4fb6efee633ab0c205bcb8)

This pull request allows that example to be simplified to this:

```nix
''
  ${pkgsForTargetPkgs.lib.strings.toShellVars' {
    vars = {
      TINOS_PFB = "${pkgsForTargetPkgs.texlivePackages.tinos}/fonts/type1/google/tinos/Tinos.pfb";
      TINOSR_TTF = "${pkgsForTargetPkgs.texlivePackages.tinos}/fonts/truetype/google/tinos/Tinos-Regular.ttf";
      PDF_TEXT_ENC = "${pkgsForTargetPkgs.groff}/share/groff/current/font/devpdf/enc/text.enc";
      PDF_TEXT_MAP = "${pkgsForTargetPkgs.groff}/share/groff/current/font/devpdf/map/text.map";
    };
    export = true;
  }}
''
```

See the commit messages for additional details.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `d7f3ff7a71dc1f8714a57fc21f7deeb4cfd3c95a`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 2 packages blacklisted:</summary>
  <ul>
    <li>nixos-install-tools</li>
    <li>tests.nixos-functions.nixos-test</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 4 packages built:</summary>
  <ul>
    <li>extra-container</li>
    <li>nixos-container</li>
    <li>nixpkgs-manual</li>
    <li>tests.lib-tests</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
