### PR TITLE
Revert "netavark: 1.17.2 -> 2.0.0"

### DIFF
--- a/pkgs/by-name/ne/netavark/package.nix
+++ b/pkgs/by-name/ne/netavark/package.nix
@@ -11,16 +11,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "netavark";
-  version = "2.0.0";
+  version = "1.17.2";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = "netavark";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-hMtYAG1OnnK1xECp8yiGEtgrWWnVfywLokOw6fzKEjw=";
+    hash = "sha256-FdJNcHYK6Jc1dNqcUr5Ne8dv1dzlHRhcjoldiihrov8=";
   };
 
-  cargoHash = "sha256-oVIOS0bzvT6FW43TJ/p0PZO/cjskzljhyxqeM0aSCCo=";
+  cargoHash = "sha256-wp/1lWc3OfNQt74m8DtpuFO/Mf07+M7numq2FMEkeGo=";
 
   nativeBuildInputs = [
     installShellFiles


### PR DESCRIPTION
`netavark` update must be done in sync with `podman` and `buildah`.

From netavark 2.0.0 release notes:

"""
This is major release with breaking changes. It is required for podman
6.0 and buildah 1.44 and only supported to be used with them together.
Packagers need to ensure they update the versions in sync.
"""

From podman 6.0.0 release notes:

"""
Due to breaking changes in this release, Podman v6.0.0 must be used
with Buildah v1.44.0, Skopeo v1.23, Netavark and Aardvark v2.0.0, and
configuration files from the container-libs repository's common/v0.68.0
release.
"""


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
