### PR TITLE
vapor: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14046,6 +14046,11 @@
     githubId = 367259;
     name = "Konstantin Alekseev";
   };
+  kalkaro = {
+    name = "Kalkaro";
+    github = "Kalkaro";
+    githubId = 177581171;
+  };
   kamadorueda = {
     name = "Kevin Amado";
     email = "kamadorueda@gmail.com";

--- a/pkgs/by-name/va/vapor/package.nix
+++ b/pkgs/by-name/va/vapor/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  fetchFromGitHub,
+  gobject-introspection,
+  gtk4,
+  libadwaita,
+  python3Packages,
+  wrapGAppsHook4,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "vapor";
+  version = "0.1.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Kalkaro";
+    repo = "vapor";
+    tag = "v0.1.0";
+    hash = "sha256-r+FiD7QND8gZLMDnE+dggBx2g9jcuDG/heZGbC4MAJU";
+  };
+
+  build-system = [
+    python3Packages.setuptools
+  ];
+
+  nativeBuildInputs = [
+    gobject-introspection
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    gtk4
+    libadwaita
+  ];
+
+  dependencies = [
+    python3Packages.pygobject3
+  ];
+
+  pythonImportsCheck = [
+    "vapor_shortcuts"
+  ];
+
+  meta = {
+    description = "Create Linux desktop launchers for Steam games with a GTK UI";
+    homepage = "https://github.com/Kalkaro/vapor";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kalkaro ];
+    mainProgram = "vapor";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
Add Vapor, a GTK application for creating Linux desktop launchers for installed Steam games and
  Steam non-Steam shortcuts.

Homepage: https://github.com/Kalkaro/vapor

Disclosure: Prepared with assistance from OpenAI Codex (GPT-5.5); reviewed and tested locally.

Tested:
- `nix-build -A vapor`
- `./result/bin/vapor --version`
- `./result/bin/vapor`

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
