### PR TITLE
[26.05] picocrypt-ng: 2.09 -> 2.18

### DIFF
--- a/pkgs/by-name/pi/picocrypt-ng/package.nix
+++ b/pkgs/by-name/pi/picocrypt-ng/package.nix
@@ -76,7 +76,10 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/Picocrypt-NG/Picocrypt-NG";
     changelog = "https://github.com/Picocrypt-NG/Picocrypt-NG/blob/${finalAttrs.version}/Changelog.md";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ tbutter ];
+    maintainers = with lib.maintainers; [
+      tbutter
+      ryand56
+    ];
     mainProgram = "picocrypt-ng-gui";
   };
 })

--- a/pkgs/by-name/pi/picocrypt-ng/package.nix
+++ b/pkgs/by-name/pi/picocrypt-ng/package.nix
@@ -16,18 +16,18 @@
 
 buildGoModule (finalAttrs: {
   pname = "picocrypt-ng";
-  version = "2.09";
+  version = "2.10";
 
   src = fetchFromGitHub {
     owner = "Picocrypt-NG";
     repo = "Picocrypt-NG";
     tag = finalAttrs.version;
-    hash = "sha256-s+93NoJ1O6/Af33pUobSA0kAhpw7W0IdA9H6CVxShQY=";
+    hash = "sha256-Rp7BgtJnV3fPed/QlWSxH8nL7cCTgMDpRGcgX5VI2l0=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/src";
 
-  vendorHash = "sha256-2c8Q7+97jSGo8lwWOYBg76K04+TFXG1DdQzVMR8G7ik=";
+  vendorHash = "sha256-yAM1jzebUlNkVWiY8lPtlelfqpFQonNcAqNmmghCdPU=";
 
   ldflags = [
     "-s"
@@ -49,6 +49,9 @@ buildGoModule (finalAttrs: {
     wrapGAppsHook3
     writableTmpDirAsHomeHook
   ];
+
+  # git ls-files doesn't work as source is not a git repo
+  checkFlags = [ "-skip=^TestOldVersionLiteralsAreAllowlisted$" ];
 
   env.CGO_ENABLED = 1;
 

--- a/pkgs/by-name/pi/picocrypt-ng/package.nix
+++ b/pkgs/by-name/pi/picocrypt-ng/package.nix
@@ -16,18 +16,19 @@
 
 buildGoModule (finalAttrs: {
   pname = "picocrypt-ng";
-  version = "2.10";
+  version = "2.17";
 
   src = fetchFromGitHub {
     owner = "Picocrypt-NG";
     repo = "Picocrypt-NG";
-    tag = finalAttrs.version;
-    hash = "sha256-Rp7BgtJnV3fPed/QlWSxH8nL7cCTgMDpRGcgX5VI2l0=";
+    # Rewritten git history many times
+    rev = "424db6105588e9fe6b929b6731ace4556a12f172";
+    hash = "sha256-Bj0LK6si1ocGriRJf5GHZ/Z2xVhtyCIiv7H5+h8Dong=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/src";
 
-  vendorHash = "sha256-yAM1jzebUlNkVWiY8lPtlelfqpFQonNcAqNmmghCdPU=";
+  vendorHash = "sha256-KaTatNjSUnQC44UsV3LFOlkad8WqLfTPFFff8Dn13DA=";
 
   ldflags = [
     "-s"
@@ -51,7 +52,14 @@ buildGoModule (finalAttrs: {
   ];
 
   # git ls-files doesn't work as source is not a git repo
-  checkFlags = [ "-skip=^TestOldVersionLiteralsAreAllowlisted$" ];
+  checkFlags =
+    let
+      skippedTests = [
+        "TestOldVersionLiteralsAreAllowlisted"
+        "TestLinuxAppIdentityContract"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   env.CGO_ENABLED = 1;
 

--- a/pkgs/by-name/pi/picocrypt-ng/package.nix
+++ b/pkgs/by-name/pi/picocrypt-ng/package.nix
@@ -16,19 +16,19 @@
 
 buildGoModule (finalAttrs: {
   pname = "picocrypt-ng";
-  version = "2.17";
+  version = "2.18";
 
   src = fetchFromGitHub {
     owner = "Picocrypt-NG";
     repo = "Picocrypt-NG";
     # Rewritten git history many times
-    rev = "424db6105588e9fe6b929b6731ace4556a12f172";
-    hash = "sha256-Bj0LK6si1ocGriRJf5GHZ/Z2xVhtyCIiv7H5+h8Dong=";
+    rev = "3261587f8b10471a6ed3c5ad132ada0f7c06e4cf";
+    hash = "sha256-wjoYh6XWV4lJpSr9GQwPnlKGkbFH0YJOp1xVZJb5uOY=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/src";
 
-  vendorHash = "sha256-KaTatNjSUnQC44UsV3LFOlkad8WqLfTPFFff8Dn13DA=";
+  vendorHash = "sha256-pbldRarOQ44bE4FPUSHvk2Qk4WQ0zKU0Hd75E717mLI=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
