### PR TITLE
nixos/unifi: open for admin portal when openFirewall is on

### DIFF
--- a/nixos/modules/services/networking/unifi.nix
+++ b/nixos/modules/services/networking/unifi.nix
@@ -134,6 +134,7 @@ in
       allowedTCPPorts = [
         8080 # Port for UAP to inform controller.
         8880 # Port for HTTP portal redirect, if guest portal is enabled.
+        8443 # Port for HTTPS admin ui.
         8843 # Port for HTTPS portal redirect, ditto.
         6789 # Port for UniFi mobile speed test.
       ];


### PR DESCRIPTION
When using the unifi nixos module you quickly get confused because the admin ui portal is never opened. You would expect the port to the admin ui to be opened when you set `openFirewall = true`, but it's only when you inspect the module you realize that you have to manually open that port.

This change opens the admin ui port (`tcp/8443`) when `openFirewall = true`. This is very similar to the proposed fix in #285628, but that replaces port 8843 with 8443 instead. Both ports need to be open.

You might argue that opening the admin port is a security risk, but IMO when you use `openFirewall` the responsibility to secure the software shifts to the user, for example setting it into a management VLAN or creating ACLs for it etc.

This PR closes #285628.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
