### PR TITLE
gajim: enable tests, update description

### DIFF
--- a/pkgs/applications/networking/instant-messengers/gajim/default.nix
+++ b/pkgs/applications/networking/instant-messengers/gajim/default.nix
@@ -13,10 +13,6 @@
   glib-networking,
   libadwaita,
 
-  # Test dependencies
-  xvfb-run,
-  dbus,
-
   # Optional dependencies
   enableJingle ? true,
   farstream,
@@ -121,26 +117,16 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     ++ extraPythonPackages python3.pkgs;
 
   nativeCheckInputs = [
-    xvfb-run
-    dbus
+    python3.pkgs.pytestCheckHook
   ];
-
-  checkPhase = ''
-    xvfb-run dbus-run-session \
-      --config-file=${dbus}/share/dbus-1/session.conf \
-      ${python3.interpreter} -m unittest discover -s test/gui -v
-    ${python3.interpreter} -m unittest discover -s test/common -v
-  '';
-
-  # test are broken in 1.7.3, 1.8.0
-  doCheck = false;
 
   # necessary for wrapGAppsHook3
   strictDeps = false;
 
   meta = {
     homepage = "http://gajim.org/";
-    description = "Jabber client written in PyGTK";
+    description = "XMPP chat client";
+    longDescription = "Gajim aims to be an easy to use and fully-featured XMPP client. Just chat with your friends or family, easily share pictures and thoughts or discuss the news with your groups.";
     changelog = "https://dev.gajim.org/gajim/gajim/-/blob/${finalAttrs.version}/ChangeLog";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [


### PR DESCRIPTION
This PR re-enables tests in the `gajim` package using `pytestCheckHook`.

I also updated the description according to the [upstream README](https://dev.gajim.org/gajim/gajim/-/blob/1ef486626454b4ddec71358b8a5c07bcfb4b45bf/README.md#gajim).
Gajim does no longer uses the term "Jabber" in the README, website or pyproject.toml (likely because of the reasons mentioned in the [XMPP FAQ](https://xmpp.org/about/faq/#where-did-xmpp-come-from))

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
