### PR TITLE
libretro.gearcoleco: init at 1.6.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14026,6 +14026,11 @@
     githubId = 6544084;
     name = "Kai Harries";
   };
+  kaistarkk = {
+    github = "KaiStarkk";
+    githubId = 1722064;
+    name = "KaiStarkk";
+  };
   kalbasit = {
     email = "wael.nasreddine@gmail.com";
     matrix = "@kalbasit:matrix.org";

--- a/pkgs/applications/emulators/libretro/cores/gearcoleco.nix
+++ b/pkgs/applications/emulators/libretro/cores/gearcoleco.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  fetchFromGitHub,
+  gitMinimal,
+  mkLibretroCore,
+}:
+
+mkLibretroCore {
+  core = "gearcoleco";
+  version = "1.6.6";
+
+  src = fetchFromGitHub {
+    owner = "drhelius";
+    repo = "Gearcoleco";
+    tag = "1.6.6";
+    hash = "sha256-4zxHejYWlmVpeLxlTpbYSA34ICUBjiEXrH0WyWygdj8=";
+  };
+
+  sourceRoot = "source/platforms/libretro";
+  makefile = "Makefile";
+
+  extraNativeBuildInputs = [ gitMinimal ];
+
+  postPatch = ''
+    chmod -R u+w ../..
+  '';
+
+  meta = {
+    description = "ColecoVision emulator core for libretro";
+    homepage = "https://github.com/drhelius/Gearcoleco";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ kaistarkk ];
+  };
+}

--- a/pkgs/applications/emulators/libretro/default.nix
+++ b/pkgs/applications/emulators/libretro/default.nix
@@ -82,6 +82,8 @@ lib.makeScope newScope (self: {
 
   genesis-plus-gx = self.callPackage ./cores/genesis-plus-gx.nix { };
 
+  gearcoleco = self.callPackage ./cores/gearcoleco.nix { };
+
   gpsp = self.callPackage ./cores/gpsp.nix { };
 
   gw = self.callPackage ./cores/gw.nix { };


### PR DESCRIPTION
Adds the Gearcoleco libretro core for ColecoVision emulation.

Validation:
- `nix build --no-link .#legacyPackages.x86_64-linux.libretro.gearcoleco`

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Ran `nixpkgs-review` on this PR.
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - No standalone executable is produced by libretro core packages; this PR builds the shared core artifact.
- [x] Checked the package against the relevant Nixpkgs contribution and packaging guidance.

Disclosure: I used OpenAI Codex (GPT-5) to help prepare this PR.
