### PR TITLE
jemalloc: add patch to fix build under gcc 16

### DIFF
--- a/pkgs/by-name/je/jemalloc/package.nix
+++ b/pkgs/by-name/je/jemalloc/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   autoreconfHook,
   # By default, jemalloc puts a je_ prefix onto all its symbols on OSX, which
   # then stops downstream builds (mariadb in particular) from detecting it. This
@@ -59,6 +60,16 @@ stdenv.mkDerivation (finalAttrs: {
     # A (longer) patch addressing the failure posted upstream at:
     # https://github.com/jemalloc/jemalloc/pull/2954
     ./skip-extent-test-with-prof-active.patch
+
+    # the nonstandard `std::__throw_bad_alloc` is no longer exposed in gcc 16.
+    # this makes it conditional on exceptions and defers to either
+    # `throw std::bad_alloc()` or `std::terminate` as appropriate.
+    # https://github.com/jemalloc/jemalloc/pull/2900
+    (fetchpatch {
+      name = "jemalloc-dont-use-nonstandard-throw-bad-alloc.patch";
+      url = "https://github.com/jemalloc/jemalloc/commit/1a15fe33a48c52bfe26ea83e49f0d317a47da3ea.patch";
+      hash = "sha256-pL9fo8UMSbFlHCo3LFFkw0qBsdrVHcEJIkLutZYa2Yg=";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
jemalloc used the nonstandard `std::__throw_bad_alloc`, which is no longer visible in GCC 16. this upstream patch makes it conditional on exceptions and defers to either `throw std::bad_alloc()` or `std::terminate` as appropriate, and fixes the build.

(part of submitting some fixes to prepare for making gcc 16 the default later this release cycle: #537781)

## Things done

- Built on platform:
  - [x] x86_64-linux (both on this commit and with `default-gcc-version = 16;` in `all-packages.nix`)
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
