### PR TITLE
libretro.emuscv: init at 0-unstable-2026-06-20

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14026,6 +14026,11 @@
     githubId = 6544084;
     name = "Kai Harries";
   };
+  kaistarkk = {
+    github = "KaiStarkk";
+    githubId = 1722064;
+    name = "KaiStarkk";
+  };
   kalbasit = {
     email = "wael.nasreddine@gmail.com";
     matrix = "@kalbasit:matrix.org";

--- a/pkgs/applications/emulators/libretro/cores/emuscv.nix
+++ b/pkgs/applications/emulators/libretro/cores/emuscv.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  fetchFromGitLab,
+  mkLibretroCore,
+  SDL2,
+}:
+mkLibretroCore {
+  core = "emuscv";
+  version = "0-unstable-2026-06-20";
+
+  src = fetchFromGitLab {
+    owner = "MaaaX-EPOCH84";
+    repo = "libretro-emuscv";
+    rev = "9c94f7c7fc9906133092ba1cf2adb8f4354236fb";
+    hash = "sha256-dY5rePjFPWljyqvJox2yTEkV2nsT9IDcT4ViT0HF9dE=";
+  };
+
+  extraBuildInputs = [ SDL2 ];
+  extraNativeBuildInputs = [ SDL2 ];
+  buildFlags = [ "build-all" ];
+
+  meta = {
+    description = "Epoch/Yeno Super Cassette Vision emulator core for libretro";
+    homepage = "https://gitlab.com/MaaaX-EPOCH84/libretro-emuscv";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ kaistarkk ];
+  };
+}

--- a/pkgs/applications/emulators/libretro/default.nix
+++ b/pkgs/applications/emulators/libretro/default.nix
@@ -64,6 +64,8 @@ lib.makeScope newScope (self: {
 
   eightyone = self.callPackage ./cores/eightyone.nix { };
 
+  emuscv = self.callPackage ./cores/emuscv.nix { };
+
   fbalpha2012 = self.callPackage ./cores/fbalpha2012.nix { };
 
   fbneo = self.callPackage ./cores/fbneo.nix { };


### PR DESCRIPTION
Adds the EmuSCV libretro core for Epoch/Yeno Super Cassette Vision emulation.

Validation:
- `nix build --no-link .#legacyPackages.x86_64-linux.libretro.emuscv`

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Ran `nixpkgs-review` on this PR.
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - No standalone binary; this PR adds a libretro core artifact, and the core builds successfully.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md, and the automation/AI policy.

Disclosure: I used OpenAI Codex (GPT-5) to help prepare this PR.
