### PR TITLE
sage: tweak cpu threshold to decrease test flakiness

### DIFF
--- a/pkgs/by-name/sa/sage/patches/lower-sleep2-test-threshold.patch
+++ b/pkgs/by-name/sa/sage/patches/lower-sleep2-test-threshold.patch
@@ -1,0 +1,32 @@
+diff --git a/src/sage/doctest/test.py b/src/sage/doctest/test.py
+index 812f8167c12..a4822642f0c 100644
+--- a/src/sage/doctest/test.py
++++ b/src/sage/doctest/test.py
+@@ -49,11 +49,11 @@ Check that :issue:`2235` has been fixed::
+ 
+ Check slow doctest warnings are correctly raised::
+ 
+-    sage: subprocess.call(["python3", "-m", "sage.doctest", "--warn-long",     # long time
++    sage: subprocess.call(["python3", "-m", "sage.doctest", "--warn-long", "0.2",     # long time
+     ....:       "--random-seed=0", "--optional=sage", "sleep2.rst"], **kwds)
+     Running doctests...
+     Doctesting 1 file.
+-    ... --warn-long --random-seed=0 sleep2.rst
++    ... --warn-long 0.2 --random-seed=0 sleep2.rst
+     **********************************************************************
+     File "sleep2.rst", line 4, in sage.doctest.tests.sleep2
+     Warning: slow doctest:
+@@ -66,11 +66,11 @@ Check slow doctest warnings are correctly raised::
+     ----------------------------------------------------------------------
+     ...
+     0
+-    sage: subprocess.call(["python3", "-m", "sage.doctest", "--format=github", "--warn-long",     # long time
++    sage: subprocess.call(["python3", "-m", "sage.doctest", "--format=github", "--warn-long", "0.2",    # long time
+     ....:       "--random-seed=0", "--optional=sage", "sleep2.rst"], **kwds)
+     Running doctests...
+     Doctesting 1 file.
+-    ... --warn-long --random-seed=0 sleep2.rst
++    ... --warn-long 0.2 --random-seed=0 sleep2.rst
+     **********************************************************************
+     ::warning title=Warning: slow doctest:,file=sleep2.rst,line=4::slow doctest:: Test ran for ...s cpu, ...s wall%0ACheck ran for ...s cpu, ...s wall%0A
+         while walltime(t) < 2: pass

--- a/pkgs/by-name/sa/sage/sage-src.nix
+++ b/pkgs/by-name/sa/sage/sage-src.nix
@@ -78,6 +78,9 @@ stdenv.mkDerivation rec {
     # a more conservative version of https://github.com/sagemath/sage/pull/37951
     ./patches/gap-element-crash.patch
 
+    # https://github.com/sagemath/sage/issues/42473
+    ./patches/lower-sleep2-test-threshold.patch
+
     # https://github.com/sagemath/sage/pull/42009, landed in 10.10.beta0
     (fetchpatch2 {
       name = "gap-root-paths.patch";


### PR DESCRIPTION
This test has been annoying me for a while (see, e.g., #531438). https://github.com/sagemath/sage/issues/42473 explains the reason behind the flakiness, and this patch tweaks a CPU time threshold to hopefully improve flakiness. If I see further failures locally, I will just disable the test altogether.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
