### PR TITLE
libretro.x1: init at 0-unstable-2026-04-20

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14026,6 +14026,11 @@
     githubId = 6544084;
     name = "Kai Harries";
   };
+  kaistarkk = {
+    github = "KaiStarkk";
+    githubId = 1722064;
+    name = "KaiStarkk";
+  };
   kalbasit = {
     email = "wael.nasreddine@gmail.com";
     matrix = "@kalbasit:matrix.org";

--- a/pkgs/applications/emulators/libretro/cores/x1.nix
+++ b/pkgs/applications/emulators/libretro/cores/x1.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkLibretroCore,
+}:
+mkLibretroCore {
+  core = "x1";
+  version = "0-unstable-2026-04-20";
+
+  src = fetchFromGitHub {
+    owner = "libretro";
+    repo = "xmil-libretro";
+    rev = "3e7960a433c3bca820f8b8f5511a2b92bd666829";
+    hash = "sha256-a7Od60evOUk+PierbNRUeRXi0LFDhCSuW9izJ0wmzMY=";
+  };
+
+  sourceRoot = "source/libretro";
+
+  postPatch = ''
+    chmod -R u+w ..
+  '';
+
+  meta = {
+    description = "Sharp X1 emulator core for libretro";
+    homepage = "https://github.com/libretro/xmil-libretro";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ kaistarkk ];
+  };
+}

--- a/pkgs/applications/emulators/libretro/default.nix
+++ b/pkgs/applications/emulators/libretro/default.nix
@@ -217,5 +217,7 @@ lib.makeScope newScope (self: {
 
   virtualjaguar = self.callPackage ./cores/virtualjaguar.nix { };
 
+  x1 = self.callPackage ./cores/x1.nix { };
+
   yabause = self.callPackage ./cores/yabause.nix { };
 })


### PR DESCRIPTION
Adds the X Millennium libretro core for Sharp X1 emulation.

Validation:
- `nix build --no-link .#legacyPackages.x86_64-linux.libretro.x1`

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Ran `nixpkgs-review` on this PR.
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - No standalone binary; this PR adds a libretro core artifact, and the core builds successfully.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md, and the automation/AI policy.

Disclosure: I used OpenAI Codex (GPT-5) to help prepare this PR.
