### PR TITLE
pkgs/nixos-render-docs: remove dead {examples,figures} table

### DIFF
--- a/doc/style.css
+++ b/doc/style.css
@@ -34,10 +34,6 @@ body {
   }
 }
 
-.list-of-examples {
-  display: none;
-}
-
 h1 {
   font-size: 2em;
   margin: 0.67em 0;

--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/manual.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/manual.py
@@ -494,9 +494,7 @@ class ManualHTMLRenderer(RendererMixin, HTMLRenderer):
                 '</div>'
             )
         nav = render_entries(root.children, self._html_params.sidebar_depth)
-        figures = build_list("Figures", "list-of-figures", root.figures)
-        examples = build_list("Examples", "list-of-examples", root.examples)
-        return f'{nav}{figures}{examples}'
+        return f'{nav}'
 
     def _make_hN(self, level: int) -> tuple[str, str]:
         # book heading := h1

--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/manual_structure.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/manual_structure.py
@@ -3,13 +3,12 @@ from __future__ import annotations
 import dataclasses as dc
 import html
 import itertools
-
-from typing import cast, get_args, Iterable, Literal, Sequence
+from typing import Iterable, Literal, Sequence, cast, get_args
 
 from markdown_it.token import Token
 
-from .utils import Freezeable
 from .src_error import SrcError
+from .utils import Freezeable
 
 # FragmentType is used to restrict structural include blocks.
 FragmentType = Literal['preface', 'part', 'chapter', 'section', 'appendix']
@@ -146,8 +145,6 @@ class TocEntry(Freezeable):
     next: TocEntry | None = None
     children: list[TocEntry] = dc.field(default_factory=list)
     starts_new_chunk: bool = False
-    examples: list[TocEntry] = dc.field(default_factory=list)
-    figures: list[TocEntry] = dc.field(default_factory=list)
 
     @property
     def root(self) -> TocEntry:
@@ -162,7 +159,7 @@ class TocEntry(Freezeable):
 
     @classmethod
     def collect_and_link(cls, xrefs: dict[str, XrefTarget], tokens: Sequence[Token]) -> TocEntry:
-        entries, examples, figures = cls._collect_entries(xrefs, tokens, 'book')
+        entries = cls._collect_entries(xrefs, tokens, 'book')
 
         def flatten_with_parent(this: TocEntry, parent: TocEntry | None) -> Iterable[TocEntry]:
             this.parent = parent
@@ -179,9 +176,6 @@ class TocEntry(Freezeable):
                 prev = c
             paths_seen.add(c.target.path)
 
-        flat[0].examples = examples
-        flat[0].figures = figures
-
         for c in flat:
             c.freeze()
 
@@ -189,37 +183,30 @@ class TocEntry(Freezeable):
 
     @classmethod
     def _collect_entries(cls, xrefs: dict[str, XrefTarget], tokens: Sequence[Token],
-                         kind: TocEntryType) -> tuple[TocEntry, list[TocEntry], list[TocEntry]]:
+                         kind: TocEntryType) -> TocEntry:
         # we assume that check_structure has been run recursively over the entire input.
         # list contains (tag, entry) pairs that will collapse to a single entry for
         # the full sequence.
         entries: list[tuple[str, TocEntry]] = []
-        examples: list[TocEntry] = []
-        figures: list[TocEntry] = []
         for token in tokens:
             if token.type.startswith('included_') and (included := token.meta.get('included')):
                 fragment_type_str = token.type[9:].removesuffix('s')
                 assert fragment_type_str in get_args(TocEntryType)
                 fragment_type = cast(TocEntryType, fragment_type_str)
                 for fragment, _path in included:
-                    subentries, subexamples, subfigures = cls._collect_entries(xrefs, fragment, fragment_type)
+                    subentries = cls._collect_entries(xrefs, fragment, fragment_type)
                     entries[-1][1].children.append(subentries)
-                    examples += subexamples
-                    figures += subfigures
             elif token.type == 'heading_open' and (id := cast(str, token.attrs.get('id', ''))):
                 while len(entries) > 1 and entries[-1][0] >= token.tag:
                     entries[-2][1].children.append(entries.pop()[1])
                 entries.append((token.tag,
                                 TocEntry(kind if token.tag == 'h1' else 'section', xrefs[id])))
                 token.meta['TocEntry'] = entries[-1][1]
-            elif token.type == 'example_open' and (id := cast(str, token.attrs.get('id', ''))):
-                examples.append(TocEntry('example', xrefs[id]))
-            elif token.type == 'figure_open' and (id := cast(str, token.attrs.get('id', ''))):
-                figures.append(TocEntry('figure', xrefs[id]))
+
 
         while len(entries) > 1:
             entries[-2][1].children.append(entries.pop()[1])
-        return (entries[0][1], examples, figures)
+        return entries[0][1]
 
 _xml_id_translate_table = {
     ord('*'): ord('_'),


### PR DESCRIPTION
We do not use the extensive list of example and figures.
I'd remove them, if we figure we need them, we can bring them back.

Problems:

- Emitting dead html
- Complexity of collecting these tables in nrd

~~Note: Due to #535702 this will temporarily lead to broken styles for local builds, until the styles and the renderer match again.~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
