### PR TITLE
uniclipboard: init at 0.16.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18421,6 +18421,12 @@
     githubId = 168955383;
     name = "Tommy B";
   };
+  mkdir700 = {
+    name = "mkdir700";
+    email = "mkdir700@gmail.com";
+    github = "mkdir700";
+    githubId = 56359329;
+  };
   mjm = {
     email = "matt@mattmoriarity.com";
     github = "mjm";

--- a/pkgs/by-name/un/uniclipboard/package.nix
+++ b/pkgs/by-name/un/uniclipboard/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+  makeWrapper,
+}:
+
+let
+  pname = "uniclipboard";
+  version = "0.16.0";
+
+  src = fetchurl {
+    url = "https://github.com/UniClipboard/UniClipboard/releases/download/v${version}/UniClipboard_${version}_amd64.AppImage";
+    hash = "sha256-QGWxY93KtEkTkIYS+xawDTc79DEM3VKBly2pHu2lpOo=";
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit pname version src;
+  };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  extraInstallCommands = ''
+    wrapProgram $out/bin/uniclipboard \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+
+    install -Dm444 ${appimageContents}/usr/share/applications/UniClipboard.desktop \
+      $out/share/applications/uniclipboard.desktop
+    substituteInPlace $out/share/applications/uniclipboard.desktop \
+      --replace-fail 'Comment=一个剪切板同步工具' 'Comment=Encrypted peer-to-peer clipboard sync'
+    cp -r ${appimageContents}/usr/share/icons $out/share/icons
+  '';
+
+  extraPkgs = pkgs: with pkgs; [ ];
+
+  meta = {
+    description = "Encrypted peer-to-peer clipboard sync between your devices";
+    longDescription = ''
+      UniClipboard syncs your clipboard securely across your devices on the local
+      network. End-to-end encrypted and powered by iroh QUIC, with direct
+      peer-to-peer sync of text, images, and files.
+    '';
+    homepage = "https://uniclipboard.app";
+    downloadPage = "https://github.com/UniClipboard/UniClipboard/releases";
+    license = lib.licenses.agpl3Only;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ mkdir700 ];
+    mainProgram = "uniclipboard";
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
Adds UniClipboard, an encrypted peer-to-peer clipboard sync desktop app. Homepage: https://uniclipboard.app

This packages the upstream x86_64 Linux AppImage using `appimageTools.wrapType2`.

AI/tooling disclosure: this PR was prepared with assistance from OpenAI Codex (GPT-5); the commits include `Assisted-by:` trailers.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Local checks completed before opening this draft:
- Confirmed no existing `pkgs/by-name/un/uniclipboard/package.nix` in Nixpkgs.
- Confirmed no existing open/closed UniClipboard PR in Nixpkgs search.
- Confirmed v0.16.0 is the latest stable UniClipboard release.
- Downloaded the upstream AppImage and verified the SHA256 hash used in the package.
- Inspected the AppImage payload for the desktop entry and icon paths used by the package.
- Ran `git diff --check`.

Still needed before marking ready for review:
- `nix-build -A uniclipboard` on x86_64-linux.
- Run `./result/bin/uniclipboard` and confirm the app starts.
- Run `nixpkgs-review rev HEAD` or equivalent.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test