### PR TITLE
[Backport release-26.05] xaos: add darwin,aarch64 support

### DIFF
--- a/pkgs/by-name/xa/xaos/package.nix
+++ b/pkgs/by-name/xa/xaos/package.nix
@@ -11,7 +11,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "xaos";
-  version = "4.3.4";
+  version = "4.3.5";
   outputs = [
     "out"
     "man"
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "xaos-project";
     repo = "XaoS";
     tag = "release-${finalAttrs.version}";
-    hash = "sha256-vOFwZbdbcrcJLHUa1QzxzadPcx5GF5uNPg+MZ7NbAPc=";
+    hash = "sha256-dGfmX55bm2BCFl7mRit88ULAcJ0VP15yVGI7nhRH0Ig=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xa/xaos/package.nix
+++ b/pkgs/by-name/xa/xaos/package.nix
@@ -70,5 +70,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://xaos-project.github.io/";
     license = lib.licenses.gpl2Plus;
     platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ coolcuber ];
   };
 })

--- a/pkgs/by-name/xa/xaos/package.nix
+++ b/pkgs/by-name/xa/xaos/package.nix
@@ -45,23 +45,21 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     substituteInPlace src/include/config.h \
       --replace-fail "/usr/share/XaoS" "${datapath}"
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace XaoS.pro \
+      --replace-fail \
+        "QMAKE_APPLE_DEVICE_ARCHS = x86_64 arm64" \
+        "QMAKE_APPLE_DEVICE_ARCHS = ${if stdenv.hostPlatform.isAarch64 then "arm64" else "x86_64"}"
   '';
 
   desktopItems = [ "xdg/xaos.desktop" ];
 
-  installPhase = ''
-    runHook preInstall
-
-    install -D bin/xaos "$out/bin/xaos"
-
+  postInstall = ''
     mkdir -p "${datapath}"
     cp -r tutorial examples catalogs "${datapath}"
-
     install -D "xdg/xaos.png" "$out/share/icons/xaos.png"
-
     install -D doc/xaos.6 "$man/man6/xaos.6"
-
-    runHook postInstall
   '';
 
   meta = finalAttrs.src.meta // {
@@ -69,7 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "xaos";
     homepage = "https://xaos-project.github.io/";
     license = lib.licenses.gpl2Plus;
-    platforms = [ "x86_64-linux" ];
+    platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ coolcuber ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^537427

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
This adds XaoS support for systems that aren't x86_64-linux.  I also had to add to add a version bump (with very minor changes) the commit adding myself as maintainer (to avoid merge conflicts).  The PRs can be found at #531857, #532740, and #537271.  I think this is worthwhile because it's a small change that adds lots of support.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
