### PR TITLE
meowfetch: init at 1.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10169,6 +10169,12 @@
     githubId = 2041764;
     name = "Andreas Wendleder";
   };
+  goobertony = {
+    github = "goobertony";
+    email = "tonygameing@proton.me";
+    githubId = 133613491;
+    name = "Tonii Bittersweet";
+  };
   goodrone = {
     email = "goodrone@gmail.com";
     github = "goodrone";

--- a/pkgs/by-name/me/meowfetch/package.nix
+++ b/pkgs/by-name/me/meowfetch/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "meowfetch";
+  version = "1.0.1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "faynopi";
+    repo = "meowfetch";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-5nUogUYc25FPQKY9oIU2bmOpgWN8bCoxEhRJQfEZOcM=";
+  };
+
+  vendorHash = "sha256-PnkXXNr+kIige1YB/vEG+sYI0X/rr+6Gtcnb0rW4YK0=";
+
+  ldflags = [ "-s" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Minimal system information fetcher program written in go";
+    homepage = "https://github.com/faynopi/meowfetch";
+    changelog = "https://github.com/faynopi/meowfetch/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [goobertony ];
+    mainProgram = "meowfetch";
+  };
+})

--- a/pkgs/by-name/me/meowfetch/package.nix
+++ b/pkgs/by-name/me/meowfetch/package.nix
@@ -28,7 +28,7 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/faynopi/meowfetch";
     changelog = "https://github.com/faynopi/meowfetch/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [goobertony ];
+    maintainers = with lib.maintainers; [ goobertony ];
     mainProgram = "meowfetch";
   };
 })


### PR DESCRIPTION
<!-- 
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
--> 
###### Description of changes:
This adds [meowfetch](https://github.com/faynopi/meowfetch), a minimal fetch program with cat theming, to nixpkgs, and adds myself (goobertony) to the maintainers list for the package. 
<img width="921" height="245" alt="meowfetch" src="https://github.com/user-attachments/assets/127251d9-3e6c-40eb-b6a9-8a011b720554" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
