### PR TITLE
arti: 2.4.0 -> 2.5.0

### DIFF
--- a/pkgs/by-name/ar/arti/package.nix
+++ b/pkgs/by-name/ar/arti/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   rustPlatform,
   fetchFromGitLab,
-  fetchpatch,
   pkg-config,
   sqlite,
   openssl,
@@ -14,7 +13,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "arti";
-  version = "2.4.0";
+  version = "2.5.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.torproject.org";
@@ -22,29 +21,18 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "core";
     repo = "arti";
     tag = "arti-v${finalAttrs.version}";
-    hash = "sha256-YLOdrHstmN2pLl75uclkbpN5h3iBs3xpraZ8XN6R/+Q=";
+    hash = "sha256-jOCFXlBI2xAzgpb7Fa8ap53SpDF6kcRGYnBXcu3vpk4=";
   };
-
-  patches = [
-    # Fixes a panic that could allow malicious directory caches to crash
-    # clients.
-    # https://gitlab.torproject.org/tpo/core/arti/-/merge_requests/4062
-    (fetchpatch {
-      name = "TROVE-2026-024.patch";
-      url = "https://gitlab.torproject.org/tpo/core/arti/-/commit/f69be8c70561629e63004788f0aa4bf898025f93.patch";
-      hash = "sha256-P0sXTKOBW7ulqQZwmTVJfrpLksLyaonuDpxGF2keDqE=";
-    })
-  ];
 
   # Working around a bug in cargo that appears with cargo-auditable, see
   # https://github.com/rust-secure-code/cargo-auditable/issues/124.
   postPatch = ''
     substituteInPlace crates/arti/Cargo.toml \
-      --replace-fail '"tor-rpcbase"' '"dep:tor-rpcbase"'
+      --replace-fail '"tokio-util"' '"dep:tokio-util"'
   '';
 
   buildAndTestSubdir = "crates/arti";
-  cargoHash = "sha256-7X3JJbt0/jxaMvBR3XQvguR7tqd96kiqX66G2byvPjM=";
+  cargoHash = "sha256-JK6ubp697jZ98ErNrZdFe0mXIez3lUZ5SmAHkyD97WQ=";
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ pkg-config ];
 


### PR DESCRIPTION
blog: https://blog.torproject.org/arti_2_5_0_released/
changelog: https://gitlab.torproject.org/tpo/core/arti/-/blob/arti-v2.5.0/CHANGELOG.md
diff: https://gitlab.torproject.org/tpo/core/arti/-/compare/arti-v2.4.0...arti-v2.5.0
trove: https://gitlab.torproject.org/tpo/core/team/-/wikis/NetworkTeam/TROVE

this release is non-breaking for users of the binary, but should provide various transparent improvements (CGO, congestion control). additionally, the upstream tag contains fixes for two medium severity DoS issues: TROVE-2026-024 and TROVE-2026-027. we already had (and now drop) the patch for the former, but this does fix the latter for us.

Fixes: TROVE-2026-027

tested:
- with `tor-browser` as a standalone proxy
- with `curl` as a socks5 proxy to connect to clearnet sites and onion services
- running a regular onion service
- running an onion service with restricted discovery/client authorization
- as a client in a test network as part of `nixosTests.tor`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
