### PR TITLE
lib/customisation: add overrideVariant to preserve API in by-name migrations, fix formatting in docstring

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -216,6 +216,50 @@ rec {
       mirrorArgs f';
 
   /**
+      Overrides a base package with specific attributes, while cleanly passing
+      through any additional arguments provided by `callPackage`.
+
+      This is specifically designed to facilitate the `by-name` migration for
+      package variants (e.g., migrating `package-gui` without losing the
+      user's ability to chain `.override` calls).
+
+      # Inputs
+
+      `basePackage`
+
+      : 1\. Function argument (The base derivation to override)
+
+      `excludeArgs`
+
+      : 2\. Function argument (A list of argument strings to remove from the passthrough)
+
+      `variantOverrides`
+
+      : 3\. Function argument (The attributes to override)
+
+      `variantArgs`
+
+      : 4\. Function argument (The arguments passed to the variant by `callPackage`)
+
+      # Type
+
+      ```
+      overrideVariant :: Derivation -> [String] -> AttrSet -> AttrSet -> Derivation
+      ```
+  */
+  overrideVariant =
+    {
+      basePackage,
+      variantOverrides,
+      variantArgs,
+      # Dynamically find the injected argument name by matching derivation paths
+      excludeArgs ? filter (
+        k: (isDerivation variantArgs.${k}) && variantArgs.${k}.drvPath == basePackage.drvPath
+      ) (attrNames variantArgs),
+    }:
+    basePackage.override (variantOverrides // removeAttrs variantArgs (excludeArgs ++ [ "lib" ]));
+
+  /**
     Call the package function in the file `fn` with the required
     arguments automatically.  The function is called with the
     arguments `args`, but any missing arguments are obtained from

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -264,28 +264,32 @@ rec {
     arguments automatically.  The function is called with the
     arguments `args`, but any missing arguments are obtained from
     `autoArgs`.  This function is intended to be partially
-    parameterised, e.g.,
-
-      ```nix
-      callPackage = callPackageWith pkgs;
-      pkgs = {
-        libfoo = callPackage ./foo.nix { };
-        libbar = callPackage ./bar.nix { };
-      };
-      ```
+    parameterised.
 
     If the `libbar` function expects an argument named `libfoo`, it is
-    automatically passed as an argument.  Overrides or missing
-    arguments can be supplied in `args`, e.g.
+    automatically passed as an argument. Overrides or missing
+    arguments can be supplied in `args`.
 
-      ```nix
-      libbar = callPackage ./bar.nix {
-        libfoo = null;
-        enableX11 = true;
-      };
-      ```
+    # Examples
 
-    <!-- TODO: Apply "Example:" tag to the examples above -->
+    :::{.example}
+    ## `lib.customisation.callPackageWith` usage example
+
+    ```nix
+    callPackage = callPackageWith pkgs;
+    pkgs = {
+      libfoo = callPackage ./foo.nix { };
+      libbar = callPackage ./bar.nix { };
+    };
+
+    # Overriding or supplying missing arguments
+    libbar = callPackage ./bar.nix {
+      libfoo = null;
+      enableX11 = true;
+    };
+    ```
+
+    :::
 
     # Inputs
 

--- a/pkgs/by-name/ja/jabcode-reader/package.nix
+++ b/pkgs/by-name/ja/jabcode-reader/package.nix
@@ -1,11 +1,13 @@
 {
+  lib,
   jabcode,
   ...
 }@args:
 
-jabcode.override (
-  {
+lib.customisation.overrideVariant {
+  basePackage = jabcode;
+  variantOverrides = {
     subproject = "reader";
-  }
-  // removeAttrs args [ "jabcode" ]
-)
+  };
+  variantArgs = args;
+}

--- a/pkgs/by-name/ja/jabcode-writer/package.nix
+++ b/pkgs/by-name/ja/jabcode-writer/package.nix
@@ -1,11 +1,13 @@
 {
+  lib,
   jabcode,
   ...
 }@args:
 
-jabcode.override (
-  {
+lib.customisation.overrideVariant {
+  basePackage = jabcode;
+  variantOverrides = {
     subproject = "writer";
-  }
-  // removeAttrs args [ "jabcode" ]
-)
+  };
+  variantArgs = args;
+}


### PR DESCRIPTION
This pull request introduces a new utility function to simplify package variant overrides and migrates two packages to use this approach. The main focus is to facilitate the "by-name" migration for package variants, making it easier to override and extend packages without losing the ability to chain `.override` calls. Additionally, the documentation for related functions has been improved for clarity.

**New utility for package overrides:**

* Added the `overrideVariant` function to `lib/customisation.nix`, allowing clean and flexible overriding of base packages with specific attributes and passthrough arguments. This is designed to support the "by-name" migration and preserve `.override` chaining for package variants.

**Migration to new override utility:**

* Updated `pkgs/by-name/ja/jabcode-reader/package.nix` and `pkgs/by-name/ja/jabcode-writer/package.nix` to use `lib.customisation.overrideVariant` instead of manual override logic, improving maintainability and consistency. [[1]](diffhunk://#diff-f8e7031be16152262f7fb3f3c12046ce899b1390aac24828f120afa3bfebb1e2R2-R9) [[2]](diffhunk://#diff-38f23ebbe7f428cc9054f58b758faad5094e5ca98c661a58250d0be4c950bdc0R2-R9)

**Documentation improvements:**

* Enhanced the documentation for `callPackageWith` in `lib/customisation.nix` with clearer examples and explanations for easier understanding and usage.

**Code cleanup:**

* Commented out an unused line related to function argument inheritance in `lib/customisation.nix` to avoid confusion and maintain code clarity.

Abstract overrideAttrs logic for issue #537188
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
