### PR TITLE
lark-cli: add updateScript

### DIFF
--- a/pkgs/by-name/la/lark-cli/package.nix
+++ b/pkgs/by-name/la/lark-cli/package.nix
@@ -3,9 +3,9 @@
   buildGoModule,
   fetchFromGitHub,
   fetchurl,
-  runCommand,
   jq,
   testers,
+  nix-update-script,
 }:
 
 buildGoModule (finalAttrs: {
@@ -25,26 +25,19 @@ buildGoModule (finalAttrs: {
 
   subPackages = [ "." ];
 
-  postPatch =
-    let
-      metaDataRaw = fetchurl {
-        name = "meta_dataraw.json";
-        url = "https://web.archive.org/web/20260626061256/https://open.feishu.cn/api/tools/open/api_definition?protocol=meta&client_version=v${finalAttrs.version}";
-        hash = "sha256-W6KOtDW6gkZIqGa0A5QL0rVjVkRjM+gwW4S3AddPN1M=";
-      };
-
-      metaData =
-        runCommand "meta_data.json"
-          {
-            nativeBuildInputs = [ jq ];
-          }
-          ''
-            jq '.data' ${metaDataRaw} > $out
-          '';
-    in
-    ''
-      cp ${metaData} internal/registry/meta_data.json
+  metaData = fetchurl {
+    name = "meta_data.json";
+    url = "https://open.feishu.cn/api/tools/open/api_definition?protocol=meta&client_version=v${finalAttrs.version}";
+    hash = "sha256-ihPrq/VzFIBnlrKxE2762NpQZzBRk7ylM3Mvg0iJfCE=";
+    postFetch = ''
+      ${lib.getExe jq} -S ".data" "$out" > normalized
+      mv normalized "$out"
     '';
+  };
+
+  postPatch = ''
+    cp ${finalAttrs.metaData} internal/registry/meta_data.json
+  '';
 
   postInstall = ''
     mv $out/bin/cli $out/bin/lark-cli
@@ -56,6 +49,16 @@ buildGoModule (finalAttrs: {
     "-X github.com/larksuite/cli/internal/build.Version=v${finalAttrs.version}"
     "-X github.com/larksuite/cli/internal/build.Date=2026-06-01"
   ];
+
+  passthru = {
+    inherit (finalAttrs) metaData;
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--custom-dep"
+        "metaData"
+      ];
+    };
+  };
 
   passthru.tests.version = testers.testVersion {
     package = finalAttrs.finalPackage;


### PR DESCRIPTION

## Description

Add a `passthru.updateScript` for `lark-cli`.

## AI usage disclosure

The initial draft of the updateScript code was generated with AI assistance.
I have reviewed, modified nearly every line, and verified the result builds
and the update script works correctly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
