### PR TITLE
omnissa-horizon-client: fix blank desktop tile labels

### DIFF
--- a/pkgs/by-name/om/omnissa-horizon-client/package.nix
+++ b/pkgs/by-name/om/omnissa-horizon-client/package.nix
@@ -8,6 +8,8 @@
   makeDesktopItem,
   makeWrapper,
   opensc,
+  liberation_ttf,
+  writeText,
   writeTextDir,
   configText ? "",
 }:
@@ -26,11 +28,42 @@ let
 
   mainProgram = "horizon-client";
 
+  # Horizon renders its broker/desktop launch-item (tile) labels with
+  # "DejaVu Sans", but fails to instantiate the font when fontconfig resolves it
+  # to a symlinked file -- which is exactly what nixpkgs' dejavu_fonts provides
+  # (it is a symlink tree into dejavu-fonts-minimal). The labels then render as
+  # blank boxes; the rest of the UI uses the GTK theme font and is unaffected.
+  # Other toolkits load the same symlinked font without issue, so this is
+  # specific to the client's font handling.
+  #
+  # The FHS sandbox bind-mounts the host's /etc/fonts, so the FHS environment's
+  # own fontconfig does not apply. Point the client at a config that keeps the
+  # host's fonts but maps "DejaVu Sans" onto a bundled, regular-file font
+  # (Liberation Sans). This is deterministic and independent of the host's
+  # font configuration.
+  fontconfigFile = writeText "omnissa-horizon-fontconfig.conf" ''
+    <?xml version="1.0"?>
+    <!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+    <fontconfig>
+      <include ignore_missing="yes">/etc/fonts/fonts.conf</include>
+      <dir>${liberation_ttf}/share/fonts</dir>
+      <match target="pattern">
+        <test name="family" qual="any">
+          <string>DejaVu Sans</string>
+        </test>
+        <edit name="family" mode="assign" binding="same">
+          <string>Liberation Sans</string>
+        </edit>
+      </match>
+    </fontconfig>
+  '';
+
   # This forces the default GTK theme (Adwaita) because Horizon is prone to
   # UI usability issues when using non-default themes, such as Adwaita-dark.
   wrapBinCommands = path: name: ''
     makeWrapper "$out/${path}/${name}" "$out/bin/${name}_wrapper" \
     --set GTK_THEME Adwaita \
+    --set FONTCONFIG_FILE "${fontconfigFile}" \
     --suffix XDG_DATA_DIRS : "${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}" \
     --suffix LD_LIBRARY_PATH : "$out/lib/omnissa/horizon/crtbora:$out/lib/omnissa"
   '';


### PR DESCRIPTION
Prior to this change, the omnissa-horizon-client renders server labels as empty boxes, while the rest of the UI renders fine (using GTK theme font).

<img width="690" height="634" alt="Screenshot From 2026-06-29 13-08-46" src="https://github.com/user-attachments/assets/59abef97-3689-44ed-810c-4c7cb3c938cf" />

With this change the server labels render correctly.

<img width="690" height="634" alt="Screenshot From 2026-06-29 14-22-32-censored" src="https://github.com/user-attachments/assets/1b4f9d4f-9d83-43f8-91eb-365cfc5e3a9d" />

(Exact server name was deliberately censored in screenshot)

Horizon renders its server labels with "DejaVu Sans" but fails to load the font when fontconfig resolves it to a symlinked file, which is what it finds if dejavu-fonts-minimal is installed on the host.

## Things done

This fix points the client at a fontconfig which maps DejaVu Sans to a font bundled in the FHS sandbox (Liberation Sans).

Claude+Opus was used in locating the issue and creating the initial fix in my local nix config before I cleaned it up and created this PR. I have fully reviewed and tested the fix, including pointing my local config at this branch and confirming the fix works.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
