### PR TITLE
libretro.sameduck: init at 0-unstable-2026-04-20

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14026,6 +14026,11 @@
     githubId = 6544084;
     name = "Kai Harries";
   };
+  kaistarkk = {
+    github = "KaiStarkk";
+    githubId = 1722064;
+    name = "KaiStarkk";
+  };
   kalbasit = {
     email = "wael.nasreddine@gmail.com";
     matrix = "@kalbasit:matrix.org";

--- a/pkgs/applications/emulators/libretro/cores/sameduck.nix
+++ b/pkgs/applications/emulators/libretro/cores/sameduck.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  fetchFromGitHub,
+  gitMinimal,
+  mkLibretroCore,
+}:
+mkLibretroCore {
+  core = "sameduck";
+  version = "0-unstable-2026-04-20";
+
+  src = fetchFromGitHub {
+    owner = "libretro";
+    repo = "sameduck";
+    rev = "f0286ee9d6c44950d9a442463ffdb1ff014a5d5b";
+    hash = "sha256-R7nay5yuxTlxbVbI0UYnzpQvPXwMJt+8hCnC90/dkR0=";
+  };
+
+  sourceRoot = "source/libretro";
+  makefile = "Makefile";
+
+  extraNativeBuildInputs = [ gitMinimal ];
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail 'MKDIR := $(shell which mkdir)' 'MKDIR := mkdir'
+    chmod -R u+w ..
+  '';
+
+  meta = {
+    description = "Mega Duck emulator core for libretro";
+    homepage = "https://github.com/libretro/sameduck";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kaistarkk ];
+  };
+}

--- a/pkgs/applications/emulators/libretro/default.nix
+++ b/pkgs/applications/emulators/libretro/default.nix
@@ -159,6 +159,8 @@ lib.makeScope newScope (self: {
 
   same_cdi = self.callPackage ./cores/same_cdi.nix { }; # the name is not a typo
 
+  sameduck = self.callPackage ./cores/sameduck.nix { };
+
   sameboy = self.callPackage ./cores/sameboy.nix { };
 
   scummvm = self.callPackage ./cores/scummvm.nix { };


### PR DESCRIPTION
Adds the SameDuck libretro core for Mega Duck emulation.

Validation:
- `nix build --no-link .#legacyPackages.x86_64-linux.libretro.sameduck`

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Ran `nixpkgs-review` on this PR.
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - No standalone binary; this PR adds a libretro core artifact, and the core builds successfully.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md, and the automation/AI policy.

Disclosure: I used OpenAI Codex (GPT-5) to help prepare this PR.
