### PR TITLE
python3Packages.tensorboard: 2.20.0 -> 2.21.0

### DIFF
--- a/pkgs/development/python-modules/tensorboard/default.nix
+++ b/pkgs/development/python-modules/tensorboard/default.nix
@@ -68,7 +68,9 @@ buildPythonPackage (finalAttrs: {
     changelog = "https://github.com/tensorflow/tensorboard/blob/${finalAttrs.version}/RELEASE.md";
     license = lib.licenses.asl20;
     mainProgram = "tensorboard";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [
+      GaetanLepage
+    ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
 })

--- a/pkgs/development/python-modules/tensorboard/default.nix
+++ b/pkgs/development/python-modules/tensorboard/default.nix
@@ -1,9 +1,7 @@
 {
   lib,
-  fetchpatch,
   fetchPypi,
   buildPythonPackage,
-  python,
 
   # dependencies
   absl-py,
@@ -16,30 +14,26 @@
   setuptools,
   tensorboard-data-server,
   werkzeug,
-  standard-imghdr,
 
+  # tests
   versionCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "tensorboard";
-  version = "2.20.0";
+  version = "2.21.0";
   format = "wheel";
+  __structuredAttrs = true;
 
   # tensorflow/tensorboard is built from a downloaded wheel, because
   # https://github.com/tensorflow/tensorboard/issues/719 blocks buildBazelPackage.
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     format = "wheel";
     dist = "py3";
     python = "py3";
-    hash = "sha256-ncn5eMuEwHI6z5o0XZbBhPApPRjxZruNWe4Jjmz6q6Y=";
+    hash = "sha256-cnkxbctr1bw5HWI96oQVMSmc3hiHMQ6BM7w0qZbTIlU=";
   };
-
-  pythonRelaxDeps = [
-    "google-auth-oauthlib"
-    "protobuf"
-  ];
 
   dependencies = [
     absl-py
@@ -52,32 +46,7 @@ buildPythonPackage rec {
     setuptools
     tensorboard-data-server
     werkzeug
-
-    # Requires 'imghdr' which has been removed from python in 3.13
-    # ModuleNotFoundError: No module named 'imghdr'
-    # https://github.com/tensorflow/tensorboard/issues/6964
-    standard-imghdr
   ];
-
-  postInstall =
-    let
-      patch = fetchpatch {
-        name = "remove-runtime-pkg_resources-dependency.patch";
-        url = "https://github.com/tensorflow/tensorboard/commit/29f809f4737489912612635d9079a61f8e570bb8.patch";
-        excludes = [
-          "tensorboard/BUILD"
-          "tensorboard/data/BUILD"
-          "tensorboard/default_test.py"
-          "tensorboard/version_test.py"
-        ];
-        hash = "sha256-+jaXI4fVQP4mOg6y94KPMMCg3XuHV/gBUDNsp3ogS6c=";
-      };
-    in
-    ''
-      pushd $out/${python.sitePackages}
-      patch -p1 < ${patch}
-      popd
-    '';
 
   pythonImportsCheck = [
     "tensorboard"
@@ -94,12 +63,12 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    changelog = "https://github.com/tensorflow/tensorboard/blob/${version}/RELEASE.md";
     description = "TensorFlow's Visualization Toolkit";
-    homepage = "https://www.tensorflow.org/";
+    homepage = "https://github.com/tensorflow/tensorboard";
+    changelog = "https://github.com/tensorflow/tensorboard/blob/${finalAttrs.version}/RELEASE.md";
     license = lib.licenses.asl20;
     mainProgram = "tensorboard";
     maintainers = [ ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/tensorflow/tensorboard/compare/2.20.0...2.21.0
Changelog: https://github.com/tensorflow/tensorboard/releases/tag/2.21.0

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
