### PR TITLE
postgresql19Packages.pg_safeupdate: fix build

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_safeupdate.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_safeupdate.nix
@@ -7,13 +7,13 @@
 
 postgresqlBuildExtension (finalAttrs: {
   pname = "pg-safeupdate";
-  version = "1.6";
+  version = "1.6-unstable-2026-06-29";
 
   src = fetchFromGitHub {
     owner = "eradman";
     repo = "pg-safeupdate";
-    tag = finalAttrs.version;
-    hash = "sha256-xky2tlb0EoKzyIYftVr7/2BYLdinhxHjXiVO3lR57MM=";
+    rev = "404fcd265f3242b432a16756bfdd078e3a4b6e0f";
+    hash = "sha256-8Y27TfcY6+QO2Fb9wi6zlKzHlDdlIB38/RffMV7MPF0=";
   };
 
   meta = {


### PR DESCRIPTION
Not a new release, yet, but fixed the PG19 build today on the master branch: https://github.com/eradman/pg-safeupdate/commit/5fe81fb58b1a4b8078b67a2386c2767fc27b0ccf

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
