### PR TITLE
build2 packages: 0.17 -> 0.18

### DIFF
--- a/pkgs/by-name/bd/bdep/package.nix
+++ b/pkgs/by-name/bd/bdep/package.nix
@@ -13,7 +13,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "bdep";
-  version = "0.17.0";
+  version = "0.18.0";
 
   outputs = [
     "out"
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   src = fetchurl {
     url = "https://pkg.cppget.org/1/alpha/build2/bdep-${finalAttrs.version}.tar.gz";
-    hash = "sha256-+2Hl5kanxWJmOpfePAvvSBSmG3kZLQv/kYIkT4J+kaQ=";
+    hash = "sha256-7pfGiIelaHQydpZqd6KiF7gwCqC9oJspig87BrKz6QU=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/bp/bpkg/package.nix
+++ b/pkgs/by-name/bp/bpkg/package.nix
@@ -15,7 +15,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "bpkg";
-  version = "0.17.0";
+  version = "0.18.0";
 
   outputs = [
     "out"
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://pkg.cppget.org/1/alpha/build2/bpkg-${finalAttrs.version}.tar.gz";
-    hash = "sha256-Yw6wvTqO+VfCo91B2BUT0A8OIN0MVhGK1USYM7hgGMs=";
+    hash = "sha256-EcDxvQ3P182gkZWkE3qI586vIlJXlDrYC2DoU0Out18=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/bu/build2-bootstrap/nix-ldflags-sysdirs.patch
+++ b/pkgs/by-name/bu/build2-bootstrap/nix-ldflags-sysdirs.patch
@@ -1,8 +1,6 @@
-diff --git a/libbuild2/cc/common.cxx b/libbuild2/cc/common.cxx
-index f848003c..0f14f9a5 100644
 --- a/libbuild2/cc/common.cxx
 +++ b/libbuild2/cc/common.cxx
-@@ -966,6 +966,17 @@ namespace build2
+@@ -1806,6 +1806,17 @@ namespace build2
      void
      msvc_extract_library_search_dirs (const strings&, dir_paths&); // msvc.cxx
  
@@ -20,11 +18,8 @@ index f848003c..0f14f9a5 100644
      dir_paths common::
      extract_library_search_dirs (const scope& bs) const
      {
-@@ -987,8 +998,19 @@ namespace build2
-           msvc_extract_library_search_dirs (v, r);
-         else
+@@ -1829,6 +1840,16 @@ namespace build2
            gcc_extract_library_search_dirs (v, r);
-+
        };
  
 +      // NIX_LDFLAGS are implicitly used when linking,

--- a/pkgs/by-name/bu/build2-bootstrap/package.nix
+++ b/pkgs/by-name/bu/build2-bootstrap/package.nix
@@ -8,20 +8,14 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "build2-bootstrap";
-  version = "0.17.0";
+  version = "0.18.1";
   src = fetchurl {
     url = "https://download.build2.org/${finalAttrs.version}/build2-toolchain-${finalAttrs.version}.tar.xz";
-    hash = "sha256-NyKonqht90JTnQ+Ru0Qp/Ua79mhVOjUHgKY0EbZIv10=";
+    hash = "sha256-pfPqudRSK8InBImVk91scBM0mhuMNyeMiyMhBz4l/xY=";
   };
   patches = [
     # Pick up sysdirs from NIX_LDFLAGS
     ./nix-ldflags-sysdirs.patch
-    # Fix build on newer clang/libcpp
-    (fetchpatch {
-      name = "new-libcpp-fix.patch";
-      url = "https://github.com/build2/build2/commit/7cf9cece1d88cd1be283ab309f9a851bd02b43d0.patch";
-      hash = "sha256-PTo1C6Aa1L9fvjiJ08KtGgVqHMw2ZlW5LSKoripL22g=";
-    })
   ];
 
   sourceRoot = "build2-toolchain-${finalAttrs.version}/build2";
@@ -43,13 +37,13 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = true;
   checkPhase = ''
     runHook preCheck
-    build2/b-boot --version
+    b/b-boot --version
     runHook postCheck
   '';
 
   installPhase = ''
     runHook preInstall
-    install -D build2/b-boot $out/bin/b
+    install -D b/b-boot $out/bin/b
     runHook postInstall
   '';
 

--- a/pkgs/by-name/bu/build2/package.nix
+++ b/pkgs/by-name/bu/build2/package.nix
@@ -16,7 +16,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "build2";
-  version = "0.17.0";
+  version = "0.18.1";
 
   outputs = [
     "out"
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://pkg.cppget.org/1/alpha/build2/build2-${finalAttrs.version}.tar.gz";
-    hash = "sha256-Kx5X/GV3GjFSbjo1mzteiHnnm4mr6+NAKIR/mEE+IdA=";
+    hash = "sha256-BLMBd/1kofVuB2MalPyuj4lXNMi3p5uuzVIJUzQv3A0=";
   };
 
   patches = [

--- a/pkgs/by-name/bu/build2/remove-config-store-paths.patch
+++ b/pkgs/by-name/bu/build2/remove-config-store-paths.patch
@@ -1,14 +1,14 @@
 --- a/libbuild2/buildfile
 +++ b/libbuild2/buildfile
-@@ -86,8 +86,11 @@ build2_config_lines = [strings]
- host_config_lines = [strings]
+@@ -109,8 +109,11 @@ host_config_no_warnings_lines = [strings]
+ build2_config_no_warnings_lines = [strings]
  
- for l: $regex.replace_lines(                                                   \
-+  $regex.replace_lines(                                                        \
-   $config.save(),                                                              \
-   '^( *(#|(config\.(test[. ]|dist\.|install\.chroot|config\.hermetic))).*|)$', \
-+  [null], return_lines),                                                       \
-+  '^.*'$getenv(NIX_STORE)'/[a-z0-9]{32}-.*$',                                  \
+ for l: $regex.replace_lines(                                                            \
++  $regex.replace_lines(                                                                 \
+   $config.save(),                                                                       \
+   '^( *(#|(config\.(build2\.|test[. ]|dist\.|install\.chroot|config\.hermetic))).*|)$', \
++  [null], return_lines),                                                                \
++  '^.*'$getenv(NIX_STORE)'/[a-z0-9]{32}-.*$',                                           \
    [null])
  {
-   build2_config_lines += $l
+   if ($defined(config.build2.host_c) && $regex.match($l, ' *config\.c[ =].*'))

--- a/pkgs/by-name/li/libbpkg/package.nix
+++ b/pkgs/by-name/li/libbpkg/package.nix
@@ -10,7 +10,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libbpkg";
-  version = "0.17.0";
+  version = "0.18.0";
   outputs = [
     "out"
     "dev"
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://pkg.cppget.org/1/alpha/build2/libbpkg-${finalAttrs.version}.tar.gz";
-    hash = "sha256-4P4+uJGWB3iblYPuErJNr8c7/pS2UhN6LXr7MY2rWDY=";
+    hash = "sha256-ROaIgIql1oXOqiwz8giTcz0landh6rITyzX3WxR16L4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/libbutl/package.nix
+++ b/pkgs/by-name/li/libbutl/package.nix
@@ -12,7 +12,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libbutl";
-  version = "0.17.0";
+  version = "0.18.1";
 
   outputs = [
     "out"
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://pkg.cppget.org/1/alpha/build2/libbutl-${finalAttrs.version}.tar.gz";
-    hash = "sha256-sFqaEf6s2rF1YcZjw5J6oY5ol5PbO9vy6NseKjrvTvs=";
+    hash = "sha256-tQl7FRJh/CJ7A5MIlxlVv5aduPy/C0shcn9l+IB1oZU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/libodb-sqlite/package.nix
+++ b/pkgs/by-name/li/libodb-sqlite/package.nix
@@ -10,7 +10,7 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "libodb-sqlite";
-  version = "2.5.0-b.27";
+  version = "2.5.0";
 
   outputs = [
     "out"
@@ -19,8 +19,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   src = fetchurl {
-    url = "https://pkg.cppget.org/1/beta/odb/libodb-sqlite-${finalAttrs.version}.tar.gz";
-    hash = "sha256-jpxtY/VMkh88IzqGYgedu5TZGVIbPpy/FZNvUaOMf+w=";
+    url = "https://pkg.cppget.org/1/stable/odb/libodb-sqlite-${finalAttrs.version}.tar.gz";
+    hash = "sha256-soq3OpAlVLum65um9MkJnR4Vgm3nofpPumRRpBCFb70=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/libodb/package.nix
+++ b/pkgs/by-name/li/libodb/package.nix
@@ -8,7 +8,7 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "libodb";
-  version = "2.5.0-b.27";
+  version = "2.5.0";
 
   outputs = [
     "out"
@@ -17,8 +17,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   src = fetchurl {
-    url = "https://pkg.cppget.org/1/beta/odb/libodb-${finalAttrs.version}.tar.gz";
-    hash = "sha256-04Et/wHYsWvJPLlcL0J2iOPV2SBFC6J32EleGw38K2Q=";
+    url = "https://pkg.cppget.org/1/stable/odb/libodb-${finalAttrs.version}.tar.gz";
+    hash = "sha256-cAA4pzxsvq0BESmxUDC3zdP3NRC2h/LEUEgI30IwRBs=";
   };
 
   nativeBuildInputs = [ build2 ];


### PR DESCRIPTION
These packages are all highly interdependent and have to be updated in lockstep, so I'm just doing it all in one commit - there's no benefit to having cherry-pickable commits as they wouldn't work individually.

closes https://github.com/NixOS/nixpkgs/issues/510888
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
