### PR TITLE
lumen: add `fzf` and `mdcat` to `PATH`

### DIFF
--- a/pkgs/by-name/lu/lumen/package.nix
+++ b/pkgs/by-name/lu/lumen/package.nix
@@ -2,8 +2,11 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  makeWrapper,
   pkg-config,
   openssl,
+  fzf,
+  mdcat,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -26,9 +29,21 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # use the non-vendored openssl
   env.OPENSSL_NO_VENDOR = 1;
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    makeWrapper
+    pkg-config
+  ];
 
   buildInputs = [ openssl ];
+
+  postFixup = ''
+    wrapProgram $out/bin/lumen --prefix PATH : ${
+      lib.makeBinPath [
+        fzf
+        mdcat
+      ]
+    }
+  '';
 
   # tests that require a git repository to run
   checkFlags = [


### PR DESCRIPTION
these are optional dependencies that can be used by the app :)

See https://github.com/jnsahaj/lumen#prerequisites

> # Prerequisites
> 
> Before you begin, ensure you have:
> 
> 1. git installed on your system
> 1. [fzf](https://github.com/junegunn/fzf) (optional) - Required for lumen explain --list command
> 1. [mdcat](https://github.com/swsnr/mdcat) (optional) - Required for pretty output formatting

I decided to leave git out because, well, you're probably not installing this without having git?

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
