### PR TITLE
ifupdown-ng: unstable-2025-09-12 -> 0.13.0, fix dependencies and check

### DIFF
--- a/pkgs/by-name/if/ifupdown-ng/package.nix
+++ b/pkgs/by-name/if/ifupdown-ng/package.nix
@@ -4,19 +4,18 @@
   fetchFromGitHub,
   libbsd,
   pkg-config,
-  coreutils,
-  iproute2,
+  atf,
+  kyua,
 }:
-
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ifupdown-ng";
-  version = "unstable-2025-09-12";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "ifupdown-ng";
     repo = "ifupdown-ng";
-    rev = "fb07d0824b20d178e7acca9e85296822ac2539ac";
-    hash = "sha256-c06NbF0LpyK3hTMxCeWyQcUP9dL17hOm3993wjW/OzQ=";
+    rev = "ifupdown-ng-${finalAttrs.version}";
+    hash = "sha256-+M8c59LjJlO1Vdl+Lo5EXjMEaHWemGWvBsDw/MaY/IE=";
   };
 
   nativeBuildInputs = [ pkg-config ];
@@ -24,22 +23,16 @@ stdenv.mkDerivation {
   buildInputs = [ libbsd ];
 
   postPatch = ''
-    # The Makefile hardcodes -static; remove it to build dynamically.
-    substituteInPlace Makefile \
-      --replace-fail ' -static ' ' '
-
-    # replace _PATH_STDPATH with a path that includes nix store locations.
+    # replace _PATH_STDPATH with a path inherited from parent process.
     # ifupdown-ng sets PATH to this value before running executor scripts.
     substituteInPlace libifupdown/lifecycle.c \
-      --replace-fail '_PATH_STDPATH' '"${
-        lib.makeBinPath [
-          iproute2
-          coreutils
-        ]
-      }:/usr/bin:/bin"'
+      --replace-fail '_PATH_STDPATH' 'getenv("PATH")'
 
     # remove hardcoded FHS paths from executor scripts so they use PATH lookup.
     substituteInPlace executors/linux/dhcp \
+      --replace-fail '[ -x /sbin/dhcpcd ]' 'command -v dhcpcd >/dev/null' \
+      --replace-fail '[ -x /usr/sbin/dhclient ]' 'command -v dhclient >/dev/null' \
+      --replace-fail '[ -x /sbin/udhcpc ]' 'command -v udhcpc >/dev/null' \
       --replace-fail '/sbin/dhcpcd' 'dhcpcd' \
       --replace-fail '/usr/sbin/dhclient' 'dhclient' \
       --replace-fail '/sbin/udhcpc' 'udhcpc'
@@ -49,6 +42,24 @@ stdenv.mkDerivation {
       --replace-fail '/sbin/wpa_passphrase' 'wpa_passphrase' \
       --replace-fail '/sbin/wpa_supplicant' 'wpa_supplicant' \
       --replace-fail '/usr/sbin/iwconfig' 'iwconfig'
+    substituteInPlace tests/linux/dhcp_test \
+      --replace-fail '/sbin/dhcpcd' 'dhcpcd' \
+      --replace-fail '/usr/sbin/dhclient' 'dhclient' \
+      --replace-fail '/sbin/udhcpc' 'udhcpc'
+    patchShebangs --build tests
+
+    # remove all uses of "which" command, in case of gre allow mock to pass without ip binary in PATH
+    substituteInPlace executors/linux/batman \
+      --replace-fail 'which' 'command -v'
+    substituteInPlace executors/linux/bridge \
+      --replace-fail 'which' 'command -v'
+    substituteInPlace executors/linux/gre \
+      --replace-fail 'which ip' 'command -v ip || echo "none"'
+  ''
+  + lib.optionalString (!stdenv.hostPlatform.isStatic) ''
+    # The Makefile hardcodes -static; remove it to build dynamically.
+    substituteInPlace Makefile \
+      --replace-fail ' -static ' ' '
   '';
 
   makeFlags = [
@@ -58,6 +69,13 @@ stdenv.mkDerivation {
 
   installFlags = [
     "DESTDIR=${placeholder "out"}"
+  ];
+
+  doCheck = true;
+
+  nativeCheckInputs = [
+    atf
+    kyua
   ];
 
   meta = {
@@ -70,6 +88,9 @@ stdenv.mkDerivation {
     homepage = "https://github.com/ifupdown-ng/ifupdown-ng";
     license = lib.licenses.isc;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ aanderse ];
+    maintainers = with lib.maintainers; [
+      aanderse
+      deinferno
+    ];
   };
-}
+})


### PR DESCRIPTION
1. Version updated to 0.13.0
2. Removed FHS paths in _PATH_STDPATH, not useful anyway as all inputs are now included in $PATH 
3. Added missing dependencies for dhcp to work
4. Added optional dependencies for PPP,WG,Ethtool,Batman and Wifi support (similar to alpine package split)
5. Added kyua doCheck tests
6. pkgsMusl and pkgsStatic builds work and pass doCheck
7. Add myself as maintainer

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
