### PR TITLE
tmux: 3.7 -> 3.7b

### DIFF
--- a/pkgs/by-name/tm/tmux/package.nix
+++ b/pkgs/by-name/tm/tmux/package.nix
@@ -25,7 +25,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tmux";
-  version = "3.7";
+  version = "3.7b";
 
   outputs = [
     "out"
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "tmux";
     repo = "tmux";
     tag = finalAttrs.version;
-    hash = "sha256-dgqI1jZjnluN/F/AjngzcaMy3TgudmkvDT336YlhGZM=";
+    hash = "sha256-CTq06XP997M0ODxQihTq34dI9H6jSRLUXLYuTWOwDpc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/tm/tmuxp/package.nix
+++ b/pkgs/by-name/tm/tmuxp/package.nix
@@ -7,12 +7,12 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "tmuxp";
-  version = "1.71.0";
+  version = "1.73.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
-    hash = "sha256-+Nsr4gNem/gB6ZMre53rfuM8Kwkiu86aGJmrxiFRorY=";
+    hash = "sha256-UExY0hC7HDWeISQ/mMZLMcMnqDko4i188MyoDbNePZc=";
   };
 
   build-system = with python3Packages; [

--- a/pkgs/development/python-modules/libtmux/default.nix
+++ b/pkgs/development/python-modules/libtmux/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "libtmux";
-  version = "0.59.0";
+  version = "0.60.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tmux-python";
     repo = "libtmux";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-RsK3nVGpgNX05tCc5kK5GFLUS5vVoe8NRKgg7Y/DzwM=";
+    hash = "sha256-1h+qkQDYRwP2peMOvKC1kk4DFcG4cwuBApsF8MmkWbo=";
   };
 
   patches = [ ./0001-fix-test_control_mode_stdout_preserves_non_ascii_out.patch ];
@@ -45,7 +45,12 @@ buildPythonPackage (finalAttrs: {
   enabledTestPaths = [ "tests" ];
 
   disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [ "tests/test/test_retry.py" ];
-  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+  disabledTests = [
+    # test is broken for tmux 3.7a and later
+    # https://github.com/tmux-python/libtmux/issues/697
+    "test_new_window_name_invalid_on_3_7"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # Fail with: 'no server running on /tmp/tmux-1000/libtmux_test8sorutj1'.
     "test_new_session_width_height"
     # AssertionError: assert '' == '$'


### PR DESCRIPTION
Diff: https://github.com/tmux/tmux/compare/3.7...3.7a

Changelog: https://github.com/tmux/tmux/raw/3.7a/CHANGES

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
