### PR TITLE
libretro.jaxe: init at 0-unstable-2026-04-02

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14026,6 +14026,11 @@
     githubId = 6544084;
     name = "Kai Harries";
   };
+  kaistarkk = {
+    github = "KaiStarkk";
+    githubId = 1722064;
+    name = "KaiStarkk";
+  };
   kalbasit = {
     email = "wael.nasreddine@gmail.com";
     matrix = "@kalbasit:matrix.org";

--- a/pkgs/applications/emulators/libretro/cores/jaxe.nix
+++ b/pkgs/applications/emulators/libretro/cores/jaxe.nix
@@ -1,0 +1,24 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkLibretroCore,
+}:
+mkLibretroCore {
+  core = "jaxe";
+  version = "0-unstable-2026-04-02";
+
+  src = fetchFromGitHub {
+    owner = "kurtjd";
+    repo = "jaxe";
+    rev = "581befc5d7273abc20ea1b137744f414aa70592c";
+    hash = "sha256-jJPg4qRxraz9wycAiWNgwXXZMF2qG8hQv7Bfexkwyqs=";
+    fetchSubmodules = true;
+  };
+
+  meta = {
+    description = "CHIP-8, S-CHIP, and XO-CHIP emulator core for libretro";
+    homepage = "https://github.com/kurtjd/jaxe";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kaistarkk ];
+  };
+}

--- a/pkgs/applications/emulators/libretro/default.nix
+++ b/pkgs/applications/emulators/libretro/default.nix
@@ -90,6 +90,8 @@ lib.makeScope newScope (self: {
 
   hatari = self.callPackage ./cores/hatari.nix { };
 
+  jaxe = self.callPackage ./cores/jaxe.nix { };
+
   mame = self.callPackage ./cores/mame.nix { };
 
   mame2000 = self.callPackage ./cores/mame2000.nix { };


### PR DESCRIPTION
Adds the JAXE libretro core for CHIP-8, S-CHIP, and XO-CHIP emulation.

Validation:
- `nix build --no-link .#legacyPackages.x86_64-linux.libretro.jaxe`

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Ran `nixpkgs-review` on this PR.
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - No standalone binary; this PR adds a libretro core artifact, and the core builds successfully.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md, and the automation/AI policy.

Disclosure: I used OpenAI Codex (GPT-5) to help prepare this PR.
