### PR TITLE
opencl-headers: 2025.07.22 -> 2026.05.29; khronos-ocl-icd-loader: 2025.07.22 -> 2026.05.29

### DIFF
--- a/pkgs/by-name/kh/khronos-ocl-icd-loader/package.nix
+++ b/pkgs/by-name/kh/khronos-ocl-icd-loader/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "opencl-icd-loader";
-  version = "2025.07.22";
+  version = "2026.05.29";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "OpenCL-ICD-Loader";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-jwviNwX7C7b9lqIS4oZ4YLEFBfBdmQfXHxW3FPPYxYs=";
+    hash = "sha256-PUfYCf2+0i+SatQerehPv97LOTDlBsQAmtHFX97UGzo=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/op/opencl-headers/package.nix
+++ b/pkgs/by-name/op/opencl-headers/package.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "opencl-headers";
-  version = "2025.07.22";
+  version = "2026.05.29";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "OpenCL-Headers";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-XcDzBt4EAsip+5/lbZwPBO7/nDGAognUkJO/2Jg4OeY=";
+    sha256 = "sha256-qL8lFtjj+rYTsNz9RALx3pIlugAkcwclbGW7VIiijXk=";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
`khronos-ocl-icd-loader` version 2026.05.29 requires newer types and functions (like `pfn_clDeinitLayer`) that are only available in the 2026 release of `opencl-headers`. 
Updating both together ensures the loader compiles successfully.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

khronos-ocl-icd-loader: https://github.com/KhronosGroup/OpenCL-ICD-Loader/compare/v2025.07.22...v2026.05.29
opencl-headers: https://github.com/KhronosGroup/OpenCL-Headers/compare/v2025.07.22...v2026.05.29

## Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
