### PR TITLE
gram: 2.2.0 -> 3.0.1

### DIFF
--- a/pkgs/by-name/gr/gram/package.nix
+++ b/pkgs/by-name/gr/gram/package.nix
@@ -6,7 +6,6 @@
   pkg-config,
   protobuf,
   fontconfig,
-  libgit2,
   openssl,
   sqlite,
   zlib,
@@ -31,7 +30,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "gram";
-  version = "2.2.0";
+  version = "3.0.1";
 
   outputs = [
     "out"
@@ -44,7 +43,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "GramEditor";
     repo = "gram";
     tag = finalAttrs.version;
-    hash = "sha256-w0uZ2qAc3Tt6QVRAX97LWW9aOs02fG1SEYCDhpUhinE=";
+    hash = "sha256-B3RmY1h0+D0aawNzevdt9f+gzozckjInhoz+t9taf8o=";
   };
 
   postPatch = ''
@@ -54,7 +53,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace-fail '$CARGO_ABOUT_VERSION' '${cargo-about.version}'
   '';
 
-  cargoHash = "sha256-+lmDbawAIRllC7LzGJ9qPMtHXPd5aMoul47YOA7nfXA=";
+  cargoHash = "sha256-pK0rUuPtWejXitbDQqh9fvdEv3aza0ZEg1XWnCmY4eE=";
 
   __structuredAttrs = true;
 
@@ -71,7 +70,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   dontUseCmakeConfigure = true;
 
   buildInputs = [
-    (libgit2.override { withExperimentalSha256 = true; })
     openssl
     sqlite
     zlib
@@ -89,16 +87,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ]
   ++ lib.optionals buildRemoteServer [ "--package=remote_server" ];
 
-  # Required on darwin because we don't have access to the proprietary Metal shader compiler.
-  buildFeatures = lib.optionals stdenv.hostPlatform.isDarwin [ "gpui/runtime_shaders" ];
-
   env = {
     ALLOW_MISSING_LICENSES = true;
     OPENSSL_NO_VENDOR = true;
-    LIBGIT2_NO_VENDOR = true;
     LIBSQLITE3_SYS_USE_PKG_CONFIG = true;
     ZSTD_SYS_USE_PKG_CONFIG = true;
     RELEASE_VERSION = finalAttrs.version;
+    GRAM_UPDATE_EXPLANATION = "Updates are handled by nixpkgs";
   };
 
   preBuild = ''


### PR DESCRIPTION
Changelogs:

- https://codeberg.org/GramEditor/gram/releases/tag/3.0.0
- https://codeberg.org/GramEditor/gram/releases/tag/3.0.1

Closes #537424

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
