### PR TITLE
onetbb: never treat warnings as fatal

### DIFF
--- a/pkgs/by-name/on/onetbb/package.nix
+++ b/pkgs/by-name/on/onetbb/package.nix
@@ -76,6 +76,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "TBB_DISABLE_HWLOC_AUTOMATIC_SEARCH" false)
+    # Treating compiler errors as warnings creates churn each compiler update,
+    # and provides little utility to us downstream.
+    (lib.cmakeBool "TBB_STRICT" false)
     (lib.cmakeBool "TBB_TEST" finalAttrs.finalPackage.doCheck)
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
@@ -83,10 +86,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   env = {
-    # Fix build with modern gcc
-    # In member function 'void std::__atomic_base<_IntTp>::store(__int_type, std::memory_order) [with _ITp = bool]',
-    NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isGNU "-Wno-error=stringop-overflow";
-
     # Fix undefined reference errors with version script under LLVM.
     NIX_LDFLAGS = lib.optionalString (
       stdenv.cc.bintools.isLLVM && lib.versionAtLeast stdenv.cc.bintools.version "17"


### PR DESCRIPTION
onetbb often triggers compiler warnings upstream, and works around them in an ad-hoc, per version manner: https://github.com/uxlfoundation/oneTBB/commit/88482f5f1a122896336d19bbeed84af8773c2e9f, https://github.com/uxlfoundation/oneTBB/commit/bdbec2060633e28b6b0e2f89e39297cf89b63e8c. if onetbb does not release before we upgrade a compiler in Nixpkgs, we end up dealing with the fallout. we encountered this failing due to `-Werror` while preparing for a gcc 16 upgrade in Nixpkgs, and the same issue came up for gcc 15 and similar (#446139). it is likely to come up again, as `-Werror` is extremely susceptible to compiler and library changes. additionally, while it may be useful for upstream onetbb, it seems to provide little value to us downstream; we just end up working around it. thus, we never treat warnings as errors by disabling upstream's cmake flag for this purpose.

(part of submitting some fixes to prepare for making gcc 16 the default later this release cycle: #537781)

## Things done

- Built on platform:
  - [x] x86_64-linux (both on this commit and with `default-gcc-version = 16;` in all-packages.nix)
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
