### PR TITLE
libretro.m2000: init at 0-unstable-2026-03-31

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14026,6 +14026,11 @@
     githubId = 6544084;
     name = "Kai Harries";
   };
+  kaistarkk = {
+    github = "KaiStarkk";
+    githubId = 1722064;
+    name = "KaiStarkk";
+  };
   kalbasit = {
     email = "wael.nasreddine@gmail.com";
     matrix = "@kalbasit:matrix.org";

--- a/pkgs/applications/emulators/libretro/cores/m2000.nix
+++ b/pkgs/applications/emulators/libretro/cores/m2000.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkLibretroCore,
+}:
+mkLibretroCore {
+  core = "m2000";
+  version = "0-unstable-2026-03-31";
+
+  src = fetchFromGitHub {
+    owner = "p2000t";
+    repo = "M2000";
+    rev = "60e12fe9ee07f024b5a0d569ddf6ad8efbffcd4b";
+    hash = "sha256-MnqeoQJ/JWdQ7VjuxLVliK65bnWwAc5slqNzr8visTU=";
+  };
+
+  sourceRoot = "source/src/libretro";
+  makefile = "Makefile";
+
+  meta = {
+    description = "Philips P2000T emulator core for libretro";
+    homepage = "https://github.com/p2000t/M2000";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ kaistarkk ];
+  };
+}

--- a/pkgs/applications/emulators/libretro/default.nix
+++ b/pkgs/applications/emulators/libretro/default.nix
@@ -104,6 +104,8 @@ lib.makeScope newScope (self: {
 
   mame2016 = self.callPackage ./cores/mame2016.nix { };
 
+  m2000 = self.callPackage ./cores/m2000.nix { };
+
   melonds = self.callPackage ./cores/melonds.nix { };
 
   melondsds = self.callPackage ./cores/melondsds.nix { };


### PR DESCRIPTION
Adds the M2000 libretro core for Philips P2000T emulation.

Validation:
- `nix build --no-link .#legacyPackages.x86_64-linux.libretro.m2000`

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Ran `nixpkgs-review` on this PR.
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - No standalone binary; this PR adds a libretro core artifact, and the core builds successfully.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md, and the automation/AI policy.

Disclosure: I used OpenAI Codex (GPT-5) to help prepare this PR.
