### PR TITLE
mkroot-utils: init at 0.5.3

### DIFF
--- a/pkgs/by-name/mk/mkroot-utils/package.nix
+++ b/pkgs/by-name/mk/mkroot-utils/package.nix
@@ -1,0 +1,49 @@
+{
+  busybox,
+  cmake,
+  fakeroot,
+  fetchFromGitLab,
+  gitUpdater,
+  lib,
+  python3,
+  stdenv,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mkroot-utils";
+  version = "0.5.3";
+
+  src = fetchFromGitLab {
+    owner = "arpa2";
+    repo = "mkroot-utils";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-BT0OSK6QzxCegj8cXQcBbdfxoj+GxfGfDkyry0JN4Jo=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    python3
+  ];
+
+  prePatch = ''
+    substituteInPlace CMakeLists.txt flash/flash.c pico/picoget.c --replace-fail '/bin/ash' '${lib.getExe' busybox "ash"}'
+    patchShebangs test
+  '';
+
+  nativeCheckInputs = [ fakeroot ];
+
+  doCheck = true;
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
+  };
+
+  meta = {
+    description = "Simple utilities to extend RunC and \"mkroot\"";
+    homepage = "https://gitlab.com/arpa2/mkroot-utils";
+    license = lib.licenses.bsd2;
+    teams = with lib.teams; [ ngi ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

@vanrein, a couple things holding back packaging:

1. <del>There's no license in the repo.</del> Added BSD 2-clause :white_check_mark: 
2. <del>No tests, the commands output usage info but I haven't done more thorough manual testing. Maybe you could do some manual testing? (Easiest way to test without cloning Nixpkgs is probably to [download the branch](https://github.com/toonn/nixpkgs/archive/refs/heads/package-mkroot-utils.zip), then running `nix-build -A mkroot-utils` in the `nixpkgs` directory will create a `result` symlink pointing at the binaries.)</del> Rick added tests and they're passing. :white_check_mark: 
3. <del>I've patched the uses of `/bin/ash` with Dash, spiritually the closest successor available in Nixpkgs. We could also use Bash instead but Ash is not packaged.</del> Switched to Busybox Ash. :white_check_mark: 


@ngi, checking in that the team is fine with picking up maintenance for this package?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
