### PR TITLE
palmier-pro: init at 0.4.5

### DIFF
--- a/pkgs/by-name/pa/palmier-pro/package.nix
+++ b/pkgs/by-name/pa/palmier-pro/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  makeWrapper,
+  nix-update-script,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "palmier-pro";
+  version = "0.4.5";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchurl {
+    url = "https://github.com/palmier-io/palmier-pro/releases/download/v${finalAttrs.version}/PalmierPro.dmg";
+    hash = "sha256-m97i2EsEYjJ0TAu+FUAFMNRAvggVbzUr1+l2EAzz9do=";
+  };
+
+  sourceRoot = ".";
+
+  unpackCmd = ''
+    mnt=$(TMPDIR=/tmp mktemp -d -t nix-XXXXXXXXXX)
+    finish() {
+      /usr/bin/hdiutil detach "$mnt" -force
+      rm -rf "$mnt"
+    }
+    trap finish EXIT
+    /usr/bin/hdiutil attach -nobrowse -mountpoint "$mnt" "$curSrc"
+    cp -a "$mnt"/PalmierPro.app "$PWD"/
+  '';
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/Applications
+    cp -r PalmierPro.app $out/Applications
+    makeWrapper $out/Applications/PalmierPro.app/Contents/MacOS/PalmierPro $out/bin/palmier-pro
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "macOS video editor built for AI";
+    homepage = "https://www.palmier.io/";
+    changelog = "https://github.com/palmier-io/palmier-pro/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    maintainers = with lib.maintainers; [ Br1ght0ne ];
+    platforms = [ "aarch64-darwin" ];
+    mainProgram = "palmier-pro";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Used .dmg from https://github.com/palmier-io/palmier-pro/releases/tag/v0.4.5 instead of building from source, as that requires Swift 6.

Assisted-By: pi coding agent with glm-5.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
