### PR TITLE
isa-l: 2.32.0 -> 2.32.1

### DIFF
--- a/pkgs/by-name/is/isa-l/package.nix
+++ b/pkgs/by-name/is/isa-l/package.nix
@@ -4,9 +4,13 @@
   fetchFromGitHub,
 
   # nativeBuildInputs
+  cmake,
   nasm,
-  autoreconfHook,
 
+  # buildInputs
+  zlib,
+
+  # nativeInstallCheckInputs
   versionCheckHook,
 
   # passthru
@@ -18,27 +22,39 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "isa-l";
-  version = "2.32.0";
+  version = "2.32.1";
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "isa-l";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-LvxAlyBUSYEVLrMGcLii7bGvN1GZY/noYRSrBqsGiMI=";
+    hash = "sha256-JizQXhfDCL8aWEv52TBuXw06HA/8t7Ram/q9vSp5/DI=";
   };
 
   nativeBuildInputs = [
+    cmake
     nasm
-    autoreconfHook
   ];
 
-  # configure.ac has two code paths for assembler detection:
-  # 1. When AS is unset: searches for nasm and tests with correct nasm syntax
-  # 2. When AS is set: tests with yasm-style syntax that nasm rejects
-  # AM_PROG_AS sets AS=as, so we must unset it to use path 1.
-  preConfigure = ''
-    unset AS
-  '';
+  buildInputs = [
+    zlib
+  ];
+
+  env = {
+    NIX_CFLAGS_COMPILE = toString [
+      "-DVERSION=\"${finalAttrs.version}\""
+    ];
+  };
+  cmakeFlags = [
+    (lib.cmakeBool "ISAL_BUILD_IGZIP_CLI" true)
+
+    # https://github.com/NixOS/nixpkgs/issues/144170
+    (lib.cmakeFeature "CMAKE_INSTALL_INCLUDEDIR" "include")
+    (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "lib")
+  ];
 
   nativeInstallCheckInputs = [
     versionCheckHook

--- a/pkgs/by-name/is/isa-l/package.nix
+++ b/pkgs/by-name/is/isa-l/package.nix
@@ -60,6 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
     versionCheckHook
   ];
   doInstallCheck = true;
+  doCheck = true;
 
   passthru = {
     tests = {


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/intel/isa-l/compare/v2.32.0...v2.32.1
Changelog: https://github.com/intel/isa-l/releases/tag/v2.32.1

cc @jbedo

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test