### PR TITLE
dovecot: fix loading plugins in doveadm

### DIFF
--- a/pkgs/by-name/do/dovecot/load-extended-modules.patch
+++ b/pkgs/by-name/do/dovecot/load-extended-modules.patch
@@ -10,3 +10,17 @@ index e0a0a5b..a7fd725 100644
 +#define CONFIG_MODULE_DIR "/run/current-system/sw/lib/dovecot/modules/settings"
  
  #define IS_WHITE(c) ((c) == ' ' || (c) == '\t')
+
+diff --git a/src/doveadm/doveadm-util.c
+ib/src/doveadm/doveadm-util.cndex e0a0a5b..a7fd725 100644
+--- a/src/doveadm/doveadm-util.c
++++ b/src/doveadm/doveadm-util.c
+@@ -19,6 +19,8 @@
+ #include <sys/stat.h>
+ #include <ctype.h>
+ 
++#define DOVEADM_MODULEDIR "/run/current-system/sw/lib/dovecot/modules/doveadm"
++
+ bool doveadm_verbose = FALSE, doveadm_debug = FALSE, doveadm_server = FALSE;
+ static struct module *modules = NULL;
+ 


### PR DESCRIPTION
doveadm does not respect the plugin path from configuration.
This patch sets the plugin search path to the current environment allowing plugins to be found.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
