### PR TITLE
tdlib-purple: init at 2.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11234,6 +11234,11 @@
     github = "HigherOrderLogic";
     githubId = 73709188;
   };
+  highghlow = {
+    name = "Alex Kravchenko";
+    github = "unhighghlow";
+    githubId = 132668972;
+  };
   hirenashah = {
     email = "hiren@hiren.io";
     github = "hirenashah";

--- a/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/default.nix
@@ -52,9 +52,9 @@ lib.makeScope newScope (
 
     purple-xmpp-http-upload = callPackage ./purple-xmpp-http-upload { };
 
+    tdlib-purple = callPackage ./tdlib-purple { };
   }
   // lib.optionalAttrs config.allowAliases {
-    tdlib-purple = throw "'pidginPackages.tdlib-purple' has been removed due to being broken for more than a year; see RFC 180"; # Added 2026-02-05
     purple-matrix = throw "'pidginPackages.purple-matrix' has been unmaintained since April 2022, so it was removed.";
     pidgin-skypeweb = throw "'pidginPackages.pidgin-skypeweb' has been removed since Skype was shut down in May 2025.";
     purple-hangouts = throw "'pidginPackages.purple-hangouts' has been removed as Hangouts Classic is obsolete and migrated to Google Chat.";

--- a/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/tdlib-purple/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/tdlib-purple/default.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  cmake,
+  libwebp,
+  pidgin,
+  tdlib,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tdlib-purple";
+  version = "0.8.1";
+
+  src = fetchFromGitHub {
+    owner = "ars3niy";
+    repo = "tdlib-purple";
+    rev = "v${version}";
+    sha256 = "sha256-mrowzTtNLyMc2WwLVIop8Mg2DbyiQs0OPXmJuM9QUnM=";
+  };
+
+  patches = [
+    # Update to tdlib 1.8.0
+    (fetchpatch {
+      url = "https://github.com/ars3niy/tdlib-purple/commit/8c87b899ddbec32ec6ab4a34ddf0dc770f97d396.patch";
+      sha256 = "sha256-sysPYPno+wS8mZwQAXtX5eVnhwKAZrtr5gXuddN3mko=";
+    })
+  ];
+
+  preConfigure = ''
+    sed -i -e 's|DESTINATION.*PURPLE_PLUGIN_DIR}|DESTINATION "lib/purple-2|' CMakeLists.txt
+    sed -i -e 's|DESTINATION.*PURPLE_DATA_DIR}|DESTINATION "share|' CMakeLists.txt
+  '';
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [
+    libwebp
+    pidgin
+    tdlib
+  ];
+
+  cmakeFlags = [ "-DNoVoip=True" ]; # libtgvoip required
+
+  env.NIX_CFLAGS_COMPILE = toString (
+    lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [ "-U__ARM_NEON__" ]
+  );
+
+  meta = {
+    homepage = "https://github.com/ars3niy/tdlib-purple";
+    description = "libpurple Telegram plugin using tdlib";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ sikmir ];
+    platforms = lib.platforms.unix;
+
+    # tdlib-purple is not actively maintained and currently not
+    # compatible with recent versions of tdlib
+    broken = true;
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/tdlib-purple/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/tdlib-purple/default.nix
@@ -9,21 +9,25 @@
   openssl,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tdlib-purple";
   version = "1.1.0";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "adrighem";
     repo = "tdlib-purple";
-    rev = "tdlib-purple-v${version}";
-    sha256 = "sha256-H7fb/kYSjplrazwMbqQD9uLVUadIsn+O810G4Qhx6Rk=";
+    tag = "tdlib-purple-v${finalAttrs.version}";
+    hash = "sha256-H7fb/kYSjplrazwMbqQD9uLVUadIsn+O810G4Qhx6Rk=";
   };
 
   preConfigure = ''
     sed -i -e 's|DESTINATION.*PURPLE_PLUGIN_DIR}|DESTINATION "lib/purple-2|' CMakeLists.txt
     sed -i -e 's|DESTINATION.*PURPLE_DATA_DIR}|DESTINATION "share|' CMakeLists.txt
   '';
+
+  strictDeps = true;
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [
@@ -42,8 +46,9 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://github.com/adrighem/tdlib-purple";
     description = "libpurple Telegram plugin using tdlib";
+    changelog = "https://github.com/adrighem/tdlib-purple/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ highghlow ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/tdlib-purple/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/tdlib-purple/default.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "tdlib-purple";
-  version = "0.9.2";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "adrighem";
     repo = "tdlib-purple";
     rev = "tdlib-purple-v${version}";
-    sha256 = "";
+    sha256 = "sha256-H7fb/kYSjplrazwMbqQD9uLVUadIsn+O810G4Qhx6Rk=";
   };
 
   preConfigure = ''

--- a/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/tdlib-purple/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/tdlib-purple/default.nix
@@ -7,6 +7,8 @@
   pidgin,
   tdlib,
   openssl,
+  pkg-config,
+  gettext,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -29,7 +31,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    libwebp
+    gettext
+  ];
+
   buildInputs = [
     libwebp
     pidgin

--- a/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/tdlib-purple/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/tdlib-purple/default.nix
@@ -2,31 +2,23 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   libwebp,
   pidgin,
   tdlib,
+  openssl,
 }:
 
 stdenv.mkDerivation rec {
   pname = "tdlib-purple";
-  version = "0.8.1";
+  version = "0.9.2";
 
   src = fetchFromGitHub {
-    owner = "ars3niy";
+    owner = "adrighem";
     repo = "tdlib-purple";
-    rev = "v${version}";
-    sha256 = "sha256-mrowzTtNLyMc2WwLVIop8Mg2DbyiQs0OPXmJuM9QUnM=";
+    rev = "tdlib-purple-v${version}";
+    sha256 = "";
   };
-
-  patches = [
-    # Update to tdlib 1.8.0
-    (fetchpatch {
-      url = "https://github.com/ars3niy/tdlib-purple/commit/8c87b899ddbec32ec6ab4a34ddf0dc770f97d396.patch";
-      sha256 = "sha256-sysPYPno+wS8mZwQAXtX5eVnhwKAZrtr5gXuddN3mko=";
-    })
-  ];
 
   preConfigure = ''
     sed -i -e 's|DESTINATION.*PURPLE_PLUGIN_DIR}|DESTINATION "lib/purple-2|' CMakeLists.txt
@@ -38,6 +30,7 @@ stdenv.mkDerivation rec {
     libwebp
     pidgin
     tdlib
+    openssl
   ];
 
   cmakeFlags = [ "-DNoVoip=True" ]; # libtgvoip required
@@ -47,14 +40,10 @@ stdenv.mkDerivation rec {
   );
 
   meta = {
-    homepage = "https://github.com/ars3niy/tdlib-purple";
+    homepage = "https://github.com/adrighem/tdlib-purple";
     description = "libpurple Telegram plugin using tdlib";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ sikmir ];
     platforms = lib.platforms.unix;
-
-    # tdlib-purple is not actively maintained and currently not
-    # compatible with recent versions of tdlib
-    broken = true;
   };
 }

--- a/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/tdlib-purple/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/tdlib-purple/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/adrighem/tdlib-purple";
     description = "libpurple Telegram plugin using tdlib";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ sikmir ];
+    maintainers = with lib.maintainers; [ highghlow ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/tdlib-purple/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/tdlib-purple/default.nix
@@ -9,11 +9,12 @@
   openssl,
   pkg-config,
   gettext,
+  python3,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tdlib-purple";
-  version = "1.1.0";
+  version = "2.0.1";
 
   __structuredAttrs = true;
 
@@ -21,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "adrighem";
     repo = "tdlib-purple";
     tag = "tdlib-purple-v${finalAttrs.version}";
-    hash = "sha256-H7fb/kYSjplrazwMbqQD9uLVUadIsn+O810G4Qhx6Rk=";
+    hash = "sha256-jWUXBBfpUE/fShLsy7MKsrCFa9tRyl+pLTLVWLNAceE=";
   };
 
   preConfigure = ''
@@ -36,6 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     libwebp
     gettext
+    python3
   ];
 
   buildInputs = [

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -2334,7 +2334,7 @@ mapAliases {
   tcptrace = throw "tcptrace has been removed as it was broken and upstream is gone"; # Added 2026-02-02
   tdesktop = throw "'tdesktop' has been renamed to/replaced by 'telegram-desktop'"; # Converted to throw 2025-10-27
   tdfgo = throw "'tdfgo' has been removed because it was removed from upstream"; # Added 2025-12-18
-  tdlib-purple = throw "'tdlib-purple' has been removed due to being broken for more than a year; see RFC 180"; # Added 2026-02-05
+  tdlib-purple = throw "'tdlib-purple' has been renamed to/replaced by 'pidginPackages.tdlib-purple'"; # Converted to throw 2025-10-27
   tdom = throw "'tdom' has been renamed to/replaced by 'tclPackages.tdom'"; # Converted to throw 2025-10-27
   teamspeak3 = throw "'teamspeak3' has been removed as it depended on qt5 webengine which is EOL"; # Added 2026-04-25
   teamspeak5_client = throw "'teamspeak5_client' has been renamed to/replaced by 'teamspeak6-client'"; # Converted to throw 2025-10-27


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

tdlib-purple was recently forked and updated to the latest tdlib, so here it is again (it was previously in nixpkgs, but was removed due to being unmaintained). I derived the package definition from the one that was present before it was removed. I tested the package: it works with the `master` pidgin and live Telegram.

Sorry if I got something wrong.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking. (Is this applicable)
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy]. (No AI used at all by me, not sure about upstream)

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
