### PR TITLE
md2: init at 0.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23113,6 +23113,12 @@
     github = "ranidspace";
     githubId = 56847308;
   };
+  rapatao = {
+    name = "Luiz H. Rapatão";
+    email = "rapatao@rapatao.com";
+    github = "rapatao";
+    githubId = 8259329;
+  };
   raphaelr = {
     email = "raphael-git@tapesoftware.net";
     matrix = "@raphi:tapesoftware.net";

--- a/pkgs/by-name/md/md2/package.nix
+++ b/pkgs/by-name/md/md2/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "md2";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "rapatao";
+    repo = "md2";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-H3X1u4BQ1dKZ/qdfjjrRWhPKGh5dGUK3raPrjTek8Qo=";
+  };
+
+  vendorHash = "sha256-6ZFEs7zWAVFTJ08UPEt3cAw8VRiEOjbtEEByI7E4UaU=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X"
+    "main.version=${finalAttrs.version}"
+  ];
+
+  meta = {
+    description = "Convert markdown files to PDF, HTML, and text";
+    homepage = "https://github.com/rapatao/md2";
+    license = lib.licenses.mit;
+    mainProgram = "md2";
+    maintainers = with lib.maintainers; [ rapatao ];
+  };
+})


### PR DESCRIPTION
## Description

Adds `md2`, a CLI tool to convert Markdown files to PDF, HTML, and text.

- Upstream: https://github.com/rapatao/md2
- Version: 0.3.0
- License: MIT
- Packaged with `buildGoModule` under `pkgs/by-name/`.
- Pure Go, no platform-specific dependencies — runs on all platforms (no `meta.platforms` restriction).

Adding myself (`rapatao`) as maintainer; I am the upstream author and use it daily on macOS.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] `nix-build -A md2` succeeds (tests run via `doCheck`, all pass)
- [x] Formatted with `nixfmt-rfc-style`
- [x] Tested execution of binary: `result/bin/md2 -version`
- [x] Fits the [meta guidelines](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)
