### PR TITLE
wasilibc: 27 -> 32, clean up, modernise

### DIFF
--- a/pkgs/by-name/wa/wasilibc/0000-relax-version-bounds.patch
+++ b/pkgs/by-name/wa/wasilibc/0000-relax-version-bounds.patch
@@ -1,0 +1,39 @@
+Commit ID: bf0251709e0440ff00036298d94177a72382979d
+Change ID: nukukykqkzqunwukokzxwlxrpxptuwzm
+Author   : Sam Pointon <sampointon@gmail.com> (2026-06-17 09:26:00)
+Committer: Sam Pointon <sampointon@gmail.com> (2026-06-17 09:27:26)
+
+    Relax strict version bounds on tools
+
+    Nixpkgs has more recent versions of these, and they work fine.
+
+diff --git a/cmake/bindings.cmake b/cmake/bindings.cmake
+index a629ecd006..14fdb8aed3 100644
+--- a/cmake/bindings.cmake
++++ b/cmake/bindings.cmake
+@@ -15,10 +15,6 @@
+     OUTPUT_VARIABLE WIT_BINDGEN_VERSION
+     OUTPUT_STRIP_TRAILING_WHITESPACE)
+ 
+-  if (NOT (WIT_BINDGEN_VERSION MATCHES "0\\.53\\.1"))
+-    message(WARNING "wit-bindgen version 0.53.1 is required, found: ${WIT_BINDGEN_VERSION}")
+-    set(WIT_BINDGEN_EXECUTABLE "")
+-  endif()
+ endif()
+ 
+ if (NOT WIT_BINDGEN_EXECUTABLE)
+diff --git a/cmake/wasi-wits.cmake b/cmake/wasi-wits.cmake
+index e21ab0258d..d72ed9bcc2 100644
+--- a/cmake/wasi-wits.cmake
++++ b/cmake/wasi-wits.cmake
+@@ -12,10 +12,6 @@
+     OUTPUT_VARIABLE WKG_VERSION
+     OUTPUT_STRIP_TRAILING_WHITESPACE)
+ 
+-  if (NOT (WKG_VERSION MATCHES "0\\.13\\.0"))
+-    message(WARNING "wkg version 0.13.0 is required, found: ${WKG_VERSION}")
+-    set(WKG_EXECUTABLE "")
+-  endif()
+ endif()
+ 
+ if (NOT WKG_EXECUTABLE)

--- a/pkgs/by-name/wa/wasilibc/package.nix
+++ b/pkgs/by-name/wa/wasilibc/package.nix
@@ -1,23 +1,44 @@
 {
   stdenvNoLibc,
+  cmake,
   fetchFromGitHub,
   lib,
+  lld,
+  llvmPackages,
+  ninja,
+  wasm-tools,
+  wit-bindgen,
+  wkg,
   firefox-unwrapped,
   firefox-esr-unwrapped,
-  enablePosixThreads ? false,
 }:
 
 stdenvNoLibc.mkDerivation (finalAttrs: {
   pname = "wasilibc";
-  version = "27";
+  version = "32";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "WebAssembly";
     repo = "wasi-libc";
     tag = "wasi-sdk-${finalAttrs.version}";
-    hash = "sha256-RIjph1XdYc1aGywKks5JApcLajbNFEuWm+Wy/GMHddg=";
+    hash = "sha256-iP/SFYvO8zQMwwbY4VvIboO+Kx195L9brpMq8cbsA7c=";
     fetchSubmodules = true;
   };
+
+  patches = [
+    ./0000-relax-version-bounds.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    lld
+    ninja
+    wasm-tools
+    wit-bindgen
+    wkg
+  ];
 
   # These flags break pkgsCross.wasi32.llvmPackages.libcxx
   hardeningDisable = [
@@ -28,45 +49,36 @@ stdenvNoLibc.mkDerivation (finalAttrs: {
   outputs = [
     "out"
     "dev"
-    "share"
   ];
 
-  # clang-13: error: argument unused during compilation: '-rtlib=compiler-rt' [-Werror,-Wunused-command-line-argument]
-  postPatch = ''
-    substituteInPlace Makefile \
-      --replace "-Werror" ""
-    patchShebangs scripts/
-  '';
-
-  preBuild = ''
-    export SYSROOT_LIB=${placeholder "out"}/lib
-    export SYSROOT_INC=${placeholder "dev"}/include
-    export SYSROOT_SHARE=${placeholder "share"}/share
-    mkdir -p "$SYSROOT_LIB" "$SYSROOT_INC" "$SYSROOT_SHARE"
-    makeFlagsArray+=(
-      "SYSROOT_LIB:=$SYSROOT_LIB"
-      "SYSROOT_INC:=$SYSROOT_INC"
-      "SYSROOT_SHARE:=$SYSROOT_SHARE"
-      "TARGET_TRIPLE:=${stdenvNoLibc.system}"
-      ${lib.strings.optionalString enablePosixThreads "THREAD_MODEL:=posix"}
-    )
-  '';
+  cmakeFlags = [
+    (lib.cmakeFeature "BUILTINS_LIB" "${llvmPackages.compiler-rt}/lib/${stdenvNoLibc.targetPlatform.parsed.kernel.name}/libclang_rt.builtins-wasm32.a")
+    #https://stackoverflow.com/questions/53633705/cmake-the-c-compiler-is-not-able-to-compile-a-simple-test-program
+    (lib.cmakeFeature "CMAKE_TRY_COMPILE_TARGET_TYPE" "STATIC_LIBRARY")
+    (lib.cmakeFeature "TARGET_TRIPLE" stdenvNoLibc.system)
+    # clang already knows to use wasm-component-ld to link
+    (lib.cmakeFeature "USE_WASM_COMPONENT_LD" "OFF")
+  ];
 
   enableParallelBuilding = true;
 
-  # We just build right into the install paths, per the `preBuild`.
-  dontInstall = true;
+  preFixup =
+    lib.optionalString (stdenvNoLibc.system != stdenvNoLibc.targetPlatform.rust.rustcTargetSpec)
+      ''
+        ln -s $out/lib/${stdenvNoLibc.system} $out/lib/${stdenvNoLibc.targetPlatform.rust.rustcTargetSpec}
+      '';
 
-  preFixup = ''
-    ln -s $share/share/undefined-symbols.txt $out/lib/wasi.imports
-    ln -s $out/lib $out/lib/${stdenvNoLibc.system}
-  ''
-  + lib.optionalString (stdenvNoLibc.system != stdenvNoLibc.targetPlatform.rust.rustcTargetSpec) ''
-    ln -s $out/lib $out/lib/${stdenvNoLibc.targetPlatform.rust.rustcTargetSpec}
-  '';
+  # TODO: run wasilibc tests. Nixpkgs never runs the check phase during cross compiles
+  # (sensibly), but this package is always cross compiled due to its nature, and the tests
+  # expect to be run in a cross-compilation environment. There are instructions on how to run
+  # them but I don't understand enough about Nixpkgs' CMake set-up to work out how to apply them.
 
-  passthru.tests = {
-    inherit firefox-unwrapped firefox-esr-unwrapped;
+  passthru = {
+    incdir = "/include/${stdenvNoLibc.system}";
+    libdir = "/lib/${stdenvNoLibc.system}";
+    tests = {
+      inherit firefox-unwrapped firefox-esr-unwrapped;
+    };
   };
 
   meta = {

--- a/pkgs/by-name/wa/wasilibc/package.nix
+++ b/pkgs/by-name/wa/wasilibc/package.nix
@@ -40,12 +40,6 @@ stdenvNoLibc.mkDerivation (finalAttrs: {
     wkg
   ];
 
-  # These flags break pkgsCross.wasi32.llvmPackages.libcxx
-  hardeningDisable = [
-    "libcxxhardeningfast"
-    "libcxxhardeningextensive"
-  ];
-
   outputs = [
     "out"
     "dev"


### PR DESCRIPTION
This is on the critical path to a wasip2 target. Supersedes #532941.

Shouldn't be merged until I can confirm Firefox hasn't been broken by the change, though I'd be surprised if it is because other smoke testing has been fine. Unfortunately both my machine and Github runners are apparently too puny to build the mighty flaming red panda.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
