### PR TITLE
rebased: init at 1.1.5

### DIFF
--- a/pkgs/by-name/re/rebased/package.nix
+++ b/pkgs/by-name/re/rebased/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenv,
+  appimageTools,
+  fetchurl,
+  makeDesktopItem,
+  git,
+}:
+
+let
+  pname = "rebased";
+  version = "1.1.5";
+
+  src = fetchurl {
+    url =
+      {
+        x86_64-linux = "https://github.com/DetachHead/rebased/releases/download/${version}/Rebased-x86_64.AppImage";
+        aarch64-linux = "https://github.com/DetachHead/rebased/releases/download/${version}/Rebased-aarch64.AppImage";
+      }
+      .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+    hash =
+      {
+        x86_64-linux = "sha256-AJumwyhrt0kD+TrG5uFFSymJt+YupXhoEtjIRNlYzuc=";
+        aarch64-linux = "sha256-G4YT1SCzRM5cjuT2RH4o1UL1Jv4AMT0iqqjyHrSuknA=";
+      }
+      .${stdenv.hostPlatform.system};
+  };
+
+  appimageContents = appimageTools.extract {
+    inherit pname version src;
+  };
+
+  desktopItem = makeDesktopItem {
+    name = "rebased";
+    exec = "rebased %U";
+    icon = "rebased";
+    desktopName = "Rebased";
+    comment = "A git client based on the IntelliJ platform";
+    categories = [
+      "Development"
+      "IDE"
+    ];
+    startupWMClass = "jetbrains-rebased";
+    startupNotify = true;
+  };
+in
+(appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraPkgs = pkgs: [
+    git
+  ];
+
+  extraInstallCommands = ''
+    install -Dm444 ${appimageContents}/usr/bin/idea.svg \
+      $out/share/icons/hicolor/scalable/apps/rebased.svg
+    install -Dm444 ${desktopItem}/share/applications/*.desktop \
+      -t $out/share/applications
+  '';
+
+  meta = {
+    description = "Git client based on the IntelliJ platform";
+    homepage = "https://github.com/DetachHead/rebased";
+    license = lib.licenses.asl20;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    mainProgram = "rebased";
+    maintainers = with lib.maintainers; [ Oops418 ];
+  };
+}).overrideAttrs
+  (_: {
+    strictDeps = true;
+    __structuredAttrs = true;
+  })


### PR DESCRIPTION
Adds `rebased`, an open-source Git client based on the IntelliJ platform.

Rebased provides a graphical interface for common Git workflows, including inspecting repositories, reviewing changes, staging and committing files, browsing history, and working with branches. It is distributed upstream as Linux AppImage builds, which this
  package wraps for Nixpkgs.

Homepage: https://github.com/DetachHead/rebased

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
