### PR TITLE
proj: enable strictDeps

### DIFF
--- a/pkgs/by-name/pr/proj/package.nix
+++ b/pkgs/by-name/pr/proj/package.nix
@@ -13,11 +13,14 @@
   nlohmann_json,
   python3,
   cacert,
+  writableTmpDirAsHomeHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "proj";
   version = "9.8.1";
+  __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "OSGeo";
@@ -50,6 +53,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeCheckInputs = [
     cacert
+    sqlite
+    writableTmpDirAsHomeHook
+  ];
+  checkInputs = [
     gtest
   ];
 
@@ -57,13 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-DUSE_EXTERNAL_GTEST=ON"
     "-DRUN_NETWORK_DEPENDENT_TESTS=OFF"
     "-DNLOHMANN_JSON_ORIGIN=external"
-    "-DEXE_SQLITE3=${buildPackages.sqlite}/bin/sqlite3"
-  ];
-
-  env.CXXFLAGS = toString [
-    # GCC 13: error: 'int64_t' in namespace 'std' does not name a type
-    "-include"
-    "cstdint"
+    "-DEXE_SQLITE3=${lib.getExe buildPackages.sqlite}"
   ];
 
   preCheck =
@@ -71,7 +72,6 @@ stdenv.mkDerivation (finalAttrs: {
       libPathEnvVar = if stdenv.hostPlatform.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH";
     in
     ''
-      export HOME=$TMPDIR
       export TMP=$TMPDIR
       export ${libPathEnvVar}=$PWD/lib
     '';


### PR DESCRIPTION
#178468 

## Things done

Checked that output is equivalent (diffoscope).

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
