### PR TITLE
gitlab-ci-verify: init at 2.11.0

### DIFF
--- a/pkgs/by-name/gi/gitlab-ci-verify/package.nix
+++ b/pkgs/by-name/gi/gitlab-ci-verify/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  writableTmpDirAsHomeHook,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "gitlab-ci-verify";
+  version = "2.11.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "timo-reymann";
+    repo = "gitlab-ci-verify";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-vy7JigEXmedvXauv8cwKuAeSZF1Nsmq+JIl8+MHiB7o=";
+    fetchSubmodules = true;
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      git rev-parse HEAD > $out/COMMIT
+      date -u -d "@$(git log -1 --pretty=%ct)" "+%Y-%m-%dT%H:%M:%SZ" > $out/SOURCE_DATE_EPOCH
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
+  };
+
+  vendorHash = "sha256-V9kN/zdVIOWeULmCBbbIZsQx94PKsrHdPL65D8MGTM0=";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  # Using -X github.com/timo-reymann/gitlab-ci-verify/internal/buildinfo.Version does not work
+  preBuild = ''
+    substituteInPlace internal/buildinfo/main.go \
+      --replace-fail "unknown" "$(cat COMMIT)" \
+      --replace-fail "Version = \"?\"" "Version = \"${finalAttrs.version}\"" \
+      --replace-fail "BuildTime = \"?\"" "BuildTime = \"$(cat SOURCE_DATE_EPOCH)\""
+  '';
+
+  doCheck = true;
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Validate and lint your gitlab ci files using ShellCheck, the Gitlab API, curated checks or even build your own checks";
+    homepage = "https://github.com/timo-reymann/gitlab-ci-verify";
+    changelog = "https://github.com/timo-reymann/gitlab-ci-verify/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ drupol ];
+    mainProgram = "gitlab-ci-verify";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
