### PR TITLE
neatmail: init at 05-unstable-2026-06-26

### DIFF
--- a/pkgs/by-name/ne/neatmail/package.nix
+++ b/pkgs/by-name/ne/neatmail/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "neatmail";
+  version = "05-unstable-2026-06-26";
+
+  src = fetchFromGitHub {
+    owner = "aligrudi";
+    repo = "neatmail";
+    rev = "5eac6d2640cd7777bb449fec46b242f2116b556b";
+    hash = "sha256-cVQNzDOT6xngzx+M6/GKjdJIg36QqnyolactxtQ3swo=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 mail $out/bin/neatmail
+    install -Dm644 README $out/share/doc/neatmail/README
+
+    runHook postInstall
+  '';
+
+  doCheck = true;
+
+  meta = {
+    description = "A text-mode email client";
+    homepage = "https://github.com/aligrudi/neatmail";
+    mainProgram = "neatmail";
+    platforms = lib.platforms.unix;
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ castorNova2 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Adds [neatmail](https://github.com/aligrudi/neatmail), a non interactive text-mode mail client for working with mbox mailboxes.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
