### PR TITLE
linux: fix systemd-boot assertion issue introducted in #535309

### DIFF
--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -531,7 +531,7 @@ in
         message = "The XBOOTLDR mount point '${toString cfg.xbootldrMountPoint}' cannot be the same as the ESP mount point '${toString efi.efiSysMountPoint}'";
       }
       {
-        assertion = (config.boot.kernelPackages.kernel.features or { efiBootStub = true; }) ? efiBootStub;
+        assertion = config.boot.kernelPackages.kernel.features.efiBootStub or true;
         message = "This kernel does not support the EFI boot stub";
       }
       {


### PR DESCRIPTION
@K900 @ninelore 

As requested in https://github.com/NixOS/nixpkgs/pull/535825#issuecomment-4817029881 I checked treewide all the assertions checking `kernel.features`.

There's 3 of them:

The one @ninelore reported that defaults to true:
https://github.com/NixOS/nixpkgs/blob/aab6fe761bf869a49fa1d422e9cb49257b9131e6/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix#L555

One in the firewall that defaults to false:
https://github.com/NixOS/nixpkgs/blob/c82077ea1b3506164fbf72488189a7a9be84bc08/nixos/modules/services/networking/firewall-iptables.nix#L46

One in graphics that defaults to false:
https://github.com/NixOS/nixpkgs/blob/6f0d45a61e26ea874e70a42717d1eb2480b14b86/nixos/modules/hardware/graphics.nix#L128

Only the one in `systemd-boot` needed change to be robust against `features` being `{}` so this PR only contains a one-line change.

As I said before, I am not a fan of `efiBootStub` defaulting to `true` but I think we agreed that this was the best fix for now.
