### PR TITLE
sonarqube-cli: init at 1.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12390,6 +12390,12 @@
     github = "JaviMerino";
     githubId = 44926;
   };
+  jayadeep-km-sonarsource = {
+    email = "jayadeep.kinavoormadam@sonarsource.com";
+    name = "Jayadeep Kinavoor Madam";
+    github = "jayadeep-km-sonarsource";
+    githubId = 156662663;
+  };
   jayesh-bhoot = {
     name = "Jayesh Bhoot";
     email = "jb@jayeshbhoot.com";

--- a/pkgs/by-name/so/sonarqube-cli/package.nix
+++ b/pkgs/by-name/so/sonarqube-cli/package.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "sonarqube-cli";
+  version = "1.2.0.3278";
+
+  src =
+    let
+      baseUrl = "https://binaries.sonarsource.com/Distribution/sonarqube-cli/${finalAttrs.version}";
+    in
+    {
+      x86_64-linux = fetchurl {
+        url = "${baseUrl}/linux/sonarqube-cli-${finalAttrs.version}-linux-x86-64.bin";
+        hash = "sha256-UIdR1ldHKTV7pBWjZxVxMLH7T15ZWdbL0WFw042l+Vc=";
+      };
+      aarch64-linux = fetchurl {
+        url = "${baseUrl}/linux/sonarqube-cli-${finalAttrs.version}-linux-arm64.bin";
+        hash = "sha256-w0NbqtRMJ5UGF6plslKCTsATBxP1RAc8SxwnFbi3CFE=";
+      };
+      aarch64-darwin = fetchurl {
+        url = "${baseUrl}/macos/sonarqube-cli-${finalAttrs.version}-macos-arm64.bin";
+        hash = "sha256-ehrq6hMONdZXDj9MjzLenvyb2hhwEIuhGJQCt7p/Ju0=";
+      };
+    }
+    .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  strictDeps = true;
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    stdenv.cc.cc.lib
+  ];
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  # The distributed binary is a Bun standalone executable: the application is
+  # appended to the runtime as trailing data that Bun locates from the end of
+  # the file. Stripping rewrites the ELF and discards that payload, leaving the
+  # bare Bun runtime, so stripping must be disabled.
+  dontStrip = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 $src $out/bin/sonar
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    export HOME=$(mktemp -d)
+    $out/bin/sonar --help 2>&1 | grep -qF "SonarQube CLI"
+    runHook postInstallCheck
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Command-line companion for SonarQube Cloud and SonarQube Server";
+    longDescription = ''
+      The SonarQube CLI (sonar) is a command-line companion for SonarQube Cloud
+      and SonarQube Server. It lets you scan for secrets, analyze local changes,
+      query projects and issues, and wire SonarQube into AI coding assistants,
+      all from your terminal.
+    '';
+    homepage = "https://www.sonarsource.com/sonarqube/cli";
+    # The public source is LGPL-3.0-or-later, but the distributed binary bundles
+    # proprietary commercial components (sonar-secrets, sca-scanner-cli), so the
+    # artifact as a whole is unfree.
+    license = lib.licenses.unfree;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    maintainers = with lib.maintainers; [
+      kmjayadeep
+      jayadeep-km-sonarsource
+    ];
+    mainProgram = "sonar";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+  };
+})

--- a/pkgs/by-name/so/sonarqube-cli/update.sh
+++ b/pkgs/by-name/so/sonarqube-cli/update.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=./. -i bash -p curl coreutils common-updater-scripts nix
+BASEDIR="$(dirname "$0")/../../../.."
+
+set -euo pipefail
+
+# The package is unfree, so evaluating it (to read the current version and the
+# per-system sources) requires unfree to be allowed.
+export NIXPKGS_ALLOW_UNFREE=1
+
+baseUrl="https://binaries.sonarsource.com/Distribution/sonarqube-cli"
+
+latestVersion=$(curl -fsSL "$baseUrl/stable.version" | tr -d '[:space:]')
+currentVersion=$(nix-instantiate --eval -E "with import ${BASEDIR} {}; lib.getVersion sonarqube-cli" | tr -d '"')
+
+echo "latest  version: $latestVersion"
+echo "current version: $currentVersion"
+
+if [[ "$latestVersion" == "$currentVersion" ]]; then
+    echo "package is up-to-date"
+    exit 0
+fi
+
+# "<nix-system> <os-path-segment> <artifact-platform>"
+for i in \
+    "x86_64-linux linux linux-x86-64" \
+    "aarch64-linux linux linux-arm64" \
+    "aarch64-darwin macos macos-arm64"
+do
+    # shellcheck disable=SC2086 # $i is intentionally split into positional args
+    set -- $i
+    prefetch=$(nix-prefetch-url "$baseUrl/$latestVersion/$2/sonarqube-cli-$latestVersion-$3.bin")
+    hash=$(nix-hash --type sha256 --to-sri "$prefetch")
+
+    (cd "$BASEDIR" && update-source-version sonarqube-cli "$latestVersion" "$hash" --system="$1" --ignore-same-version)
+done


### PR DESCRIPTION
Adds sonarqube-cli, official cli from Sonarqube

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
