### PR TITLE
nixos/1password-gui: add MCP server wrapper

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -733,6 +733,7 @@ in
 
       onepassword = 31001; # 1Password requires that its GID be larger than 1000
       onepassword-cli = 31002; # 1Password requires that its GID be larger than 1000
+      onepassword-mcp = 31003; # 1Password requires that its GID be larger than 1000
 
       users = 100;
       nixbld = 30000;

--- a/nixos/modules/programs/_1password-gui.nix
+++ b/nixos/modules/programs/_1password-gui.nix
@@ -28,6 +28,8 @@ in
         '';
       };
 
+      mcpServer.enable = lib.mkEnableOption "the 1Password Environments local MCP server";
+
       package =
         lib.mkPackageOption pkgs "1Password GUI" {
           default = [ "_1password-gui" ];
@@ -45,12 +47,22 @@ in
   config = lib.mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
     users.groups.onepassword.gid = config.ids.gids.onepassword;
+    users.groups.onepassword-mcp = lib.mkIf cfg.mcpServer.enable {
+      gid = config.ids.gids.onepassword-mcp;
+    };
 
     security.wrappers = {
       "1Password-BrowserSupport" = {
         source = "${cfg.package}/share/1password/1Password-BrowserSupport";
         owner = "root";
         group = "onepassword";
+        setuid = false;
+        setgid = true;
+      };
+      "1password-mcp" = lib.mkIf cfg.mcpServer.enable {
+        source = "${cfg.package}/share/1password/1password-mcp";
+        owner = "root";
+        group = "onepassword-mcp";
         setuid = false;
         setgid = true;
       };

--- a/pkgs/by-name/_1/_1password-gui/linux.nix
+++ b/pkgs/by-name/_1/_1password-gui/linux.nix
@@ -124,9 +124,28 @@ stdenv.mkDerivation {
       # Icons
       cp -a resources/icons $out/share
 
+      mcpServer="$out/share/1password/1password-mcp"
+      legacyMcpServer="$out/share/1password/onepassword-mcp"
+
+      # Stable releases use 1password-mcp, while older beta releases still use
+      # onepassword-mcp. Normalize both variants to expose the canonical name,
+      # retain the legacy path, and patch the actual binary rather than a symlink.
+      if [[ -e "$mcpServer" ]]; then
+        mcpServerSource="$mcpServer"
+        [[ -e "$legacyMcpServer" ]] || ln -s 1password-mcp "$legacyMcpServer"
+      elif [[ -e "$legacyMcpServer" ]]; then
+        mcpServerSource="$legacyMcpServer"
+        ln -s onepassword-mcp "$mcpServer"
+      else
+        echo "1Password MCP server binary not found" >&2
+        exit 1
+      fi
+
       interp="$(cat $NIX_CC/nix-support/dynamic-linker)"
       patchelf --set-interpreter $interp $out/share/1password/{1password,1Password-BrowserSupport,1Password-LastPass-Exporter,op-ssh-sign}
+      patchelf --set-interpreter "$interp" "$mcpServerSource"
       patchelf --set-rpath ${rpath}:$out/share/1password $out/share/1password/{1password,1Password-BrowserSupport,1Password-LastPass-Exporter,op-ssh-sign}
+      patchelf --set-rpath ${rpath}:$out/share/1password "$mcpServerSource"
       for file in $(find $out -type f -name \*.so\* ); do
         patchelf --set-rpath ${rpath}:$out/share/1password $file
       done


### PR DESCRIPTION
## Description of changes

Add an optional NixOS module wrapper for the bundled 1Password Environments MCP server, using the canonical command name `1password-mcp`.

The upstream Linux installer creates a dedicated `onepassword-mcp` group and sets the setgid bit on the MCP server so the 1Password desktop app can validate local MCP clients via Linux peer credentials.

The packaged stable release bundles `1password-mcp`, while the older packaged beta release still bundles `onepassword-mcp`. The package normalizes both layouts so the module can consistently expose `/run/wrappers/bin/1password-mcp`, retains the legacy package path, and patches the actual binary rather than a symlink.

This mirrors the existing NixOS integration style used for 1Password browser support and CLI desktop integration.

I could not find an existing nixpkgs issue or PR for wrapping `1password-mcp` with the dedicated `onepassword-mcp` group.

Related, but not a duplicate: #258139 covers `op` desktop integration, whereas this PR handles the bundled 1Password Environments MCP server.

Automation disclosure: this PR was prepared with assistance from OpenAI Codex. I reviewed the changes and verified the behavior locally on my NixOS machine. The commit includes the required `Assisted-by:` trailer.

## Testing

- `treefmt nixos/modules/programs/_1password-gui.nix nixos/modules/misc/ids.nix pkgs/by-name/_1/_1password-gui/linux.nix`
- `nix-instantiate --parse nixos/modules/programs/_1password-gui.nix`
- `nix-instantiate --parse nixos/modules/misc/ids.nix`
- `nix-instantiate --parse pkgs/by-name/_1/_1password-gui/linux.nix`
- `git diff --check`
- evaluated `programs._1password-gui.mcpServer.enable = true` with both stable and beta packages
- evaluated the disabled case and confirmed `security.wrappers."1password-mcp"` is absent
- `NIXPKGS_ALLOW_UNFREE=1 nix-build -A _1password-gui --no-out-link`
- `NIXPKGS_ALLOW_UNFREE=1 nix-build -A _1password-gui-beta --no-out-link`
- verified the stable and beta package outputs expose both MCP server names with the expected relative symlink direction
- verified the actual stable and beta MCP binaries have the Nix interpreter and RUNPATH
- ran `nixpkgs-review wip` against the latest `master`; `_1password-gui` and `_1password-gui-beta` both built successfully
- ran an ad hoc KVM-backed `nixosTest` for stable and beta, verifying GID 31003, `/run/wrappers/bin/1password-mcp`, ownership `root:onepassword-mcp`, mode `2511` with setgid, absence of the legacy wrapper name, package symlink direction, and initialization through the wrapper as a regular user
- verified 1Password MCP authentication succeeds locally

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
