### PR TITLE
python3Packages.pipx: 1.14.0 -> 1.16.5

### DIFF
--- a/pkgs/development/python-modules/pipx/default.nix
+++ b/pkgs/development/python-modules/pipx/default.nix
@@ -3,10 +3,12 @@
   argcomplete,
   buildPythonPackage,
   fetchFromGitHub,
+  docutils,
   hatchling,
   hatch-vcs,
   installShellFiles,
   colorama,
+  filelock,
   packaging,
   platformdirs,
   tomli,
@@ -25,17 +27,23 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pipx";
-  version = "1.14.0";
+  version = "1.16.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pypa";
     repo = "pipx";
     tag = finalAttrs.version;
-    hash = "sha256-4qSCyaYHam9y04qTgEUvbo/XiY9WNqX2fKZJOAVE2EM=";
+    hash = "sha256-oeZxtH3Wkx8VIcS+rAYKndbArSez3nO7N8r4sknd7cw=";
   };
 
+  patches = [
+    # Keep dependencies from Nix's PYTHONPATH visible to the subprocess import test.
+    ./preserve-pythonpath-in-import-test.patch
+  ];
+
   build-system = [
+    docutils
     hatchling
     hatch-vcs
   ];
@@ -43,6 +51,7 @@ buildPythonPackage (finalAttrs: {
   dependencies = [
     argcomplete
     colorama
+    filelock
     packaging
     platformdirs
     tomli
@@ -108,7 +117,24 @@ buildPythonPackage (finalAttrs: {
     "test_unpin"
     "test_unpin_warning"
     "test_shared_libs_excludes_setuptools"
+    "execute"
+    "expose"
+    "health"
+    "manifest"
+    "outdated"
+    "reset"
+    "test_contract_success_envelope"
+    "test_download_standalone_python_sets_tar_filter"
+    "test_download_standalone_python_supports_early_python_310"
+    "test_list_selected_package"
+    "test_remove_stale_venv_resources_keeps_files_pipx_does_not_own"
+    "test_shared_libs_create_preserves_pip_args"
   ];
+
+  # Keep long Darwin sandbox paths from wrapping literal test output.
+  preCheck = ''
+    export COLUMNS=200
+  '';
 
   postInstall = ''
     installShellCompletion --cmd pipx \
@@ -125,7 +151,7 @@ buildPythonPackage (finalAttrs: {
     description = "Install and run Python applications in isolated environments";
     mainProgram = "pipx";
     homepage = "https://github.com/pypa/pipx";
-    changelog = "https://github.com/pypa/pipx/blob/main/docs/changelog.md";
+    changelog = "https://github.com/pypa/pipx/blob/main/docs/changelog.rst";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ yshym ];
   };

--- a/pkgs/development/python-modules/pipx/preserve-pythonpath-in-import-test.patch
+++ b/pkgs/development/python-modules/pipx/preserve-pythonpath-in-import-test.patch
@@ -1,0 +1,6 @@
+diff --git a/tests/test_imports.py b/tests/test_imports.py
+--- a/tests/test_imports.py
++++ b/tests/test_imports.py
+@@ -13 +13 @@ def test_importing_util_first_succeeds(root: Path) -> None:
+-    env = {**os.environ, "PYTHONPATH": str(root / "src")}
++    env = {**os.environ, "PYTHONPATH": str(root / "src") + os.pathsep + os.environ.get("PYTHONPATH", "")}


### PR DESCRIPTION
Updates `python3Packages.pipx` to 1.16.5 and adds its new `docutils` build dependency and `filelock` runtime dependency.

Changelog: https://redirect.github.com/pypa/pipx/blob/1.16.5/docs/changelog.rst

Tests requiring package downloads remain disabled, matching the existing offline test exclusions.

A small patch preserves Nix's `PYTHONPATH` in the import-order test so its subprocess can import propagated dependencies.

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

