### PR TITLE
openrgb: 1.0rc2 -> 1.0rc3

### DIFF
--- a/pkgs/by-name/op/openrgb/package.nix
+++ b/pkgs/by-name/op/openrgb/package.nix
@@ -1,8 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitLab,
-  fetchpatch,
+  fetchFromCodeberg,
   libusb1,
   hidapi,
   pkg-config,
@@ -16,22 +15,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "openrgb";
-  version = "1.0rc2";
+  version = "1.0rc3";
 
-  src = fetchFromGitLab {
-    owner = "CalcProgrammer1";
+  src = fetchFromCodeberg {
+    owner = "OpenRGB";
     repo = "OpenRGB";
     tag = "release_candidate_${finalAttrs.version}";
-    hash = "sha256-vdIA9i1ewcrfX5U7FkcRR+ISdH5uRi9fz9YU5IkPKJQ=";
+    hash = "sha256-x7B3Ht9+JM+w/3qL5Ku08r05BBLrbuO5JBqP4fnJ0nc=";
   };
 
   patches = [
     ./system-plugins-env.patch
-    (fetchpatch {
-      name = "Install-systemd-service-under-PREFIX.patch";
-      url = "https://gitlab.com/CalcProgrammer1/OpenRGB/-/commit/b58b3c0402131918b3b988631f42617020df9346.patch";
-      hash = "sha256-q5i5BNjaLbsXSYEXKQOR/cMm5ExckmW1n2r9H0j09T0=";
-    })
   ];
 
   nativeBuildInputs = [
@@ -116,7 +110,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Open source RGB lighting control";
-    homepage = "https://gitlab.com/CalcProgrammer1/OpenRGB";
+    changelog = "https://codeberg.org/OpenRGB/OpenRGB/releases/tag/${finalAttrs.src.tag}";
+    homepage = "https://openrgb.org";
     maintainers = with lib.maintainers; [ johnrtitor ];
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;


### PR DESCRIPTION
Diff: https://codeberg.org/OpenRGB/OpenRGB/compare/release_candidate_1.0rc2...release_candidate_1.0rc3

Note: I could not test this on a real machine, yet.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
