### PR TITLE
whisper-cli: init at 0.211.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14039,6 +14039,12 @@
     githubId = 6544084;
     name = "Kai Harries";
   };
+  kakooch = {
+    email = "kaveh@kaveh.org";
+    github = "kakooch";
+    githubId = 2082821;
+    name = "Kaveh Ranjbar";
+  };
   kalbasit = {
     email = "wael.nasreddine@gmail.com";
     matrix = "@kalbasit:matrix.org";

--- a/pkgs/by-name/wh/whisper-cli/package.nix
+++ b/pkgs/by-name/wh/whisper-cli/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "whisper-cli";
+  version = "0.124.3";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "whisper-sec";
+    repo = "whisper-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-fmwwGJ36nSifzjwlSOeJWOBP3gHw7c2uC0wd4/lVnXs=";
+  };
+
+  vendorHash = "sha256-q0BFXYgeD8wTXzAUB5tAEk3b5rHbG58duYqSaATacMI=";
+
+  subPackages = [ "cmd/whisper" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/whisper-sec/whisper-cli/internal/cli.Version=${finalAttrs.version}"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Give your agent a real, routable Whisper IPv6 identity in one command";
+    homepage = "https://whisper.online";
+    changelog = "https://github.com/whisper-sec/whisper-cli/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "whisper";
+    maintainers = with lib.maintainers; [ kakooch ];
+  };
+})

--- a/pkgs/by-name/wh/whisper-cli/package.nix
+++ b/pkgs/by-name/wh/whisper-cli/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "whisper-cli";
+  version = "0.210.1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "whisper-sec";
+    repo = "whisper-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-W4w8uWkAP91X/XksrLkZImlXRn5/tlegd0U1SZN4ldc=";
+  };
+
+  vendorHash = "sha256-igwMhV0vG+B6BzMWaJS1EkmigJZpKXDpi1Y06wENHn0=";
+
+  subPackages = [ "cmd/whisper" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/whisper-sec/whisper-cli/internal/cli.Version=${finalAttrs.version}"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Give your agent a real, routable Whisper IPv6 identity in one command";
+    homepage = "https://whisper.online";
+    changelog = "https://github.com/whisper-sec/whisper-cli/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "whisper";
+    maintainers = with lib.maintainers; [ kakooch ];
+  };
+})

--- a/pkgs/by-name/wh/whisper-cli/package.nix
+++ b/pkgs/by-name/wh/whisper-cli/package.nix
@@ -8,17 +8,17 @@
 
 buildGoModule (finalAttrs: {
   pname = "whisper-cli";
-  version = "0.210.1";
+  version = "0.211.0";
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "whisper-sec";
     repo = "whisper-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-W4w8uWkAP91X/XksrLkZImlXRn5/tlegd0U1SZN4ldc=";
+    hash = "sha256-mTq2M05ILi3aJ7yROoyZz3nx8tvqWAgG44Ty77tDsq8=";
   };
 
-  vendorHash = "sha256-igwMhV0vG+B6BzMWaJS1EkmigJZpKXDpi1Y06wENHn0=";
+  vendorHash = "sha256-0il3bPeRFbZG8JOoM/usJtkafW4QpYxCYvW/eYX3hvo=";
 
   subPackages = [ "cmd/whisper" ];
 


### PR DESCRIPTION
Adds the Whisper CLI (`whisper`), a Go/Cobra command-line tool for giving an agent a routable Whisper IPv6 identity. Upstream is MIT-licensed: https://github.com/whisper-sec/whisper-cli, homepage https://whisper.online.

The `whisper-*` attribute space already holds speech tools (`whisper-cpp`, `whisperx`, `openai-whisper`), so this package is named `whisper-cli`. The binary stays `whisper` via `meta.mainProgram`, which only soft-collides with `openai-whisper`'s `whisper` binary (attribute names do not collide).

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`: `versionCheckHook` runs `whisper --version` in `installCheckPhase` (`Successfully managed to find version 0.210.1`).
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. `./result/bin/whisper --version` → `whisper version 0.210.1`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test



---

Disclosure, per the [automation/AI policy]: Claude Code (claude-opus-5) assisted with the design and
review of this packaging, and with drafting this pull request summary. The commit carries the required
`Assisted-by:` trailer; this note discloses the summary separately, as the policy asks.
