### PR TITLE
ruby_3_4: 3.4.9 -> 3.4.10

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -405,8 +405,8 @@ in
   };
 
   ruby_3_4 = generic {
-    version = rubyVersion "3" "4" "9" "";
-    hash = "sha256-e7TU9egHzCclHRTZ1ghtGCxbJYdRkeRKsVtwnNen3Zw=";
+    version = rubyVersion "3" "4" "10" "";
+    hash = "sha256-7O4tByoU8tFDR91W39j+XDEwq/URe/qsvaD075zEKew=";
     cargoHash = "sha256-5Tp8Kth0yO89/LIcU8K01z6DdZRr8MAA0DPKqDEjIt0=";
   };
 


### PR DESCRIPTION
Updates Ruby 3.4 to 3.4.10.

Release notes: https://github.com/ruby/ruby/releases/tag/v3_4_10

Targeting staging because ruby_3_4 is the default ruby in nixpkgs.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests
  - [ ] Package tests
  - [ ] lib/tests
- [ ] Ran `nixpkgs-review`
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits CONTRIBUTING.md and relevant READMEs.
