### PR TITLE
b-em: init at unstable-2026-06-30

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14039,6 +14039,11 @@
     githubId = 6544084;
     name = "Kai Harries";
   };
+  kaistarkk = {
+    github = "KaiStarkk";
+    githubId = 1722064;
+    name = "KaiStarkk";
+  };
   kalbasit = {
     email = "wael.nasreddine@gmail.com";
     matrix = "@kalbasit:matrix.org";

--- a/pkgs/by-name/b-/b-em/package.nix
+++ b/pkgs/by-name/b-/b-em/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  allegro5,
+  alsa-lib,
+  jack2,
+  zlib,
+}:
+
+stdenv.mkDerivation {
+  pname = "b-em";
+  version = "unstable-2026-06-30";
+
+  src = fetchFromGitHub {
+    owner = "stardot";
+    repo = "b-em";
+    rev = "6018d5e91a097d0a6dc0aee95e0477845e12660c";
+    hash = "sha256-9X5zQZaGPiEEiGvjrk57264jBZNTgWT03amqpHIuVl8=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    allegro5
+    alsa-lib
+    jack2
+    zlib
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  enableParallelBuilding = true;
+
+  postInstall = ''
+    # The upstream install target copies optional ROM, disc, and tape images.
+    # Keep Nixpkgs output to the emulator and support files only.
+    rm -rf "$out/share/b-em/roms" "$out/share/b-em/discs" "$out/share/b-em/tapes"
+    install -Dm644 icon/b-em.svg "$out/share/icons/hicolor/scalable/apps/b-em.svg"
+  '';
+
+  meta = {
+    description = "BBC Micro emulator";
+    homepage = "https://github.com/stardot/b-em";
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "b-em";
+    maintainers = with lib.maintainers; [ kaistarkk ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description

Adds `b-em`, a BBC Micro emulator.

## Things done

- Built on x86_64-linux with `nix build --no-link -f . b-em`.

Disclosure: AI was used to assist with this PR body, disclosed separately from commits as required by [CONTRIBUTING.md line 932](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#L932). I am responsible for this contribution under [CONTRIBUTING.md line 908](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#L908).