### PR TITLE
onlyoffice-documentserver: update v8

### DIFF
--- a/pkgs/by-name/on/onlyoffice-documentserver/x2t.nix
+++ b/pkgs/by-name/on/onlyoffice-documentserver/x2t.nix
@@ -15,8 +15,7 @@
   icu,
   jdk,
   lib,
-  nodejs_22,
-  nodejs-slim_22,
+  nodejs-slim,
   openssl,
   pkg-config,
   python3,
@@ -223,9 +222,6 @@ let
   });
   web-apps = buildNpmPackage (finalAttrs: {
     name = "onlyoffice-core-web-apps";
-
-    # workaround for https://github.com/NixOS/nixpkgs/issues/477803
-    nodejs = nodejs_22;
 
     src = fetchFromGitHub {
       owner = "ONLYOFFICE";
@@ -732,8 +728,6 @@ let
       qmakeFlags
       ++ icuQmakeFlags
       ++ [
-        # c++1z for nodejs-slim_22.libv8 (20 seems to produce errors around 'is_void_v' there)
-        # c++ 20 for nodejs_23.libv8
         "CONFIG+=c++2a"
         # v8_base.h will set nMaxVirtualMemory to 4000000000/5000000000
         # which is not page-aligned, so disable memory limitation for now
@@ -743,6 +737,13 @@ let
       ];
     preConfigure = ''
       cd $BUILDRT
+
+      # We need to build statically to be able to piggy-back
+      # on nodejs's v8
+      substituteInPlace \
+        DesktopEditor/doctrenderer/doctrenderer.pri \
+        --replace-fail "CONFIG += shared" "CONFIG += staticlib" \
+        --replace-fail "CONFIG += plugin" ""
 
       substituteInPlace \
         DesktopEditor/doctrenderer/nativecontrol.h \
@@ -761,15 +762,25 @@ let
       done
 
       echo "== v8 =="
+      substituteInPlace \
+        DesktopEditor/doctrenderer/js_internal/v8/v8_base.h \
+        --replace-fail "args.Holder" "args.This"
+      substituteInPlace \
+        DesktopEditor/doctrenderer/js_internal/v8/v8_base.cpp \
+        --replace-fail "args.Holder" "args.This"
+
       mkdir -p Common/3dParty/v8_89/v8/out.gn/linux_64
-      # using nodejs_22 here is a workaround for https://github.com/NixOS/nixpkgs/issues/477805
-      ln -s ${nodejs-slim_22.libv8}/lib Common/3dParty/v8_89/v8/out.gn/linux_64/obj
-      tar xf ${nodejs-slim_22.libv8.src} --one-top-level=/tmp/xxxxx
+      ln -s ${nodejs-slim.libv8}/lib Common/3dParty/v8_89/v8/out.gn/linux_64/obj
+      tar xf ${nodejs-slim.libv8.src} --one-top-level=/tmp/xxxxx
       for i in /tmp/xxxxx/*/deps/v8/*; do
         cp -r $i Common/3dParty/v8_89/v8/
       done
 
       cd $BUILDRT/DesktopEditor/doctrenderer
+    '';
+    installPhase = ''
+      mkdir -p $out/lib
+      cp ../../build/lib/*/*.a $out/lib
     '';
     passthru.tests = lib.attrsets.genAttrs [ "embed/external" "embed/internal" "js_internal" "json" ] (
       test:
@@ -885,9 +896,24 @@ let
       xpsfile
       djvufile
     ];
-    qmakeFlags = qmakeFlags ++ icuQmakeFlags;
+    qmakeFlags =
+      qmakeFlags
+      ++ icuQmakeFlags
+      ++ [
+        "QMAKE_LFLAGS+=-licui18n"
+      ];
     preConfigure = ''
       source ${fixIcu}
+
+      # We need to build statically to be able to piggy-back
+      # on nodejs's v8
+      substituteInPlace \
+        $BUILDRT/DesktopEditor/doctrenderer/doctrenderer.pri \
+        --replace-fail "CONFIG += shared" "CONFIG += staticlib" \
+        --replace-fail "CONFIG += plugin" ""
+
+      echo "LIBS += -L${openssl'.out}/lib -lcrypto" >> $BUILDRT/DesktopEditor/allthemesgen/allthemesgen.pro
+      echo "LIBS += -L${nodejs-slim.libv8}/lib -lv8 -pthread" >> $BUILDRT/DesktopEditor/allthemesgen/allthemesgen.pro
     '';
     dontStrip = true;
     installPhase = ''
@@ -956,9 +982,25 @@ buildCoreComponent "X2tConverter/build/Qt" {
     starmath
     ooxmlsignature
   ];
-  qmakeFlags = qmakeFlags ++ icuQmakeFlags ++ [ "X2tConverter.pro" ];
+  qmakeFlags =
+    qmakeFlags
+    ++ icuQmakeFlags
+    ++ [
+      "QMAKE_LFLAGS+=-licui18n"
+      "X2tConverter.pro"
+    ];
   preConfigure = ''
     source ${fixIcu}
+
+    # We need to build statically to be able to piggy-back
+    # on nodejs's v8
+    substituteInPlace \
+      $BUILDRT/DesktopEditor/doctrenderer/doctrenderer.pri \
+      --replace-fail "CONFIG += shared" "CONFIG += staticlib" \
+      --replace-fail "CONFIG += plugin" ""
+
+    echo "LIBS += -L${nodejs-slim.libv8}/lib -lv8 -pthread" >> $BUILDRT/X2tConverter/build/Qt/X2tConverter.pro
+    echo "LIBS += -L${openssl'.out}/lib -lcrypto" >> $BUILDRT/X2tConverter/build/Qt/X2tConverter.pro
 
     # (not as patch because of line endings)
     sed -i '47 a #include <limits>' $BUILDRT/Common/OfficeFileFormatChecker2.cpp


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Draft because it depends on #520553 getting merged first

~(currently fails because libboost is built against a different icu version than nodejs's v8)~

Rebased and tested, successfully loads, edits and saves a docx through nextcloud


Fixes #477803

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
