### PR TITLE
ark-pixel-font: use buildPythonApplication and default python3

### DIFF
--- a/pkgs/by-name/ar/ark-pixel-font/package.nix
+++ b/pkgs/by-name/ar/ark-pixel-font/package.nix
@@ -5,7 +5,7 @@
   nix-update-script,
 }:
 
-python312Packages.buildPythonPackage rec {
+python312Packages.buildPythonApplication rec {
   pname = "ark-pixel-font";
   version = "2025.08.24";
   pyproject = false;

--- a/pkgs/by-name/ar/ark-pixel-font/package.nix
+++ b/pkgs/by-name/ar/ark-pixel-font/package.nix
@@ -1,11 +1,11 @@
 {
   lib,
-  python312Packages,
+  python3Packages,
   fetchFromGitHub,
   nix-update-script,
 }:
 
-python312Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "ark-pixel-font";
   version = "2025.08.24";
   pyproject = false;
@@ -17,7 +17,7 @@ python312Packages.buildPythonApplication rec {
     hash = "sha256-kxct994UmZhJBMlXZmayN24eiKqeG9T7GdyfsjBYpn0=";
   };
 
-  dependencies = with python312Packages; [
+  dependencies = with python3Packages; [
     pixel-font-builder
     pixel-font-knife
     unidata-blocks


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
