### PR TITLE
ldash: init at 1.3.1

### DIFF
--- a/pkgs/by-name/ld/ldash/package.nix
+++ b/pkgs/by-name/ld/ldash/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitea,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ldash";
+  version = "1.3.1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "md-weber";
+    repo = "ldash";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ji1sgzDjJ8KVUVaKzhhCFBgIAAzRS2NQ7DTvJxb3PKA=";
+  };
+
+  cargoHash = "sha256-9/Dk3FQuSlUWPm4z3VadJl5FYtZ1gFY9mdZwiSXzzvc=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "This is a TUI for hledger to show a nice dashboard";
+    homepage = "https://codeberg.org/md-weber/ldash";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ matthewcroughan ];
+    mainProgram = "ldash";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Packaging assisted by `nix-init`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
