### PR TITLE
t3code: 0.0.27 -> 0.0.28

### DIFF
--- a/pkgs/by-name/t3/t3code/package.nix
+++ b/pkgs/by-name/t3/t3code/package.nix
@@ -1,7 +1,7 @@
 {
   cctools,
   copyDesktopItems,
-  electron_40,
+  electron_41,
   fetchFromGitHub,
   installShellFiles,
   lib,
@@ -49,7 +49,7 @@ stdenv.mkDerivation (
   finalAttrs:
   let
     appName = "T3 Code (Alpha)";
-    electron = electron_40;
+    electron = electron_41;
     pnpm = pnpm_10;
     desktopIcon =
       if stdenv.hostPlatform.isDarwin then
@@ -80,7 +80,7 @@ stdenv.mkDerivation (
   in
   {
     pname = "t3code";
-    version = "0.0.27";
+    version = "0.0.28";
     strictDeps = true;
     __structuredAttrs = true;
 
@@ -88,7 +88,7 @@ stdenv.mkDerivation (
       owner = "pingdotgg";
       repo = "t3code";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-KwiF6A7pTlkzr43FJ9XM+oEXBOEtw3vrazVOjBaD5lU=";
+      hash = "sha256-InVrw9L281QSSPrHSiZuivmb+FkYEd6FkHwHIAAxmGk=";
     };
 
     postPatch = ''
@@ -136,18 +136,8 @@ stdenv.mkDerivation (
         ;
 
       fetcherVersion = 4;
-      hash = "sha256-vpL0kjDAtxnBpm+izcJ06KXuzX888yxmzrcEc9yKtm0=";
+      hash = "sha256-+JqW/iI0wdRPxyL7y6ggD/+AvwwZXs9+fSUtG/SgW9s=";
     };
-
-    # This workaround turns the `pnpmWorkspaces` array into a space-separated
-    # string. This format is supported by both `pnpmConfigHook` and `pnpmBuildHook`.
-    # TODO: remove this when`pnpmConfigHook` supports `___structuredAttrs = true;`
-    # https://github.com/NixOS/nixpkgs/issues/528547
-    preConfigure = ''
-      __pnpmWorkspaces="''${pnpmWorkspaces[@]}"
-      unset pnpmWorkspaces
-      declare -g pnpmWorkspaces="$__pnpmWorkspaces"
-    '';
 
     preBuild = ''
       node scripts/update-release-package-versions.ts ${finalAttrs.version}
@@ -181,7 +171,9 @@ stdenv.mkDerivation (
       mkdir --parents "$out"/libexec/t3code/apps/desktop "$out"/libexec/t3code/apps/server
       cp --recursive --no-preserve=mode node_modules "$out"/libexec/t3code
       cp --recursive --no-preserve=mode apps/server/{node_modules,dist} "$out"/libexec/t3code/apps/server
-      cp --recursive --no-preserve=mode apps/desktop/{node_modules,dist-electron} "$out"/libexec/t3code/apps/desktop
+      cp --recursive --no-preserve=mode \
+        apps/desktop/{package.json,node_modules,dist-electron} \
+        "$out"/libexec/t3code/apps/desktop
 
       mkdir --parents "$out"/libexec/t3code/apps/desktop/prod-resources
       install --mode=444 ${desktopIcon} \
@@ -193,10 +185,16 @@ stdenv.mkDerivation (
         --add-flags "$out"/libexec/t3code/apps/server/dist/bin.mjs ${runtimePathWrapperArgs}
 
       makeWrapper ${lib.getExe electron} "$out"/bin/t3code-desktop \
-        --add-flags "$out"/libexec/t3code/apps/desktop/dist-electron/main.cjs \
+        --add-flags "$out"/libexec/t3code/apps/desktop \
         --inherit-argv0 ${runtimePathWrapperArgs}
     ''
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      # node-pty tries to chmod this helper at runtime, but the Nix store is
+      # immutable by then.
+      find "$out"/libexec/t3code \
+        -path '*/node-pty/prebuilds/darwin-*/spawn-helper' \
+        -exec chmod 755 {} +
+
       mkdir --parents "$out/Applications/${appName}.app/Contents/"{MacOS,Resources}
       png2icns \
         "$out/Applications/${appName}.app/Contents/Resources/t3code.icns" \


### PR DESCRIPTION
https://github.com/pingdotgg/t3code/releases/tag/v0.0.28

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
