### PR TITLE
Nextcloud34 & package updates

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -94,3 +94,10 @@
 - The `newuidmap` and `newgidmap` security wrappers are now installed with `cap_setuid`/`cap_setgid` file capabilities instead of the setuid-root bit, matching shadow's `--with-fcaps` install mode and other major distributions. Rootless containers (podman, docker-rootless, unprivileged user namespaces) are unaffected. The only behavioural change is that mapping host uid 0 via `/etc/subuid` (which NixOS never configures by default) additionally requires `cap_setfcap`; users who explicitly grant uid 0 in a subuid range can restore the previous behaviour with `security.wrappers.newuidmap.capabilities = lib.mkForce "cap_setuid,cap_setfcap+ep";`.
 
 - `zoneminder` has been updated to 1.38.x release. See [upstream release note](https://github.com/ZoneMinder/zoneminder/releases/tag/1.38.0). While database migration should happen automatically, it's recommended that you make a backup of the database before upgrading your system.
+
+- The latest available version of Nextcloud is v34 (available as `pkgs.nextcloud34`). The installation logic is as follows:
+  - If [`services.nextcloud.package`](#opt-services.nextcloud.package) is specified explicitly, this package will be installed (**recommended**)
+  - If `system.stateVersion` is >=26.11, `pkgs.nextcloud34` will be installed by default.
+  - If [`system.stateVersion`](#opt-system.stateVersion) is >=26.05, `pkgs.nextcloud33` will be installed by default.
+  - If [`system.stateVersion`](#opt-system.stateVersion) is >=25.11, `pkgs.nextcloud32` will be installed by default.
+  - Please note that Nextcloud prohibits skipping major versions while upgrading. You can upgrade to specific versions by declaring `services.nextcloud.package = pkgs.nextcloud33;`.

--- a/nixos/modules/services/web-apps/nextcloud.md
+++ b/nixos/modules/services/web-apps/nextcloud.md
@@ -5,7 +5,7 @@ self-hostable cloud platform. The server setup can be automated using
 [services.nextcloud](#opt-services.nextcloud.enable). A
 desktop client is packaged at `pkgs.nextcloud-client`.
 
-The current default by NixOS is `nextcloud33` which is also the latest
+The current default by NixOS is `nextcloud34` which is also the latest
 major version available.
 
 ## Basic usage {#module-services-nextcloud-basic-usage}

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -467,6 +467,7 @@ in
       relatedPackages = [
         "nextcloud32"
         "nextcloud33"
+        "nextcloud34"
       ];
     };
     phpPackage = lib.mkPackageOption pkgs "php" {
@@ -1195,7 +1196,7 @@ in
       {
         warnings =
           let
-            latest = 33;
+            latest = 34;
             upgradeWarning = major: nixos: ''
               A legacy Nextcloud install (from before NixOS ${nixos}) may be installed.
 
@@ -1228,7 +1229,8 @@ in
           ++ (lib.optional (lib.versionOlder cfg.package.version "30") (upgradeWarning 29 "24.11"))
           ++ (lib.optional (lib.versionOlder cfg.package.version "31") (upgradeWarning 30 "25.05"))
           ++ (lib.optional (lib.versionOlder cfg.package.version "32") (upgradeWarning 31 "25.11"))
-          ++ (lib.optional (lib.versionOlder cfg.package.version "33") (upgradeWarning 32 "26.05"));
+          ++ (lib.optional (lib.versionOlder cfg.package.version "33") (upgradeWarning 32 "26.05"))
+          ++ (lib.optional (lib.versionOlder cfg.package.version "34") (upgradeWarning 33 "26.11"));
 
         services.nextcloud.package = lib.mkDefault (
           if pkgs ? nextcloud then
@@ -1241,8 +1243,10 @@ in
             pkgs.nextcloud31
           else if lib.versionOlder stateVersion "26.05" then
             pkgs.nextcloud32
-          else
+          else if lib.versionOlder stateVersion "26.11" then
             pkgs.nextcloud33
+          else
+            pkgs.nextcloud34
         );
 
         services.nextcloud.phpOptions = lib.mkMerge [

--- a/nixos/tests/nextcloud/default.nix
+++ b/nixos/tests/nextcloud/default.nix
@@ -149,5 +149,6 @@ listToAttrs (
   concatMap genTests [
     32
     33
+    34
   ]
 )

--- a/pkgs/servers/nextcloud/default.nix
+++ b/pkgs/servers/nextcloud/default.nix
@@ -5,6 +5,7 @@
   nixosTests,
   nextcloud32Packages,
   nextcloud33Packages,
+  nextcloud34Packages,
 }:
 
 let
@@ -65,6 +66,12 @@ in
     version = "33.0.6";
     hash = "sha256-eRghpVAplE3gQxnPyvysSujn71a0zR78JjG/MLedFt4=";
     packages = nextcloud33Packages;
+  };
+
+  nextcloud34 = generic {
+    version = "34.0.1";
+    hash = "sha256-BOnDL8P+Ofa2qKGJFe9a/SgKVrSn90Thj1+i7/+8SmM=";
+    packages = nextcloud34Packages;
   };
 
   # tip: get the sha with:

--- a/pkgs/servers/nextcloud/default.nix
+++ b/pkgs/servers/nextcloud/default.nix
@@ -20,16 +20,12 @@ let
       pname = "nextcloud";
       inherit version;
 
+      __structuredAttrs = true;
+      strictDeps = true;
+
       src = fetchurl {
         url = "https://download.nextcloud.com/server/releases/nextcloud-${version}.tar.bz2";
         inherit hash;
-      };
-
-      passthru = {
-        tests = lib.filterAttrs (
-          key: _: (lib.hasSuffix (lib.versions.major version) key)
-        ) nixosTests.nextcloud;
-        inherit packages;
       };
 
       installPhase = ''
@@ -38,6 +34,13 @@ let
         cp -R . $out/
         runHook postInstall
       '';
+
+      passthru = {
+        tests = lib.filterAttrs (
+          key: _: (lib.hasSuffix (lib.versions.major version) key)
+        ) nixosTests.nextcloud;
+        inherit packages;
+      };
 
       meta = {
         changelog = "https://nextcloud.com/changelog/#${lib.replaceStrings [ "." ] [ "-" ] version}";

--- a/pkgs/servers/nextcloud/packages/33.json
+++ b/pkgs/servers/nextcloud/packages/33.json
@@ -40,9 +40,9 @@
     ]
   },
   "contacts": {
-    "hash": "sha256-L0ro4VoU1GDMcs1m7qGns+S8y5+n1Q0oQ5EO1ojdLr0=",
-    "url": "https://github.com/nextcloud-releases/contacts/releases/download/v8.7.2/contacts-v8.7.2.tar.gz",
-    "version": "8.7.2",
+    "hash": "sha256-Lgw+wF40FlZTlbw5IXG/eUW8Chaw5Cm1i9f2R8YyPRU=",
+    "url": "https://github.com/nextcloud-releases/contacts/releases/download/v8.7.3/contacts-v8.7.3.tar.gz",
+    "version": "8.7.3",
     "description": "The Nextcloud contacts app is a user interface for Nextcloud's CardDAV server. Easily sync contacts from various devices with your Nextcloud and edit them online.\n\n* 🚀 **Integration with other Nextcloud apps!** Currently Mail and Calendar – more to come.\n* 🎉 **Never forget a birthday!** You can sync birthdays and other recurring events with your Nextcloud Calendar.\n* 👥 **Sharing of Adressbooks!** You want to share your contacts with your friends or coworkers? No problem!\n* 🙈 **We’re not reinventing the wheel!** Based on the great and open SabreDAV library.",
     "homepage": "https://github.com/nextcloud/contacts#readme",
     "licenses": [
@@ -50,9 +50,9 @@
     ]
   },
   "cookbook": {
-    "hash": "sha256-Xn2yvgVL7XPIN8awCaH5mznRMW9Jcr0s2E19D13Hm8I=",
-    "url": "https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.7/cookbook-0.11.7.tar.gz",
-    "version": "0.11.7",
+    "hash": "sha256-eOB04pPqR5rthxK+yrpxuxgZes9chxjRKhy2yd+kIME=",
+    "url": "https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.8/cookbook-0.11.8.tar.gz",
+    "version": "0.11.8",
     "description": "A library for all your recipes. It uses JSON files following the schema.org recipe format. To add a recipe to the collection, you can paste in the URL of the recipe, and the provided web page will be parsed and downloaded to whichever folder you specify in the app settings.",
     "homepage": "https://github.com/nextcloud/cookbook/",
     "licenses": [
@@ -150,9 +150,9 @@
     ]
   },
   "groupfolders": {
-    "hash": "sha256-2jy9p4pu2OXdi8JENFCBcPSDHnGIQkpzuyKkjxALAE4=",
-    "url": "https://github.com/nextcloud-releases/groupfolders/releases/download/v21.0.8/groupfolders-v21.0.8.tar.gz",
-    "version": "21.0.8",
+    "hash": "sha256-2LlfB3hCX2RvIxG6W0LY4vz9833C/TX8rI0/Ab3jiiE=",
+    "url": "https://github.com/nextcloud-releases/groupfolders/releases/download/v21.0.9/groupfolders-v21.0.9.tar.gz",
+    "version": "21.0.9",
     "description": "Team Folders (formerly \"Group Folders\") allows administrators to create and manage shared\nfolders for selected teams within Nextcloud.\n\nAdmins can grant one or more teams access to a folder, configure permissions (such as read,\nwrite, and sharing rights), and assign storage quotas from the Team Folders section (under\nadmin settings). The app also supports advanced permissions and integration with Nextcloud’s\ntrash and versioning systems.\n\nAs of Hub 10 / Nextcloud 31, admins must be members of a team to assign that team to a Team\nFolder.",
     "homepage": "https://github.com/nextcloud/groupfolders",
     "licenses": [
@@ -160,9 +160,9 @@
     ]
   },
   "guests": {
-    "hash": "sha256-w1uPtTZEQFJlhfobGflHf17GEYF3oBPwhieumWfYaDk=",
-    "url": "https://github.com/nextcloud-releases/guests/releases/download/v4.7.5/guests-v4.7.5.tar.gz",
-    "version": "4.7.5",
+    "hash": "sha256-MK3P6fMKYWgKkYTPy9oQFTea/B2iJoZANVVT/HFEnKI=",
+    "url": "https://github.com/nextcloud-releases/guests/releases/download/v4.8.0/guests-v4.8.0.tar.gz",
+    "version": "4.8.0",
     "description": "👥 Allows for better collaboration with external users by allowing users to create guests account.\n\nGuests accounts can be created from the share menu by entering either the recipients email or name and choosing \"create guest account\", once the share is created the guest user will receive an email notification about the mail with a link to set their password.\n\nGuests users can only access files shared to them and cannot create any files outside of shares, additionally, the apps accessible to guest accounts are whitelisted.",
     "homepage": "https://github.com/nextcloud/guests/",
     "licenses": [
@@ -210,9 +210,9 @@
     ]
   },
   "mail": {
-    "hash": "sha256-GkLTk3Q1mSUGhU6lsNHmHGkwW6u4XoDCOj405vi8xuY=",
-    "url": "https://github.com/nextcloud-releases/mail/releases/download/v5.10.3/mail-v5.10.3.tar.gz",
-    "version": "5.10.3",
+    "hash": "sha256-c0pMd+A2Fbxa/20BAkg3lPeVRIdu0XRTbAGJxb/9NT0=",
+    "url": "https://github.com/nextcloud-releases/mail/releases/download/v5.10.7/mail-v5.10.7.tar.gz",
+    "version": "5.10.7",
     "description": "**💌 A mail app for Nextcloud**\n\n- **🚀 Integration with other Nextcloud apps!** Currently Contacts, Calendar & Files – more to come.\n- **📥 Multiple mail accounts!** Personal and company account? No problem, and a nice unified inbox. Connect any IMAP account.\n- **🔒 Send & receive encrypted mails!** Using the great [Mailvelope](https://mailvelope.com) browser extension.\n- **🙈 We’re not reinventing the wheel!** Based on the great [Horde](https://www.horde.org) libraries.\n- **📬 Want to host your own mail server?** We do not have to reimplement this as you could set up [Mail-in-a-Box](https://mailinabox.email)!\n\n## Ethical AI Rating\n\n### Priority Inbox\n\nPositive:\n* The software for training and inferencing of this model is open source.\n* The model is created and trained on-premises based on the user's own data.\n* The training data is accessible to the user, making it possible to check or correct for bias or optimise the performance and CO2 usage.\n\n### Thread Summaries (opt-in)\n\n**Rating:** 🟢/🟡/🟠/🔴\n\nThe rating depends on the installed text processing backend. See [the rating overview](https://docs.nextcloud.com/server/latest/admin_manual/ai/index.html) for details.\n\nLearn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud.com/blog/nextcloud-ethical-ai-rating/).",
     "homepage": "https://github.com/nextcloud/mail#readme",
     "licenses": [
@@ -270,9 +270,9 @@
     ]
   },
   "oidc": {
-    "hash": "sha256-CTnFegGasnG+2MPK6c0H01OjrEKSM0WALwns9nJySaA=",
-    "url": "https://github.com/H2CK/oidc/releases/download/1.17.0/oidc-1.17.0.tar.gz",
-    "version": "1.17.0",
+    "hash": "sha256-5CJjNvbZHuadT+7IHMNJSp8r47kZqzQwMey7ccpe/4Y=",
+    "url": "https://github.com/H2CK/oidc/releases/download/2.0.3/oidc-2.0.3.tar.gz",
+    "version": "2.0.3",
     "description": "Nextcloud as OpenID Connect Identity Provider\n\nWith this app you can use Nextcloud as OpenID Connect Identity Provider. If other services\nare configured correctly, you are able to access those services with your Nextcloud login.\n\nFull documentation can be found at:\n\n- [User Documentation](https://github.com/H2CK/oidc/wiki#user-documentation)\n- [Developer Documentation](https://github.com/H2CK/oidc/wiki#developer-documentation)",
     "homepage": "https://github.com/H2CK/oidc",
     "licenses": [
@@ -390,9 +390,9 @@
     ]
   },
   "spreed": {
-    "hash": "sha256-1oIezD9c7DPPGlFXfKrt/+3ohQpcD+JiKKArRXiDRYM=",
-    "url": "https://github.com/nextcloud-releases/spreed/releases/download/v23.0.7/spreed-v23.0.7.tar.gz",
-    "version": "23.0.7",
+    "hash": "sha256-/katcYNLcsdnjHA+4ES+kdvhzuPNdDSv5Ann7X0+5xI=",
+    "url": "https://github.com/nextcloud-releases/spreed/releases/download/v23.0.8/spreed-v23.0.8.tar.gz",
+    "version": "23.0.8",
     "description": "Chat, video & audio-conferencing using WebRTC\n\n* 💬 **Chat** Nextcloud Talk comes with a simple text chat, allowing you to share or upload files from your Nextcloud Files app or local device and mention other participants.\n* 👥 **Private, group, public and password protected calls!** Invite someone, a whole group or send a public link to invite to a call.\n* 🌐 **Federated chats** Chat with other Nextcloud users on their servers\n* 💻 **Screen sharing!** Share your screen with the participants of your call.\n* 🚀 **Integration with other Nextcloud apps** like Files, Calendar, User status, Dashboard, Flow, Maps, Smart picker, Contacts, Deck, and many more.\n* 🌉 **Sync with other chat solutions** With [Matterbridge](https://github.com/42wim/matterbridge/) being integrated in Talk, you can easily sync a lot of other chat solutions to Nextcloud Talk and vice-versa.",
     "homepage": "https://github.com/nextcloud/spreed",
     "licenses": [
@@ -410,9 +410,9 @@
     ]
   },
   "tasks": {
-    "hash": "sha256-nJFU65dthPRWd/SClKM/suZdYU3ic3QsIcXiPzUkQ6c=",
-    "url": "https://github.com/nextcloud/tasks/releases/download/v0.18.0/tasks.tar.gz",
-    "version": "0.18.0",
+    "hash": "sha256-DJiNUFMcm/okbmwx8/lTaa3eFim6cNFRlJFatW4kaHs=",
+    "url": "https://github.com/nextcloud/tasks/releases/download/v0.18.1/tasks.tar.gz",
+    "version": "0.18.1",
     "description": "Once enabled, a new Tasks menu will appear in your Nextcloud apps menu. From there you can add and delete tasks, edit their title, description, start and due dates and mark them as important. Tasks can be shared between users. Tasks can be synchronized using CalDav (each task list is linked to an Nextcloud calendar, to sync it to your local client: Thunderbird, Evolution, KDE Kontact, iCal … - just add the calendar as a remote calendar in your client). You can download your tasks as ICS files using the download button for each calendar.",
     "homepage": "https://github.com/nextcloud/tasks/",
     "licenses": [
@@ -430,9 +430,9 @@
     ]
   },
   "twofactor_admin": {
-    "hash": "sha256-dx8bEsC/rSAKN9rwP2hf3d8G3f3J1RzCrSqU6BbcvRY=",
-    "url": "https://github.com/nextcloud-releases/twofactor_admin/releases/download/v4.11.1/twofactor_admin-v4.11.1.tar.gz",
-    "version": "4.11.1",
+    "hash": "sha256-IkHzIqRBhG6zr+8y5ifrRfsKl9TyMDx7G1JGogbQrDM=",
+    "url": "https://github.com/nextcloud-releases/twofactor_admin/releases/download/v4.12.0/twofactor_admin-v4.12.0.tar.gz",
+    "version": "4.12.0",
     "description": "This two-factor auth (2FA) provider for Nextcloud allows admins to generate a one-time\n\t\tcode for users to log into a 2FA protected account. This is helpful in situations where\n\t\tusers have lost access to their other 2FA methods or mandatory 2FA without any previously\n\t\tenabled 2FA provider.",
     "homepage": "",
     "licenses": [
@@ -480,9 +480,9 @@
     ]
   },
   "user_saml": {
-    "hash": "sha256-rEeaUUYhsTVLZDo11Xh/wGI3k97Tq5J0Jn18QY1M1Xs=",
-    "url": "https://github.com/nextcloud-releases/user_saml/releases/download/v8.1.2/user_saml-v8.1.2.tar.gz",
-    "version": "8.1.2",
+    "hash": "sha256-LDiWtEaVJbNECJkcn80L4behkUyUsRlDFDd2lk2g+pE=",
+    "url": "https://github.com/nextcloud-releases/user_saml/releases/download/v8.1.4/user_saml-v8.1.4.tar.gz",
+    "version": "8.1.4",
     "description": "Using the SSO & SAML app of your Nextcloud you can make it easily possible to integrate your existing Single-Sign-On solution with Nextcloud. In addition, you can use the Nextcloud LDAP user provider to keep the convenience for users. (e.g. when sharing)\nThe following providers are supported and tested at the moment:\n\n* **SAML 2.0**\n\t* OneLogin\n\t* Shibboleth\n\t* Active Directory Federation Services (ADFS)\n\t* Authentik\n\n* **Authentication via Environment Variable**\n\t* Kerberos (mod_auth_kerb)\n\t* Any other provider that authenticates using the environment variable\n\nWhile theoretically any other authentication provider implementing either one of those standards is compatible, we like to note that they are not part of any internal test matrix.",
     "homepage": "https://github.com/nextcloud/user_saml",
     "licenses": [

--- a/pkgs/servers/nextcloud/packages/34.json
+++ b/pkgs/servers/nextcloud/packages/34.json
@@ -20,9 +20,9 @@
     ]
   },
   "checksum": {
-    "hash": "sha256-xA+BdtbAJVtM6YO5vdW7lfOGlyAkEhHlaCMvHmoHYX4=",
-    "url": "https://github.com/westberliner/checksum/releases/download/v2.1.0/checksum.tar.gz",
-    "version": "2.0.3",
+    "hash": "sha256-6qPZvsml3LBYuuDnMwHg4WssxyQjr6op3AKlsMBLCGk=",
+    "url": "https://github.com/westberliner/checksum/releases/download/v2.1.2/checksum.tar.gz",
+    "version": "2.1.2",
     "description": "Allows users to create a hash checksum of a file.\n        Possible algorithms are md5, sha1, sha256, sha384, sha512, sha3-256, sha3-512 and crc32.\n\n        Just open the details view of the file (Sidebar). There should be a new tab called \"Checksum\".\n        Select a algorithm and it will try to generate a hash.\n        If you want an other algorithm, just click on the reload button.",
     "homepage": "https://github.com/westberliner/checksum/",
     "licenses": [
@@ -40,13 +40,13 @@
     ]
   },
   "contacts": {
-    "hash": "sha256-rFKmEZtyQgFjGBN44H167hGQP+n72uhUEiXlD7OguTI=",
-    "url": "https://github.com/nextcloud-releases/contacts/releases/download/v8.3.15/contacts-v8.3.15.tar.gz",
-    "version": "8.3.15",
+    "hash": "sha256-Lgw+wF40FlZTlbw5IXG/eUW8Chaw5Cm1i9f2R8YyPRU=",
+    "url": "https://github.com/nextcloud-releases/contacts/releases/download/v8.7.3/contacts-v8.7.3.tar.gz",
+    "version": "8.7.3",
     "description": "The Nextcloud contacts app is a user interface for Nextcloud's CardDAV server. Easily sync contacts from various devices with your Nextcloud and edit them online.\n\n* 🚀 **Integration with other Nextcloud apps!** Currently Mail and Calendar – more to come.\n* 🎉 **Never forget a birthday!** You can sync birthdays and other recurring events with your Nextcloud Calendar.\n* 👥 **Sharing of Adressbooks!** You want to share your contacts with your friends or coworkers? No problem!\n* 🙈 **We’re not reinventing the wheel!** Based on the great and open SabreDAV library.",
     "homepage": "https://github.com/nextcloud/contacts#readme",
     "licenses": [
-      "agpl"
+      "AGPL-3.0-or-later"
     ]
   },
   "cookbook": {
@@ -60,9 +60,9 @@
     ]
   },
   "cospend": {
-    "hash": "sha256-mclcZDNmvpYX/2q7azyiTLSCiTYvk7ILeqtb/8+0ADQ=",
-    "url": "https://github.com/julien-nc/cospend-nc/releases/download/v3.2.0/cospend-3.2.0.tar.gz",
-    "version": "3.2.0",
+    "hash": "sha256-3uphQHtKlW8kXeLA5hMDpT14lEf+tnJyy4hfKioBDSw=",
+    "url": "https://github.com/julien-nc/cospend-nc/releases/download/v4.0.2/cospend-4.0.2.tar.gz",
+    "version": "4.0.2",
     "description": "# Nextcloud Cospend 💰\n\nNextcloud Cospend is a group/shared budget manager. It was inspired by the great [IHateMoney](https://github.com/spiral-project/ihatemoney/).\n\nYou can use it when you share a house, when you go on vacation with friends, whenever you share expenses with a group of people.\n\nIt lets you create projects with members and bills. Each member has a balance computed from the project bills. Balances are not an absolute amount of money at members disposal but rather a relative information showing if a member has spent more for the group than the group has spent for her/him, independently of exactly who spent money for whom. This way you can see who owes the group and who the group owes. Ultimately you can ask for a settlement plan telling you which payments to make to reset members balances.\n\nProject members are independent from Nextcloud users. Projects can be shared with other Nextcloud users or via public links.\n\n[MoneyBuster](https://gitlab.com/eneiluj/moneybuster) Android client is [available in F-Droid](https://f-droid.org/packages/net.eneiluj.moneybuster/) and on the [Play store](https://play.google.com/store/apps/details?id=net.eneiluj.moneybuster).\n\n[PayForMe](https://github.com/mayflower/PayForMe) iOS client is currently under developpement!\n\nThe private and public APIs are documented using [the Nextcloud OpenAPI extractor](https://github.com/nextcloud/openapi-extractor/). This documentation can be accessed directly in Nextcloud. All you need is to install Cospend (>= v1.6.0) and use the [the OCS API Viewer app](https://apps.nextcloud.com/apps/ocs_api_viewer) to browse the OpenAPI documentation.\n\n## Features\n\n* ✎ Create/edit/delete projects, members, bills, bill categories, currencies\n* ⚖ Check member balances\n* 🗠 Display project statistics\n* ♻ Display settlement plan\n* Move bills from one project to another\n* Move bills to trash before actually deleting them\n* Archive old projects before deleting them\n* 🎇 Automatically create reimbursement bills from settlement plan\n* 🗓 Create recurring bills (day/week/month/year)\n* 📊 Optionally provide custom amount for each member in new bills\n* 🔗 Link personal files to bills (picture of physical receipt for example)\n* 👩 Public links for people outside Nextcloud (can be password protected)\n* 👫 Share projects with Nextcloud users/groups/circles\n* 🖫 Import/export projects as csv (compatible with csv files from IHateMoney and SplitWise)\n* 🔗 Generate link/QRCode to easily add projects in MoneyBuster\n* 🗲 Implement Nextcloud notifications and activity stream\n\nThis app usually support the 2 or 3 last major versions of Nextcloud.\n\nThis app is under development.\n\n🌍 Help us to translate this app on [Nextcloud-Cospend/MoneyBuster Crowdin project](https://crowdin.com/project/moneybuster).\n\n⚒ Check out other ways to help in the [contribution guidelines](https://github.com/julien-nc/cospend-nc/blob/master/CONTRIBUTING.md).\n\n## Documentation\n\n* [User documentation](https://github.com/julien-nc/cospend-nc/blob/master/docs/user.md)\n* [Admin documentation](https://github.com/julien-nc/cospend-nc/blob/master/docs/admin.md)\n* [Developer documentation](https://github.com/julien-nc/cospend-nc/blob/master/docs/dev.md)\n* [CHANGELOG](https://github.com/julien-nc/cospend-nc/blob/master/CHANGELOG.md#change-log)\n* [AUTHORS](https://github.com/julien-nc/cospend-nc/blob/master/AUTHORS.md#authors)\n\n## Known issues\n\n* It does not make you rich\n\nAny feedback will be appreciated.\n\n\n\n## Donation\n\nI develop this app during my free time.\n\n* [Donate with Paypal](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=66PALMY8SF5JE) (you don't need a paypal account)\n* [Donate with Liberapay : ![Donate using Liberapay](https://liberapay.com/assets/widgets/donate.svg)](https://liberapay.com/eneiluj/donate)",
     "homepage": "https://github.com/julien-nc/cospend-nc",
     "licenses": [
@@ -80,9 +80,9 @@
     ]
   },
   "deck": {
-    "hash": "sha256-InDmm6aj8y8qfZ7i765XJIh4q0vsTlVtxA6n0E6rll0=",
-    "url": "https://github.com/nextcloud-releases/deck/releases/download/v1.16.7/deck-v1.16.7.tar.gz",
-    "version": "1.16.7",
+    "hash": "sha256-xbXx5NDVnR/qFk+29yrWTfsZL/NTKfvLd1D0IGf9Ie4=",
+    "url": "https://github.com/nextcloud-releases/deck/releases/download/v1.18.2/deck-v1.18.2.tar.gz",
+    "version": "1.18.2",
     "description": "Deck is a kanban style organization tool aimed at personal planning and project organization for teams integrated with Nextcloud.\n\n\n- 📥 Add your tasks to cards and put them in order\n- 📄 Write down additional notes in Markdown\n- 🔖 Assign labels for even better organization\n- 👥 Share with your team, friends or family\n- 📎 Attach files and embed them in your Markdown description\n- 💬 Discuss with your team using comments\n- ⚡ Keep track of changes in the activity stream\n- 🚀 Get your project organized",
     "homepage": "https://github.com/nextcloud/deck",
     "licenses": [
@@ -90,19 +90,19 @@
     ]
   },
   "end_to_end_encryption": {
-    "hash": "sha256-McIkFt53L1O+kb4zA3VisbgCKlcdht/DqPQKDOQTLds=",
-    "url": "https://github.com/nextcloud-releases/end_to_end_encryption/releases/download/v1.18.2/end_to_end_encryption-v1.18.2.tar.gz",
-    "version": "1.18.2",
+    "hash": "sha256-Z6MyXz//LNVy7Mt+yFbHIY5zGEMfsdwnAEDFsIcrs1M=",
+    "url": "https://github.com/nextcloud-releases/end_to_end_encryption/releases/download/v2.2.0/end_to_end_encryption-v2.2.0.tar.gz",
+    "version": "2.2.0",
     "description": "## **End-to-End Encryption**\n\n### For End Users\n\n**Protect your most sensitive files with strong encryption.**\n\nThe End-to-End Encryption app gives you complete control over your data privacy.\nWith this app, you can encrypt specific folders so that only you (and those you trust) can access their contents.\nYour files are encrypted on your device before they reach the server, ensuring that no one—not even the server administrator—can read them.\n\n**Benefits:**\n- 🔒 **True privacy**: Files are encrypted on your device and can only be decrypted by you\n- 📱 **Works across all platforms**: Fully supported on desktop, Android, iOS clients, and as you wish even in the browser\n- 🎯 **Selective encryption**: Choose which folders to encrypt\n- 🛡️ **Secure sharing**: Share encrypted files with other users or even secure public upload using the encrypted file drop\n\n---\n\n### For Administrators\n\n**Enterprise-ready end-to-end encryption infrastructure for your Nextcloud instance.**\n\nThis app provides all the necessary server-side APIs and infrastructure to enable End-to-End encryption (E2EE) for your users.\nIt ensures that encrypted data remains secure throughout its lifecycle on your server.\n\n**Technical highlights:**\n- 🔐 **Complete API suite**: Provides all client-side APIs needed for E2EE implementation\n- 🔒 **Secure FileDrop integration**: Enables secure file sharing with encryption\n- 🛡️ **Zero-knowledge architecture**: Server never has access to encryption keys\n- ⚙️ **Group restrictions**: Limit app usage to specific user groups if needed\n- 🔄 **Background job management**: Automatic rollback handling for failed operations\n\n### Setup\nThis application provides the server-side infrastructure for end-to-end encryption, but it requires client support to function.\nTo enable end-to-end encryption, users will need to install the corresponding client-side app on their devices (desktop, Android, iOS) or use the web client.\n\nUsing the web interface, after enabling it in the personal settings, allows you to encrypt files and folders directly in the browser,\nproviding a seamless experience without needing additional software. But also requires some kind of trust in the server as the code is delivered by the server and could be manipulated.\n\nOnce enable through clients or the web interface, you can create encrypted folders and upload or move files into them.\nThe clients and the web interface will handle the encryption and decryption processes automatically.\n\n⚠️ This comes with some limitations and caveats, as only normal file operations can be handled.\nMeaning that some apps in the web interface do not work with encrypted files.",
     "homepage": "https://github.com/nextcloud/end_to_end_encryption",
     "licenses": [
-      "agpl"
+      "AGPL-3.0-or-later"
     ]
   },
   "files_automatedtagging": {
-    "hash": "sha256-Y/GpyHsZ1Jks+yyy2Nqj0BOwVRWma1xfGoVuZZoSRDE=",
-    "url": "https://github.com/nextcloud-releases/files_automatedtagging/releases/download/v3.0.3/files_automatedtagging-v3.0.3.tar.gz",
-    "version": "3.0.3",
+    "hash": "sha256-3lsRT8oZ4lP1Kngl8E47rc/7FJmiaXv/x3BfGMfHcC8=",
+    "url": "https://github.com/nextcloud-releases/files_automatedtagging/releases/download/v5.0.0/files_automatedtagging-v5.0.0.tar.gz",
+    "version": "5.0.0",
     "description": "An app for Nextcloud that automatically assigns tags to newly uploaded files based on some conditions.\n\nThe tags can later be used to control retention, file access, automatic script execution and more.\n\n## How it works\nTo define tags, administrators can create and manage a set of rule groups. Each rule group consists of one or more rules combined through operators. Rules can include criteria like file type, size, time and more. A request matches a group if all rules evaluate to true. On uploading a file all defined groups are evaluated and when matching, the given tags are assigned to the file.",
     "homepage": "https://github.com/nextcloud/files_automatedtagging",
     "licenses": [
@@ -120,9 +120,9 @@
     ]
   },
   "files_retention": {
-    "hash": "sha256-48fC7VDNZs2+qienMP5hBAWgRkm/i+Q2WXnrd8fz16Q=",
-    "url": "https://github.com/nextcloud-releases/files_retention/releases/download/v3.0.0/files_retention-v3.0.0.tar.gz",
-    "version": "3.0.0",
+    "hash": "sha256-aHcg9eKEd/4CXNUy5rrWmw9pP/mf54wp/PVQfqrHSM0=",
+    "url": "https://github.com/nextcloud-releases/files_retention/releases/download/v5.0.0/files_retention-v5.0.0.tar.gz",
+    "version": "5.0.0",
     "description": "An app for Nextcloud to control automatic deletion of files after a given time.\nOptionally the users can be informed the day before.",
     "homepage": "https://github.com/nextcloud/files_retention",
     "licenses": [
@@ -150,9 +150,9 @@
     ]
   },
   "groupfolders": {
-    "hash": "sha256-rOa82k/IwJdAweCzkZKLLqiOtP63eRdq98zxlnttFzc=",
-    "url": "https://github.com/nextcloud-releases/groupfolders/releases/download/v20.1.16/groupfolders-v20.1.16.tar.gz",
-    "version": "20.1.16",
+    "hash": "sha256-zyN6n2oSeO+I2wyc2Q9l1TUumdVmEThvERGC7xBkm3s=",
+    "url": "https://github.com/nextcloud-releases/groupfolders/releases/download/v22.0.2/groupfolders-v22.0.2.tar.gz",
+    "version": "22.0.2",
     "description": "Team Folders (formerly \"Group Folders\") allows administrators to create and manage shared\nfolders for selected teams within Nextcloud.\n\nAdmins can grant one or more teams access to a folder, configure permissions (such as read,\nwrite, and sharing rights), and assign storage quotas from the Team Folders section (under\nadmin settings). The app also supports advanced permissions and integration with Nextcloud’s\ntrash and versioning systems.\n\nAs of Hub 10 / Nextcloud 31, admins must be members of a team to assign that team to a Team\nFolder.",
     "homepage": "https://github.com/nextcloud/groupfolders",
     "licenses": [
@@ -170,9 +170,9 @@
     ]
   },
   "impersonate": {
-    "hash": "sha256-mOlaUYaGRoYITwjIpwhUnKLh9HOVef77dCpFP4bC5RQ=",
-    "url": "https://github.com/nextcloud-releases/impersonate/releases/download/v3.0.1/impersonate-v3.0.1.tar.gz",
-    "version": "3.0.1",
+    "hash": "sha256-6bhdZIlDSvLQXxYYg5vP2YWdvGt75YAUhZL1EaRI7WY=",
+    "url": "https://github.com/nextcloud-releases/impersonate/releases/download/v5.0.0/impersonate-v5.0.0.tar.gz",
+    "version": "5.0.0",
     "description": "By installing the impersonate app of your Nextcloud you enable administrators to impersonate other users on the Nextcloud server. This is especially useful for debugging issues reported by users.\n\nTo impersonate a user an administrator has to simply follow the following four steps:\n\n1. Login as administrator to Nextcloud.\n2. Open users administration interface.\n3. Select the impersonate button on the affected user.\n4. Confirm the impersonation.\n\nThe administrator is then logged-in as the user, to switch back to the regular user account they simply have to press the logout button.\n\n**Note:**\n\n- This app is not compatible with instances that have encryption enabled.\n- While impersonate actions are logged note that actions performed impersonated will be logged as the impersonated user.\n- Impersonating a user is only possible after their first login.\n- You can limit which users/groups can use impersonation in Administration settings > Additional settings.",
     "homepage": "https://github.com/nextcloud/impersonate",
     "licenses": [
@@ -190,9 +190,9 @@
     ]
   },
   "integration_openai": {
-    "hash": "sha256-91/93BQyZVUrE21krXBTLp1nbdyoNxfDyDODf2hgdIM=",
-    "url": "https://github.com/nextcloud-releases/integration_openai/releases/download/v3.10.1/integration_openai-v3.10.1.tar.gz",
-    "version": "3.10.1",
+    "hash": "sha256-vt2td3UDJMm1g3BbnV3x/pf92hhuYppk95IFygRxHFY=",
+    "url": "https://github.com/nextcloud-releases/integration_openai/releases/download/v4.5.1/integration_openai-v4.5.1.tar.gz",
+    "version": "4.5.1",
     "description": "⚠️ The smart pickers have been removed from this app\nas they are now included in the [Assistant app](https://apps.nextcloud.com/apps/assistant).\n\nThis app implements:\n\n* Text generation providers: Free prompt, Summarize, Headline, Context Write, Chat, and Reformulate (using any available large language model)\n* A Translation provider (using any available language model)\n* A SpeechToText provider (using Whisper)\n* An image generation provider\n\n⚠️ Context Write, Summarize, Headline and Reformulate have mainly been tested with OpenAI.\nThey might work when connecting to other services, without any guarantee.\n\nInstead of connecting to the OpenAI API for these, you can also connect to a self-hosted [LocalAI](https://localai.io) instance or [Ollama](https://ollama.com/) instance\nor to any service that implements an API similar to the OpenAI one, for example:\n[IONOS AI Model Hub](https://docs.ionos.com/cloud/ai/ai-model-hub), [Plusserver](https://www.plusserver.com/en/ai-platform/) or [MistralAI](https://mistral.ai).\n\n⚠️ This app is mainly tested with OpenAI. We do not guarantee it works perfectly\nwith other services that implement OpenAI-compatible APIs with slight differences.\n\n## Improve AI task pickup speed\n\nTo avoid task processing execution delay, setup at 4 background job workers in the main server (where Nextcloud is installed). The setup process is documented here: https://docs.nextcloud.com/server/latest/admin_manual/ai/overview.html#improve-ai-task-pickup-speed\n\n## Ethical AI Rating\n### Rating for Text generation using ChatGPT via the OpenAI API: 🔴\n\nNegative:\n* The software for training and inference of this model is proprietary, limiting running it locally or training by yourself\n* The trained model is not freely available, so the model can not be run on-premises\n* The training data is not freely available, limiting the ability of external parties to check and correct for bias or optimise the model's performance and CO2 usage.\n\n\n### Rating for Translation using ChatGPT via the OpenAI API: 🔴\n\nNegative:\n* The software for training and inference of this model is proprietary, limiting running it locally or training by yourself\n* The trained model is not freely available, so the model can not be run on-premises\n* The training data is not freely available, limiting the ability of external parties to check and correct for bias or optimise the model's performance and CO2 usage.\n\n### Rating for Image generation using DALL·E via the OpenAI API: 🔴\n\nNegative:\n* The software for training and inferencing of this model is proprietary, limiting running it locally or training by yourself\n* The trained model is not freely available, so the model can not be ran on-premises\n* The training data is not freely available, limiting the ability of external parties to check and correct for bias or optimise the model’s performance and CO2 usage.\n\n\n### Rating for Speech-To-Text using Whisper via the OpenAI API: 🟡\n\nPositive:\n* The software for training and inferencing of this model is open source\n* The trained model is freely available, and thus can run on-premise\n\nNegative:\n* The training data is not freely available, limiting the ability of external parties to check and correct for bias or optimise the model’s performance and CO2 usage.\n\n### Rating for Text-To-Speech via the OpenAI API: 🔴\n\nNegative:\n* The software for training and inferencing of this model is proprietary, limiting running it locally or training by yourself\n* The trained model is not freely available, so the model can not be ran on-premises\n* The training data is not freely available, limiting the ability of external parties to check and correct for bias or optimise the model’s performance and CO2 usage.\n\n### Rating for Text generation via LocalAI: 🟢\n\nPositive:\n* The software for training and inferencing of this model is open source\n* The trained model is freely available, and thus can be ran on-premises\n* The training data is freely available, making it possible to check or correct for bias or optimise the performance and CO2 usage.\n\n\n### Rating for Image generation using Stable Diffusion via LocalAI : 🟡\n\nPositive:\n* The software for training and inferencing of this model is open source\n* The trained model is freely available, and thus can be ran on-premises\n\nNegative:\n* The training data is not freely available, limiting the ability of external parties to check and correct for bias or optimise the model’s performance and CO2 usage.\n\n\n### Rating for Speech-To-Text using Whisper via LocalAI: 🟡\n\nPositive:\n* The software for training and inferencing of this model is open source\n* The trained model is freely available, and thus can be ran on-premises\n\nNegative:\n* The training data is not freely available, limiting the ability of external parties to check and correct for bias or optimise the model’s performance and CO2 usage.\n\nLearn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud.com/blog/nextcloud-ethical-ai-rating/).",
     "homepage": "https://github.com/nextcloud/integration_openai",
     "licenses": [
@@ -200,9 +200,9 @@
     ]
   },
   "integration_paperless": {
-    "hash": "sha256-j+X0JyLA2BgtPZcKQ5kqpk6LJevAgE6cbgdOF1IE6eo=",
-    "url": "https://github.com/nextcloud-releases/integration_paperless/releases/download/v1.0.10/integration_paperless-v1.0.10.tar.gz",
-    "version": "1.0.10",
+    "hash": "sha256-euTLlCwXSo23aPfhW1Xn0sxjVvc9u2626NJm0ob1W8o=",
+    "url": "https://github.com/nextcloud-releases/integration_paperless/releases/download/v1.0.13/integration_paperless-v1.0.13.tar.gz",
+    "version": "1.0.13",
     "description": "Integration with the [Paperless](https://docs.paperless-ngx.com) Document Management System.\nIt adds a file action menu item that can be used to upload a file from your Nextcloud Files to Paperless.",
     "homepage": "",
     "licenses": [
@@ -260,9 +260,9 @@
     ]
   },
   "notes": {
-    "hash": "sha256-G/npepK65ZAaF8k2ZsSsDzbd/mjGnKpdI2ixi+avf9w=",
-    "url": "https://github.com/nextcloud-releases/notes/releases/download/v5.0.2/notes-v5.0.2.tar.gz",
-    "version": "5.0.2",
+    "hash": "sha256-/54d/UfkYLSPt8Coi4/zcheZx8mKXW34CIrvFEfYFLI=",
+    "url": "https://github.com/nextcloud-releases/notes/releases/download/v6.0.1/notes-v6.0.1.tar.gz",
+    "version": "6.0.1",
     "description": "The Notes app is a distraction free notes taking app for [Nextcloud](https://www.nextcloud.com/). It provides categories for better organization and supports formatting using [Markdown](https://en.wikipedia.org/wiki/Markdown) syntax. Notes are saved as files in your Nextcloud, so you can view and edit them with every Nextcloud client. Furthermore, a separate [REST API](https://github.com/nextcloud/notes/blob/master/docs/api/README.md) allows for an easy integration into apps ([Android](https://github.com/nextcloud/notes-android), [iOS](https://github.com/nextcloud/notes-ios), as well as [3rd-party apps](https://github.com/nextcloud/notes/wiki#3rd-party-clients) which allow convenient access to your Nextcloud notes). Further features include marking notes as favorites.",
     "homepage": "https://github.com/nextcloud/notes",
     "licenses": [
@@ -279,20 +279,10 @@
       "agpl"
     ]
   },
-  "oidc_login": {
-    "hash": "sha256-KBa8A7aC0uS6FQoOSa7nIkaaYe+A2KeAtzfqoKw0Gn4=",
-    "url": "https://github.com/pulsejet/nextcloud-oidc-login/releases/download/v3.3.1/oidc_login.tar.gz",
-    "version": "3.3.1",
-    "description": "# OpenID Connect Login\n\nProvides user creation and login via one single OpenID Connect provider. Even though this is a fork of [nextcloud-social-login](https://github.com/zorn-v/nextcloud-social-login), it fundamentally differs in two ways - aims for simplistic, single provider login (and hence is very minimalistic), and it supports having LDAP as the primary user backend. This way, you can use OpenID Connect to login to Nextcloud while maintaining an LDAP backend with attributes with the LDAP plugin.\n\n### Features\n\n- Automatic [Identity provider endpoints discovery](https://openid.net/specs/openid-connect-discovery-1_0.html)\n- User creation at first login\n- User profile update at login (name, email, avatar, groups etc.)\n- Group creation\n- Automatic redirection from the nextcloud login page to the Identity Provider login page\n- WebDAV endpoints `Bearer` and `Basic` authentication\n- Optional removal of special characters in UID\n- Mapping of multiple names to a single display name\n- Mapping for birthdate",
-    "homepage": "https://github.com/pulsejet/nextcloud-single-openid-connect",
-    "licenses": [
-      "agpl"
-    ]
-  },
   "onlyoffice": {
-    "hash": "sha256-sMgBVVAv6n6TlrvcndzRLc1xPJ6eA4hYBqDpiDabW1k=",
-    "url": "https://github.com/ONLYOFFICE/onlyoffice-nextcloud/releases/download/v9.14.2/onlyoffice.tar.gz",
-    "version": "9.14.2",
+    "hash": "sha256-QaohaMbw7bncBqreb5W8XngzqqwqALnsGgT494xfr/E=",
+    "url": "https://github.com/ONLYOFFICE/onlyoffice-nextcloud/releases/download/v10.1.2/onlyoffice.tar.gz",
+    "version": "10.1.2",
     "description": "The ONLYOFFICE app for Nextcloud brings powerful document editing and collaboration tools directly to your Nextcloud environment. With this integration, you can seamlessly create, edit, and co-author text documents, spreadsheets, presentations, and PDFs, as well as build and fill out PDF forms.\n\nCollaborate with your team in real time, make use of Track Changes, version history, comments, integrated chat, and more. Work together on files with federated cloud sharing. Flexible access permissions allow you to control who can view, edit, or comment, ensuring secure role-based collaboration tailored to your needs. Documents can also be protected with watermarks, password settings, and encryption for added security.\n\nThe app offers support for over 50 file formats, including DOCX, XLSX, PPTX, PDF, RTF, TXT, CSV, ODT, ODS, ODP, EPUB, FB2, HTML, HWP, HWPX, Pages, Numbers, Keynote, etc. Seamless desktop and mobile app integration means you'll have access to your Nextcloud files wherever you go.\n\nFurthermore, you can seamlessly connect any AI assistant, including local ones, directly to the editors to work faster and more efficient. This allows you to leverage various AI models for tasks like chatbot interactions, translations, OCR, and more.\n\nWhether you’re working with internal teams or external collaborators, the ONLYOFFICE app for Nextcloud enhances productivity, simplifies workflows, and ensures your files remain secure.",
     "homepage": "https://www.onlyoffice.com",
     "licenses": [
@@ -370,9 +360,9 @@
     ]
   },
   "richdocuments": {
-    "hash": "sha256-oLV1AFCGt/ukZ06TkOpEBGxOPQ3Z66dY2rpDj0tXiP4=",
-    "url": "https://github.com/nextcloud-releases/richdocuments/releases/download/v9.1.0/richdocuments-v9.1.0.tar.gz",
-    "version": "9.1.0",
+    "hash": "sha256-uGoXL/LnFaWlLRDdx95qmhD4HIW3p51CWlpKiWTScYg=",
+    "url": "https://github.com/nextcloud-releases/richdocuments/releases/download/v11.0.0/richdocuments-v11.0.0.tar.gz",
+    "version": "11.0.0",
     "description": "This application can connect to a Collabora Online (or other) server (WOPI-like Client). Nextcloud is the WOPI Host. Please read the documentation to learn more about that.\n\nYou can also edit your documents off-line with the Collabora Office app from the **[Android](https://play.google.com/store/apps/details?id=com.collabora.libreoffice)** and **[iOS](https://apps.apple.com/us/app/collabora-office/id1440482071)** store.",
     "homepage": "https://collaboraoffice.com/",
     "licenses": [
@@ -390,9 +380,9 @@
     ]
   },
   "spreed": {
-    "hash": "sha256-Px8WFUNSRRWMcR/keUhoss7sjOUfXB9IAKdFKPzuSqs=",
-    "url": "https://github.com/nextcloud-releases/spreed/releases/download/v22.0.15/spreed-v22.0.15.tar.gz",
-    "version": "22.0.15",
+    "hash": "sha256-Mh59Quq8LORxUb2tZsKDxx+zz7HeSl+1lAFrnGf54Wc=",
+    "url": "https://github.com/nextcloud-releases/spreed/releases/download/v24.0.2/spreed-v24.0.2.tar.gz",
+    "version": "24.0.2",
     "description": "Chat, video & audio-conferencing using WebRTC\n\n* 💬 **Chat** Nextcloud Talk comes with a simple text chat, allowing you to share or upload files from your Nextcloud Files app or local device and mention other participants.\n* 👥 **Private, group, public and password protected calls!** Invite someone, a whole group or send a public link to invite to a call.\n* 🌐 **Federated chats** Chat with other Nextcloud users on their servers\n* 💻 **Screen sharing!** Share your screen with the participants of your call.\n* 🚀 **Integration with other Nextcloud apps** like Files, Calendar, User status, Dashboard, Flow, Maps, Smart picker, Contacts, Deck, and many more.\n* 🌉 **Sync with other chat solutions** With [Matterbridge](https://github.com/42wim/matterbridge/) being integrated in Talk, you can easily sync a lot of other chat solutions to Nextcloud Talk and vice-versa.",
     "homepage": "https://github.com/nextcloud/spreed",
     "licenses": [
@@ -400,13 +390,13 @@
     ]
   },
   "tables": {
-    "hash": "sha256-SQbCET4MdP8+clGAfgat3G2kAefB75BjJnZKanN3EDI=",
-    "url": "https://github.com/nextcloud-releases/tables/releases/download/v1.0.9/tables-v1.0.9.tar.gz",
-    "version": "1.0.9",
+    "hash": "sha256-ZAvytGd4S5dMNLbWi2bURaBOZRGNk5F+vjqKmRfYSL0=",
+    "url": "https://github.com/nextcloud-releases/tables/releases/download/v2.2.0/tables-v2.2.0.tar.gz",
+    "version": "2.2.0",
     "description": "Manage data the way you need it.\n\nWith this app you are able to create your own tables with individual columns. You can start with a template or from scratch and add your wanted columns.\nYou can choose from the following column types:\n- Text line or rich text\n- Link to urls or other nextcloud resources\n- Numbers\n- Progress bar\n- Stars rating\n- Yes/No tick\n- Date and/or time\n- (Multi) selection\n- Users, groups and teams\n\nShare your tables and views with users and groups within your cloud.\n\nHave a good time and manage whatever you want.",
     "homepage": "https://github.com/nextcloud/tables",
     "licenses": [
-      "agpl"
+      "AGPL-3.0-or-later"
     ]
   },
   "tasks": {
@@ -415,16 +405,6 @@
     "version": "0.18.1",
     "description": "Once enabled, a new Tasks menu will appear in your Nextcloud apps menu. From there you can add and delete tasks, edit their title, description, start and due dates and mark them as important. Tasks can be shared between users. Tasks can be synchronized using CalDav (each task list is linked to an Nextcloud calendar, to sync it to your local client: Thunderbird, Evolution, KDE Kontact, iCal … - just add the calendar as a remote calendar in your client). You can download your tasks as ICS files using the download button for each calendar.",
     "homepage": "https://github.com/nextcloud/tasks/",
-    "licenses": [
-      "agpl"
-    ]
-  },
-  "theming_customcss": {
-    "hash": "sha256-Fgu31s+K4MFUgvNe9mAVHi9C0iJnv40v1onUMk+lFZk=",
-    "url": "https://github.com/nextcloud/theming_customcss/releases/download/v1.20.0/theming_customcss.tar.gz",
-    "version": "1.20.0",
-    "description": "This app allows admins to customize the appearance of their Nextcloud instance by adding their own CSS rules.\n\nThe rules can be added in the admin settings in the \"Theming\" section. This allows you to easily adjust the look and feel of your Nextcloud instance without having to modify any files on the server.",
-    "homepage": "",
     "licenses": [
       "agpl"
     ]
@@ -450,9 +430,9 @@
     ]
   },
   "unroundedcorners": {
-    "hash": "sha256-0+fOJnPsuengy8TPzTKizDnDXTlZStalFDOv+dFlRgc=",
-    "url": "https://github.com/OliverParoczai/nextcloud-unroundedcorners/releases/download/v1.1.5/unroundedcorners-v1.1.5.tar.gz",
-    "version": "1.1.5",
+    "hash": "sha256-RCnXfnl2dJ0NpcNJ+0+jcSsp/h4hHemPg3fkjkFoGl0=",
+    "url": "https://github.com/OliverParoczai/nextcloud-unroundedcorners/releases/download/v1.1.6/unroundedcorners-v1.1.6.tar.gz",
+    "version": "1.1.6",
     "description": "# Unrounded Corners\nA Nextcloud app that restores the corners of buttons and widgets to their original looks by unrounding them.",
     "homepage": "https://github.com/OliverParoczai/nextcloud-unroundedcorners",
     "licenses": [

--- a/pkgs/servers/nextcloud/packages/apps/memories.nix
+++ b/pkgs/servers/nextcloud/packages/apps/memories.nix
@@ -18,10 +18,11 @@ let
       srcHash = "sha256-KyUfrKHnRO3lMin0seSNFRnRRTPo12NbbvbkSpxSMQE=";
     };
     "33" = {
-      version = "8.0.1";
-      appHash = "sha256-B+O78qjBQbmMnFAvH/5a+YBive+rkBG9AKTX7G3qNR0=";
-      srcHash = "sha256-t/DiGJzSey9YpV5GkepKSGjr5gXc9KWDBtSY5UPRlEU=";
+      version = "8.1.0";
+      appHash = "sha256-SQ1gPdfICFqNBJM0dJOfKIJ/E1tBBcBQOjRdb/mKb04=";
+      srcHash = "sha256-T0oz5d4kPX/Pm06vKGTrltUFd1pKccsz5IDjv/Vmuz0=";
     };
+    "34" = latestVersionForNc."33";
   };
   currentVersionInfo =
     latestVersionForNc.${ncVersion}

--- a/pkgs/servers/nextcloud/packages/apps/recognize.nix
+++ b/pkgs/servers/nextcloud/packages/apps/recognize.nix
@@ -27,6 +27,11 @@ let
       appHash = "sha256-x3LXZKDWmzCYLTaNqSvgu4Gvrn6w2c/jifNCx1oaw1U=";
       modelHash = "sha256-Yx/NJwtD4ltETpkzlcadZsFKqEmMneoZaXiHVSB1WoE=";
     };
+    "34" = {
+      version = "12.0.0";
+      appHash = "sha256-1TpfDRMmJ7d5MPp0iTr/RpZHAG7LDsXof9u35O3+5Mg=";
+      modelHash = "sha256-+ec7kRPyWPVTk2wgRKMOP5mdmSnpv9mZmiRicEDKD6A=";
+    };
   };
   currentVersionInfo =
     latestVersionForNc.${ncVersion}
@@ -74,7 +79,9 @@ stdenv.mkDerivation rec {
     substituteInPlace recognize/lib/**/*.php \
       --replace-quiet "\$this->settingsService->getSetting('node_binary')" "'${lib.getExe nodejs}'" \
       --replace-quiet "\$this->config->getAppValueString('node_binary', '""')" "'${lib.getExe nodejs}'" \
-      --replace-quiet "\$this->config->getAppValueString('node_binary')" "'${lib.getExe nodejs}'"
+      --replace-quiet "\$this->config->getAppValueString('node_binary')" "'${lib.getExe nodejs}'" \
+      --replace-quiet "\$this->config->getAppValueString('node_binary', ''', lazy: true)" "'${lib.getExe nodejs}'" \
+      --replace-quiet "\$this->config->getAppValueString('node_binary', lazy: true)" "'${lib.getExe nodejs}'"
     test "$(grep "get[a-zA-Z]*('node_binary'" recognize/lib/**/*.php | wc -l)" -eq 0
 
     # Skip trying to install it... (less warnings in the log)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2614,10 +2614,12 @@ with pkgs;
   inherit (callPackages ../servers/nextcloud { })
     nextcloud32
     nextcloud33
+    nextcloud34
     ;
 
   nextcloud32Packages = callPackage ../servers/nextcloud/packages { ncVersion = "32"; };
   nextcloud33Packages = callPackage ../servers/nextcloud/packages { ncVersion = "33"; };
+  nextcloud34Packages = callPackage ../servers/nextcloud/packages { ncVersion = "34"; };
 
   nextcloud-notify_push = callPackage ../servers/nextcloud/notify_push.nix { };
 


### PR DESCRIPTION
Rebases #530277 on master & additional package update.

## Things done

* nextcloud34: 34.0.1
* nextcloud{32,33,34}: App Update
* nixpkgs-vet fixes:
  * `__structuredAttrs = true;`
  * `strictDeps = true;`

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
