### PR TITLE
kitops: init at 1.15.0

### DIFF
--- a/pkgs/by-name/ki/kitops/package.nix
+++ b/pkgs/by-name/ki/kitops/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  __structuredAttrs = true;
+  pname = "kitops";
+  version = "1.15.0";
+
+  src = fetchFromGitHub {
+    owner = "kitops-ml";
+    repo = "kitops";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ySn91TIkWOd3myjcscmcN0jhbjp0mAYm9R2nG0bnTVo=";
+  };
+
+  vendorHash = "sha256-lT1xSuwEZMVjy18pQSuqybfgULyagJX4hCWUYdNrQ8M=";
+
+  subPackages = [ "." ];
+
+  ldflags = [
+    "-s"
+    "-X github.com/kitops-ml/kitops/pkg/lib/constants.Version=v${finalAttrs.version}"
+  ];
+
+  postInstall = ''
+    mv $out/bin/kitops $out/bin/kit
+  '';
+
+  # The testing/ integration suite requires network access.
+  doCheck = false;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+
+  # kit's root command resolves a config home directory via $KITOPS_HOME
+  # (falling back to XDG-style paths); without it the version subcommand
+  # exits before printing its version, so point it at TMPDIR for the check.
+  # versionCheckHook wipes the environment unless the var is listed here.
+  versionCheckKeepEnvironment = [ "KITOPS_HOME" ];
+  preVersionCheck = ''
+    export KITOPS_HOME="$TMPDIR"
+  '';
+
+  meta = {
+    description = "Open source DevOps tool for packaging and versioning AI/ML models, datasets, code, and configuration into an OCI Artifact";
+    homepage = "https://github.com/kitops-ml/kitops";
+    changelog = "https://github.com/kitops-ml/kitops/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ gbhu753 ];
+    mainProgram = "kit";
+  };
+})

--- a/pkgs/by-name/ki/kitops/package.nix
+++ b/pkgs/by-name/ki/kitops/package.nix
@@ -30,8 +30,28 @@ buildGoModule (finalAttrs: {
     mv $out/bin/kitops $out/bin/kit
   '';
 
-  # The testing/ integration suite requires network access.
-  doCheck = false;
+  # These tests start the `kit dev` server or otherwise exercise code paths
+  # that contact a registry, which requires network access unavailable in
+  # the build sandbox.
+  checkFlags =
+    let
+      skippedTests = [
+        "TestDevCommand"
+        "TestDevDirectory"
+        "TestDevReferenceExtraction"
+        "TestListFormatVariants"
+      ];
+    in
+    [ "-skip=^(${builtins.concatStringsSep "|" skippedTests})$" ];
+
+  # `subPackages` limits the default `getGoDirs` to the root package, which has
+  # no tests, so run the whole module's test suite explicitly.
+  checkPhase = ''
+    runHook preCheck
+    export GOFLAGS=''${GOFLAGS//-trimpath/}
+    go test ./... "$checkFlags"
+    runHook postCheck
+  '';
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];


### PR DESCRIPTION
Adds KitOps, a CNCF open source DevOps tool for packaging, versioning, and sharing AI/ML models, datasets, code, and configuration as OCI artifacts (ModelKits / ModelPack format).


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
