### PR TITLE
postgresqlPackages.vectorchord: fix build with rustc 1.96

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/vectorchord/0001-build-fix-target-features-for-rustc-1.96.patch
+++ b/pkgs/servers/sql/postgresql/ext/vectorchord/0001-build-fix-target-features-for-rustc-1.96.patch
@@ -1,0 +1,26 @@
+From 47ddb993b550a2b41a8b97397c6b1c8ec27b66f2 Mon Sep 17 00:00:00 2001
+From: Yaroslav Bolyukin <iam@lach.pw>
+Date: Tue, 30 Jun 2026 18:01:55 +0200
+Subject: [PATCH] build: fix target features for rustc 1.96
+
+Signed-off-by: Yaroslav Bolyukin <iam@lach.pw>
+---
+ crates/simd_macros/src/target.rs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/crates/simd_macros/src/target.rs b/crates/simd_macros/src/target.rs
+index 0f3c60c..e11262b 100644
+--- a/crates/simd_macros/src/target.rs
++++ b/crates/simd_macros/src/target.rs
+@@ -23,7 +23,7 @@ pub const TARGET_CPUS: &[TargetCpu] = &[
+         target_cpu: "v4",
+         target_arch: "x86_64",
+         target_features: &[
+-            "avx512bw", "avx512cd", "avx512dq", "avx512vl", // simd
++            "avx512f", "avx512bw", "avx512cd", "avx512dq", "avx512vl", // simd
+             "bmi1", "bmi2", "lzcnt", "movbe", "popcnt", // bit-operations
+         ],
+     },
+-- 
+2.54.0
+

--- a/pkgs/servers/sql/postgresql/ext/vectorchord/package.nix
+++ b/pkgs/servers/sql/postgresql/ext/vectorchord/package.nix
@@ -23,6 +23,11 @@ buildPgrxExtension (finalAttrs: {
 
   cargoHash = "sha256-IXOCzKJArNOcb/2TcJbLz1XdCquUpyF/cLHYU5vmlko=";
 
+  patches = [
+    # Build is broken with rustc 1.96, upstream fix PR: https://github.com/supervc-stack/VectorChord/pull/467
+    ./0001-build-fix-target-features-for-rustc-1.96.patch
+  ];
+
   # Include upgrade scripts in the final package
   # https://github.com/supervc-stack/VectorChord/blob/0.5.0/crates/make/src/main.rs#L366
   postInstall = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Build fails on rustc 1.96, fix submitted upstream: https://github.com/supervc-stack/VectorChord/pull/467

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
