### PR TITLE
lens: 2024.11.261604 -> 2026.6.260931, add update script and maintainer

### DIFF
--- a/pkgs/by-name/le/lens/darwin.nix
+++ b/pkgs/by-name/le/lens/darwin.nix
@@ -4,6 +4,7 @@
   version,
   src,
   meta,
+  updateScript,
   undmg,
 }:
 
@@ -29,4 +30,6 @@ stdenv.mkDerivation {
   '';
 
   dontFixup = true;
+
+  passthru = { inherit updateScript; };
 }

--- a/pkgs/by-name/le/lens/linux.nix
+++ b/pkgs/by-name/le/lens/linux.nix
@@ -3,6 +3,7 @@
   version,
   src,
   meta,
+  updateScript,
   appimageTools,
   makeWrapper,
 }:
@@ -20,6 +21,8 @@ appimageTools.wrapType2 {
     src
     meta
     ;
+
+  passthru = { inherit updateScript; };
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/by-name/le/lens/package.nix
+++ b/pkgs/by-name/le/lens/package.nix
@@ -8,20 +8,20 @@
 let
 
   pname = "lens-desktop";
-  version = "2024.11.261604";
+  version = "2026.6.260931";
 
   sources = {
     x86_64-linux = {
       url = "https://api.k8slens.dev/binaries/Lens-${version}-latest.x86_64.AppImage";
-      hash = "sha256-AbuEU5gOckVU+eDIFnomc7ryLq68ihuk3c0XosoJp74=";
+      hash = "sha512-P9PrtbGKaHNlzZsm10ovkYCBBfQpVWBgcVsYLETMwINP2bzrIIK5HVbkbcTEUsxK90L7MQmFwpAssojW0b9G5Q==";
     };
     x86_64-darwin = {
       url = "https://api.k8slens.dev/binaries/Lens-${version}-latest.dmg";
-      hash = "sha256-MQQRGTCe+LEHXJi6zjnpENbtlWNP+XVH9rWXRMk+26w=";
+      hash = "sha512-I/i9s7O3jT+eNqqUu6B+rB+YbegKhAsZwHlc3mp2wNWW9YDilQbzKrhF9Fq2dSz2WKVZUscBtSGtXCuiPcFXzw==";
     };
     aarch64-darwin = {
       url = "https://api.k8slens.dev/binaries/Lens-${version}-latest-arm64.dmg";
-      hash = "sha256-aakJCLnQBAnUdrrniTcahS+q3/kP09mlaPTV8FW5afI=";
+      hash = "sha512-eCE3w7NlYrHiexCirH2wFN0nOO3qAt5acbldXbDMVIrG94tbgM8Y5ZO8/YIUN45XbotYtKW8/Nw+WsrTp6DPBg==";
     };
   };
 

--- a/pkgs/by-name/le/lens/package.nix
+++ b/pkgs/by-name/le/lens/package.nix
@@ -41,6 +41,8 @@ let
     platforms = builtins.attrNames sources;
   };
 
+  updateScript = ./update.sh;
+
 in
 if stdenv.hostPlatform.isDarwin then
   callPackage ./darwin.nix {
@@ -49,6 +51,7 @@ if stdenv.hostPlatform.isDarwin then
       version
       src
       meta
+      updateScript
       ;
   }
 else
@@ -58,5 +61,6 @@ else
       version
       src
       meta
+      updateScript
       ;
   }

--- a/pkgs/by-name/le/lens/package.nix
+++ b/pkgs/by-name/le/lens/package.nix
@@ -35,6 +35,7 @@ let
     license = lib.licenses.lens;
     maintainers = with lib.maintainers; [
       dbirks
+      qweered
       RossComputerGuy
       starkca90
     ];

--- a/pkgs/by-name/le/lens/update.sh
+++ b/pkgs/by-name/le/lens/update.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p common-updater-scripts curl yq-go jq
+
+set -euo pipefail
+
+base="https://api.k8slens.dev/binaries"
+
+# Lens is built with electron-builder, which publishes an auto-update manifest
+# next to each binary. These manifests carry both the latest version and the
+# base64 sha512 digest of every artifact, so we can bump all platforms without
+# downloading the (~250 MiB) images ourselves.
+linux_manifest=$(curl -sfL "$base/latest-linux.yml" | yq -o=json)
+mac_manifest=$(curl -sfL "$base/latest-mac.yml" | yq -o=json)
+
+# The manifest reports e.g. "2026.6.260931-latest"; the "-latest" suffix only
+# lives in the download URL, so drop it from the Nix version.
+version=$(jq -r '.version' <<<"$linux_manifest")
+version=${version%-latest}
+
+# electron-builder records base64-encoded sha512 digests, which are already
+# valid Nix SRI hashes once prefixed with "sha512-". Match artifacts by filename
+# suffix (endswith) rather than a regex to keep jq's string escaping out of play.
+manifest_hash() {
+  echo "sha512-$(jq -r --arg suffix "$1" '.files[] | select(.url | endswith($suffix)) | .sha512' <<<"$2" | head -n1)"
+}
+
+appimage_hash=$(manifest_hash '.x86_64.AppImage' "$linux_manifest")
+dmg_hash=$(manifest_hash '-latest.dmg' "$mac_manifest")
+arm64_dmg_hash=$(manifest_hash '-arm64.dmg' "$mac_manifest")
+
+# The three platforms share one version but have distinct hashes. --system picks
+# which source (and therefore which hash) update-source-version rewrites; passing
+# the hash explicitly avoids a download. The version is written on the first call,
+# so the darwin calls need --ignore-same-version to not early-exit as "unchanged".
+update-source-version lens "$version" "$appimage_hash" --system=x86_64-linux
+update-source-version lens "$version" "$dmg_hash" --system=x86_64-darwin --ignore-same-version
+update-source-version lens "$version" "$arm64_dmg_hash" --system=aarch64-darwin --ignore-same-version


### PR DESCRIPTION
Also switch the pinned hashes to sha512 SRI, sourced directly from the
upstream electron-builder update manifests (latest-linux.yml /
latest-mac.yml).

Assisted-by: claude-code with claude-opus-4-8[1m]-high

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
