### PR TITLE
mdbook-linkcheck2: cleanup, enable tests, and propagate cacert

### DIFF
--- a/pkgs/by-name/md/mdbook-linkcheck2/package.nix
+++ b/pkgs/by-name/md/mdbook-linkcheck2/package.nix
@@ -43,6 +43,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       scandiravian
+      stepbrobd
     ];
   };
 })

--- a/pkgs/by-name/md/mdbook-linkcheck2/package.nix
+++ b/pkgs/by-name/md/mdbook-linkcheck2/package.nix
@@ -2,25 +2,39 @@
   lib,
   fetchFromGitHub,
   rustPlatform,
-  testers,
-  mdbook-linkcheck2,
+  cacert,
+  versionCheckHook,
+  nix-update-script,
 }:
+
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "mdbook-linkcheck2";
   version = "0.12.2";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "marxin";
     repo = "mdbook-linkcheck2";
     tag = "v${finalAttrs.version}";
-    sha256 = "sha256-D0pteKtmBDkqcaonbNzL6tyo97x+qQhn6oY88+4VGFE=";
+    hash = "sha256-D0pteKtmBDkqcaonbNzL6tyo97x+qQhn6oY88+4VGFE=";
   };
 
   cargoHash = "sha256-XY1epCro/BqHm95HVP1eK0oVLSPYjD2hU7IdiEkgNMM=";
 
-  doCheck = false; # tries to access network to test broken web link functionality
+  propagatedNativeBuildInputs = [ cacert ];
 
-  passthru.tests.version = testers.testVersion { package = mdbook-linkcheck2; };
+  checkFlags = map (t: "--skip=${t}") [
+    "check_all_links_in_a_valid_book"
+    "correctly_find_broken_links"
+  ];
+
+  # see https://github.com/NixOS/nixpkgs/pull/531531#pullrequestreview-4492334034
+  # should be dropped in the next update
+  doInstallCheck = false;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Backend for mdbook which will check your links for you";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

follow up https://github.com/NixOS/nixpkgs/pull/531531

and propagate cacert ref https://github.com/nix-community/colmena/pull/341

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
