### PR TITLE
nixos/ollama: replace gnu parallel with xargs for paralellism

### DIFF
--- a/nixos/modules/services/misc/ollama.nix
+++ b/nixos/modules/services/misc/ollama.nix
@@ -306,15 +306,17 @@ in
       script =
         let
           binaryInputs = lib.mapAttrs (_: lib.getExe) {
-            parallel = pkgs.parallel;
             awk = pkgs.gawk;
             sed = pkgs.gnused;
           };
+
           inherit (binaryInputs)
-            parallel
             awk
             sed
             ;
+
+          nproc = lib.getExe' pkgs.coreutils "nproc";
+          xargs = lib.getExe' pkgs.findutils "xargs";
 
           declaredModelsRegex = lib.pipe cfg.loadModels [
             (map lib.escapeRegex)
@@ -344,7 +346,7 @@ in
             fi
           ''}
 
-          '${parallel}' --tag '${ollama}' pull ::: ${lib.escapeShellArgs cfg.loadModels}
+          printf "%s\0" ${lib.escapeShellArgs cfg.loadModels} | '${xargs}' -0 -r -n 1 -P "$('${nproc}')" '${ollama}' pull
         '';
     };
 


### PR DESCRIPTION
Switch the model pulling mechanism from pkgs.parallel to standard xargs paired with nproc. This removes GNU Parallel (Perl runtime dependency) from system closure.

Tested with my configuration.

```
REMOVED
[R.] parallel 20260422

SIZE: 28.2 GiB -> 28.2 GiB
DIFF: -790 KiB
```

Here's the systemd service running:

```
● ollama-model-loader.service - Download ollama models in the background
     Loaded: loaded (/etc/systemd/system/ollama-model-loader.service; enabled; preset: ignored)
     Active: active (running) since Wed 2026-07-01 18:37:24 IST; 2s ago
 Invocation: f4f3cdac187643dc81861330c7e5ebd9
   Main PID: 43008 (ollama-model-lo)
         IP: 4.2K in, 4K out
         IO: 747K read, 0B written
      Tasks: 21 (limit: 18001)
     Memory: 21.6M (peak: 43.3M, swap: 180K, swap peak: 180K, zswap: 31.4K)
        CPU: 72ms
     CGroup: /system.slice/ollama-model-loader.service
             ├─43008 /nix/store/gik3rh1vz2jlgnifb9dh6vc6sxwwz9jj-bash-5.3p9/bin/bash /nix/store/cdv94wc4ixfxrw8bn2wy17lanqbnf1n3-unit-script-ollama-model-loader-start/bin/ollama-model-loader-start
             ├─43011 /nix/store/c1cjgg6p8m8fssivzrc2p13mwwml3p3v-findutils-4.10.0/bin/xargs -I {} -P 12 /nix/store/kjyjch54vq02syb8bncaqhv5685jlg1z-ollama-0.30.7/bin/ollama pull {}
             ├─43019 /nix/store/kjyjch54vq02syb8bncaqhv5685jlg1z-ollama-0.30.7/bin/ollama pull hf.co/empero-ai/Qwythos-9B-Claude-Mythos-5-1M-GGUF:Q6_K
             └─43020 /nix/store/kjyjch54vq02syb8bncaqhv5685jlg1z-ollama-0.30.7/bin/ollama pull hf.co/HauhauCS/Qwen3.5-9B-Uncensored-HauhauCS-Aggressive:Q6_K

Jul 01 18:37:26 Ainz-NIX ollama-model-loader-start[43020]: [56B blob data]
Jul 01 18:37:26 Ainz-NIX ollama-model-loader-start[43019]: [56B blob data]
Jul 01 18:37:26 Ainz-NIX ollama-model-loader-start[43020]: [56B blob data]
Jul 01 18:37:26 Ainz-NIX ollama-model-loader-start[43019]: [56B blob data]
Jul 01 18:37:26 Ainz-NIX ollama-model-loader-start[43020]: [56B blob data]
Jul 01 18:37:26 Ainz-NIX ollama-model-loader-start[43019]: [112B blob data]
Jul 01 18:37:26 Ainz-NIX ollama-model-loader-start[43020]: [112B blob data]
Jul 01 18:37:26 Ainz-NIX ollama-model-loader-start[43019]: [56B blob data]
Jul 01 18:37:26 Ainz-NIX ollama-model-loader-start[43020]: [56B blob data]
Jul 01 18:37:26 Ainz-NIX ollama-model-loader-start[43019]: [112B blob data]
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
  - [x] Tested with my own configuration
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
