### PR TITLE
kdePackages.plasma-bigscreen: missing cec dep

### DIFF
--- a/pkgs/kde/plasma/plasma-bigscreen/default.nix
+++ b/pkgs/kde/plasma/plasma-bigscreen/default.nix
@@ -1,9 +1,11 @@
 {
+  lib,
   mkKdeDerivation,
   plasma-workspace,
   pkg-config,
   qtwebengine,
   libcec,
+  libcec_platform,
   sdl3,
 }:
 
@@ -19,7 +21,7 @@ mkKdeDerivation {
   '';
 
   extraCmakeFlags = [
-    "-DQT_FIND_PRIVATE_MODULES=ON"
+    (lib.cmakeBool "QT_FIND_PRIVATE_MODULES" true)
   ];
 
   extraNativeBuildInputs = [
@@ -30,6 +32,7 @@ mkKdeDerivation {
     qtwebengine
 
     libcec
+    libcec_platform
     sdl3
   ];
 


### PR DESCRIPTION
## Things done

For plasma bigscreen to have CEC support, `libcec_platform` is needed.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
