### PR TITLE
cpp-interop: init at 1.9.0

### DIFF
--- a/pkgs/by-name/cp/cpp-interop/package.nix
+++ b/pkgs/by-name/cp/cpp-interop/package.nix
@@ -1,0 +1,118 @@
+{
+  lib,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  python3,
+  llvmPackages_21,
+  libffi,
+  libxml2,
+  ncurses,
+  zlib,
+  zstd,
+
+  # Which interpreter backend to build against. CppInterOp can use either
+  # clang-repl (from upstream LLVM/Clang) or Cling. They are mutually exclusive.
+  interpreter ? "clang-repl", # "clang-repl" | "cling"
+}:
+
+let
+  llvmPackages = llvmPackages_21;
+  inherit (llvmPackages) stdenv;
+
+  useCling = interpreter == "cling";
+  llvm = llvmPackages.llvm;
+  clang = llvmPackages.clang-unwrapped;
+in
+
+assert lib.assertOneOf "interpreter" interpreter [
+  "clang-repl"
+  "cling"
+];
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cpp-interop-${interpreter}";
+  version = "1.9.0";
+
+  src = fetchFromGitHub {
+    owner = "compiler-research";
+    repo = "CppInterOp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-am2WObER9dlNQU/VMTY2ScMe/w8c4N8m/DVyNwHiBnw=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    python3
+  ];
+
+  buildInputs = [
+    llvm
+    clang
+    libffi
+    libxml2
+    ncurses
+    zlib
+    zstd
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" true)
+    (lib.cmakeBool "CPPINTEROP_USE_CLING" useCling)
+    (lib.cmakeBool "CPPINTEROP_USE_REPL" (!useCling))
+    # The unit tests pull in GoogleTest and lit from the LLVM build tree, which
+    # is not exposed by the nixpkgs LLVM packaging. Keep them off for now.
+    (lib.cmakeBool "CPPINTEROP_ENABLE_TESTING" false)
+    "-DLLVM_DIR=${llvm.dev}/lib/cmake/llvm"
+    "-DClang_DIR=${clang.dev}/lib/cmake/clang"
+  ];
+
+  # Smoke test: drive the interpreter to JIT-compile and run a function, proving
+  # the installed library, headers and runtime linking all work together.
+  doInstallCheck = !useCling;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    cat > smoke.cpp <<'EOF'
+    #include "CppInterOp/CppInterOp.h"
+    #include <cstdio>
+    int main() {
+      Cpp::CreateInterpreter();
+      if (Cpp::Declare("int square(int x) { return x * x; }") != 0) return 1;
+      bool hadError = false;
+      intptr_t result = Cpp::Evaluate("square(7)", &hadError);
+      if (hadError) return 2;
+      if (result != 49) { std::printf("expected 49, got %ld\n", (long)result); return 3; }
+      if (Cpp::GetNamed("square") == nullptr) return 4;
+      return 0;
+    }
+    EOF
+
+    $CXX -std=c++17 smoke.cpp -I$out/include -L$out/lib -lclangCppInterOp -o smoke
+    LD_LIBRARY_PATH=$out/lib ./smoke
+
+    runHook postInstallCheck
+  '';
+
+  meta = {
+    description = "Clang-based C++ interoperability library (${interpreter} backend)";
+    homepage = "https://github.com/compiler-research/CppInterOp";
+    changelog = "https://github.com/compiler-research/CppInterOp/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [
+      asl20
+      llvm-exception
+    ];
+    maintainers = with lib.maintainers; [ thomasjm ];
+    platforms = lib.platforms.unix;
+    # The cling backend needs a Cling built against the same LLVM (19-21) as
+    # CppInterOp, plus Cling's matching LLVM/Clang toolchain for the build. The
+    # nixpkgs `cling` is still an LLVM 18 fork, so this variant cannot be built
+    # yet; the clang-repl backend is the supported one. Flip this off once a
+    # compatible Cling is packaged.
+    broken = useCling;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1874,6 +1874,9 @@ with pkgs;
     singleBinary = false;
   };
 
+  cpp-interop-clang-repl = cpp-interop.override { interpreter = "clang-repl"; };
+  cpp-interop-cling = cpp-interop.override { interpreter = "cling"; };
+
   cron = isc-cron;
 
   # Top-level fix-point used in `cudaPackages`' internals


### PR DESCRIPTION
CppInterOp is a Clang-based C++ Interoperability Library. Landing it here is a first step towards packaging [xeus-cpp](https://github.com/compiler-research/xeus-cpp), a modern Jupyter kernel for C++.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
