### PR TITLE
libretro.theodore: init at 0-unstable-2026-04-03

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14026,6 +14026,11 @@
     githubId = 6544084;
     name = "Kai Harries";
   };
+  kaistarkk = {
+    github = "KaiStarkk";
+    githubId = 1722064;
+    name = "KaiStarkk";
+  };
   kalbasit = {
     email = "wael.nasreddine@gmail.com";
     matrix = "@kalbasit:matrix.org";

--- a/pkgs/applications/emulators/libretro/cores/theodore.nix
+++ b/pkgs/applications/emulators/libretro/cores/theodore.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkLibretroCore,
+}:
+mkLibretroCore {
+  core = "theodore";
+  version = "0-unstable-2026-04-03";
+
+  src = fetchFromGitHub {
+    owner = "Zlika";
+    repo = "theodore";
+    rev = "121ae2513d3ee29f0aaf765a64dc086d57e7a4c7";
+    hash = "sha256-dEBjoxtX59J4pHMbLLlcJTh/R0458B9XkfvYHSGX89Q=";
+  };
+
+  makefile = "Makefile";
+
+  meta = {
+    description = "Thomson MO/TO emulator core for libretro";
+    homepage = "https://github.com/Zlika/theodore";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ kaistarkk ];
+  };
+}

--- a/pkgs/applications/emulators/libretro/default.nix
+++ b/pkgs/applications/emulators/libretro/default.nix
@@ -183,6 +183,8 @@ lib.makeScope newScope (self: {
 
   tgbdual = self.callPackage ./cores/tgbdual.nix { };
 
+  theodore = self.callPackage ./cores/theodore.nix { };
+
   thepowdertoy = self.callPackage ./cores/thepowdertoy.nix { };
 
   tic80 = self.callPackage ./cores/tic80.nix { };


### PR DESCRIPTION
Adds the Theodore libretro core for Thomson MO/TO emulation.

Validation:
- `nix build --no-link .#legacyPackages.x86_64-linux.libretro.theodore`

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Ran `nixpkgs-review` on this PR.
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - No standalone binary; this PR adds a libretro core artifact, and the core builds successfully.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md, and the automation/AI policy.

Disclosure: I used OpenAI Codex (GPT-5) to help prepare this PR.
