### PR TITLE
jellyfin-mpv-shim: 2.9.0 -> 2.10.0, minor cleanup 

### DIFF
--- a/pkgs/by-name/je/jellyfin-mpv-shim/package.nix
+++ b/pkgs/by-name/je/jellyfin-mpv-shim/package.nix
@@ -10,12 +10,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "jellyfin-mpv-shim";
-  version = "2.9.0";
+  version = "2.10.0";
   pyproject = true;
 
+  # contains shaderpacks
   src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-YrwMvP66LAWKgx/yWBkWIkZtJ4a0YnhCiL7xB6fGm0E=";
+    pname = "jellyfin_mpv_shim";
+    inherit version;
+    hash = "sha256-ZWmJQJAGAonStZyWww4P+034f2vGnTwLua7KUOqoBBE=";
   };
 
   nativeBuildInputs = [
@@ -29,29 +31,23 @@ python3Packages.buildPythonApplication rec {
   dependencies = with python3Packages; [
     jellyfin-apiclient-python
     mpv
-    pillow
     python-mpv-jsonipc
+    requests
 
-    # gui dependencies
+    # gui + mirror dependencies
+    pillow
     pystray
     tkinter
-
-    # display_mirror dependencies
-    jinja2
-    pywebview
 
     # discord rich presence dependency
     pypresence
   ];
 
-  # override $HOME directory:
-  #   error: [Errno 13] Permission denied: '/homeless-shelter'
-  #
-  # remove jellyfin_mpv_shim/win_utils.py:
-  #   ModuleNotFoundError: No module named 'win32gui'
   preCheck = ''
     export HOME=$TMPDIR
 
+    # remove jellyfin_mpv_shim/win_utils.py:
+    #   ModuleNotFoundError: No module named 'win32gui'
     rm jellyfin_mpv_shim/win_utils.py
   '';
 
@@ -60,7 +56,7 @@ python3Packages.buildPythonApplication rec {
       --replace-fail "check_updates: bool = True" "check_updates: bool = False" \
       --replace-fail "notify_updates: bool = True" "notify_updates: bool = False"
     # python-mpv renamed to mpv with 1.0.4
-    substituteInPlace setup.py \
+    substituteInPlace pyproject.toml \
       --replace-fail "python-mpv" "mpv" \
       --replace-fail "mpv-jsonipc" "python_mpv_jsonipc"
   '';
@@ -70,7 +66,7 @@ python3Packages.buildPythonApplication rec {
     for s in 16 32 48 64 128 256; do
       mkdir -p $out/share/icons/hicolor/''${s}x''${s}/apps
       ln -s $out/${python3Packages.python.sitePackages}/jellyfin_mpv_shim/integration/jellyfin-''${s}.png \
-        $out/share/icons/hicolor/''${s}x''${s}/apps/${pname}.png
+        $out/share/icons/hicolor/''${s}x''${s}/apps/jellyfin-mpv-shim.png
     done
   '';
 
@@ -84,9 +80,9 @@ python3Packages.buildPythonApplication rec {
 
   desktopItems = [
     (makeDesktopItem {
-      name = pname;
-      exec = pname;
-      icon = pname;
+      name = "jellyfin-mpv-shim";
+      exec = "jellyfin-mpv-shim";
+      icon = "jellyfin-mpv-shim";
       desktopName = "Jellyfin MPV Shim";
       categories = [
         "Video"
@@ -123,5 +119,6 @@ python3Packages.buildPythonApplication rec {
     ];
     maintainers = with lib.maintainers; [ jojosch ];
     mainProgram = "jellyfin-mpv-shim";
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/python-mpv-jsonipc/default.nix
+++ b/pkgs/development/python-modules/python-mpv-jsonipc/default.nix
@@ -2,38 +2,32 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  requests,
-  tqdm,
-  websocket-client,
+  setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "python-mpv-jsonipc";
-  version = "1.2.1";
-  format = "setuptools";
+  version = "1.2.2";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "iwalton3";
     repo = "python-mpv-jsonipc";
-    rev = "v${version}";
-    hash = "sha256-ugdLUmo5w+IbtmL2b6+la1X01mWNmnXr9j6e99oPWpE=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9QfGsJW08YqATP4+G3bADkjxHoauSF7BmcsIi56fBKI=";
   };
+
+  build-system = [ setuptools ];
 
   # 'mpv-jsonipc' does not have any tests
   doCheck = false;
-
-  propagatedBuildInputs = [
-    requests
-    tqdm
-    websocket-client
-  ];
 
   pythonImportsCheck = [ "python_mpv_jsonipc" ];
 
   meta = {
     homepage = "https://github.com/iwalton3/python-mpv-jsonipc";
     description = "Python API to MPV using JSON IPC";
-    license = lib.licenses.gpl3;
+    license = lib.licenses.asl20;
     maintainers = [ ];
   };
-}
+})


### PR DESCRIPTION
Side effect: this removes many deps from my system:

```
assimp: 6.0.5 → ∅, -14.0 MiB
binutils-wrapper: -55.3 KiB
clang: 21.1.8 → ∅, -863.7 MiB
clang-wrapper: 21.1.8 → ∅, -71.8 KiB
compiler-rt-libc: 21.1.8 → ∅, -36.4 MiB
jellyfin-mpv-shim: 2.9.0 → 2.10.0, 268.8 KiB
pyside6: 6.11.0 → ∅, -50.4 MiB
python3.13-bottle: 0.13.4 → ∅, -853.2 KiB
python3.13-jinja2: 3.1.6 → ∅, -1.8 MiB
python3.13-proxy-tools: 0.1.0 → ∅, -37.4 KiB
python3.13-python-mpv-jsonipc: 1.2.1 → 1.2.2
python3.13-pywebview: 6.1 → ∅, -2.6 MiB
python3.13-qtpy: 2.4.3 → ∅, -792.9 KiB
python3.13-tkinter: 3.13.13 → ∅, -1.2 MiB
qt3d: 6.11.1 → ∅, -20.2 MiB
qtcharts: 6.11.1 → ∅, -5.8 MiB
qtdatavis3d: 6.11.1 → ∅, -4.2 MiB
qthttpserver: 6.11.1 → ∅, -520.0 KiB
qtnetworkauth: 6.11.1 → ∅, -645.5 KiB
qtremoteobjects: 6.11.1 → ∅, -2.6 MiB
qtscxml: 6.11.1 → ∅, -3.2 MiB
qtserialbus: 6.11.1 → ∅, -1.4 MiB
shiboken6: 6.11.0 → ∅, -654.4 KiB
shiboken6-generator: 6.11.0 → ∅, -4.2 MiB
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
