### PR TITLE
step-ca: 0.29.0 -> 0.30.2

### DIFF
--- a/pkgs/by-name/st/step-ca/package.nix
+++ b/pkgs/by-name/st/step-ca/package.nix
@@ -13,7 +13,7 @@
 
 buildGoModule rec {
   pname = "step-ca";
-  version = "0.29.0";
+  version = "0.30.2";
 
   src = fetchFromGitHub {
     owner = "smallstep";
@@ -24,10 +24,10 @@ buildGoModule rec {
     # Use forceFetchGit to fetch the source as git repo, as fetchGit isn't effected,
     # see https://github.com/NixOS/nixpkgs/issues/84312#issuecomment-2475948960.
     forceFetchGit = true;
-    hash = "sha256-TFpgVE394r6FkRWovlmDd3v/tGic2CekmO1Hp7S6KCE=";
+    hash = "sha256-4cvrjAVvMDHlNhY/lbfgl6ZvX5LJGnPx0Km2BjPX8iU=";
   };
 
-  vendorHash = "sha256-9PlJaB3BCwoE+uFo5jUggANSH7ZWnintZYBgFL21LZ4=";
+  vendorHash = "sha256-FBkQXKNtstQ+F7jvKUj6oCbsri+SjGKy0tG59TtUHPQ=";
 
   ldflags = [
     "-w"


### PR DESCRIPTION
Diff: https://github.com/smallstep/certificates/compare/v0.29.0...v0.30.2

Changelog: https://github.com/smallstep/certificates/releases/tag/v0.30.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
