### PR TITLE
doc: document when newer builtins become usable

### DIFF
--- a/doc/functions.md
+++ b/doc/functions.md
@@ -4,6 +4,7 @@ The Nixpkgs repository has several utility functions to manipulate Nix expressio
 
 ```{=include=} sections
 functions/library.md
+functions/newer-builtins.section.md
 functions/generators.section.md
 functions/debug.section.md
 functions/prefer-remote-fetch.section.md

--- a/doc/functions/newer-builtins.section.md
+++ b/doc/functions/newer-builtins.section.md
@@ -1,0 +1,39 @@
+# Using Newer Builtins {#sec-newer-builtins}
+
+Newer versions of Nix sometimes create new builtin functions, which can add new functionality or be more efficient versions of existing functions in `lib`.
+However, these new builtins can only be used in limited ways until they have been supported for a significant period of time by all popular implementations of Nix.
+This is because of Nixpkgs' compatibility promise with both older versions of and popular alternate implementations of Nix.
+
+The minimum featureset of Nix that Nixpkgs requires is listed in `lib/minfeatures.nix`.
+In addition to the features explicitly listed, any builtin present in Nix 2.18 is able to be used.
+An evaluation of Nixpkgs with a version of Nix not supporting the requirements will fail.
+There is no specific process for adding new required features.
+
+The usage of functions not within the required features list has to be done with care.
+In general, packages must not use the newer builtin themselves.
+Instead, `lib` can utilize these functions to improve the efficiency of existing functions, while still providing a fallback implementation in Nix for older versions.
+
+```nix
+{
+  # In lib
+  addOne = builtins.addOne or (x: x + 1); # implementation without new builtins
+}
+```
+
+Even when a builtin may be used directly, try to use the applicable `lib` function instead when available.
+Using `lib` functions makes it much easier to evolve their functionality over time, because they are not bound to Nix's strict backwards compatibility policy.
+
+<!--## Builtins From Alternate Nix Implementations {#sec-nix-fork-builtins}
+
+TODO: Fill in this section once the status of PRs like #498999 is determined.
+
+Some implementations of Nix provide additional language builtins that are not present in upstream Nix.
+While useful for improving performance for the users of the implementation, usage of these can be problematic because they bind Nixpkgs to the (possibly varied) implementations of the function.
+These builtins...
+
+Depending on the outcome, some ideas:
+- may be used, provided their behavior matches the calling `lib` function exactly and a fallback implementation remains available indefinitely. They should never be called within packages.
+- must not be used, because we can't make guarantees about their behavior.
+- <omit the section entirely>
+
+-->

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -472,6 +472,9 @@
   "chap-overlays": [
     "index.html#chap-overlays"
   ],
+  "sec-newer-builtins": [
+    "index.html#sec-newer-builtins"
+  ],
   "sec-nixpkgs-release-26.11": [
     "release-notes.html#sec-nixpkgs-release-26.11"
   ],

--- a/lib/minfeatures.nix
+++ b/lib/minfeatures.nix
@@ -6,6 +6,9 @@ let
     }
     {
       description = "`builtins.nixVersion` reports at least 2.18";
+      # Note: This can never be updated, because Lix will always
+      # report 2.18 despite supporting newer features. (Hence the need
+      # for a feature-based minimum.)
       condition = builtins ? nixVersion && builtins.compareVersions "2.18" builtins.nixVersion != 1;
     }
   ];


### PR DESCRIPTION
Based on https://discourse.nixos.org/t/when-is-a-nix-builtin-function-builtins-considered-ready-to-be-used-inside-nixpkgs/35369.

Made against Nixpkgs instead of nix.dev because of #536632.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
