### PR TITLE
onlyoffice-documentserver: use icu78

### DIFF
--- a/pkgs/by-name/on/onlyoffice-documentserver/x2t.nix
+++ b/pkgs/by-name/on/onlyoffice-documentserver/x2t.nix
@@ -12,7 +12,7 @@
   optipng,
   x265,
   libde265,
-  icu,
+  icu78,
   jdk,
   lib,
   nodejs_22,
@@ -30,6 +30,9 @@
 }:
 
 let
+  # default at the time of writing is still 76,
+  # but libv8 from nodejs_22 needs 78
+  icu = icu78;
   openssl' = openssl.override {
     enableMD2 = true;
     static = true;
@@ -41,8 +44,11 @@ let
       $BUILDRT/Common/3dParty/icu/icu.pri \
       --replace-fail "ICU_MAJOR_VER = 74" "ICU_MAJOR_VER = ${lib.versions.major icu.version}"
 
-    mkdir $BUILDRT/Common/3dParty/icu/linux_64
-    ln -s ${icu}/lib $BUILDRT/Common/3dParty/icu/linux_64/build
+    mkdir -p $BUILDRT/Common/3dParty/icu/linux_64/build
+    ln -s ${icu.dev}/include $BUILDRT/Common/3dParty/icu/linux_64/build/include
+    for i in ${icu}/lib/* ; do
+      ln -s $i $BUILDRT/Common/3dParty/icu/linux_64/build/$(basename $i)
+    done
   '';
   icuQmakeFlags = [
     "QMAKE_LFLAGS+=-Wl,--no-undefined"


### PR DESCRIPTION
This is needed so that doctrenderer uses the same version of icu as the nodejs.libv8 . This is a little scary because it's a different version of icu than boost is built with, but seems to work out in practice. After #520553 this should ideally be in sync again.

Fixes #536824


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
