### PR TITLE
pdfcpu: 0.12.1 → 0.13.0

### DIFF
--- a/pkgs/by-name/pd/pdfcpu/package.nix
+++ b/pkgs/by-name/pd/pdfcpu/package.nix
@@ -77,9 +77,9 @@ buildGoModule (finalAttrs: {
       if stdenv.hostPlatform.isDarwin then "Library/Application Support" else ".config"
     }"/pdfcpu
     versionOutput="$($out/bin/pdfcpu version)"
-    for part in ${finalAttrs.version} $(cut -c1-8 COMMIT) $(cat SOURCE_DATE); do
+    for part in ${finalAttrs.version} "$(cut -c1-8 COMMIT)" "$(cat SOURCE_DATE)"; do
       if [[ ! "$versionOutput" =~ "$part" ]]; then
-          echo version output did not contain expected part $part . Output was:
+          echo version output did not contain expected part \"$part\" . Output was:
           echo "$versionOutput"
           exit 3
       fi

--- a/pkgs/by-name/pd/pdfcpu/package.nix
+++ b/pkgs/by-name/pd/pdfcpu/package.nix
@@ -77,7 +77,7 @@ buildGoModule (finalAttrs: {
       if stdenv.hostPlatform.isDarwin then "Library/Application Support" else ".config"
     }"/pdfcpu
     versionOutput="$($out/bin/pdfcpu version)"
-    for part in ${finalAttrs.version} $(cat COMMIT | cut -c1-8) $(cat SOURCE_DATE); do
+    for part in ${finalAttrs.version} $(cut -c1-8 COMMIT) $(cat SOURCE_DATE); do
       if [[ ! "$versionOutput" =~ "$part" ]]; then
           echo version output did not contain expected part $part . Output was:
           echo "$versionOutput"

--- a/pkgs/by-name/pd/pdfcpu/package.nix
+++ b/pkgs/by-name/pd/pdfcpu/package.nix
@@ -90,6 +90,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "PDF processor written in Go";
+    changelog = "https://pdfcpu.io/changelog/";
     homepage = "https://pdfcpu.io";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ doronbehar ];

--- a/pkgs/by-name/pd/pdfcpu/package.nix
+++ b/pkgs/by-name/pd/pdfcpu/package.nix
@@ -9,13 +9,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "pdfcpu";
-  version = "0.12.1";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "pdfcpu";
     repo = "pdfcpu";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-xAWzn32evg3PmHlevL38P06zOof3a4mmLmNuFfO2gAU=";
+    hash = "sha256-o+gg/XdsPotmuk+H62Bzu4zG9Zu2HABlr4S/YhbtCiI=";
     # Apparently upstream requires that the compiled executable will know the
     # commit hash and the date of the commit. This information is also presented
     # in the output of `pdfcpu version` which we use as a sanity check in the
@@ -33,12 +33,12 @@ buildGoModule (finalAttrs: {
     postFetch = ''
       cd "$out"
       git rev-parse HEAD > $out/COMMIT
-      git log -1 --pretty=%cd --date=format:'%Y-%m-%dT%H:%M:%SZ' > $out/SOURCE_DATE
+      git log -1 --pretty=%cd --date=format:'%Y-%m-%d %H:%M:%S UTC' > $out/SOURCE_DATE
       find "$out" -name .git -print0 | xargs -0 rm -rf
     '';
   };
 
-  vendorHash = "sha256-5+zHlHp/8Jp9TE87IUgJqQHDINNe7ah34jPW/n5ORz8=";
+  vendorHash = "sha256-yieD29GFQQrYVbYNwFHDQX9l0KOKu0usng1OPoaVBZ8=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/pd/pdfcpu/package.nix
+++ b/pkgs/by-name/pd/pdfcpu/package.nix
@@ -48,8 +48,10 @@ buildGoModule (finalAttrs: {
 
   # ldflags based on metadata from git and source
   preBuild = ''
-    ldflags+=" -X main.commit=$(cat COMMIT)"
-    ldflags+=" -X main.date=$(cat SOURCE_DATE)"
+    ldflags+=(
+      "-X 'main.commit=$(cat COMMIT)'"
+      "-X 'main.date=$(cat SOURCE_DATE)'"
+    )
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
