### PR TITLE
doc/manual: reword 'nixpkgs reference manual' to just 'nixpkgs' manual

### DIFF
--- a/doc/build-helpers/dev-shell-tools.chapter.md
+++ b/doc/build-helpers/dev-shell-tools.chapter.md
@@ -2,7 +2,7 @@
 
 The `nix-shell` command has popularized the concept of transient shell environments for development or testing purposes.
 <!--
-  We should try to document the product, not its development process in the Nixpkgs reference manual,
+  We should try to document the product, not its development process in the Nixpkgs manual,
   but *something* needs to be said to provide context for this library.
   This is the most future proof sentence I could come up with while Nix itself does not yet make use of this.
   Relevant is the current status of the devShell attribute "project": https://github.com/NixOS/nix/issues/7501

--- a/doc/manual.md.in
+++ b/doc/manual.md.in
@@ -1,4 +1,4 @@
-# Nixpkgs Reference Manual {#nixpkgs-manual}
+# Nixpkgs Manual {#nixpkgs-manual}
 ## Version @MANUAL_VERSION@
 
 ```{=include=} chapters

--- a/nixos/tests/playwright-python.nix
+++ b/nixos/tests/playwright-python.nix
@@ -29,7 +29,7 @@
               "firefox": {},
               "webkit": {}
             }
-            needle = re.compile("Nix.*Reference Manual")
+            needle = re.compile("Nix.* Manual")
             if len(sys.argv) != 3 or sys.argv[1] not in browsers.keys():
                 print(f"usage: {sys.argv[0]} [{'|'.join(browsers.keys())}] <url>")
                 sys.exit(1)

--- a/pkgs/by-name/uv/uv/package.nix
+++ b/pkgs/by-name/uv/uv/package.nix
@@ -72,7 +72,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       Due to `uv`'s (over)eager fetching of dynamically-linked Python executables,
       as well as vendoring of dynamically-linked libraries within Python modules distributed via PyPI,
       NixOS users can run into issues when managing Python projects.
-      See the Nixpkgs Reference Manual entry for `uv` for information on how to mitigate these issues:
+      See the Nixpkgs Manual entry for `uv` for information on how to mitigate these issues:
       https://nixos.org/manual/nixpkgs/unstable/#sec-uv.
 
       For building Python projects with `uv` and Nix outside of nixpkgs, check out `uv2nix` at https://github.com/pyproject-nix/uv2nix.


### PR DESCRIPTION
Following from #536632 the nixpkgs manual does not only include reference docs

Problems calling it reference manual:

- Misleading
- Additional word to display in links and sidebar entries

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
