### PR TITLE
python3Packages.pylance: 7.0.0 -> 8.0.0

### DIFF
--- a/pkgs/development/python-modules/lance-namespace-urllib3-client/default.nix
+++ b/pkgs/development/python-modules/lance-namespace-urllib3-client/default.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "lance-namespace-urllib3-client";
-  version = "0.7.7";
+  version = "0.8.6";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -26,7 +26,7 @@ buildPythonPackage (finalAttrs: {
     owner = "lancedb";
     repo = "lance-namespace";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-f+jtRAq4mI6y3q9Jt2ZqAMhXhNRavld88vWKz3VypBs=";
+    hash = "sha256-QYzVsarjTg2arNNuCFbVgtA7rfLTm6AJD3liNr3QuSU=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/python/lance_namespace_urllib3_client";

--- a/pkgs/development/python-modules/lance-namespace/default.nix
+++ b/pkgs/development/python-modules/lance-namespace/default.nix
@@ -30,7 +30,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "lance-namespace";
-  version = "0.7.7";
+  version = "0.8.6";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -38,7 +38,7 @@ buildPythonPackage (finalAttrs: {
     owner = "lancedb";
     repo = "lance-namespace";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-f+jtRAq4mI6y3q9Jt2ZqAMhXhNRavld88vWKz3VypBs=";
+    hash = "sha256-QYzVsarjTg2arNNuCFbVgtA7rfLTm6AJD3liNr3QuSU=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/python/lance_namespace";

--- a/pkgs/development/python-modules/pylance/default.nix
+++ b/pkgs/development/python-modules/pylance/default.nix
@@ -34,7 +34,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pylance";
-  version = "7.0.0";
+  version = "8.0.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -42,7 +42,7 @@ buildPythonPackage (finalAttrs: {
     owner = "lancedb";
     repo = "lance";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-wOFfG2CPt292WkdLUM+5Rl0OKej9b8WzV9LRpCoao3M=";
+    hash = "sha256-pxggvF23u3Wfm6YdaHwbDUZDUwtJ4tOaTLViUfGZ0B8=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/python";
@@ -54,7 +54,7 @@ buildPythonPackage (finalAttrs: {
       src
       sourceRoot
       ;
-    hash = "sha256-8ngtq1AlOj0ZgiAwsibz1MGxSJ8kfIbXCafsIneOMqA=";
+    hash = "sha256-VSy1cOshPLAic+1HkTGiavdNRffiEVAlWThNeebJSyg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/pylance/default.nix
+++ b/pkgs/development/python-modules/pylance/default.nix
@@ -28,6 +28,7 @@
   pandas,
   pillow,
   polars,
+  psutil,
   pytestCheckHook,
   tqdm,
 }:
@@ -94,6 +95,7 @@ buildPythonPackage (finalAttrs: {
     pandas
     pillow
     polars
+    psutil
     pytestCheckHook
     tqdm
   ]


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/lancedb/lance/compare/v7.0.0...v8.0.0
Changelog: https://github.com/lancedb/lance/releases/tag/v8.0.0

cc @natsukium

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test