### PR TITLE
picolibc: use stdenvNoLibc + depsBuildBuild; top-level: picolibc as a libc; lib/systems: add picolibc

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -170,6 +170,8 @@ let
             "relibc"
           else if final.isMusl then
             "musl"
+          else if final.isPicolibc then
+            "picolibc"
           else if final.isUClibc then
             "uclibc"
           else if final.isAndroid then

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -435,6 +435,9 @@ rec {
         muslabin32
         muslabi64
       ];
+    isPicolibc = {
+      abi = abis.picolibc;
+    };
     isUClibc =
       with abis;
       map (a: { abi = a; }) [

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -743,6 +743,8 @@ rec {
     };
     musl = { };
 
+    picolibc = { };
+
     uclibceabi = {
       float = "soft";
       eabi = true;

--- a/pkgs/by-name/pi/picolibc/package.nix
+++ b/pkgs/by-name/pi/picolibc/package.nix
@@ -45,7 +45,7 @@
   fast-bufio ? false,
   io-wchar ? false,
 
-  # Internaltionalization options
+  # Internationalization options
   # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/meson_options.txt#L181
   mb-capable ? false,
   mb-extended-charsets ? false,

--- a/pkgs/by-name/pi/picolibc/package.nix
+++ b/pkgs/by-name/pi/picolibc/package.nix
@@ -1,5 +1,5 @@
 {
-  stdenv,
+  stdenvNoLibc,
   fetchFromGitHub,
   lib,
   meson,
@@ -19,8 +19,8 @@
 
   # Testing options
   # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/meson_options.txt#L75
-  picolib ? stdenv.hostPlatform.isNone,
-  semihost ? stdenv.hostPlatform.isNone,
+  picolib ? stdenvNoLibc.hostPlatform.isNone,
+  semihost ? stdenvNoLibc.hostPlatform.isNone,
 
   # Stdio Options
   # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/meson_options.txt#L114
@@ -34,7 +34,7 @@
   # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/meson_options.txt#L129
   io-float-exact ? true,
   atomic-ungetc ? true,
-  posix-console ? !stdenv.hostPlatform.isNone,
+  posix-console ? !stdenvNoLibc.hostPlatform.isNone,
   format-default ? "double",
   printf-aliases ? true,
   io-percent-b ? false,
@@ -55,7 +55,7 @@
 
   # Startup/shutdown options
   # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/meson_options.txt#L198
-  picocrt ? stdenv.hostPlatform.isNone,
+  picocrt ? stdenvNoLibc.hostPlatform.isNone,
   picocrt-enable-mmu ? true,
   picocrt-lib ? true,
   picoexit ? true,
@@ -65,7 +65,7 @@
   # Legacy (non-picoexit) startup/shutdown options
   # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/meson_options.txt#L217
   newlib-atexit-dynamic-alloc ? false,
-  newlib-global-atexit ? !stdenv.hostPlatform.isNone,
+  newlib-global-atexit ? !stdenvNoLibc.hostPlatform.isNone,
   newlib-register-fini ? false,
 
   # Malloc options
@@ -80,9 +80,9 @@
   # TLS storage options
   # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/meson_options.txt#L244
   thread-local-storage ? "picolibc",
-  tls-model ? if stdenv.hostPlatform.isNone then "local-exec" else "global-dynamic",
+  tls-model ? if stdenvNoLibc.hostPlatform.isNone then "local-exec" else "global-dynamic",
   newlib-global-errno ? false,
-  errno-function ? if stdenv.hostPlatform.isNone then "false" else "auto",
+  errno-function ? if stdenvNoLibc.hostPlatform.isNone then "false" else "auto",
   tls-rp2040 ? false,
 
   # Math options
@@ -92,9 +92,9 @@
 let
   inherit (lib.strings) mesonBool mesonOption;
 
-  canExecute = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+  canExecute = stdenvNoLibc.buildPlatform.canExecute stdenvNoLibc.hostPlatform;
 in
-stdenv.mkDerivation (finalAttrs: {
+stdenvNoLibc.mkDerivation (finalAttrs: {
   pname = "picolibc";
   version = "1.8.9-2";
   strictDeps = true;

--- a/pkgs/by-name/pi/picolibc/package.nix
+++ b/pkgs/by-name/pi/picolibc/package.nix
@@ -1,5 +1,6 @@
 {
   stdenvNoLibc,
+  buildPackages,
   fetchFromGitHub,
   lib,
   meson,
@@ -111,6 +112,10 @@ stdenvNoLibc.mkDerivation (finalAttrs: {
     hash = "sha256-djOZKkinsaaYD4tUEA6mKdo+5em0GP1/+rI0mIm7Vs8=";
   };
 
+  depsBuildBuild = lib.optionals canExecute [
+    buildPackages.stdenv.cc
+  ];
+
   nativeBuildInputs = [
     meson
     ninja
@@ -187,6 +192,8 @@ stdenvNoLibc.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals finalAttrs.finalPackage.doCheck [
     (mesonBool "tests" true)
+    (mesonBool "native-tests" canExecute)
+    (mesonBool "native-math-tests" canExecute)
     # Something is broken with this and I'm not sure what.
     (mesonOption "tests-cdefs" "false")
   ];

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -130,6 +130,9 @@ let
         !stdenv.hostPlatform.isDarwin
         && !stdenv.hostPlatform.isAndroid
         && !(stdenv.hostPlatform.useLLVM or false)
+        # Avoids eager evaluation on isGNU up the chain since Meson uses Python
+        # which uses OpenSSL
+        && stdenv.targetPlatform.libc != "picolibc"
         && stdenv.cc.isGNU;
 
       nativeBuildInputs =

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5745,6 +5745,8 @@ with pkgs;
       relibc
     else if libc == "llvm" then
       llvmPackages_20.libc
+    else if libc == "picolibc" then
+      picolibc
     else
       throw "Unknown libc ${libc}";
 


### PR DESCRIPTION
Copied `pkgs.newlib`’s use of stdenvNoLibc + depsBuildBuild to fix the issue of a circular reference if libc is set to Picolibc <https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/ne/newlib/package.nix>. Hopefully resolves part of the on/off/closed WIP @ #509186

closes #545713 closes #546709 (if it isn’t merged)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.