### PR TITLE
lepton: fix build with cmake 4

### DIFF
--- a/pkgs/by-name/le/lepton/package.nix
+++ b/pkgs/by-name/le/lepton/package.nix
@@ -24,6 +24,9 @@ stdenv.mkDerivation {
   ];
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ glibc.static ];
 
+  # CMake 4 rejects cmake_minimum_required < 3.5 (upstream uses 2.8).
+  cmakeFlags = [ (lib.cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.5") ];
+
   meta = {
     homepage = "https://github.com/dropbox/lepton";
     description = "Tool to losslessly compress JPEGs";


### PR DESCRIPTION
CMake 4 fails configure for packages with `cmake_minimum_required` < 3.5.
dropbox/lepton still declares 2.8; set `CMAKE_POLICY_VERSION_MINIMUM=3.5`.

Observed via nfd.1l.is (`/api/builds`). No open nixpkgs issue/PR for this package.
Only reverse dependency in-tree: `gb-backup` (builds with this change).

Assisted by Grok 4.3 (xAI); human-reviewed before submission.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test