### PR TITLE
nix: revert accursed curl patch from nix too

### DIFF
--- a/pkgs/tools/package-management/nix/dependencies.nix
+++ b/pkgs/tools/package-management/nix/dependencies.nix
@@ -4,6 +4,7 @@ regular@{
   aws-sdk-cpp,
   fetchFromGitHub,
   pkgs,
+  curl,
 }:
 
 {
@@ -34,5 +35,12 @@ regular@{
       # only a stripped down version is built which takes a lot less resources to build
       requiredSystemFeatures = [ ];
     };
+
+    # curl_multi_wakeup is busted since https://github.com/NixOS/nixpkgs/pull/525953 and missed the wakeup (seems like) on first download enqueue?
+    curl = curl.overrideAttrs (prevAttrs: {
+      patches = lib.filter (
+        patch: !lib.strings.hasSuffix "fix-wakeup-consumption.patch" patch
+      ) prevAttrs.patches;
+    });
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Nix got affected less tragically than Lix. Symptoms include explosive ~~diarrhea~~ waiting on the first download to start. I have yet to root cause this and why this is surfaced so infrequently and only in some cases.

One example that seems to reliably get stuck without a wakeup is downloading the flake registry on commands like:

```
nix flake prefetch "https://channels.nixos.org/nixos-24.11/nixexprs.tar.xz"
```

Waits exactly for 10s for the first download to start, which is wakeup timeout of the worker thread.

Yet commands like:

```
nix path-info /nix/store/zi2bj2hlavv8q743li2s9diqbcpmrf9b-hello-2.12.3 --store https://cache.nixos.org --refresh
```

Don't suffer from this issue, which is why it look so long to notice. At least that's how I found it when investigating why prefetch commands were slow in the test suite.

See: b8366ce116010da7a7cba3451f9832397b29a20d

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
