### PR TITLE
haskellPackages.*: compile a few test suites with threaded runtime

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1564,6 +1564,21 @@ with haskellLib;
   yaya-quickcheck = doJailbreak super.yaya-quickcheck;
   yaya-unsafe = doJailbreak super.yaya-unsafe;
 
+  # https://github.com/ghcjs/jsaddle/pull/165
+  jsaddle-warp = appendPatch (fetchpatch {
+    name = "add-threaded-flag";
+    url = "https://github.com/ghcjs/jsaddle/commit/71942e99e33cec69bff307e6289d2b0e714f8279.patch";
+    relative = "jsaddle-warp";
+    sha256 = "sha256-mDztKB2rktARDA2gMM+zGyavnAEAlF1Ik23Ji52tGSE";
+  }) super.jsaddle-warp;
+
+  # https://github.com/fpco/http-reverse-proxy/pull/53/
+  http-reverse-proxy = appendPatch (fetchpatch {
+    name = "add-threaded-flag";
+    url = "https://github.com/fpco/http-reverse-proxy/commit/47f81a066b37115d5bd120583570d45345aab3e0.patch";
+    sha256 = "sha256-sLZTVlypqeI9i+3K/1IxAJFAywcxE4JM00giUGpJIKI";
+  }) super.http-reverse-proxy;
+
   # chell-quickcheck doesn't work with QuickCheck >= 2.15 with no known fix yet
   # https://github.com/typeclasses/chell/issues/5
   system-filepath = dontCheck super.system-filepath;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
