### PR TITLE
Reapply "postgresql: fix overrides being forgotten on withPackages"

### DIFF
--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -24,7 +24,7 @@ let
       let
         attrName = if jitSupport then "${version}_jit" else version;
         postgresql = import path { inherit self; };
-        attrValue = if jitSupport then postgresql.withJIT else postgresql.withoutJIT;
+        attrValue = if jitSupport then postgresql.withJIT else postgresql;
       in
       self.lib.nameValuePair attrName attrValue
     ) versions;

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -563,7 +563,7 @@ let
           psqlSchema = lib.versions.major version;
 
           withJIT = if jitSupport then this.withPackages (_: [ this.jit ]) else null;
-          withoutJIT = this;
+          withoutJIT = this.withPackages (_: [ ]);
 
           pkgs =
             let

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -553,64 +553,64 @@ let
           (withBlocksize == null && withWalBlocksize == null);
       installCheckTarget = "check-world";
 
-      passthru =
-        let
-          this = self.callPackage generic args;
-        in
-        {
-          inherit dlSuffix;
+      passthru = {
+        inherit dlSuffix;
 
-          psqlSchema = lib.versions.major version;
+        psqlSchema = lib.versions.major version;
 
-          withJIT = if jitSupport then this.withPackages (_: [ this.jit ]) else null;
-          withoutJIT = this.withPackages (_: [ ]);
+        withJIT =
+          if jitSupport then
+            finalAttrs.finalPackage.withPackages (_: [ finalAttrs.finalPackage.jit ])
+          else
+            null;
+        withoutJIT = finalAttrs.finalPackage.withPackages (_: [ ]);
 
-          pkgs =
-            let
-              scope = {
-                inherit
-                  jitSupport
-                  pythonSupport
-                  perlSupport
-                  tclSupport
-                  ;
-                inherit (llvmPackages) llvm;
-                postgresql = this;
-                stdenv = stdenv';
-                postgresqlTestExtension = newSuper.callPackage ./postgresqlTestExtension.nix { };
-                postgresqlBuildExtension = newSuper.callPackage ./postgresqlBuildExtension.nix { };
-              };
-              newSelf = self // scope;
-              newSuper = {
-                callPackage = newScope (scope // this.pkgs);
-              };
-            in
-            import ./ext.nix newSelf newSuper;
-
-          withPackages = postgresqlWithPackages {
-            inherit buildEnv lib makeBinaryWrapper;
-            postgresql = this;
-          };
-
-          pg_config = buildPackages.callPackage ./pg_config.nix {
-            inherit (finalAttrs) finalPackage;
-            outputs = {
-              out = lib.getOutput "out" finalAttrs.finalPackage;
-              man = lib.getOutput "man" finalAttrs.finalPackage;
+        pkgs =
+          let
+            scope = {
+              inherit
+                jitSupport
+                pythonSupport
+                perlSupport
+                tclSupport
+                ;
+              inherit (llvmPackages) llvm;
+              postgresql = finalAttrs.finalPackage;
+              stdenv = stdenv';
+              postgresqlTestExtension = newSuper.callPackage ./postgresqlTestExtension.nix { };
+              postgresqlBuildExtension = newSuper.callPackage ./postgresqlBuildExtension.nix { };
             };
-          };
+            newSelf = self // scope;
+            newSuper = {
+              callPackage = newScope (scope // finalAttrs.finalPackage.pkgs);
+            };
+          in
+          import ./ext.nix newSelf newSuper;
 
-          tests = {
-            postgresql = nixosTests.postgresql.postgresql.passthru.override finalAttrs.finalPackage;
-            postgresql-replication = nixosTests.postgresql.postgresql-replication.passthru.override finalAttrs.finalPackage;
-            postgresql-tls-client-cert = nixosTests.postgresql.postgresql-tls-client-cert.passthru.override finalAttrs.finalPackage;
-            postgresql-wal-receiver = nixosTests.postgresql.postgresql-wal-receiver.passthru.override finalAttrs.finalPackage;
-            pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-          }
-          // lib.optionalAttrs jitSupport {
-            postgresql-jit = nixosTests.postgresql.postgresql-jit.passthru.override finalAttrs.finalPackage;
+        withPackages = postgresqlWithPackages {
+          inherit buildEnv lib makeBinaryWrapper;
+          postgresql = finalAttrs.finalPackage;
+        };
+
+        pg_config = buildPackages.callPackage ./pg_config.nix {
+          inherit (finalAttrs) finalPackage;
+          outputs = {
+            out = lib.getOutput "out" finalAttrs.finalPackage;
+            man = lib.getOutput "man" finalAttrs.finalPackage;
           };
         };
+
+        tests = {
+          postgresql = nixosTests.postgresql.postgresql.passthru.override finalAttrs.finalPackage;
+          postgresql-replication = nixosTests.postgresql.postgresql-replication.passthru.override finalAttrs.finalPackage;
+          postgresql-tls-client-cert = nixosTests.postgresql.postgresql-tls-client-cert.passthru.override finalAttrs.finalPackage;
+          postgresql-wal-receiver = nixosTests.postgresql.postgresql-wal-receiver.passthru.override finalAttrs.finalPackage;
+          pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+        }
+        // lib.optionalAttrs jitSupport {
+          postgresql-jit = nixosTests.postgresql.postgresql-jit.passthru.override finalAttrs.finalPackage;
+        };
+      };
 
       meta = {
         homepage = "https://www.postgresql.org";


### PR DESCRIPTION
This reapplies #488692, which was reverted in #490513, due to https://github.com/NixOS/nixpkgs/pull/488692#issuecomment-3902513725.

That same failure is now avoided by the very first commit in this PR: There is no need to use the `withoutJIT` helper for the attributes exposed at the top-level by default.

cc @MagicRB @trofi 

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
