### PR TITLE
accountsservice: 26.13.3 -> 26.27.3

### DIFF
--- a/pkgs/by-name/ac/accountsservice/fix-paths.patch
+++ b/pkgs/by-name/ac/accountsservice/fix-paths.patch
@@ -78,15 +78,6 @@ index da6428c..682842d 100644
                          argv[1] = "-s";
                          argv[2] = shell;
                          argv[3] = "--";
-@@ -3163,7 +3163,7 @@ user_change_icon_file_classic_authorized_cb (Daemon                *daemon,
-                         return;
-                 }
- 
--                argv[0] = "/bin/cat";
-+                argv[0] = "@coreutils@/bin/cat";
-                 argv[1] = filename;
-                 argv[2] = NULL;
- 
 @@ -3279,7 +3279,7 @@ user_change_locked_authorized_cb (Daemon                *daemon,
                  } else {
                          const gchar *argv[5];

--- a/pkgs/by-name/ac/accountsservice/package.nix
+++ b/pkgs/by-name/ac/accountsservice/package.nix
@@ -9,7 +9,6 @@
   gobject-introspection,
   polkit,
   systemdLibs,
-  coreutils,
   meson,
   mesonEmulatorHook,
   dbus,
@@ -23,7 +22,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "accountsservice";
-  version = "26.13.3";
+  version = "26.27.3";
 
   outputs = [
     "out"
@@ -35,13 +34,13 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "accountsservice";
     repo = "accountsservice";
     tag = finalAttrs.version;
-    hash = "sha256-ZIfkBlEaITX2rDcV5al4e2IFP238MXOlWeGoh+3+DoQ=";
+    hash = "sha256-/n0YCPZaf1SsTScidFUZcxfJkpv/+Bnb6Z7oKL+clgE=";
   };
 
   patches = [
     # Hardcode dependency paths.
     (replaceVars ./fix-paths.patch {
-      inherit shadow coreutils;
+      inherit shadow;
     })
 
     # Do not try to create directories in /var, that will not work in Nix sandbox.


### PR DESCRIPTION
changelog: https://gitlab.freedesktop.org/accountsservice/accountsservice/-/releases/26.26.9
diff: https://gitlab.freedesktop.org/accountsservice/accountsservice/-/compare/26.13.3...26.26.9

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. (from #530879)
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
