### PR TITLE
vtk: Propagate qt6 when built withQt6

### DIFF
--- a/pkgs/development/libraries/vtk/generic.nix
+++ b/pkgs/development/libraries/vtk/generic.nix
@@ -219,6 +219,9 @@ stdenv.mkDerivation (finalAttrs: {
     libx11
     gl2ps
   ]
+  ++ lib.optionals withQt6 [
+    qt6.qttools
+  ]
   # create meta package providing dist-info for python3Pacakges.vtk that common cmake build does not do
   ++ lib.optionals pythonSupport [
     (python3Packages.mkPythonMetaPackage {


### PR DESCRIPTION
Qt6 is required by downstream packages, because it is referenced in generated CMake files. This can be seen easily by running:

    $ rg -F 'find_package(Qt6' $(nix-build -A vtkWithQt6)
    /nix/store/cyyrdnp8z0kkllm9p9gnzkpd5fgx71gr-vtk-9.5.2/lib/cmake/vtk/VTK-vtk-module-find-packages.cmake
    215:  find_package(Qt6
    1014:  find_package(Qt6
    1061:  find_package(Qt6
    1108:  find_package(Qt6

Without this change, downstream packages can fail with CMake errors similar to the following:

    CMake Warning at /nix/store/89qm6ksd5ha06fjq4dkzfq777qbangzp-vtk-9.5.2/lib/cmake/vtk/VTK-vtk-module-find-packages.cmake:1108 (find_package):
      By not providing "FindQt6.cmake" in CMAKE_MODULE_PATH this project has
      asked CMake to find a package configuration file provided by "Qt6", but
      CMake did not find one.

      Could not find a package configuration file provided by "Qt6" (requested
      version 6.11) with any of the following names:

        Qt6Config.cmake
        qt6-config.cmake

      Add the installation prefix of "Qt6" to CMAKE_PREFIX_PATH or set "Qt6_DIR"
      to a directory containing one of the above files.  If "Qt6" provides a
      separate development package or SDK, be sure it has been installed.

We experience these errors in [nix-ros-overlay](https://github.com/lopsided98/nix-ros-overlay).
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
