### PR TITLE
python3Packages.llama-index-core: 0.14.19 -> 0.14.23

### DIFF
--- a/pkgs/development/python-modules/llama-index-core/default.nix
+++ b/pkgs/development/python-modules/llama-index-core/default.nix
@@ -38,14 +38,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "llama-index-core";
-  version = "0.14.19";
+  version = "0.14.23";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "run-llama";
     repo = "llama_index";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-xcssJPBXq3bjSD13nsR6jRTmTWPVks8aKHZCZ3lSKY4=";
+    hash = "sha256-JH8J8lnW3QNMWUV5MD4zWoc9zaXfvGRxVXtI47sPg2o=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/${finalAttrs.pname}";
@@ -112,29 +112,31 @@ buildPythonPackage (finalAttrs: {
   disabledTestPaths = [
     # Tests require network access
     "tests/agent/"
+    "tests/base/llms/"
     "tests/callbacks/"
     "tests/chat_engine/"
     "tests/evaluation/"
     "tests/indices/"
     "tests/ingestion/"
+    "tests/llms/"
     "tests/memory/"
+    "tests/multi_modal_llms/"
     "tests/node_parser/"
     "tests/objects/"
     "tests/playground/"
     "tests/postprocessor/"
+    "tests/prompts/"
     "tests/query_engine/"
     "tests/question_gen/"
     "tests/response_synthesizers/"
     "tests/retrievers/"
+    "tests/schema/"
     "tests/selectors/"
+    "tests/test_prompt_helper_empty_input.py"
     "tests/test_utils.py"
     "tests/text_splitter/"
     "tests/token_predictor/"
     "tests/tools/"
-    "tests/schema/"
-    "tests/multi_modal_llms/"
-    "tests/prompts/"
-    "tests/base/llms/"
   ];
 
   disabledTests = [


### PR DESCRIPTION
Changelog: https://github.com/run-llama/llama_index/blob/v0.14.23/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
