### PR TITLE
nasm: 3.01 -> 3.02

### DIFF
--- a/pkgs/by-name/na/nasm/package.nix
+++ b/pkgs/by-name/na/nasm/package.nix
@@ -9,23 +9,20 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nasm";
-  version = "3.01";
+  version = "3.02";
 
   src = fetchurl {
     url = "https://www.nasm.us/pub/nasm/releasebuilds/${finalAttrs.version}/nasm-${finalAttrs.version}.tar.xz";
-    hash = "sha256-tzJMvobnZ7ZfJvRn7YsSrYDhJOPMuJB2hVyY5Dqe3dQ=";
+    hash = "sha256-hzNuulO0rP6RdCSrXVANKwBU2fUUjTXCJzzPLPtxLw0=";
   };
 
   patches = [
-    # Backport patches fixing nasm with gcc 15 and musl (and other?) platforms
-    # https://github.com/netwide-assembler/nasm/issues/169
+    # Backport the fix for https://github.com/netwide-assembler/nasm/issues/203
+    # buffer overflow.
     (fetchpatch {
-      url = "https://github.com/netwide-assembler/nasm/commit/44e89ba9b650b5e1533bca43682e167f51a3511f.patch";
-      hash = "sha256-zVeMFhoSY/HGYr4meIWBgt5Unq1fA8lM6h1Cl5fpbxo=";
-    })
-    (fetchpatch {
-      url = "https://github.com/netwide-assembler/nasm/commit/746e7c9efa37cec9a44d84a1e96b8c38f385cc1f.patch";
-      hash = "sha256-aXVS70O/wUkW8xtkwF7uwrQfTgGcNvxHrtGC0sjIPto=";
+      name = "output-oob-fix.patch";
+      url = "https://github.com/netwide-assembler/nasm/commit/8890d723d0aa9ed1a790e2ce1c55eee8dfa0cf94.patch";
+      hash = "sha256-m03+bhKTgKlqeRLGZIy6GO5BTPIJ3r398VQrtN4waaw=";
     })
   ];
 


### PR DESCRIPTION
Changes: https://www.nasm.us/docs/3.02/nasmac.html


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
