### PR TITLE
nixos/tests/flarum: init

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -622,6 +622,7 @@ in
   flannel = runTestOn [ "x86_64-linux" ] ./flannel.nix;
   flap-alerted = runTest ./flap-alerted.nix;
   flaresolverr = runTest ./flaresolverr.nix;
+  flarum = runTest ./flarum.nix;
   flood = runTest ./flood.nix;
   fluent-bit = runTest ./fluent-bit.nix;
   fluentd = runTest ./fluentd.nix;

--- a/nixos/tests/flarum.nix
+++ b/nixos/tests/flarum.nix
@@ -1,0 +1,52 @@
+{ lib, ... }:
+{
+  name = "flarum";
+
+  meta = {
+    maintainers = with lib.maintainers; [
+      fsagbuya
+      jasonodoom
+    ];
+  };
+
+  nodes.machine =
+    { ... }:
+    {
+      # Flarum installs and migrates the database on first boot and runs a
+      # MariaDB server alongside PHP-FPM and nginx, so give the VM some headroom.
+      virtualisation.memorySize = 2048;
+
+      services.flarum = {
+        enable = true;
+        forumTitle = "NixOS Flarum Test Forum";
+        domain = "localhost";
+        baseUrl = "http://localhost";
+
+        # Run `flarum install` against the locally provisioned MariaDB. Safe here
+        # because the VM always starts from a fresh, empty database.
+        createDatabaseLocally = true;
+
+        adminUser = "admin";
+        adminEmail = "admin@example.com";
+        # Flarum rejects admin passwords shorter than 8 characters.
+        initialAdminPassword = "flarum-admin-password";
+      };
+    };
+
+  testScript = ''
+    start_all()
+
+    # PHP-FPM is ordered after the oneshot installer (Type=oneshot, no
+    # RemainAfterExit), so waiting on it implies the install/migrate finished.
+    machine.wait_for_unit("phpfpm-flarum.service")
+    machine.wait_for_unit("nginx.service")
+    machine.wait_for_open_port(80)
+
+    # The forum front page is server-rendered and embeds the configured title.
+    machine.wait_until_succeeds("curl -sf http://localhost/ -o /dev/null")
+    machine.succeed("curl -sf http://localhost/ | grep -F 'NixOS Flarum Test Forum'")
+
+    # The admin API endpoint should respond, confirming the app booted cleanly.
+    machine.succeed("curl -sf http://localhost/api -o /dev/null")
+  '';
+}

--- a/pkgs/by-name/fl/flarum/package.nix
+++ b/pkgs/by-name/fl/flarum/package.nix
@@ -2,6 +2,7 @@
   lib,
   php,
   fetchFromGitHub,
+  nixosTests,
 }:
 
 php.buildComposerProject2 (finalAttrs: {
@@ -18,6 +19,8 @@ php.buildComposerProject2 (finalAttrs: {
   composerLock = ./composer.lock;
   composerStrictValidation = false;
   vendorHash = "sha256-EHl+Mr6y5A51EpLPAWUGtiPkLOky6KvsSY4JWHeyO28=";
+
+  passthru.tests.module = nixosTests.flarum;
 
   meta = {
     changelog = "https://github.com/flarum/framework/blob/main/CHANGELOG.md";


### PR DESCRIPTION
Adds a NixOS VM test for Flarum (install + front page/API checks) and links it via `passthru.tests`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
