### PR TITLE
nixos/nix-flakes: Accept URL-like flakerefs in nix.registry options

### DIFF
--- a/nixos/modules/config/nix-flakes.nix
+++ b/nixos/modules/config/nix-flakes.nix
@@ -15,13 +15,12 @@ let
     mkIf
     mkOption
     types
+    isString
+    isPath
+    parseFlakeRef
     ;
 
   cfg = config.nix;
-
-  flakeRefFormat = ''
-    The format of flake references is described in {manpage}`nix3-flake(1)`.
-  '';
 
 in
 {
@@ -40,12 +39,31 @@ in
                   path
                   package
                 ]);
+              referenceType = types.oneOf [
+                types.path
+                types.str
+                referenceAttrs
+              ];
+              maybeParseFlakeRef =
+                x:
+                if isPath x then
+                  {
+                    type = "path";
+                    path = x;
+                  }
+                else if isString x then
+                  parseFlakeRef x
+                else
+                  x;
+              flakeRefFormat = ''
+                The format of flake references is described in {manpage}`nix3-flake(1)`.
+              '';
             in
             { config, name, ... }:
             {
               options = {
                 from = mkOption {
-                  type = referenceAttrs;
+                  type = referenceType;
                   example = {
                     type = "indirect";
                     id = "nixpkgs";
@@ -55,24 +73,22 @@ in
 
                     ${flakeRefFormat}
                   '';
+                  apply = maybeParseFlakeRef;
                 };
                 to = mkOption {
-                  type = referenceAttrs;
-                  example = {
-                    type = "github";
-                    owner = "my-org";
-                    repo = "my-nixpkgs";
-                  };
+                  type = referenceType;
+                  example = "github:my-org/my-nixpkgs";
                   description = ''
                     The flake reference {option}`from` is rewritten to.
 
                     ${flakeRefFormat}
                   '';
+                  apply = maybeParseFlakeRef;
                 };
                 flake = mkOption {
                   type = types.nullOr types.attrs;
                   default = null;
-                  example = literalExpression "nixpkgs";
+                  example = literalExpression "inputs.nixpkgs";
                   description = ''
                     The flake input {option}`from` is rewritten to.
                   '';


### PR DESCRIPTION
Options `nix.registry.<name>.to` and `nix.registry.<name>.from` only accepted Attribute set representation as described by man nix3-flake(1).

This adds support for URL-like syntax as well. Paths are also accepted and converted to absolute store paths.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - ~~Package update: when the change is major or breaking.~~
- NixOS Release Notes
  - ~~Module addition: when adding a new NixOS module.~~
  - ~~Module update: when the change is significant.~~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
