### PR TITLE
nixos/nix: Support local-only store

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -184,3 +184,5 @@
   - Please note that Nextcloud prohibits skipping major versions while upgrading. You can upgrade to specific versions by declaring `services.nextcloud.package = pkgs.nextcloud33;`.
 
 - `trilium-desktop` and `trilium-server` have been updated to 0.104.0. This release includes security hardening fixes that may break functionality. [See upstream release note for details](https://github.com/TriliumNext/Trilium/releases/tag/v0.104.0).
+
+- `nix` now supports running in "daemonless" mode by setting `nix.daemon.enable = false`. Under this mode all store operations must go through the [local store type](https://nix.dev/manual/nix/latest/store/types/local-store), which typically requires root permissions.

--- a/nixos/modules/config/nix.nix
+++ b/nixos/modules/config/nix.nix
@@ -135,6 +135,24 @@ in
 
   options = {
     nix = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Whether to enable Nix.
+          Disabling Nix makes the system hard to modify and the Nix programs and configuration will not be made available by NixOS itself.
+        '';
+      };
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.nix;
+        defaultText = lib.literalExpression "pkgs.nix";
+        description = ''
+          This option specifies the Nix package instance to use throughout the system.
+        '';
+      };
+
       checkConfig = mkOption {
         type = types.bool;
         default = true;

--- a/nixos/modules/config/nix.nix
+++ b/nixos/modules/config/nix.nix
@@ -91,6 +91,25 @@ let
       "nix.conf"
       cfg.settings;
 
+  makeNixBuildUser = nr: {
+    name = "nixbld${toString nr}";
+    value = {
+      description = "Nix build user ${toString nr}";
+
+      /*
+        For consistency with the setgid(2), setuid(2), and setgroups(2)
+        calls in `libstore/build.cc', don't add any supplementary group
+        here except "nixbld".
+      */
+      uid = builtins.add config.ids.uids.nixbld nr;
+      isSystemUser = true;
+      group = "nixbld";
+      extraGroups = [ "nixbld" ];
+    };
+  };
+
+  nixbldUsers = lib.listToAttrs (map makeNixBuildUser (lib.range 1 cfg.nrBuildUsers));
+
 in
 {
   imports = [
@@ -177,6 +196,16 @@ in
           keep-derivations = true
         '';
         description = "Additional text appended to {file}`nix.conf`.";
+      };
+
+      nrBuildUsers = lib.mkOption {
+        type = lib.types.int;
+        description = ''
+          Number of `nixbld` user accounts created to
+          perform secure concurrent builds.  If you receive an error
+          message saying that “all build users are currently in use”,
+          you should increase this value.
+        '';
       };
 
       settings = mkOption {
@@ -384,6 +413,20 @@ in
   };
 
   config = mkIf cfg.enable {
+    environment.systemPackages = [
+      nixPackage
+      pkgs.nix-info
+    ]
+    ++ lib.optional config.programs.bash.completion.enable pkgs.nix-bash-completions;
+
+    systemd.tmpfiles.rules = [
+      "d  /nix/var                           0755 root root - -"
+      "L+ /nix/var/nix/gcroots/booted-system 0755 root root - /run/booted-system"
+      # Boot-time cleanup
+      "R! /nix/var/nix/gcroots/tmp           -    -    -    - -"
+      "R! /nix/var/nix/temproots             -    -    -    - -"
+    ];
+
     environment.etc."nix/nix.conf".source = nixConf;
     nix.settings = {
       trusted-public-keys = [ "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=" ];
@@ -391,5 +434,19 @@ in
       substituters = mkAfter [ "https://cache.nixos.org/" ];
       system-features = defaultSystemFeatures;
     };
+
+    nix.nrBuildUsers = lib.mkDefault (
+      if cfg.settings.auto-allocate-uids or false then
+        0
+      else
+        lib.max 32 (if cfg.settings.max-jobs == "auto" then 0 else cfg.settings.max-jobs)
+    );
+
+    users.users = nixbldUsers;
+
+    services.displayManager.hiddenUsers = lib.attrNames nixbldUsers;
+
+    # Legacy configuration conversion.
+    nix.settings.sandbox-fallback = false;
   };
 }

--- a/nixos/modules/programs/lix.nix
+++ b/nixos/modules/programs/lix.nix
@@ -32,7 +32,16 @@ let
 in
 
 {
-  config = lib.mkIf (cfg.enable && nixPackage.pname == "lix") {
+  config = lib.mkIf (cfg.daemon.enable && nixPackage.pname == "lix") {
+    assertions = [
+      {
+        assertion = cfg.enable;
+        message = ''
+          Enabling the Lix Daemon requires also enabling Nix (config.nix.enable = true).
+        '';
+      }
+    ];
+
     # Require the tun kernel module for pasta, can be disabled if pasta is not used.
     boot.kernelModules.tun = lib.mkDefault true;
 

--- a/nixos/modules/programs/lix.nix
+++ b/nixos/modules/programs/lix.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 let
@@ -30,31 +29,12 @@ let
     };
   };
 
-  makeNixBuildUser = nr: {
-    name = "nixbld${toString nr}";
-    value = {
-      description = "Lix build user ${toString nr}";
-      uid = builtins.add config.ids.uids.nixbld nr;
-      isSystemUser = true;
-      group = "nixbld";
-      extraGroups = [ "nixbld" ];
-    };
-  };
-
-  nixbldUsers = lib.listToAttrs (map makeNixBuildUser (lib.range 1 cfg.nrBuildUsers));
-
 in
 
 {
   config = lib.mkIf (cfg.enable && nixPackage.pname == "lix") {
     # Require the tun kernel module for pasta, can be disabled if pasta is not used.
     boot.kernelModules.tun = lib.mkDefault true;
-
-    environment.systemPackages = [
-      nixPackage
-      pkgs.nix-info
-    ]
-    ++ lib.optional (config.programs.bash.completion.enable) pkgs.nix-bash-completions;
 
     systemd.packages = [ nixPackage ];
 
@@ -113,19 +93,5 @@ in
 
     # Set up the environment variables for running Nix.
     environment.sessionVariables = cfg.envVars;
-
-    nix.nrBuildUsers = lib.mkDefault (
-      if cfg.settings.auto-allocate-uids or false then
-        0
-      else
-        lib.max 32 (if cfg.settings.max-jobs == "auto" then 0 else cfg.settings.max-jobs)
-    );
-
-    users.users = nixbldUsers;
-
-    services.displayManager.hiddenUsers = lib.attrNames nixbldUsers;
-
-    # Legacy configuration conversion.
-    nix.settings.sandbox-fallback = false;
   };
 }

--- a/nixos/modules/services/system/nix-daemon.nix
+++ b/nixos/modules/services/system/nix-daemon.nix
@@ -166,24 +166,6 @@ in
 
     nix = {
 
-      enable = lib.mkOption {
-        type = lib.types.bool;
-        default = true;
-        description = ''
-          Whether to enable Nix.
-          Disabling Nix makes the system hard to modify and the Nix programs and configuration will not be made available by NixOS itself.
-        '';
-      };
-
-      package = lib.mkOption {
-        type = lib.types.package;
-        default = pkgs.nix;
-        defaultText = lib.literalExpression "pkgs.nix";
-        description = ''
-          This option specifies the Nix package instance to use throughout the system.
-        '';
-      };
-
       daemonUser = lib.mkOption {
         type = lib.types.str;
         default = "root";

--- a/nixos/modules/services/system/nix-daemon.nix
+++ b/nixos/modules/services/system/nix-daemon.nix
@@ -249,77 +249,75 @@ in
 
   ###### implementation
 
-  config = lib.mkMerge [
-    (lib.mkIf (cfg.enable && nixPackage.pname != "lix") {
+  config = lib.mkIf (cfg.enable && nixPackage.pname != "lix") {
 
-      systemd.packages = [ nixPackage ];
+    systemd.packages = [ nixPackage ];
 
-      # The upstream Nix tmpfiles.d file assumes the daemon runs as root
-      systemd.tmpfiles.packages = lib.mkIf (cfg.daemonUser == "root") [ nixPackage ];
+    # The upstream Nix tmpfiles.d file assumes the daemon runs as root
+    systemd.tmpfiles.packages = lib.mkIf (cfg.daemonUser == "root") [ nixPackage ];
 
-      systemd.sockets.nix-daemon.wantedBy = [ "sockets.target" ];
+    systemd.sockets.nix-daemon.wantedBy = [ "sockets.target" ];
 
-      systemd.services.nix-daemon = {
-        path = [
-          nixPackage
-          config.programs.ssh.package
-        ]
-        # For running "newuidmap"
-        ++ lib.optional (cfg.daemonUser != "root") "/run/wrappers";
+    systemd.services.nix-daemon = {
+      path = [
+        nixPackage
+        config.programs.ssh.package
+      ]
+      # For running "newuidmap"
+      ++ lib.optional (cfg.daemonUser != "root") "/run/wrappers";
 
-        environment =
-          cfg.envVars
-          // {
-            CURL_CA_BUNDLE = config.security.pki.caBundle;
-          }
-          // config.networking.proxy.envVars;
+      environment =
+        cfg.envVars
+        // {
+          CURL_CA_BUNDLE = config.security.pki.caBundle;
+        }
+        // config.networking.proxy.envVars;
 
-        serviceConfig = {
-          CPUSchedulingPolicy = cfg.daemonCPUSchedPolicy;
-          IOSchedulingClass = cfg.daemonIOSchedClass;
-          IOSchedulingPriority = cfg.daemonIOSchedPriority;
-        };
-
-        restartTriggers = [ config.environment.etc."nix/nix.conf".source ];
-
-        # `stopIfChanged = false` changes to switch behavior
-        # from   stop -> update units -> start
-        #   to   update units -> restart
-        #
-        # The `stopIfChanged` setting therefore controls a trade-off between a
-        # more predictable lifecycle, which runs the correct "version" of
-        # the `ExecStop` line, and on the other hand the availability of
-        # sockets during the switch, as the effectiveness of the stop operation
-        # depends on the socket being stopped as well.
-        #
-        # As `nix-daemon.service` does not make use of `ExecStop`, we prefer
-        # to keep the socket up and available. This is important for machines
-        # that run Nix-based services, such as automated build, test, and deploy
-        # services, that expect the daemon socket to be available at all times.
-        #
-        # Notably, the Nix client does not retry on failure to connect to the
-        # daemon socket, and the in-process RemoteStore instance will disable
-        # itself. This makes retries infeasible even for services that are
-        # aware of the issue. Failure to connect can affect not only new client
-        # processes, but also new RemoteStore instances in existing processes,
-        # as well as existing RemoteStore instances that have not saturated
-        # their connection pool.
-        #
-        # Also note that `stopIfChanged = true` does not kill existing
-        # connection handling daemons, as one might wish to happen before a
-        # breaking Nix upgrade (which is rare). The daemon forks that handle
-        # the individual connections split off into their own sessions, causing
-        # them not to be stopped by systemd.
-        # If a Nix upgrade does require all existing daemon processes to stop,
-        # nix-daemon must do so on its own accord, and only when the new version
-        # starts and detects that Nix's persistent state needs an upgrade.
-        stopIfChanged = false;
-
+      serviceConfig = {
+        CPUSchedulingPolicy = cfg.daemonCPUSchedPolicy;
+        IOSchedulingClass = cfg.daemonIOSchedClass;
+        IOSchedulingPriority = cfg.daemonIOSchedPriority;
       };
 
-      # Set up the environment variables for running Nix.
-      environment.sessionVariables = cfg.envVars;
-    })
-  ];
+      restartTriggers = [ config.environment.etc."nix/nix.conf".source ];
+
+      # `stopIfChanged = false` changes to switch behavior
+      # from   stop -> update units -> start
+      #   to   update units -> restart
+      #
+      # The `stopIfChanged` setting therefore controls a trade-off between a
+      # more predictable lifecycle, which runs the correct "version" of
+      # the `ExecStop` line, and on the other hand the availability of
+      # sockets during the switch, as the effectiveness of the stop operation
+      # depends on the socket being stopped as well.
+      #
+      # As `nix-daemon.service` does not make use of `ExecStop`, we prefer
+      # to keep the socket up and available. This is important for machines
+      # that run Nix-based services, such as automated build, test, and deploy
+      # services, that expect the daemon socket to be available at all times.
+      #
+      # Notably, the Nix client does not retry on failure to connect to the
+      # daemon socket, and the in-process RemoteStore instance will disable
+      # itself. This makes retries infeasible even for services that are
+      # aware of the issue. Failure to connect can affect not only new client
+      # processes, but also new RemoteStore instances in existing processes,
+      # as well as existing RemoteStore instances that have not saturated
+      # their connection pool.
+      #
+      # Also note that `stopIfChanged = true` does not kill existing
+      # connection handling daemons, as one might wish to happen before a
+      # breaking Nix upgrade (which is rare). The daemon forks that handle
+      # the individual connections split off into their own sessions, causing
+      # them not to be stopped by systemd.
+      # If a Nix upgrade does require all existing daemon processes to stop,
+      # nix-daemon must do so on its own accord, and only when the new version
+      # starts and detects that Nix's persistent state needs an upgrade.
+      stopIfChanged = false;
+
+    };
+
+    # Set up the environment variables for running Nix.
+    environment.sessionVariables = cfg.envVars;
+  };
 
 }

--- a/nixos/modules/services/system/nix-daemon.nix
+++ b/nixos/modules/services/system/nix-daemon.nix
@@ -7,7 +7,6 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 let
@@ -15,25 +14,6 @@ let
   cfg = config.nix;
 
   nixPackage = cfg.package.out;
-
-  makeNixBuildUser = nr: {
-    name = "nixbld${toString nr}";
-    value = {
-      description = "Nix build user ${toString nr}";
-
-      /*
-        For consistency with the setgid(2), setuid(2), and setgroups(2)
-        calls in `libstore/build.cc', don't add any supplementary group
-        here except "nixbld".
-      */
-      uid = builtins.add config.ids.uids.nixbld nr;
-      isSystemUser = true;
-      group = "nixbld";
-      extraGroups = [ "nixbld" ];
-    };
-  };
-
-  nixbldUsers = lib.listToAttrs (map makeNixBuildUser (lib.range 1 cfg.nrBuildUsers));
 
 in
 
@@ -264,37 +244,13 @@ in
         default = { };
         description = "Environment variables used by Nix.";
       };
-
-      nrBuildUsers = lib.mkOption {
-        type = lib.types.int;
-        description = ''
-          Number of `nixbld` user accounts created to
-          perform secure concurrent builds.  If you receive an error
-          message saying that “all build users are currently in use”,
-          you should increase this value.
-        '';
-      };
     };
   };
 
   ###### implementation
 
   config = lib.mkMerge [
-    (lib.mkIf cfg.enable {
-      systemd.tmpfiles.rules = [
-        "d  /nix/var                           0755 root root - -"
-        "L+ /nix/var/nix/gcroots/booted-system 0755 root root - /run/booted-system"
-        # Boot-time cleanup
-        "R! /nix/var/nix/gcroots/tmp           -    -    -    - -"
-        "R! /nix/var/nix/temproots             -    -    -    - -"
-      ];
-    })
     (lib.mkIf (cfg.enable && nixPackage.pname != "lix") {
-      environment.systemPackages = [
-        nixPackage
-        pkgs.nix-info
-      ]
-      ++ lib.optional (config.programs.bash.completion.enable) pkgs.nix-bash-completions;
 
       systemd.packages = [ nixPackage ];
 
@@ -363,20 +319,6 @@ in
 
       # Set up the environment variables for running Nix.
       environment.sessionVariables = cfg.envVars;
-
-      nix.nrBuildUsers = lib.mkDefault (
-        if cfg.settings.auto-allocate-uids or false then
-          0
-        else
-          lib.max 32 (if cfg.settings.max-jobs == "auto" then 0 else cfg.settings.max-jobs)
-      );
-
-      users.users = nixbldUsers;
-
-      services.displayManager.hiddenUsers = lib.attrNames nixbldUsers;
-
-      # Legacy configuration conversion.
-      nix.settings.sandbox-fallback = false;
     })
   ];
 

--- a/nixos/modules/services/system/nix-daemon.nix
+++ b/nixos/modules/services/system/nix-daemon.nix
@@ -146,6 +146,15 @@ in
 
     nix = {
 
+      daemon.enable = lib.mkOption {
+        type = lib.types.bool;
+        default = config.nix.enable;
+        defaultText = lib.literalExpression "config.nix.enable";
+        description = ''
+          Whether to enable the Nix Daemon.
+        '';
+      };
+
       daemonUser = lib.mkOption {
         type = lib.types.str;
         default = "root";
@@ -249,7 +258,15 @@ in
 
   ###### implementation
 
-  config = lib.mkIf (cfg.enable && nixPackage.pname != "lix") {
+  config = lib.mkIf (cfg.daemon.enable && nixPackage.pname != "lix") {
+    assertions = [
+      {
+        assertion = cfg.enable;
+        message = ''
+          Enabling the Nix Daemon requires also enabling Nix (config.nix.enable = true).
+        '';
+      }
+    ];
 
     systemd.packages = [ nixPackage ];
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -963,6 +963,7 @@ in
   litestream = runTest ./litestream.nix;
   livebook-service = runTest ./livebook-service.nix;
   livekit = runTest ./networking/livekit.nix;
+  lix = runTest ./lix.nix;
   lk-jwt-service = runTest ./matrix/lk-jwt-service.nix;
   llama-swap = runTest ./web-servers/llama-swap.nix;
   lldap = runTest ./lldap.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1179,6 +1179,7 @@ in
   nix-daemon-firewall = runTest ./nix-daemon-firewall.nix;
   nix-daemon-unprivileged = runTest ./nix-daemon-unprivileged.nix;
   nix-ld = runTest ./nix-ld.nix;
+  nix-local-store = runTest ./nix-local-store.nix;
   nix-misc = handleTest ./nix/misc.nix { };
   nix-required-mounts = runTest ./nix-required-mounts;
   nix-serve = runTest ./nix-serve.nix;

--- a/nixos/tests/lix.nix
+++ b/nixos/tests/lix.nix
@@ -1,0 +1,21 @@
+{ ... }: {
+  name = "lix";
+
+  nodes.machine = { pkgs, ... }: {
+    nix.package = pkgs.lix;
+
+    environment.etc."test.nix".text = ''
+      derivation {
+        name = "test";
+        builder = "/bin/sh";
+        args = [ "-c" "echo succeeded > $out" ];
+        system = "${pkgs.stdenv.hostPlatform.system}";
+      }
+    '';
+  };
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("sockets.target")
+    machine.succeed("NIX_REMOTE=daemon nix-build /etc/test.nix")
+  '';
+}

--- a/nixos/tests/nix-local-store.nix
+++ b/nixos/tests/nix-local-store.nix
@@ -1,0 +1,26 @@
+{ ... }: {
+  name = "nix-local-store";
+
+  nodes.machine = { pkgs, ... }: {
+    nix.daemon.enable = false;
+    nix.settings = {
+      experimental-features = [ "nix-command" ];
+      log-lines = 26;
+    };
+    # Easiest way to get a file onto the machine
+    environment.etc."test.nix".text = ''
+      derivation {
+        name = "test";
+        builder = "/bin/sh";
+        args = [ "-c" "echo succeeded > $out" ];
+        system = "${pkgs.stdenv.hostPlatform.system}";
+      }
+    '';
+  };
+  testScript = ''
+    start_all()
+    machine.succeed("nix-build /etc/test.nix")
+    log_lines = machine.succeed("nix config show log-lines").strip()
+    assert int(log_lines) == 26, "Nix settings not respected by local store"
+  '';
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Restructures options under the `nix`, `nix-daemon`, and `lix` modules to support NixOS configurations that are not running the Nix daemon. The value is you can manage your machine via Nix, but without the added complexity/security surface of the daemon. I tried to implement this with `nix.enable = false`, but this does not work because other critical modules depend on that option ([e.g.](https://github.com/NixOS/nixpkgs/blob/b051529a7681b482a0fa166de932ed9fb54f7520/nixos/modules/system/activation/activation-script.nix#L281)).

This PR is easiest to review per-commit. Pointed to `staging-nixos` because this rebuilds NixOS tests due to module ordering.

Changes:
- Moves options & related config that are need for the `local` store type out of `nix-daemon` module and into `nix` module.
- Removes now duplicated settings from `lix`.
- Adds VM tests for `nix-local-store` and `lix`
- Adds assertions to `lix` and `nix-daemon` modules that require `nix` to be enabled, maintaining pre-existing invariant

Full disclosure, I do not use Lix--I just added the VM test as a quick sanity check. This change also inherently ties the Nix and Lix projects together via shared settings in the `nix` module--but that still seems to be valid today.

No AI used.

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
