### PR TITLE
rsync: fix pkgsStatic itemize test failure

### DIFF
--- a/pkgs/by-name/rs/rsync/package.nix
+++ b/pkgs/by-name/rs/rsync/package.nix
@@ -85,6 +85,14 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals (stdenv.hostPlatform.isMusl && stdenv.hostPlatform.isx86_64) [
     # fix `multiversioning needs 'ifunc' which is not supported on this target` error
     "--disable-roll-simd"
+  ]
+  # Linux can hard-link symlinks; configure defaults this check to "no" when
+  # cross-compiling (e.g. pkgsStatic) because it cannot run the probe.
+  # That leaves hardlink_symlinks false while itemize still reports identical
+  # --copy-dest/--link-dest symlinks with blank attribute flags, so
+  # testsuite/itemize.test fails (https://github.com/NixOS/nixpkgs/issues/537437).
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform != stdenv.buildPlatform) [
+    "rsync_cv_can_hardlink_symlink=yes"
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Resolves #537437

`pkgsStatic.rsync` failed in `testsuite/itemize.test` because configure
defaults `rsync_cv_can_hardlink_symlink` to `no` when cross-compiling
(cannot run the probe). On Linux, hardlinking symlinks works, and with
matching attrs `--copy-dest` / `--link-dest` still itemize identical
symlinks as `cL` with blank attribute flags. The test only expects that
output when `hardlink_symlinks` is true (otherwise it expects `cLc.t......`).

Set the configure cache variable for Linux cross builds so capability
detection matches the host kernel and the itemize expectations agree.

Assisted-by: Grok (xAI) — investigation, patch, and PR text; human reviews
and submits.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test