### PR TITLE
powertop-macos: init at 1.3.3

### DIFF
--- a/pkgs/by-name/po/powertop-macos/package.nix
+++ b/pkgs/by-name/po/powertop-macos/package.nix
@@ -1,0 +1,61 @@
+{
+  fetchurl,
+  lib,
+  makeWrapper,
+  nix-update-script,
+  rcodesign,
+  stdenvNoCC,
+  unzip,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "powertop-macos";
+  version = "1.3.3";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchurl {
+    url = "https://github.com/kDolphin/PowerTop/releases/download/v${finalAttrs.version}/PowerTop.zip";
+    hash = "sha256-GIuhJVyKjFsltlg9zZByHryaIYV6F+5Uj1yTucOL9Gw=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    rcodesign
+    unzip
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    app="$out/Applications/PowerTop.app"
+    mkdir -p "$out/Applications"
+    cp -R PowerTop.app "$app"
+
+    makeWrapper "$app/Contents/MacOS/PowerTop" "$out/bin/powertop-macos"
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    ${lib.getExe rcodesign} sign "$out/Applications/PowerTop.app"
+  '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--use-github-releases" ]; };
+
+  meta = {
+    changelog = "https://github.com/kDolphin/PowerTop/releases/tag/v${finalAttrs.version}";
+    description = "Menu bar app for monitoring MacBook power usage";
+    homepage = "https://github.com/kDolphin/PowerTop";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    mainProgram = "powertop-macos";
+    platforms = [ "aarch64-darwin" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
Add the macOS PowerTop (https://github.com/kDolphin/PowerTop) menu bar application under a macOS-qualified name to avoid colliding with the existing Linux powertop package.

Upstream is source-available and ships build.sh, but the source build currently requires newer Apple Swift Observation macro support than nixpkgs' Swift 5.10 provides. Package the upstream release zip instead and mark the package as binaryNativeCode.

Assisted-by: OpenAI Codex <codex@openai.com>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
