### PR TITLE
nixosTests.dashy: use systemd-nspawn instead of qemu

### DIFF
--- a/nixos/tests/web-apps/dashy.nix
+++ b/nixos/tests/web-apps/dashy.nix
@@ -1,6 +1,5 @@
 { pkgs, lib, ... }:
 let
-
   customSettings = {
     pageInfo = {
       title = "My Custom Dashy Title";
@@ -45,29 +44,29 @@ in
         }
       ];
     };
-  nodes = {
-    machine = { };
+  containers = {
+    container = { };
 
-    machine-custom = {
+    custom = {
       services.dashy.settings = customSettings;
     };
   };
 
   testScript = ''
     start_all()
-    machine.wait_for_unit("nginx.service")
-    machine.wait_for_open_port(80)
+    container.wait_for_unit("nginx.service")
+    container.wait_for_open_port(80)
 
-    actual = machine.succeed("curl -v --stderr - http://dashy.local/", timeout=10)
+    actual = container.succeed("curl -v --stderr - http://dashy.local/", timeout=10)
     expected = "<title>Dashy</title>"
     assert expected in actual, \
       f"unexpected reply from Dashy, expected: '{expected}' got: '{actual}'"
 
-    machine_custom.wait_for_unit("nginx.service")
-    machine_custom.wait_for_open_port(80)
+    custom.wait_for_unit("nginx.service")
+    custom.wait_for_open_port(80)
 
-    actual_custom = machine_custom.succeed("curl -s --stderr - http://dashy.local/conf.yml", timeout=10).strip()
-    expected_custom = machine_custom.succeed("cat ${customSettingsYaml}").strip()
+    actual_custom = custom.succeed("curl -s --stderr - http://dashy.local/conf.yml", timeout=10).strip()
+    expected_custom = custom.succeed("cat ${customSettingsYaml}").strip()
 
     assert expected_custom == actual_custom, \
       f"unexpected reply from Dashy, expected: '{expected_custom}' got: '{actual_custom}'"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Switch the tests for `dashy-ui` (which covers `services.dashy`) from `nodes` to `containers`. Reduces test script time from 189.47s -> 6.99s (96% less) as tested locally. 
Machine name was changed from `machine-custom` to `custom` to remain within the 15 character limit for network interfaces.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
