### PR TITLE
frotz and sfrotz: fix changelog link

### DIFF
--- a/pkgs/by-name/fr/frotz/package.nix
+++ b/pkgs/by-name/fr/frotz/package.nix
@@ -83,7 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://davidgriffith.gitlab.io/frotz/";
-    changelog = "https://gitlab.com/DavidGriffith/frotz/-/raw/${finalAttrs.version}/NEWS";
+    changelog = "https://gitlab.com/DavidGriffith/frotz/-/raw/${finalAttrs.version}/ChangeLog";
     description = "Z-machine interpreter for Infocom games and other interactive fiction (${frontend})";
     mainProgram = progName;
     platforms = lib.platforms.unix;


### PR DESCRIPTION
Helping out with issue #514132.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] ran `nix eval .#frotz.meta.changelog` and followed the link
- [x] ran `nix eval .#sfrotz.meta.changelog` and followed the link
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
