### PR TITLE
sleuthkit: use finalAttrs.src.name instead of hardcoding `source`

### DIFF
--- a/pkgs/by-name/sl/sleuthkit/package.nix
+++ b/pkgs/by-name/sl/sleuthkit/package.nix
@@ -67,11 +67,11 @@ stdenv.mkDerivation (finalAttrs: {
     export ANT_ARGS="-Doffline=true -Ddefault-jar-location=$IVY_HOME/lib"
 
     # pre-positioning these jar files allows -Doffline=true to work
-    mkdir -p source/{bindings,case-uco}/java $IVY_HOME
-    cp -r ${finalAttrs.rdeps}/bindings/java/lib source/bindings/java
-    chmod -R 755 source/bindings/java
-    cp -r ${finalAttrs.rdeps}/case-uco/java/lib source/case-uco/java
-    chmod -R 755 source/case-uco/java
+    mkdir -p ${finalAttrs.src.name}/{bindings,case-uco}/java $IVY_HOME
+    cp -r ${finalAttrs.rdeps}/bindings/java/lib ${finalAttrs.src.name}/bindings/java
+    chmod -R 755 ${finalAttrs.src.name}/bindings/java
+    cp -r ${finalAttrs.rdeps}/case-uco/java/lib ${finalAttrs.src.name}/case-uco/java
+    chmod -R 755 ${finalAttrs.src.name}/case-uco/java
     cp -r ${finalAttrs.rdeps}/lib $IVY_HOME
     chmod -R 755 $IVY_HOME
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
