### PR TITLE
antigravity-cli: fix updateScript and refactor versioning

### DIFF
--- a/pkgs/by-name/an/antigravity-cli/package.nix
+++ b/pkgs/by-name/an/antigravity-cli/package.nix
@@ -6,8 +6,9 @@
   versionCheckHook,
 }:
 let
-  wholeVersion = "1.0.12-6156052174077952"; # unfortunately this has dumb versioning
-  version = builtins.head (lib.splitString "-" wholeVersion);
+  version = "1.0.12";
+  buildId = "6156052174077952";
+  wholeVersion = "${version}-${buildId}";
 
   throwSystem = throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}";
 

--- a/pkgs/by-name/an/antigravity-cli/update.sh
+++ b/pkgs/by-name/an/antigravity-cli/update.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p bash nix-update common-updater-scripts nix jq
+#!nix-shell -i bash -p bash nix jq curl python3
 
 set -euo pipefail
 
+script_dir="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+package_file="$script_dir/package.nix"
 baseUrl=https://storage.googleapis.com/antigravity-public/antigravity-cli
 
-currentVersion=$(nix-instantiate --eval --raw -E "with import ./. {}; antigravity-cli.version or (lib.getVersion antigravity-cli)")
-latestVersion=$(curl $baseUrl/latest)
+currentVersion=$(grep -oP 'version = "\K[^"]+' "$package_file")
+latestVersion=$(curl -fsSL $baseUrl/latest)
 
 if [[ "$currentVersion" == "$latestVersion" ]]; then
     echo "package is up-to-date: $currentVersion"
@@ -14,16 +16,54 @@ if [[ "$currentVersion" == "$latestVersion" ]]; then
 fi
 
 # urls unfortunately include a weird buildid that make it hard to get
-latestWholeVersion=$(curl $baseUrl/$latestVersion/manifest.json | jq -r '.platforms."linux-x64".url' | cut -d/ -f6)
+latestWholeVersion=$(curl -fsSL $baseUrl/$latestVersion/manifest.json | jq -r '.platforms."linux-x64".url' | cut -d/ -f6)
+latestBuildId=${latestWholeVersion#*-}
 
-update-source-version --version-key=wholeVersion antigravity-cli $latestWholeVersion || true
-
+declare -A hashes
 for system in \
     x86_64-linux \
     aarch64-linux \
     x86_64-darwin \
     aarch64-darwin; do
-    hash=$(nix store prefetch-file --json --hash-type sha256 \
-      $(nix-instantiate --eval --raw -E "with import ./. {}; antigravity-cli.src.url" --system "$system") | jq -r '.hash')
-    update-source-version --version-key=wholeVersion antigravity-cli $latestWholeVersion $hash --system=$system --ignore-same-version
+    case $system in
+        x86_64-linux) arch="linux-x64/cli_linux_x64.tar.gz" ;;
+        aarch64-linux) arch="linux-arm/cli_linux_arm64.tar.gz" ;;
+        aarch64-darwin) arch="darwin-arm/cli_mac_arm64.tar.gz" ;;
+        x86_64-darwin) arch="darwin-x64/cli_mac_x64.tar.gz" ;;
+    esac
+    url="$baseUrl/$latestWholeVersion/$arch"
+    hash=$(nix store prefetch-file --json --hash-type sha256 "$url" | jq -r '.hash')
+    hashes[$system]=$hash
 done
+
+python3 - "$package_file" "$latestVersion" "$latestBuildId" \
+    "${hashes[x86_64-linux]}" "${hashes[aarch64-linux]}" \
+    "${hashes[aarch64-darwin]}" "${hashes[x86_64-darwin]}" << 'EOF'
+import sys
+import re
+
+package_file = sys.argv[1]
+new_version = sys.argv[2]
+new_build_id = sys.argv[3]
+hashes = {
+    "x86_64-linux": sys.argv[4],
+    "aarch64-linux": sys.argv[5],
+    "aarch64-darwin": sys.argv[6],
+    "x86_64-darwin": sys.argv[7],
+}
+
+with open(package_file, 'r') as f:
+    content = f.read()
+
+content = re.sub(r'version = "[^"]+";', f'version = "{new_version}";', content)
+content = re.sub(r'buildId = "[^"]+";', f'buildId = "{new_build_id}";', content)
+
+for system, new_hash in hashes.items():
+    pattern = rf'({system}\s*=\s*fetchurl\s*\{{[^}}]*hash\s*=\s*")[^"]+(")'
+    content = re.sub(pattern, rf'\1{new_hash}\2', content)
+
+with open(package_file, 'w') as f:
+    f.write(content)
+EOF
+
+echo "Successfully updated antigravity-cli to $latestVersion"


### PR DESCRIPTION
### Problem
The automated update bot (`r-ryntm` / `nixpkgs-update`) was failing to update `antigravity-cli` because it checks if the old version string followed by a double quote exists in the package's Nix file (e.g. searching for `"1.0.12\""`). However, in `antigravity-cli`'s `package.nix`, the version attribute was defined dynamically:
```nix
wholeVersion = "1.0.12-6156052174077952";
version = builtins.head (lib.splitString "-" wholeVersion);
```
Since `1.0.12` is followed by a hyphen (`-`) rather than a double quote (`"`), the bot's check failed. Furthermore, the custom `update.sh` script required a full Nix evaluation of Nixpkgs, which fails inside sparse checkouts.

### Solution
1. **Refactored Variable Structure**: Declared `version` and `buildId` as separate variables in `package.nix`, defining `wholeVersion` dynamically via interpolation:
   ```nix
   version = "1.0.12";
   buildId = "6156052174077952";
   wholeVersion = "${version}-${buildId}";
   ```
   This exposes the version string as a simple literal `"1.0.12"` so that the bot can find and replace it.
2. **Rewrote `update.sh`**: Modified the script to parse the version locally using grep, construct the URLs, and update the fields using a Python string-replacement snippet instead of calling `update-source-version` and `nix-instantiate` on the root of Nixpkgs. This makes it completely self-contained and compatible with sparse checkouts.

---

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [X] Verified syntax of `package.nix` with `nix-instantiate --parse`
  - [X] Verified that `update.sh` runs successfully locally and updates files
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)
- [X] Follows the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy)

*Disclosure: This contribution was prepared with the assistance of Gemini 3.5 Flash (Medium) via Antigravity CLI.*