### PR TITLE
kegs: init at 0.91-unstable-2011-10-18

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14039,6 +14039,11 @@
     githubId = 6544084;
     name = "Kai Harries";
   };
+  kaistarkk = {
+    github = "KaiStarkk";
+    githubId = 1722064;
+    name = "KaiStarkk";
+  };
   kalbasit = {
     email = "wael.nasreddine@gmail.com";
     matrix = "@kalbasit:matrix.org";

--- a/pkgs/by-name/ke/kegs/package.nix
+++ b/pkgs/by-name/ke/kegs/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  perl,
+  libx11,
+  libxext,
+}:
+
+stdenv.mkDerivation {
+  pname = "kegs";
+  version = "0.91-unstable-2011-10-18";
+
+  src = fetchFromGitHub {
+    owner = "aufflick";
+    repo = "kegs";
+    rev = "dc8899440147204b0e4ab99731cc56796eb6fdc3";
+    hash = "sha256-ie+r0hx4DombqZxvaq5FbrwVfOA+i0CjKa8nnV39BCE=";
+  };
+
+  sourceRoot = "source/src";
+
+  nativeBuildInputs = [ perl ];
+
+  buildInputs = [
+    libx11
+    libxext
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  postPatch = ''
+    ln -sf vars_x86linux vars
+    substituteInPlace vars_x86linux \
+      --replace-fail "CC = cc" "CC = $CC" \
+      --replace-fail "PERL = perl" "PERL = ${lib.getExe perl}" \
+      --replace-fail "-march=pentium" "" \
+      --replace-fail "XOPTS = -I/usr/X11R6/include" "XOPTS ="
+    substituteInPlace Makefile \
+      --replace-fail "XLIBS = -L/usr/X11R6/lib" "XLIBS =" \
+      --replace-fail "mv xkegs .." ""
+  '';
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 xkegs "$out/bin/xkegs"
+    install -Dm644 ../README.md "$out/share/doc/kegs/README.md"
+    install -Dm644 ../README.compile.txt "$out/share/doc/kegs/README.compile.txt"
+    install -Dm644 ../README.a2.compatibility.txt "$out/share/doc/kegs/README.a2.compatibility.txt"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Apple IIgs emulator";
+    homepage = "https://github.com/aufflick/kegs";
+    license = lib.licenses.gpl2Only;
+    mainProgram = "xkegs";
+    maintainers = with lib.maintainers; [ kaistarkk ];
+    platforms = lib.platforms.linux;
+    badPlatforms = lib.platforms.bigEndian;
+  };
+}


### PR DESCRIPTION
## Description

Adds `kegs`, an Apple IIgs emulator.

## Things done

- Built on x86_64-linux with `nix build --no-link -f . kegs`.

Disclosure: AI was used to assist with this PR body, disclosed separately from commits as required by [CONTRIBUTING.md line 932](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#L932). I am responsible for this contribution under [CONTRIBUTING.md line 908](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#L908).