### PR TITLE
xmcl: init at 0.59.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19573,6 +19573,12 @@
     githubId = 26014535;
     name = "Negate This";
   };
+  Neila = {
+    email = "neilaspace@outlook.com";
+    github = "neila-a";
+    githubId = 78797625;
+    name = "Neil Alen";
+  };
   neilmayhew = {
     email = "nix@neil.mayhew.name";
     github = "neilmayhew";

--- a/pkgs/by-name/xm/xmcl/package.nix
+++ b/pkgs/by-name/xm/xmcl/package.nix
@@ -22,6 +22,9 @@ stdenv.mkDerivation (finalAttrs: {
   };
   unpackPhase = "dpkg -x $src ./";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   # Tools needed during the build process itself
   nativeBuildInputs = [
     dpkg # Unpacks the deb file

--- a/pkgs/by-name/xm/xmcl/package.nix
+++ b/pkgs/by-name/xm/xmcl/package.nix
@@ -1,0 +1,75 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  electron,
+  makeWrapper,
+  dpkg,
+  ...
+}:
+let
+  githubRepo = "https://github.com/Voxelum/x-minecraft-launcher";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xmcl";
+  version = "0.59.1";
+
+  src = fetchurl {
+    # Use the deb file because there aren't resources like icons in the tarball.
+    # However, the rpm file can be used as well.
+    url = "${githubRepo}/releases/download/v${finalAttrs.version}/xmcl-${finalAttrs.version}-amd64.deb";
+    sha256 = "1f68xy5kxp8sshn0bmhwq3rh4ihb8aygvwyadgik5bh776y3h9d8";
+  };
+  unpackPhase = "dpkg -x $src ./";
+
+  # Tools needed during the build process itself
+  nativeBuildInputs = [
+    dpkg # Unpacks the deb file
+    makeWrapper # Creates wrapper scripts
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    # Directly copying ./usr to $out will cause strange paths because of unknown reasons.
+    mkdir -p $out/share
+    cp -r ./usr/share/* $out/share
+
+    mkdir -p $out/opt/xmcl
+    cp -r ./opt/xmcl/resources/app.asar $out/opt/xmcl
+    makeWrapper ${
+      # Yes, XMCL uses Electron 29.3.1 instead of the latest version,
+      # but 29.3.1 is too old to exist in nixpkgs.
+      lib.getExe electron
+    } $out/bin/xmcl \
+      --argv0 "xmcl" \
+      --add-flags "$out/opt/xmcl/app.asar" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+      --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
+      --set-default ELECTRON_IS_DEV 0 
+
+    # Substitute placeholder paths in the desktop file
+    substituteInPlace $out/share/applications/xmcl.desktop --replace "Exec=/opt/xmcl/xmcl %U" "Exec=$out/bin/xmcl %U" 
+                            
+    runHook postInstall
+  '';
+  
+  meta = {
+    description = "An Open Source Minecraft Launcher with Modern UX";
+    longDescription = ''
+      XMCL is an Open Source Minecraft Launcher with Modern UX. 
+      It provides a Disk Efficient way to manage all your Mods.
+    '';
+    homepage = githubRepo;
+    mainProgram = "xmcl";
+    license = lib.licenses.mit;
+    # XMCL does supports MacOS, but I haven't any darwin devices for test.
+    platforms = lib.lists.filter (
+      platform: lib.strings.hasSuffix "linux" platform
+    ) electron.meta.platforms;
+    maintainers = with lib.maintainers; [
+      Neila
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/xm/xmcl/package.nix
+++ b/pkgs/by-name/xm/xmcl/package.nix
@@ -1,69 +1,102 @@
 {
   stdenv,
   lib,
-  fetchurl,
+  fetchFromGitHub,
   electron,
   makeWrapper,
-  dpkg,
+  pnpm_10, # XMCL uses 10.33.3
+  makeDesktopItem,
+  fetchPnpmDeps,
+  copyDesktopItems,
   ...
 }:
 let
-  githubRepo = "https://github.com/Voxelum/x-minecraft-launcher";
+  execPlaceholder = "TO_BE_REPLACED";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "xmcl";
-  version = "0.59.1";
+  version = "0.61.0";
 
-  src = fetchurl {
-    # Use the deb file because there aren't resources like icons in the tarball.
-    # However, the rpm file can be used as well.
-    url = "${githubRepo}/releases/download/v${finalAttrs.version}/xmcl-${finalAttrs.version}-amd64.deb";
-    sha256 = "1f68xy5kxp8sshn0bmhwq3rh4ihb8aygvwyadgik5bh776y3h9d8";
+  src = fetchFromGitHub {
+    owner = "Voxelum";
+    repo = "x-minecraft-launcher";
+    rev = "22a37c31aca0266fd4e91e22f1540e7c15a2c521";
+    hash = "sha256-mQ2HvB4W4pC4Keb4ex4mUUSpzYgiUFEjXZGvZl/SKkc=";
   };
-  unpackPhase = "dpkg -x $src ./";
 
-  strictDeps = true;
-  __structuredAttrs = true;
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    pnpm = pnpm_10;
+    fetcherVersion = 3;
+    hash = "sha256-Yuxuqr1BiviSw+dGNHLs2jAy8ADlBvRks6Kmy7FmCMw=";
+  };
 
   # Tools needed during the build process itself
   nativeBuildInputs = [
-    dpkg # Unpacks the deb file
     makeWrapper # Creates wrapper scripts
+    copyDesktopItems
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm build:renderer
+    NODE_ENV=production pnpm run --prefix=xmcl-electron-app compile
+
+    runHook postBuild
+  '';
+
+  # Though the desktop file can be generated from config in {xmcl}/electron-builder.ts,
+  # manually writing here is a more simple way.
+  desktopItems = [
+    (makeDesktopItem {
+      name = finalAttrs.pname;
+      desktopName = "X Minecraft Launcher";
+      exec = execPlaceholder;
+      terminal = false;
+      icon = finalAttrs.pname;
+      startupWMClass = finalAttrs.pname;
+      mimeTypes = [ "x-scheme-handler/${finalAttrs.pname}" ];
+      comment = finalAttrs.meta.description;
+      categories = [
+        "Game"
+      ];
+    })
   ];
 
   installPhase = ''
     runHook preInstall
 
-    # Directly copying ./usr to $out will cause strange paths because of unknown reasons.
-    mkdir -p $out/share
-    cp -r ./usr/share/* $out/share
+    mkdir -p $out/opt
+    cp -r ./xmcl-electron-app/dist $out/opt/xmcl
 
-    mkdir -p $out/opt/xmcl
-    cp -r ./opt/xmcl/resources/app.asar $out/opt/xmcl
     makeWrapper ${
       # Yes, XMCL uses Electron 29.3.1 instead of the latest version,
       # but 29.3.1 is too old to exist in nixpkgs.
       lib.getExe electron
     } $out/bin/xmcl \
       --argv0 "xmcl" \
-      --add-flags "$out/opt/xmcl/app.asar" \
+      --add-flags "$out/opt/xmcl" \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
       --set-default ELECTRON_IS_DEV 0 
 
-    # Substitute placeholder paths in the desktop file
-    substituteInPlace $out/share/applications/xmcl.desktop --replace "Exec=/opt/xmcl/xmcl %U" "Exec=$out/bin/xmcl %U" 
-                            
     runHook postInstall
+
+    # Yes, after postInstall
+    # Substitute placeholder paths in the desktop file
+    substituteInPlace $out/share/applications/xmcl.desktop --replace-warn "Exec=${execPlaceholder}" "Exec=$out/bin/xmcl %U"                  
   '';
-  
+
+  # It's downloaded from a *normal* url instead of a GitHub repository.
+  #passthru.updateScript = nix-update-script { };
   meta = {
     description = "An Open Source Minecraft Launcher with Modern UX";
     longDescription = ''
       XMCL is an Open Source Minecraft Launcher with Modern UX. 
       It provides a Disk Efficient way to manage all your Mods.
     '';
-    homepage = githubRepo;
+    homepage = "https://xmcl.app/";
     mainProgram = "xmcl";
     license = lib.licenses.mit;
     # XMCL does supports MacOS, but I haven't any darwin devices for test.

--- a/pkgs/by-name/xm/xmcl/package.nix
+++ b/pkgs/by-name/xm/xmcl/package.nix
@@ -17,6 +17,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "xmcl";
   version = "0.61.0";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "Voxelum";
     repo = "x-minecraft-launcher";


### PR DESCRIPTION
Added package [XMCL](https://github.com/Voxelum/x-minecraft-launcher).  It's a Minecraft launcher which uses symbolic and hard links.

In theory, as XMCL is open-source (MIT), this package can be built from source code.  
However, I encountered issues with jq when `fetchPnpmDeps`, so I still used the method of building from the already built binary.

Since this program is run by Electron, theoretically it should support aarch. But I don't have aarch hardware for testing. MacOS (darwin) is the same.  
However, I believe that aarch's Linux should follow the same architecture, so this package is marked as usable with aarch; for MacOS, I can't even unpack dmg files, and I  think I should not work on something completely unexpected.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
