### PR TITLE
Nominatim import / replicate / update mechanism

### DIFF
--- a/nixos/modules/services/search/nominatim.nix
+++ b/nixos/modules/services/search/nominatim.nix
@@ -26,6 +26,7 @@ in
     };
 
     package = lib.mkPackageOption pkgs.python3Packages "nominatim-api" { };
+    cliPackage = lib.mkPackageOption pkgs "nominatim" { };
 
     hostName = lib.mkOption {
       type = lib.types.str;
@@ -68,6 +69,89 @@ in
         example = ''
           Nominatim_Config.Page_Title='My Nominatim instance';
           Nominatim_Config.Nominatim_API_Endpoint='https://localhost/';
+        '';
+      };
+    };
+
+    maps = lib.mkOption {
+      description = ''
+        An attrset of maps to be imported into the nominatim database.
+      '';
+      type = lib.types.attrsOf (
+        lib.types.submodule {
+          options = {
+            enable =
+              lib.mkEnableOption ''
+                downloading this map into nominatim.
+
+                Note that disabling or removing a map from your config will not
+                remove it from nominatim once it has been downloaded.
+              ''
+              // {
+                default = true;
+              };
+            mapUrl = lib.mkOption {
+              type = lib.types.str;
+              description = ''
+                The url at which to download the main map
+              '';
+              example = "https://planet.openstreetmap.org/pbf/planet-latest.osm.pbf";
+            };
+            replicationUrl = lib.mkOption {
+              type = lib.types.str;
+              description = ''
+                The url under which the diffs and the `state.txt` file can be found
+              '';
+              example = "https://planet.openstreetmap.org/replication/hour";
+            };
+          };
+        }
+      );
+    };
+
+    updates = {
+      enable = lib.mkEnableOption "Regular updates of nominatim maps";
+      startAt = lib.mkOption {
+        type = lib.types.either lib.types.str (lib.types.listOf lib.types.str);
+        default = "hourly";
+        description = ''
+          How often and when to update nominatim maps
+
+          The format is described in
+          {manpage}`systemd.time(7)`.
+        '';
+      };
+    };
+
+    importanceData = {
+      enable = lib.mkEnableOption ''
+        wikimedia importance data for nominatim
+
+        See [upstream documentation on importance data]<https://nominatim.org/release-docs/latest/admin/Import/#downloading-additional-data>
+        for more information.
+      '';
+      url = lib.mkOption {
+        type = lib.types.str;
+        default = "https://nominatim.org/data/wikimedia-importance.sql.gz";
+        description = ''
+          Url for the importance data.
+        '';
+      };
+      secondaryUrl = lib.mkOption {
+        type = lib.types.str;
+        default = "https://nominatim.org/data/wikimedia-secondary-importance.sql.gz";
+        description = ''
+          Url for the secondary importance data.
+        '';
+      };
+      startAt = lib.mkOption {
+        type = lib.types.either lib.types.str (lib.types.listOf lib.types.str);
+        default = "yearly";
+        description = ''
+          How often and when to update importance data
+
+          The format is described in
+          {manpage}`systemd.time(7)`.
         '';
       };
     };
@@ -165,10 +249,23 @@ in
         + lib.optionalString (cfg.database.extraConnectionParams != null) (
           ";" + cfg.database.extraConnectionParams
         );
+      serviceEnvironment = {
+        PYTHONPATH =
+          with pkgs.python3Packages;
+          pkgs.python3Packages.makePythonPath [
+            cfg.package
+            falcon
+            uvicorn
+            nominatim-api
+          ];
+        NOMINATIM_DATABASE_DSN = nominatimApiDsn;
+        NOMINATIM_DATABASE_WEBUSER = cfg.database.apiUser;
+      }
+      // cfg.settings;
     in
     lib.mkIf cfg.enable {
       # CLI package
-      environment.systemPackages = [ pkgs.nominatim ];
+      environment.systemPackages = [ cfg.cliPackage ];
 
       # Database
       users.users.${cfg.database.superUser} = lib.mkIf localDb {
@@ -192,8 +289,6 @@ in
         ];
       };
 
-      # TODO: add nominatim-update service
-
       systemd.services.nominatim-init = lib.mkIf localDb {
         after = [ "postgresql-setup.service" ];
         requires = [ "postgresql-setup.service" ];
@@ -209,7 +304,7 @@ in
           db_exists=$(${pkgs.postgresql}/bin/psql --dbname postgres -tAc "$sql")
 
           if [ "$db_exists" == "0" ]; then
-            ${lib.getExe pkgs.nominatim} import --prepare-database
+            ${lib.getExe cfg.cliPackage} import --prepare-database
           else
             echo "Database ${cfg.database.dbname} already exists. Skipping ..."
           fi
@@ -254,19 +349,7 @@ in
           KillMode = "mixed";
           TimeoutStopSec = 5;
         };
-        environment = {
-          PYTHONPATH =
-            with pkgs.python3Packages;
-            pkgs.python3Packages.makePythonPath [
-              cfg.package
-              falcon
-              uvicorn
-              nominatim-api
-            ];
-          NOMINATIM_DATABASE_DSN = nominatimApiDsn;
-          NOMINATIM_DATABASE_WEBUSER = cfg.database.apiUser;
-        }
-        // cfg.settings;
+        environment = serviceEnvironment;
       };
 
       systemd.sockets.nominatim = {
@@ -277,6 +360,126 @@ in
           SocketUser = cfg.database.apiUser;
           SocketGroup = config.services.nginx.group;
         };
+      };
+
+      systemd.services.nominatim-import-map-data = lib.mkIf (cfg.maps != { }) {
+        description = "Import nominatim map data";
+        serviceConfig = {
+          User = cfg.database.superUser;
+          StateDirectory = "nominatim";
+          Type = "oneshot";
+        };
+        script =
+          let
+            importOneMap =
+              mapName:
+              {
+                enable,
+                mapUrl,
+                replicationUrl,
+              }:
+              lib.optionalString enable ''
+                cd "$STATE_DIRECTORY"
+                mkdir -p "${mapName}"
+                cd "${mapName}"
+                export NOMINATIM_REPLICATION_URL="${replicationUrl}"
+
+                if [[ ! -f ./initial-setup-done ]]; then
+                  echo ">>> ${mapName}: No existing data found. Importing fresh map."
+
+                  echo ">>> ${mapName}: Downloading the initial map (this can take some time)"
+                  curl --silent --show-error -L -o map.osm.pbf "${mapUrl}"
+
+                  echo ">>> ${mapName}: Importing the initial map (this can take a lot of time!)"
+                  nominatim import --continue import-from-file --project-dir "$STATE_DIRECTORY" --osm-file map.osm.pbf
+                  rm map.osm.pbf
+                  nominatim replication --verbose --project-dir "$STATE_DIRECTORY" --init
+
+                  touch ./initial-setup-done
+
+                else
+                ${
+                  if cfg.updates.enable then
+                    ''
+                      echo ">>> Refreshing functions"
+                      nominatim refresh --functions --project-dir "$STATE_DIRECTORY"
+
+                      echo ">>> Migrating DB if needed"
+                      nominatim admin --migrate --project-dir "$STATE_DIRECTORY"
+
+                      echo ">>> Checking replication URL is reachable ($NOMINATIM_REPLICATION_URL)"
+                      curl --location --head --fail-with-body "$NOMINATIM_REPLICATION_URL" &> /dev/null
+
+                      echo ">>> ${mapName}: Updating and indexing..."
+                      nominatim replication --verbose --project-dir "$STATE_DIRECTORY" --catch-up
+                    ''
+                  else
+                    ''
+                      echo ">>> ${mapName}: Existing data found, and updates are disabled. leaving as-is.
+                    ''
+                }
+                fi
+                echo ">>> ${mapName}: Checking database"
+                nominatim admin --project-dir "$STATE_DIRECTORY" --check-database
+              '';
+          in
+          ''
+            set -euo pipefail
+
+            nominatim --version
+
+            (flock -n 9 || ( echo "failed to acquire lock" && exit 1 ) # Don't try to update map data and importance files at the same time
+
+              ${lib.concatStringsSep "\n" (lib.mapAttrsToList importOneMap cfg.maps)}
+
+            ) 9>"$STATE_DIRECTORY/update-lock"
+          '';
+        path = [
+          cfg.cliPackage
+          pkgs.curl
+          config.services.postgresql.package
+          pkgs.flock
+        ];
+        after = [ "nominatim.service" ];
+        requires = [ "nominatim.service" ];
+        wantedBy = [ "multi-user.target" ];
+        startAt = cfg.updates.startAt;
+        environment = serviceEnvironment;
+      };
+
+      systemd.services.nominatim-import-importance-data = lib.mkIf cfg.importanceData.enable {
+        description = "Import nominatim wikimedia importance data";
+        serviceConfig = {
+          User = cfg.database.superUser;
+          StateDirectory = "nominatim";
+          Type = "oneshot";
+        };
+        script = ''
+          set -euo pipefail
+
+          (flock -n 9 || ( echo "failed to acquire lock" && exit 1 ) # Don't try to update map data and importance files at the same time
+
+            echo ">>> downloading wikimedia importance files"
+            curl --silent -L -A "Wget/1.21.2" ${cfg.importanceData.url} -o "$STATE_DIRECTORY/wikimedia-importance.sql.gz"
+            curl --silent -L -A "Wget/1.21.2" ${cfg.importanceData.secondaryUrl} -o "$STATE_DIRECTORY/secondary_importance.sql.gz"
+
+            echo ">>> Refresh data"
+            nominatim refresh --wiki-data --secondary-importance --importance --project-dir "$STATE_DIRECTORY"
+
+            rm "$STATE_DIRECTORY/wikimedia-importance.sql.gz"
+            rm "$STATE_DIRECTORY/secondary_importance.sql.gz"
+
+          ) 9>"$STATE_DIRECTORY/update-lock"
+        '';
+        path = [
+          cfg.cliPackage
+          pkgs.curl
+          config.services.postgresql.package
+          pkgs.flock
+        ];
+        after = [ "nominatim-import-map-data.service" ];
+        wantedBy = [ "multi-user.target" ];
+        startAt = cfg.importanceData.startAt;
       };
 
       services.nginx = {

--- a/nixos/modules/services/search/nominatim.nix
+++ b/nixos/modules/services/search/nominatim.nix
@@ -26,7 +26,7 @@ in
     };
 
     package = lib.mkPackageOption pkgs.python3Packages "nominatim-api" { };
-    cliPackage = lib.mkPackageOption pkgs "nominatim" { };
+    cli.package = lib.mkPackageOption pkgs "nominatim" { };
 
     hostName = lib.mkOption {
       type = lib.types.str;
@@ -265,7 +265,7 @@ in
     in
     lib.mkIf cfg.enable {
       # CLI package
-      environment.systemPackages = [ cfg.cliPackage ];
+      environment.systemPackages = [ cfg.cli.package ];
 
       # Database
       users.users.${cfg.database.superUser} = lib.mkIf localDb {
@@ -304,7 +304,7 @@ in
           db_exists=$(${pkgs.postgresql}/bin/psql --dbname postgres -tAc "$sql")
 
           if [ "$db_exists" == "0" ]; then
-            ${lib.getExe cfg.cliPackage} import --prepare-database
+            ${lib.getExe cfg.cli.package} import --prepare-database
           else
             echo "Database ${cfg.database.dbname} already exists. Skipping ..."
           fi
@@ -435,7 +435,7 @@ in
             ) 9>"$STATE_DIRECTORY/update-lock"
           '';
         path = [
-          cfg.cliPackage
+          cfg.cli.package
           pkgs.curl
           config.services.postgresql.package
           pkgs.flock
@@ -472,7 +472,7 @@ in
           ) 9>"$STATE_DIRECTORY/update-lock"
         '';
         path = [
-          cfg.cliPackage
+          cfg.cli.package
           pkgs.curl
           config.services.postgresql.package
           pkgs.flock

--- a/nixos/modules/services/search/nominatim.nix
+++ b/nixos/modules/services/search/nominatim.nix
@@ -380,8 +380,8 @@ in
               }:
               lib.optionalString enable ''
                 cd "$STATE_DIRECTORY"
-                mkdir -p "${mapName}"
-                cd "${mapName}"
+                mkdir -p "import-map-data/${mapName}"
+                cd "import-map-data/${mapName}"
                 export NOMINATIM_REPLICATION_URL="${replicationUrl}"
 
                 if [[ ! -f ./initial-setup-done ]]; then
@@ -459,9 +459,12 @@ in
 
           (flock -n 9 || ( echo "failed to acquire lock" && exit 1 ) # Don't try to update map data and importance files at the same time
 
+            mkdir -p "$STATE_DIRECTORY/import-importance-data"
+            cd "$STATE_DIRECTORY/import-importance-data"
+
             echo ">>> downloading wikimedia importance files"
-            curl --silent -L -A "Wget/1.21.2" ${cfg.importanceData.url} -o "$STATE_DIRECTORY/wikimedia-importance.sql.gz"
-            curl --silent -L -A "Wget/1.21.2" ${cfg.importanceData.secondaryUrl} -o "$STATE_DIRECTORY/secondary_importance.sql.gz"
+            curl --silent -L -A "Wget/1.21.2" ${cfg.importanceData.url} -o "wikimedia-importance.sql.gz"
+            curl --silent -L -A "Wget/1.21.2" ${cfg.importanceData.secondaryUrl} -o "secondary_importance.sql.gz"
 
             echo ">>> Refresh data"
             nominatim refresh --wiki-data --secondary-importance --importance --project-dir "$STATE_DIRECTORY"

--- a/nixos/modules/services/search/nominatim.nix
+++ b/nixos/modules/services/search/nominatim.nix
@@ -389,10 +389,14 @@ in
 
                   echo ">>> ${mapName}: Downloading the initial map (this can take some time)"
                   curl --silent --show-error -L -o map.osm.pbf "${mapUrl}"
+                  trap 'rm -rf map.osm.pbf' EXIT
 
                   echo ">>> ${mapName}: Importing the initial map (this can take a lot of time!)"
                   nominatim import --continue import-from-file --project-dir "$STATE_DIRECTORY" --osm-file map.osm.pbf
+
                   rm map.osm.pbf
+                  trap - EXIT
+
                   nominatim replication --verbose --project-dir "$STATE_DIRECTORY" --init
 
                   touch ./initial-setup-done
@@ -460,6 +464,9 @@ in
           (flock -n 9 || ( echo "failed to acquire lock" && exit 1 ) # Don't try to update map data and importance files at the same time
 
             mkdir -p "$STATE_DIRECTORY/import-importance-data"
+
+            TRAP 'rm -rf $STATE_DIRECTORY/import-importance-data/*' EXIT
+
             cd "$STATE_DIRECTORY/import-importance-data"
 
             echo ">>> downloading wikimedia importance files"
@@ -468,9 +475,6 @@ in
 
             echo ">>> Refresh data"
             nominatim refresh --wiki-data --secondary-importance --importance --project-dir "$STATE_DIRECTORY"
-
-            rm "$STATE_DIRECTORY/wikimedia-importance.sql.gz"
-            rm "$STATE_DIRECTORY/secondary_importance.sql.gz"
 
           ) 9>"$STATE_DIRECTORY/update-lock"
         '';

--- a/nixos/tests/nominatim.nix
+++ b/nixos/tests/nominatim.nix
@@ -3,14 +3,53 @@
 let
   # Andorra - the smallest dataset in Europe (3.1 MB)
   osmData = pkgs.fetchurl {
-    url = "https://web.archive.org/web/20250430211212/https://download.geofabrik.de/europe/andorra-latest.osm.pbf";
-    hash = "sha256-Ey+ipTOFUm80rxBteirPW5N4KxmUsg/pCE58E/2rcyE=";
+    url = "https://web.archive.org/web/20260512192410/https://download.geofabrik.de/europe/andorra-latest.osm.pbf";
+    hash = "sha256-WaHtCa0rM0Bt+Z5LgziK3+e2LoN4LNIHD/dM/ugrUZo=";
+  };
+
+  # I do not understand why 817 and 818 are necessary to create a new way id in
+  # the database. I would have expected 783 to do it, since it the osc file
+  # contains a <create> <way> entry, or 818 on its own. But neither work.  I
+  # don't know enough about nominatim to interrogate it further.
+  #
+  # I also don't understand how nominatim is able to update without entries
+  # 783-817 which should come after the "latest" snapshot we have.
+  osmReplicationOsc817 = pkgs.fetchurl {
+    url = "https://web.archive.org/web/20260630022039/http://download.geofabrik.de/europe/andorra-updates/000/004/817.osc.gz";
+    hash = "sha256-pJx4FUiLGAhG0au3odDyB4OKOcCLO99j935P49IYvhA=";
+  };
+  osmReplicationState817 = pkgs.fetchurl {
+    url = "https://web.archive.org/web/20260630021033/http://download.geofabrik.de/europe/andorra-updates/000/004/817.state.txt";
+    hash = "sha256-Nip2VmMLj3eXccFH7t8O1CvcJ1MGaVqwNo9AieDH830=";
+  };
+
+  osmReplicationOsc818 = pkgs.fetchurl {
+    url = "https://web.archive.org/web/20260630021137/http://download.geofabrik.de/europe/andorra-updates/000/004/818.osc.gz";
+    hash = "sha256-FVqIb2cjWt+SzTZD5uFJhDB4nBr19vXR0tvDVsmEPx8=";
+  };
+  osmReplicationState818 = pkgs.fetchurl {
+    url = "https://web.archive.org/web/20260630021306/http://download.geofabrik.de/europe/andorra-updates/000/004/818.state.txt";
+    hash = "sha256-jUWee+5iGVTuqwXMs7lVd4Sp0+4aGGHRFKa+GysYd1g=";
+  };
+
+  importanceData = pkgs.fetchurl {
+    url = "https://web.archive.org/web/20260630052740/https://nominatim.org/data/wikimedia-importance.sql.gz";
+    hash = "sha256-iVxdEnMKHVqA7aiifBLnwAqy8rUtLEwnXYtpX0rWR9M=";
+  };
+  secondaryImportanceData = pkgs.fetchurl {
+    url = "https://web.archive.org/web/20260630052803/https://nominatim.org/data/wikimedia-secondary-importance.sql.gz";
+    hash = "sha256-T4wCwGPWaO5ZGWQho787M9STDaJ0Bb/yg5+9QB2oNVk=";
+  };
+
+  lastWay = {
+    initial = "1510680045";
+    updated = "1529990579";
   };
 in
 {
   name = "nominatim";
   meta = {
-    maintainers = with lib.teams; geospatial.members ++ ngi.members;
+    maintainers = with lib.teams; geospatial.members ++ ngi.members ++ [ lib.maintainers.taeer ];
   };
 
   nodes = {
@@ -109,6 +148,68 @@ in
           enableACME = false;
         };
       };
+
+    nominatimUpdate =
+      { config, pkgs, ... }:
+      {
+        # needed for large importance data
+        # TODO: we could shrink this if we stub out a dummy importance file
+        virtualisation.diskSize = 15 * 1024;
+        environment.etc = {
+          "osm/importance-data/wikimedia-importance.sql.gz".source = importanceData;
+          "osm/importance-data/wikimedia-secondary-importance.sql.gz".source = secondaryImportanceData;
+
+          "osm/map/andorra-latest.osm.pbf".source = osmData;
+
+          "osm/replication/000/004/817.state.txt".source = osmReplicationState817;
+          "osm/replication/000/004/817.osc.gz".source = osmReplicationOsc817;
+
+          "osm/replication/000/004/818.state.txt".source = osmReplicationState818;
+          "osm/replication/000/004/818.osc.gz".source = osmReplicationOsc818;
+
+          "osm/replication/state.txt".source = osmReplicationState818;
+        };
+        services.nginx = {
+          enable = true;
+          virtualHosts.localhost = {
+            locations."/" = {
+              root = "/etc/osm/";
+              extraConfig = ''
+                autoindex on;
+              '';
+            };
+          };
+        };
+        # Nominatim
+        services.nominatim = {
+          enable = true;
+          hostName = "nominatim";
+          settings = {
+            NOMINATIM_IMPORT_STYLE = "admin";
+          };
+          ui.enable = false;
+          maps.andorra = {
+            mapUrl = "http://localhost/map/andorra-latest.osm.pbf";
+            replicationUrl = "http://localhost/replication";
+          };
+          updates = {
+            enable = true;
+            startAt = [ ];
+          };
+          importanceData = {
+            enable = true;
+            startAt = [ ];
+            url = "http://localhost/importance-data/wikimedia-importance.sql.gz";
+            secondaryUrl = "http://localhost/importance-data/wikimedia-secondary-importance.sql.gz";
+          };
+        };
+
+        # Disable SSL
+        services.nginx.virtualHosts.nominatim = {
+          forceSSL = false;
+          enableACME = false;
+        };
+      };
   };
 
   testScript = ''
@@ -116,7 +217,7 @@ in
     nominatim.start()
     nominatim.wait_for_unit("nominatim.service")
 
-    # Import OSM data
+    # Import OSM data directly
     nominatim.succeed("""
       cd /tmp
       sudo -u nominatim \
@@ -200,5 +301,52 @@ in
       curl --verbose "http://localhost/reverse?format=json" 2>&1 \
       | grep "Content-Type: application/json"
     """)
+    nominatim.shutdown()
+    api.shutdown()
+
+    nominatimUpdate.start()
+
+    # The service is Type=oneshot without RemainAfterExit=yes. Once it
+    # is finished it is no longer active and wait_for_unit will fail.
+    # When that happens we check if it actually failed.
+    try:
+        nominatimUpdate.wait_for_unit("nominatim-import-map-data.service")
+    except:
+        nominatimUpdate.fail("systemctl is-failed nominatim-import-map-data.service")
+    try:
+        nominatimUpdate.wait_for_unit("nominatim-import-importance-data.service")
+    except:
+        nominatimUpdate.fail("systemctl is-failed nominatim-import-importance-data.service")
+
+    # basic functionality
+    nominatimUpdate.succeed("sudo -u nominatim-api nominatim search --query Andorra")
+
+    # check importance data was installed and database tables created
+    nominatimUpdate.succeed("sudo -u nominatim psql -At -d nominatim -c '\\d' > tables")
+    nominatimUpdate.succeed("grep 'wikimedia_importance' tables")
+    nominatimUpdate.succeed("grep 'wikipedia_article' tables")
+    nominatimUpdate.succeed("grep 'wikipedia_redirect' tables")
+    nominatimUpdate.succeed("grep 'secondary_importance' tables")
+    nominatimUpdate.succeed("grep 'secondary_importance_rid_seq' tables")
+
+    # baseline last way check
+    nominatimUpdate.succeed("sudo -u nominatim psql -At -d nominatim -c 'select max(id) from planet_osm_ways;' > last_way")
+    nominatimUpdate.succeed("[ $(cat last_way) -eq ${lastWay.initial} ]")
+
+    # replicate / update
+    nominatimUpdate.start_job("nominatim-import-map-data.service")
+    try:
+        nominatimUpdate.wait_for_unit("nominatim-import-map-data.service")
+    except:
+        nominatimUpdate.fail("systemctl is-failed nominatim-import-map-data.service")
+
+    # check that we have in fact updated (last way changes frequently)
+    nominatimUpdate.succeed("sudo -u nominatim psql -At -d nominatim -c 'select max(id) from planet_osm_ways;' > last_way")
+    nominatimUpdate.succeed("[ $(cat last_way) -eq ${lastWay.updated} ]")
+
+    # test there are no warnings, i.e. missing importance data
+    # FIXME: this warns, even though importance data is properly installed
+    # nominatimUpdate.succeed("sudo -u nominatim nominatim admin --project-dir /var/lib/nominatim --check-database | tee db_check")
+    # nominatimUpdate.succeed("! cat db_check | grep -q WARNING")
   '';
 }

--- a/pkgs/by-name/no/nominatim/package.nix
+++ b/pkgs/by-name/no/nominatim/package.nix
@@ -58,6 +58,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     python-dotenv
     pyyaml
     mwparserfromhell
+    osmium
   ];
 
   propagatedBuildInputs = [


### PR DESCRIPTION
Added import/update functionality to the nominatim module, as well as testing for said functionality. This is a port of what we've been doing at Bevuta for quite a while.

This does feel a little opinionated for NixOS, but
(a) There doesn't appear to be a neutral / default / blessed-by-upstream way to replicate
(b) Nominatim is kind of useless without map replication

Let me know if there's a different way to resolve this tension that is preferred.

I also added myself as a maintainer for the test. I don't think there's anywhere to list maintainers on modules.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
