### PR TITLE
nixos/ollama: rename services.ollama.models to modelsDir

### DIFF
--- a/nixos/modules/services/misc/ollama.nix
+++ b/nixos/modules/services/misc/ollama.nix
@@ -37,6 +37,18 @@ in
       "ollama"
       "acceleration"
     ] "Set `services.ollama.package` to one of `pkgs.ollama[,-vulkan,-rocm,-cuda,-cpu]` instead.")
+    (lib.mkRenamedOptionModule
+      [
+        "services"
+        "ollama"
+        "models"
+      ]
+      [
+        "services"
+        "ollama"
+        "modelsDir"
+      ]
+    )
   ];
 
   options = {
@@ -91,7 +103,7 @@ in
           The home directory that the ollama service is started in.
         '';
       };
-      models = lib.mkOption {
+      modelsDir = lib.mkOption {
         type = types.str;
         default = "${cfg.home}/models";
         defaultText = "\${config.services.ollama.home}/models";
@@ -207,7 +219,7 @@ in
         cfg.environmentVariables
         // {
           HOME = cfg.home;
-          OLLAMA_MODELS = cfg.models;
+          OLLAMA_MODELS = cfg.modelsDir;
           OLLAMA_HOST = "${cfg.host}:${toString cfg.port}";
         }
         // lib.optionalAttrs (cfg.rocmOverrideGfx != null) {
@@ -226,7 +238,7 @@ in
           StateDirectory = [ "ollama" ];
           ReadWritePaths = [
             cfg.home
-            cfg.models
+            cfg.modelsDir
           ];
 
           CapabilityBoundingSet = [ "" ];


### PR DESCRIPTION
It was ambigious with loadModels.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
