### PR TITLE
libretro.pd777: init at 0-unstable-2026-06-19

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14026,6 +14026,11 @@
     githubId = 6544084;
     name = "Kai Harries";
   };
+  kaistarkk = {
+    github = "KaiStarkk";
+    githubId = 1722064;
+    name = "KaiStarkk";
+  };
   kalbasit = {
     email = "wael.nasreddine@gmail.com";
     matrix = "@kalbasit:matrix.org";

--- a/pkgs/applications/emulators/libretro/cores/pd777.nix
+++ b/pkgs/applications/emulators/libretro/cores/pd777.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  fetchFromGitHub,
+  gitMinimal,
+  mkLibretroCore,
+}:
+mkLibretroCore {
+  core = "pd777";
+  version = "0-unstable-2026-06-19";
+
+  src = fetchFromGitHub {
+    owner = "mittonk";
+    repo = "PD777";
+    rev = "118c8f893073f2e59eba6eb9fd1dd34d36318605";
+    hash = "sha256-j52fWDJ5V0+9IsFT2lhdrkNWe/oaUrGUsLiki84CRXM=";
+  };
+
+  sourceRoot = "source/source/libretro";
+
+  extraNativeBuildInputs = [ gitMinimal ];
+
+  postPatch = ''
+    chmod -R u+w ..
+  '';
+
+  meta = {
+    description = "Epoch Cassette Vision emulator core for libretro";
+    homepage = "https://github.com/mittonk/PD777";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kaistarkk ];
+  };
+}

--- a/pkgs/applications/emulators/libretro/default.nix
+++ b/pkgs/applications/emulators/libretro/default.nix
@@ -134,6 +134,8 @@ lib.makeScope newScope (self: {
 
   parallel-n64 = self.callPackage ./cores/parallel-n64.nix { };
 
+  pd777 = self.callPackage ./cores/pd777.nix { };
+
   pcsx2 = self.callPackage ./cores/pcsx2.nix { };
 
   pcsx-rearmed = self.callPackage ./cores/pcsx-rearmed.nix { };


### PR DESCRIPTION
Adds the PD777 libretro core for Epoch Cassette Vision emulation.

Validation:
- `nix build --no-link .#legacyPackages.x86_64-linux.libretro.pd777`

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Ran `nixpkgs-review` on this PR.
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - No standalone binary; this PR adds a libretro core artifact, and the core builds successfully.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md, and the automation/AI policy.

Disclosure: I used OpenAI Codex (GPT-5) to help prepare this PR.
