### PR TITLE
python3Packages.metbrewer: init at 0-unstable-2025-01-03

### DIFF
--- a/pkgs/development/python-modules/metbrewer/default.nix
+++ b/pkgs/development/python-modules/metbrewer/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # dependencies
+  colour,
+  matplotlib,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "metbrewer";
+  version = "0-unstable-2025-01-03";
+  format = "setuptools";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "BlakeRMills";
+    repo = "MetBrewer";
+    rev = "58839e5ac7c7d604c8704581f7b201a29986b814";
+    hash = "sha256-yjK067ICn9ZoPAKkTbbTnO6TA0d0xNRRwQ1hOC2I2E4=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/Python";
+
+  dependencies = [
+    colour
+    matplotlib
+  ];
+
+  pythonImportsCheck = [
+    "met_brewer"
+  ];
+
+  meta = {
+    homepage = "https://github.com/BlakeRMills/MetBrewer";
+    description = "Palettes inspired by works at the Metropolitan Museum of Art in New York.";
+    license = lib.licenses.cc0;
+    maintainers = with lib.maintainers; [ grandjeanlab ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10080,6 +10080,8 @@ self: super: with self; {
 
   metawear = callPackage ../development/python-modules/metawear { };
 
+  metbrewer = callPackage ../development/python-modules/metbrewer { };
+
   meteo-lt-pkg = callPackage ../development/python-modules/meteo-lt-pkg { };
 
   meteoalertapi = callPackage ../development/python-modules/meteoalertapi { };


### PR DESCRIPTION
Init python package metbrewer, a set of color palettes inspired by the met museum artworks 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
