### PR TITLE
[release-26.05] icinga2: 2.15.1 -> 2.15.5

### DIFF
--- a/pkgs/by-name/ic/icinga2/package.nix
+++ b/pkgs/by-name/ic/icinga2/package.nix
@@ -30,13 +30,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "icinga2${nameSuffix}";
-  version = "2.15.1";
+  version = "2.15.5";
 
   src = fetchFromGitHub {
     owner = "icinga";
     repo = "icinga2";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-w/eD07yzBm3x4G74OuGwkmpBzj63UoklmcKxVi5lx8E=";
+    hash = "sha256-39yGo0pwq+hkpc9re7hOb7HXyWTwsdEMTRWYzZxjAvo=";
   };
 
   patches = [


### PR DESCRIPTION
Explicitly requested by https://github.com/NixOS/nixpkgs/pull/512680#issuecomment-4844055149.

Release notes (latest first):
- https://github.com/Icinga/icinga2/releases/tag/v2.15.5
- https://github.com/Icinga/icinga2/releases/tag/v2.15.4
- https://github.com/Icinga/icinga2/releases/tag/v2.15.3
- https://github.com/Icinga/icinga2/releases/tag/v2.15.2

GitHub security advisories (worse first):
- https://github.com/Icinga/icinga2/security/advisories/GHSA-vj39-ww8j-vvx5
- https://github.com/Icinga/icinga2/security/advisories/GHSA-jgqj-x5j9-vgcm
- https://github.com/Icinga/icinga2/security/advisories/GHSA-wh38-wg57-5w7g


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
