### PR TITLE
Revert "ctranslate2: don't set default nvcc arch flags"

### DIFF
--- a/pkgs/by-name/ct/ctranslate2/package.nix
+++ b/pkgs/by-name/ct/ctranslate2/package.nix
@@ -51,13 +51,6 @@ stdenv'.mkDerivation (finalAttrs: {
         'CMAKE_MINIMUM_REQUIRED(VERSION 3.10 FATAL_ERROR)'
 
     sed -e '1i #include <cstdint>' -i third_party/cxxopts/include/cxxopts.hpp
-
-    # Prevent setting the default nvcc arch flags, which can be
-    # ones that don't work with the current CUDA version
-    substituteInPlace CMakeLists.txt \
-      --replace-fail \
-        'list(APPEND CUDA_NVCC_FLAGS ''${ARCH_FLAGS})' \
-        ""
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
Reverts NixOS/nixpkgs#536525
Closes NixOS/nixpkgs#537514