### PR TITLE
sysd-manager: init at 2.20.4

### DIFF
--- a/pkgs/by-name/sy/sysd-manager/package.nix
+++ b/pkgs/by-name/sy/sysd-manager/package.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  wrapGAppsHook4,
+  cairo,
+  gdk-pixbuf,
+  glib,
+  gtk4,
+  gtksourceview5,
+  libadwaita,
+  pango,
+  nix-update-script,
+  systemd,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "sysd-manager";
+  version = "2.20.4";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "plrigaux";
+    repo = "sysd-manager";
+    tag = finalAttrs.version;
+    hash = "sha256-D7oI7ajwx6mtoUIMgW1OfnJ28/p/qm86XF8w90cNNpM=";
+  };
+
+  cargoHash = "sha256-j5KeHK66RtyuVem+6N3dRI+jjfCt1Bu2CFmDg9SqhCc=";
+
+  checkFlags = [
+    # Broken upstream tests
+    "--skip=widget::creator::first_page::tests::test_unit_name_regex"
+    "--skip=widget::unit_list::tests::test_id_extracts_correct_substring"
+  ];
+
+  preBuild = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  postInstall = ''
+    install -Dm644 data/schemas/io.github.plrigaux.sysd-manager.gschema.xml \
+      $out/share/glib-2.0/schemas/io.github.plrigaux.sysd-manager.gschema.xml
+    glib-compile-schemas $out/share/glib-2.0/schemas
+
+    install -Dm644 data/applications/io.github.plrigaux.sysd-manager.desktop \
+      $out/share/applications/io.github.plrigaux.sysd-manager.desktop
+
+    install -Dm644 data/icons/hicolor/scalable/apps/io.github.plrigaux.sysd-manager.svg \
+      $out/share/icons/hicolor/scalable/apps/io.github.plrigaux.sysd-manager.svg
+
+    install -Dm644 data/metainfo/io.github.plrigaux.sysd-manager.metainfo.xml \
+      $out/share/metainfo/io.github.plrigaux.sysd-manager.metainfo.xml
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  nativeCheckInputs = [
+    systemd
+  ];
+
+  buildInputs = [
+    cairo
+    gdk-pixbuf
+    glib
+    gtk4
+    gtksourceview5
+    libadwaita
+    pango
+    systemd
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A user-friendly GUI to manage systemd units";
+    homepage = "https://github.com/plrigaux/sysd-manager";
+    changelog = "https://github.com/plrigaux/sysd-manager/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ jlesquembre ];
+    mainProgram = "sysd-manager";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
