### PR TITLE
urx: 0.9.0 -> 0.10.0

### DIFF
--- a/pkgs/by-name/ur/urx/package.nix
+++ b/pkgs/by-name/ur/urx/package.nix
@@ -9,16 +9,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "urx";
-  version = "0.9.0";
+  version = "0.10.0";
 
   src = fetchFromGitHub {
     owner = "hahwul";
     repo = "urx";
     tag = finalAttrs.version;
-    hash = "sha256-NSPEAA+tD1CdCjRj3myQB8bPdMhT7H76qAIIWx2z++I=";
+    hash = "sha256-mGFTCKsubT+gIUxdgRAhE69WtgMghkKII/73Auffrt4=";
   };
 
-  cargoHash = "sha256-nPm4ofmu03Rb12spjb+m36C6EauJIppgqTkX1oJF3uk=";
+  cargoHash = "sha256-PRP+iGH3fzfPOUQZAaIab7BSAUGZyxF1MX7tbfAIDks=";
 
   nativeBuildInputs = [ pkg-config ];
 
@@ -32,6 +32,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     # Tests require network access
     "--skip=providers"
     "--skip=network::client::tests"
+    "--skip=link_extractor::tests::test_client_is_built_once_and_reused"
+    "--skip=link_extractor::tests::test_reused_client_extracts_from_multiple_urls"
+    "--skip=status_checker::tests::test_client_is_built_once_and_reused"
+    "--skip=status_checker::tests::test_clones_share_one_client"
+    "--skip=status_checker::tests::test_reused_client_checks_multiple_urls"
   ];
 
   doInstallCheck = true;


### PR DESCRIPTION
Changelog: https://github.com/hahwul/urx/releases/tag/0.10.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
