### PR TITLE
squix: 0.4.0-beta -> 0.5.0-beta

### DIFF
--- a/pkgs/by-name/sq/squix/package.nix
+++ b/pkgs/by-name/sq/squix/package.nix
@@ -10,16 +10,16 @@ buildGoModule (finalAttrs: {
   __structuredAttrs = true;
 
   pname = "squix";
-  version = "0.4.0-beta";
+  version = "0.5.0-beta";
 
   src = fetchFromGitHub {
     owner = "eduardofuncao";
     repo = "squix";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-lJOXzBgVgRdUi+btu/eOlYXDLhS2FLEnJQ/UjGk5jF4=";
+    hash = "sha256-R/y1fl4MehZ+VDWBtSL3EDzVBsAdCeR5nS687vwk1IM=";
   };
 
-  vendorHash = "sha256-JRmNajvCb57dMo8eggOD1m4N01p2RSK8r49pmBB56Z0=";
+  vendorHash = "sha256-kSv3VAQi+qdT29gZAjLmHauItaMFd9NG7bdRtQE1MZo=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
Bump squix 0.4.0-beta -> 0.5.0-beta

The full changelog can be found here: https://github.com/eduardofuncao/squix/compare/v0.4.0-beta...v0.5.0-beta

Notable changes since v0.4.0-beta:
- bubbletea/lipgloss migrated to v2
- Print number of modified rows after exec query (INSERT/UPDATE/DELETE)
- CSV file viewing (`squix explore file.csv`)
- Configurable keybinds via config.yaml
- Persist last query after failed run for `squix run`
- URL connection-string userinfo encodes special chars correctly now

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
