### PR TITLE
libretro.gearsystem: init at 3.4.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14026,6 +14026,11 @@
     githubId = 6544084;
     name = "Kai Harries";
   };
+  kaistarkk = {
+    github = "KaiStarkk";
+    githubId = 1722064;
+    name = "KaiStarkk";
+  };
   kalbasit = {
     email = "wael.nasreddine@gmail.com";
     matrix = "@kalbasit:matrix.org";

--- a/pkgs/applications/emulators/libretro/cores/gearsystem.nix
+++ b/pkgs/applications/emulators/libretro/cores/gearsystem.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  fetchFromGitHub,
+  gitMinimal,
+  mkLibretroCore,
+}:
+
+mkLibretroCore {
+  core = "gearsystem";
+  version = "3.4.1";
+
+  src = fetchFromGitHub {
+    owner = "drhelius";
+    repo = "gearsystem";
+    tag = "gearsystem-3.4.1";
+    hash = "sha256-o7vSSrMimbOL0BMi9GtgGsYD0wTJTaq4kWuD3yEDcZM=";
+  };
+
+  sourceRoot = "source/platforms/libretro";
+  makefile = "Makefile";
+
+  extraNativeBuildInputs = [ gitMinimal ];
+
+  postPatch = ''
+    chmod -R u+w ../..
+  '';
+
+  meta = {
+    description = "Sega Master System, Game Gear, and SG-1000 emulator core for libretro";
+    homepage = "https://github.com/drhelius/gearsystem";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ kaistarkk ];
+  };
+}

--- a/pkgs/applications/emulators/libretro/default.nix
+++ b/pkgs/applications/emulators/libretro/default.nix
@@ -82,6 +82,8 @@ lib.makeScope newScope (self: {
 
   genesis-plus-gx = self.callPackage ./cores/genesis-plus-gx.nix { };
 
+  gearsystem = self.callPackage ./cores/gearsystem.nix { };
+
   gpsp = self.callPackage ./cores/gpsp.nix { };
 
   gw = self.callPackage ./cores/gw.nix { };


### PR DESCRIPTION
Adds the Gearsystem libretro core for Sega Master System, Game Gear, and SG-1000 emulation.

Validation:
- `nix build --no-link .#legacyPackages.x86_64-linux.libretro.gearsystem`

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Ran `nixpkgs-review` on this PR.
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - No standalone executable is produced by libretro core packages; this PR builds the shared core artifact.
- [x] Checked the package against the relevant Nixpkgs contribution and packaging guidance.

Disclosure: I used OpenAI Codex (GPT-5) to help prepare this PR.
