### PR TITLE
librewolf-unwrapped: 152.0.2-1 -> 152.0.4-1

### DIFF
--- a/pkgs/by-name/li/librewolf-unwrapped/src.json
+++ b/pkgs/by-name/li/librewolf-unwrapped/src.json
@@ -1,11 +1,11 @@
 {
-  "packageVersion": "152.0.2-1",
+  "packageVersion": "152.0.4-1",
   "source": {
-    "rev": "152.0.2-1",
-    "hash": "sha256-CgH0HOtNbdoHMZ/MJL/zPK0Gn+e+qqtZjqPDSq63gX8="
+    "rev": "152.0.4-1",
+    "hash": "sha256-sbL3lZyYaewS84Yhb9HOHgV3xPvzbu+IcjdAW1hdlAY="
   },
   "firefox": {
-    "version": "152.0.2",
-    "hash": "sha512-5OVM///P1XUerFgXp7dLDvCqQ/wA7yk5fMnfmqUlcrInK5bmA3OnDXEr5NyEkXDY1cG0SfPql4tKso3uGQVrAw=="
+    "version": "152.0.4",
+    "hash": "sha512-DFZiq6j7iXkCr5Xbsv2YixltnPmui5h66J4KZJKsdTuNS4u3sydJCcLrIAqwmN81biPNYIRVZGf1XmkScxfzmg=="
   }
 }


### PR DESCRIPTION
diff: https://codeberg.org/librewolf/source/compare/152.0.2-1...152.0.4-1
mfsa: https://www.mozilla.org/en-US/security/advisories/mfsa2026-62

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
