### PR TITLE
python3Packages.native-sparse-attention-pytorch: init at 0.2.3

### DIFF
--- a/pkgs/development/python-modules/native-sparse-attention-pytorch/default.nix
+++ b/pkgs/development/python-modules/native-sparse-attention-pytorch/default.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  hatchling,
+  einops,
+  einx,
+  jaxtyping,
+  local-attention,
+  rotary-embedding-torch,
+  torch,
+  tqdm,
+  wandb,
+  pytest,
+  pytestCheckHook,
+  nix-update-script,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "native-sparse-attention-pytorch";
+  version = "0.2.3";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchPypi {
+    pname = "native_sparse_attention_pytorch";
+    inherit (finalAttrs) version;
+    hash = "sha256-e5SBu1LuVl1QmIaMc0UoXog0IkiRX/jj5i9/6UW+LaA=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    einops
+    einx
+    jaxtyping
+    local-attention
+    rotary-embedding-torch
+    torch
+  ];
+
+  optional-dependencies = {
+    examples = [
+      tqdm
+      wandb
+    ];
+    test = [
+      pytest
+      tqdm
+    ];
+  };
+
+  pythonImportsCheck = [
+    "native_sparse_attention_pytorch"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    tqdm
+  ];
+
+  enabledTestPaths = [ "tests/" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Native Sparse Attention";
+    homepage = "https://pypi.org/project/native-sparse-attention-pytorch";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jlesquembre ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11170,6 +11170,10 @@ self: super: with self; {
 
   natasha = callPackage ../development/python-modules/natasha { };
 
+  native-sparse-attention-pytorch =
+    callPackage ../development/python-modules/native-sparse-attention-pytorch
+      { };
+
   nats-py = callPackage ../development/python-modules/nats-py { };
 
   nats-python = callPackage ../development/python-modules/nats-python { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://pypi.org/project/native-sparse-attention-pytorch/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
