### PR TITLE
tmuxPlugins.tmux-fzf-links: init at 1.4.16

### DIFF
--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -1076,6 +1076,7 @@ in
       description = "Tmux plugin to open links in fzf";
       license = lib.licenses.mit;
       platforms = lib.platforms.unix;
+      maintainers = with lib.maintainers; [ anned20 ];
     };
   };
 

--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -1061,6 +1061,24 @@ in
     };
   };
 
+  tmux-fzf-links = mkTmuxPlugin {
+    pluginName = "tmux-fzf-links";
+    rtpFilePath = "fzf-links.tmux";
+    version = "1.4.16";
+    src = fetchFromGitHub {
+      owner = "alberti42";
+      repo = "tmux-fzf-links";
+      rev = "1.4.16";
+      hash = "sha256-KzqdB5JmWFUI95iwlB91KH/zrFNhB4RP6DAi4By6KUE=";
+    };
+    meta = {
+      homepage = "https://github.com/alberti42/tmux-fzf-links";
+      description = "Tmux plugin to open links in fzf";
+      license = lib.licenses.mit;
+      platforms = lib.platforms.unix;
+    };
+  };
+
   tmux-powerline = mkTmuxPlugin {
     pluginName = "powerline";
     version = "3.0.0";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add [https://github.com/alberti42/tmux-fzf-links](https://github.com/alberti42/tmux-fzf-links) package as tmuxPlugin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
