### PR TITLE
obsidian-headless: init at 0.0.14

### DIFF
--- a/pkgs/by-name/ob/obsidian-headless/package.nix
+++ b/pkgs/by-name/ob/obsidian-headless/package.nix
@@ -1,0 +1,105 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nodejs,
+  srcOnly,
+  node-gyp,
+  pnpm_11,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  makeWrapper,
+  python3,
+  cctools,
+  versionCheckHook,
+}:
+
+let
+  nodeSources = srcOnly nodejs;
+  pnpm = pnpm_11;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "obsidian-headless";
+  version = "0.0.14";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "obsidianmd";
+    repo = "obsidian-headless";
+    tag = finalAttrs.version;
+    hash = "sha256-ue2M9maFyvabGH9qTDOpAJS4OPwCikpAMYm/M/XRGKo=";
+  };
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      ;
+    inherit pnpm;
+    fetcherVersion = 4;
+    hash = "sha256-xkQHk86msMBs7FXqJNoKdSzB0IxyqfFf6rBnPom4YxU=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    node-gyp
+    pnpmConfigHook
+    pnpm
+    makeWrapper
+    python3
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    cctools.libtool
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pushd node_modules/better-sqlite3
+    npm run build-release --offline "--nodedir=${nodeSources}"
+    mv build/Release/better_sqlite3.node .
+    rm -rf build
+    mkdir -p build/Release
+    mv better_sqlite3.node build/Release/
+    rm -rf deps src # build-only dependencies
+    popd
+
+    rm -rf btime/win32-* # never needed
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/obsidian-headless
+    cp -r cli.js btime node_modules package.json $out/lib/obsidian-headless/
+
+    mkdir -p $out/bin
+    makeWrapper ${lib.getExe nodejs} $out/bin/ob \
+      --add-flags $out/lib/obsidian-headless/cli.js
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  doInstallCheck = true;
+
+  meta = {
+    description = "Headless client for Obsidian Sync and Obsidian Publish";
+    homepage = "https://github.com/obsidianmd/obsidian-headless";
+    changelog = "https://github.com/obsidianmd/obsidian-headless/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.obsidian;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    maintainers = with lib.maintainers; [
+      nadir-ishiguro
+    ];
+    mainProgram = "ob";
+  };
+})


### PR DESCRIPTION
based on https://github.com/NixOS/nixpkgs/pull/508487

Done since then:

 - updated to 0.0.14
 - rev -> tag after upstream released tags
 - `fetcherVersion = 3` -> `fetcherVersion = 4`
 - added versionCheckHook
 - use upstream pnpm lockfile
 - shortened description to one sentence
 - added platforms
 - meta.license.unlicense -> meta.license.obsidian
 - added changelog
 -  added nadir-ishiguro as maintainer
 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
