### PR TITLE
libfetch: init at 0.1.0-unstable-2026-06-3

### DIFF
--- a/pkgs/by-name/li/libfetch/package.nix
+++ b/pkgs/by-name/li/libfetch/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenv,
+  openssl,
+  gnumake,
+  fetchFromGitea,
+}:
+
+let
+  pname = "libfetch";
+  gitRev = "94465f087e10c933962139f3c72dbcc75a107943";
+in
+stdenv.mkDerivation {
+  inherit pname;
+  version = "0.1.0-unstable-2026-06-30";
+
+  # NOTE: binary doesn't depend on library output
+  outputs = [
+    "bin"
+    "dev"
+    "lib"
+    "out"
+    "devman"
+  ];
+
+  src = fetchFromGitea {
+    domain = "gitea.foss-daily.org";
+    owner = "kayoubi13";
+    repo = "libfetch";
+    rev = gitRev;
+    hash = "sha256-7EGCuXZ9qCgCoYWtpoQZzaP4SuEZYxShg2imy/0eMHs=";
+  };
+
+  nativeBuildInputs = [ gnumake ];
+  buildInputs = [ openssl ];
+
+  installTargets = [ "install" ];
+  installFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  postFixup = ''
+    mkdir -p ${placeholder "out"}/share/man/man3/ $bin $dev $lib $devman
+    cp $src/fetch.3 ${placeholder "out"}/share/man/man3/
+    cp -r ${placeholder "out"}/bin $bin/
+    cp -r ${placeholder "out"}/lib $lib/
+    cp -r ${placeholder "out"}/share $devman/
+
+    ls -la
+  '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  # passthru.tests = {
+  #   # NOTE(ProducerMatt): this is useful for checking for fails but it's overkill for
+  #   # hydra and very coarse. If FreeBSD has a test suite for fetch then I can't find it.
+  #   # TODO: make sure this actually counts as a failure if it doesn't finish
+  #   largeFileDownload = runCommand "${pname}-test-largeFileDownload" { } ''
+  #     fetch -o /dev/null https://proof.ovh.net/files/1Gb.dat
+  #   '';
+  # };
+
+  meta = with lib; {
+    description = "A Linux port of FreeBSD's libfetch library and fetch utility.";
+    homepage = "https://gitea.foss-daily.org/kayoubi13/libfetch";
+    changelog = "https://gitea.foss-daily.org/kayoubi13/libfetch/commit/${gitRev}";
+    license = licenses.bsd3;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    mainProgram = "fetch";
+    maintainers = with maintainers; [
+      ProducerMatt
+      kayoubi13
+    ];
+  };
+}


### PR DESCRIPTION
This submits `libfetch` as a Nixpkg. Original repo is numbered 0.1.0 as there's no clear version numbering for `libfetch` in the FreeBSD source.

I took the time to split the outputs into multiple outs, but I haven't used them a lot in the past so I'm unsure if I did it correctly.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] ~~aarch64-darwin~~ doesn't build, so I've limited it to Linux only.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).
Command: `nixpkgs-review pr 537145 --package libfetch`
Commit: `eff5fad20fa971fd987389efa8f92b8f33a0845f`
---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>libfetch</li>
  </ul>
</details>

Command: `nixpkgs-review pr 537145 --pkgs=pkgsCross.aarch64-multiplatform --package libfetch`
Commit: `eff5fad20fa971fd987389efa8f92b8f33a0845f`
---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>pkgsCross.aarch64-multiplatform.libfetch</li>
  </ul>
</details>