### PR TITLE
ioping: Fix cross compilation

### DIFF
--- a/pkgs/by-name/io/ioping/package.nix
+++ b/pkgs/by-name/io/ioping/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  pkgsCross,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -15,12 +16,19 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-9lJEjns8ttjgI52ZXeWgL77GMd7o7IvefBJ5UH9y9ks=";
   };
 
-  makeFlags = [ "PREFIX=$(out)" ];
+  makeFlags = [
+    "PREFIX=$(out)"
+    "CC:=$(CC)"
+  ];
 
   outputs = [
     "out"
     "man"
   ];
+
+  passthru.tests = {
+    aarch64-cross = pkgsCross.aarch64-multiplatform.ioping;
+  };
 
   meta = {
     description = "Disk I/O latency measuring tool";


### PR DESCRIPTION
Cross compilation was broken from x86_64 -> aarch64.

```
$> nix log /nix/store/x0vp7klvm918i4fh2xy13kgxvfxa6vhh-ioping-aarch64-unknown-linux-gnu-1.3.drv
copying path '/nix/store/0vk8b4p3p7djn86s68xszhwpwb89av0l-libgcc-aarch64-unknown-linux-gnu-15.2.0' from 'https://cache.nixos.org'...
copying path '/nix/store/i0caqqa6v8qywsna1cz220rzlfhb2q8x-linux-headers-6.18.7' from 'https://cache.nixos.org'...
copying path '/nix/store/sa0593q2whb4bgmwjvxwczpj526y6l5x-aarch64-unknown-linux-gnu-binutils-2.46' from 'https://cache.nixos.org'...
copying path '/nix/store/7i3dinwln3r2rq8yfzjqsvrdqr1a4d9a-gnu-config-2024-01-01' from 'https://cache.nixos.org'...
copying path '/nix/store/qpxfhz32726i8ds1356hy9bxl896pzqg-update-autotools-gnu-config-scripts-hook' from 'https://cache.nixos.org'...
copying path '/nix/store/r1sdgcf4zwv0v0bzz1nyfh19i0y6yhx3-glibc-aarch64-unknown-linux-gnu-2.42-67' from 'https://cache.nixos.org'...
copying path '/nix/store/achn9gvarnpay971hsvc0d8pyq9izd6y-aarch64-unknown-linux-gnu-gcc-15.2.0-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/k9jms64ib75gc6k7pgyaca2hjin726d5-glibc-aarch64-unknown-linux-gnu-2.42-67-bin' from 'https://cache.nixos.org'...
copying path '/nix/store/2xzifm4c0h9d0yv91az0v1c0bxd14h23-glibc-aarch64-unknown-linux-gnu-2.42-67-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/pqv89b50bbcpzkg4nc40vzvallfgwjkb-aarch64-unknown-linux-gnu-binutils-wrapper-2.46' from 'https://cache.nixos.org'...
copying path '/nix/store/3cnp8nvl7j2q1d4fbljiirmnb24qdvhx-aarch64-unknown-linux-gnu-gcc-15.2.0' from 'https://cache.nixos.org'...
copying path '/nix/store/h9521w3mldf00p2zfr76w5qhhp7rfmly-aarch64-unknown-linux-gnu-gcc-wrapper-15.2.0' from 'https://cache.nixos.org'...
copying path '/nix/store/x93ybh3d28isxdc4c1icgy4s4gncdlfx-stdenv-linux' from 'https://cache.nixos.org'...
Running phase: unpackPhase
unpacking source archive /nix/store/787vs5bsd9j8cqghmnz4dh85v14di419-source
source root is source
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
no configure script, doing nothing
Running phase: buildPhase
build flags: SHELL=/nix/store/zh1ijdhb6gng1509b1zrilb6xlzx60j6-bash-5.3p9/bin/bash PREFIX=\$\(out\)
/nix/store/zh1ijdhb6gng1509b1zrilb6xlzx60j6-bash-5.3p9/bin/bash: line 1: gcc: command not found
/nix/store/zh1ijdhb6gng1509b1zrilb6xlzx60j6-bash-5.3p9/bin/bash: line 1: gcc: command not found
gcc -o ioping ioping.c -DEXTRA_VERSION=\"\" -g -O2 -funroll-loops -ftree-vectorize -std=gnu99 -Wall -Wextra -pedantic  -lm -lrt
/nix/store/zh1ijdhb6gng1509b1zrilb6xlzx60j6-bash-5.3p9/bin/bash: line 1: gcc: command not found
make: *** [Makefile:96: ioping] Error 127
```

This PR fixes the cross build by overriding the CC make flag in the derivation to properly specify the compiler needed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
