### PR TITLE
terminusdb: 12.0.4 -> 12.0.6

### DIFF
--- a/pkgs/by-name/te/terminusdb/package.nix
+++ b/pkgs/by-name/te/terminusdb/package.nix
@@ -71,13 +71,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "terminusdb";
-  version = "12.0.4";
+  version = "12.0.6";
 
   src = fetchFromGitHub {
     owner = "terminusdb";
     repo = "terminusdb";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-vJifp0U4FrbtI86M8pt022BQWIIeK8jWWFG1Ch1m7IQ=";
+    hash = "sha256-TxLTPwESQ9pGrm/piWyyTwKlYtVogXRdQjnppvjX8F8=";
     leaveDotGit = true;
     postFetch = ''
       # Will be used for `TERMINUSDB_GIT_HASH`
@@ -90,7 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src cargoRoot;
-    hash = "sha256-SvWS18amC4FHuXc/N6e+tomwnVfJ/KlTLIACfl72Nqc=";
+    hash = "sha256-WymXMJaUKz/IT2gDgQYagin1Sfg1akqCU+mkYUs40Ic=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/te/terminusdb/package.nix
+++ b/pkgs/by-name/te/terminusdb/package.nix
@@ -100,6 +100,12 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace $cargoDepsCopy/*/tikv-jemalloc-sys-*/build.rs \
       --replace-fail 'format!("{orig_makeflags} {makeflags}")' \
                      'format!("{makeflags} {orig_makeflags}")'
+
+    # Hardcode terminus_home to a Nix store path that will exist both
+    # at compile time (via the symlink in preBuild) and at runtime.
+    substituteInPlace src/load_paths.pl \
+      --replace-fail "top_level_directory(TopDir)," \
+                     "TopDir = '$out/share/terminusdb',"
   '';
 
   strictDeps = true;
@@ -151,6 +157,11 @@ stdenv.mkDerivation (finalAttrs: {
   preBuild = ''
     export TERMINUSDB_GIT_HASH=$(cat $src/COMMIT)
     export TERMINUSDB_JWT_ENABLED=true
+
+    # Point terminus_home at the build directory during compilation
+    # so the Rust dylib and Prolog sources are findable.
+    mkdir -p $out/share/terminusdb
+    ln --symbolic --force --no-target-directory $PWD/src $out/share/terminusdb/src
   '';
 
   # Required for Prolog initialisation
@@ -160,6 +171,10 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
     installBin terminusdb
     installManPage $src/docs/terminusdb.1
+
+    # Replace with the Nix store source so schema files are findable
+    # at runtime (the build directory no longer exists).
+    ln --symbolic --force --no-target-directory $src/src $out/share/terminusdb/src
     runHook postInstall
   '';
 

--- a/pkgs/by-name/te/terminusdb/tests.nix
+++ b/pkgs/by-name/te/terminusdb/tests.nix
@@ -19,7 +19,7 @@ buildNpmPackage {
 
   sourceRoot = "${terminusdb.src.name}/tests";
 
-  npmDepsHash = "sha256-R2kbwHhlja5mH2AGpyiiVCz3YmSWF9cWptOTdcZb0PM=";
+  npmDepsHash = "sha256-AkTKdkKTCWExd3U1fkoXoF9znbIGzVGtQl06wfIVOeM=";
 
   # Test-only JS adjustments live here so the runtime package stays untouched
   postPatch = ''


### PR DESCRIPTION
Updates TerminusDB.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
