### PR TITLE
jetring: init at 0.32; debian-archive-keyring: init at 2025.1

### DIFF
--- a/pkgs/by-name/de/debian-archive-keyring/package.nix
+++ b/pkgs/by-name/de/debian-archive-keyring/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  fetchFromGitLab,
+  stdenvNoCC,
+  nix-update-script,
+  jetring,
+  gnupg,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "debian-archive-keyring";
+  version = "2025.1";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "release-team";
+    repo = "debian-archive-keyring";
+    tag = finalAttrs.version;
+    hash = "sha256-NaVbca1mx0j4hfSncX8hh8PbtB92yGeZUUdp4Nx9JoY=";
+  };
+
+  nativeBuildInputs = [
+    jetring
+    gnupg
+  ];
+
+  makeFlags = [ "DESTDIR=$(out)" ];
+
+  postInstall = ''
+    mv $out/usr/share $out/share
+    rm -d $out/usr
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "GnuPG archive keys of the Debian archive";
+    homepage = "https://salsa.debian.org/release-team/debian-archive-keyring";
+    license = lib.licenses.publicDomain;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.skyesoss ];
+  };
+})

--- a/pkgs/by-name/je/jetring/package.nix
+++ b/pkgs/by-name/je/jetring/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  fetchFromGitLab,
+  stdenvNoCC,
+  nix-update-script,
+  installShellFiles,
+  makeWrapper,
+  perl,
+  gnupg,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "jetring";
+  version = "0.32";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "debian";
+    repo = "jetring";
+    tag = "debian/${finalAttrs.version}";
+    hash = "sha256-oaZXy/BO0mDYvDPW0OP38fXZTZSrcUCW7uYuwCMBPDc=";
+  };
+
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+  ];
+
+  buildInputs = [
+    perl
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    installBin jetring-{accept,apply,build,diff,explode,gen,review,signindex,checksum}
+
+    for f in $out/bin/*; do
+      wrapProgram "$f" --prefix PATH : ${lib.makeBinPath [ gnupg ]}
+    done
+
+    installManPage *.{1,7}
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Maintenance of gpg keyrings using changesets";
+    homepage = "https://salsa.debian.org/debian/jetring";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.skyesoss ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Packages such as `apt` and `dpkg` rely on the existence of the Debian keyring to install packages properly.
This is important for packages already in nixpkgs such as `mkosi`, where one needs to construct a FHS environment containing these keys in order to build images.
It is also needed for new packages such as mmdebstrap (#270095).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
