### PR TITLE
 wasmer: 7.1.0 -> 7.2.0 

### DIFF
--- a/pkgs/by-name/wa/wasmer/package.nix
+++ b/pkgs/by-name/wa/wasmer/package.nix
@@ -10,7 +10,7 @@
   curl,
   writeShellApplication,
   installShellFiles,
-  llvmPackages_21,
+  llvmPackages_22,
   libffi,
   libxml2,
   fixDarwinDylibNames,
@@ -20,26 +20,26 @@
 }:
 
 let
-  v8Version = "11.9.2";
+  v8Version = "11.9.7";
 
   # Prebuilt V8 from wasmerio's custom builds, only evaluated when withV8 = true.
 
   # Per-platform hashes, auto-updated via the general updateScript
   v8Hashes = {
-    "v8-linux-amd64.tar.xz" = "sha256-nTCVdBKtyVMb7lE+Db4RDsShKkLbG/0r980ejd+EAvo=";
-    "v8-linux-musl-amd64.tar.xz" = "sha256-XgRs3I46B2PG7Jrv5E+KSeuNfXLhgB7R66cAkA/Bvv8=";
-    "v8-darwin-arm64.tar.xz" = "sha256-xAG1PcAGw8a0A9k8d78/whTUXnqdfRZBz8yrg/+iz0M=";
+    "v8-linux-amd64.tar.xz" = "sha256-VOGZOKA07neIixDPJ3BLGeMX37/o9o16X4rYlo/nMbo=";
+    "v8-linux-musl.tar.xz" = "sha256-drD0YfCA56zej5PFR1olfdUMOOlgYo8LGbxWEJ1NusY=";
+    "v8-darwin-aarch64.tar.xz" = "sha256-Vk0ys6MjHSa8Gjd7XN0Jj4gyxORU0yP7hEmYk1ENeq4=";
   };
 
   v8Prebuilt =
     let
       assetName =
         if stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64 && stdenv.hostPlatform.isMusl then
-          "v8-linux-musl-amd64.tar.xz"
+          "v8-linux-musl.tar.xz"
         else if stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64 then
           "v8-linux-amd64.tar.xz"
         else if stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64 then
-          "v8-darwin-arm64.tar.xz"
+          "v8-darwin-aarch64.tar.xz"
         else
           throw "withV8 = true is not supported on ${stdenv.hostPlatform.system}";
     in
@@ -61,7 +61,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wasmer";
-  version = "7.1.0";
+  version = "7.2.0";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -70,13 +70,13 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "wasmerio";
     repo = "wasmer";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-A1SkZY+iSR9xlu6R1p9uZYsGFPAOifuYTHtEXaEgves=";
+    hash = "sha256-HiMxBABLkX0i5jGowZU7dWhW46hvtcvbX7rskL3i+iY=";
     fetchSubmodules = true;
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-wBEwGKjj9DdZESFlXS8T7B0Xdp7yMe08DYTGr4wnTVI=";
+    hash = "sha256-+O/JbgozCHF/QBABMtxqkGFQYtAQwu6OUDoD5EZZmXs=";
   };
 
   nativeBuildInputs = [
@@ -89,42 +89,34 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
 
   buildInputs = lib.optionals withLLVM [
-    llvmPackages_21.llvm
+    llvmPackages_22.llvm
     libffi
     libxml2
   ];
 
   postPatch =
-    # In 7.1.0 there is no nice flag to toggle napi/v8 on or off,
-    # so we manually delete the Makefile entry when we don't want v8
-    # TODO: v7.2.0 pre-release has a flag, when updating to 7.2.0
-    #  add "ENABLE_NAPI_V8=${if withV8 then "1" else "0"}" to makeFlags
-    lib.optionalString (!withV8) ''
-      substituteInPlace Makefile \
-        --replace-fail '	build_wasmer_extra_features += napi-v8' ""
-    ''
-    +
-      lib.optionalString stdenv.hostPlatform.isDarwin
-        # `install -Dm644 /dev/stdin DEST` fails on darwin with
-        # "skipping file '/dev/stdin', as it was replaced while being copied".
-        (
-          ''
-            substituteInPlace Makefile \
-              --replace-fail 'echo "$$pc" | install -Dm644 /dev/stdin "$(DESTDIR)"/lib/pkgconfig/wasmer.pc;' \
-                             'mkdir -p "$(DESTDIR)/lib/pkgconfig" && printf "%s\n" "$$pc" > "$(DESTDIR)/lib/pkgconfig/wasmer.pc";'
-          ''
-          # install-capi-lib hardcodes libwasmer.so and a Linux SONAME symlink chain
-          # (also marked Linux only in the Makefile)
-          + ''
-            substituteInPlace Makefile \
-              --replace-fail 'install-capi-lib ' ""
-          ''
-        );
+    lib.optionalString stdenv.hostPlatform.isDarwin
+      # `install -Dm644 /dev/stdin DEST` fails on darwin with
+      # "skipping file '/dev/stdin', as it was replaced while being copied".
+      (
+        ''
+          substituteInPlace Makefile \
+            --replace-fail 'echo "$$pc" | install -Dm644 /dev/stdin "$(DESTDIR)"/lib/pkgconfig/wasmer.pc;' \
+                           'mkdir -p "$(DESTDIR)/lib/pkgconfig" && printf "%s\n" "$$pc" > "$(DESTDIR)/lib/pkgconfig/wasmer.pc";'
+        ''
+        # install-capi-lib hardcodes libwasmer.so and a Linux SONAME symlink chain
+        # (also marked Linux only in the Makefile)
+        + ''
+          substituteInPlace Makefile \
+            --replace-fail 'install-capi-lib ' ""
+        ''
+      );
 
   makeFlags = [
     "WASMER_INSTALL_PREFIX=${placeholder "out"}"
     "DESTDIR=${placeholder "out"}"
     "ENABLE_LLVM=${if withLLVM then "1" else "0"}"
+    "ENABLE_NAPI_V8=${if withV8 then "1" else "0"}"
   ];
 
   # Default all target includes headless C API which doesn't get installed
@@ -136,7 +128,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   env =
     lib.optionalAttrs withLLVM {
-      LLVM_SYS_211_PREFIX = llvmPackages_21.llvm.dev;
+      LLVM_SYS_221_PREFIX = llvmPackages_22.llvm.dev;
     }
     // lib.optionalAttrs withV8 {
       # build.rs skips the download when these are set; see resolve_explicit_v8 in lib/napi/build.rs

--- a/pkgs/by-name/wa/wasmer/update.sh
+++ b/pkgs/by-name/wa/wasmer/update.sh
@@ -1,9 +1,20 @@
-old_version=$(grep -oP '^  version = "\K[^"]+(?=";)' pkgs/by-name/wa/wasmer/package.nix)
+set -euo pipefail
+
+pkg=pkgs/by-name/wa/wasmer/package.nix
+
+die() {
+  echo "update-wasmer: error: $*" >&2
+  exit 1
+}
+
+[ -f "$pkg" ] || die "cannot find $pkg (run from the nixpkgs root)"
+
+old_version=$(grep -oP '^  version = "\K[^"]+(?=";)' "$pkg")
 echo "Current wasmer version: $old_version"
 
 nix-update wasmer "$@"
 
-new_version=$(grep -oP '^  version = "\K[^"]+(?=";)' pkgs/by-name/wa/wasmer/package.nix)
+new_version=$(grep -oP '^  version = "\K[^"]+(?=";)' "$pkg")
 if [ "$old_version" = "$new_version" ]; then
   echo "Already at $old_version, nothing to do"
   exit 0
@@ -14,10 +25,16 @@ echo "Updated wasmer $old_version -> $new_version"
 # lib/napi is a submodule, so resolve its pinned SHA first, then fetch build.rs from that repo.
 echo "Fetching PREBUILT_V8_VERSION from lib/napi/build.rs..."
 napi_sha=$(curl -fsSL "https://api.github.com/repos/wasmerio/wasmer/contents/lib/napi?ref=v${new_version}" \
-           | grep -oP '"sha":\s*"\K[^"]+' | head -1)
+           | grep -oP '"sha":\s*"\K[^"]+' | head -1) \
+  || die "failed to query lib/napi submodule SHA for v${new_version} (does the tag exist?)"
+[ -n "$napi_sha" ] || die "could not resolve lib/napi submodule SHA for v${new_version}"
+
 new_v8=$(curl -fsSL "https://raw.githubusercontent.com/wasmerio/napi/${napi_sha}/build.rs" \
-         | grep -oP 'PREBUILT_V8_VERSION\s*:\s*&str\s*=\s*"\K[^"]+')
-cur_v8=$(grep -oP '^  v8Version = "\K[^"]+(?=";)' pkgs/by-name/wa/wasmer/package.nix)
+         | grep -oP 'PREBUILT_V8_VERSION\s*:\s*&str\s*=\s*"\K[^"]+') \
+  || die "failed to fetch build.rs from wasmerio/napi@${napi_sha}"
+[ -n "$new_v8" ] || die "could not parse PREBUILT_V8_VERSION from wasmerio/napi@${napi_sha}/build.rs (format may have changed)"
+
+cur_v8=$(grep -oP '^  v8Version = "\K[^"]+(?=";)' "$pkg")
 echo "V8: current=$cur_v8, required=$new_v8"
 
 if [ "$new_v8" = "$cur_v8" ]; then
@@ -25,25 +42,35 @@ if [ "$new_v8" = "$cur_v8" ]; then
   exit 0
 fi
 
-echo "V8 bumped $cur_v8 -> $new_v8, fetching hashes for all platforms..."
-sed -i "s|^  v8Version = \"[^\"]*\";$|  v8Version = \"$new_v8\";|" \
-  pkgs/by-name/wa/wasmer/package.nix
+# The asset filenames live in the v8Hashes attrset (also referenced by the
+# assetName mapping below it). Treat package.nix as the single source of truth
+# so this list can never drift from what the derivation actually fetches.
+mapfile -t assets < <(grep -oP '^\s*"\Kv8-[^"]+\.tar\.xz(?=" = "sha256)' "$pkg")
+[ "${#assets[@]}" -gt 0 ] || die "found no v8 assets in the v8Hashes attrset of $pkg"
+
+echo "V8 bumped $cur_v8 -> $new_v8, fetching hashes for ${#assets[@]} platform(s)..."
+sed -i "s|^  v8Version = \"[^\"]*\";$|  v8Version = \"$new_v8\";|" "$pkg"
 
 base="https://github.com/wasmerio/v8-custom-builds/releases/download/$new_v8"
-declare -A assets=(
-  ["v8-linux-amd64.tar.xz"]="$base/v8-linux-amd64.tar.xz"
-  ["v8-linux-musl-amd64.tar.xz"]="$base/v8-linux-musl-amd64.tar.xz"
-  ["v8-darwin-arm64.tar.xz"]="$base/v8-darwin-arm64.tar.xz"
-)
-
-for asset in "${!assets[@]}"; do
-  url="${assets[$asset]}"
+for asset in "${assets[@]}"; do
+  url="$base/$asset"
   echo "  Fetching hash for $asset..."
-  hash=$(nix-prefetch-url --type sha256 "$url" 2>/dev/null \
-         | xargs nix hash convert --hash-algo sha256 --to sri)
+  # Do not suppress errors here: a 404 usually means upstream renamed the asset
+  # between releases (e.g. v8-darwin-arm64 -> v8-darwin-aarch64), in which case
+  # the asset key in package.nix must be updated by hand before this can work.
+  if ! raw=$(nix-prefetch-url --type sha256 "$url"); then
+    die "could not download $url
+    The asset may have been renamed in the $new_v8 release. Check
+      https://github.com/wasmerio/v8-custom-builds/releases/tag/$new_v8
+    and update the v8Hashes keys and the assetName mapping in $pkg to match,
+    then re-run this script."
+  fi
+  hash=$(nix hash convert --hash-algo sha256 --to sri "$raw") \
+    || die "failed to convert hash for $asset ($raw)"
   echo "  $asset -> $hash"
-  sed -i "s|\"$asset\" = \"[^\"]*\"|\"$asset\" = \"$hash\"|" \
-    pkgs/by-name/wa/wasmer/package.nix
+  sed -i "s|\"$asset\" = \"[^\"]*\"|\"$asset\" = \"$hash\"|" "$pkg"
+  grep -qF "\"$asset\" = \"$hash\"" "$pkg" \
+    || die "failed to write hash for $asset into $pkg (pattern did not match)"
 done
 
 echo "Done"


### PR DESCRIPTION
Updates wasmer to 7.2.0: https://github.com/wasmerio/wasmer/blob/v7.2.0/CHANGELOG.md

There was a little manual intervention required, so the r-ryantm couldn't have done this automatically, but besides that, the `updateScript` was failing with no error message.
This PR also improves the update script a bit, to be more clear about errors encountered, as well as being more robust against semantic drift (the V8 tags being renamed in `.nix` but not `.sh`).
For the update script fixes I used Claude Code to assist.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
