### PR TITLE
nixos/nginx: add acmeS3BucketHost option to virtualHosts

### DIFF
--- a/nixos/modules/services/misc/radicle.nix
+++ b/nixos/modules/services/misc/radicle.nix
@@ -267,10 +267,13 @@ in
           # Type of a single virtual host, or null.
           type = lib.types.nullOr (
             lib.types.submodule (
-              lib.recursiveUpdate (import ../web-servers/nginx/vhost-options.nix { inherit config lib; }) {
-                options.serverName = {
-                  default = "radicle-${config.networking.hostName}.${config.networking.domain}";
-                  defaultText = "radicle-\${config.networking.hostName}.\${config.networking.domain}";
+              lib.modules.importApply ../web-servers/nginx/vhost-options.nix {
+                nixosConfig = config;
+                overrideFn = lib.flip lib.recursiveUpdate {
+                  options.serverName = {
+                    default = "radicle-${config.networking.hostName}.${config.networking.domain}";
+                    defaultText = "radicle-\${config.networking.hostName}.\${config.networking.domain}";
+                  };
                 };
               }
             )

--- a/nixos/modules/services/monitoring/librenms.nix
+++ b/nixos/modules/services/monitoring/librenms.nix
@@ -285,7 +285,7 @@ in
 
     nginx = mkOption {
       type = types.submodule (
-        recursiveUpdate (import ../web-servers/nginx/vhost-options.nix { inherit config lib; }) { }
+        modules.importApply ../web-servers/nginx/vhost-options.nix { nixosConfig = config; }
       );
       default = { };
       example = literalExpression ''

--- a/nixos/modules/services/networking/fedimintd.nix
+++ b/nixos/modules/services/networking/fedimintd.nix
@@ -207,9 +207,7 @@ let
           };
           config = mkOption {
             type = types.submodule (
-              recursiveUpdate (import ../web-servers/nginx/vhost-options.nix {
-                inherit config lib;
-              }) { }
+              lib.modules.importApply ../web-servers/nginx/vhost-options.nix { nixosConfig = config; }
             );
             default = { };
             description = "Overrides to the nginx vhost section for api";

--- a/nixos/modules/services/web-apps/agorakit.nix
+++ b/nixos/modules/services/web-apps/agorakit.nix
@@ -208,9 +208,7 @@ in
 
     nginx = mkOption {
       type = types.submodule (
-        recursiveUpdate (import ../web-servers/nginx/vhost-options.nix {
-          inherit config lib;
-        }) { }
+        modules.importApply ../web-servers/nginx/vhost-options.nix { nixosConfig = config; }
       );
       default = { };
       example = ''

--- a/nixos/modules/services/web-apps/akkoma.nix
+++ b/nixos/modules/services/web-apps/akkoma.nix
@@ -1155,7 +1155,9 @@ in
       nginx = mkOption {
         type =
           with types;
-          nullOr (submodule (import ../web-servers/nginx/vhost-options.nix { inherit config lib; }));
+          nullOr (
+            submodule (lib.modules.importApply ../web-servers/nginx/vhost-options.nix { nixosConfig = config; })
+          );
         default = null;
         description = ''
           Extra configuration for the nginx virtual host of Akkoma.

--- a/nixos/modules/services/web-apps/anuko-time-tracker.nix
+++ b/nixos/modules/services/web-apps/anuko-time-tracker.nix
@@ -135,7 +135,7 @@ in
 
     nginx = lib.mkOption {
       type = lib.types.submodule (
-        lib.recursiveUpdate (import ../web-servers/nginx/vhost-options.nix { inherit config lib; }) { }
+        lib.modules.importApply ../web-servers/nginx/vhost-options.nix { nixosConfig = config; }
       );
       default = { };
       example = lib.literalExpression ''

--- a/nixos/modules/services/web-apps/bentopdf.nix
+++ b/nixos/modules/services/web-apps/bentopdf.nix
@@ -27,7 +27,9 @@ in
       enable = lib.mkEnableOption "a virtualhost to serve bentopdf through nginx";
 
       virtualHost = lib.mkOption {
-        type = lib.types.submodule (import ../web-servers/nginx/vhost-options.nix { inherit config lib; });
+        type = lib.types.submodule (
+          lib.modules.importApply ../web-servers/nginx/vhost-options.nix { nixosConfig = config; }
+        );
         default = { };
         example = lib.literalExpression ''
           {

--- a/nixos/modules/services/web-apps/bookstack.nix
+++ b/nixos/modules/services/web-apps/bookstack.nix
@@ -347,7 +347,7 @@ in
     nginx = lib.mkOption {
       type = lib.types.nullOr (
         lib.types.submodule (
-          lib.recursiveUpdate (import ../web-servers/nginx/vhost-options.nix { inherit config lib; }) { }
+          lib.modules.importApply ../web-servers/nginx/vhost-options.nix { nixosConfig = config; }
         )
       );
       default = null;

--- a/nixos/modules/services/web-apps/davis.nix
+++ b/nixos/modules/services/web-apps/davis.nix
@@ -222,8 +222,7 @@ in
     nginx = lib.mkOption {
       type = lib.types.nullOr (
         lib.types.submodule (
-          lib.recursiveUpdate (import ../web-servers/nginx/vhost-options.nix { inherit config lib; }) {
-          }
+          lib.modules.importApply ../web-servers/nginx/vhost-options.nix { nixosConfig = config; }
         )
       );
       default = { };

--- a/nixos/modules/services/web-apps/dolibarr.nix
+++ b/nixos/modules/services/web-apps/dolibarr.nix
@@ -248,11 +248,14 @@ in
     nginx = mkOption {
       type = types.nullOr (
         types.submodule (
-          lib.recursiveUpdate (import ../web-servers/nginx/vhost-options.nix { inherit config lib; }) {
-            # enable encryption by default,
-            # as sensitive login and Dolibarr (ERP) data should not be transmitted in clear text.
-            options.forceSSL.default = true;
-            options.enableACME.default = true;
+          lib.modules.importApply ../web-servers/nginx/vhost-options.nix {
+            nixosConfig = config;
+            overrideFn = lib.flip lib.recursiveUpdate {
+              # enable encryption by default,
+              # as sensitive login and Dolibarr (ERP) data should not be transmitted in clear text.
+              options.forceSSL.default = true;
+              options.enableACME.default = true;
+            };
           }
         )
       );

--- a/nixos/modules/services/web-apps/fediwall.nix
+++ b/nixos/modules/services/web-apps/fediwall.nix
@@ -92,7 +92,7 @@ in
     };
     nginx = lib.mkOption {
       type = lib.types.submodule (
-        lib.recursiveUpdate (import ../web-servers/nginx/vhost-options.nix { inherit config lib; }) { }
+        lib.modules.importApply ../web-servers/nginx/vhost-options.nix { nixosConfig = config; }
       );
       default = { };
       example = lib.literalExpression ''

--- a/nixos/modules/services/web-apps/fluidd.nix
+++ b/nixos/modules/services/web-apps/fluidd.nix
@@ -22,7 +22,9 @@ in
     };
 
     nginx = mkOption {
-      type = types.submodule (import ../web-servers/nginx/vhost-options.nix { inherit config lib; });
+      type = types.submodule (
+        lib.modules.importApply ../web-servers/nginx/vhost-options.nix { nixosConfig = config; }
+      );
       default = { };
       example = literalExpression ''
         {

--- a/nixos/modules/services/web-apps/gancio.nix
+++ b/nixos/modules/services/web-apps/gancio.nix
@@ -147,11 +147,14 @@ in
 
     nginx = mkOption {
       type = types.submodule (
-        lib.recursiveUpdate (import ../web-servers/nginx/vhost-options.nix { inherit config lib; }) {
-          # enable encryption by default,
-          # as sensitive login credentials should not be transmitted in clear text.
-          options.forceSSL.default = true;
-          options.enableACME.default = true;
+        lib.modules.importApply ../web-servers/nginx/vhost-options.nix {
+          nixosConfig = config;
+          overrideFn = lib.flip lib.recursiveUpdate {
+            # enable encryption by default,
+            # as sensitive login credentials should not be transmitted in clear text.
+            options.forceSSL.default = true;
+            options.enableACME.default = true;
+          };
         }
       );
       default = { };

--- a/nixos/modules/services/web-apps/jirafeau.nix
+++ b/nixos/modules/services/web-apps/jirafeau.nix
@@ -87,7 +87,9 @@ in
     };
 
     nginxConfig = mkOption {
-      type = types.submodule (import ../web-servers/nginx/vhost-options.nix { inherit config lib; });
+      type = types.submodule (
+        lib.modules.importApply ../web-servers/nginx/vhost-options.nix { nixosConfig = config; }
+      );
       default = { };
       example = literalExpression ''
         {

--- a/nixos/modules/services/web-apps/kanboard.nix
+++ b/nixos/modules/services/web-apps/kanboard.nix
@@ -63,7 +63,9 @@ in
     };
     nginx = lib.mkOption {
       type = lib.types.nullOr (
-        lib.types.submodule (import ../web-servers/nginx/vhost-options.nix { inherit config lib; })
+        lib.types.submodule (
+          lib.modules.importApply ../web-servers/nginx/vhost-options.nix { nixosConfig = config; }
+        )
       );
       default = { };
       description = ''

--- a/nixos/modules/services/web-apps/limesurvey.nix
+++ b/nixos/modules/services/web-apps/limesurvey.nix
@@ -230,7 +230,7 @@ in
 
     nginx.virtualHost = mkOption {
       type = types.submodule (
-        recursiveUpdate (import ../web-servers/nginx/vhost-options.nix { inherit config lib; }) { }
+        lib.modules.importApply ../web-servers/nginx/vhost-options.nix { nixosConfig = config; }
       );
       example = literalExpression ''
         {

--- a/nixos/modules/services/web-apps/mainsail.nix
+++ b/nixos/modules/services/web-apps/mainsail.nix
@@ -22,7 +22,9 @@ in
     };
 
     nginx = mkOption {
-      type = types.submodule (import ../web-servers/nginx/vhost-options.nix { inherit config lib; });
+      type = types.submodule (
+        lib.modules.importApply ../web-servers/nginx/vhost-options.nix { nixosConfig = config; }
+      );
       default = { };
       example = literalExpression ''
         {

--- a/nixos/modules/services/web-apps/matomo.nix
+++ b/nixos/modules/services/web-apps/matomo.nix
@@ -101,11 +101,14 @@ in
       nginx = mkOption {
         type = types.nullOr (
           types.submodule (
-            recursiveUpdate (import ../web-servers/nginx/vhost-options.nix { inherit config lib; }) {
-              # enable encryption by default,
-              # as sensitive login and Matomo data should not be transmitted in clear text.
-              options.forceSSL.default = true;
-              options.enableACME.default = true;
+            lib.modules.importApply ../web-servers/nginx/vhost-options.nix {
+              nixosConfig = config;
+              overrideFn = lib.flip lib.recursiveUpdate {
+                # enable encryption by default,
+                # as sensitive login and Matomo data should not be transmitted in clear text.
+                options.forceSSL.default = true;
+                options.enableACME.default = true;
+              };
             }
           )
         );

--- a/nixos/modules/services/web-apps/misskey.nix
+++ b/nixos/modules/services/web-apps/misskey.nix
@@ -231,7 +231,9 @@ in
         webserver = lib.mkOption {
           type = lib.types.attrTag {
             nginx = lib.mkOption {
-              type = lib.types.submodule (import ../web-servers/nginx/vhost-options.nix);
+              type = lib.types.submodule (
+                lib.modules.importApply ../web-servers/nginx/vhost-options.nix { nixosConfig = config; }
+              );
               default = { };
               description = ''
                 Extra configuration for the nginx virtual host of Misskey.

--- a/nixos/modules/services/web-apps/monica.nix
+++ b/nixos/modules/services/web-apps/monica.nix
@@ -211,7 +211,7 @@ in
 
     nginx = mkOption {
       type = types.submodule (
-        recursiveUpdate (import ../web-servers/nginx/vhost-options.nix { inherit config lib; }) { }
+        lib.modules.importApply ../web-servers/nginx/vhost-options.nix { nixosConfig = config; }
       );
       default = { };
       example = ''

--- a/nixos/modules/services/web-apps/movim.nix
+++ b/nixos/modules/services/web-apps/movim.nix
@@ -530,7 +530,9 @@ in
 
       nginx = mkOption {
         type = types.nullOr (
-          types.submodule (import ../web-servers/nginx/vhost-options.nix { inherit config lib; })
+          types.submodule (
+            lib.modules.importApply ../web-servers/nginx/vhost-options.nix { nixosConfig = config; }
+          )
         );
         default = null;
         example =

--- a/nixos/modules/services/web-apps/pixelfed.nix
+++ b/nixos/modules/services/web-apps/pixelfed.nix
@@ -128,9 +128,7 @@ in
       nginx = mkOption {
         type = types.nullOr (
           types.submodule (
-            import ../web-servers/nginx/vhost-options.nix {
-              inherit config lib;
-            }
+            lib.modules.importApply ../web-servers/nginx/vhost-options.nix { nixosConfig = config; }
           )
         );
         default = null;

--- a/nixos/modules/services/web-apps/slskd.nix
+++ b/nixos/modules/services/web-apps/slskd.nix
@@ -40,7 +40,9 @@ in
       };
 
       nginx = mkOption {
-        type = types.submodule (import ../web-servers/nginx/vhost-options.nix { inherit config lib; });
+        type = types.submodule (
+          lib.modules.importApply ../web-servers/nginx/vhost-options.nix { nixosConfig = config; }
+        );
         default = { };
         example = lib.literalExpression ''
           {

--- a/nixos/modules/services/web-apps/snipe-it.nix
+++ b/nixos/modules/services/web-apps/snipe-it.nix
@@ -240,7 +240,7 @@ in
 
     nginx = mkOption {
       type = types.submodule (
-        recursiveUpdate (import ../web-servers/nginx/vhost-options.nix { inherit config lib; }) { }
+        lib.modules.importApply ../web-servers/nginx/vhost-options.nix { nixosConfig = config; }
       );
       default = { };
       example = literalExpression ''

--- a/nixos/modules/services/web-apps/strichliste.nix
+++ b/nixos/modules/services/web-apps/strichliste.nix
@@ -396,9 +396,7 @@ in
 
       virtualHost = mkOption {
         type = types.submodule (
-          import ../web-servers/nginx/vhost-options.nix {
-            inherit config lib;
-          }
+          lib.modules.importApply ../web-servers/nginx/vhost-options.nix { nixosConfig = config; }
         );
         example = lib.literalExpression ''
           {

--- a/nixos/modules/services/web-apps/zabbix.nix
+++ b/nixos/modules/services/web-apps/zabbix.nix
@@ -208,7 +208,9 @@ in
       };
 
       nginx.virtualHost = mkOption {
-        type = types.submodule (import ../web-servers/nginx/vhost-options.nix);
+        type = types.submodule (
+          lib.modules.importApply ../web-servers/nginx/vhost-options.nix { nixosConfig = config; }
+        );
         example = literalExpression ''
           {
             forceSSL = true;

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -1323,8 +1323,8 @@ in
       virtualHosts = mkOption {
         type = types.attrsOf (
           types.submodule (
-            import ./vhost-options.nix {
-              inherit config lib;
+            modules.importApply ./vhost-options.nix {
+              nixosConfig = config;
             }
           )
         );

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -460,6 +460,17 @@ let
             ''
               location ^~ /.well-known/acme-challenge/ {
                 ${optionalString (vhost.acmeFallbackHost != null) "try_files $uri @acme-fallback;"}
+                ${optionalString (vhost.acmeS3BucketHost != null) ''
+                  proxy_redirect off;
+                  proxy_set_header Host ${vhost.acmeS3BucketHost};
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_hide_header x-amz-version-id;
+                  proxy_hide_header x-amz-server-side-encryption;
+                  proxy_hide_header x-amz-id-2;
+                  proxy_hide_header x-amz-request-id;
+                  proxy_pass https://${vhost.acmeS3BucketHost};
+                ''}
                 ${optionalString (vhost.acmeRoot != null) "root ${vhost.acmeRoot};"}
                 auth_basic off;
                 auth_request off;
@@ -1429,6 +1440,31 @@ in
           message = ''
             Options services.nginx.service.virtualHosts.<name>.enableACME and
             services.nginx.virtualHosts.<name>.useACMEHost are mutually exclusive.
+          '';
+        }
+
+        {
+          assertion = all (
+            host:
+            !(host.enableACME || host.useACMEHost != null)
+            || (
+              (config.security.acme.certs.${defaultTo host.serverName host.useACMEHost}.s3Bucket != null)
+              -> (host.acmeS3BucketHost != null)
+            )
+          ) (attrValues virtualHosts);
+          message = ''
+            Option services.nginx.service.virtualHosts.<name>.acmeS3BucketHost need to be set
+            accordingly with security.acme.certs.<name>.s3Bucket (usually to "<s3Bucket>.<end-point>").
+          '';
+        }
+
+        {
+          assertion = all (
+            host: (host.acmeS3BucketHost != null -> (host.acmeRoot == null && host.acmeFallbackHost == null))
+          ) (attrValues virtualHosts);
+          message = ''
+            Options services.nginx.service.virtualHosts.<name>.acmeS3BucketHost is mutually exclusive to both
+            services.nginx.virtualHosts.<name>.acmeRoot and services.nginx.virtualHosts.<name>.acmeFallbackHost.
           '';
         }
 

--- a/nixos/modules/services/web-servers/nginx/location-options.nix
+++ b/nixos/modules/services/web-servers/nginx/location-options.nix
@@ -3,12 +3,9 @@
 # has additional options that affect the web server as a whole, like
 # the user/group to run under.)
 
-{ lib, config }:
-
-with lib;
-
-{
-  options = {
+{ nixosConfig }:
+{ lib, ... }: {
+  options = with lib; {
     basicAuth = mkOption {
       type = types.attrsOf types.str;
       default = { };
@@ -143,7 +140,7 @@ with lib;
 
     recommendedProxySettings = mkOption {
       type = types.bool;
-      default = config.services.nginx.recommendedProxySettings;
+      default = nixosConfig.services.nginx.recommendedProxySettings;
       defaultText = literalExpression "config.services.nginx.recommendedProxySettings";
       description = ''
         Enable recommended proxy settings.
@@ -152,7 +149,7 @@ with lib;
 
     recommendedUwsgiSettings = mkOption {
       type = types.bool;
-      default = config.services.nginx.recommendedUwsgiSettings;
+      default = nixosConfig.services.nginx.recommendedUwsgiSettings;
       defaultText = literalExpression "config.services.nginx.recommendedUwsgiSettings";
       description = ''
         Enable recommended uwsgi settings.

--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -133,9 +133,11 @@ overrideFn {
 
     acmeRoot = mkOption {
       type = types.nullOr types.str;
-      default = "/var/lib/acme/acme-challenge";
+      default = if (config.acmeS3BucketHost != null) then null else "/var/lib/acme/acme-challenge";
+      defaultText = literalExpression ''if (config.acmeS3BucketHost != null) then null else "/var/lib/acme/acme-challenge"'';
       description = ''
         Directory for the ACME challenge, which is **public**. Don't put certs or keys in here.
+        Default to /var/lib/acme/acme-challenge or null if `acmeS3BucketHost` is set.
         Set to null to inherit from config.security.acme.
       '';
     };
@@ -150,6 +152,15 @@ overrideFn {
         With this option, you could request certificates for the present domain
         with an ACME client that is running on another host, which you would
         specify here.
+      '';
+    };
+
+    acmeS3BucketHost = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        Host of the S3 bucket which to proxy requests.
+        Mandatory if security.acme.certs.<name>.s3Bucket is not null for this virtual host.
       '';
     };
 

--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -3,11 +3,13 @@
 # has additional options that affect the web server as a whole, like
 # the user/group to run under.)
 
-{ config, lib, ... }:
-
-with lib;
 {
-  options = {
+  nixosConfig,
+  overrideFn ? x: x,
+}:
+{ config, lib, ... }:
+overrideFn {
+  options = with lib; {
     serverName = mkOption {
       type = types.nullOr types.str;
       default = null;
@@ -358,8 +360,8 @@ with lib;
     locations = mkOption {
       type = types.attrsOf (
         types.submodule (
-          import ./location-options.nix {
-            inherit lib config;
+          lib.modules.importApply ./location-options.nix {
+            inherit nixosConfig;
           }
         )
       );


### PR DESCRIPTION
so that `security.acme.certs.<name>.s3Bucket` (#262806) can be used with nginx.

Also apply (first commit) a fix similar to https://github.com/NixOS/nixpkgs/pull/345913/changes/a047c98140f3c79ab8e2b728d823cbbbfd2509c0 (from #345913) in order to be able to use local config in vhost-options.nix. The main diff is that I used an additional `overrideFn` arg to the vhost-options module, to preserve options overrides and thus the associated generated documentation, also it could eventually allow to select a subset of options in order to implement https://github.com/NixOS/nixpkgs/issues/313412.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
