### PR TITLE
lib.systems: add xtensa + esp

### DIFF
--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -103,6 +103,7 @@ let
     "s390x-none"
     "vc4-none"
     "x86_64-none"
+    "xtensa-none"
 
     # OpenBSD
     "i686-openbsd"

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -228,6 +228,16 @@ rec {
     libc = "newlib";
   };
 
+  xtensa-esp-elf = {
+    config = "xtensa-esp-elf";
+    libc = "picolibc";
+  };
+
+  xtensa-none-elf = {
+    config = "xtensa-none-elf";
+    libc = "picolibc";
+  };
+
   m68k = {
     config = "m68k-unknown-linux-gnu";
   };

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -294,6 +294,11 @@ rec {
     isJavaScript = {
       cpu = cpuTypes.javascript;
     };
+    isXtensa = {
+      cpu = {
+        family = "xtensa";
+      };
+    };
 
     is32bit = {
       cpu = {

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -347,6 +347,12 @@ rec {
         family = "sparc";
       };
 
+      xtensa = {
+        bits = 32;
+        significantByte = littleEndian;
+        family = "xtensa";
+      };
+
       wasm32 = {
         bits = 32;
         significantByte = littleEndian;
@@ -500,6 +506,7 @@ rec {
     apple = { };
     pc = { };
     knuth = { };
+    esp = { };
     # Actually matters, unlocking some MinGW-w64-specific options in GCC. See
     # bottom of https://sourceforge.net/p/mingw-w64/wiki2/Unicode%20apps/
     w64 = { };
@@ -859,8 +866,16 @@ rec {
           secondComponent = elemAt l 1;
           thirdComponent = elemAt l 2;
         in
+        # cpu-vendor-abi
+        if secondComponent == "esp" then
+          {
+            cpu = head l;
+            vendor = secondComponent;
+            kernel = "none";
+            abi = thirdComponent;
+          }
         # cpu-kernel-environment
-        if secondComponent == "linux" || elem thirdComponent linuxComponents then
+        else if secondComponent == "linux" || elem thirdComponent linuxComponents then
           {
             cpu = head l;
             kernel = secondComponent;

--- a/pkgs/build-support/lib/meson.nix
+++ b/pkgs/build-support/lib/meson.nix
@@ -15,6 +15,8 @@ let
       "ppc64"
     else if isPower then
       "ppc"
+    else if isXtensa then
+      "xtensa"
     else
       platform.uname.processor;
 


### PR DESCRIPTION
~~Branched off of #537028 (hence extra commits, but we don’t get stacked diffs in this UI’s workflow \*grumble\*)~~ covers similar to #509186 but I want to say this is more correct since the triplet is what autotools & the like expect. The other `-elf` entries use it as ABI. @theoparis


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.