### PR TITLE
tlwg-arundina: init at 0.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11902,6 +11902,13 @@
     email = "itepastra@gmail.com";
     keys = [ { fingerprint = "E681 4CAF 06AE B076 D55D  3E32 A16C DCBF 1472 541F"; } ];
   };
+  itscrystalline = {
+    email = "real@iw2tryhard.dev";
+    name = "Wararat C.";
+    github = "itscrystalline";
+    githubId = 62128640;
+    keys = [ { fingerprint = "48F3 C33F B4F7 A31C C4C5  2129 EA4F 5486 0C2B D5D4"; } ];
+  };
   itsvic-dev = {
     email = "contact@itsvic.dev";
     name = "Victor B.";

--- a/pkgs/by-name/tl/tlwg-arundina/package.nix
+++ b/pkgs/by-name/tl/tlwg-arundina/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  autoconf-archive,
+  fontforge,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tlwg-arundina";
+  version = "0.4.0";
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "tlwg";
+    repo = "fonts-arundina";
+    rev = "v${finalAttrs.version}";
+    sha256 = "sha256-ZiLMqgl+kpf9bT9591f20hH+fB2H5po37Mn4jfWAIhM=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    autoconf-archive
+  ];
+
+  buildInputs = [ fontforge ];
+
+  meta = {
+    description = "The Arundina font, provided by the Thai Linux Working Group.";
+    homepage = "https://github.com/tlwg/fonts-arundina";
+    license = with lib.licenses; [ bitstreamVera ];
+    maintainers = [ lib.maintainers.itscrystalline ];
+  };
+})


### PR DESCRIPTION
The Arundina font, provided by the Thai Linux Working Group.

https://github.com/tlwg/fonts-arundina

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core"
        functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in
      `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and
      other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test