### PR TITLE
[staging-next] pango, tk: fix build on darwin

### DIFF
--- a/pkgs/by-name/pa/pango/package.nix
+++ b/pkgs/by-name/pa/pango/package.nix
@@ -154,6 +154,8 @@ stdenv.mkDerivation (finalAttrs: {
       "pangofc"
       "pangoft2"
       "pangoot"
+    ]
+    ++ lib.optionals x11Support [
       "pangoxft"
     ];
   };

--- a/pkgs/by-name/pa/pango/package.nix
+++ b/pkgs/by-name/pa/pango/package.nix
@@ -25,6 +25,8 @@
   buildPackages,
   gobject-introspection,
   testers,
+  # TODO: Clean up on `staging`.
+  llvmPackages,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -58,6 +60,10 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals withIntrospection [
     gi-docgen
     gobject-introspection
+  ]
+  # TODO: Clean up on `staging`.
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    llvmPackages.lld
   ];
 
   buildInputs = [
@@ -83,8 +89,17 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # Fontconfig error: Cannot load default config file
-  env.FONTCONFIG_FILE = makeFontsConf {
-    fontDirectories = [ freefont_ttf ];
+  env = {
+    FONTCONFIG_FILE = makeFontsConf {
+      fontDirectories = [ freefont_ttf ];
+    };
+  }
+  // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    # workaround for ld64 hardening issue
+    #
+    # TODO: Clean up on `staging`
+    CC_LD = "lld";
+    OBJC_LD = "lld";
   };
 
   # Run-time dependency gi-docgen found: NO (tried pkgconfig and cmake)

--- a/pkgs/development/libraries/tk/generic.nix
+++ b/pkgs/development/libraries/tk/generic.nix
@@ -9,6 +9,8 @@
   zlib,
   patches ? [ ],
   enableAqua ? stdenv.hostPlatform.isDarwin,
+  # TODO: Clean up on `staging`.
+  llvmPackages,
   ...
 }:
 
@@ -74,6 +76,10 @@ tcl.mkTclDerivation {
   ++ lib.optionals (lib.versionAtLeast tcl.version "9.0") [
     # Only used to detect the presence of zlib. Could be replaced with a stub.
     zip
+  ]
+  # TODO: Clean up on `staging`.
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    llvmPackages.lld
   ];
   buildInputs = lib.optionals (lib.versionAtLeast tcl.version "9.0") [
     zlib
@@ -89,9 +95,16 @@ tcl.mkTclDerivation {
 
   inherit tcl;
 
-  env = lib.optionalAttrs (lib.versionOlder tcl.version "8.6") {
-    NIX_CFLAGS_COMPILE = "-std=gnu17";
-  };
+  env =
+    lib.optionalAttrs (lib.versionOlder tcl.version "8.6") {
+      NIX_CFLAGS_COMPILE = "-std=gnu17";
+    }
+    // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+      # workaround for ld64 hardening issue
+      #
+      # TODO: Clean up on `staging`
+      NIX_CFLAGS_COMPILE = "-fuse-ld=lld";
+    };
 
   passthru = rec {
     inherit (tcl) release version;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Same problem as in #536363, so fixed the same way. Comments so it's easy to clean up on next staging cycle.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
