### PR TITLE
shared-mime-info: 2.4 -> 2.5.1

### DIFF
--- a/pkgs/by-name/sh/shared-mime-info/package.nix
+++ b/pkgs/by-name/sh/shared-mime-info/package.nix
@@ -10,10 +10,20 @@
   glib,
   shared-mime-info,
 }:
-
+let
+  # Upstream doesn't pin the version of `xdgmime` in their git repository,
+  # so it has to be fetched separately.
+  xdgmime = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "xdg";
+    repo = "xdgmime";
+    rev = "04ce4cd90cb3fa77d5348662de221a6f33b21b17";
+    hash = "sha256-0sjH6qG0RYb1kCw4+veTpzv1zJCzoTd2LPa9pqsZrgY=";
+  };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "shared-mime-info";
-  version = "2.4";
+  version = "2.5.1";
 
   outputs = [
     "out"
@@ -24,9 +34,13 @@ stdenv.mkDerivation (finalAttrs: {
     domain = "gitlab.freedesktop.org";
     owner = "xdg";
     repo = "shared-mime-info";
-    rev = finalAttrs.version;
-    hash = "sha256-5eyMkfSBUOD7p8woIYTgz5C/L8uQMXyr0fhL0l23VMA=";
+    tag = finalAttrs.version;
+    hash = "sha256-FZFrsCYRyLSFWSOlAt+f6jUEVNy52plhEytu+0tFFvU=";
   };
+
+  postPatch = ''
+    ln -s ${xdgmime} subprojects/xdgmime
+  '';
 
   nativeBuildInputs = [
     meson
@@ -46,6 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   mesonFlags = [
     "-Dupdate-mimedb=true"
+    "-Dbuild-spec=false"
   ];
 
   meta = {

--- a/pkgs/by-name/sh/shared-mime-info/package.nix
+++ b/pkgs/by-name/sh/shared-mime-info/package.nix
@@ -10,10 +10,20 @@
   glib,
   shared-mime-info,
 }:
-
+let
+  # Upstream doesn't pin the version of `xdgmime` in their git repository,
+  # so it has to be fetched separately.
+  xdgmime = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "xdg";
+    repo = "xdgmime";
+    rev = "04ce4cd90cb3fa77d5348662de221a6f33b21b17";
+    hash = "sha256-0sjH6qG0RYb1kCw4+veTpzv1zJCzoTd2LPa9pqsZrgY=";
+  };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "shared-mime-info";
-  version = "2.4";
+  version = "2.5.1";
 
   outputs = [
     "out"
@@ -24,9 +34,17 @@ stdenv.mkDerivation (finalAttrs: {
     domain = "gitlab.freedesktop.org";
     owner = "xdg";
     repo = "shared-mime-info";
-    rev = finalAttrs.version;
-    hash = "sha256-5eyMkfSBUOD7p8woIYTgz5C/L8uQMXyr0fhL0l23VMA=";
+    tag = finalAttrs.version;
+    hash = "sha256-FZFrsCYRyLSFWSOlAt+f6jUEVNy52plhEytu+0tFFvU=";
   };
+
+  # Disable fuzzing support for xdgmime: shared-mime-info doesn't use it,
+  # and it requires Linux-only APIs
+  postPatch = ''
+    cp -r --no-preserve=mode ${xdgmime} subprojects/xdgmime
+    substituteInPlace subprojects/xdgmime/meson.build \
+      --replace-fail "subdir('fuzzing')" ""
+  '';
 
   nativeBuildInputs = [
     meson
@@ -46,6 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   mesonFlags = [
     "-Dupdate-mimedb=true"
+    "-Dbuild-spec=false"
   ];
 
   meta = {


### PR DESCRIPTION
changelog: https://gitlab.freedesktop.org/xdg/shared-mime-info/-/blob/2.5.1/NEWS
diff: https://gitlab.freedesktop.org/xdg/shared-mime-info/-/compare/2.4...2.5.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] <s>x86_64-darwin (currently fails)</s> No more x86_64-darwin! -mdaniels5757
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
