### PR TITLE
cockpit: deal with data races in tests

### DIFF
--- a/nixos/tests/cockpit.nix
+++ b/nixos/tests/cockpit.nix
@@ -102,7 +102,6 @@ in
                   from selenium.webdriver.firefox.options import Options
                   from selenium.webdriver.support.ui import WebDriverWait
                   from selenium.webdriver.support import expected_conditions as EC
-                  from time import sleep
 
 
                   def log(msg):
@@ -129,18 +128,13 @@ in
                       wait.until(EC.presence_of_element_located((by, query)))
 
 
-                  def wait_title_contains(title, timeout=10):
+                  def wait_title_contains(title, timeout=30):
                       wait = WebDriverWait(driver, timeout)
                       wait.until(EC.title_contains(title))
 
 
                   def find_element(by, query):
                       return driver.find_element(by, query)
-
-
-                  def set_value(elem, value):
-                      script = 'arguments[0].value = arguments[1]'
-                      return driver.execute_script(script, elem, value)
 
 
                   log("Waiting for the homepage to load")
@@ -151,36 +145,45 @@ in
 
                   log("Homepage loaded!")
 
+                  # Prefer send_keys over setting .value via JS: Cockpit's login
+                  # form (and PatternFly widgets) do not always react to the latter.
                   log("Filling out username")
                   login_input = find_element(By.CSS_SELECTOR, 'input#login-user-input')
-                  set_value(login_input, "${user}")
+                  login_input.clear()
+                  login_input.send_keys("${user}")
 
                   log("Filling out password")
-                  password_input = find_element(By.CSS_SELECTOR, 'input#login-password-input')
-                  set_value(password_input, "${password}")
+                  password_input = find_element(
+                      By.CSS_SELECTOR, 'input#login-password-input'
+                  )
+                  password_input.clear()
+                  password_input.send_keys("${password}")
 
                   log("Submitting credentials for login")
                   driver.find_element(By.CSS_SELECTOR, 'button#login-button').click()
 
-                  # driver.implicitly_wait(1)
-                  # driver.get("https://server:7890/system")
-
                   log("Waiting dashboard to load")
                   wait_title_contains("${user}@server")
 
-                  log("Waiting for the frontend to initialize")
-                  sleep(1)
-
                   log("Looking for that banner that tells about limited access")
-                  container_iframe = find_element(By.CSS_SELECTOR, 'iframe.container-frame')
+                  wait_elem(By.CSS_SELECTOR, 'iframe.container-frame', timeout=30)
+                  container_iframe = find_element(
+                      By.CSS_SELECTOR, 'iframe.container-frame'
+                  )
                   driver.switch_to.frame(container_iframe)
-
-                  assert "Web console is running in limited access mode" in driver.page_source
+                  # Wait for the overview iframe to render the limited-access alert.
+                  # Fixed sleeps were flaky after Cockpit 364 (slower SPA init).
+                  phrase = "Web console is running in limited access mode"
+                  WebDriverWait(driver, 30).until(
+                      lambda d: phrase in d.page_source
+                  )
 
                   log("Clicking the sudo button")
+                  # Button label is "Turn on administrative access"
                   for button in driver.find_elements(By.TAG_NAME, "button"):
-                      if 'admin' in button.text:
+                      if 'admin' in button.text.casefold():
                           button.click()
+                          break
                   driver.switch_to.default_content()
 
                   log("Checking that /nonexistent is not a thing")
@@ -189,13 +192,17 @@ in
 
                   log("Checking plugin path")
                   driver.get("https://server:7890/hello-test")
-                  sleep(2)
+                  wait_elem(By.CSS_SELECTOR, 'iframe.container-frame', timeout=30)
                   for iframe in driver.find_elements(By.TAG_NAME, "iframe"):
                       if "hello-test" in (iframe.get_attribute("src") or ""):
                           driver.switch_to.frame(iframe)
                           break
-                  text = driver.find_element(By.ID, "output").text
-                  sleep(1)
+                  output = find_element(By.ID, "output")
+                  WebDriverWait(driver, 30).until(
+                      lambda d: "SUCCESS: Hello, world!" in output.text
+                      or output.text.startswith("FAILED:")
+                  )
+                  text = output.text
                   assert "SUCCESS: Hello, world!" in text, f"Plugin failed: {text}"
 
                   driver.close()
@@ -215,8 +222,10 @@ in
 
     server.wait_for_unit("sockets.target")
     server.wait_for_open_port(7890)
+    # Port open is not enough: cockpit-ws may still be finishing startup.
+    server.wait_until_succeeds("curl -k https://127.0.0.1:7890 -o /dev/null")
 
-    client.succeed("curl -k https://server:7890 -o /dev/stderr")
+    client.wait_until_succeeds("curl -k https://server:7890 -o /dev/stderr")
     print(client.succeed("whoami"))
     client.succeed('PYTHONUNBUFFERED=1 selenium-script')
   '';


### PR DESCRIPTION
Harden `nixosTests.cockpit` against flaky timing seen with Cockpit 364 (e.g. on #532225, now merged).

The package still works; the selenium/NixOS test was racing on:
- login (JS `.value` vs real input events)
- limited-access banner / overview iframe init
- hello-plugin spawn still on `Loading...`
- `wait_for_open_port` before cockpit-ws answers HTTPS

Changes: `send_keys` for login, `WebDriverWait` for title/banner/plugin output, and `wait_until_succeeds(curl …)` before the selenium step.

Verified with `nixosTests.cockpit.driverInteractive` (`--no-interactive`) on x86_64-linux.

Cherry-picked from `6be8ad17d4a551f1a9b2784895b8a82e41b3c8f2`.

**AI disclosure:** Non-trivial assistance from Grok (xAI) for debugging and drafting the test hardening; commit includes `Assisted-by:` trailer. Human (lucasew) reviewed and is accountable.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


