### PR TITLE
mopidy-youtube: 3.7 -> 4.0

### DIFF
--- a/pkgs/applications/audio/mopidy/youtube.nix
+++ b/pkgs/applications/audio/mopidy/youtube.nix
@@ -9,14 +9,14 @@
 
 pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-youtube";
-  version = "3.7";
+  version = "4.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "natumbri";
     repo = "mopidy-youtube";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-iFt7r8Ljymc+grNJiOClTHkZOeo7AcYpcNc8tLMPROk=";
+    hash = "sha256-zNK44Nh60jQKsMlgofU8UJp8DkswusLKjNUFSWRdKME=";
   };
 
   postPatch = ''
@@ -27,6 +27,8 @@ pythonPackages.buildPythonApplication (finalAttrs: {
       --replace-fail 'patcher = mock.patch.object(youtube, "youtube_dl", spec=youtube_dl)' \
       'patcher = mock.patch.object(youtube, "youtube_dl", spec=yt_dlp)' \
       --replace-fail '"youtube_dl_package": "youtube_dl",' '"youtube_dl_package": "yt_dlp",'
+    substituteInPlace tests/test_extension.py \
+      --replace-fail 'assert "musicapi_cookie" in schema' 'assert "musicapi_cookiefile" in schema'
   '';
 
   build-system = [


### PR DESCRIPTION
Updates mopidy-youtube to v4.0.

Release: https://github.com/natumbri/mopidy-youtube/releases/tag/v4.0

 No upstream changelog entry for v4.0 is present in `CHANGELOG.rst`. The v4.0 test suite
 still referenced the old `musicapi_cookie` config key, so the package patch updates that
 assertion to `musicapi_cookiefile`.

Closes #528790

Assisted-by: pi coding agent / Mika (OpenAI GPT-5.5)

## Things done

   <!-- Please check what applies. Note that these are not hard requirements but merely
 serve as information for reviewers. -->

   - Built on platform:
     - [x] x86_64-linux
     - [ ] aarch64-linux
     - [ ] aarch64-darwin
   - Tested, as applicable:
     - [ ] [NixOS tests] in [nixos/tests].
     - [ ] [Package tests] at `passthru.tests`.
     - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
   - [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
   - [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
   - Nixpkgs Release Notes
     - [ ] Package update: when the change is major or breaking.
   - NixOS Release Notes
     - [ ] Module addition: when adding a new NixOS module.
     - [ ] Module update: when the change is significant.
   - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other
 READMEs.
   - [x] Follows the [automation/AI policy].

   [NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
   [Package tests]:
 https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
   [nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

   [CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
   [automation/AI policy]:
 https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
   [lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
   [maintainers/README.md]:
 https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
   [nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
   [pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
   [pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
