### PR TITLE
tor-browser: update obselete .desktop filename

### DIFF
--- a/pkgs/by-name/to/tor-browser/package.nix
+++ b/pkgs/by-name/to/tor-browser/package.nix
@@ -167,7 +167,7 @@ stdenv.mkDerivation rec {
 
   desktopItems = [
     (makeDesktopItem {
-      name = "torbrowser";
+      name = "tor-browser";
       exec = "tor-browser %U";
       icon = "tor-browser";
       desktopName = "Tor Browser";


### PR DESCRIPTION
Looks like the `name` (`torbrowser`) of the `.desktop` file in `tor-browser` was chosen [a long time ago](https://github.com/NixOS/nixpkgs/pull/12199/changes/87c3063d686ffa8a8eb928e23c8db70f61e45b7b), back when the package was named `torbrowser`. Since then, the package name has been updated [many times](https://github.com/NixOS/nixpkgs/pull/256941#issue-1909951216), yet the `.desktop` `name` entry remained. In its current form, the said entry breaks the convention synchronizing `.desktop` filename with binary name (`/nix/store/.../bin/$name` / `$name.desktop`), which appears to be common among browsers.

For instance, because `mullvad-browser` launches the [Mullvad Browser](https://gitlab.torproject.org/tpo/applications/mullvad-browser), one would expect the presence of [`mullvad-browser.desktop`](https://github.com/NixOS/nixpkgs/blob/95ca1e203c0750115fd4a6f17d5a245dfe6b1edd/pkgs/by-name/mu/mullvad-browser/package.nix#L157). Likewise, `firefox` pairs with `firefox.desktop`, `librewolf` pairs with `librewolf.desktop`, and `google-chrome` pairs with `google-chrome.desktop`. Notably, conforming to this convention would prove beneficial for users configuring the default web browser via [`xdg.mime`](https://github.com/NixOS/nixpkgs/blob/95ca1e203c0750115fd4a6f17d5a245dfe6b1edd/nixos/modules/config/xdg/mime.nix#L47-L62).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
