### PR TITLE
rustplatform.cargoSetupHook: force common system libs

### DIFF
--- a/pkgs/build-support/rust/hooks/cargo-setup-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-setup-hook.sh
@@ -86,6 +86,61 @@ cargoSetupPostPatchHook() {
     echo "Finished cargoSetupPostPatchHook"
 }
 
+cargoUseSystemLibs() {
+  # Sentinel directory that doesn't exist. For packages
+  # Where you tell it directories, but can't force it to only
+  # use system libraries
+  #
+  # Note that this isn't perfect, as some have fallbacks if their probing fails.
+  local -r sentinel_dir="$(mktemp -du nixpkgs.XXXX)/use/system/library"
+
+  # https://docs.rs/system-deps/8.0.0/system_deps/#internally-build-system-libraries
+  SYSTEM_DEPS_BUILD_INTERNAL="never"
+
+  # https://github.com/aws/aws-lc-rs/blob/741dbf573a64b6a1e1e6b7c1131a0f8153a28441/aws-lc-sys/README.md#automatic-detection
+  export AWS_LC_SYS_USE_SYSTEM="1"
+
+  # https://github.com/rust-openssl/rust-openssl/blob/b46d5ec06144795e8f9e118c44bebd392956917a/openssl-sys/build/main.rs#L53
+  export OPENSSL_NO_VENDOR="1"
+
+  # 1 = Links statically to the vendored one
+  # 0 = Use pkg-config
+  # https://github.com/rust-lang/libz-sys/blob/2ce3271849d85329b668e0bac9f21427ecf8aef9/build.rs#L256
+  export LIBZ_SYS_STATIC="0"
+
+  # https://github.com/rusqlite/rusqlite/blob/db83b9b08d9cab73f912501eefb8df7b100acd7d/libsqlite3-sys/build.rs#L53
+  export LIBSQLITE3_SYS_USE_PKG_CONFIG="1"
+
+  # https://github.com/gyscos/zstd-rs/blob/ad18ca4e275aed9acc3087d7c1c65d03ab67ad6e/zstd-safe/zstd-sys/build.rs#L279
+  export ZSTD_SYS_USE_PKG_CONFIG="1"
+
+  # https://github.com/rust-lang/git2-rs/blob/a00922bcdf0f78419aa5dd0d3643e73ce01672a8/libgit2-sys/build.rs#L95
+  export LIBGIT2_NO_VENDOR="1"
+
+  # https://github.com/sodiumoxide/sodiumoxide/blob/3057acb1a030ad86ed8892a223d64036ab5e8523/libsodium-sys/build.rs#L34
+  export SODIUM_USE_PKG_CONFIG="1"
+
+  # https://github.com/rust-onig/rust-onig/blob/73e63eb3eea6d93d24a4aadf7fea580287750c7d/onig_sys/build.rs#L250
+  export RUSTONIG_SYSTEM_LIBONIG="1"
+
+  # We can only supply the src dir.
+  # https://github.com/nginx/ngx-rust/tree/main/nginx-sys#input-variables
+  # Since we don't want to pull it in for every build, we set it to a dummy value
+  # in all builds, but lets the user set it via `env.NGINX_SOURCE_DIR = nginx.src`
+  export NGINX_SOURCE_DIR="${NGINX_SOURCE_DIR:-"$sentinel_dir/nginx/src"}"
+
+  # We can only supply the lib and include dirs
+  # https://github.com/duckdb/duckdb-rs/blob/ea700a79534c8e8c22a9ac685135f15c31de91d3/crates/libduckdb-sys/build.rs#L203
+  # Set to sentinel by default again
+  # There is also a DUCKDB_LIB_DIR var, but I think only one needs to be set.
+  export DUCKDB_DOWNLOAD_LIB="0"
+  export DUCKDB_INCLUDE_DIR="${DUCKDB_INCLUDE_DIR:-"$sentinel_dir/duckdb/include"}"
+}
+
+if [[ -z "${dontCargoUseSystemLibs-}" ]]; then
+  preConfigureHook+=(cargoUseSystemLibs)
+fi
+
 if [ -z "${dontCargoSetupPostUnpack-}" ]; then
   postUnpackHooks+=(cargoSetupPostUnpackHook)
 fi


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

> [!IMPORTANT]  
> Do not let this PR be merged before adding a release note
> Since release-notes this early in the release cycle are annoying I will add it right before merging. Or a committer can add a commit doing so. 

## Things done

We want to use system libraries as often as possible. This forces certain common libraries to fail to build if in the tree, and not using system libraries. This is done by setting environement variables that either:

1. Force to use system libs
2. Set directories to dummy sentinels

The first is generally easy, as probing usually occurs via `pkg-config`, so you just do the same thing as any other package: add pkg-config to `nativeBuildInputs`, then add your library to `buildInputs`.

The second is slightly weirder as it is ad-hoc per Rust crate. You need to set vars for lib/include/src for each package in the environment with whatever variable it wants. 

I selected the libraries by going on crates.io, searching "-sys", and going through the first few pages. 

I will add a release note before merging as I don't really want to deal with release-notes through the review cycle. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
