### PR TITLE
bun: 1.3.13 -> 1.3.14

### DIFF
--- a/pkgs/by-name/bu/bun/package.nix
+++ b/pkgs/by-name/bu/bun/package.nix
@@ -17,7 +17,7 @@
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
-  version = "1.3.13";
+  version = "1.3.14";
   pname = "bun";
 
   src =
@@ -81,19 +81,19 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     sources = {
       "aarch64-darwin" = fetchurl {
         url = "https://github.com/oven-sh/bun/releases/download/bun-v${finalAttrs.version}/bun-darwin-aarch64.zip";
-        hash = "sha256-VGfj9l26Umuf6pjwzOBO+vwMY+Fpcz7Ce4dqOtMtoZA=";
+        hash = "sha256-2LliIYKK1vl6x6wKt+lYcjQa92MAHogD6CZ2UsJlJiA=";
       };
       "aarch64-linux" = fetchurl {
         url = "https://github.com/oven-sh/bun/releases/download/bun-v${finalAttrs.version}/bun-linux-aarch64.zip";
-        hash = "sha256-cLrkGzkIsKEg4eWMXIrzDnSvrjuNEbDT/djnh937SyI=";
+        hash = "sha256-on/7Y6gxA3WDbg1vZorhf6jY0YuIw3yCHGUzGXOhmjs=";
       };
       "x86_64-darwin" = fetchurl {
         url = "https://github.com/oven-sh/bun/releases/download/bun-v${finalAttrs.version}/bun-darwin-x64-baseline.zip";
-        hash = "sha256-qYumpIDyL9qbNDYmuQak4mqlNhi/hdK8WSjs8rpF8O0=";
+        hash = "sha256-PjWtb1OXGpg0v55nhuKt9ytfGSHMmpxf3gc9KXKUQHY=";
       };
       "x86_64-linux" = fetchurl {
         url = "https://github.com/oven-sh/bun/releases/download/bun-v${finalAttrs.version}/bun-linux-x64.zip";
-        hash = "sha256-ecB3H6i5LDOq5B4VoODTB+qZ0OLwAxfHHGxTI3p44lo=";
+        hash = "sha256-lR7iruhV8IWVruxiJSJqKY0/6oOj3NZGXAnLzN9+hI8=";
       };
     };
     updateScript = writeShellScript "update-bun" ''


### PR DESCRIPTION
Updates bun from 1.3.13 to 1.3.14.

Changelog: https://bun.sh/blog/bun-v1.3.14

## Things done

- Built on platform:
  - [x] aarch64-darwin
- Refreshed release hashes for all four platforms (aarch64-darwin, aarch64-linux, x86_64-darwin, x86_64-linux); each `passthru.sources.<platform>` fixed-output derivation builds successfully.
- [x] Tested basic functionality: `./result/bin/bun --version` prints `1.3.14`.
- [x] Follows the automation/AI policy.

## Disclosure

This change was prepared with assistance from Fugu in the Oh My Pi agent harness. The primary model name and version identifier exposed by the harness is `sakana/fugu`. The version bump and hashes were reviewed and verified by building the package and all per-platform source derivations. The commit carries the required `Assisted-by:` trailer.