### PR TITLE
nixos/matrix-authentication-service: fix extra config file loading

### DIFF
--- a/nixos/modules/services/matrix/matrix-authentication-service.nix
+++ b/nixos/modules/services/matrix/matrix-authentication-service.nix
@@ -379,13 +379,16 @@ in
       type = lib.types.attrsOf lib.types.str;
       default = { };
       description = ''
-        Name -> source file path. Exposed to the unit via LoadCredential and
-        readable inside the service at ''${CREDENTIALS_DIRECTORY}/<name>.
+        Mapping of credential name to  source file-path. Exposed to the unit via LoadCredential and
+        readable inside the service at `''${CREDENTIALS_DIRECTORY}/<name>`.
 
-        For example :
+        For example:
+
+        ```
         services.matrix-authentication-service.credentials."synapse-secret" = "/run/agenix/synapse-shared";
         services.matrix-authentication-service.settings.matrix.secret_file =
           "\''${CREDENTIALS_DIRECTORY}/synapse-secret";
+        ```
       '';
     };
   };

--- a/nixos/modules/services/matrix/matrix-authentication-service.nix
+++ b/nixos/modules/services/matrix/matrix-authentication-service.nix
@@ -43,6 +43,9 @@ let
     else
       pruned;
   configFile = format.generate "config.yaml" finalSettings;
+
+  extraConfigArgs = lib.imap0 (i: _: "%d/config-${toString i}") cfg.extraConfigFiles;
+  configFileArgs = [ configFile ] ++ extraConfigArgs;
 in
 {
   meta.maintainers = with lib.maintainers; [
@@ -388,13 +391,14 @@ in
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
         DynamicUser = true;
+        LoadCredential = lib.imap0 (i: path: "config-${toString i}:${path}") cfg.extraConfigFiles;
         ExecStartPre = ''
           ${getExe cfg.package} config check \
-            ${concatMapStringsSep " " (x: "--config ${x}") ([ configFile ] ++ cfg.extraConfigFiles)}
+            ${concatMapStringsSep " " (x: "--config ${x}") configFileArgs}
         '';
         ExecStart = ''
           ${getExe cfg.package} server \
-            ${concatMapStringsSep " " (x: "--config ${x}") ([ configFile ] ++ cfg.extraConfigFiles)}
+            ${concatMapStringsSep " " (x: "--config ${x}") configFileArgs}
         '';
         Restart = "on-failure";
         RestartSec = "1s";
@@ -436,6 +440,7 @@ in
         # Working and state directories
         StateDirectory = "matrix-authentication-service";
         StateDirectoryMode = "0700";
+        RuntimeDirectory = "matrix-authentication-service";
         WorkingDirectory = "/var/lib/matrix-authentication-service";
       };
     };

--- a/nixos/modules/services/matrix/matrix-authentication-service.nix
+++ b/nixos/modules/services/matrix/matrix-authentication-service.nix
@@ -14,13 +14,11 @@ let
     isAttrs
     isList
     mapAttrs
-    mkDefault
     mkEnableOption
     mkIf
     mkOption
     mkPackageOption
     optional
-    optionalAttrs
     types
     ;
 

--- a/nixos/modules/services/matrix/matrix-authentication-service.nix
+++ b/nixos/modules/services/matrix/matrix-authentication-service.nix
@@ -385,7 +385,7 @@ in
         For example :
         services.matrix-authentication-service.credentials."synapse-secret" = "/run/agenix/synapse-shared";
         services.matrix-authentication-service.settings.matrix.secret_file =
-          "''${CREDENTIALS_DIRECTORY}/synapse-secret";
+          "\''${CREDENTIALS_DIRECTORY}/synapse-secret";
       '';
     };
   };

--- a/nixos/modules/services/matrix/matrix-authentication-service.nix
+++ b/nixos/modules/services/matrix/matrix-authentication-service.nix
@@ -11,6 +11,7 @@ let
     filter
     filterAttrs
     getExe
+    getExe'
     isAttrs
     isList
     mapAttrs
@@ -44,8 +45,10 @@ let
       pruned;
   configFile = format.generate "config.yaml" finalSettings;
 
-  extraConfigArgs = lib.imap0 (i: _: "%d/config-${toString i}") cfg.extraConfigFiles;
-  configFileArgs = [ configFile ] ++ extraConfigArgs;
+  extraConfigFiles = lib.imap0 (
+    i: _: "$CREDENTIALS_DIRECTORY/config-${toString i}"
+  ) cfg.extraConfigFiles;
+  runtimeConfig = "/run/matrix-authentication-service/config.yaml";
 in
 {
   meta.maintainers = with lib.maintainers; [
@@ -371,6 +374,20 @@ in
         such as the Matrix homeserver if it's running on the same host.
       '';
     };
+
+    credentials = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      description = ''
+        Name -> source file path. Exposed to the unit via LoadCredential and
+        readable inside the service at ''${CREDENTIALS_DIRECTORY}/<name>.
+
+        For example :
+        services.matrix-authentication-service.credentials."synapse-secret" = "/run/agenix/synapse-shared";
+        services.matrix-authentication-service.settings.matrix.secret_file =
+          "''${CREDENTIALS_DIRECTORY}/synapse-secret";
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -391,14 +408,20 @@ in
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
         DynamicUser = true;
-        LoadCredential = lib.imap0 (i: path: "config-${toString i}:${path}") cfg.extraConfigFiles;
-        ExecStartPre = ''
-          ${getExe cfg.package} config check \
-            ${concatMapStringsSep " " (x: "--config ${x}") configFileArgs}
+        LoadCredential =
+          (lib.imap0 (i: path: "config-${toString i}:${path}") cfg.extraConfigFiles)
+          ++ (lib.mapAttrsToList (name: path: "${name}:${path}") cfg.credentials);
+        ExecStartPre = pkgs.writeShellScript "mas-prepare" ''
+          ${getExe' pkgs.gettext "envsubst"} \
+            '$CREDENTIALS_DIRECTORY' \
+            < ${configFile} \
+            > /run/matrix-authentication-service/config.yaml
+          ${getExe cfg.package} config check --config ${runtimeConfig} \
+            ${concatMapStringsSep " " (x: "--config ${x}") extraConfigFiles}
         '';
         ExecStart = ''
-          ${getExe cfg.package} server \
-            ${concatMapStringsSep " " (x: "--config ${x}") configFileArgs}
+          ${getExe cfg.package} server --config ${runtimeConfig} \
+            ${concatMapStringsSep " " (x: "--config ${x}") extraConfigFiles}
         '';
         Restart = "on-failure";
         RestartSec = "1s";

--- a/nixos/tests/matrix/matrix-authentication-service.nix
+++ b/nixos/tests/matrix/matrix-authentication-service.nix
@@ -237,13 +237,14 @@ in
               {
                 id = masULID;
                 client_id = oidcClientID;
-                client_secret = oidcClientSecret;
+                client_secret_file = "\${CREDENTIALS_DIRECTORY}/oidc_client_secret";
                 issuer = "https://${dexDomain}:5556";
                 scope = "openid email profile";
                 token_endpoint_auth_method = "client_secret_post";
               }
             ];
           };
+          credentials.oidc_client_secret = "${pkgs.writeText "oidc-client-secret" oidcClientSecret}";
         };
         services.postgresql.authentication = pkgs.lib.mkOverride 10 ''
           local all all trust


### PR DESCRIPTION
Currently, because MAS service is using dynamic users, it cannot simply load the files `extraConfigFiles` so the option is almost fully broken.
To fix this, I almost stole the solution in [nixos/modules/services/monitoring/prometheus/alertmanager-ntfy.nix](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/monitoring/prometheus/alertmanager-ntfy.nix)
We load the file using the `LoadCredential` feature of systemd.

Tested, the generated service looks like this : 
```
systemctl cat matrix-authentication-service.service
# /etc/systemd/system/matrix-authentication-service.service -> /nix/store/r8brh9ah6j4bb0gs4khgav4n7jw8fs9k-unit-matrix-authentication-service.service/matrix-authentication-service.service
[Unit]
After=matrix-synapse.service
Wants=matrix-synapse.service

[Service]
Environment="LOCALE_ARCHIVE=/nix/store/yn7dyl3b4g45j5mcnqc8fr2a7y0iz1ls-glibc-locales-2.42-61/lib/locale/locale-archive"
Environment="PATH=/nix/store/9ypz3flqsrl5xl495mm8h645gadjsxi1-coreutils-9.11/bin:/nix/store/c1cjgg6p8m8fssivzrc2p13mwwml3p3v-findutils-4.10.0/bin:/nix/store/gn94gpcp5q08x4v6g8mvw8v4r65rcjzk-gnugrep-3.12/bin:/nix/store/kgxafhycw2kybbqih759ykc2043qyi5j-gnused-4.9/bin:/ni>
Environment="TZDIR=/nix/store/v2hsfkf03b3l79rhcxw4nq7w79kr3qkw-tzdata-2026b/share/zoneinfo"
AmbientCapabilities=
CapabilityBoundingSet=
DynamicUser=true
EnvironmentFile=/run/agenix/mas_config
ExecStart=/nix/store/9kcq33rpsf1nk916qvns3ynflcdqqd0a-matrix-authentication-service-1.17.0/bin/mas-cli server \
  --config /nix/store/5a4ayim858lh6g2ciqs3ya1dvkdisgq1-config.yaml --config %d/config-0

ExecStartPre=/nix/store/fl3mm9lq93n2iczlimrj27pp4i6dc95f-unit-script-matrix-authentication-service-pre-start/bin/matrix-authentication-service-pre-start
ExecStartPre=/nix/store/9kcq33rpsf1nk916qvns3ynflcdqqd0a-matrix-authentication-service-1.17.0/bin/mas-cli config check \
  --config /nix/store/5a4ayim858lh6g2ciqs3ya1dvkdisgq1-config.yaml --config %d/config-0

LoadCredential=config-0:/persistent/secrets.yaml
LockPersonality=true
NoNewPrivileges=true
PrivateDevices=true
PrivateMounts=true
PrivateTmp=true
ProcSubset=pid
ProtectClock=true
ProtectControlGroups=true
ProtectHome=true
ProtectHostname=true
ProtectKernelLogs=true
ProtectKernelModules=true
ProtectKernelTunables=true
ProtectProc=invisible
ProtectSystem=strict
RemoveIPC=true
Restart=on-failure
RestartSec=1s
RestrictAddressFamilies=AF_UNIX
RestrictAddressFamilies=AF_INET
RestrictAddressFamilies=AF_INET6
RestrictNamespaces=true
RestrictRealtime=true
RestrictSUIDSGID=true
StateDirectory=matrix-authentication-service
StateDirectoryMode=0700
SupplementaryGroups=matrix-synapse
SystemCallArchitectures=native
SystemCallErrorNumber=EPERM
SystemCallFilter=@system-service
UMask=0077
WorkingDirectory=/var/lib/matrix-authentication-service

[Install]
WantedBy=multi-user.target
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test