### PR TITLE
stalwart_0_16: limit cargo build to server package

### DIFF
--- a/pkgs/by-name/st/stalwart_0_16/package.nix
+++ b/pkgs/by-name/st/stalwart_0_16/package.nix
@@ -112,6 +112,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ++ lib.optionals withFoundationdb [ "foundationdb" ]
   ++ lib.optionals stalwartEnterprise [ "enterprise" ];
 
+  cargoBuildFlags = [
+    "-p"
+    "stalwart"
+  ];
+  cargoTestFlags = finalAttrs.cargoBuildFlags;
+
   doCheck = true;
   nativeCheckInputs = [
     openssl


### PR DESCRIPTION
`stalwart_0_16` currently invokes Cargo at the workspace root without a package selector. Upstream's 0.16 workspace includes a heavy `tests` crate, so Hydra's aarch64 build spends time compiling code that is not part of the shipped server binary.

Hydra evidence: recent `nixpkgs/unstable/stalwart_0_16.aarch64-linux` builds `333222674`, `333158312`, and `332395468` timed out. Build `333222674` ran for 2h31m23s and its log included `Compiling tests v0.16.10 (/build/source/tests)` before timing out.

This change scopes both build and check phases to the shipped server package with `-p stalwart`, preserving the existing feature set, skipped tests, `migrate_v016` symlink, and passthru packages.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Validation:

- `nix fmt -- pkgs/by-name/st/stalwart_0_16/package.nix` -> formatted 1 file, 0 changed after the treefmt fix.
- `git diff upstream/master...HEAD --check` succeeds.
- `./ci/nixpkgs-vet.sh master https://github.com/NixOS/nixpkgs.git` succeeds.
- NixOS/nixpkgs PR workflow on head `02ccfd5b658f703cdfb23145ca804586c4d618fb` is green, including treefmt, parse, nixpkgs-vet, eval, and `no PR failures`.
- `nix build .#stalwart_0_16 --print-build-logs` succeeds on x86_64-linux.
- Build log confirms `cargoBuildHook flags: ... -p stalwart` and `cargoCheckHook flags: ... -p stalwart`.
- Build log has no `Compiling tests` or `/build/source/tests` entries.
- `./result/bin/stalwart --version` -> `0.16.11`.
- aarch64 binary proof is pending in `caniko/nixpkgs-review-gha` run https://github.com/caniko/nixpkgs-review-gha/actions/runs/28449205372.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
