### PR TITLE
pyroscope: 1.20.3 -> 2.1.0

### DIFF
--- a/pkgs/by-name/py/pyroscope/package.nix
+++ b/pkgs/by-name/py/pyroscope/package.nix
@@ -1,25 +1,23 @@
 {
-  stdenv,
   buildGoModule,
   lib,
   fetchFromGitHub,
   versionCheckHook,
-  installShellFiles,
   nix-update-script,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "pyroscope";
-  version = "1.20.3";
+  version = "2.1.0";
 
   src = fetchFromGitHub {
     owner = "grafana";
     repo = "pyroscope";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-IZA6xaZgjcS/3QBsz2L12QEBeCzRFAv+Qpag+O4aOVI=";
+    hash = "sha256-7bY3qmN05m/OxFyDxdwlxsvYrwzhdbkX0XhGqOzCZSA=";
   };
 
-  vendorHash = "sha256-hy/MM/VOy182MM+Fd+PDVivHwduG2zkBUOWqOnFtWRI=";
+  vendorHash = "sha256-UGWfrnpTgzR09T5jDL24d/Bs8+HBWi4g1YzZyy7ULWY=";
   proxyVendor = true;
 
   subPackages = [
@@ -28,10 +26,10 @@ buildGoModule (finalAttrs: {
   ];
 
   ldflags = [
-    "-X=github.com/grafana/pyroscope/pkg/util/build.Branch=${finalAttrs.src.rev}"
-    "-X=github.com/grafana/pyroscope/pkg/util/build.Version=${finalAttrs.version}"
-    "-X=github.com/grafana/pyroscope/pkg/util/build.Revision=${finalAttrs.src.rev}"
-    "-X=github.com/grafana/pyroscope/pkg/util/build.BuildDate=1970-01-01T00:00:00Z"
+    "-X=github.com/grafana/pyroscope/v2/pkg/util/build.Branch=${finalAttrs.src.rev}"
+    "-X=github.com/grafana/pyroscope/v2/pkg/util/build.Version=${finalAttrs.version}"
+    "-X=github.com/grafana/pyroscope/v2/pkg/util/build.Revision=${finalAttrs.src.rev}"
+    "-X=github.com/grafana/pyroscope/v2/pkg/util/build.BuildDate=1970-01-01T00:00:00Z"
   ];
 
   # We're overriding the version in 'ldFlags', so we should check that the
@@ -39,14 +37,6 @@ buildGoModule (finalAttrs: {
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
   versionCheckProgram = "${placeholder "out"}/bin/${finalAttrs.meta.mainProgram}";
-
-  nativeBuildInputs = [ installShellFiles ];
-  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
-    installShellCompletion --cmd pyroscope \
-      --bash <($out/bin/pyroscope completion bash) \
-      --fish <($out/bin/pyroscope completion fish) \
-      --zsh <($out/bin/pyroscope completion zsh)
-  '';
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
Updates pyroscope to 2.1.0.

Release notes: https://github.com/grafana/pyroscope/releases/tag/v2.1.0

Drops the old shell-completion install step because pyroscope v2 no longer provides `completion` subcommands.

Closes #537446.
Supersedes #511292.

Assisted-by: pi coding agent / Mika (OpenAI GPT-5.5)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
