### PR TITLE
stalwart_0_16: 0.16.10 -> 0.16.11

### DIFF
--- a/pkgs/by-name/st/stalwart_0_16/package.nix
+++ b/pkgs/by-name/st/stalwart_0_16/package.nix
@@ -50,7 +50,7 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "stalwart" + (lib.optionalString stalwartEnterprise "-enterprise");
-  version = "0.16.10";
+  version = "0.16.11";
 
   __structuredAttrs = true;
 
@@ -58,10 +58,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "stalwartlabs";
     repo = "stalwart";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-zP2FwRX9eaP8xn8WElf/1N4doHnvZ4rKQLYrUDoYwkQ=";
+    hash = "sha256-0A8IjetGV4h4qdpm44eZb0sNQ4abulb2+VUAeYWItT0=";
   };
 
-  cargoHash = "sha256-HVS89Wtjb2nIdyygP8bPRbVhyMRnJlZDfoCQqiMdVe0=";
+  cargoHash = "sha256-OpoQzNNm5JUrnk1tRZL9JUpDQnGH73Lj6SW52gSthl0=";
 
   env = {
     # https://docs.rs/openssl/latest/openssl/#manual
@@ -211,6 +211,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
       "smtp::management::queue::manage_queue"
       # NOTE: long running test(s), needs live dependencies, likely to fail on systems under high load
       "smtp::inbound::antispam::antispam"
+      # flaky test (darwin): ... panicked at tests/src/smtp/inbound/mod.rs:287:18:
+      # Unexpected event: Refresh
+      # (linux): Invalid address: failed to lookup address information: Temporary failure in name resolution
+      "smtp::outbound::dane::dane_verify"
     ]
     # ... panicked at tests/src/lib.rs:49:13: Errors: [ Build { ... , message: "Invalid address: failed to lookup address information: Temporary failure in name resolution", }, ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
@@ -233,9 +237,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       "smtp::lookup::utils::strategies"
       "smtp::management::report::manage_reports"
       "smtp::outbound::dane::dane_test"
-      # since 0.16.10
-      "smtp::outbound::dane::dane_downgrade_on_tlsa_servfail"
-      "smtp::outbound::dane::dane_verify"
       "smtp::outbound::extensions::extensions"
       "smtp::outbound::fallback_relay::fallback_relay"
       "smtp::outbound::ip_lookup::ip_lookup_strategy"
@@ -250,6 +251,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
       "smtp::reporting::tls::report_tls"
       "store::search_tests"
       "store::store_tests"
+      # since 0.16.10
+      "smtp::outbound::dane::dane_downgrade_on_tlsa_servfail"
     ]
   ) (test: "--skip=${test}");
 


### PR DESCRIPTION
* diff: https://github.com/stalwartlabs/stalwart/compare/v0.16.10...v0.16.11
* changelog: https://github.com/stalwartlabs/stalwart/releases/tag/v0.16.11


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
