### PR TITLE
python3Packages.deepwave: 0.0.26 -> 0.0.27

### DIFF
--- a/pkgs/development/python-modules/deepwave/default.nix
+++ b/pkgs/development/python-modules/deepwave/default.nix
@@ -2,37 +2,44 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  cmake,
+
+  # build-system
+  ninja,
   scikit-build-core,
+
+  # nativeBuildInputs
+  cmake,
+
+  # dependencies
   torch,
+
+  # tests
   pytestCheckHook,
   scipy,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "deepwave";
-  version = "0.0.26";
+  version = "0.0.27";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "ar4";
     repo = "deepwave";
-    tag = "v${version}";
-    hash = "sha256-gjFbBn7fJiLZUm+97xf6xd7C+OkEoeFe3061tFkJhFk=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-zOyoycCJjx4HJEnkAD5r7d+qxO5A+d0dCgx2oRjxPuU=";
   };
 
-  # Return to project root to locate `pyproject.toml` for build
-  preBuild = ''
-    cd ..
-  '';
+  build-system = [
+    ninja
+    scikit-build-core
+  ];
 
   nativeBuildInputs = [
     cmake
   ];
-
-  build-system = [
-    scikit-build-core
-  ];
+  dontUseCmakeConfigure = true;
 
   dependencies = [
     torch
@@ -52,4 +59,4 @@ buildPythonPackage rec {
     platforms = lib.intersectLists lib.platforms.x86_64 lib.platforms.linux;
     maintainers = [ ];
   };
-}
+})


### PR DESCRIPTION
## Things done

Diff: https://github.com/ar4/deepwave/compare/v0.0.26...v0.0.27

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
