### PR TITLE
doc/manual: init example packaging guide 

### DIFF
--- a/doc/build-helpers.md
+++ b/doc/build-helpers.md
@@ -25,6 +25,5 @@ build-helpers/dev-shell-tools.chapter.md
 build-helpers/special.md
 build-helpers/images.md
 hooks/index.md
-languages-frameworks/index.md
 packages/index.md
 ```

--- a/doc/first-package.chapter.md
+++ b/doc/first-package.chapter.md
@@ -1,0 +1,84 @@
+# Package your first application {#chap-first-package}
+
+Package an application with Nixpkgs by picking the build helper for its language and setting a few attributes.
+
+Each language ecosystem has its own build helper.
+See [](#chap-language-support) for the full set.
+
+## Package a Go application {#first-package-go}
+
+`buildGoModule` builds Go programs that use Go modules.
+
+Write the package to `package.nix`:
+
+:::{.example #ex-first-package-go}
+
+# Package `pet` with `buildGoModule`
+
+```nix
+# package.nix
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+}:
+buildGoModule (finalAttrs: {
+  pname = "pet";
+  version = "0.3.4";
+
+  src = fetchFromGitHub {
+    owner = "knqyf263";
+    repo = "pet";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Gjw1dRrgM8D3G7v6WIM2+50r4HmTXvx0Xxme2fH9TlQ=";
+  };
+
+  vendorHash = "sha256-6hCgv2/8UIRHw1kCe3nLkxF23zE/7t5RDwEjSzX3pBQ=";
+
+  meta = {
+    description = "Simple command-line snippet manager, written in Go";
+    homepage = "https://github.com/knqyf263/pet";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kalbasit ];
+  };
+})
+```
+
+:::
+
+`buildGoModule` needs `pname`, `version`, `src`, and `vendorHash`.
+
+Pin Nixpkgs and call the package from `default.nix`:
+
+```nix
+# default.nix
+let
+  nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/archive/nixos-unstable.tar.gz";
+  pkgs = import nixpkgs { };
+in
+pkgs.callPackage ./package.nix { }
+```
+
+Build it:
+
+```shell
+$ nix-build ./default.nix
+# or equivalent
+$ nix-build
+```
+
+Run it:
+
+```shell
+$ ./result/bin/pet --help
+pet - Simple command-line snippet manager.
+```
+
+`vendorHash` pins the fetched dependencies.
+To find its value:
+
+1. Set `vendorHash` to an empty string `""`.
+2. Run `nix-build`.
+3. Copy the correct value from the error into `vendorHash`.
+
+See the [Go reference](#sec-language-go) for every attribute and advanced usage.

--- a/doc/languages-frameworks/index.md
+++ b/doc/languages-frameworks/index.md
@@ -2,6 +2,10 @@
 
 The [standard build environment](#chap-stdenv) makes it easy to build typical Autotools-based packages with very little code. Any other kind of package can be accommodated by overriding the appropriate phases of `stdenv`. However, there are specialised functions in Nixpkgs to easily build packages for other programming languages, such as Perl or Haskell. These are described in this chapter.
 
+::: {.tip}
+New to packaging? Start with [](#chap-first-package), then return here for the ecosystem you need.
+:::
+
 Each supported language or software ecosystem has its own package set named `<language or ecosystem>Packages`, which can be explored in various ways:
 
 - Search on [search.nixos.org](https://search.nixos.org/packages)

--- a/doc/manual.md.in
+++ b/doc/manual.md.in
@@ -17,6 +17,10 @@ contributing.md
 interoperability.md
 ```
 
+```{=include=} chapters
+languages-frameworks/index.md
+```
+
 ```{=include=} appendix html:into-file=//release-notes.html
 release-notes/release-notes.md
 ```

--- a/doc/manual.md.in
+++ b/doc/manual.md.in
@@ -3,6 +3,7 @@
 
 ```{=include=} chapters
 preface.chapter.md
+first-package.chapter.md
 ```
 
 ```{=include=} parts

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -2,6 +2,9 @@
   "chap-build-helpers-finalAttrs": [
     "index.html#chap-build-helpers-finalAttrs"
   ],
+  "chap-first-package": [
+    "index.html#chap-first-package"
+  ],
   "chap-release-notes": [
     "release-notes.html#chap-release-notes"
   ],
@@ -105,6 +108,9 @@
   "ex-build-helpers-extendMkDerivation": [
     "index.html#ex-build-helpers-extendMkDerivation"
   ],
+  "ex-first-package-go": [
+    "index.html#ex-first-package-go"
+  ],
   "ex-modularServiceCompliance-nixos": [
     "index.html#ex-modularServiceCompliance-nixos"
   ],
@@ -130,6 +136,9 @@
   ],
   "ex-writeShellApplication": [
     "index.html#ex-writeShellApplication"
+  ],
+  "first-package-go": [
+    "index.html#first-package-go"
   ],
   "friction-graphics": [
     "index.html#friction-graphics"


### PR DESCRIPTION
A large cluster of users ask: "How do I package software?"

This guide is the entry point and then fans out into the respective language chapters.
I also moved the language chapters into the hierarchical top level (directly into `manual.md.in`) 

This violates the intended `part -> chapter -> section -> ... ` ordering. But is already done in other places, and i think we should remove enforcing this ordering.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
