### PR TITLE
fotowall: init at 1.1.0

### DIFF
--- a/pkgs/by-name/fo/fotowall/package.nix
+++ b/pkgs/by-name/fo/fotowall/package.nix
@@ -1,0 +1,40 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  qt6,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fotowall";
+  version = "1.1.0";
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "fotowall";
+    repo = "fotowall";
+    rev = "v${version}";
+    hash = "sha256-3zgZ9yuS7N/pqWF9CczMSjWb1afMFaNYPRgwEo/AZp8=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtsvg
+  ];
+
+  meta = {
+    description = "Pictures collage & creativity tool";
+    homepage = "https://github.com/fotowall/fotowall";
+    license = lib.licenses.gpl2Plus;
+    maintainers = [ ];
+    platforms = lib.platforms.linux;
+    mainProgram = "fotowall";
+  };
+}


### PR DESCRIPTION
I am the maintainer of Fotowall, a `Qt6` application for creating photo collages and printing large posters. I would like to add it to nixpkgs, and am willing to maintain it.

Building with Nix on Linux is tested upstream in the [fotowall/fotowall](https://github.com/fotowall/fotowall) repository, and I confirmed that the proposed derivation builds and executes as expected.
I do not have a Mac so I have not tested on this platform, but on principle it should also work.

Thanks!

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
