### PR TITLE
pseudo: init at 1.9.8

### DIFF
--- a/pkgs/by-name/ps/pseudo/package.nix
+++ b/pkgs/by-name/ps/pseudo/package.nix
@@ -1,0 +1,112 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  installShellFiles,
+  makeWrapper,
+  python3,
+  sqlite,
+  # check inputs
+  versionCheckHook,
+  acl,
+  attr,
+  coreutils,
+  tcl,
+  which,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pseudo";
+  version = "1.9.8";
+
+  src = fetchgit {
+    url = "https://git.yoctoproject.org/pseudo";
+    tag = "pseudo-${finalAttrs.version}";
+    hash = "sha256-JfKPUpCy5sB4fTQaC7GA+PlkI2jqlMGqF8wbyqVzwzg=";
+  };
+
+  postPatch = ''
+    patchShebangs .
+
+    substituteInPlace test/test-execl.sh \
+      --replace-fail "/usr/bin/env" "${lib.getExe' coreutils "env"}"
+    substituteInPlace test/test-env_i.sh \
+      --replace-fail "C=C env" "C=C ${lib.getExe' coreutils "env"}"
+  '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+    python3
+  ];
+
+  buildInputs = [
+    sqlite
+  ];
+
+  dontDisableStatic = true;
+
+  configureFlags = [
+    "--bits=${if stdenv.hostPlatform.is64bit then "64" else "32"}"
+    # avoid configure's x86-only arch CFLAGS guess (e.g., -m64)
+    "--cflags="
+    "--with-sqlite=${lib.getDev sqlite}"
+    "--with-sqlite-lib=${lib.getLib sqlite}/lib"
+  ];
+
+  doCheck = true;
+  checkTarget = "test";
+  checkInputs = [
+    acl
+    attr
+    tcl
+    which
+  ];
+
+  # Provide a minimal database with the users/groups the tests reference.
+  preCheck = ''
+    export PSEUDO_PASSWD="$NIX_BUILD_TOP/pseudo-passwd"
+    mkdir -p "$PSEUDO_PASSWD/etc"
+    printf 'root:x:0:0:root:/root:/bin/sh\nbin:x:1:1:bin:/:/sbin/nologin\n' > "$PSEUDO_PASSWD/etc/passwd"
+    printf 'root:x:0:\nbin:x:1:\n' > "$PSEUDO_PASSWD/etc/group"
+  '';
+
+  installTargets = [
+    "install-bin"
+    "install-lib"
+  ];
+
+  postInstall = ''
+    installManPage *.1
+
+    # pseudo derives its prefix from argv[0] and defaults its database under it,
+    # i.e., into the read-only store. Set the prefix and a writable state dir.
+    for prog in pseudo pseudodb pseudolog; do
+      wrapProgram "$out/bin/$prog" \
+        --set-default PSEUDO_PREFIX "$out" \
+        --run 'export PSEUDO_LOCALSTATEDIR="''${PSEUDO_LOCALSTATEDIR:-''${XDG_RUNTIME_DIR:-/run/user/$UID}/pseudo}"'
+    done
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "-V";
+
+  meta = {
+    description = "Analogue to sudo and an alternative to fakeroot";
+    longDescription = ''
+      The pseudo utility offers a way to run commands in a virtualized "root" environment,
+      allowing ordinary users to run commands which give the illusion of creating
+      device nodes, changing file ownership, and otherwise doing things necessary for
+      creating distribution packages or filesystems.
+    '';
+    mainProgram = "pseudo";
+    homepage = "https://git.yoctoproject.org/pseudo";
+    license = lib.licenses.lgpl21Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ veehaitch ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
