### PR TITLE
fcitx5-sitelen-pona: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/by-name/fc/fcitx5-sitelen-pona/package.nix
+++ b/pkgs/by-name/fc/fcitx5-sitelen-pona/package.nix
@@ -5,17 +5,18 @@
   libime,
   fcitx5,
   qt6Packages,
+  nix-update-script,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "fcitx5-sitelen-pona";
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "Toastberries";
     repo = "fcitx5-sitelen-pona";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ZLp/p5umewp1seXFPtMevVBXfoNwHXAojYl5jWHHsTU=";
+    hash = "sha256-/pauEuE+hNdWhAz4CnSqySnF0h1toNGngHKOO9ntDnY=";
   };
 
   strictDeps = true;
@@ -53,6 +54,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   __structuredAttrs = true;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     inherit (fcitx5.meta) platforms;


### PR DESCRIPTION
Update to 1.2.0

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
