### PR TITLE
python3Packages.torchaudio: skip the most time-consuming tests

### DIFF
--- a/pkgs/by-name/mu/music-assistant/package.nix
+++ b/pkgs/by-name/mu/music-assistant/package.nix
@@ -238,6 +238,14 @@ pythonPackages.buildPythonApplication (finalAttrs: {
     "tests/providers/airplay/test_player.py::test_start_pairing__pin_decision"
   ];
 
+  disabledTests = lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+    # RuntimeError: failed to initialize QNNPACK
+    "test_beat_detection"
+    "test_extended_analysis_fields"
+    "test_finalize_returns_audio_analysis_data"
+    "test_finalize_returns_none_on_early_exit"
+  ];
+
   pythonImportsCheck = [ "music_assistant" ];
 
   passthru = {

--- a/pkgs/by-name/mu/music-assistant/package.nix
+++ b/pkgs/by-name/mu/music-assistant/package.nix
@@ -38,15 +38,16 @@ in
 assert
   (lib.elem "ariacast" providers) -> throw "music-assistant: ariacast has not been packaged, yet.";
 
-pythonPackages.buildPythonApplication rec {
+pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "music-assistant";
   version = "2.9.4";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "music-assistant";
     repo = "server";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-PiSBghhlxknijRqghkO8wn1CB2XqaJrjrvGNvZUlNbo=";
   };
 
@@ -93,7 +94,7 @@ pythonPackages.buildPythonApplication rec {
       --replace-fail "except BrokenPipeError, ConnectionResetError:" "except (BrokenPipeError, ConnectionResetError):"
 
     substituteInPlace pyproject.toml \
-      --replace-fail "0.0.0" "${version}" \
+      --replace-fail "0.0.0" "${finalAttrs.version}" \
       --replace-fail "==" ">="
 
     rm -rv \
@@ -191,7 +192,7 @@ pythonPackages.buildPythonApplication rec {
       pytestCheckHook
       writableTmpDirAsHomeHook
     ]
-    ++ lib.concatAttrValues optional-dependencies
+    ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies
     ++ (lib.concatMap (provider: providerPackages.${provider} pythonPackages) [
       "acoustid_lookup"
       "audible"
@@ -252,7 +253,7 @@ pythonPackages.buildPythonApplication rec {
 
   meta = {
     broken = stdenv.hostPlatform.isDarwin;
-    changelog = "https://github.com/music-assistant/server/releases/tag/${version}";
+    changelog = "https://github.com/music-assistant/server/releases/tag/${finalAttrs.src.tag}";
     description = "Music Assistant is a music library manager for various music sources which can easily stream to a wide range of supported players";
     longDescription = ''
       Music Assistant is a free, opensource Media library manager that connects to your streaming services and a wide
@@ -267,4 +268,4 @@ pythonPackages.buildPythonApplication rec {
     ];
     mainProgram = "mass";
   };
-}
+})

--- a/pkgs/development/python-modules/nnaudio/default.nix
+++ b/pkgs/development/python-modules/nnaudio/default.nix
@@ -73,6 +73,7 @@ buildPythonPackage (finalAttrs: {
   ]
   ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
     # Test fixture matrix has other values
+    "test_cqt_1992_v2_linear[cpu]"
     "test_cqt_1992_v2_log[cpu]"
   ];
 

--- a/pkgs/development/python-modules/nnaudio/default.nix
+++ b/pkgs/development/python-modules/nnaudio/default.nix
@@ -1,15 +1,21 @@
 {
   lib,
+  stdenv,
+  fetchurl,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchurl,
-  librosa,
-  numpy,
-  pytestCheckHook,
+
+  # build-system
   setuptools,
+
+  # dependencies
+  numpy,
   scipy,
-  stdenv,
   torch,
+
+  # tests
+  librosa,
+  pytestCheckHook,
   writableTmpDirAsHomeHook,
 }:
 let
@@ -26,6 +32,7 @@ buildPythonPackage (finalAttrs: {
   pname = "nnaudio";
   version = "0.3.4";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "KinWaiCheuk";

--- a/pkgs/development/python-modules/nnaudio/default.nix
+++ b/pkgs/development/python-modules/nnaudio/default.nix
@@ -64,6 +64,11 @@ buildPythonPackage (finalAttrs: {
     export NUMBA_CACHE_DIR=$(mktemp -d)
   '';
 
+  # urllib3.exceptions.MaxRetryError
+  # On darwin the tests fail to locate the audio files and fallback to downloading them from the
+  # internet
+  doCheck = !stdenv.hostPlatform.isDarwin;
+
   disabledTests = [
     # AttributeError: module 'scipy.signal' has no attribute 'blackmanharris'
     "test_cfp_original[cpu]"

--- a/pkgs/development/python-modules/torchaudio/default.nix
+++ b/pkgs/development/python-modules/torchaudio/default.nix
@@ -126,6 +126,8 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
 
     # Very long to run
     "AutogradCPUTest"
+    "TestAutogradLfilterCPU"
+    "TestWav2Vec2Model"
   ]
   ++ lib.optionals (hostPlatform.isLinux && hostPlatform.isAarch64) [
     # AssertionError: Tensor-likes are not close!

--- a/pkgs/development/python-modules/usearch/default.nix
+++ b/pkgs/development/python-modules/usearch/default.nix
@@ -19,6 +19,7 @@
 buildPythonPackage {
   inherit (pkgs.usearch) pname version src;
   pyproject = true;
+  __structuredAttrs = true;
 
   postPatch = ''
     substituteInPlace python/usearch/__init__.py \

--- a/pkgs/development/python-modules/usearch/default.nix
+++ b/pkgs/development/python-modules/usearch/default.nix
@@ -59,6 +59,12 @@ buildPythonPackage {
     writableTmpDirAsHomeHook
   ];
 
+  disabledTests = lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+    # Numerical precision error (AssertionError)
+    "test_index_clustering"
+    "test_index_retrieval"
+  ];
+
   meta = {
     inherit (pkgs.usearch.meta)
       description


### PR DESCRIPTION
## Things done

- **python3Packages.torchaudio: skip the most time-consuming tests** Drop a few more tests. This cuts down the build time by several factors.
- **python3Packages.nnaudio: cleanup**
- **python3Packages.nnaudio: skip failing test on aarch64-linux**
- **python3Packages.nnaudio: disable tests on darwin as they fail in the sanbdox**
- **python3Packages.usearch: skip failing tests on aarch64-linux**
- **python3Packages.usearch: enable __structuredAttrs**
- **music-assistant: cleanup**
- **music-assistant: skip failing tests on aarch64-linux**

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
