### PR TITLE
webcord: 4.13.0 -> 4.13.2

### DIFF
--- a/pkgs/by-name/we/webcord-vencord/package.nix
+++ b/pkgs/by-name/we/webcord-vencord/package.nix
@@ -1,6 +1,6 @@
 {
   # allow overriding electron
-  electron_41,
+  electron_42,
   webcord,
   replaceVars,
   lib,
@@ -8,7 +8,7 @@
 }:
 
 # nixpkgs-update: no auto update
-(webcord.override { inherit electron_41; }).overrideAttrs (old: {
+(webcord.override { inherit electron_42; }).overrideAttrs (old: {
   pname = "webcord-vencord";
 
   patches = (old.patches or [ ]) ++ [

--- a/pkgs/by-name/we/webcord/package.nix
+++ b/pkgs/by-name/we/webcord/package.nix
@@ -5,23 +5,23 @@
   copyDesktopItems,
   python3,
   xdg-utils,
-  electron_41,
+  electron_42,
   makeDesktopItem,
   nodejs_22,
 }:
 
 buildNpmPackage.override { nodejs = nodejs_22; } rec {
   pname = "webcord";
-  version = "4.13.0";
+  version = "4.13.2";
 
   src = fetchFromGitHub {
     owner = "SpacingBat3";
     repo = "WebCord";
     tag = "v${version}";
-    hash = "sha256-XUhaGZkHTLZlOuzh7aN9tIk7uBayiEID4MbmADhwvLs=";
+    hash = "sha256-td04ayA1AVDy6WCPQH3Y8zmZ6VfObqzFvm+cD8WZum4=";
   };
 
-  npmDepsHash = "sha256-KJMHQlCW/2AYG2Z0oshyMEvFiKsZgG4NKmsHMYrnyUE=";
+  npmDepsHash = "sha256-LLxDJOLLBnjHRHTH/q1o3szu+armmwx9ZIKYKHUO+Z0=";
 
   makeCacheWritable = true;
 
@@ -56,7 +56,7 @@ buildNpmPackage.override { nodejs = nodejs_22; } rec {
       install -Dm644 sources/assets/icons/app.png $out/share/icons/hicolor/256x256/apps/webcord.png
 
       # Add xdg-utils to path via suffix, per PR #181171
-      makeWrapper '${lib.getExe electron_41}' $out/bin/webcord \
+      makeWrapper '${lib.getExe electron_42}' $out/bin/webcord \
         --suffix PATH : "${binPath}" \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
         --add-flags $out/lib/node_modules/webcord/


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
