### PR TITLE
ncdu: 2.9.2 -> 2.10.0, update source

### DIFF
--- a/pkgs/by-name/nc/ncdu/1.nix
+++ b/pkgs/by-name/nc/ncdu/1.nix
@@ -1,8 +1,9 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   pkg-config,
+  autoreconfHook,
   ncurses,
   versionCheckHook,
 }:
@@ -11,12 +12,20 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "ncdu";
   version = "1.22";
 
-  src = fetchurl {
-    url = "https://dev.yorhel.nl/download/ncdu-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-CtbAltwE1RIFgRBHYMAbj06X1BkdbJ73llT6PGkaF2s=";
+  src = fetchFromGitHub {
+    owner = "BratishkaErik";
+    repo = "ncdu";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KcI3sXyD/gt+n8JbSdzdoQYNmjKMPLlIPpZSPAHGb40=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    autoreconfHook
+  ];
 
   buildInputs = [ ncurses ];
 
@@ -25,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Disk usage analyzer with an ncurses interface";
-    homepage = "https://dev.yorhel.nl/ncdu";
+    homepage = "https://github.com/BratishkaErik/ncdu";
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ pSub ];

--- a/pkgs/by-name/nc/ncdu/package.nix
+++ b/pkgs/by-name/nc/ncdu/package.nix
@@ -1,27 +1,35 @@
 {
   lib,
   stdenv,
-  fetchurl,
   ncurses,
+  fetchFromGitHub,
   pkg-config,
-  zig_0_15,
+  zig_0_16,
+  nix-update-script,
   zstd,
   installShellFiles,
   versionCheckHook,
   pie ? stdenv.hostPlatform.isDarwin,
 }:
-
+let
+  zig = zig_0_16;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "ncdu";
-  version = "2.9.2";
+  version = "2.10.0";
 
-  src = fetchurl {
-    url = "https://dev.yorhel.nl/download/ncdu-${finalAttrs.version}.tar.gz";
-    hash = "sha256-6RE1KBy2ZWnyykwLrCdyRpkeflJSTAyoy6PeXI6Bzsk=";
+  src = fetchFromGitHub {
+    owner = "BratishkaErik";
+    repo = "ncdu";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-YfvuXW0IaRaUNReLe/hMgYA2geDLvt1bprJAbOCFCQk=";
   };
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   nativeBuildInputs = [
-    zig_0_15
+    zig.hook
     installShellFiles
     pkg-config
   ];
@@ -31,7 +39,28 @@ stdenv.mkDerivation (finalAttrs: {
     zstd
   ];
 
-  zigBuildFlags = lib.optional pie "-Dpie=true";
+  deps = zig.fetchDeps {
+    inherit (finalAttrs) pname version src;
+    fetchAll = true;
+    hash = "sha256-vk4wMIpKEQObFXuNd5szQQU6z0NyVJKInOMDiEn4A5k=";
+  };
+
+  postPatch = ''
+    mkdir -p zig-system-dir
+
+    for file in ${finalAttrs.deps}/*; do
+       dir="zig-system-dir/$(basename "$file" .tar.gz)"
+       mkdir -p "$dir"
+
+       tar -xzf "$file" -C "$dir" --strip-components=1
+    done
+  '';
+
+  zigBuildFlags = [
+    "--system"
+    "zig-system-dir"
+  ]
+  ++ lib.optional pie "-Dpie=true";
 
   postInstall = ''
     installManPage ncdu.1
@@ -40,12 +69,12 @@ stdenv.mkDerivation (finalAttrs: {
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
 
-  passthru.updateScript = ./update.sh;
+  passthru.updateScript = nix-update-script { };
 
   meta = {
-    homepage = "https://dev.yorhel.nl/ncdu";
+    homepage = "https://github.com/BratishkaErik/ncdu";
     description = "Disk usage analyzer with an ncurses interface";
-    changelog = "https://dev.yorhel.nl/ncdu/changes2";
+    changelog = "https://github.com/BratishkaErik/ncdu/releases";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       pSub
@@ -53,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
       defelo
       ryan4yin
     ];
-    inherit (zig_0_15.meta) platforms;
+    inherit (zig.meta) platforms;
     mainProgram = "ncdu";
   };
 })

--- a/pkgs/by-name/nc/ncdu/update.sh
+++ b/pkgs/by-name/nc/ncdu/update.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env nix-shell
-#!nix-shell -i bash -p common-updater-scripts coreutils gnused nix-update
-
-version=$(list-git-tags --url=https://g.blicky.net/ncdu.git | tail -1 | sed 's/^v//')
-nix-update --version="$version" ncdu


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Per the discussion [here](https://github.com/NixOS/nixpkgs/pull/536889), @BratishkaErik maintains a fork of the package at https://github.com/BratishkaErik/ncdu, so its better to just move the source as the original website could be going down as described in https://github.com/NixOS/nixpkgs/issues/536471 .

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
