### PR TITLE
libdjinterop: 0.26.1 -> 0.27.1

### DIFF
--- a/pkgs/by-name/li/libdjinterop/package.nix
+++ b/pkgs/by-name/li/libdjinterop/package.nix
@@ -2,8 +2,10 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   boost,
   cmake,
+  howard-hinnant-date,
   ninja,
   pkg-config,
   sqlite,
@@ -22,6 +24,21 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-Uiz2VZef0+H9NfPgOPT1XVBKCiTXC/n8VKVveXEy40c=";
   };
 
+  patches = [
+    # https://github.com/xsco/libdjinterop/pull/188
+    # adds options to use system howard-hinnant-date and sqlite_modern_cpp
+    # additionally bumps version in CMakeLists.txt, fixed in postPatch
+    (fetchpatch2 {
+      url = "https://github.com/xsco/libdjinterop/commit/d21f713440633e41d37df14c8e5cc16be7595a7a.patch";
+      hash = "sha256-QPgSU1BYl+RAb3sJn5LkbqovhBgCLYw44+d8pr7Tx3M=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+    --replace-fail "VERSION 0.27.2" "VERSION 0.27.1"
+  '';
+
   nativeBuildInputs = [
     cmake
     ninja
@@ -35,8 +52,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     boost
+    howard-hinnant-date
     sqlite
     zlib
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "SYSTEM_DATE_H" true)
   ];
 
   meta = {

--- a/pkgs/by-name/li/libdjinterop/package.nix
+++ b/pkgs/by-name/li/libdjinterop/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch2,
   boost,
   cmake,
   ninja,
@@ -14,22 +13,14 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "libdjinterop";
 
-  version = "0.26.1";
+  version = "0.27.1";
 
   src = fetchFromGitHub {
     owner = "xsco";
     repo = "libdjinterop";
     rev = finalAttrs.version;
-    hash = "sha256-HwNhCemqVR1xNSbcht0AuwTfpRhVi70ZH5ksSTSRFoc=";
+    hash = "sha256-Uiz2VZef0+H9NfPgOPT1XVBKCiTXC/n8VKVveXEy40c=";
   };
-
-  patches = [
-    # https://github.com/xsco/libdjinterop/pull/161
-    (fetchpatch2 {
-      url = "https://github.com/xsco/libdjinterop/commit/94ce315cd5155bd031eeccfec12fbeb8e399dd14.patch";
-      hash = "sha256-WahMsFeetSlHHiIyaC04YxTiXDxD1ooASqoIP2TK9R0=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/li/libdjinterop/package.nix
+++ b/pkgs/by-name/li/libdjinterop/package.nix
@@ -3,11 +3,12 @@
   stdenv,
   fetchFromGitHub,
   fetchpatch2,
+  testers,
+  validatePkgConfig,
   boost,
   cmake,
   howard-hinnant-date,
   ninja,
-  pkg-config,
   sqlite,
   zlib,
 }:
@@ -42,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     ninja
-    pkg-config
+    validatePkgConfig
   ];
 
   outputs = [
@@ -57,9 +58,27 @@ stdenv.mkDerivation (finalAttrs: {
     zlib
   ];
 
+  propagatedBuildInputs = [
+    howard-hinnant-date
+    sqlite
+    zlib
+  ];
+
+  strictDeps = true;
+
   cmakeFlags = [
     (lib.cmakeBool "SYSTEM_DATE_H" true)
   ];
+
+  doCheck = true;
+
+  passthru.tests = {
+    cmake-config = testers.hasCmakeConfigModules {
+      package = finalAttrs.finalPackage;
+      moduleNames = [ "DjInterop" ];
+    };
+    pkg-config = testers.hasPkgConfigModules { package = finalAttrs.finalPackage; };
+  };
 
   meta = {
     homepage = "https://github.com/xsco/libdjinterop";
@@ -67,5 +86,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.lgpl3;
     maintainers = with lib.maintainers; [ benley ];
     platforms = lib.platforms.unix;
+    pkgConfigModules = [ "djinterop" ];
   };
 })

--- a/pkgs/by-name/li/libdjinterop/package.nix
+++ b/pkgs/by-name/li/libdjinterop/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \
-    --replace-fail "VERSION 0.27.2" "VERSION 0.27.1"
+      --replace-fail "VERSION 0.27.2" "VERSION ${finalAttrs.version}"
   '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/mi/mixxx/package.nix
+++ b/pkgs/by-name/mi/mixxx/package.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
   # Should be removed when bumping to 2.6.x
   postPatch = ''
     substituteInPlace CMakeLists.txt \
-      --replace-warn "LIBDJINTEROP_VERSION 0.24.3" "LIBDJINTEROP_VERSION 0.26.1"
+      --replace-warn "LIBDJINTEROP_VERSION 0.24.3" "LIBDJINTEROP_VERSION 0.27.1"
   '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/mi/mixxx/package.nix
+++ b/pkgs/by-name/mi/mixxx/package.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
   # Should be removed when bumping to 2.6.x
   postPatch = ''
     substituteInPlace CMakeLists.txt \
-      --replace-warn "LIBDJINTEROP_VERSION 0.24.3" "LIBDJINTEROP_VERSION 0.27.1"
+      --replace-warn "LIBDJINTEROP_VERSION 0.24.3" "LIBDJINTEROP_VERSION ${libdjinterop.version}"
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
Changes: https://github.com/xsco/libdjinterop/compare/0.26.1...0.27.1

Tested with Mixxx, including an engine export (which uses libdjinterop). 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
