### PR TITLE
cfait: init at 1.0.9

### DIFF
--- a/pkgs/by-name/cf/cfait/package.nix
+++ b/pkgs/by-name/cf/cfait/package.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  libxkbcommon,
+  oniguruma,
+  vulkan-loader,
+  zstd,
+  stdenv,
+  wayland,
+  nix-update-script,
+  withGui ? false,
+}:
+
+let
+  rpathLibs = lib.optionals stdenv.hostPlatform.isLinux [
+    wayland
+    libxkbcommon
+    vulkan-loader
+  ];
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "cfait${lib.optionalString withGui "-gui"}";
+  version = "1.0.9";
+
+  src = fetchFromGitHub {
+    owner = "trougnouf";
+    repo = "cfait";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8wbQdCWpyzOjawdp/78cKPiBixhLfU5OBUZvKW0i6yY=";
+  };
+
+  cargoHash = "sha256-wIMrfW2atR64xUd8li+dplK1qQW2tvA+Fim9kf+xAt4=";
+
+  buildFeatures = lib.optionals withGui [ "gui" ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    oniguruma
+    zstd
+  ]
+  ++ rpathLibs;
+
+  env = {
+    RUSTONIG_SYSTEM_LIBONIG = true;
+    ZSTD_SYS_USE_PKG_CONFIG = true;
+  };
+
+  postInstall = lib.optionalString withGui (
+    lib.optionalString stdenv.hostPlatform.isLinux ''
+      # patchelf generates an ELF that binutils' "strip" doesn't like:
+      #    strip: not enough room for program headers, try linking with -N
+      # As a workaround, strip manually before running patchelf.
+      # $STRIP -S $out/bin/cfait-gui
+
+      patchelf --add-rpath "${lib.makeLibraryPath rpathLibs}" $out/bin/cfait-gui
+    ''
+    + ''
+      # Remove TUI binary from GUI package to keep them separate
+      rm $out/bin/cfait
+    ''
+  );
+
+  dontPatchELF = true;
+
+  doCheck = false; # Some checks fail on NixOS
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Take control of your TODO list";
+    homepage = "https://github.com/trougnouf/cfait";
+    changelog = "https://github.com/trougnouf/cfait/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = with lib.licenses; [
+      ofl
+      agpl3Only
+      gpl3Only
+    ];
+    maintainers = with lib.maintainers; [ nemeott ];
+    mainProgram = "cfait${lib.optionalString withGui "-gui"}";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8548,6 +8548,8 @@ with pkgs;
 
   cdxj-indexer = with python3Packages; toPythonApplication cdxj-indexer;
 
+  cfait-gui = callPackage ../by-name/cf/cfait/package.nix { withGui = true; };
+
   chromium = callPackage ../applications/networking/browsers/chromium (config.chromium or { });
 
   cni = callPackage ../applications/networking/cluster/cni { };


### PR DESCRIPTION
Added Cfait, a "fast and powerful, offline-first task manager for your terminal [and], desktop". It is a keyboard-centric to-do list with CalDAV sync support. It provides both a TUI and GUI: `cfait` and `cfait-gui` binaries respectively. Here is the repo: https://github.com/trougnouf/cfait.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
