### PR TITLE
rocksdb_10_10: init at 10.10.1

### DIFF
--- a/pkgs/by-name/au/autotier/package.nix
+++ b/pkgs/by-name/au/autotier/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   fetchpatch,
   pkg-config,
-  rocksdb,
+  rocksdb_10_10,
   boost,
   fuse3,
   lib45d,
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
   env.EXTRA_CFLAGS = "-std=c++20 -fno-char8_t";
 
   buildInputs = [
-    rocksdb
+    rocksdb_10_10
     boost
     fuse3
     lib45d

--- a/pkgs/by-name/bl/blockstream-electrs/package.nix
+++ b/pkgs/by-name/bl/blockstream-electrs/package.nix
@@ -3,7 +3,7 @@
   electrum,
   fetchFromGitHub,
   lib,
-  rocksdb,
+  rocksdb_10_10,
   rust-jemalloc-sys,
   rustPlatform,
   stdenv,
@@ -34,8 +34,8 @@ rustPlatform.buildRustPackage rec {
 
   env = {
     # Dynamically link rocksdb
-    ROCKSDB_INCLUDE_DIR = "${rocksdb}/include";
-    ROCKSDB_LIB_DIR = "${rocksdb}/lib";
+    ROCKSDB_INCLUDE_DIR = "${rocksdb_10_10}/include";
+    ROCKSDB_LIB_DIR = "${rocksdb_10_10}/lib";
 
     # External binaries for integration tests are provided via nixpkgs. Skip
     # trying to download them.

--- a/pkgs/by-name/ma/matrix-conduit/package.nix
+++ b/pkgs/by-name/ma/matrix-conduit/package.nix
@@ -6,7 +6,7 @@
   sqlite,
   stdenv,
   nixosTests,
-  rocksdb,
+  rocksdb_10_10,
   rust-jemalloc-sys,
 }:
 
@@ -37,12 +37,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
   buildInputs = [
     sqlite
     rust-jemalloc-sys
-    rocksdb
+    rocksdb_10_10
   ];
 
   env = {
-    ROCKSDB_INCLUDE_DIR = "${rocksdb}/include";
-    ROCKSDB_LIB_DIR = "${rocksdb}/lib";
+    ROCKSDB_INCLUDE_DIR = "${rocksdb_10_10}/include";
+    ROCKSDB_LIB_DIR = "${rocksdb_10_10}/lib";
   };
 
   # tests failed on x86_64-darwin with SIGILL: illegal instruction

--- a/pkgs/by-name/ro/rocksdb/package.nix
+++ b/pkgs/by-name/ro/rocksdb/package.nix
@@ -20,18 +20,21 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocksdb";
-  version = "10.10.1";
+  version = "11.1.2";
 
   src = fetchFromGitHub {
     owner = "facebook";
     repo = "rocksdb";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-gszW+YY8ZZ7cRVCIXuahGopqqswNRnagZLUYYmRxzGY=";
+    hash = "sha256-gZ3epZY9gbrX/pzHc4YpoSqWkKcRLlw41ERGNO3UOvg=";
   };
 
   patches = lib.optional (
     lib.versionAtLeast finalAttrs.version "6.29.3" && enableLiburing
   ) ./fix-findliburing.patch;
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   nativeBuildInputs = [
     cmake
@@ -73,9 +76,9 @@ stdenv.mkDerivation (finalAttrs: {
     "-DWITH_GFLAGS=0"
     "-DUSE_RTTI=1"
     "-DROCKSDB_INSTALL_ON_WINDOWS=YES" # harmless elsewhere
-    (lib.optional sse42Support "-DFORCE_SSE42=1")
     "-DFAIL_ON_WARNINGS=NO"
   ]
+  ++ lib.optional sse42Support "-DFORCE_SSE42=1"
   ++ lib.optional (!enableShared) "-DROCKSDB_BUILD_SHARED=0";
 
   # otherwise "cc1: error: -Wformat-security ignored without -Wformat [-Werror=format-security]"
@@ -119,7 +122,7 @@ stdenv.mkDerivation (finalAttrs: {
   postFixup = ''
     if [ -f "$out"/lib/pkgconfig/rocksdb.pc ]; then
       substituteInPlace "$out"/lib/pkgconfig/rocksdb.pc \
-        --replace '="''${prefix}//' '="/'
+        --replace-fail '="''${prefix}//' '="/'
     fi
   '';
 
@@ -131,6 +134,7 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [
       adev
+      debtquity
     ];
   };
 })

--- a/pkgs/by-name/so/solana-agave/package.nix
+++ b/pkgs/by-name/so/solana-agave/package.nix
@@ -17,7 +17,7 @@
   clang,
   llvm,
   llvmPackages,
-  rocksdb,
+  rocksdb_10_10,
   nix-update-script,
 }:
 
@@ -64,7 +64,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     RUSTFLAGS = "--cap-lints warn";
     # Use the pre-built rocksdb from nixpkgs instead of compiling from source.
     # This avoids GCC 13+ compatibility issues with missing <cstdint> includes.
-    ROCKSDB_LIB_DIR = "${rocksdb}/lib";
+    ROCKSDB_LIB_DIR = "${rocksdb_10_10}/lib";
   };
 
   # Disabling tests because:

--- a/pkgs/by-name/so/solana-cli/package.nix
+++ b/pkgs/by-name/so/solana-cli/package.nix
@@ -14,7 +14,7 @@
   clang,
   libclang,
   libusb1,
-  rocksdb,
+  rocksdb_10_10,
   # Taken from https://github.com/anza-xyz/agave/blob/master/scripts/agave-build-lists.sh
   solanaPkgs ? [
     "solana"
@@ -58,7 +58,7 @@ rustPlatform.buildRustPackage rec {
 
     # Used by build.rs in the rocksdb-sys crate. If we don't set these, it would
     # try to build RocksDB from source.
-    ROCKSDB_LIB_DIR = "${rocksdb}/lib";
+    ROCKSDB_LIB_DIR = "${rocksdb_10_10}/lib";
 
     # Require this on darwin otherwise the compiler starts rambling about missing
     # cmath functions

--- a/pkgs/by-name/st/stalwart_0_15/package.nix
+++ b/pkgs/by-name/st/stalwart_0_15/package.nix
@@ -12,7 +12,7 @@
   stdenv,
   nix-update-script,
   nixosTests,
-  rocksdb,
+  rocksdb_10_10,
   callPackage,
   withFoundationdb ? false,
   stalwartEnterprise ? false,
@@ -73,8 +73,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   env = {
     OPENSSL_NO_VENDOR = true;
     ZSTD_SYS_USE_PKG_CONFIG = true;
-    ROCKSDB_INCLUDE_DIR = "${rocksdb}/include";
-    ROCKSDB_LIB_DIR = "${rocksdb}/lib";
+    ROCKSDB_INCLUDE_DIR = "${rocksdb_10_10}/include";
+    ROCKSDB_LIB_DIR = "${rocksdb_10_10}/lib";
   }
   //
     lib.optionalAttrs
@@ -182,7 +182,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   __darwinAllowLocalNetworking = true;
 
   passthru = {
-    inherit rocksdb; # make used rocksdb version available (e.g., for backup scripts)
+    inherit rocksdb_10_10; # make used rocksdb version available (e.g., for backup scripts)
     webadmin = buildPackages.callPackage ./webadmin.nix { };
     spam-filter = callPackage ./spam-filter.nix { };
     updateScript = nix-update-script { };

--- a/pkgs/by-name/st/stalwart_0_16/package.nix
+++ b/pkgs/by-name/st/stalwart_0_16/package.nix
@@ -11,7 +11,7 @@
   zstd,
   stdenv,
   nix-update-script,
-  rocksdb,
+  rocksdb_10_10,
   callPackage,
   python3Packages,
   cacert,
@@ -69,8 +69,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     OPENSSL_DIR = lib.getDev openssl;
     OPENSSL_LIB_DIR = "${lib.getLib openssl}/lib";
     ZSTD_SYS_USE_PKG_CONFIG = true;
-    ROCKSDB_INCLUDE_DIR = "${rocksdb}/include";
-    ROCKSDB_LIB_DIR = "${rocksdb}/lib";
+    ROCKSDB_INCLUDE_DIR = "${rocksdb_10_10}/include";
+    ROCKSDB_LIB_DIR = "${rocksdb_10_10}/lib";
   }
   //
     lib.optionalAttrs
@@ -268,7 +268,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   passthru = {
-    inherit rocksdb; # make used rocksdb version available (e.g., for backup scripts)
+    inherit rocksdb_10_10; # make used rocksdb version available (e.g., for backup scripts)
     webui = callPackage ./webui.nix { };
     spam-filter = callPackage ./spam-filter.nix { };
     updateScript = nix-update-script { };

--- a/pkgs/by-name/su/surrealdb/package.nix
+++ b/pkgs/by-name/su/surrealdb/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   pkg-config,
   openssl,
-  rocksdb,
+  rocksdb_10_10,
   testers,
   protobuf,
   backend ? "rocksdb",
@@ -57,8 +57,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     PROTOC_INCLUDE = "${protobuf}/include";
   }
   // lib.optionalAttrs hasRocksDB {
-    ROCKSDB_INCLUDE_DIR = "${rocksdb}/include";
-    ROCKSDB_LIB_DIR = "${rocksdb}/lib";
+    ROCKSDB_INCLUDE_DIR = "${rocksdb_10_10}/include";
+    ROCKSDB_LIB_DIR = "${rocksdb_10_10}/lib";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ze/zenoh-backend-filesystem/package.nix
+++ b/pkgs/by-name/ze/zenoh-backend-filesystem/package.nix
@@ -5,7 +5,7 @@
   pkg-config,
   bzip2,
   zstd,
-  rocksdb,
+  rocksdb_10_10,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -32,8 +32,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   env = {
-    ROCKSDB_INCLUDE_DIR = "${rocksdb}/include";
-    ROCKSDB_LIB_DIR = "${rocksdb}/lib";
+    ROCKSDB_INCLUDE_DIR = "${rocksdb_10_10}/include";
+    ROCKSDB_LIB_DIR = "${rocksdb_10_10}/lib";
     ZSTD_SYS_USE_PKG_CONFIG = true;
   };
 

--- a/pkgs/by-name/ze/zenoh-backend-rocksdb/package.nix
+++ b/pkgs/by-name/ze/zenoh-backend-rocksdb/package.nix
@@ -5,7 +5,7 @@
   pkg-config,
   bzip2,
   zstd,
-  rocksdb,
+  rocksdb_10_10,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -32,8 +32,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   env = {
-    ROCKSDB_INCLUDE_DIR = "${rocksdb}/include";
-    ROCKSDB_LIB_DIR = "${rocksdb}/lib";
+    ROCKSDB_INCLUDE_DIR = "${rocksdb_10_10}/include";
+    ROCKSDB_LIB_DIR = "${rocksdb_10_10}/lib";
     ZSTD_SYS_USE_PKG_CONFIG = true;
   };
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1973,6 +1973,9 @@ mapAliases {
   rl_json = throw "'rl_json' has been renamed to/replaced by 'tclPackages.rl_json'"; # Converted to throw 2025-10-27
   rockbox_utility = throw "'rockbox_utility' has been renamed to/replaced by 'rockbox-utility'"; # Converted to throw 2025-10-27
   rockcraft = throw "rockcraft was removed in Sep 25 following removal of LXD from nixpkgs"; # Added 2025-09-18
+  rocksdb_6_23 = throw "rocksdb_6_23 has been removed from nixpkgs, use `rocksdb` or build this version from source"; # Added 2026-06-30
+  rocksdb_7_10 = throw "rocksdb_7_10 has been removed from nixpkgs, use `rocksdb` or build this version from source"; # Added 2026-06-30
+  rocksdb_8_11 = throw "rocksdb_8_11 has been removed from nixpkgs, use `rocksdb` or build this version from source"; # Added 2026-06-30
   rofi-emoji-wayland = throw "'rofi-emoji-wayland' has been merged into `rofi-emoji as 'rofi-wayland' has been merged into 'rofi'"; # Added 2025-09-06
   rofi-wayland = throw "'rofi-wayland' has been merged into 'rofi'"; # Added 2025-09-06
   rofi-wayland-unwrapped = throw "'rofi-wayland-unwrapped' has been merged into 'rofi-unwrapped'"; # Added 2025-09-06

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6660,6 +6660,17 @@ with pkgs;
 
   reposilitePlugins = recurseIntoAttrs (callPackage ../by-name/re/reposilite/plugins.nix { });
 
+  rocksdb_10_10 = rocksdb.overrideAttrs rec {
+    pname = "rocksdb";
+    version = "10.10.1";
+    src = fetchFromGitHub {
+      owner = "facebook";
+      repo = pname;
+      rev = "v${version}";
+      hash = "sha256-gszW+YY8ZZ7cRVCIXuahGopqqswNRnagZLUYYmRxzGY=";
+    };
+  };
+
   rocksdb_9_10 = rocksdb.overrideAttrs rec {
     pname = "rocksdb";
     version = "9.10.0";
@@ -6671,17 +6682,6 @@ with pkgs;
     };
   };
 
-  rocksdb_8_11 = rocksdb.overrideAttrs rec {
-    pname = "rocksdb";
-    version = "8.11.4";
-    src = fetchFromGitHub {
-      owner = "facebook";
-      repo = pname;
-      rev = "v${version}";
-      hash = "sha256-ZrU7G3xeimF3H2LRGBDHOq936u5pH/3nGecM4XEoWc8=";
-    };
-  };
-
   rocksdb_8_3 = rocksdb.overrideAttrs rec {
     pname = "rocksdb";
     version = "8.3.2";
@@ -6690,28 +6690,6 @@ with pkgs;
       repo = pname;
       rev = "v${version}";
       hash = "sha256-mfIRQ8nkUbZ3Bugy3NAvOhcfzFY84J2kBUIUBcQ2/Qg=";
-    };
-  };
-
-  rocksdb_7_10 = rocksdb.overrideAttrs rec {
-    pname = "rocksdb";
-    version = "7.10.2";
-    src = fetchFromGitHub {
-      owner = "facebook";
-      repo = pname;
-      rev = "v${version}";
-      hash = "sha256-U2ReSrJwjAXUdRmwixC0DQXht/h/6rV8SOf5e2NozIs=";
-    };
-  };
-
-  rocksdb_6_23 = rocksdb.overrideAttrs rec {
-    pname = "rocksdb";
-    version = "6.23.3";
-    src = fetchFromGitHub {
-      owner = "facebook";
-      repo = pname;
-      rev = "v${version}";
-      hash = "sha256-SsDqhjdCdtIGNlsMj5kfiuS3zSGwcxi4KV71d95h7yk=";
     };
   };
 


### PR DESCRIPTION
* add alias for rocksdb_10_10
* remove unused rocksdb_* package entries (rocksdb_6_23, rocksdb_7_10,
  rocksdb_8_11)
* add `throws` for removed rocksdb packages

Related to: #536878

---
{autotier|matrix-conduit|solana-cli|stalwart_0_15|stalwart_0_16|surrealdb|zenoh-backend-filesystem|zenoh-backend-rocksdb}: update rocksdb dependency

* pin rocksdb to `rocksdb_10_10`

Related to: #536878

---

rocksdb: 10.10.1 -> 11.1.2 

* add self to maintainer list
* diff: facebook/rocksdb@v10.10.1...v11.1.2
* changelog: https://github.com/facebook/rocksdb/releases/tag/v11.1.2

Resolves: #536878
Supercedes: #507793
Supercedes: #536573

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
