### PR TITLE
glibc: fix CVE-2026-5435 and CVE-2026-6238

### DIFF
--- a/pkgs/development/libraries/glibc/0001-resolv-Check-for-inet_ntop-failure-in-ns_sprintrrf.patch
+++ b/pkgs/development/libraries/glibc/0001-resolv-Check-for-inet_ntop-failure-in-ns_sprintrrf.patch
@@ -1,0 +1,69 @@
+From 4d9c6b19fcb34fab03fb7dab8f6d36a2cc4ef982 Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Fri, 19 Jun 2026 18:22:20 +0200
+Subject: [PATCH 1/3] resolv: Check for inet_ntop failure in ns_sprintrrf
+
+This makes the output more consistent (either failure or complete
+output) and helps with systematic testing with varying buffer
+sizes.
+
+Reviewed-by: Carlos O'Donell <carlos@redhat.com>
+Reviewed-by: Adhemerval Zanella <adhemerval.zanella@linaro.org>
+(cherry picked from commit cd0db208d56a2cecd528b8ae96df752ba5344d9a)
+---
+ resolv/ns_print.c | 18 +++++++++++-------
+ 1 file changed, 11 insertions(+), 7 deletions(-)
+
+diff --git a/resolv/ns_print.c b/resolv/ns_print.c
+index cef2212fd2..cb680fb74e 100644
+--- a/resolv/ns_print.c
++++ b/resolv/ns_print.c
+@@ -140,8 +140,9 @@ ns_sprintrrf(const u_char *msg, size_t msglen,
+ 	switch (type) {
+ 	case ns_t_a:
+ 	  if (rdlen != (size_t)NS_INADDRSZ)
+-			goto formerr;
+-		(void) inet_ntop(AF_INET, rdata, buf, buflen);
++		  goto formerr;
++		if (inet_ntop (AF_INET, rdata, buf, buflen) == NULL)
++		  return -1;
+ 		addlen(strlen(buf), &buf, &buflen);
+ 		break;
+ 
+@@ -307,9 +308,10 @@ ns_sprintrrf(const u_char *msg, size_t msglen,
+ 	    }
+ 
+ 	case ns_t_aaaa:
+-	  if (rdlen != (size_t)NS_IN6ADDRSZ)
+-			goto formerr;
+-		(void) inet_ntop(AF_INET6, rdata, buf, buflen);
++		if (rdlen != (size_t)NS_IN6ADDRSZ)
++		  goto formerr;
++		if (inet_ntop (AF_INET6, rdata, buf, buflen) == NULL)
++		  return -1;
+ 		addlen(strlen(buf), &buf, &buflen);
+ 		break;
+ 
+@@ -400,7 +402,8 @@ ns_sprintrrf(const u_char *msg, size_t msglen,
+ 			goto formerr;
+ 
+ 		/* Address. */
+-		(void) inet_ntop(AF_INET, rdata, buf, buflen);
++		if (inet_ntop (AF_INET, rdata, buf, buflen) == NULL)
++		  return -1;
+ 		addlen(strlen(buf), &buf, &buflen);
+ 		rdata += NS_INADDRSZ;
+ 
+@@ -542,7 +545,8 @@ ns_sprintrrf(const u_char *msg, size_t msglen,
+ 			if (rdata + pbyte >= edata) goto formerr;
+ 			memset(&a, 0, sizeof(a));
+ 			memcpy(&a.s6_addr[pbyte], rdata, sizeof(a) - pbyte);
+-			(void) inet_ntop(AF_INET6, &a, buf, buflen);
++			if (inet_ntop (AF_INET6, &a, buf, buflen) == NULL)
++			  return -1;
+ 			addlen(strlen(buf), &buf, &buflen);
+ 			rdata += sizeof(a) - pbyte;
+ 		}
+-- 
+2.54.0
+

--- a/pkgs/development/libraries/glibc/0002-resolv-More-types-as-unknown-in-ns_sprintrrf-CVE-202.patch
+++ b/pkgs/development/libraries/glibc/0002-resolv-More-types-as-unknown-in-ns_sprintrrf-CVE-202.patch
@@ -1,0 +1,134 @@
+From 103658e72f5aaeb36a5e405f9abaa1b687488fc1 Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Fri, 19 Jun 2026 18:22:20 +0200
+Subject: [PATCH 2/3] resolv: More types as unknown in ns_sprintrrf
+ (CVE-2026-5435)
+
+Specifically, CERT, TKEY, TSIG, OPT.  This removes the buggy
+implementations of TSIG, fixing bug 34033, and partially
+fixing bug 34069.
+
+Reviewed-by: Carlos O'Donell <carlos@redhat.com>
+Reviewed-by: Adhemerval Zanella <adhemerval.zanella@linaro.org>
+(cherry picked from commit ca44a6609c29a683b03575fa035c6d17aa591e72)
+---
+ resolv/ns_print.c | 96 -----------------------------------------------
+ 1 file changed, 96 deletions(-)
+
+diff --git a/resolv/ns_print.c b/resolv/ns_print.c
+index cb680fb74e..8c876b147e 100644
+--- a/resolv/ns_print.c
++++ b/resolv/ns_print.c
+@@ -437,96 +437,6 @@ ns_sprintrrf(const u_char *msg, size_t msglen,
+ 		break;
+ 	    }
+ 
+-	case ns_t_cert: {
+-		u_int c_type, key_tag, alg;
+-		int n;
+-		unsigned int siz;
+-		char base64_cert[8192], tmp[40];
+-		const char *leader;
+-
+-		c_type  = ns_get16(rdata); rdata += NS_INT16SZ;
+-		key_tag = ns_get16(rdata); rdata += NS_INT16SZ;
+-		alg = (u_int) *rdata++;
+-
+-		len = SPRINTF((tmp, "%d %d %d ", c_type, key_tag, alg));
+-		T(addstr(tmp, len, &buf, &buflen));
+-		siz = (edata-rdata)*4/3 + 4; /* "+4" accounts for trailing \0 */
+-		if (siz > sizeof(base64_cert) * 3/4) {
+-			const char *str = "record too long to print";
+-			T(addstr(str, strlen(str), &buf, &buflen));
+-		}
+-		else {
+-			len = b64_ntop(rdata, edata-rdata, base64_cert, siz);
+-
+-			if (len < 0)
+-				goto formerr;
+-			else if (len > 15) {
+-				T(addstr(" (", 2, &buf, &buflen));
+-				leader = "\n\t\t";
+-				spaced = 0;
+-			}
+-			else
+-				leader = " ";
+-
+-			for (n = 0; n < len; n += 48) {
+-				T(addstr(leader, strlen(leader),
+-					 &buf, &buflen));
+-				T(addstr(base64_cert + n, MIN(len - n, 48),
+-					 &buf, &buflen));
+-			}
+-			if (len > 15)
+-				T(addstr(" )", 2, &buf, &buflen));
+-		}
+-		break;
+-	    }
+-
+-	case ns_t_tkey: {
+-		/* KJD - need to complete this */
+-		u_long t;
+-		int mode, err, keysize;
+-
+-		/* Algorithm name. */
+-		T(addname(msg, msglen, &rdata, origin, &buf, &buflen));
+-		T(addstr(" ", 1, &buf, &buflen));
+-
+-		/* Inception. */
+-		t = ns_get32(rdata);  rdata += NS_INT32SZ;
+-		len = SPRINTF((tmp, "%lu ", t));
+-		T(addstr(tmp, len, &buf, &buflen));
+-
+-		/* Expiration. */
+-		t = ns_get32(rdata);  rdata += NS_INT32SZ;
+-		len = SPRINTF((tmp, "%lu ", t));
+-		T(addstr(tmp, len, &buf, &buflen));
+-
+-		/* Mode , Error, Key Size. */
+-		/* Priority, Weight, Port. */
+-		mode = ns_get16(rdata);  rdata += NS_INT16SZ;
+-		err  = ns_get16(rdata);  rdata += NS_INT16SZ;
+-		keysize  = ns_get16(rdata);  rdata += NS_INT16SZ;
+-		len = SPRINTF((tmp, "%u %u %u ", mode, err, keysize));
+-		T(addstr(tmp, len, &buf, &buflen));
+-
+-		/* XXX need to dump key, print otherdata length & other data */
+-		break;
+-	    }
+-
+-	case ns_t_tsig: {
+-		/* BEW - need to complete this */
+-		int n;
+-
+-		T(len = addname(msg, msglen, &rdata, origin, &buf, &buflen));
+-		T(addstr(" ", 1, &buf, &buflen));
+-		rdata += 8; /*%< time */
+-		n = ns_get16(rdata); rdata += INT16SZ;
+-		rdata += n; /*%< sig */
+-		n = ns_get16(rdata); rdata += INT16SZ; /*%< original id */
+-		sprintf(buf, "%d", ns_get16(rdata));
+-		rdata += INT16SZ;
+-		addlen(strlen(buf), &buf, &buflen);
+-		break;
+-	    }
+-
+ 	case ns_t_a6: {
+ 		struct in6_addr a;
+ 		int pbyte, pbit;
+@@ -561,12 +471,6 @@ ns_sprintrrf(const u_char *msg, size_t msglen,
+ 		break;
+ 	    }
+ 
+-	case ns_t_opt: {
+-		len = SPRINTF((tmp, "%u bytes", class));
+-		T(addstr(tmp, len, &buf, &buflen));
+-		break;
+-	    }
+-
+ 	default:
+ 		snprintf (errbuf, sizeof (errbuf), "unknown RR type %d", type);
+ 		comment = errbuf;
+-- 
+2.54.0
+

--- a/pkgs/development/libraries/glibc/0003-resolv-Fix-buffer-overreads-in-ns_sprintrrf-CVE-2026.patch
+++ b/pkgs/development/libraries/glibc/0003-resolv-Fix-buffer-overreads-in-ns_sprintrrf-CVE-2026.patch
@@ -1,0 +1,66 @@
+From 2290143edc27486196815874dca5a528c118a73f Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Fri, 19 Jun 2026 18:22:20 +0200
+Subject: [PATCH 3/3] resolv: Fix buffer overreads in ns_sprintrrf
+ (CVE-2026-6238)
+
+Check that the RDATA payload does not require more than RDATALEN
+bytes while processing it.  The fixes cover A6, LOC records.
+(CERT, TKEY, TSIG were fixed before, by switching to the generic
+formatter.)
+
+The vulnerable LOC record handling was first introduced before
+glibc 2.0, in commit ee188d555b8c32ad9704a7440cab400af967292f.
+
+CERT, TSIG, TKEY handling came with commit
+b43b13ac2544b11f35be301d1589b51a8473e32b, released with glibc 2.2.
+
+A6 record handling was introduced in commit
+91633816430e7ec5a19fe3ff510a7c4822a9557e ("* resolv/ns_print.c
+(ns_sprintrrf): Handle ns_t_a6 and ns_t_opt."), which went into glibc
+2.7.
+
+This fixes bug 34069.
+
+Reviewed-by: Carlos O'Donell <carlos@redhat.com>
+Reviewed-by: Adhemerval Zanella <adhemerval.zanella@linaro.org>
+(cherry picked from commit a7b60d23bbb56eaef59f4962e4140062e552600a)
+---
+ resolv/ns_print.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/resolv/ns_print.c b/resolv/ns_print.c
+index 8c876b147e..6832255a25 100644
+--- a/resolv/ns_print.c
++++ b/resolv/ns_print.c
+@@ -318,7 +318,8 @@ ns_sprintrrf(const u_char *msg, size_t msglen,
+ 	case ns_t_loc: {
+ 		char t[255];
+ 
+-		/* XXX protocol format checking? */
++		if (rdlen != 16)
++		  goto formerr;
+ 		(void) loc_ntoa(rdata, t);
+ 		T(addstr(t, strlen(t), &buf, &buflen));
+ 		break;
+@@ -452,13 +453,14 @@ ns_sprintrrf(const u_char *msg, size_t msglen,
+ 
+ 		/* address suffix: provided only when prefix len != 128 */
+ 		if (pbit < 128) {
+-			if (rdata + pbyte >= edata) goto formerr;
++			unsigned int bytelen = sizeof(a) - pbyte;
++			if (edata - rdata < bytelen) goto formerr;
+ 			memset(&a, 0, sizeof(a));
+-			memcpy(&a.s6_addr[pbyte], rdata, sizeof(a) - pbyte);
++			memcpy(&a.s6_addr[pbyte], rdata, bytelen);
+ 			if (inet_ntop (AF_INET6, &a, buf, buflen) == NULL)
+ 			  return -1;
+ 			addlen(strlen(buf), &buf, &buflen);
+-			rdata += sizeof(a) - pbyte;
++			rdata += bytelen;
+ 		}
+ 
+ 		/* prefix name: provided only when prefix len > 0 */
+-- 
+2.54.0
+

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -116,6 +116,15 @@ stdenv.mkDerivation (
       # enable parallel & reproducible build of glibcLocales
       ./0001-localedata-allow-reproducible-parallel-install-of-lo.patch
       ./0002-Makeconfig-make-inst_complocaledir-overridable.patch
+
+      # Security fixes.
+      #
+      # Can be dropped on 2.44. The first patch is only to make it
+      # easier to backport the fix for CVE-2026-6238 and it seems
+      # useful in its own right anyhow.
+      ./0001-resolv-Check-for-inet_ntop-failure-in-ns_sprintrrf.patch
+      ./0002-resolv-More-types-as-unknown-in-ns_sprintrrf-CVE-202.patch
+      ./0003-resolv-Fix-buffer-overreads-in-ns_sprintrrf-CVE-2026.patch
     ]
     /*
       NVCC does not support ARM intrinsics. Since <math.h> is pulled in by almost


### PR DESCRIPTION
I backported the fixes from glibc master. There were some slight conflicts, but nothing complicated.

`0001-resolv-Check-for-inet_ntop-failure-in-ns_sprintrrf.patch` was backported to avoid having to modify the fix for CVE-2026-6238.

Fixes https://github.com/NixOS/nixpkgs/issues/514680.
Fixes https://github.com/NixOS/nixpkgs/issues/514679.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
