### PR TITLE
firefoxpwa-unwrapped: 2.18.2 -> 2.18.4

### DIFF
--- a/pkgs/by-name/fi/firefoxpwa-unwrapped/package.nix
+++ b/pkgs/by-name/fi/firefoxpwa-unwrapped/package.nix
@@ -16,13 +16,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "firefoxpwa-unwrapped";
-  version = "2.18.2";
+  version = "2.18.4";
 
   src = fetchFromGitHub {
     owner = "filips123";
     repo = "PWAsForFirefox";
     rev = "v${version}";
-    hash = "sha256-eNJKR6dmG4dDKwvWjC0Nbzk5ixNJtnRXjWJgxc9W5i8=";
+    hash = "sha256-Rz0H6dpeTnKHRnmBUZicjgzRSrcpamuGDJRw/lqD/7k=";
   };
 
   sourceRoot = "${src.name}/native";


### PR DESCRIPTION
 Update the PWAsForFirefox native component from 2.18.2 to 2.18.4.

   2.18.3 and 2.18.4 fix Firefox 152 compatibility issues:
   - https://github.com/filips123/PWAsForFirefox/releases/tag/v2.18.3
   - https://github.com/filips123/PWAsForFirefox/releases/tag/v2.18.4

   Closes #536843.

   Assisted-by: pi coding agent / Mika (OpenAI GPT-5.5)

   ## Things done

   <!-- Please check what applies. Note that these are not hard requirements but merely
 serve as information for reviewers. -->

   - Built on platform:
     - [x] x86_64-linux
     - [ ] aarch64-linux
     - [ ] aarch64-darwin
   - Tested, as applicable:
     - [x] [NixOS tests] in [nixos/tests].
     - [ ] [Package tests] at `passthru.tests`.
     - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
   - [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
   - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
   - Nixpkgs Release Notes
     - [ ] Package update: when the change is major or breaking.
   - NixOS Release Notes
     - [ ] Module addition: when adding a new NixOS module.
     - [ ] Module update: when the change is significant.
   - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other
 READMEs.
   - [x] Follows the [automation/AI policy].

   [NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
   [Package tests]:
 https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
   [nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

   [CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
   [automation/AI policy]:
 https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
   [lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
   [maintainers/README.md]:
 https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
   [nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
   [pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
   [pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test