### PR TITLE
rust: 1.96.0 -> 1.96.1

### DIFF
--- a/pkgs/development/compilers/rust/1_96.nix
+++ b/pkgs/development/compilers/rust/1_96.nix
@@ -50,8 +50,8 @@ let
 in
 import ./default.nix
   {
-    rustcVersion = "1.96.0";
-    rustcSha256 = "sha256-6QqesVOylIr6yEDb6dd7ZON2cG8oZDh+53F/dFAEO0Q=";
+    rustcVersion = "1.96.1";
+    rustcSha256 = "sha256-0Km1GYxBhoU4rhKvKAZBY1UdBtzOqxHvCxvJqm6Yt6c=";
 
     llvmSharedForBuild = llvmSharedFor pkgsBuildBuild;
     llvmSharedForHost = llvmSharedFor pkgsBuildHost;
@@ -65,27 +65,27 @@ import ./default.nix
     # Note: the version MUST be the same version that we are building. Upstream
     # ensures that each released compiler can compile itself:
     # https://github.com/NixOS/nixpkgs/pull/351028#issuecomment-2438244363
-    bootstrapVersion = "1.96.0";
+    bootstrapVersion = "1.96.1";
 
     # fetch hashes by running `print-hashes.sh ${bootstrapVersion}`
     bootstrapHashes = {
-      i686-unknown-linux-gnu = "1547d452083642c33118cc7fce1697d702ff94fdb4875bf5448fe5b1a6300bbd";
-      x86_64-unknown-linux-gnu = "c1130e4f7976f230766ab062b105b1fb050d6a78177db2246a5878fd6a589680";
-      x86_64-unknown-linux-musl = "545aff63f37dea2fcbd8037b877219fca6fbba97660bdcb8d3a0fc5df5fa9edf";
-      arm-unknown-linux-gnueabihf = "31758cb4175a0b7d2868d149c711ebfbe7b780a9cba5d2f84dce58ddf5a283e4";
-      armv7-unknown-linux-gnueabihf = "737d8ab2ace6107e4a3af4189b0e18f805adcafcc00195d5a377fe33e36577ce";
-      aarch64-unknown-linux-gnu = "20d5ebe3916fe489891fc577574e47fc679cdf62080c1bb1be6b6905ff4e275b";
-      aarch64-unknown-linux-musl = "f55a1f02736d9bcd38969a30f2e6bde8184fd36f13e94f773cac068a56407f16";
-      x86_64-apple-darwin = "ddaf6a98ccc500891a74bcb95807a04c89a0d1ad7b9c58bd7116620ff6f903a8";
-      aarch64-apple-darwin = "d97daf14c5c346c2d5a3271880d5a06d9885ec9af7e1fd2f072986e338526f8c";
-      powerpc64-unknown-linux-gnu = "e49b9fb0671cadef9e5b81871bcfc1dc2c53d7503de7f2d7fa34b7cacc7f62e6";
-      powerpc64le-unknown-linux-gnu = "0a80537d96ea86e6520687fa03841f2dfde2c7154ae4bf517d9664d4f13b0c31";
-      powerpc64le-unknown-linux-musl = "1deb71349f7ba2af27b9f348429fdae1d7841e6ad6c1bfd5fa9e759922fc79c3";
-      riscv64gc-unknown-linux-gnu = "ffdf86a600890771414ada76c711800114501c390631aa7b9c3cbfb94a2f6db3";
-      s390x-unknown-linux-gnu = "d29755bb2292ca25ec35ae1407379132a5d87cd916247e895162b93cb91dc5ae";
-      loongarch64-unknown-linux-gnu = "3a86d71a43f434234d3ac578ef06a5da86fe5c75ac34e9e43f60fe650577bed2";
-      loongarch64-unknown-linux-musl = "6cf0e53ed4678306de34d0f38b934e6dea1b0de56a4f99b725d56be49e1ba8ee";
-      x86_64-unknown-freebsd = "5457c15df17ff963b582b95c55fae3bc3736468e4df765182c75c19b1b6e8e74";
+      i686-unknown-linux-gnu = "9a3ef03fa419d662fbaf9b152a81db96379781771e6853ca06e31215fb177449";
+      x86_64-unknown-linux-gnu = "b177534946e6e5422d8a75398b39625c08eabad675c08bd3d6565d3ba90c8450";
+      x86_64-unknown-linux-musl = "12404d68457d3344877fbba3fde2c68743cd200fc70475451568e18076cc2a3d";
+      arm-unknown-linux-gnueabihf = "c0c4b52bf5614dfcf6b9e94876f97509c71831fc09b8f0f0e228e13ce896ea92";
+      armv7-unknown-linux-gnueabihf = "59320d46850c750b0a0d3e49939c00c3eed9917fab9a633300fb4d04bd8cfebc";
+      aarch64-unknown-linux-gnu = "212cebf45b0669b2176eb08ffa17c90b07f9de2689d6aae3604d78699fa4f5c2";
+      aarch64-unknown-linux-musl = "9e936f24cfd76db8a45ab352919336978531c0fb4eab7a7bdecc76b9562fcbdb";
+      x86_64-apple-darwin = "c19cc27b3387e2dfe7eb4b5becc75ab5acf348b2a7f2142ad3716d93a0abaa2a";
+      aarch64-apple-darwin = "c080e506af9cba3ca9472c17d989c2d8d5bcfc818eb5e196c77beee982788b50";
+      powerpc64-unknown-linux-gnu = "7133e2e1ccf0eb66c4feeca8a2bbf21ad3223904a3459b3f228ff7c8dfc76871";
+      powerpc64le-unknown-linux-gnu = "4cde26acb968f98fdb2f7f52e7f78b75a24afdea38abed7217e1cd02c6acbe06";
+      powerpc64le-unknown-linux-musl = "d20d271134a11b3ba74c1c54fb926ea09f1c629321dcf53fb5d510f1ac1125a6";
+      riscv64gc-unknown-linux-gnu = "b4c54315491239d2a4816535cea22a57ad1021e2529812ccfc938e64c53da276";
+      s390x-unknown-linux-gnu = "17cb4a74048429dc03be326f976b35500c96290af248ed212071bafb4e366762";
+      loongarch64-unknown-linux-gnu = "7f646ab7f798e7258db25286cbaed4fb54cae90afe44efebc7ff6c6120e4d3d9";
+      loongarch64-unknown-linux-musl = "fd8e5e02e5c4bf879a54a31ebc4c24bbd2feb353a54b4e690e1cd04a97c60354";
+      x86_64-unknown-freebsd = "8f5f247b7195a8925c092949c4eea96a6228d67e643dc10d97b1ed7c17e4c433";
     };
 
     selectRustPackage = pkgs: pkgs.rust_1_96;


### PR DESCRIPTION
blog: https://blog.rust-lang.org/releases/1.96.1
changelog: https://github.com/rust-lang/rust/releases/tag/1.96.1
diff: https://github.com/rust-lang/rust/compare/1.96.0...1.96.1

Packages built on x86_64-linux:
- [x] `fd`
- [x] `ripgrep`
- [x] `wezterm`
- [x] `rustfmt`
- [x] `clippy`
- [ ] `firefox` (will run overnight)

The security fixes for libssh2 are not relevant to us, as our cargo uses the Nixpkgs-provided libssh2. (We should make sure we have all those patches though… I don't think we do.)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
