### PR TITLE
release: drop x86_64-darwin from supported systems

### DIFF
--- a/pkgs/top-level/release-supported-systems.json
+++ b/pkgs/top-level/release-supported-systems.json
@@ -2,5 +2,4 @@
   "aarch64-linux",
   "aarch64-darwin",
   "x86_64-linux",
-  "x86_64-darwin"
 ]


### PR DESCRIPTION
Thanks to https://github.com/NixOS/nixpkgs/pull/493997 we can drop `x86_64-darwin` from master's "supported systems" without affecting stable branches. Among other things, this means `ci/eval` will not evaluate `x86_64-darwin` on unstable branches and `x86_64-darwin` won't be included in the comparison artifact.

I suppose that hydra explicitly provides its own `supportedSystem` list when importing `release.nix`, so I didn't "clean up" `supportedDarwin` added in 533eb9866c6dfe56637f2f8c76fcca3c7b47f72f.

I assume this doesn't need its own release note, because it's an implementation detail of the `x86_64-darwin` deprecation/removal that is already publicly announced.

### Usage

Grepping for `release-supported-systems.json`, the main usage is CI and the top-level release bootstrap:

https://github.com/NixOS/nixpkgs/blob/e1c1b84752fb0897897380a3cae9dc7fcab91ca3/ci/eval/default.nix#L56

https://github.com/NixOS/nixpkgs/blob/e1c1b84752fb0897897380a3cae9dc7fcab91ca3/ci/eval/outpaths.nix#L14

https://github.com/NixOS/nixpkgs/blob/e1c1b84752fb0897897380a3cae9dc7fcab91ca3/ci/eval/README.md#L13

https://github.com/NixOS/nixpkgs/blob/e1c1b84752fb0897897380a3cae9dc7fcab91ca3/ci/github-script/supportedSystems.js#L5

https://github.com/NixOS/nixpkgs/blob/e1c1b84752fb0897897380a3cae9dc7fcab91ca3/pkgs/top-level/release.nix#L22

https://github.com/NixOS/nixpkgs/blob/e1c1b84752fb0897897380a3cae9dc7fcab91ca3/pkgs/top-level/release-haskell.nix#L13

https://github.com/NixOS/nixpkgs/blob/e1c1b84752fb0897897380a3cae9dc7fcab91ca3/pkgs/top-level/release-staging.nix#L15

cc @emilazy in case there are implications I've not considered.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
