### PR TITLE
tw: init at 0-unstable-2026-06-23

### DIFF
--- a/pkgs/development/ocaml-modules/alcobar/default.nix
+++ b/pkgs/development/ocaml-modules/alcobar/default.nix
@@ -1,0 +1,49 @@
+{
+  afl-persistent,
+  alcotest,
+  buildDunePackage,
+  calendar,
+  cmdliner,
+  fetchurl,
+  fpath,
+  lib,
+  ocaml,
+  pprint,
+  uucp,
+  uunf,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "alcobar";
+  version = "0.3.1";
+  minimalOCamlVersion = "4.10";
+  __structuredAttrs = true;
+
+  src = fetchurl {
+    url = "https://github.com/samoht/alcobar/releases/download/v${finalAttrs.version}/alcobar-${finalAttrs.version}.tbz";
+    hash = "sha256-V2UnvLrtf+XXkp7uFlrIpxg6+fZqwhCS/J7C3Nw+eVU=";
+  };
+
+  propagatedBuildInputs = [
+    afl-persistent
+    alcotest
+    cmdliner
+  ];
+
+  checkInputs = [
+    calendar
+    fpath
+    pprint
+    uucp
+    uunf
+  ];
+  doCheck = lib.versionAtLeast ocaml.version "5.0";
+
+  meta = {
+    description = "Crowbar with an Alcotest-compatible API";
+    homepage = "https://github.com/samoht/alcobar";
+    changelog = "https://github.com/samoht/alcobar/blob/v${finalAttrs.version}/CHANGES.md";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vog ];
+  };
+})

--- a/pkgs/development/ocaml-modules/cascade/default.nix
+++ b/pkgs/development/ocaml-modules/cascade/default.nix
@@ -1,0 +1,52 @@
+{
+  alcobar,
+  buildDunePackage,
+  dune-build-info,
+  fetchFromGitHub,
+  lambdasoup,
+  lib,
+  logs,
+  mdx,
+  memtrace,
+  psq,
+  uutf,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "cascade";
+  version = "0-unstable-2026-06-26";
+  minimalOCamlVersion = "5.2";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "samoht";
+    repo = "cascade";
+    rev = "434c07be7ec1a63213a234946d57937e4d080feb";
+    hash = "sha256-6g8UKsXdR0PxihrOiMVC36q7+bomMByPDbmuISL7h4U=";
+  };
+
+  propagatedBuildInputs = [
+    dune-build-info
+    logs
+    psq
+    uutf
+  ];
+  buildInputs = [
+    lambdasoup
+    memtrace
+  ];
+
+  nativeCheckInputs = [ mdx.bin ];
+  checkInputs = [
+    (mdx.override { inherit logs; })
+    alcobar
+  ];
+  doCheck = true;
+
+  meta = {
+    description = "CSS generation and manipulation library for OCaml";
+    homepage = "https://github.com/samoht/cascade";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vog ];
+  };
+})

--- a/pkgs/development/ocaml-modules/tw/default.nix
+++ b/pkgs/development/ocaml-modules/tw/default.nix
@@ -1,0 +1,55 @@
+{
+  buildDunePackage,
+  cascade,
+  cmdliner,
+  fetchFromGitHub,
+  fmt,
+  lib,
+  ocaml,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "tw";
+  version = "0-unstable-2026-06-23";
+  minimalOCamlVersion = "5.2";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "samoht";
+    repo = "tw";
+    rev = "594d35df46ec2afcfe97632923331badf2940b93";
+    hash = "sha256-vCRq0FCBIxc/AQg+R2Hig7nqwJGxgy2jedLbAsKaIoA=";
+  };
+
+  propagatedBuildInputs = [ cascade ];
+  buildInputs = [
+    cmdliner
+    fmt
+  ];
+
+  # Disabling tests because they check for byte-for-byte identical
+  # output with tailwindcss, so they are tied to a specific
+  # tailwindcss version, and would prevent independent upgrades of tw
+  # and tailwindcss.
+  doCheck = false;
+
+  outputs = [
+    "bin"
+    "lib"
+    "out"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    dune install --prefix=$bin --libdir=$lib/lib/ocaml/${ocaml.version}/site-lib
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Type-safe Tailwind CSS v4 in OCaml";
+    homepage = "https://github.com/samoht/tw";
+    mainProgram = "tw";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vog ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1213,6 +1213,8 @@ with pkgs;
     )
   );
 
+  tw = ocamlPackages.tw.bin;
+
   wrapRetroArch = retroarch-bare.wrapper;
 
   # Aliases kept here because they are easier to use

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -2191,6 +2191,8 @@ let
 
         tuntap = callPackage ../development/ocaml-modules/tuntap { };
 
+        tw = callPackage ../development/ocaml-modules/tw { };
+
         twt = callPackage ../development/ocaml-modules/twt { };
 
         type_eq = callPackage ../development/ocaml-modules/type_eq { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -24,6 +24,8 @@ let
 
         aeneas = callPackage ../development/ocaml-modules/aeneas { };
 
+        alcobar = callPackage ../development/ocaml-modules/alcobar { };
+
         alcotest = callPackage ../development/ocaml-modules/alcotest { };
 
         alcotest-lwt = callPackage ../development/ocaml-modules/alcotest/lwt.nix { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -245,6 +245,8 @@ let
           git-binary = pkgs.git;
         };
 
+        cascade = callPackage ../development/ocaml-modules/cascade { };
+
         cbor = callPackage ../development/ocaml-modules/cbor { };
 
         cfstream = callPackage ../development/ocaml-modules/cfstream { };


### PR DESCRIPTION
This PR adds the "tw" command line tool, as well as two required OCaml libraries.

See also:

* https://github.com/samoht/tw

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
