### PR TITLE
iredis: 1.15.2 -> 1.16.1

### DIFF
--- a/pkgs/by-name/ir/iredis/package.nix
+++ b/pkgs/by-name/ir/iredis/package.nix
@@ -7,22 +7,20 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "iredis";
-  version = "1.15.2";
+  version = "1.16.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "laixintao";
     repo = "iredis";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-g/gQb9QOyfa7kyHCUZf/kLZRO5IE8389BUCYz8Sqr8o=";
+    hash = "sha256-m8XDNzHgMWBgcN3AyFlb8K/UNXbGhH4toKBiX5Q4/QY=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail 'packaging = "^23.0"' 'packaging = "*"' \
-      --replace-fail 'wcwidth = "0.1.9"' 'wcwidth = "*"' \
-      --replace-fail 'redis = "^5.0.0"' 'redis = "*"'
-  '';
+  pythonRelaxDeps = [
+    "packaging"
+    "redis"
+  ];
 
   nativeBuildInputs = with python3.pkgs; [
     poetry-core
@@ -37,7 +35,6 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     pygments
     python-dateutil
     redis
-    wcwidth
   ];
 
   nativeCheckInputs = with python3.pkgs; [

--- a/pkgs/by-name/ir/iredis/package.nix
+++ b/pkgs/by-name/ir/iredis/package.nix
@@ -1,14 +1,16 @@
 {
   lib,
   stdenv,
-  python3,
+  python3Packages,
   fetchFromGitHub,
+  versionCheckHook,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "iredis";
   version = "1.16.1";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "laixintao";
@@ -22,11 +24,11 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     "redis"
   ];
 
-  nativeBuildInputs = with python3.pkgs; [
+  build-system = with python3Packages; [
     poetry-core
   ];
 
-  propagatedBuildInputs = with python3.pkgs; [
+  dependencies = with python3Packages; [
     click
     configobj
     mistune
@@ -37,7 +39,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     redis
   ];
 
-  nativeCheckInputs = with python3.pkgs; [
+  nativeCheckInputs = with python3Packages; [
     freezegun
     pexpect
     pytestCheckHook
@@ -61,6 +63,11 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   ];
 
   pythonImportsCheck = [ "iredis" ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
 
   meta = {
     description = "Terminal Client for Redis with AutoCompletion and Syntax Highlighting";


### PR DESCRIPTION
changelog: https://github.com/laixintao/iredis/blob/v1.16.1/CHANGELOG.md
diff: https://github.com/laixintao/iredis/compare/v1.15.2...v1.16.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
