### PR TITLE
openmw: 0.50.0 -> 0.51.0

### DIFF
--- a/pkgs/by-name/op/openmw/package.nix
+++ b/pkgs/by-name/op/openmw/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitLab,
   fetchpatch,
+  nix-update-script,
 
   SDL2,
   boost,
@@ -35,7 +36,7 @@ assert lib.assertOneOf "GLPreference" GLPreference [
 ];
 stdenv.mkDerivation (finalAttrs: {
   pname = "openmw";
-  version = "0.50.0";
+  version = "0.51.0";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -82,7 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "OpenMW";
     repo = "openmw";
     tag = "openmw-${finalAttrs.version}";
-    hash = "sha256-mPwNyKKqPSZJtcIyx3IhLe3iHOpx6p4+l1wJZqyDMqg=";
+    hash = "sha256-D+2nEQRkAjmDvRoas9bYPmdygQYT3MAv46n73OonE0o=";
   };
 
   postPatch = ''
@@ -132,6 +133,15 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "OPENMW_USE_SYSTEM_RECASTNAVIGATION" true)
     (lib.cmakeBool "OPENMW_OSX_DEPLOYMENT" isDarwin)
   ];
+
+  env.LANG = "C.UTF-8";
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "openmw-(.*)"
+    ];
+  };
 
   meta = {
     description = "Unofficial open source engine reimplementation of the game Morrowind";


### PR DESCRIPTION
## Things done

`qtbase` really should be setting `LANG`, but we do it here to silence the build.

Also add `nix-update-script` so this can happen automatically going forward.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
