### PR TITLE
openttd-nml: 0.8.1 -> 0.9.0, adopt, modernise, enable upstream tests

### DIFF
--- a/pkgs/by-name/op/openttd-nml/package.nix
+++ b/pkgs/by-name/op/openttd-nml/package.nix
@@ -7,14 +7,14 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "openttd-nml";
-  version = "0.8.1";
+  version = "0.9.0";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "OpenTTD";
     repo = "nml";
     tag = finalAttrs.version;
-    hash = "sha256-swAkUhduIhcfbAvKsPaJNBXcv8T6GDaxk3KKLLa9GQ8=";
+    hash = "sha256-FVGjXh04uHZM9vZNzjdYEk4ClMR9t0kl44JePrUGx84=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/op/openttd-nml/package.nix
+++ b/pkgs/by-name/op/openttd-nml/package.nix
@@ -11,6 +11,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "OpenTTD";

--- a/pkgs/by-name/op/openttd-nml/package.nix
+++ b/pkgs/by-name/op/openttd-nml/package.nix
@@ -30,7 +30,8 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   doInstallCheck = true;
 
   meta = {
-    homepage = "http://openttdcoop.org/";
+    changelog = "https://github.com/OpenTTD/nml/releases/tag/${finalAttrs.version}";
+    homepage = "https://github.com/OpenTTD/nml";
     description = "Compiler for OpenTTD NML files";
     mainProgram = "nmlc";
     license = lib.licenses.gpl2Plus;

--- a/pkgs/by-name/op/openttd-nml/package.nix
+++ b/pkgs/by-name/op/openttd-nml/package.nix
@@ -1,14 +1,16 @@
 {
   lib,
   fetchFromGitHub,
-  python3,
+  python3Packages,
   versionCheckHook,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "openttd-nml";
   version = "0.9.0";
-  format = "setuptools";
+  pyproject = true;
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "OpenTTD";
@@ -17,17 +19,23 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     hash = "sha256-FVGjXh04uHZM9vZNzjdYEk4ClMR9t0kl44JePrUGx84=";
   };
 
+  build-system = [
+    python3Packages.setuptools
+  ];
+
   postPatch = ''
     echo 'version = "${finalAttrs.version}"' > nml/__version__.py
+
+    # Ply's source code is vendored.
+    substituteInPlace pyproject.toml \
+      --replace-fail '"setuptools", "ply"' '"setuptools"'
   '';
 
-  propagatedBuildInputs = with python3.pkgs; [
-    pillow
+  dependencies = [
+    python3Packages.pillow
   ];
 
   nativeInstallCheckInputs = [ versionCheckHook ];
-
-  doInstallCheck = true;
 
   meta = {
     changelog = "https://github.com/OpenTTD/nml/releases/tag/${finalAttrs.version}";

--- a/pkgs/by-name/op/openttd-nml/package.nix
+++ b/pkgs/by-name/op/openttd-nml/package.nix
@@ -37,6 +37,17 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   nativeInstallCheckInputs = [ versionCheckHook ];
 
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    export PYTHON=${python3Packages.python}/bin/python
+    export NMLC=$out/bin/nmlc
+
+    make regression
+
+    runHook postInstallCheck
+  '';
+
   meta = {
     changelog = "https://github.com/OpenTTD/nml/releases/tag/${finalAttrs.version}";
     homepage = "https://github.com/OpenTTD/nml";

--- a/pkgs/by-name/op/openttd-nml/package.nix
+++ b/pkgs/by-name/op/openttd-nml/package.nix
@@ -34,6 +34,6 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     description = "Compiler for OpenTTD NML files";
     mainProgram = "nmlc";
     license = lib.licenses.gpl2Plus;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.magicquark ];
   };
 })


### PR DESCRIPTION
# Updates to `openttd-nml`

### Version Bump from 0.8.1 -> 0.9.0
- Changelog: https://github.com/OpenTTD/nml/releases/tag/0.9.0
- Closes: https://github.com/NixOS/nixpkgs/pull/512467

### Adopt
- As this package is unmaintained, I have adopted it.

### Update / Modernise
- The `meta.homepage`  has been updated.
- `meta.changelog` has been added.
- Use `pyproject = true` instead of `format = "setuptools"`, updating the derivation accordingly.
- Add `__structuredAttrs = true` and `strictDeps = true`. I have cross-compiled to `pkgsCross.aarch64-multiplatform` for verification that the dependencies are set correctly.
- Remove `doInstallCheck = true` as it is enabled by default.

### Enable Upstream Tests
- The upstream repository includes a set of regression tests, these have been enabled.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
