### PR TITLE
rust-aws-lc-sys: init at 5.0.0

### DIFF
--- a/pkgs/by-name/ru/rust-aws-lc-sys/package.nix
+++ b/pkgs/by-name/ru/rust-aws-lc-sys/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenvNoCC,
+  writeText,
+  aws-lc,
+}:
+
+stdenvNoCC.mkDerivation {
+  inherit (aws-lc) version;
+  pname = "rust-aws-lc-sys";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    ln -s ${lib.getLib aws-lc}/lib $out/lib
+    ln -s ${lib.getDev aws-lc}/include $out/include
+    ln -s ${lib.getDev aws-lc}/share $out/share
+
+    runHook postInstall
+  '';
+
+  setupHook = ./setup-hook.sh;
+
+  meta = {
+    inherit (aws-lc.meta) license platforms maintainers;
+    description = "Low-level bindings to the AWS-LC library for the Rust programming language";
+    homepage = "https://github.com/aws/aws-lc-rs";
+  };
+}

--- a/pkgs/by-name/ru/rust-aws-lc-sys/setup-hook.sh
+++ b/pkgs/by-name/ru/rust-aws-lc-sys/setup-hook.sh
@@ -1,0 +1,1 @@
+export AWS_LC_SYS_SYSTEM_DIR="@out@"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This allows dynamic linking of aws-lc for aws-lc-rs: [aws/aws-lc-rs@main/aws-lc-sys/README.md#using-a-system-installed-aws-lc](https://github.com/aws/aws-lc-rs/blob/main/aws-lc-sys/README.md#using-a-system-installed-aws-lc)

Notably, aws-lc-sys requires a singular output for `AWS_LC_SYS_SYSTEM_DIR`, hence the symlinks. 

This does require a very new version of aws-lc-rs to work (v1.17.1). As such, I don't think changing the `default-crate-overrides.nix` makes sense yet.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
