### PR TITLE
late-cli: init at 0.33.13

### DIFF
--- a/pkgs/by-name/la/late-cli/package.nix
+++ b/pkgs/by-name/la/late-cli/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "late-cli";
+  version = "0.33.13";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "mpiorowski";
+    repo = "late-sh";
+    tag = "v${finalAttrs.version}-cli";
+    hash = "sha256-D09d4VTyb7qjW+8cQ9DUMdtp+OM47qOmyBmnFb3juHg=";
+  };
+
+  cargoHash = "sha256-JofFkvcd0SMED7RQxPYa8s4cEn55sUDD1vn+waQemm0=";
+
+  cargoBuildFlags = [
+    "--package=late-cli"
+    "--bin=late"
+  ];
+
+  meta = {
+    description = "Companion CLI for late.sh";
+    longDescription = ''
+      late-cli is a companion CLI for late.sh, a cozy terminal cloubhouse for developers.
+      It provides local audio playback, paired controls, and visualizer sync.
+    '';
+    homepage = "https://late.sh";
+    changelog = "https://github.com/mpiorowski/late-sh/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.fsl11Mit;
+    maintainers = with lib.maintainers; [ Br1ght0ne ];
+    mainProgram = "late";
+  };
+})

--- a/pkgs/by-name/la/late-cli/package.nix
+++ b/pkgs/by-name/la/late-cli/package.nix
@@ -2,6 +2,8 @@
   lib,
   fetchFromGitHub,
   rustPlatform,
+  versionCheckHook,
+  nix-update-script,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "late-cli";
@@ -23,10 +25,23 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--bin=late"
   ];
 
+  env.LATE_CLI_VERSION = finalAttrs.version;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--use-github-releases"
+      "--version-regex"
+      "^v([0-9.]+)-cli$"
+    ];
+  };
+
   meta = {
     description = "Companion CLI for late.sh";
     longDescription = ''
-      late-cli is a companion CLI for late.sh, a cozy terminal cloubhouse for developers.
+      late-cli is a companion CLI for late.sh, a cozy terminal clubhouse for developers.
       It provides local audio playback, paired controls, and visualizer sync.
     '';
     homepage = "https://late.sh";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Repo is https://github.com/mpiorowski/late-sh. The CLI is part of the late-sh monorepo, and releases that change the CLI have the `-cli` suffix. The latest release is https://github.com/mpiorowski/late-sh/releases/tag/v0.33.13-cli.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
