### PR TITLE
lizzieyzy: init at 2.5.3

### DIFF
--- a/pkgs/by-name/li/lizzieyzy/package.nix
+++ b/pkgs/by-name/li/lizzieyzy/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  jre,
+  maven,
+}:
+
+maven.buildMavenPackage (finalAttrs: {
+  pname = "lizzieyzy";
+  version = "2.5.3";
+
+  src = fetchFromGitHub {
+    owner = "yzyray";
+    repo = "lizzieyzy";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-CVRJww1wNO9Ofpq7tu1SpcNL0c4WryhbMeLr2vH6IjQ=";
+  };
+
+  mvnHash = "sha256-07i0HLG00utWEpOF6F1g3pK0yN0QSzZo5ZNBbQgfuPY=";
+
+  nativeBuildInputs = [
+    maven
+    makeBinaryWrapper
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/lizzieyzy
+    install -Dm644 target/lizzie-yzy${finalAttrs.version}.jar $out/share/lizzieyzy/lizzie-yzy.jar
+    install -Dm644 target/lizzie-yzy${finalAttrs.version}-shaded.jar $out/share/lizzieyzy/lizzie-yzy-shaded.jar
+
+    makeWrapper ${jre}/bin/java $out/bin/lizzieyzy \
+      --add-flags "-jar $out/share/lizzieyzy/lizzie-yzy-shaded.jar"
+
+    runHook postInstall
+  '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    description = "LizzieYzy is a GUI for Game of Go";
+    mainProgram = "lizzieyzy";
+    longDescription = ''
+      LizzieYzy is a graphical interface that supports multiple Go Engines such
+      as Katago, LeelaZero, Leela, ZenGTP, SAI, Pachi or other GTP engines.
+    '';
+    homepage = "https://github.com/yzyray/lizzieyzy/";
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+    ];
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [
+      omnipotententity
+    ];
+    inherit (jre.meta) platforms;
+  };
+})


### PR DESCRIPTION
Adds LizzieYzy as a package, which is a GUI for the game of Go that interfaces with various Go Engines (some of which are also packaged in NixPkgs).

This is a fairly popular GUI for Go, and tends to be used more in Asia than other alternatives (such as Katrain, Sabaki, and Ogatak).

[Homepage](https://github.com/yzyray/lizzieyzy/tree/main)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].