### PR TITLE
haskellPackages.{yaya*}: allow doctest 0.25

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1551,6 +1551,15 @@ with haskellLib;
   servant-auth-docs = doJailbreak super.servant-auth-docs;
   servant-swagger = doJailbreak super.servant-swagger;
 
+  # 2026-06-29: allow doctest 0.25
+  # https://github.com/sellout/yaya/issues/91
+  yaya = doJailbreak super.yaya;
+  yaya-containers = doJailbreak super.yaya-containers;
+  yaya-hedgehog = doJailbreak super.yaya-hedgehog;
+  yaya-lens = doJailbreak super.yaya-lens;
+  yaya-quickcheck = doJailbreak super.yaya-quickcheck;
+  yaya-unsafe = doJailbreak super.yaya-unsafe;
+
   # chell-quickcheck doesn't work with QuickCheck >= 2.15 with no known fix yet
   # https://github.com/typeclasses/chell/issues/5
   system-filepath = dontCheck super.system-filepath;


### PR DESCRIPTION

## Things done

- Built on platform:
  - [x] x86_64-linux
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
