### PR TITLE
python3Packages.asynch: init at 0.3.1

### DIFF
--- a/pkgs/development/python-modules/asynch/default.nix
+++ b/pkgs/development/python-modules/asynch/default.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  poetry-core,
+  ciso8601,
+  leb128,
+  lz4,
+  pytz,
+  tzlocal,
+  zstd,
+  clickhouse-cityhash,
+  nix-update-script,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "asynch";
+  version = "0.3.1";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-2Ls8F5OnSi6dRMx+hAbq0884GMEezW2EBbcCsjFIxYQ=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    ciso8601
+    leb128
+    lz4
+    pytz
+    tzlocal
+    zstd
+  ];
+
+  pythonRelaxDeps = [ "pytz" ];
+
+  optional-dependencies = {
+    compression = [
+      clickhouse-cityhash
+    ];
+  };
+
+  pythonImportsCheck = [
+    "asynch"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "An asyncio driver for ClickHouse with native TCP support";
+    homepage = "https://pypi.org/project/asynch";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jlesquembre ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1224,6 +1224,8 @@ self: super: with self; {
 
   asyncer = callPackage ../development/python-modules/asyncer { };
 
+  asynch = callPackage ../development/python-modules/asynch { };
+
   asyncinotify = callPackage ../development/python-modules/asyncinotify { };
 
   asyncio-dgram = callPackage ../development/python-modules/asyncio-dgram { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
