### PR TITLE
ctranslate2: pass gencode flags to the CUDA build

### DIFF
--- a/pkgs/by-name/ct/ctranslate2/package.nix
+++ b/pkgs/by-name/ct/ctranslate2/package.nix
@@ -84,6 +84,11 @@ stdenv'.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals (stdenv.hostPlatform.gcc.arch or null != null) [
     (lib.cmakeBool "ENABLE_CPU_DISPATCH" false)
+  ]
+  ++ lib.optionals withCUDA [
+    # The legacy FindCUDA path reads arch flags only from CUDA_NVCC_FLAGS, not
+    # setupCudaHook's CMAKE_CUDA_ARCHITECTURES; otherwise nvcc defaults to sm_52.
+    (lib.cmakeFeature "CUDA_NVCC_FLAGS" (lib.concatStringsSep ";" cudaPackages.flags.gencode))
   ];
 
   buildInputs =


### PR DESCRIPTION
Closes #537514.

> **Disclosure (automation/AI policy):** the diagnosis, patch, and this description were produced with LLM assistance (Claude). Verified by building the CUDA variant locally (`nix build`); a human reviewed it before submission.

`ctranslate2` + CUDA fails to build: nvcc targets **sm_52**, so the fp16 AWQ kernels abort in ptxas.

**Cause:** #536525 removed the only line feeding arch flags to ct2's legacy FindCUDA path (`cuda_add_library` reads `CUDA_NVCC_FLAGS`; it ignores `CMAKE_CUDA_ARCHITECTURES` from `setupCudaHook`). nvcc then uses its built-in default — **sm_52 on cudaPackages 12.x** (the current default). CUDA 13's sm_75 default hides it. Hydra stays green because the default build is CPU-only (`cudaSupport = false`).

**Impact:** every CUDA build of ctranslate2 and dependents — faster-whisper, whisperx, wyoming-faster-whisper, libretranslate, whisper-ctranslate2.

**Fix:** feed the configured gencode into `CUDA_NVCC_FLAGS` (as `opensubdiv` does). Sidesteps FindCUDA's `cuda_select_nvcc_arch_flags`, which #536525 rightly avoided.

**Verified:** builds with CUDA on x86_64-linux, `cudaCapabilities = ["8.9"]`.

**Repro:** `nix-build -A ctranslate2 --arg config '{ cudaSupport = true; allowUnfree = true; }'`

<details><summary>Build log (before fix)</summary>

```
$ nix-build -A ctranslate2 --arg config '{ cudaSupport = true; allowUnfree = true; }'
...
[ 44%] Building NVCC (Device) object CMakeFiles/ctranslate2.dir/src/ops/awq/ctranslate2_generated_dequantize_gpu.cu.o
ptxas .../dequantize_gpu.ptx, line 145; error   : Feature 'f16 arithemetic and compare instructions' requires .target sm_53 or higher
ptxas .../dequantize_gpu.ptx, line 151; error   : Feature 'f16 arithemetic and compare instructions' requires .target sm_53 or higher
  [ ...16 more identical f16 / sm_53 errors... ]
ptxas fatal   : Ptx assembly aborted due to errors
CMake Error at ctranslate2_generated_dequantize_gpu.cu.o.Release.cmake:278 (message):
  Error generating file
  .../src/ops/awq/ctranslate2_generated_dequantize_gpu.cu.o
make[2]: *** [CMakeFiles/ctranslate2.dir/build.make:238: .../awq/ctranslate2_generated_dequantize_gpu.cu.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:390: CMakeFiles/ctranslate2.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

</details>

cc @hexa @misuzu · regression from #536525


