### PR TITLE
nixos/jujutsu: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -28,6 +28,8 @@
 
 - [FlapAlerted](https://github.com/Kioubit/FlapAlerted), detects BGP flapping events and provides statistics based on BGP update messages. Available as [services.flap-alerted](#opt-services.flap-alerted.enable).
 
+- [Jujutsu](https://github.com/jj-vcs/jj), a Git-compatible VCS which focuses on ease-of-use and powerful history rewriting. Available as [programs.jujutsu](#opt-programs.jujutsu.enable).
+
 - [gocron](https://github.com/flohoss/gocron), a task scheduler with web interface. Available as [services.gocron](#opt-services.gocron.enable).
 
 - [Unpackerr](https://unpackerr.zip), extracts downloads for Radarr, Sonarr, Lidarr, Readarr, and/or a Watch folder. Available as [services.unpackerr](#opt-services.unpackerr.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -248,6 +248,7 @@
   ./programs/jai-jail.nix
   ./programs/java.nix
   ./programs/joycond-cemuhook.nix
+  ./programs/jujutsu.nix
   ./programs/k3b.nix
   ./programs/k40-whisperer.nix
   ./programs/kbdlight.nix

--- a/nixos/modules/programs/jujutsu.nix
+++ b/nixos/modules/programs/jujutsu.nix
@@ -1,0 +1,84 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.programs.jujutsu;
+  format = pkgs.formats.toml { };
+
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    versionAtLeast
+    ;
+
+  inherit (lib.types)
+    submodule
+    nullOr
+    either
+    str
+    listOf
+    ;
+
+in
+{
+  meta.maintainers = pkgs.jujutsu.meta.maintainers;
+
+  options.programs.jujutsu = {
+    enable = mkEnableOption "`jujutsu`, a powerful Git-compatible VCS";
+
+    settings = mkOption {
+      type = submodule {
+        freeformType = format.type;
+
+        options = {
+          ui.default-command = mkOption {
+            type = nullOr (either str (listOf str));
+            example = [
+              "log"
+              "--reversed"
+            ];
+            description = "The default subcommand to run";
+            default = null;
+          };
+
+          revset-aliases."immutable_heads()" = mkOption {
+            type = nullOr str;
+            example = "builtin_immutable_heads() | ~mine()";
+            description = "The set of commits to consider immutable";
+            default = null;
+          };
+        };
+      };
+
+      default = { };
+      description = ''
+        Generates the system-wide config.toml file. Refer to
+        <https://docs.jj-vcs.dev/latest/config> for details
+        on supported values.
+      '';
+    };
+
+    package = mkPackageOption pkgs "jujutsu" { };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = versionAtLeast "0.43.0" cfg.package.version;
+        message = "jujutsu is too old. The version supplied is ${cfg.package.version}, and support for system-wide configuration was added in 0.43.0";
+      }
+    ];
+
+    environment = {
+      systemPackages = [ cfg.package ];
+
+      etc."jj/config.toml".source = format.generate "jujutsu-config.toml" cfg.settings;
+    };
+  };
+}

--- a/pkgs/by-name/ju/jujutsu/package.nix
+++ b/pkgs/by-name/ju/jujutsu/package.nix
@@ -90,6 +90,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       thoughtpolice
       emily
       bbigras
+      graysontinker
     ];
     mainProgram = "jj";
   };


### PR DESCRIPTION
The next jujutsu version will enable controlling config system-wide (https://github.com/jj-vcs/jj/pull/9463), so making a module for it. First time making a module so let me know if there are any improvements to be made.

Not tested yet since the changes are only in prerelease.

Added myself as maintainer. I'm a very new user but I'm loving it so far.

Depends on #537635.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
