### PR TITLE
qman: a few minor improvements

### DIFF
--- a/pkgs/by-name/qm/qman/package.nix
+++ b/pkgs/by-name/qm/qman/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  runtimeShell,
   man-db,
   groff,
   xdg-utils,
@@ -34,8 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   postPatch = ''
-    substituteInPlace src/qman_tests_list.sh \
-      --replace-fail "/usr/bin/env bash" ${runtimeShell}
+    patchShebangs --build src/qman_tests_list.sh
     substituteInPlace src/config_def.py \
       --replace-fail "/usr/bin/man" ${man-db}/bin/man \
       --replace-fail "/usr/bin/groff" ${groff}/bin/groff \

--- a/pkgs/by-name/qm/qman/package.nix
+++ b/pkgs/by-name/qm/qman/package.nix
@@ -17,6 +17,7 @@
   xz,
   cunit,
   nix-update-script,
+  versionCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -62,6 +63,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   mesonFlags = [
     "-Dconfigdir=${placeholder "out"}/etc/xdg/qman"
+  ];
+
+  doInstallCheck = true;
+  versionCheckKeepEnvironment = [
+    "TERM"
+  ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
   ];
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
The PR does a few minor improvements to the `qman` derivation:

  - adds version check
  - switches to `patchShebangs` instead of manual `substituteInPlace`

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
