### PR TITLE
sbsigntool: make unused-but-set-variable non-fatal for gcc 16

### DIFF
--- a/pkgs/by-name/sb/sbsigntool/package.nix
+++ b/pkgs/by-name/sb/sbsigntool/package.nix
@@ -61,6 +61,10 @@ stdenv.mkDerivation (finalAttrs: {
     automake --add-missing -Wno-portability
   '';
 
+  # GCC 16's unused variable analysis is more advanced, leading to a build
+  # failure since sbsigntool builds with -Wno-error.
+  configureFlags = [ "CFLAGS=-Wno-error=unused-but-set-variable" ];
+
   makeFlags = [
     "AR=${stdenv.cc.targetPrefix}ar"
   ];


### PR DESCRIPTION
since sbsigntool builds with -Werror by default, and gcc 16's unused variable analysis is better than previous versions, this causes a build failure.

(part of submitting some fixes to prepare for making gcc 16 the default later this release cycle: #537781)

## Things done

- Built on platform:
  - [x] x86_64-linux (both on this commit and with `default-gcc-version = 16;` in all-packages.nix)
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
