### PR TITLE
tlp: 1.9.1 -> 1.10.2

### DIFF
--- a/pkgs/by-name/tl/tlp-pd/package.nix
+++ b/pkgs/by-name/tl/tlp-pd/package.nix
@@ -18,7 +18,6 @@ python3Packages.buildPythonApplication {
 
   dependencies = with python3Packages; [
     pygobject3
-    dbus-python
   ];
 
   makeFlags = [ "DESTDIR=${placeholder "out"}" ];

--- a/pkgs/tools/misc/tlp/default.nix
+++ b/pkgs/tools/misc/tlp/default.nix
@@ -30,13 +30,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "tlp";
-  version = "1.9.1";
+  version = "1.10.2";
 
   src = fetchFromGitHub {
     owner = "linrunner";
     repo = "TLP";
     rev = version;
-    hash = "sha256-23B+KV0VrvfSneKIFB9sm9iZZm8uZRk+r60W13++J4g=";
+    hash = "sha256-/xTg53eJ+AKrlG++nQGLsosaWzg1JrwGIGB2+h0MZDI=";
   };
 
   # XXX: See patch files for relevant explanations.

--- a/pkgs/tools/misc/tlp/patches/0001-makefile-correctly-sed-paths.patch
+++ b/pkgs/tools/misc/tlp/patches/0001-makefile-correctly-sed-paths.patch
@@ -22,8 +22,8 @@ diff --git a/Makefile b/Makefile
 index 41eb38d..df3abb7 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -57,17 +57,17 @@ _VAR     = $(DESTDIR)$(TLP_VAR)
- 
+@@ -70,16 +70,16 @@
+
  SED = sed \
  	-e "s|@TLPVER@|$(TLPVER)|g" \
 -	-e "s|@TLP_SBIN@|$(TLP_SBIN)|g" \
@@ -41,11 +41,10 @@ index 41eb38d..df3abb7 100644
 -	-e "s|@TLP_CONFDEF@|$(TLP_CONFDEF)|g" \
 -	-e "s|@TLP_CONFREN@|$(TLP_CONFREN)|g" \
 -	-e "s|@TLP_CONFDPR@|$(TLP_CONFDPR)|g" \
--	-e "s|@TLP_CONF@|$(TLP_CONF)|g" \
 +	-e "s|@TLP_CONFDEF@|$(_CONFDEF)|g" \
 +	-e "s|@TLP_CONFREN@|$(_CONFREN)|g" \
 +	-e "s|@TLP_CONFDPR@|$(_CONFDPR)|g" \
-+	-e "s|@TLP_CONF@|$(_CONF)|g" \
+ 	-e "s|@TLP_SDSL@|$(TLP_SDSL)|g" \
  	-e "s|@TLP_RUN@|$(TLP_RUN)|g"   \
  	-e "s|@TLP_VAR@|$(TLP_VAR)|g"
  


### PR DESCRIPTION
Based on https://github.com/NixOS/nixpkgs/pull/515803. Seems like the author
hasn't gotten around to updating it.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
