### PR TITLE
koboldcpp: refactor

### DIFF
--- a/pkgs/by-name/ko/koboldcpp-cuda/package.nix
+++ b/pkgs/by-name/ko/koboldcpp-cuda/package.nix
@@ -1,0 +1,7 @@
+{ koboldcpp }:
+
+koboldcpp.override {
+  cublasSupport = true;
+  rocmSupport = false;
+  vulkanSupport = false;
+}

--- a/pkgs/by-name/ko/koboldcpp-metal/package.nix
+++ b/pkgs/by-name/ko/koboldcpp-metal/package.nix
@@ -1,0 +1,8 @@
+{ koboldcpp }:
+
+koboldcpp.override {
+  cublasSupport = false;
+  rocmSupport = false;
+  metalSupport = true;
+  vulkanSupport = false;
+}

--- a/pkgs/by-name/ko/koboldcpp-rocm/package.nix
+++ b/pkgs/by-name/ko/koboldcpp-rocm/package.nix
@@ -1,0 +1,7 @@
+{ koboldcpp }:
+
+koboldcpp.override {
+  cublasSupport = false;
+  rocmSupport = true;
+  vulkanSupport = false;
+}

--- a/pkgs/by-name/ko/koboldcpp-vulkan/package.nix
+++ b/pkgs/by-name/ko/koboldcpp-vulkan/package.nix
@@ -1,0 +1,7 @@
+{ koboldcpp }:
+
+koboldcpp.override {
+  cublasSupport = false;
+  rocmSupport = false;
+  vulkanSupport = true;
+}

--- a/pkgs/by-name/ko/koboldcpp/ggml-fix-gfx9-apu-detection.patch
+++ b/pkgs/by-name/ko/koboldcpp/ggml-fix-gfx9-apu-detection.patch
@@ -1,0 +1,68 @@
+From 67eb56c430fd4e899b014437ed32e8b964245eb2 Mon Sep 17 00:00:00 2001
+From: tomasuz <tomas.martisius9@gmail.com>
+Date: Wed, 19 Aug 2026 15:33:42 +0300
+Subject: [PATCH] CUDA/HIP: do not classify gfx909 and gfx90c APUs as CDNA
+
+gfx909 (Raven2) and gfx90c (Renoir/Cezanne/Barcelo) are Vega-class
+integrated GPUs without MFMA. Their architecture numbers, however, fall
+inside the numeric range spanned by CDNA1..CDNA4:
+
+  CDNA1  0x908   (MI100)
+  gfx909 0x909   <- Raven2 APU
+  CDNA2  0x90a   (MI210)
+  gfx90c 0x90c   <- Renoir/Cezanne/Barcelo APU
+  CDNA3  0x942   (MI300)
+
+The plain numeric comparisons in GGML_CUDA_CC_IS_CDNA/CDNA1/CDNA2
+therefore misdetect these APUs as MI100/MI210. Host code then selects
+MFMA configurations, while the device code, which is gated on the
+__gfx908__/__gfx90a__/__gfx942__/__gfx950__ macros, compiles the
+non-MFMA variant. The resulting host/device disagreement makes kernel
+launches fail on __launch_bounds__.
+
+Add an explicit GGML_CUDA_CC_IS_GFX9_APU() predicate, exclude it from
+the CDNA checks and include it in GGML_CUDA_CC_IS_GCN(), which matches
+what these GPUs actually are.
+
+Found while investigating launch failures on a Ryzen 5000-series
+(Cezanne, gfx90c) integrated GPU. The change is detection-only and does
+not alter behaviour for discrete CDNA parts.
+---
+ ggml/src/ggml-cuda/common.cuh | 17 +++++++++++++----
+ 1 file changed, 13 insertions(+), 4 deletions(-)
+
+diff --git a/ggml/src/ggml-cuda/common.cuh b/ggml/src/ggml-cuda/common.cuh
+index d27d8acb1d37..3aea245bab58 100644
+--- a/ggml/src/ggml-cuda/common.cuh
++++ b/ggml/src/ggml-cuda/common.cuh
+@@ -68,6 +68,8 @@
+ #define GGML_CUDA_CC_GCN4       (GGML_CUDA_CC_OFFSET_AMD + 0x803)  // Tonga, Fiji, Polaris, minimum for fast fp16
+ #define GGML_CUDA_CC_VEGA       (GGML_CUDA_CC_OFFSET_AMD + 0x900)  // Vega56/64, minimum for fp16 dual issue
+ #define GGML_CUDA_CC_VEGA20     (GGML_CUDA_CC_OFFSET_AMD + 0x906)  // MI50/Radeon VII, minimum for dp4a
++#define GGML_CUDA_CC_RAVEN2     (GGML_CUDA_CC_OFFSET_AMD + 0x909)  // Raven2 APU, Vega-class, no MFMA
++#define GGML_CUDA_CC_RENOIR     (GGML_CUDA_CC_OFFSET_AMD + 0x90c)  // Renoir/Cezanne/Barcelo APU, Vega-class, no MFMA
+ #define GGML_CUDA_CC_CDNA1      (GGML_CUDA_CC_OFFSET_AMD + 0x908)  // MI100, minimum for MFMA, acc registers
+ #define GGML_CUDA_CC_CDNA2      (GGML_CUDA_CC_OFFSET_AMD + 0x90a)  // MI210 (gfx90a), minimum acc register renaming
+ #define GGML_CUDA_CC_CDNA3      (GGML_CUDA_CC_OFFSET_AMD + 0x942)  // MI300
+@@ -88,10 +90,17 @@
+ #define GGML_CUDA_CC_IS_RDNA3_5(cc) (cc >= GGML_CUDA_CC_RDNA3_5 && cc < GGML_CUDA_CC_RDNA4)
+ #define GGML_CUDA_CC_IS_RDNA3(cc)   (GGML_CUDA_CC_IS_RDNA3_0(cc) || GGML_CUDA_CC_IS_RDNA3_5(cc))
+ #define GGML_CUDA_CC_IS_RDNA4(cc)   (cc >= GGML_CUDA_CC_RDNA4)
+-#define GGML_CUDA_CC_IS_GCN(cc)     (cc > GGML_CUDA_CC_OFFSET_AMD && cc < GGML_CUDA_CC_CDNA1)
+-#define GGML_CUDA_CC_IS_CDNA(cc)    (cc >= GGML_CUDA_CC_CDNA1 && cc < GGML_CUDA_CC_RDNA1)
+-#define GGML_CUDA_CC_IS_CDNA1(cc)   (cc >= GGML_CUDA_CC_CDNA1 && cc < GGML_CUDA_CC_CDNA2)
+-#define GGML_CUDA_CC_IS_CDNA2(cc)   (cc >= GGML_CUDA_CC_CDNA2 && cc < GGML_CUDA_CC_CDNA3)
++// gfx909 (Raven2) and gfx90c (Renoir/Cezanne/Barcelo) are Vega-class integrated GPUs, but their
++// architecture numbers fall inside the range spanned by CDNA1..CDNA4, so a plain numeric comparison
++// misdetects them as MI100/MI210. The host would then select MFMA configs while the device code,
++// gated on the __gfx908__/__gfx90a__/__gfx942__/__gfx950__ macros, compiles the non-MFMA variant.
++// The resulting host/device disagreement makes kernel launches fail on __launch_bounds__.
++#define GGML_CUDA_CC_IS_GFX9_APU(cc) (cc == GGML_CUDA_CC_RAVEN2 || cc == GGML_CUDA_CC_RENOIR)
++
++#define GGML_CUDA_CC_IS_GCN(cc)     ((cc > GGML_CUDA_CC_OFFSET_AMD && cc < GGML_CUDA_CC_CDNA1) || GGML_CUDA_CC_IS_GFX9_APU(cc))
++#define GGML_CUDA_CC_IS_CDNA(cc)    (cc >= GGML_CUDA_CC_CDNA1 && cc < GGML_CUDA_CC_RDNA1 && !GGML_CUDA_CC_IS_GFX9_APU(cc))
++#define GGML_CUDA_CC_IS_CDNA1(cc)   (cc >= GGML_CUDA_CC_CDNA1 && cc < GGML_CUDA_CC_CDNA2 && !GGML_CUDA_CC_IS_GFX9_APU(cc))
++#define GGML_CUDA_CC_IS_CDNA2(cc)   (cc >= GGML_CUDA_CC_CDNA2 && cc < GGML_CUDA_CC_CDNA3 && !GGML_CUDA_CC_IS_GFX9_APU(cc))
+ #define GGML_CUDA_CC_IS_CDNA3(cc)   (cc >= GGML_CUDA_CC_CDNA3 && cc < GGML_CUDA_CC_CDNA4)
+ #define GGML_CUDA_CC_IS_CDNA4(cc)   (cc >= GGML_CUDA_CC_CDNA4 && cc < GGML_CUDA_CC_RDNA1)
+ 

--- a/pkgs/by-name/ko/koboldcpp/nixos-runtime-paths.patch
+++ b/pkgs/by-name/ko/koboldcpp/nixos-runtime-paths.patch
@@ -1,0 +1,121 @@
+--- a/koboldcpp.py
++++ b/koboldcpp.py
+@@ -5080,8 +5080,7 @@
+         if os.name == "posix" and "DISPLAY" in os.environ:  # UNIX-like systems
+             clean_env = os.environ.copy()
+             clean_env.pop("LD_LIBRARY_PATH", None)
+-            clean_env["PATH"] = "/usr/bin:/bin"
+-            result = subprocess.run(["/usr/bin/env", "xdg-open", target_url], check=True, env=clean_env)
++            result = subprocess.run(["xdg-open", target_url], check=True, env=clean_env)
+             if result.returncode == 0:
+                 return  # fallback successful
+         raise RuntimeError("no xdg-open")
+@@ -8181,8 +8180,7 @@
+         try: # Run `zenity --help` and pipe to grep
+             sc_clean_env = os.environ.copy()
+             sc_clean_env.pop("LD_LIBRARY_PATH", None)
+-            sc_clean_env["PATH"] = "/usr/bin:/bin"
+-            scargs = ['/usr/bin/env', zenity_bin, '--help']
++            scargs = [zenity_bin, '--help']
+             result = subprocess.run(scargs, env=sc_clean_env, capture_output=True, text=True, encoding="utf-8", timeout=10)
+ 
+             if result.returncode == 0 and "--file" in result.stdout:
+@@ -8198,7 +8196,7 @@
+         raise Exception("Zenity not working correctly, falling back to TK GUI.")
+ 
+     # Build args based on keywords
+-    args = ['/usr/bin/env', zenity_bin, ('--file' if using_yad else '--file-selection')]
++    args = [zenity_bin, ('--file' if using_yad else '--file-selection')]
+     for k, v in kwargs.items():
+         if v is True:
+             args.append(f'--{k.replace("_", "-").strip("-")}')
+@@ -8227,7 +8225,6 @@
+ 
+     clean_env = os.environ.copy()
+     clean_env.pop("LD_LIBRARY_PATH", None)
+-    clean_env["PATH"] = "/usr/bin:/bin"
+ 
+     procres = subprocess.run(
+         args,
+@@ -9742,7 +9739,7 @@
+             if sys.platform == "linux":
+                 # Create an unnamed pipe, launch a terminal that reads from the read-end FD
+                 r, w = os.pipe()
+-                extra_terminal_process = subprocess.Popen(["xterm", "-hold","-e", f"bash -c 'cat <&{r}'"], pass_fds=[r])
++                extra_terminal_process = subprocess.Popen(["xterm", "-hold", "-e", "@shell@", "-c", f"cat <&{r}"], pass_fds=[r])
+                 writer = os.fdopen(w, "w", buffering=1)
+                 redirector = StdoutRedirector(writer)
+                 sys.stdout = redirector
+@@ -10816,35 +10813,31 @@
+     try:
+         global sslvalid
+         httpsaffix = ("https" if sslvalid else "http")
+-        ssladd = (" --no-tls-verify" if sslvalid else "")
+         def run_tunnel():
+             tunnelproc = None
+             tunneloutput = ""
+             tunnelrawlog = ""
+             time.sleep(0.2)
+-            tunnelbinary = ""
++            tunnelbinary = shutil.which("cloudflared")
++            if not tunnelbinary:
++                raise RuntimeError("cloudflared is required for --remotetunnel")
+             if os.name == 'nt':
+                 print("Starting Cloudflare Tunnel for Windows, please wait...", flush=True)
+-                tunnelbinary = "cloudflared.exe"
+             elif sys.platform=="darwin":
+                 print("Starting Cloudflare Tunnel for MacOS, please wait...", flush=True)
+-                tunnelbinary = "./cloudflared"
+             elif sys.platform == "linux" and platform.machine().lower() == "aarch64":
+                 print("Starting Cloudflare Tunnel for ARM64 Linux, please wait...", flush=True)
+-                tunnelbinary = "./cloudflared-linux-arm64"
+             else:
+                 print("Starting Cloudflare Tunnel for Linux, please wait...", flush=True)
+-                tunnelbinary = "./cloudflared-linux-amd64"
+ 
+             tunnelproc = None
+             displayedport = (args.port if not args.proxy_port else args.proxy_port)
+-            if sys.platform == "linux":
+-                clean_env = os.environ.copy()
+-                clean_env.pop("LD_LIBRARY_PATH", None)
+-                clean_env["PATH"] = "/usr/bin:/bin"
+-                tunnelproc = subprocess.Popen(f"{tunnelbinary} tunnel --url {httpsaffix}://localhost:{int(displayedport)}{ssladd}", text=True, encoding='utf-8', shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, env=clean_env)
+-            else:
+-                tunnelproc = subprocess.Popen(f"{tunnelbinary} tunnel --url {httpsaffix}://localhost:{int(displayedport)}{ssladd}", text=True, encoding='utf-8', shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
++            tunnelargs = [tunnelbinary, "tunnel", "--url", f"{httpsaffix}://localhost:{int(displayedport)}"]
++            if sslvalid:
++                tunnelargs.append("--no-tls-verify")
++            clean_env = os.environ.copy()
++            clean_env.pop("LD_LIBRARY_PATH", None)
++            tunnelproc = subprocess.Popen(tunnelargs, text=True, encoding='utf-8', stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, env=clean_env)
+             time.sleep(10)
+ 
+             def tunnel_reader():
+@@ -10880,18 +10873,6 @@
+             time.sleep(0.5)
+             tunnelproc.wait()
+ 
+-        if os.name == 'nt':
+-            downloader_internal("https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-windows-amd64.exe", "cloudflared.exe", True, 500000)
+-        elif sys.platform=="darwin":
+-            downloader_internal("https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-darwin-amd64.tgz", "cloudflared-darwin-amd64.tgz", True, 500000)
+-            subprocess.run("tar -xzf cloudflared-darwin-amd64.tgz", shell=True)
+-            subprocess.run("chmod +x 'cloudflared'", shell=True)
+-        elif sys.platform == "linux" and platform.machine().lower() == "aarch64":
+-            downloader_internal("https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-arm64", "cloudflared-linux-arm64", True, 500000)
+-            subprocess.run("chmod +x 'cloudflared-linux-arm64'", shell=True)
+-        else:
+-            downloader_internal("https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64", "cloudflared-linux-amd64", True, 500000)
+-            subprocess.run("chmod +x 'cloudflared-linux-amd64'", shell=True)
+         print("Attempting to start tunnel thread...", flush=True)
+         tunnel_thread = threading.Thread(target=run_tunnel)
+         tunnel_thread.start()
+@@ -12612,7 +12593,7 @@
+     if args.onready:
+         def onready_subprocess():
+             print("Starting Post-Load subprocess...")
+-            subprocess.run(args.onready, shell=True)
++            subprocess.run(args.onready, shell=True, executable="@shell@")
+         timer_thread = threading.Timer(1, onready_subprocess) #1 second delay
+         timer_thread.start()
+ 

--- a/pkgs/by-name/ko/koboldcpp/package.nix
+++ b/pkgs/by-name/ko/koboldcpp/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  buildEnv,
   fetchFromGitHub,
   stdenv,
   makeWrapper,
@@ -15,12 +16,20 @@
 
   cublasSupport ? config.cudaSupport,
 
+  rocmSupport ? config.rocmSupport,
+  rocmPackages ? { },
+  rocmGpuTargets ? rocmPackages.clr.localGpuTargets or rocmPackages.clr.gpuTargets or [ ],
+
   vulkanSupport ? false,
   vulkan-loader,
   shaderc,
   metalSupport ? false,
   nix-update-script,
 }:
+
+assert lib.assertMsg (!(cublasSupport && rocmSupport)) ''
+  koboldcpp: CUDA (cublasSupport) and ROCm (rocmSupport) are mutually exclusive
+'';
 
 let
   version = "1.119";
@@ -40,12 +49,42 @@ let
     in
     "${cudaMaxCapability}0";
 
-  libraryPathWrapperArgs = lib.optionals (cublasSupport && stdenv.hostPlatform.isLinux) [
-    "--prefix"
-    "LD_LIBRARY_PATH"
-    ":"
-    (lib.makeLibraryPath [ addDriverRunpath.driverLink ])
+  libraryPathWrapperArgs =
+    lib.optionals (cublasSupport && stdenv.hostPlatform.isLinux) [
+      "--prefix"
+      "LD_LIBRARY_PATH"
+      ":"
+      (lib.makeLibraryPath [ addDriverRunpath.driverLink ])
+    ]
+    ++ lib.optionals (rocmSupport && stdenv.hostPlatform.isLinux) [
+      "--prefix"
+      "LD_LIBRARY_PATH"
+      ":"
+      "${rocmPath}/lib"
+      "--set-default"
+      "HIP_PATH"
+      "${rocmPath}"
+      "--set-default"
+      "ROCM_PATH"
+      "${rocmPath}"
+    ];
+
+  # 1.119's Makefile expects a single ROCM_PATH that provides hipconfig,
+  # hipcc, amdhip64, hipblas, and rocblas. clr ships hipconfig plus the
+  # HIP/LLVM compiler, but hipconfig is wrapped with ROCM_PATH=clr so
+  # `hipconfig -C` never emits hipblas/rocblas/hipblas-common include
+  # flags
+  rocmBuildInputs = with rocmPackages; [
+    clr
+    hipblas
+    hipblas-common
+    rocblas
   ];
+
+  rocmPath = buildEnv {
+    name = "rocm-path";
+    paths = rocmBuildInputs;
+  };
 
   runtimePath = [ tk ];
 
@@ -67,13 +106,20 @@ let
     "koboldcpp_noavx2"
   ]
   ++ lib.optionals cublasSupport [ "koboldcpp_cublas" ]
+  ++ lib.optionals rocmSupport [ "koboldcpp_hipblas" ]
   ++ lib.optionals vulkanSupport [ "koboldcpp_vulkan" ]
   ++ lib.optionals (vulkanSupport && stdenv.hostPlatform.isx86) [
     "koboldcpp_vulkan_failsafe"
     "koboldcpp_vulkan_noavx2"
   ];
 
-  effectiveStdenv = if cublasSupport then cudaPackages.backendStdenv else stdenv;
+  effectiveStdenv =
+    if cublasSupport then
+      cudaPackages.backendStdenv
+    else if rocmSupport then
+      rocmPackages.stdenv
+    else
+      stdenv;
 
   metalFailsafe = stdenv.mkDerivation {
     pname = "koboldcpp-macos-failsafe";
@@ -105,6 +151,8 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
   strictDeps = true;
 
+  patches = [ ./ggml-fix-gfx9-apu-detection.patch ];
+
   enableParallelBuilding = true;
 
   nativeBuildInputs = [
@@ -115,6 +163,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     autoAddDriverRunpath
     cudaPackages.cuda_nvcc
   ]
+  ++ lib.optionals rocmSupport [ rocmPackages.clr ]
   ++ lib.optionals vulkanSupport [ shaderc ];
 
   pythonInputs = builtins.attrValues { inherit (python3Packages) tkinter customtkinter packaging; };
@@ -128,16 +177,23 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     cudaPackages.cuda_cudart
     cudaPackages.cccl
   ]
+  ++ lib.optionals rocmSupport rocmBuildInputs
   ++ lib.optionals vulkanSupport [
     vulkan-loader
   ];
 
   pythonPath = finalAttrs.pythonInputs;
 
-  env = lib.optionalAttrs vulkanSupport {
-    # 1.119's vulkan-shaders-gen recipe prefers bundled glslc-linux when this is set
-    LLAMA_USE_BUNDLED_GLSLC = "";
-  };
+  env =
+    lib.optionalAttrs rocmSupport {
+      # Keep this as an environment variable so the Makefile can append
+      # its required HIP defines and hipconfig flags
+      HIPFLAGS = "-I${rocmPath}/include";
+    }
+    // lib.optionalAttrs vulkanSupport {
+      # 1.119's vulkan-shaders-gen recipe prefers bundled glslc-linux when this is set
+      LLAMA_USE_BUNDLED_GLSLC = "";
+    };
 
   makeFlags = [
     "LLAMA_PORTABLE=1"
@@ -147,6 +203,13 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     "CUBLAS_FLAGS=-DGGML_USE_CUDA"
     "CUBLASLD_FLAGS=-L${lib.getOutput "stubs" cudaPackages.cuda_cudart}/lib/stubs -lcuda -lcublas -lcudart -lcublasLt -lpthread -ldl -lrt"
     "NVCCFLAGS=--forward-unknown-to-host-compiler -use_fast_math -extended-lambda -Wno-deprecated-gpu-targets -DKCPP_LIMIT_CUDA_MAX_ARCH=${cudaMaxArch} ${cudaPackages.flags.gencodeString}"
+  ]
+  ++ lib.optionals rocmSupport [
+    "LLAMA_HIPBLAS=1"
+    "ROCM_PATH=${rocmPath}"
+    "HCC=${rocmPath}/bin/hipcc"
+    "HCXX=${rocmPath}/bin/hipcc"
+    "GPU_TARGETS=${builtins.concatStringsSep " " rocmGpuTargets}"
   ]
   ++ lib.optionals vulkanSupport [
     "LLAMA_VULKAN=1"
@@ -184,6 +247,8 @@ effectiveStdenv.mkDerivation (finalAttrs: {
       ${lib.escapeShellArgs makeWrapperArgs}
   '';
 
+  requiredSystemFeatures = lib.optionals rocmSupport [ "big-parallel" ];
+
   passthru.updateScript = nix-update-script { };
 
   meta = {
@@ -202,7 +267,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
       _4evy
     ];
     platforms = if metalSupport then lib.platforms.darwin else lib.platforms.unix;
-    badPlatforms = lib.optionals cublasSupport lib.platforms.darwin;
+    badPlatforms = lib.optionals (cublasSupport || rocmSupport) lib.platforms.darwin;
     broken = metalSupport && !effectiveStdenv.hostPlatform.isDarwin;
   };
 })

--- a/pkgs/by-name/ko/koboldcpp/package.nix
+++ b/pkgs/by-name/ko/koboldcpp/package.nix
@@ -1,6 +1,9 @@
 {
   lib,
   buildEnv,
+  cacert,
+  cloudflared,
+  curl,
   fetchFromGitHub,
   stdenv,
   makeWrapper,
@@ -23,8 +26,11 @@
   vulkanSupport ? false,
   vulkan-loader,
   shaderc,
+  vulkan-tools,
   metalSupport ? false,
   nix-update-script,
+  xdg-utils,
+  xterm,
 }:
 
 assert lib.assertMsg (!(cublasSupport && rocmSupport)) ''
@@ -86,15 +92,35 @@ let
     paths = rocmBuildInputs;
   };
 
-  runtimePath = [ tk ];
+  runtimePath = [
+    cloudflared
+    curl
+    tk
+  ]
+  ++ lib.optionals rocmSupport [ rocmPackages.clr ]
+  ++ lib.optionals vulkanSupport [
+    vulkan-tools
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    xdg-utils
+    xterm
+  ];
 
   makeWrapperArgs = [
     "--prefix"
     "PATH"
     ":"
     (lib.makeBinPath runtimePath)
+    "--set-default"
+    "SSL_CERT_FILE"
+    "${cacert}/etc/ssl/certs/ca-bundle.crt"
   ]
-  ++ libraryPathWrapperArgs;
+  ++ libraryPathWrapperArgs
+  ++ lib.optionals metalSupport [
+    "--set-default"
+    "GGML_METAL_PATH_RESOURCES"
+    "${placeholder "out"}/libexec/koboldcpp"
+  ];
 
   libraries = [
     "koboldcpp_default"
@@ -150,9 +176,21 @@ effectiveStdenv.mkDerivation (finalAttrs: {
 
   __structuredAttrs = true;
   strictDeps = true;
+  patches = [
+    ./nixos-runtime-paths.patch
+    ./ggml-fix-gfx9-apu-detection.patch
+  ];
 
-  patches = [ ./ggml-fix-gfx9-apu-detection.patch ];
-
+  postPatch = lib.concatStringsSep "\n" [
+    ''
+      substituteInPlace koboldcpp.py \
+        --replace-fail '@shell@' '${effectiveStdenv.shell}'
+    ''
+    # Prefer nixpkgs shaderc's glslc; 1.119 otherwise picks the bundled binary
+    ''
+      rm -f glslc-linux
+    ''
+  ];
   enableParallelBuilding = true;
 
   nativeBuildInputs = [
@@ -166,7 +204,15 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals rocmSupport [ rocmPackages.clr ]
   ++ lib.optionals vulkanSupport [ shaderc ];
 
-  pythonInputs = builtins.attrValues { inherit (python3Packages) tkinter customtkinter packaging; };
+  pythonInputs = builtins.attrValues {
+    inherit (python3Packages)
+      customtkinter
+      darkdetect
+      jinja2
+      psutil
+      tkinter
+      ;
+  };
 
   buildInputs = [
     tk
@@ -183,6 +229,8 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   ];
 
   pythonPath = finalAttrs.pythonInputs;
+
+  inherit makeWrapperArgs;
 
   env =
     lib.optionalAttrs rocmSupport {
@@ -219,32 +267,38 @@ effectiveStdenv.mkDerivation (finalAttrs: {
 
   buildFlags = builtLibraries;
 
-  installPhase = ''
-    runHook preInstall
+  installPhase = lib.concatStringsSep "\n" [
+    ''
+      runHook preInstall
 
-    mkdir -p "$out/bin"
+      installDir="$out/libexec/koboldcpp"
+      mkdir -p "$installDir" "$out/bin"
 
-    install -Dm755 koboldcpp.py "$out/bin/koboldcpp.unwrapped"
-    install -Dm755 ${lib.escapeShellArgs (map (library: "${library}.so") builtLibraries)} "$out/bin"
-    cp -r embd_res "$out/bin"
+      install -Dm755 koboldcpp.py "$installDir/koboldcpp"
+      install -Dm644 json_to_gbnf.py "$installDir/json_to_gbnf.py"
+      install -Dm755 ${lib.escapeShellArgs (map (library: "${library}.so") builtLibraries)} "$installDir"
+      cp -r --no-preserve=mode embd_res "$installDir"
+      cp -r --no-preserve=mode kcpp_adapters "$installDir"
+    ''
 
-    ${lib.optionalString metalSupport ''
-      install -Dm755 ${metalFailsafe}/lib/koboldcpp_failsafe.so "$out/bin"
-      install -Dm644 *.metal "$out/bin"
-    ''}
+    (lib.optionalString metalSupport ''
+      install -Dm755 ${metalFailsafe}/lib/koboldcpp_failsafe.so "$installDir"
+      install -Dm644 *.metal "$installDir"
+    '')
 
-    ${lib.optionalString (!koboldLiteSupport) ''
-      rm "$out/bin/embd_res/kcpp_docs.embd"
-      rm "$out/bin/embd_res/klite.embd"
-    ''}
+    (lib.optionalString (!koboldLiteSupport) ''
+      rm "$installDir/embd_res/kcpp_docs.embd"
+      rm "$installDir/embd_res/klite.embd"
+    '')
 
-    runHook postInstall
-  '';
+    ''
+      runHook postInstall
+    ''
+  ];
 
   postFixup = ''
-    wrapPythonProgramsIn "$out/bin" "''${pythonPath[*]}"
-    makeWrapper "$out/bin/koboldcpp.unwrapped" "$out/bin/koboldcpp" \
-      ${lib.escapeShellArgs makeWrapperArgs}
+    wrapPythonProgramsIn "$out/libexec/koboldcpp" "''${pythonPath[*]}"
+    ln -s ../libexec/koboldcpp/koboldcpp "$out/bin/koboldcpp"
   '';
 
   requiredSystemFeatures = lib.optionals rocmSupport [ "big-parallel" ];
@@ -266,8 +320,13 @@ effectiveStdenv.mkDerivation (finalAttrs: {
       maxstrid
       _4evy
     ];
-    platforms = if metalSupport then lib.platforms.darwin else lib.platforms.unix;
-    badPlatforms = lib.optionals (cublasSupport || rocmSupport) lib.platforms.darwin;
+    platforms =
+      if cublasSupport || rocmSupport then
+        lib.platforms.linux
+      else if metalSupport then
+        lib.platforms.darwin
+      else
+        lib.platforms.unix;
     broken = metalSupport && !effectiveStdenv.hostPlatform.isDarwin;
   };
 })

--- a/pkgs/by-name/ko/koboldcpp/package.nix
+++ b/pkgs/by-name/ko/koboldcpp/package.nix
@@ -3,8 +3,11 @@
   buildEnv,
   cacert,
   cloudflared,
+  copyDesktopItems,
   curl,
   fetchFromGitHub,
+  icoutils,
+  makeDesktopItem,
   stdenv,
   makeWrapper,
   python3Packages,
@@ -211,6 +214,8 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   enableParallelBuilding = true;
 
   nativeBuildInputs = [
+    copyDesktopItems
+    icoutils
     makeWrapper
     python3Packages.wrapPython
   ]
@@ -284,6 +289,29 @@ effectiveStdenv.mkDerivation (finalAttrs: {
 
   buildFlags = builtLibraries;
 
+  desktopItems = [
+    (makeDesktopItem {
+      name = "koboldcpp";
+      desktopName = "KoboldCpp (Launcher)";
+      comment = "Run GGML and GGUF models with the KoboldAI interface";
+      icon = "koboldcpp";
+      exec = "koboldcpp";
+      categories = [
+        "Utility"
+        "TextTools"
+      ];
+      keywords = [
+        "AI"
+        "GGML"
+        "GGUF"
+        "KoboldAI"
+        "LLM"
+      ];
+      startupNotify = true;
+      terminal = true;
+    })
+  ];
+
   installPhase = lib.concatStringsSep "\n" [
     ''
       runHook preInstall
@@ -296,6 +324,16 @@ effectiveStdenv.mkDerivation (finalAttrs: {
       install -Dm755 ${lib.escapeShellArgs (map (library: "${library}.so") builtLibraries)} "$installDir"
       cp -r --no-preserve=mode embd_res "$installDir"
       cp -r --no-preserve=mode kcpp_adapters "$installDir"
+    ''
+
+    # Install the project licenses and icon alongside the generated desktop
+    # item
+    ''
+      install -Dm644 LICENSE.md MIT_LICENSE_GGML_SDCPP_LLAMACPP_ONLY.md \
+        -t "$out/share/licenses/koboldcpp"
+      mkdir -p "$out/share/icons/hicolor/64x64/apps"
+      icotool --extract --index 1 \
+        --output "$out/share/icons/hicolor/64x64/apps/koboldcpp.png" niko.ico
     ''
 
     (lib.optionalString metalSupport ''
@@ -337,6 +375,13 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     PYTHONPATH="$installDir" ${python3Packages.python.interpreter} -c \
       'from json_to_gbnf import SchemaConverter'
 
+    # Check the desktop integration artifacts added by this variant-independent
+    # package
+    test -f "$out/share/applications/koboldcpp.desktop"
+    test -f "$out/share/icons/hicolor/64x64/apps/koboldcpp.png"
+    test -f "$out/share/licenses/koboldcpp/LICENSE.md"
+    test -f "$out/share/licenses/koboldcpp/MIT_LICENSE_GGML_SDCPP_LLAMACPP_ONLY.md"
+
     # Verify every selected backend was installed
     ${lib.concatMapStringsSep "\n" (name: ''
       test -f "$installDir/${name}.so"
@@ -372,6 +417,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
       with lib.licenses;
       [
         agpl3Only
+        mit
       ]
       ++ lib.optional cublasSupport nvidiaCudaRedist;
     mainProgram = "koboldcpp";

--- a/pkgs/by-name/ko/koboldcpp/package.nix
+++ b/pkgs/by-name/ko/koboldcpp/package.nix
@@ -29,6 +29,7 @@
   vulkan-tools,
   metalSupport ? false,
   nix-update-script,
+  versionCheckHook,
   xdg-utils,
   xterm,
 }:
@@ -169,6 +170,22 @@ let
   };
 
   builtLibraries = if metalSupport then lib.remove "koboldcpp_failsafe" libraries else libraries;
+
+  allBackendLibraries = [
+    "koboldcpp_default"
+    "koboldcpp_failsafe"
+    "koboldcpp_noavx2"
+    "koboldcpp_cublas"
+    "koboldcpp_hipblas"
+    "koboldcpp_vulkan"
+    "koboldcpp_vulkan_failsafe"
+    "koboldcpp_vulkan_noavx2"
+  ];
+
+  # libcuda is supplied by the host driver and is unavailable in the
+  # build sandbox. Every other installed backend can be load-tested
+  # hermetically
+  loadableLibraries = lib.remove "koboldcpp_cublas" libraries;
 in
 effectiveStdenv.mkDerivation (finalAttrs: {
   pname = "koboldcpp";
@@ -299,6 +316,48 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   postFixup = ''
     wrapPythonProgramsIn "$out/libexec/koboldcpp" "''${pythonPath[*]}"
     ln -s ../libexec/koboldcpp/koboldcpp "$out/bin/koboldcpp"
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = effectiveStdenv.buildPlatform.canExecute effectiveStdenv.hostPlatform;
+  versionCheckProgramArg = "--version";
+
+  postInstallCheck = ''
+    # Exercise CLI parsing separately from the resource checks
+    helpOutput="$("$out/bin/koboldcpp" --help)"
+    echo "$helpOutput" | grep -F -- '--usecuda'
+    echo "$helpOutput" | grep -F -- '--usevulkan'
+    echo "$helpOutput" | grep -F -- '--gpulayers'
+
+    # Check packaged runtime resources and the standalone JSON converter
+    installDir="$out/libexec/koboldcpp"
+    test -f "$installDir/json_to_gbnf.py"
+    test -f "$installDir/embd_res/lcpp.gz.embd"
+    test -f "$installDir/kcpp_adapters/AutoGuess.json"
+    PYTHONPATH="$installDir" ${python3Packages.python.interpreter} -c \
+      'from json_to_gbnf import SchemaConverter'
+
+    # Verify every selected backend was installed
+    ${lib.concatMapStringsSep "\n" (name: ''
+      test -f "$installDir/${name}.so"
+    '') libraries}
+
+    # Load every backend whose driver dependencies are available in the sandbox
+    ${lib.concatMapStringsSep "\n" (name: ''
+      ${python3Packages.python.interpreter} -c \
+        'import ctypes, sys; ctypes.CDLL(sys.argv[1])' \
+        "$installDir/${name}.so"
+    '') loadableLibraries}
+
+    # Reject backend libraries that the selected variant should not contain
+    ${lib.concatMapStringsSep "\n" (name: ''
+      test ! -e "$installDir/${name}.so"
+    '') (lib.subtractLists libraries allBackendLibraries)}
+
+    ${lib.optionalString metalSupport ''
+      # Metal builds should install the single merged shader source used at runtime
+      test -f "$installDir/ggml-metal-merged.metal"
+    ''}
   '';
 
   requiredSystemFeatures = lib.optionals rocmSupport [ "big-parallel" ];

--- a/pkgs/by-name/ko/koboldcpp/package.nix
+++ b/pkgs/by-name/ko/koboldcpp/package.nix
@@ -5,6 +5,7 @@
   makeWrapper,
   python3Packages,
   tk,
+  autoAddDriverRunpath,
   addDriverRunpath,
 
   koboldLiteSupport ? true,
@@ -13,40 +14,96 @@
   cudaPackages ? { },
 
   cublasSupport ? config.cudaSupport,
-  # You can find a full list here: https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/
-  # For example if you're on an RTX 3060 that means you're using "Ampere" and you need to pass "sm_86"
-  cudaArches ? cudaPackages.flags.realArches or [ ],
 
-  clblastSupport ? stdenv.hostPlatform.isLinux,
-  clblast,
-  ocl-icd,
-
-  vulkanSupport ? true,
+  vulkanSupport ? false,
   vulkan-loader,
   shaderc,
-  metalSupport ? stdenv.hostPlatform.isDarwin,
+  metalSupport ? false,
   nix-update-script,
 }:
 
 let
-  makeBool = option: bool: (if bool then "${option}=1" else "");
-
-  libraryPathWrapperArgs = lib.optionalString config.cudaSupport ''
-    --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ addDriverRunpath.driverLink ]}"
-  '';
-
-  effectiveStdenv = if cublasSupport then cudaPackages.backendStdenv else stdenv;
-in
-effectiveStdenv.mkDerivation (finalAttrs: {
-  pname = "koboldcpp";
   version = "1.119";
 
   src = fetchFromGitHub {
     owner = "LostRuins";
     repo = "koboldcpp";
-    tag = "v${finalAttrs.version}";
+    tag = "v${version}";
     hash = "sha256-WJVbzh4BGLiQdd/rzqSe2Q9PGqMpsqmQNQf33INJkd8=";
   };
+
+  cudaMaxArch =
+    let
+      cudaMaxCapability = lib.removeSuffix "a" (
+        cudaPackages.flags.dropDots (lib.last cudaPackages.flags.cudaCapabilities)
+      );
+    in
+    "${cudaMaxCapability}0";
+
+  libraryPathWrapperArgs = lib.optionals (cublasSupport && stdenv.hostPlatform.isLinux) [
+    "--prefix"
+    "LD_LIBRARY_PATH"
+    ":"
+    (lib.makeLibraryPath [ addDriverRunpath.driverLink ])
+  ];
+
+  runtimePath = [ tk ];
+
+  makeWrapperArgs = [
+    "--prefix"
+    "PATH"
+    ":"
+    (lib.makeBinPath runtimePath)
+  ]
+  ++ libraryPathWrapperArgs;
+
+  libraries = [
+    "koboldcpp_default"
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isx86 || metalSupport) [
+    "koboldcpp_failsafe"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isx86 [
+    "koboldcpp_noavx2"
+  ]
+  ++ lib.optionals cublasSupport [ "koboldcpp_cublas" ]
+  ++ lib.optionals vulkanSupport [ "koboldcpp_vulkan" ]
+  ++ lib.optionals (vulkanSupport && stdenv.hostPlatform.isx86) [
+    "koboldcpp_vulkan_failsafe"
+    "koboldcpp_vulkan_noavx2"
+  ];
+
+  effectiveStdenv = if cublasSupport then cudaPackages.backendStdenv else stdenv;
+
+  metalFailsafe = stdenv.mkDerivation {
+    pname = "koboldcpp-macos-failsafe";
+    inherit src version;
+
+    __structuredAttrs = true;
+    strictDeps = true;
+
+    enableParallelBuilding = true;
+    makeFlags = [ "LLAMA_PORTABLE=1" ];
+    buildFlags = [ "koboldcpp_macos_failsafe" ];
+
+    installPhase = ''
+      runHook preInstall
+
+      install -Dm755 koboldcpp_macos_failsafe.so \
+        "$out/lib/koboldcpp_failsafe.so"
+
+      runHook postInstall
+    '';
+  };
+
+  builtLibraries = if metalSupport then lib.remove "koboldcpp_failsafe" libraries else libraries;
+in
+effectiveStdenv.mkDerivation (finalAttrs: {
+  pname = "koboldcpp";
+  inherit src version;
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   enableParallelBuilding = true;
 
@@ -54,15 +111,11 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     makeWrapper
     python3Packages.wrapPython
   ]
+  ++ lib.optionals cublasSupport [
+    autoAddDriverRunpath
+    cudaPackages.cuda_nvcc
+  ]
   ++ lib.optionals vulkanSupport [ shaderc ];
-
-  postPatch = ''
-    nixLog "patching $PWD/Makefile to remove explicit linking against CUDA driver"
-    substituteInPlace "$PWD/Makefile" \
-      --replace-fail \
-        'CUBLASLD_FLAGS = -lcuda ' \
-        'CUBLASLD_FLAGS = '
-  '';
 
   pythonInputs = builtins.attrValues { inherit (python3Packages) tkinter customtkinter packaging; };
 
@@ -72,13 +125,8 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   ++ finalAttrs.pythonInputs
   ++ lib.optionals cublasSupport [
     cudaPackages.libcublas
-    cudaPackages.cuda_nvcc
     cudaPackages.cuda_cudart
     cudaPackages.cccl
-  ]
-  ++ lib.optionals clblastSupport [
-    clblast
-    ocl-icd
   ]
   ++ lib.optionals vulkanSupport [
     vulkan-loader
@@ -86,15 +134,27 @@ effectiveStdenv.mkDerivation (finalAttrs: {
 
   pythonPath = finalAttrs.pythonInputs;
 
+  env = lib.optionalAttrs vulkanSupport {
+    # 1.119's vulkan-shaders-gen recipe prefers bundled glslc-linux when this is set
+    LLAMA_USE_BUNDLED_GLSLC = "";
+  };
+
   makeFlags = [
-    (makeBool "LLAMA_CUBLAS" cublasSupport)
-    (makeBool "LLAMA_CLBLAST" clblastSupport)
-    (makeBool "LLAMA_VULKAN" vulkanSupport)
-    (makeBool "LLAMA_METAL" metalSupport)
+    "LLAMA_PORTABLE=1"
   ]
   ++ lib.optionals cublasSupport [
-    "CUDA_DOCKER_ARCH=${builtins.head cudaArches}"
-  ];
+    "LLAMA_CUBLAS=1"
+    "CUBLAS_FLAGS=-DGGML_USE_CUDA"
+    "CUBLASLD_FLAGS=-L${lib.getOutput "stubs" cudaPackages.cuda_cudart}/lib/stubs -lcuda -lcublas -lcudart -lcublasLt -lpthread -ldl -lrt"
+    "NVCCFLAGS=--forward-unknown-to-host-compiler -use_fast_math -extended-lambda -Wno-deprecated-gpu-targets -DKCPP_LIMIT_CUDA_MAX_ARCH=${cudaMaxArch} ${cudaPackages.flags.gencodeString}"
+  ]
+  ++ lib.optionals vulkanSupport [
+    "LLAMA_VULKAN=1"
+    "LLAMA_USE_BUNDLED_GLSLC="
+  ]
+  ++ lib.optionals metalSupport [ "LLAMA_METAL=1" ];
+
+  buildFlags = builtLibraries;
 
   installPhase = ''
     runHook preInstall
@@ -102,16 +162,17 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     mkdir -p "$out/bin"
 
     install -Dm755 koboldcpp.py "$out/bin/koboldcpp.unwrapped"
-    cp *.so "$out/bin"
-    cp embd_res/*.embd "$out/bin"
+    install -Dm755 ${lib.escapeShellArgs (map (library: "${library}.so") builtLibraries)} "$out/bin"
+    cp -r embd_res "$out/bin"
 
     ${lib.optionalString metalSupport ''
-      cp *.metal "$out/bin"
+      install -Dm755 ${metalFailsafe}/lib/koboldcpp_failsafe.so "$out/bin"
+      install -Dm644 *.metal "$out/bin"
     ''}
 
     ${lib.optionalString (!koboldLiteSupport) ''
-      rm "$out/bin/kcpp_docs.embd"
-      rm "$out/bin/klite.embd"
+      rm "$out/bin/embd_res/kcpp_docs.embd"
+      rm "$out/bin/embd_res/klite.embd"
     ''}
 
     runHook postInstall
@@ -120,21 +181,28 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   postFixup = ''
     wrapPythonProgramsIn "$out/bin" "''${pythonPath[*]}"
     makeWrapper "$out/bin/koboldcpp.unwrapped" "$out/bin/koboldcpp" \
-      --prefix PATH : ${lib.makeBinPath [ tk ]} ${libraryPathWrapperArgs}
+      ${lib.escapeShellArgs makeWrapperArgs}
   '';
 
   passthru.updateScript = nix-update-script { };
 
   meta = {
     changelog = "https://github.com/LostRuins/koboldcpp/releases/tag/v${finalAttrs.version}";
-    description = "Way to run various GGML and GGUF models";
+    description = "Easy-to-use AI text-generation software for GGML and GGUF models";
     homepage = "https://github.com/LostRuins/koboldcpp";
-    license = lib.licenses.agpl3Only;
+    license =
+      with lib.licenses;
+      [
+        agpl3Only
+      ]
+      ++ lib.optional cublasSupport nvidiaCudaRedist;
     mainProgram = "koboldcpp";
     maintainers = with lib.maintainers; [
       maxstrid
       _4evy
     ];
-    platforms = lib.platforms.unix;
+    platforms = if metalSupport then lib.platforms.darwin else lib.platforms.unix;
+    badPlatforms = lib.optionals cublasSupport lib.platforms.darwin;
+    broken = metalSupport && !effectiveStdenv.hostPlatform.isDarwin;
   };
 })


### PR DESCRIPTION
Refactored `koboldcpp`

Mainly, I split it into separate packages for each backend and added some missing dependencies

The default package now builds the CPU version, and there are separate variants for CUDA, ROCm, Vulkan, and Metal.

Tested CUDA and CPU with [SmolLM2-135M-Instruct-Q2_K.gguf](https://huggingface.co/bartowski/SmolLM2-135M-Instruct-GGUF/tree/main)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
