### PR TITLE
kubernetes-helmPlugins.helm-unittest: fix per-arch exec error

### DIFF
--- a/pkgs/applications/networking/cluster/helm/plugins/helm-unittest.nix
+++ b/pkgs/applications/networking/cluster/helm/plugins/helm-unittest.nix
@@ -2,7 +2,6 @@
   buildGoModule,
   fetchFromGitHub,
   lib,
-  yq-go,
   nix-update-script,
 }:
 
@@ -22,21 +21,29 @@ buildGoModule {
 
   vendorHash = "sha256-4ckjM520MGYb64LbjYURe7AIScm4aGbj81rGKSSYaAo=";
 
-  # NOTE: Remove the install and upgrade hooks.
   postPatch = ''
-    sed -i '/^hooks:/,+2 d' plugin.yaml
+    # Remove the install and upgrade hooks.
+    sed -i '/^platformHooks:[[:space:]]*$/,/^[^[:space:]]/d' plugin.yaml
+    # Remove the per-platform commands
+    sed -i '/^platformCommand:[[:space:]]*$/,/^[^[:space:]]/d' plugin.yaml
+    # Add a simple runtime config
+    cat <<'EOF' >> ./plugin.yaml
+    platformCommand:
+      - command: "''$HELM_PLUGIN_DIR/helm-unittest"
+    EOF
   '';
 
-  postInstall = ''
-    install -dm755 $out/helm-unittest
-    mv $out/bin/helm-unittest $out/helm-unittest/untt
-    rmdir $out/bin
-    install -m644 -Dt $out/helm-unittest plugin.yaml
-  '';
+  subPackages = [ "cmd/helm-unittest" ];
 
-  nativeCheckInputs = [
-    yq-go
-  ];
+  installPhase = ''
+    runHook preInstall
+
+    install -dm755 "$out/helm-unittest"
+    install -m755 -Dt "$out/helm-unittest" "$GOPATH/bin/helm-unittest"
+    install -m644 -Dt "$out/helm-unittest" ./plugin.yaml
+
+    runHook postInstall
+  '';
 
   passthru = {
     updateScript = nix-update-script { };


### PR DESCRIPTION
## Things done

Fixed this issue around plugin.yaml:

```text
Error: fork/exec /nix/store/c1b7cgaxppxy2zb2r5plvxwsrnc4d0q6-helm-plugins/helm-unittest/untt-linux-amd64: no such file or directory
```

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
