### PR TITLE
opencode-desktop: fix desktop file name and StartupWMClass to match app_id

### DIFF
--- a/pkgs/by-name/op/opencode-desktop/package.nix
+++ b/pkgs/by-name/op/opencode-desktop/package.nix
@@ -124,11 +124,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   desktopItems = lib.optional stdenvNoCC.hostPlatform.isLinux (makeDesktopItem {
-    name = "opencode-desktop";
+    name = "ai.opencode.desktop";
     desktopName = "OpenCode";
     exec = "opencode-desktop %U";
     icon = "opencode-desktop";
-    startupWMClass = "OpenCode";
+    startupWMClass = "ai.opencode.desktop";
     categories = [ "Development" ];
     mimeTypes = [ "x-scheme-handler/opencode" ];
   });


### PR DESCRIPTION
## Problem

The Electron app sets its application ID to `ai.opencode.desktop` ([`APP_IDS`](https://github.com/anomalyco/opencode/blob/dev/packages/desktop/src/main/index.ts#L47-L51) → [`app.setAppUserModelId(appId)`](https://github.com/anomalyco/opencode/blob/dev/packages/desktop/src/main/index.ts#L130)), but the nixpkgs desktop item defines `name = "opencode-desktop"` with `startupWMClass = "OpenCode"`. This mismatch causes desktop environments to fail associating the running window with the launcher icon.

The upstream [`electron-builder.config.ts`](https://github.com/anomalyco/opencode/blob/dev/packages/desktop/electron-builder.config.ts) already generates the correct values — [`desktopName: \`${appId}.desktop\``](https://github.com/anomalyco/opencode/blob/dev/packages/desktop/electron-builder.config.ts#L53) and [`StartupWMClass: appId`](https://github.com/anomalyco/opencode/blob/dev/packages/desktop/electron-builder.config.ts#L102) — but the nixpkgs derivation overrides this with its own `makeDesktopItem` call using hardcoded values.

## Fix

Align the `name` and `startupWMClass` fields in `makeDesktopItem` with the app_id set by the upstream code (`pkgs/by-name/op/opencode-desktop/package.nix`):

| Field | Before | After |
|---|---|---|
| `name` | `opencode-desktop` | `ai.opencode.desktop` |
| `startupWMClass` | `OpenCode` | `ai.opencode.desktop` |

The desktop file is now `ai.opencode.desktop.desktop` with `StartupWMClass=ai.opencode.desktop`, matching the upstream `electron-builder.config.ts`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s):
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)
  - [ ] Package tests at `passthru.tests`
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality
- [x] Tested basic functionality of all binary files (verified desktop file name and StartupWMClass match)
- [ ] Ran `nixpkgs-review` on this PR (see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage))
- Nixpkgs Release Notes:
  - [ ] Package update: when the change is major or breaking
- NixOS Release Notes:
  - [ ] Module addition: when adding a new NixOS module
  - [ ] Module update: when the change is significant
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md) and other READMEs
- [x] Follows the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy)

---

*AI disclosure: This contribution was created with assistance from opencode (model: deepseek-v4-flash-free). The changes have been reviewed by a human contributor.*