### PR TITLE
libretro.jollycv: init at 0-unstable-2026-04-02

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14026,6 +14026,11 @@
     githubId = 6544084;
     name = "Kai Harries";
   };
+  kaistarkk = {
+    github = "KaiStarkk";
+    githubId = 1722064;
+    name = "KaiStarkk";
+  };
   kalbasit = {
     email = "wael.nasreddine@gmail.com";
     matrix = "@kalbasit:matrix.org";

--- a/pkgs/applications/emulators/libretro/cores/jollycv.nix
+++ b/pkgs/applications/emulators/libretro/cores/jollycv.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  fetchFromGitHub,
+  gitMinimal,
+  mkLibretroCore,
+}:
+mkLibretroCore {
+  core = "jollycv";
+  version = "0-unstable-2026-04-02";
+
+  src = fetchFromGitHub {
+    owner = "libretro";
+    repo = "jollycv";
+    rev = "9ceb88e4370b2e04a597b03a9ffe4551c899d6c2";
+    hash = "sha256-r0qqv6MipTJecCxxrSs0ptNT0hsWrdwuzdbyZQ5U1jU=";
+  };
+
+  sourceRoot = "source/libretro";
+  makefile = "Makefile";
+
+  extraNativeBuildInputs = [ gitMinimal ];
+
+  postPatch = ''
+    chmod -R u+w ..
+  '';
+
+  meta = {
+    description = "ColecoVision, CreatiVision, and My Vision emulator core for libretro";
+    homepage = "https://github.com/libretro/jollycv";
+    license = with lib.licenses; [
+      bsd3
+      mit
+    ];
+    maintainers = with lib.maintainers; [ kaistarkk ];
+  };
+}

--- a/pkgs/applications/emulators/libretro/default.nix
+++ b/pkgs/applications/emulators/libretro/default.nix
@@ -90,6 +90,8 @@ lib.makeScope newScope (self: {
 
   hatari = self.callPackage ./cores/hatari.nix { };
 
+  jollycv = self.callPackage ./cores/jollycv.nix { };
+
   mame = self.callPackage ./cores/mame.nix { };
 
   mame2000 = self.callPackage ./cores/mame2000.nix { };


### PR DESCRIPTION
Adds the JollyCV libretro core for ColecoVision, CreatiVision, and My Vision emulation.

Validation:
- `nix build --no-link .#legacyPackages.x86_64-linux.libretro.jollycv`

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Ran `nixpkgs-review` on this PR.
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - No standalone binary; this PR adds a libretro core artifact, and the core builds successfully.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md, and the automation/AI policy.

Disclosure: I used OpenAI Codex (GPT-5) to help prepare this PR.
