### PR TITLE
kopuz: 0.6.0 -> 0.8.2

### DIFF
--- a/pkgs/by-name/ko/kopuz/package.nix
+++ b/pkgs/by-name/ko/kopuz/package.nix
@@ -4,6 +4,7 @@
   rustPlatform,
   pkg-config,
   cmake,
+  git,
   openssl,
   tailwindcss_4,
   dioxus-cli,
@@ -20,28 +21,30 @@
   xdotool,
   wayland,
   dbus,
+  libayatana-appindicator,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   __structuredAttrs = true;
 
   pname = "kopuz";
-  version = "0.6.0";
+  version = "0.8.2";
 
   src = fetchFromGitHub {
     owner = "Kopuz-org";
     repo = "kopuz";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-+HT76hfgTEkEVV1wn2r97PshoRJ08r4fTrExmQDuymg=";
+    hash = "sha256-d6wSefvx2KT1EyhLq2pn9MSDtW+AvDj7WVz27MJeTmg=";
   };
 
-  cargoHash = "sha256-lTGrwN2CGbmOgrjjbqrizNWPQoxWrEbDkcjhjMergoE=";
+  cargoHash = "sha256-fr65eE8wFWtW/PT5ZACGMcNCo/QNo9xf39LVBQMGLVk=";
 
   nativeBuildInputs = [
     pkg-config
     cmake
     tailwindcss_4
     dioxus-cli
+    git
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     wrapGAppsHook3
@@ -60,12 +63,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
     xdotool
     wayland
     dbus
+    libayatana-appindicator
   ];
 
   buildPhase = ''
     runHook preBuild
 
-    tailwindcss -i tailwind.css -o kopuz/assets/tailwind.css --minify
+    tailwindcss -i tailwind.css -o crates/kopuz/assets/tailwind.css --minify
 
     ${lib.optionalString stdenv.hostPlatform.isDarwin ''
             mkdir -p "$TMPDIR/fake-bin"
@@ -95,11 +99,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
           install -Dm644 data/com.temidaradev.kopuz.desktop \
             $out/share/applications/com.temidaradev.kopuz.desktop
           substituteInPlace $out/share/applications/com.temidaradev.kopuz.desktop \
+            --replace-fail "Exec=kopuz" "Exec=$out/bin/kopuz"
 
           install -Dm644 data/com.temidaradev.kopuz.metainfo.xml \
             $out/share/metainfo/com.temidaradev.kopuz.metainfo.xml
 
-          install -Dm644 kopuz/assets/logo.png \
+          install -Dm644 crates/kopuz/assets/logo.png \
             $out/share/icons/hicolor/256x256/apps/com.temidaradev.kopuz.png
         ''
       else
@@ -119,6 +124,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     gappsWrapperArgs+=(
       --chdir $out/bin
       --prefix PATH : ${lib.makeBinPath [ yt-dlp ]}
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libayatana-appindicator ]}
     )
   '';
 


### PR DESCRIPTION
Updated kopuz version to v0.8.2 from v0.6.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
