### PR TITLE
kea: fixup python output

### DIFF
--- a/pkgs/by-name/ke/kea/package.nix
+++ b/pkgs/by-name/ke/kea/package.nix
@@ -25,6 +25,8 @@
 
   # tests
   nixosTests,
+  testers,
+  kea,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -63,6 +65,8 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonEnable "postgresql" withPostgresql)
     (lib.mesonOption "localstatedir" "/var")
     (lib.mesonOption "runstatedir" "/run")
+    (lib.mesonOption "python.platlibdir" "${placeholder "python"}/${python3.sitePackages}")
+    (lib.mesonOption "python.purelibdir" "${placeholder "python"}/${python3.sitePackages}")
   ];
 
   postConfigure = ''
@@ -105,11 +109,6 @@ stdenv.mkDerivation (finalAttrs: {
     ninja doc
   '';
 
-  postFixup = ''
-    mkdir -p $python/lib
-    mv $out/lib/python* $python/lib/
-  '';
-
   passthru.tests = {
     kea = nixosTests.kea;
     prefix-delegation = nixosTests.systemd-networkd-ipv6-prefix-delegation;
@@ -118,6 +117,12 @@ stdenv.mkDerivation (finalAttrs: {
     };
     networking-networkd = lib.recurseIntoAttrs {
       inherit (nixosTests.networking.networkd) dhcpDefault dhcpSimple dhcpOneIf;
+    };
+
+    version = testers.testVersion {
+      package = kea;
+      command = "kea-shell -v";
+      version = finalAttrs.version;
     };
   };
 


### PR DESCRIPTION
When the python libraries were moved to a separate output, this broke the use of kea-shell which did not load the python support libraries correctly anymore.

The reworks the python split to use the builtin options of the meson builds instead.

The usability of `kea-shell` is now tested in the build.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
