### PR TITLE
fetchCargoVendor: make crates.io URL configurable

### DIFF
--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -465,6 +465,10 @@ also be used:
 * `patches`: patches to apply before vendoring. This is useful when
   the `Cargo.lock`/`Cargo.toml` files need to be patched before
   vendoring.
+* `cratesMirrorUrl`: the mirror used to download crates.io registry
+  tarballs. The download URL is constructed as
+  `${cratesMirrorUrl}/${name}/${version}/download`. When unset (the
+  default), the built-in crates.io mirror is used.
 
 If a `Cargo.lock` file is available, you can alternatively use the
 `importCargoLock` function. In contrast to `fetchCargoVendor`, this

--- a/pkgs/build-support/rust/fetch-cargo-vendor-util.py
+++ b/pkgs/build-support/rust/fetch-cargo-vendor-util.py
@@ -3,6 +3,7 @@ import hashlib
 import json
 import multiprocessing as mp
 import re
+import os
 import shutil
 import subprocess
 import sys
@@ -62,6 +63,17 @@ def download_file_with_checksum(session: requests.Session, url: str, destination
     return checksum
 
 
+# Default crates download mirror. Overridable via the
+# CARGO_VENDOR_CRATES_MIRROR_URL environment variable.
+# Use static.crates.io (CDN) instead of crates.io/api to avoid the 1 req/sec
+# rate limit on the API servers.
+DEFAULT_CRATES_MIRROR_URL = "https://static.crates.io/crates"
+
+
+def get_crates_mirror_url() -> str:
+    return os.environ.get("CARGO_VENDOR_CRATES_MIRROR_URL", DEFAULT_CRATES_MIRROR_URL).rstrip("/")
+
+
 def get_download_url_for_tarball(pkg: dict[str, Any]) -> str:
     # TODO: support other registries
     #       maybe fetch config.json from the registry root and get the dl key
@@ -69,9 +81,7 @@ def get_download_url_for_tarball(pkg: dict[str, Any]) -> str:
     if pkg["source"] != "registry+https://github.com/rust-lang/crates.io-index":
         raise Exception("Only the default crates.io registry is supported.")
 
-    # Use static.crates.io (CDN) instead of crates.io/api to avoid the 1 req/sec
-    # rate limit on the API servers.
-    return f"https://static.crates.io/crates/{pkg["name"]}/{pkg["version"]}/download"
+    return f"{get_crates_mirror_url()}/{pkg["name"]}/{pkg["version"]}/download"
 
 
 def download_tarball(session: requests.Session, pkg: dict[str, Any], out_dir: Path) -> None:

--- a/pkgs/build-support/rust/fetch-cargo-vendor.nix
+++ b/pkgs/build-support/rust/fetch-cargo-vendor.nix
@@ -45,6 +45,7 @@ let
     "version"
     "nativeBuildInputs"
     "hash"
+    "cratesMirrorUrl"
   ];
 
   fetchCargoVendorUtil = writers.writePython3Bin "fetch-cargo-vendor-util" {
@@ -65,6 +66,10 @@ in
   name ? if args ? pname && args ? version then "${args.pname}-${args.version}" else "cargo-deps",
   hash ? (throw "fetchCargoVendor requires a `hash` value to be set for ${name}"),
   nativeBuildInputs ? [ ],
+  # Mirror used to download tarballs. The download URL is constructed as
+  # "${cratesMirrorUrl}/${name}/${version}/download". When null, the default is
+  # used.
+  cratesMirrorUrl ? null,
   ...
 }@args:
 
@@ -106,7 +111,14 @@ let
       outputHashAlgo = if hash == "" then "sha256" else null;
       outputHashMode = "recursive";
     }
-    // removeAttrs args removedArgs
+    // removeAttrs args (removedArgs ++ [ "env" ])
+    // {
+      env =
+        lib.optionalAttrs (cratesMirrorUrl != null) {
+          CARGO_VENDOR_CRATES_MIRROR_URL = cratesMirrorUrl;
+        }
+        // (args.env or { });
+    }
   );
 in
 runCommand "${name}-vendor"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
