### PR TITLE
python3Packages.granian: 2.7.5 -> 2.7.8

### DIFF
--- a/pkgs/development/python-modules/granian/default.nix
+++ b/pkgs/development/python-modules/granian/default.nix
@@ -20,14 +20,14 @@
 
 buildPythonPackage rec {
   pname = "granian";
-  version = "2.7.5";
+  version = "2.7.8";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "emmett-framework";
     repo = "granian";
     tag = "v${version}";
-    hash = "sha256-6NOag3PHI4BOi5JuulRqhKeyDWuMxxu0bfb8ViQxDWY=";
+    hash = "sha256-89Kl/MrotK0fv0oAayUuZXyLLG9PPM1km57ER+dM1jw=";
   };
 
   # Granian forces a custom allocator for all the things it runs,
@@ -40,7 +40,7 @@ buildPythonPackage rec {
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-R4thKT3lMo/CFv+CokGSDzynTKOMCLRjVEy7Ojip4qA=";
+    hash = "sha256-mnqtzZ2+xuxUezhsgw+gr6MmWbi4Z4j0bHndys6vHFw=";
   };
 
   nativeBuildInputs = with rustPlatform; [

--- a/pkgs/development/python-modules/granian/no-alloc.patch
+++ b/pkgs/development/python-modules/granian/no-alloc.patch
@@ -1,5 +1,5 @@
 diff --git a/Cargo.toml b/Cargo.toml
-index e1b6a3d..8fe77cf 100644
+index a33fb2c..8426d66 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
 @@ -46,3 +46,2 @@ itertools = "0.14"
@@ -7,8 +7,8 @@ index e1b6a3d..8fe77cf 100644
 -mimalloc = { version = "0.1.49", default-features = false, features = ["local_dynamic_tls"], optional = true }
  mime_guess = "=2.0"
 @@ -58,3 +57,2 @@ socket2 = { version = "=0.6", features = ["all"] }
- sysinfo = "=0.38"
--tikv-jemallocator = { version = "0.6.0", default-features = false, features = ["disable_initial_exec_tls"], optional = true }
+ sysinfo = "=0.39"
+-tikv-jemallocator = { version = "=0.7", default-features = false, features = ["disable_initial_exec_tls"], optional = true }
  tls-listener = { version = "=0.11", git = "https://github.com/gi0baro/tls-listener.git", branch = "0.11.x", features = ["rustls-ring", "rustls-tls12"] }
 @@ -68,6 +66,2 @@ pyo3-build-config = "=0.27"
  


### PR DESCRIPTION
Changelog:
https://github.com/emmett-framework/granian/releases/tag/v2.7.8
https://github.com/emmett-framework/granian/releases/tag/v2.7.7
https://github.com/emmett-framework/granian/releases/tag/v2.7.6


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
