### PR TITLE
[26.05] curl: cross fixes

### DIFF
--- a/pkgs/by-name/cu/curlMinimal/package.nix
+++ b/pkgs/by-name/cu/curlMinimal/package.nix
@@ -264,7 +264,8 @@ stdenv.mkDerivation (finalAttrs: {
   + lib.optionalString isCross ''
     patchShebangs --update --host "''${!outputBin}/bin"
   '';
-  disallowedReferences = lib.optional isCross buildPackages.runtimeShellPackage;
+  outputChecks.bin.disallowedReferences = lib.optional isCross buildPackages.runtimeShellPackage;
+  outputChecks.out.disallowedReferences = lib.optional isCross buildPackages.runtimeShellPackage;
   buildInputs = lib.optional isCross runtimeShellPackage;
 
   passthru =

--- a/pkgs/by-name/cu/curlMinimal/package.nix
+++ b/pkgs/by-name/cu/curlMinimal/package.nix
@@ -6,6 +6,8 @@
   perl,
   nixosTests,
   autoreconfHook,
+  buildPackages,
+  runtimeShellPackage,
   brotliSupport ? false,
   brotli,
   c-aresSupport ? false,
@@ -82,6 +84,9 @@ assert
     ]) > 1
   );
 
+let
+  isCross = !lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "curl";
   version = "8.20.0";
@@ -248,7 +253,19 @@ stdenv.mkDerivation (finalAttrs: {
     ln $out/lib/libcurl${stdenv.hostPlatform.extensions.sharedLibrary} $out/lib/libcurl-gnutls${stdenv.hostPlatform.extensions.sharedLibrary}
     ln $out/lib/libcurl${stdenv.hostPlatform.extensions.sharedLibrary} $out/lib/libcurl-gnutls${stdenv.hostPlatform.extensions.sharedLibrary}.4
     ln $out/lib/libcurl${stdenv.hostPlatform.extensions.sharedLibrary} $out/lib/libcurl-gnutls${stdenv.hostPlatform.extensions.sharedLibrary}.4.4.0
+  ''
+  # The wcurl shell script found in `''${!outputBin}/bin`, is located in the
+  # source along with all the scripts patched in `postPatch` above.
+  # `patchShebangs` at that stage causes the host intended wcurl script to get
+  # the buildPlatform's runtimeShell shebang, instead of the hostPlatform's. To
+  # make sure this doesn't happen we disallow it, and fix it above in the
+  # postInstall, and also with the conditional hostPlatform's
+  # runtimeShellPackage added in buildInputs.
+  + lib.optionalString isCross ''
+    patchShebangs --update --host "''${!outputBin}/bin"
   '';
+  disallowedReferences = lib.optional isCross buildPackages.runtimeShellPackage;
+  buildInputs = lib.optional isCross runtimeShellPackage;
 
   passthru =
     let


### PR DESCRIPTION
- **curl{,Minimal}: patch shebang of wcurl script with host runtimeShell**
- **curl: allow runtimeShellPackage to be referenced by curl.dev**

Backports of https://github.com/NixOS/nixpkgs/pull/493004 and https://github.com/NixOS/nixpkgs/pull/536570

Supersedes https://github.com/NixOS/nixpkgs/pull/535878


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
