### PR TITLE
wp-scanner: init at 2.0.1-unstable-2026-03-17

### DIFF
--- a/pkgs/by-name/wp/wp-scanner/package.nix
+++ b/pkgs/by-name/wp/wp-scanner/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  python3,
+}:
+
+python3.pkgs.buildPythonApplication (finalAttrs: {
+  pname = "wp-scanner";
+  version = "2.0.1-unstable-2026-03-17";
+  pyproject = false;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Triotion";
+    repo = "WP-Scanner";
+    rev = "1f75728384ca5422f69cf5f1d0a284c36b0ed45a";
+    hash = "sha256-gIfOxoiVdRKa2GGDy9GMi7+6u2Lh/yVdin/hY9lh4bs=";
+  };
+
+  dependencies = with python3.pkgs; [
+    beautifulsoup4
+    colorama
+    lxml
+    packaging
+    python-dateutil
+    requests
+    tqdm
+    urllib3
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -vD wp_scanner.py $out/bin/wp-scanner
+    install -vd $out/${python3.sitePackages}/
+    cp -R data modules $out/${python3.sitePackages}
+
+    runHook postInstall
+  '';
+
+  # Project has no tests
+  doCheck = false;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Wordpress Security Scanner and Auto Exploiter";
+    homepage = "https://github.com/Triotion/WP-Scanner";
+    # https://github.com/Triotion/WP-Scanner/issues/2
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "wp-scanner";
+  };
+})


### PR DESCRIPTION
Wordpress Security Scanner and Auto Exploiter

https://github.com/Triotion/WP-Scanner

Related to https://github.com/NixOS/nixpkgs/issues/81418

- https://github.com/Triotion/WP-Scanner/issues/2
- https://github.com/Triotion/WP-Scanner/issues/3

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
