### PR TITLE
sqlite_modern_cpp: init at 3.2-unstable-2023-12-03

### DIFF
--- a/pkgs/by-name/sq/sqlite-modern-cpp/package.nix
+++ b/pkgs/by-name/sq/sqlite-modern-cpp/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  catch2,
+  cmake,
+  sqlite,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sqlite-modern-cpp";
+  version = "3.2-unstable-2023-12-03";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "SqliteModernCpp";
+    repo = "sqlite_modern_cpp";
+    rev = "6e3009973025e0016d5573529067714201338c80";
+    hash = "sha256-DD1EV3rBWe813TEHpa8nCnwHQjUizB5NOx5uGep5tJc=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    catch2
+    sqlite
+  ];
+
+  strictDeps = true;
+
+  cmakeFlags = [
+    (lib.cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.5")
+    (lib.cmakeBool "HUNTER_ENABLED" false)
+  ];
+
+  doCheck = true;
+
+  dontUseCmakeInstall = true;
+
+  preConfigure = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'find_package(sqlite3 CONFIG REQUIRED)' \
+                     'find_package(SQLite3 REQUIRED)' \
+      --replace-fail 'sqlite3::sqlite3' 'SQLite::SQLite3'
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/include
+    cp -r $src/hdr/. $out/include/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Lightweight C++ wrapper around sqlite3 C api";
+    homepage = "https://github.com/SqliteModernCpp/sqlite_modern_cpp";
+    # no changelog for unstable version, change to
+    # https://github.com/SqliteModernCpp/sqlite_modern_cpp/releases/tag/v${finalAttrs.version}
+    # if there are new releases in the future
+    changelog = "https://github.com/SqliteModernCpp/sqlite_modern_cpp/releases";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tetov ];
+  };
+})


### PR DESCRIPTION
Adding header only library sqlite_modern_cpp with the ultimate goal to replace the vendored headers in [libdjinterop](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/li/libdjinterop/package.nix).

This is a C++ wrapper for sqlite ([upstream](https://github.com/SqliteModernCpp/sqlite_modern_cpp/)).

Commit used is taken from the default branch "dev" since latest tagged release is 9 years old and not compatible with libdjinterop.

CMake builds tests and could be skipped.

Tested with libdjinterop in https://github.com/NixOS/nixpkgs/pull/536693. That PR bumps and adds a patch that introduces CMake flag `SYSTEM_SQLITE_MODERN_CPP`. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
