### PR TITLE
hcom: init at 0.7.23

### DIFF
--- a/pkgs/by-name/hc/hcom/package.nix
+++ b/pkgs/by-name/hc/hcom/package.nix
@@ -24,6 +24,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
   doCheck = true;
   nativeCheckInputs = [ writableTmpDirAsHomeHook ];
 
+  checkFlags = [
+    # tries to read $PATH
+    "--skip=shell_env::tests::resolver_discards_stderr_without_breaking_env_resolution"
+    # tries to read shell pid
+    "--skip=shell_env::tests::timeout_kills_shell_process_group"
+  ];
+
+  # tons of unit tests use local ports
+  __darwinAllowLocalNetworking = true;
+
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
 

--- a/pkgs/by-name/hc/hcom/package.nix
+++ b/pkgs/by-name/hc/hcom/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  writableTmpDirAsHomeHook,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "hcom";
+  version = "0.7.22";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "aannoo";
+    repo = "hcom";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-nYJ/S6/yNaMU8dJ4NoQbNHa133Ui4mHxc/2Dfmzga90=";
+  };
+
+  cargoHash = "sha256-3wDLq7qymMO5NUK9ekbh9+ij+zp5Ny1lFcxVmHzti+4=";
+
+  doCheck = true;
+  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Let AI agents message, watch, and spawn each other across terminals";
+    homepage = "https://github.com/aannoo/hcom";
+    changelog = "https://github.com/aannoo/hcom/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ Br1ght0ne ];
+    mainProgram = "hcom";
+  };
+})

--- a/pkgs/by-name/hc/hcom/package.nix
+++ b/pkgs/by-name/hc/hcom/package.nix
@@ -9,17 +9,17 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "hcom";
-  version = "0.7.22";
+  version = "0.7.23";
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "aannoo";
     repo = "hcom";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-nYJ/S6/yNaMU8dJ4NoQbNHa133Ui4mHxc/2Dfmzga90=";
+    hash = "sha256-58AcL/hOi8Fl1Nq6QBOyM7Uf7ZUjBabU4PBzZWo25Vo=";
   };
 
-  cargoHash = "sha256-3wDLq7qymMO5NUK9ekbh9+ij+zp5Ny1lFcxVmHzti+4=";
+  cargoHash = "sha256-cGhssU75BrNmHqxYWvqRcjNxB70rxYHXBz3hZDY+was=";
 
   doCheck = true;
   nativeCheckInputs = [ writableTmpDirAsHomeHook ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/aannoo/hcom - "a CLI that agents can use to message, watch, and spawn each other across terminals"

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
