### PR TITLE
python3Packages.jax: disable test broken with numpy 2.5

### DIFF
--- a/pkgs/development/python-modules/jax/default.nix
+++ b/pkgs/development/python-modules/jax/default.nix
@@ -132,6 +132,10 @@ buildPythonPackage (finalAttrs: {
     # --numprocesses.
     # New test in jax 0.10.2 (tests/random_impl_test.py).
     "test_random_bits"
+
+    # Jax uses deprecated numpy logic as an oracle. Fixed upstream in jax 0.11.0, can't be properly backported.
+    # https://github.com/jax-ml/jax/commit/d219f03b589a1075f499148113aa9c647e1be0b9
+    "testCross"
   ]
   ++ lib.optionals usingMKL [
     # See


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

```
FAILED tests/lax_numpy_test.py::LaxBackedNumpyTests::testCross0 - ValueError: Both input arrays must be (arrays of) 3-dimensional vectors, but they are 2 and 2 dimensional instead.
FAILED tests/lax_numpy_test.py::LaxBackedNumpyTests::testCross1 - ValueError: Both input arrays must be (arrays of) 3-dimensional vectors, but they are 2 and 3 dimensional instead.
FAILED tests/lax_numpy_test.py::LaxBackedNumpyTests::testCross2 - ValueError: Both input arrays must be (arrays of) 3-dimensional vectors, but they are 2 and 2 dimensional instead.
FAILED tests/lax_numpy_test.py::LaxBackedNumpyTests::testCross3 - ValueError: Both input arrays must be (arrays of) 3-dimensional vectors, but they are 2 and 2 dimensional instead.
FAILED tests/lax_numpy_test.py::LaxBackedNumpyTests::testCross4 - ValueError: Both input arrays must be (arrays of) 3-dimensional vectors, but they are 2 and 2 dimensional instead.
FAILED tests/lax_numpy_test.py::LaxBackedNumpyTests::testCross5 - ValueError: Both input arrays must be (arrays of) 3-dimensional vectors, but they are 2 and 2 dimensional instead.
FAILED tests/lax_numpy_test.py::LaxBackedNumpyTests::testCross6 - ValueError: Both input arrays must be (arrays of) 3-dimensional vectors, but they are 2 and 3 dimensional instead.
FAILED tests/lax_numpy_test.py::LaxBackedNumpyTests::testCross8 - ValueError: Both input arrays must be (arrays of) 3-dimensional vectors, but they are 2 and 2 dimensional instead.
FAILED tests/lax_numpy_test.py::LaxBackedNumpyTests::testCross9 - ValueError: Both input arrays must be (arrays of) 3-dimensional vectors, but they are 2 and 3 dimensional instead.
```

This is caused by deprecation in numpy 2.5.
Jax commit https://github.com/jax-ml/jax/commit/d219f03b589a1075f499148113aa9c647e1be0b9 is supposed to fix this, but it is too far into jax 0.11 development, so it can't be applied as a patch. (It is not fixed by https://github.com/NixOS/nixpkgs/pull/527987 on master)
Given that the test is testing the deprecated functionality anyway (it has a DeprecationWarning suppression), I don't think fixing it makes any sense.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
