### PR TITLE
libretro.freechaf: init at 0-unstable-2026-04-20

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14026,6 +14026,11 @@
     githubId = 6544084;
     name = "Kai Harries";
   };
+  kaistarkk = {
+    github = "KaiStarkk";
+    githubId = 1722064;
+    name = "KaiStarkk";
+  };
   kalbasit = {
     email = "wael.nasreddine@gmail.com";
     matrix = "@kalbasit:matrix.org";

--- a/pkgs/applications/emulators/libretro/cores/freechaf.nix
+++ b/pkgs/applications/emulators/libretro/cores/freechaf.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkLibretroCore,
+}:
+mkLibretroCore {
+  core = "freechaf";
+  version = "0-unstable-2026-04-20";
+
+  src = fetchFromGitHub {
+    owner = "libretro";
+    repo = "FreeChaF";
+    rev = "76c7a84f1f7e80f3e6f2bba96fe100cb24e99124";
+    hash = "sha256-gLmDO2yzZbdcD82IUT6NWR0umUExtBqnAK+ltBxGPiM=";
+    fetchSubmodules = true;
+  };
+
+  makefile = "Makefile";
+
+  meta = {
+    description = "Fairchild Channel F emulator core for libretro";
+    homepage = "https://github.com/libretro/FreeChaF";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ kaistarkk ];
+  };
+}

--- a/pkgs/applications/emulators/libretro/default.nix
+++ b/pkgs/applications/emulators/libretro/default.nix
@@ -74,6 +74,8 @@ lib.makeScope newScope (self: {
 
   fmsx = self.callPackage ./cores/fmsx.nix { };
 
+  freechaf = self.callPackage ./cores/freechaf.nix { };
+
   freeintv = self.callPackage ./cores/freeintv.nix { };
 
   fuse = self.callPackage ./cores/fuse.nix { };


### PR DESCRIPTION
Adds the FreeChaF libretro core for Fairchild Channel F emulation.

Validation:
- `nix build --no-link .#legacyPackages.x86_64-linux.libretro.freechaf`

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Ran `nixpkgs-review` on this PR.
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - No standalone binary; this PR adds a libretro core artifact, and the core builds successfully.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md, and the automation/AI policy.

Disclosure: I used OpenAI Codex (GPT-5) to help prepare this PR.
