### PR TITLE
pulumi: 3.192.0 -> 3.253.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28864,6 +28864,11 @@
     github = "UnsolvedCypher";
     githubId = 3170853;
   };
+  untio11 = {
+    name = "Robin Kneepkens";
+    github = "untio11";
+    githubId = 14060658;
+  };
   uralbash = {
     email = "root@uralbash.ru";
     github = "uralbash";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19889,6 +19889,12 @@
     github = "niklaskorz";
     githubId = 590517;
   };
+  niklasravnsborg = {
+    name = "Niklas Ravnsborg";
+    github = "niklasravnsborg";
+    githubId = 6717303;
+    keys = [ { fingerprint = "0C90 DD8A 0EE9 93DF 8D58  7AF9 8360 E6C5 8AE8 F3ED"; } ];
+  };
   niklasthorild = {
     name = "Niklas Thorild";
     email = "niklas@thorild.se";

--- a/pkgs/by-name/pu/pulumi/extra/mk-pulumi-package.nix
+++ b/pkgs/by-name/pu/pulumi/extra/mk-pulumi-package.nix
@@ -80,6 +80,19 @@ let
                  -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "${version}"/g' \
                  setup.py
             fi
+
+            # Pulumi Python SDKs use `pkg_resources` to find their current version at
+            # runtime. However, `pkg_resources` has been deprecated from `setuptools`
+            # since v82.0.0 (https://setuptools.pypa.io/en/stable/history.html#v82-0-0).
+            #
+            # Bypass this problem by:
+            # - removing the `pkg_resources` import and,
+            # - patching the plugin `version` string as a literal instead of requesting
+            #   it via `pkg_resources`.
+            find . -name "_utilities.py" -exec sed -i \
+              -e 's/import pkg_resources//g' \
+              -e 's/pkg_resources.require(root_package)\[0\].version/"${version}"/g' \
+              {} +
           '';
 
           # Auto-generated; upstream does not have any tests.

--- a/pkgs/by-name/pu/pulumi/package.nix
+++ b/pkgs/by-name/pu/pulumi/package.nix
@@ -17,18 +17,18 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "pulumi";
-  version = "3.192.0";
+  version = "3.248.0";
 
   src = fetchFromGitHub {
     owner = "pulumi";
     repo = "pulumi";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-rcDXC+xlUa67afuXvmEv8UNsYWBvQQ0P4httdtdcrh4=";
+    hash = "sha256-Ew2+bOqiiwnHxszC980uWWcPqbE/ObDk9m+LOKg/u+I=";
     # Some tests rely on checkout directory name
     name = "pulumi";
   };
 
-  vendorHash = "sha256-BaFw8EnPd2GPA/p9wm8XpVy/iE8gqbteRnMQC8Z4NHQ=";
+  vendorHash = "sha256-Bk8or6B4dBzrQpoq4cf8FzlTLc4XVMhu67lrXQ6Nrcc=";
 
   sourceRoot = "${finalAttrs.src.name}/pkg";
 
@@ -60,22 +60,16 @@ buildGoModule (finalAttrs: {
     # Skip tests that fail in Nix sandbox.
     "-skip=^${
       lib.concatStringsSep "$|^" [
-        # Concurrent map modification in test case.
-        # TODO: remove after the fix is merged and released.
-        # https://github.com/pulumi/pulumi/pull/19200
-        "TestGetDocLinkForPulumiType"
-
         # Seems to require TTY.
         "TestProgressEvents"
-
-        # Flaky; upstream “fixed” it by increasing timeout.
-        # https://github.com/pulumi/pulumi/pull/20116
-        "TestAnalyzerCancellation"
+        "TestInfoXTerm"
+        "TestInfoVT102"
 
         # Tries to clone repo: https://github.com/pulumi/test-repo.git
         "TestValidateRelativeDirectory"
         "TestRepoLookup"
         "TestDSConfigureGit"
+        "TestResolvePackage"
 
         # Tries to clone repo: github.com/pulumi/templates.git
         "TestGenerateOnlyProjectCheck"
@@ -89,6 +83,9 @@ buildGoModule (finalAttrs: {
         "TestPulumiNewWithRegistryTemplates"
         "TestRunNewYesNoTemplate"
         "TestRunNewYesWithTemplate"
+        "TestNewCmdYesWritesMinimalPulumiYAMLWithExplicitName"
+        "TestNewCmdYesSanitizesDefaultDirectoryName"
+        "TestNewCmdYesUsesCurrentDirectoryNameByDefault"
 
         # Connects to https://api.pulumi.com/…
         "TestGetLatestPluginIncludedVersion"
@@ -108,6 +105,10 @@ buildGoModule (finalAttrs: {
         # Downloads pulumi-resource-random from Pulumi plugin registry.
         "TestPluginInstallCancellation"
 
+        # Fails to create/run test-plugin.
+        "TestPluginRunCommand"
+        "TestPluginRunCommandError"
+
         # Requires language-specific tooling and/or Internet access.
         "TestGenerateProgram"
         "TestGenerateProgramVersionSelection"
@@ -117,6 +118,44 @@ buildGoModule (finalAttrs: {
         "TestGeneratePackageTwo"
         "TestParseAndRenderDocs"
         "TestImportResourceRef"
+        "TestImportPathPattern"
+        "TestL2ResourceAssetArchive"
+
+        # Require reading from a local credential file.
+        "TestAuthRequiredMessageChecksClaimWhenTokenLocallyValidButRejected"
+        "TestAuthRequiredMessageFallsBackToLocalClaimWhenValidationFails"
+        "TestAuthRequiredMessageOmitsClaimURLWhenClaimIsNotClaimable"
+        "TestAuthRequiredMessagePrintsClaimInstructionWhenTokenExpiredButClaimValid"
+        "TestAuthRequiredMessageSkipsValidationWhenClaimMarkedUnavailable"
+        "TestCurrentEnvTokenFailsWithInaccessibleExplicitPath"
+        "TestCurrentEnvTokenStoresInDefaultPathWhenWritable"
+        "TestCurrentInvalidAgentCredentialsWithActiveClaimDoesNotSignup"
+        "TestCurrentRejectedAgentCredentialsWithUnexpiredTokenDoesNotSignup"
+        "TestCurrentSignupAgentAccountStoresClaimTokenURL"
+        "TestCurrentSignupAgentAccountStoresRefreshToken"
+        "TestCurrentSignupAgentAccountWithoutRefreshTokenLeavesAccountEmpty"
+        "TestCurrentValidAgentCredentialsWithExpiredClaimDoesNotSignup"
+        "TestGetBackendAccountDoesNotFallbackToAgentCredentialsWithExplicitPath"
+        "TestGetCurrentCloudURLFallsBackToAgentCredentials"
+        "TestLoginUsesAgentSignupInNonInteractiveAgentMode"
+        "TestMaybePrintClaimWarningPrintsForUsedAgentCredentials"
+        "TestMaybePrintClaimWarningRequiresAgentCredentialsUsed"
+        "TestProcessCmdErrorsDoesNotPrintAgentAuthRequiredInstructionForAPINonUnauthorized"
+        "TestProcessCmdErrorsDoesNotPrintClaimURLForUnauthorizedClaimedAccount"
+        "TestProcessCmdErrorsPrintsAgentAuthRequiredInstruction"
+        "TestProcessCmdErrorsPrintsAgentAuthRequiredInstructionForAPIUnauthorized"
+        "TestProcessCmdErrorsPrintsAgentClaimWarningForNonLoginError"
+        "TestRetrievePrivatePulumiCloudTemplateFallsBackToAgentCredentials"
+
+        # Probably flaky.
+        "TestTokenSourceWithClient"
+
+        # Requires invoking pulumi binary.
+        "TestDecryptEncryptedLog"
+        "TestDecryptGzipLog"
+
+        # Requires unavailable access token.
+        "TestRunNewYesWithAILanguage"
       ]
     }$"
   ];
@@ -189,6 +228,7 @@ buildGoModule (finalAttrs: {
     maintainers = with lib.maintainers; [
       veehaitch
       tie
+      untio11
     ];
   };
 })

--- a/pkgs/by-name/pu/pulumi/package.nix
+++ b/pkgs/by-name/pu/pulumi/package.nix
@@ -183,6 +183,10 @@ buildGoModule (finalAttrs: {
     updateScript = _experimental-update-script-combinators.sequence [
       (nix-update-script { })
       (nix-update-script {
+        attrPath = "pulumiPackages.pulumi-bun";
+        extraArgs = [ "--version=skip" ];
+      })
+      (nix-update-script {
         attrPath = "pulumiPackages.pulumi-go";
         extraArgs = [ "--version=skip" ];
       })
@@ -203,7 +207,12 @@ buildGoModule (finalAttrs: {
       };
 
       # Test building packages that reuse our version and src.
-      inherit (pulumiPackages) pulumi-go pulumi-nodejs pulumi-python;
+      inherit (pulumiPackages)
+        pulumi-bun
+        pulumi-go
+        pulumi-nodejs
+        pulumi-python
+        ;
       pythonPackage = python3Packages.pulumi;
       pythonPackageProtobuf5 =
         (python3Packages.overrideScope (

--- a/pkgs/by-name/pu/pulumi/package.nix
+++ b/pkgs/by-name/pu/pulumi/package.nix
@@ -17,18 +17,18 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "pulumi";
-  version = "3.248.0";
+  version = "3.253.0";
 
   src = fetchFromGitHub {
     owner = "pulumi";
     repo = "pulumi";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Ew2+bOqiiwnHxszC980uWWcPqbE/ObDk9m+LOKg/u+I=";
+    hash = "sha256-ZwK9IXuKD583MJ+6VG9CsrEIwh4aJGBlCXys/TYfrmg=";
     # Some tests rely on checkout directory name
     name = "pulumi";
   };
 
-  vendorHash = "sha256-Bk8or6B4dBzrQpoq4cf8FzlTLc4XVMhu67lrXQ6Nrcc=";
+  vendorHash = "sha256-5HYYesdKfZqCqDNrD2LZc25hxrczxRV/jsMXWeFT6fc=";
 
   sourceRoot = "${finalAttrs.src.name}/pkg";
 

--- a/pkgs/by-name/pu/pulumi/package.nix
+++ b/pkgs/by-name/pu/pulumi/package.nix
@@ -235,9 +235,10 @@ buildGoModule (finalAttrs: {
     license = lib.licenses.asl20;
     mainProgram = "pulumi";
     maintainers = with lib.maintainers; [
-      veehaitch
+      nicoo
       tie
       untio11
+      veehaitch
     ];
   };
 })

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-bun/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-bun/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildGoModule,
+  symlinkJoin,
+  pulumi,
+  pulumi-nodejs,
+}:
+let
+  unwrapped = buildGoModule (finalAttrs: {
+    pname = "pulumi-bun-unwrapped";
+    inherit (pulumi) version src;
+
+    sourceRoot = "${finalAttrs.src.name}/sdk/nodejs/cmd/pulumi-language-bun";
+
+    vendorHash = null;
+
+    ldflags = [
+      "-s"
+      "-w"
+      "-X=github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${finalAttrs.version}"
+    ];
+  });
+in
+symlinkJoin (finalAttrs: {
+  pname = "pulumi-bun";
+  inherit (pulumi) version;
+
+  paths = [
+    unwrapped
+    pulumi-nodejs
+  ];
+
+  passthru = {
+    inherit unwrapped;
+  };
+
+  meta = {
+    homepage = "https://www.pulumi.com/docs/iac/languages-sdks/javascript/";
+    description = "Language host for Pulumi programs written in TypeScript & JavaScript (Bun)";
+    license = lib.licenses.asl20;
+    mainProgram = "pulumi-language-bun";
+    maintainers = with lib.maintainers; [
+      niklasravnsborg
+    ];
+  };
+})

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-go/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-go/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/sdk/go/pulumi-language-go";
 
-  vendorHash = "sha256-jwsdMSLDn2PNJFIIVhqwBLH7acFTOFLPgVNMKbI5DZE=";
+  vendorHash = "sha256-QW3fB8ytb3LpyO0wd0dy3x8Jxl/3C1MTbdu3VUgZCBs=";
 
   ldflags = [
     "-s"
@@ -20,7 +20,9 @@ buildGoModule (finalAttrs: {
   checkFlags = [
     "-skip=^${
       lib.concatStringsSep "$|^" [
-        "TestLanguage"
+        "TestLanguagePublished"
+        "TestLanguageLocal"
+        "TestLanguageExtraTypes"
         "TestPluginsAndDependencies_vendored"
         "TestPluginsAndDependencies_subdir"
         "TestPluginsAndDependencies_moduleMode"
@@ -35,6 +37,7 @@ buildGoModule (finalAttrs: {
     mainProgram = "pulumi-language-go";
     maintainers = with lib.maintainers; [
       tie
+      untio11
     ];
   };
 })

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-go/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-go/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/sdk/go/pulumi-language-go";
 
-  vendorHash = "sha256-QW3fB8ytb3LpyO0wd0dy3x8Jxl/3C1MTbdu3VUgZCBs=";
+  vendorHash = "sha256-NTIOTy6pLJgnxI6AP87Nfljr551fvih/b9c59VYg3PA=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-nodejs/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-nodejs/package.nix
@@ -12,7 +12,7 @@ buildGoModule (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/sdk/nodejs/cmd/pulumi-language-nodejs";
 
-  vendorHash = "sha256-Q5Pk2f3EAiM4oit1vhc+PMEuMxdbrKAue3e0pnrZw2c=";
+  vendorHash = "sha256-+ZlUFiSDrq3KGvXMT+uQIQL78aMW+UVmyFO6iZ2X4AA=";
 
   ldflags = [
     "-s"
@@ -23,8 +23,10 @@ buildGoModule (finalAttrs: {
   checkFlags = [
     "-skip=^${
       lib.concatStringsSep "$|^" [
-        "TestLanguage"
         "TestGetProgramDependencies"
+        "TestLanguageTSC"
+        "TestLanguageTSNode"
+        "TestLanguageBun"
       ]
     }$"
   ];
@@ -41,8 +43,7 @@ buildGoModule (finalAttrs: {
 
   postInstall = ''
     cp -t "$out/bin" \
-      ../../dist/pulumi-resource-pulumi-nodejs \
-      ../../dist/pulumi-analyzer-policy
+      ../../dist/pulumi-resource-pulumi-nodejs
   '';
 
   meta = {
@@ -52,6 +53,7 @@ buildGoModule (finalAttrs: {
     mainProgram = "pulumi-language-nodejs";
     maintainers = with lib.maintainers; [
       tie
+      untio11
     ];
   };
 })

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-nodejs/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-nodejs/package.nix
@@ -12,7 +12,7 @@ buildGoModule (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/sdk/nodejs/cmd/pulumi-language-nodejs";
 
-  vendorHash = "sha256-+ZlUFiSDrq3KGvXMT+uQIQL78aMW+UVmyFO6iZ2X4AA=";
+  vendorHash = "sha256-q+7Qm3HL2avVtx29Cz066BOD7tgyukEwj1FinzmEdw8=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-python/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-python/package.nix
@@ -12,7 +12,7 @@ buildGoModule (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/sdk/python/cmd/pulumi-language-python";
 
-  vendorHash = "sha256-BfkjDesPdPDV2uILYaMJFIvaEBKT15ukwaReAL3yziw=";
+  vendorHash = "sha256-1P90hdwBwCNRfR1PDSHQuEOCcrbnoJrmU4ggG7ktAGY=";
 
   ldflags = [
     "-s"
@@ -23,8 +23,10 @@ buildGoModule (finalAttrs: {
   checkFlags = [
     "-skip=^${
       lib.concatStringsSep "$|^" [
-        "TestLanguage"
-        "TestDeterminePulumiPackages"
+        "TestLanguageDefault"
+        "TestLanguageTOML"
+        "TestLanguageClasses"
+        "TestListPulumiPackageInfos"
       ]
     }$"
   ];
@@ -42,8 +44,7 @@ buildGoModule (finalAttrs: {
   postInstall = ''
     cp -t "$out/bin" \
       ../pulumi-language-python-exec \
-      ../../dist/pulumi-resource-pulumi-python \
-      ../../dist/pulumi-analyzer-policy-python
+      ../../dist/pulumi-resource-pulumi-python
   '';
 
   passthru.tests.smokeTest = callPackage ./smoke-test/default.nix { };
@@ -55,6 +56,7 @@ buildGoModule (finalAttrs: {
     mainProgram = "pulumi-language-python";
     maintainers = with lib.maintainers; [
       tie
+      untio11
     ];
   };
 })

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-python/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-python/package.nix
@@ -12,7 +12,7 @@ buildGoModule (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/sdk/python/cmd/pulumi-language-python";
 
-  vendorHash = "sha256-1P90hdwBwCNRfR1PDSHQuEOCcrbnoJrmU4ggG7ktAGY=";
+  vendorHash = "sha256-JlfRmBrowYYcKG+lkG6DCxWIibb0V1NVbpgPT86iRFU=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-python/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-python/package.nix
@@ -55,6 +55,7 @@ buildGoModule (finalAttrs: {
     license = lib.licenses.asl20;
     mainProgram = "pulumi-language-python";
     maintainers = with lib.maintainers; [
+      nicoo
       tie
       untio11
     ];

--- a/pkgs/development/python-modules/pulumi/default.nix
+++ b/pkgs/development/python-modules/pulumi/default.nix
@@ -12,6 +12,10 @@
   pyyaml,
   debugpy,
   pip,
+  opentelemetry-api,
+  opentelemetry-sdk,
+  opentelemetry-instrumentation-grpc,
+  opentelemetry-exporter-otlp-proto-grpc,
   pytest,
   pytest-asyncio,
   pytest-timeout,
@@ -48,6 +52,10 @@ buildPythonPackage {
     pyyaml
     debugpy
     pip
+    opentelemetry-api
+    opentelemetry-sdk
+    opentelemetry-instrumentation-grpc
+    opentelemetry-exporter-otlp-proto-grpc
   ];
 
   pythonRelaxDeps = [
@@ -55,6 +63,10 @@ buildPythonPackage {
     "grpcio"
     "pip"
     "semver"
+    "opentelemetry-api"
+    "opentelemetry-sdk"
+    "opentelemetry-instrumentation-grpc"
+    "opentelemetry-exporter-otlp-proto-grpc"
   ];
 
   nativeCheckInputs = [
@@ -64,19 +76,20 @@ buildPythonPackage {
     pulumi-python
   ];
 
-  disabledTestPaths = [
-    # TODO: remove disabledTestPaths once the test is fixed upstream.
-    # https://github.com/pulumi/pulumi/pull/19080#discussion_r2309611222
-    "lib/test/provider/experimental/test_property_value.py::test_nesting"
-  ];
-
+  # CheckPhase script based on:
   # https://github.com/pulumi/pulumi/blob/0acaf8060640fdd892abccf1ce7435cd6aae69fe/sdk/python/scripts/test_fast.sh#L10-L11
   # https://github.com/pulumi/pulumi/blob/0acaf8060640fdd892abccf1ce7435cd6aae69fe/sdk/python/scripts/test_fast.sh#L16
+  # Script updated in https://github.com/pulumi/pulumi/pull/21365
+  #
+  # Ignore lib/test/langhost because tests require `uv` / virtualenv which is not supported in the Nix sandbox.
   installCheckPhase = ''
     runHook preInstallCheck
     declare -a _disabledTestPathsArray
     concatTo _disabledTestPathsArray disabledTestPaths
-    ${python.executable} -m pytest --junit-xml= --ignore=lib/test/automation lib/test \
+    ${python.executable} -m pytest --junit-xml= \
+      --ignore=lib/test/automation \
+      --ignore=lib/test/langhost \
+      lib/test \
       "''${_disabledTestPathsArray[@]/#/--deselect=}"
     pushd lib/test_with_mocks
     ${python.executable} -m pytest --junit-xml=
@@ -95,6 +108,7 @@ buildPythonPackage {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       tie
+      untio11
     ];
   };
 }

--- a/pkgs/development/python-modules/pulumi/default.nix
+++ b/pkgs/development/python-modules/pulumi/default.nix
@@ -117,6 +117,7 @@ buildPythonPackage {
     homepage = "https://www.pulumi.com";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
+      nicoo
       tie
       untio11
     ];

--- a/pkgs/development/python-modules/pulumi/default.nix
+++ b/pkgs/development/python-modules/pulumi/default.nix
@@ -76,6 +76,16 @@ buildPythonPackage {
     pulumi-python
   ];
 
+  disabledTestPaths = [
+    # Fail due to missing `pytest.mark.asyncio`, as of v3.253.0
+    "lib/test/test_deprecated.py::DeprecatedTests::test_non_deprecated_can_be_called"
+    "lib/test/test_deprecated.py::DeprecatedTests::test_deprecated_can_be_called"
+    "lib/test/test_deprecated.py::DeprecatedTests::test_deprecated_can_passthrough"
+    "lib/test/test_deprecated.py::DeprecatedTests::test_deprecated_prints_warnings"
+    "lib/test/runtime/test_resource_dep_cycle.py"
+    "lib/test/test_broken_dynamic_provider.py"
+  ];
+
   # CheckPhase script based on:
   # https://github.com/pulumi/pulumi/blob/0acaf8060640fdd892abccf1ce7435cd6aae69fe/sdk/python/scripts/test_fast.sh#L10-L11
   # https://github.com/pulumi/pulumi/blob/0acaf8060640fdd892abccf1ce7435cd6aae69fe/sdk/python/scripts/test_fast.sh#L16


### PR DESCRIPTION
- Updated `pulumi` and `pulumiPackages.{pulumi-go node-js pulumi-python}`, which directly depend on the main `pulumi` version.
- Removed `postInstall` lines copying language policy analyzers as these are installed at runtime like resources since [v3.227.0](https://github.com/pulumi/pulumi/releases/tag/v3.227.0)
- Removed skipped tests after verifying related PR's are closed:
  - https://github.com/pulumi/pulumi/pull/19200
  - https://github.com/pulumi/pulumi/pull/20116
- Added myself to `maintainers-list.nix` and to `meta.maintainers` of the packages I updated.
- Added (new) missing dependencies to `python-modules.pulumi`
  - Also disabled some failing tests there.
- Cherry-picked commits from https://github.com/NixOS/nixpkgs/pull/516851 adding `pulumiPackages.pulumi-bun` and adding @niklasravnsborg as maintainer, with consent of the original author.

No LLM-generated code or documentation is included in this change.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
    - Ran `nix build -f . "pulumi.tests^*" --arg config "{ sandbox = true; }"` locally.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Ran `pulumi version` and `pulumi help`, both run normally.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
