### PR TITLE
sourceHighlight: patch to fix build with gcc 16

### DIFF
--- a/pkgs/by-name/so/sourceHighlight/gcc16-disambiguate-regex-ranges-test.patch
+++ b/pkgs/by-name/so/sourceHighlight/gcc16-disambiguate-regex-ranges-test.patch
@@ -1,0 +1,57 @@
+diff --git a/lib/tests/test_regexranges_main.cpp b/lib/tests/test_regexranges_main.cpp
+index 567d79230c..e28bba47e5 100644
+--- a/lib/tests/test_regexranges_main.cpp
++++ b/lib/tests/test_regexranges_main.cpp
+@@ -12,26 +12,26 @@
+ using namespace std;
+ using namespace srchilite;
+ 
+-RegexRanges ranges;
++RegexRanges regexRanges;
+ 
+ void check_range_regex(const string &s, bool expectedTrue = true) {
+     cout << "checking " << s << endl;
+     if (expectedTrue)
+-        assertTrue(ranges.addRegexRange(s));
++        assertTrue(regexRanges.addRegexRange(s));
+     else
+-        assertFalse(ranges.addRegexRange(s));
++        assertFalse(regexRanges.addRegexRange(s));
+ }
+ 
+ void check_match(const string &line, const string &expected = "") {
+     cout << "searching inside " << line;
+     const boost::regex *matched = 0;
+     if (expected != "") {
+-        matched = ranges.matches(line);
++        matched = regexRanges.matches(line);
+         assertTrue(matched != 0);
+         assertEquals(expected, matched->str());
+         cout << " found " << *matched << endl;
+     } else {
+-        assertTrue(ranges.matches(line) == 0);
++        assertTrue(regexRanges.matches(line) == 0);
+         cout << " not found" << endl;
+     }
+ }
+@@ -39,9 +39,9 @@
+ void check_in_range(const string &s, bool expectedTrue = true) {
+     cout << "checking " << s << "... ";
+     if (expectedTrue) {
+-        assertTrue(ranges.isInRange(s));
++        assertTrue(regexRanges.isInRange(s));
+     } else {
+-        assertFalse(ranges.isInRange(s));
++        assertFalse(regexRanges.isInRange(s));
+     }
+     cout << expectedTrue << endl;
+ }
+@@ -57,7 +57,7 @@
+     check_range_regex("{notclosed");
+ 
+     // reset regular expressions
+-    ranges.clear();
++    regexRanges.clear();
+ 
+     check_range_regex("/// foo");
+     check_range_regex("/// bar");

--- a/pkgs/by-name/so/sourceHighlight/package.nix
+++ b/pkgs/by-name/so/sourceHighlight/package.nix
@@ -37,6 +37,11 @@ stdenv.mkDerivation rec {
       url = "https://git.savannah.gnu.org/cgit/src-highlite.git/patch/?id=ab9fe5cb9b85c5afab94f2a7f4b6d7d473c14ee9";
       hash = "sha256-wmSLgLnLuFE+IC6AjxzZp/HEnaOCS1VfY2cac0T7Y+w=";
     })
+
+    # GCC 16 detects ambiguity in the `ranges` name in a test (conflicts with
+    # `namespace std::range { }` from GCC), so we rename the variable to
+    # disambiguate.
+    ./gcc16-disambiguate-regex-ranges-test.patch
   ]
   ++ lib.optionals stdenv.cc.isClang [
     # Adds compatibility with C++17 by removing the `register` storage class specifier.


### PR DESCRIPTION
The `ranges` name in the test here conflicts with the `namespace std::ranges { }` from GCC 16, causing this test to fail to build with "error: reference to 'ranges' is ambiguous". To avoid this, we simply rename the variable. Since this is a test-only patch, this should be very low risk.

(part of submitting some fixes to prepare for making gcc 16 the default later this release cycle: #537781)

## Things done

- Built on platform:
  - [x] x86_64-linux (both on this commit and with `default-gcc-version = 16;` in all-packages.nix)
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
