### PR TITLE
remnote: 1.26.11 -> 1.26.20

### DIFF
--- a/pkgs/by-name/re/remnote/package.nix
+++ b/pkgs/by-name/re/remnote/package.nix
@@ -2,6 +2,7 @@
   lib,
   fetchurl,
   appimageTools,
+  makeWrapper,
   writeScript,
 }:
 let
@@ -11,16 +12,21 @@ let
     url = "https://download2.remnote.io/remnote-desktop2/RemNote-${version}.AppImage";
     hash = "sha256-3F1lC/3ek6k3x6qZ4WswJRe/QYEy3iTNMhMmLtR6i0U=";
   };
-  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+  appimageContents = appimageTools.extract { inherit pname version src; };
 in
 appimageTools.wrapType2 {
   inherit pname version src;
+
+  nativeBuildInputs = [ makeWrapper ];
 
   extraInstallCommands = ''
     install -Dm444 ${appimageContents}/remnote.desktop -t $out/share/applications
     substituteInPlace $out/share/applications/remnote.desktop \
       --replace-fail 'Exec=AppRun --no-sandbox %U' 'Exec=remnote %u'
     install -Dm444 ${appimageContents}/remnote.png -t $out/share/icons/hicolor/512x512/apps
+
+    wrapProgram $out/bin/remnote \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-wayland-ime=true --wayland-text-input-version=3}}"
   '';
 
   passthru.updateScript = writeScript "update.sh" ''

--- a/pkgs/by-name/re/remnote/package.nix
+++ b/pkgs/by-name/re/remnote/package.nix
@@ -39,6 +39,7 @@ appimageTools.wrapType2 {
   meta = {
     description = "Note-taking application focused on learning and productivity";
     homepage = "https://remnote.com/";
+    changelog = "https://feedback.remnote.com/changelog";
     maintainers = with lib.maintainers; [ talal ];
     license = lib.licenses.unfree;
     platforms = [ "x86_64-linux" ];

--- a/pkgs/by-name/re/remnote/package.nix
+++ b/pkgs/by-name/re/remnote/package.nix
@@ -7,10 +7,10 @@
 }:
 let
   pname = "remnote";
-  version = "1.26.11";
+  version = "1.26.20";
   src = fetchurl {
     url = "https://download2.remnote.io/remnote-desktop2/RemNote-${version}.AppImage";
-    hash = "sha256-3F1lC/3ek6k3x6qZ4WswJRe/QYEy3iTNMhMmLtR6i0U=";
+    hash = "sha256-3/gb/7LO18exAmFYzzfJM7lCbMPrVqCcD32LfkVIO5g=";
   };
   appimageContents = appimageTools.extract { inherit pname version src; };
 in

--- a/pkgs/by-name/re/remnote/package.nix
+++ b/pkgs/by-name/re/remnote/package.nix
@@ -39,7 +39,7 @@ appimageTools.wrapType2 {
   meta = {
     description = "Note-taking application focused on learning and productivity";
     homepage = "https://remnote.com/";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ talal ];
     license = lib.licenses.unfree;
     platforms = [ "x86_64-linux" ];
     mainProgram = "remnote";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I noticed that RemNote has no maintainer so I've added myself as maintainer since I'm also maintaining [RemNote's Flatpak](https://github.com/flathub/com.remnote.RemNote) on Flathub.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
