### PR TITLE
fbpad: init at 05

### DIFF
--- a/pkgs/by-name/fb/fbpad/package.nix
+++ b/pkgs/by-name/fb/fbpad/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fbpad";
+  version = "05";
+
+  src = fetchFromGitHub {
+    owner = "aligrudi";
+    repo = "fbpad";
+    tag = finalAttrs.version;
+    hash = "sha256-Tue5bwTNBi3HaWtrY8Prv6kehpxsZeqlwW8ENYtFPj0=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 fbpad $out/bin/fbpad
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A Linux framebuffer terminal emulator";
+    homepage = "https://github.com/aligrudi/fbpad";
+    mainProgram = "fbpad";
+    platforms = lib.platforms.linux;
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ castorNova2 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Adds [fbpad](https://github.com/aligrudi/fbpad) which is Linux framebuffer virtual terminal.

**Note:** Before use, user must create a .fbpad file. Instructions are given in upstream's README.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
