### PR TITLE
nixos/systemd/resolved: fix resolvedConf generation

### DIFF
--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -30,9 +30,8 @@ let
 
   dnsmasqResolve = config.services.dnsmasq.enable && config.services.dnsmasq.resolveLocalQueries;
 
-  transformSettings =
-    settings:
-    lib.mapAttrs (
+  transformSettings = settings: {
+    Resolve = lib.mapAttrs (
       key: value:
       # concat lists for options that should result in space-separated values
       if
@@ -47,8 +46,9 @@ let
       else
         value
     ) settings;
+  };
 
-  resolvedConf = settingsToSections (transformSettings cfg.settings);
+  resolvedConf = settingsToSections (transformSettings cfg.settings.Resolve);
 in
 {
   imports = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

The `transformSettings` function takes `cfg.settings`: and `map`s over the attrs, checking each key if it is `"DNS"` `"Domains"` or  `"FallbackDNS"`. But `cfg.settings` is `{ Resolve = {...} }` and will never match the function. This means that empty lists will be ignored. 

before: 
```
trace: [Resolve]
Cache=no-negative
194.242.2.3#adblock.dns.mullvad.net
DNS=194.242.2.4#base.dns.mullvad.net
DNS=194.242.2.2#dns.mullvad.net
DNSOverTLS=true
DNSSEC=true
Domains=~.
```

after:
```
trace: [Resolve]
Cache=no-negative
DNS=194.242.2.3#adblock.dns.mullvad.net 194.242.2.4#base.dns.mullvad.net 194.242.2.2#dns.mullvad.net
DNSOverTLS=true
DNSSEC=true
Domains=~.
FallbackDNS=
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
