### PR TITLE
toml11: make maybe-uninitialized non-fatal for gcc 16

### DIFF
--- a/pkgs/by-name/to/toml11/package.nix
+++ b/pkgs/by-name/to/toml11/package.nix
@@ -37,6 +37,11 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
   ];
   cmakeFlags = [
+    # GCC 16 warns that various uses of `fmt` in value.hpp are used
+    # uninitialized. This may be a true failure, but it does not seem like a
+    # major concern, so we silence it for now.
+    # https://github.com/ToruNiina/toml11/issues/313
+    (lib.cmakeFeature "CMAKE_CXX_FLAGS" "-Wno-error=maybe-uninitialized")
     (lib.cmakeBool "TOML11_BUILD_TOML_TESTS" finalAttrs.finalPackage.doCheck)
   ];
   checkInputs = [


### PR DESCRIPTION
GCC 16 flags various calls here as if they're uninitialized, but they appear (to me as a non-C++ expert) to be false positives. Accordingly, we make those non-fatal. This fixes the build on GCC 16.

<details>
<summary>The full logs before this patch with GCC 16</summary>

```ansi
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/ph6c3r5699f6fqbffih06xfzn4x6j75r-source
source root is source
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
applying patch /nix/store/mkxnvhqxg0bhfa8ymsk29h169f5imigh-literal-operator-whitespace.patch
patching file include/toml11/fwd/literal_fwd.hpp
patching file include/toml11/impl/literal_impl.hpp
substituteStream() in derivation toml11-4.4.0: WARNING: pattern \"doctest.h\" doesn't match anything in file 'tests/to_json.cpp'
substituteStream() in derivation toml11-4.4.0: WARNING: pattern \"doctest.h\" doesn't match anything in file 'tests/to_toml.cpp'
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
cmake flags: -DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF -DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_LOCALEDIR=/nix/store/066gdml9620vnsm5jm2fw3grkn993lq5-toml11-4.4.0/share/locale -DCMAKE_INSTALL_LIBEXECDIR=/nix/store/066gdml9620vnsm5jm2fw3grkn993lq5-toml11-4.4.0/libexec -DCMAKE_INSTALL_LIBDIR=/nix/store/066gdml9620vnsm5jm2fw3grkn993lq5-toml11-4.4.0/lib -DCMAKE_INSTALL_DOCDIR=/nix/store/066gdml9620vnsm5jm2fw3grkn993lq5-toml11-4.4.0/share/doc/toml11 -DCMAKE_INSTALL_INFODIR=/nix/store/066gdml9620vnsm5jm2fw3grkn993lq5-toml11-4.4.0/share/info -DCMAKE_INSTALL_MANDIR=/nix/store/066gdml9620vnsm5jm2fw3grkn993lq5-toml11-4.4.0/share/man -DCMAKE_INSTALL_INCLUDEDIR=/nix/store/066gdml9620vnsm5jm2fw3grkn993lq5-toml11-4.4.0/include -DCMAKE_INSTALL_SBINDIR=/nix/store/066gdml9620vnsm5jm2fw3grkn993lq5-toml11-4.4.0/sbin -DCMAKE_INSTALL_BINDIR=/nix/store/066gdml9620vnsm5jm2fw3grkn993lq5-toml11-4.4.0/bin -DCMAKE_INSTALL_NAME_DIR=/nix/store/066gdml9620vnsm5jm2fw3grkn993lq5-toml11-4.4.0/lib -DCMAKE_STRIP=/nix/store/h1ph78242ynwmllizw26fjy5l9jyjqxf-gcc-wrapper-16.1.0/bin/strip -DCMAKE_RANLIB=/nix/store/h1ph78242ynwmllizw26fjy5l9jyjqxf-gcc-wrapper-16.1.0/bin/ranlib -DCMAKE_AR=/nix/store/h1ph78242ynwmllizw26fjy5l9jyjqxf-gcc-wrapper-16.1.0/bin/ar -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_INSTALL_PREFIX=/nix/store/066gdml9620vnsm5jm2fw3grkn993lq5-toml11-4.4.0 -DTOML11_BUILD_TOML_TESTS:BOOL=TRUE
-- The CXX compiler identification is GNU 16.1.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /nix/store/h1ph78242ynwmllizw26fjy5l9jyjqxf-gcc-wrapper-16.1.0/bin/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake Deprecation Warning at CMakeLists.txt:25 (cmake_policy):
  The OLD behavior for policy CMP0127 will be removed from a future version
  of CMake.

  The cmake-policies(7) manual explains that the OLD behaviors of all
  policies are deprecated and that a policy should be set to OLD only under
  specific short-term circumstances.  Projects should be ported to the NEW
  behavior and not rely on setting a policy to OLD.


-- Performing Test TOML11_COMPILER_SUPPORTS_WALL
-- Performing Test TOML11_COMPILER_SUPPORTS_WALL - Success
-- Performing Test TOML11_COMPILER_SUPPORTS_WEXTRA
-- Performing Test TOML11_COMPILER_SUPPORTS_WEXTRA - Success
-- Performing Test TOML11_COMPILER_SUPPORTS_WPEDANTIC
-- Performing Test TOML11_COMPILER_SUPPORTS_WPEDANTIC - Success
-- Performing Test TOML11_COMPILER_SUPPORTS_WERROR
-- Performing Test TOML11_COMPILER_SUPPORTS_WERROR - Success
-- Performing Test TOML11_COMPILER_SUPPORTS_WSIGN_CONVERSION
-- Performing Test TOML11_COMPILER_SUPPORTS_WSIGN_CONVERSION - Success
-- Performing Test TOML11_COMPILER_SUPPORTS_WCONVERSION
-- Performing Test TOML11_COMPILER_SUPPORTS_WCONVERSION - Success
-- Performing Test TOML11_COMPILER_SUPPORTS_WDUPLICATED_COND
-- Performing Test TOML11_COMPILER_SUPPORTS_WDUPLICATED_COND - Success
-- Performing Test TOML11_COMPILER_SUPPORTS_WDUPLICATED_BRANCHES
-- Performing Test TOML11_COMPILER_SUPPORTS_WDUPLICATED_BRANCHES - Success
-- Performing Test TOML11_COMPILER_SUPPORTS_WLOGICAL_OP
-- Performing Test TOML11_COMPILER_SUPPORTS_WLOGICAL_OP - Success
-- Performing Test TOML11_COMPILER_SUPPORTS_WDOUBLE_PROMOTION
-- Performing Test TOML11_COMPILER_SUPPORTS_WDOUBLE_PROMOTION - Success
-- Performing Test TOML11_COMPILER_SUPPORTS_WRANGE_LOOP_ANALYSIS
-- Performing Test TOML11_COMPILER_SUPPORTS_WRANGE_LOOP_ANALYSIS - Failed
-- Performing Test TOML11_COMPILER_SUPPORTS_WUNDEF
-- Performing Test TOML11_COMPILER_SUPPORTS_WUNDEF - Success
-- Performing Test TOML11_COMPILER_SUPPORTS_WSHADOW
-- Performing Test TOML11_COMPILER_SUPPORTS_WSHADOW - Success
-- Configuring done (4.1s)
-- Generating done (0.2s)
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_C_COMPILER
    CMAKE_EXPORT_NO_PACKAGE_REGISTRY
    CMAKE_FIND_USE_PACKAGE_REGISTRY
    CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY


-- Build files have been written to: /build/source/build
cmake: enabled parallel building
cmake: enabled parallel installing
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
build flags: -j16 SHELL=/nix/store/xb2dx1c5a9n1brgjkf45prdhggaxawwf-bash-5.3p9/bin/bash
[  1%] Building CXX object tests/CMakeFiles/toml11_decoder.dir/to_json.cpp.o
[  2%] Building CXX object tests/CMakeFiles/toml11_test_utility.dir/utility.cpp.o
[  3%] Building CXX object tests/CMakeFiles/toml11_encoder.dir/to_toml.cpp.o
[  4%] Building CXX object tests/CMakeFiles/toml11_decoder_v1_1_0.dir/to_json.cpp.o
[  5%] Linking CXX static library libtoml11_test_utility.a
[  5%] Built target toml11_test_utility
[  6%] Building CXX object tests/CMakeFiles/test_comments.dir/test_comments.cpp.o
[  7%] Building CXX object tests/CMakeFiles/test_datetime.dir/test_datetime.cpp.o
[  8%] Building CXX object tests/CMakeFiles/test_location.dir/test_location.cpp.o
[  9%] Building CXX object tests/CMakeFiles/test_error_message.dir/test_error_message.cpp.o
[ 10%] Building CXX object tests/CMakeFiles/test_get.dir/test_get.cpp.o
[ 11%] Building CXX object tests/CMakeFiles/test_literal.dir/test_literal.cpp.o
[ 13%] Building CXX object tests/CMakeFiles/test_parse_null.dir/test_parse_null.cpp.o
[ 14%] Building CXX object tests/CMakeFiles/test_format_integer.dir/test_format_integer.cpp.o
[ 15%] Building CXX object tests/CMakeFiles/test_get_or.dir/test_get_or.cpp.o
[ 16%] Building CXX object tests/CMakeFiles/test_format_table.dir/test_format_table.cpp.o
[ 17%] Building CXX object tests/CMakeFiles/test_find.dir/test_find.cpp.o
[ 18%] Building CXX object tests/CMakeFiles/test_format_floating.dir/test_format_floating.cpp.o
[ 19%] Building CXX object tests/CMakeFiles/test_find_or.dir/test_find_or.cpp.o
[ 20%] Linking CXX executable test_location
[ 20%] Built target test_location
[ 21%] Building CXX object tests/CMakeFiles/test_parse_boolean.dir/test_parse_boolean.cpp.o
[ 22%] Linking CXX executable test_datetime
[ 22%] Built target test_datetime
[ 23%] Building CXX object tests/CMakeFiles/test_parse_integer.dir/test_parse_integer.cpp.o
[ 25%] Linking CXX executable test_format_floating
[ 25%] Built target test_format_floating
[ 26%] Building CXX object tests/CMakeFiles/test_parse_floating.dir/test_parse_floating.cpp.o
[ 27%] Linking CXX executable toml11_decoder_v1_1_0
[ 28%] Linking CXX executable toml11_decoder
[ 28%] Built target toml11_decoder_v1_1_0
[ 29%] Building CXX object tests/CMakeFiles/test_parse_string.dir/test_parse_string.cpp.o
[ 29%] Built target toml11_decoder
[ 30%] Building CXX object tests/CMakeFiles/test_parse_datetime.dir/test_parse_datetime.cpp.o
[ 31%] Linking CXX executable test_parse_boolean
[ 31%] Built target test_parse_boolean
[ 32%] Building CXX object tests/CMakeFiles/test_parse_array.dir/test_parse_array.cpp.o
[ 33%] Linking CXX executable toml11_encoder
[ 34%] Linking CXX executable test_get_or
[ 34%] Built target toml11_encoder
[ 34%] Built target test_get_or
[ 35%] Building CXX object tests/CMakeFiles/test_parse_inline_table.dir/test_parse_inline_table.cpp.o
[ 36%] Building CXX object tests/CMakeFiles/test_parse_table_keys.dir/test_parse_table_keys.cpp.o
[ 38%] Linking CXX executable test_find
[ 38%] Built target test_find
[ 39%] Building CXX object tests/CMakeFiles/test_parse_table.dir/test_parse_table.cpp.o
[ 40%] Linking CXX executable test_parse_null
[ 40%] Built target test_parse_null
[ 41%] Building CXX object tests/CMakeFiles/test_parse.dir/test_parse.cpp.o
[ 42%] Linking CXX executable test_get
[ 42%] Built target test_get
[ 43%] Building CXX object tests/CMakeFiles/test_result.dir/test_result.cpp.o
[ 44%] Linking CXX executable test_literal
[ 44%] Built target test_literal
[ 45%] Building CXX object tests/CMakeFiles/test_scanner.dir/test_scanner.cpp.o
[ 46%] Linking CXX executable test_find_or
[ 46%] Built target test_find_or
[ 47%] Building CXX object tests/CMakeFiles/test_serialize.dir/test_serialize.cpp.o
[ 48%] Linking CXX executable test_format_integer
[ 50%] Linking CXX executable test_format_table
[ 50%] Built target test_format_integer
[ 51%] Building CXX object tests/CMakeFiles/test_syntax_boolean.dir/test_syntax_boolean.cpp.o
[ 51%] Built target test_format_table
[ 52%] Building CXX object tests/CMakeFiles/test_syntax_integer.dir/test_syntax_integer.cpp.o
[ 53%] Linking CXX executable test_comments
[ 53%] Built target test_comments
[ 54%] Building CXX object tests/CMakeFiles/test_syntax_floating.dir/test_syntax_floating.cpp.o
[ 55%] Linking CXX executable test_error_message
[ 55%] Built target test_error_message
[ 56%] Building CXX object tests/CMakeFiles/test_syntax_string.dir/test_syntax_string.cpp.o
[ 57%] Linking CXX executable test_parse_integer
[ 57%] Built target test_parse_integer
[ 58%] Building CXX object tests/CMakeFiles/test_syntax_datetime.dir/test_syntax_datetime.cpp.o
[ 59%] Linking CXX executable test_result
[ 59%] Built target test_result
[ 60%] Building CXX object tests/CMakeFiles/test_syntax_key.dir/test_syntax_key.cpp.o
[ 61%] Linking CXX executable test_syntax_boolean
[ 61%] Built target test_syntax_boolean
[ 63%] Building CXX object tests/CMakeFiles/test_syntax_comment.dir/test_syntax_comment.cpp.o
[ 64%] Linking CXX executable test_syntax_integer
[ 64%] Built target test_syntax_integer
[ 65%] Building CXX object tests/CMakeFiles/test_spec.dir/test_spec.cpp.o
[ 66%] Linking CXX executable test_scanner
[ 67%] Linking CXX executable test_syntax_floating
[ 67%] Built target test_syntax_floating
[ 68%] Building CXX object tests/CMakeFiles/test_storage.dir/test_storage.cpp.o
[ 69%] Linking CXX executable test_parse_floating
[ 69%] Built target test_scanner
[ 70%] Building CXX object tests/CMakeFiles/test_traits.dir/test_traits.cpp.o
[ 70%] Built target test_parse_floating
[ 71%] Building CXX object tests/CMakeFiles/test_types.dir/test_types.cpp.o
[ 72%] Linking CXX executable test_parse_datetime
[ 72%] Built target test_parse_datetime
[ 73%] Building CXX object tests/CMakeFiles/test_utility.dir/test_utility.cpp.o
[ 75%] Linking CXX executable test_parse_table_keys
[ 75%] Built target test_parse_table_keys
[ 76%] Building CXX object tests/CMakeFiles/test_user_defined_conversion.dir/test_user_defined_conversion.cpp.o
[ 77%] Linking CXX executable test_parse_array
[ 77%] Built target test_parse_array
[ 78%] Building CXX object tests/CMakeFiles/test_value.dir/test_value.cpp.o
[ 79%] Linking CXX executable test_syntax_string
[ 79%] Built target test_syntax_string
[ 80%] Building CXX object tests/CMakeFiles/test_accessed.dir/test_accessed.cpp.o
[ 81%] Linking CXX executable test_syntax_datetime
[ 81%] Built target test_syntax_datetime
[ 82%] Building CXX object tests/CMakeFiles/test_visit.dir/test_visit.cpp.o
[ 83%] Linking CXX executable test_spec
[ 83%] Built target test_spec
[ 84%] Linking CXX executable test_syntax_key
[ 85%] Linking CXX executable test_parse_table
[ 85%] Built target test_syntax_key
[ 85%] Built target test_parse_table
[ 86%] Linking CXX executable test_storage
[ 86%] Built target test_storage
[ 88%] Linking CXX executable test_syntax_comment
[ 88%] Built target test_syntax_comment
[ 89%] Linking CXX executable test_traits
[ 89%] Built target test_traits
[ 90%] Linking CXX executable test_parse
[ 91%] Linking CXX executable test_types
[ 91%] Built target test_parse
[ 91%] Built target test_types
[ 92%] Linking CXX executable test_utility
[ 92%] Built target test_utility
[ 93%] Linking CXX executable test_parse_string
[ 93%] Built target test_parse_string
[ 94%] Linking CXX executable test_parse_inline_table
[ 94%] Built target test_parse_inline_table
[ 95%] Linking CXX executable test_visit
[ 96%] Linking CXX executable test_accessed
[ 96%] Built target test_visit
[ 96%] Built target test_accessed
[ 97%] Linking CXX executable test_serialize
[ 97%] Built target test_serialize
[ 98%] Linking CXX executable test_user_defined_conversion
[ 98%] Built target test_user_defined_conversion
In file included from /build/source/include/toml11/types.hpp:9,
                 from /build/source/include/toml11/skip.hpp:8,
                 from /build/source/include/toml11/parser.hpp:10,
                 from /build/source/tests/utility.hpp:6,
                 from /build/source/tests/test_value.cpp:4:
In member function 'toml::basic_value<TypeConcig>& toml::basic_value<TypeConcig>::operator=(const std::chrono::duration<_Rep, _Period>&) [with Rep = long int; Period = std::ratio<3600>; TypeConfig = toml::type_config]',
    inlined from 'void test_ctors(T, U, FMT) [with toml::value_t TYPE = toml::value_t::local_time; T = std::chrono::duration<long int, std::ratio<3600> >; U = std::chrono::duration<long int>; FMT = toml::local_time_format_info]' at /build/source/tests/test_value.cpp:303:33:
/build/source/include/toml11/value.hpp:905:13: error: '((unsigned char*)((char*)&x_assign_different_type + offsetof(toml::value, toml::basic_value<toml::type_config>::<unnamed>)))[16]' may be used uninitialized [-Werror=maybe-uninitialized]
  905 |             fmt = this->as_local_time_fmt();
      |             ^~~
/build/source/tests/test_value.cpp: In function 'void test_ctors(T, U, FMT) [with toml::value_t TYPE = toml::value_t::local_time; T = std::chrono::duration<long int, std::ratio<3600> >; U = std::chrono::duration<long int>; FMT = toml::local_time_format_info]':
/build/source/tests/test_value.cpp:302:21: note: 'x_assign_different_type' declared here
  302 |         toml::value x_assign_different_type(true);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~
In member function 'toml::basic_value<TypeConcig>& toml::basic_value<TypeConcig>::operator=(const std::chrono::duration<_Rep, _Period>&) [with Rep = long int; Period = std::ratio<3600>; TypeConfig = toml::type_config]',
    inlined from 'void test_ctors(T, U, FMT) [with toml::value_t TYPE = toml::value_t::local_time; T = std::chrono::duration<long int, std::ratio<3600> >; U = std::chrono::duration<long int>; FMT = toml::local_time_format_info]' at /build/source/tests/test_value.cpp:303:33:
/build/source/include/toml11/value.hpp:905:13: error: '((const toml::local_time_format_info*)((char*)&x_assign_different_type + offsetof(toml::value, toml::basic_value<toml::type_config>::<unnamed>)))[1].toml::local_time_format_info::subsecond_precision' may be used uninitialized [-Werror=maybe-uninitialized]
  905 |             fmt = this->as_local_time_fmt();
      |             ^~~
/build/source/tests/test_value.cpp: In function 'void test_ctors(T, U, FMT) [with toml::value_t TYPE = toml::value_t::local_time; T = std::chrono::duration<long int, std::ratio<3600> >; U = std::chrono::duration<long int>; FMT = toml::local_time_format_info]':
/build/source/tests/test_value.cpp:302:21: note: 'x_assign_different_type' declared here
  302 |         toml::value x_assign_different_type(true);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~
In member function 'toml::basic_value<TypeConcig>& toml::basic_value<TypeConcig>::operator=(local_time_type) [with TypeConfig = toml::type_config]',
    inlined from 'void test_ctors(T, U, FMT) [with toml::value_t TYPE = toml::value_t::local_time; T = toml::local_time; U = toml::local_time; FMT = toml::local_time_format_info]' at /build/source/tests/test_value.cpp:303:33:
/build/source/include/toml11/value.hpp:865:13: error: '((unsigned char*)((char*)&x_assign_different_type + offsetof(toml::value, toml::basic_value<toml::type_config>::<unnamed>)))[16]' may be used uninitialized [-Werror=maybe-uninitialized]
  865 |             fmt = this->as_local_time_fmt();
      |             ^~~
/build/source/tests/test_value.cpp: In function 'void test_ctors(T, U, FMT) [with toml::value_t TYPE = toml::value_t::local_time; T = toml::local_time; U = toml::local_time; FMT = toml::local_time_format_info]':
/build/source/tests/test_value.cpp:302:21: note: 'x_assign_different_type' declared here
  302 |         toml::value x_assign_different_type(true);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~
In member function 'toml::basic_value<TypeConcig>& toml::basic_value<TypeConcig>::operator=(local_time_type) [with TypeConfig = toml::type_config]',
    inlined from 'void test_ctors(T, U, FMT) [with toml::value_t TYPE = toml::value_t::local_time; T = toml::local_time; U = toml::local_time; FMT = toml::local_time_format_info]' at /build/source/tests/test_value.cpp:303:33:
/build/source/include/toml11/value.hpp:865:13: error: '((const toml::local_time_format_info*)((char*)&x_assign_different_type + offsetof(toml::value, toml::basic_value<toml::type_config>::<unnamed>)))[1].toml::local_time_format_info::subsecond_precision' may be used uninitialized [-Werror=maybe-uninitialized]
  865 |             fmt = this->as_local_time_fmt();
      |             ^~~
/build/source/tests/test_value.cpp: In function 'void test_ctors(T, U, FMT) [with toml::value_t TYPE = toml::value_t::local_time; T = toml::local_time; U = toml::local_time; FMT = toml::local_time_format_info]':
/build/source/tests/test_value.cpp:302:21: note: 'x_assign_different_type' declared here
  302 |         toml::value x_assign_different_type(true);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~
In member function 'toml::basic_value<TypeConcig>& toml::basic_value<TypeConcig>::operator=(local_datetime_type) [with TypeConfig = toml::type_config]',
    inlined from 'void test_ctors(T, U, FMT) [with toml::value_t TYPE = toml::value_t::local_datetime; T = toml::local_datetime; U = toml::local_datetime; FMT = toml::local_datetime_format_info]' at /build/source/tests/test_value.cpp:303:33:
/build/source/include/toml11/value.hpp:946:13: error: '((__vector(2) unsigned char*)((char*)&x_assign_different_type + offsetof(toml::value, toml::basic_value<toml::type_config>::<unnamed>)))[8]' may be used uninitialized [-Werror=maybe-uninitialized]
  946 |             fmt = this->as_local_datetime_fmt();
      |             ^~~
/build/source/tests/test_value.cpp: In function 'void test_ctors(T, U, FMT) [with toml::value_t TYPE = toml::value_t::local_datetime; T = toml::local_datetime; U = toml::local_datetime; FMT = toml::local_datetime_format_info]':
/build/source/tests/test_value.cpp:302:21: note: 'x_assign_different_type' declared here
  302 |         toml::value x_assign_different_type(true);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~
In member function 'toml::basic_value<TypeConcig>& toml::basic_value<TypeConcig>::operator=(local_datetime_type) [with TypeConfig = toml::type_config]',
    inlined from 'void test_ctors(T, U, FMT) [with toml::value_t TYPE = toml::value_t::local_datetime; T = toml::local_datetime; U = toml::local_datetime; FMT = toml::local_datetime_format_info]' at /build/source/tests/test_value.cpp:303:33:
/build/source/include/toml11/value.hpp:946:13: error: '((const toml::local_datetime_format_info*)((char*)&x_assign_different_type + offsetof(toml::value, toml::basic_value<toml::type_config>::<unnamed>)))[1].toml::local_datetime_format_info::subsecond_precision' may be used uninitialized [-Werror=maybe-uninitialized]
  946 |             fmt = this->as_local_datetime_fmt();
      |             ^~~
/build/source/tests/test_value.cpp: In function 'void test_ctors(T, U, FMT) [with toml::value_t TYPE = toml::value_t::local_datetime; T = toml::local_datetime; U = toml::local_datetime; FMT = toml::local_datetime_format_info]':
/build/source/tests/test_value.cpp:302:21: note: 'x_assign_different_type' declared here
  302 |         toml::value x_assign_different_type(true);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~
In member function 'toml::basic_value<TypeConcig>& toml::basic_value<TypeConcig>::operator=(std::chrono::_V2::system_clock::time_point) [with TypeConfig = toml::type_config]',
    inlined from 'void test_ctors(T, U, FMT) [with toml::value_t TYPE = toml::value_t::offset_datetime; T = std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long int, std::ratio<1, 1000000000> > >; U = std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long int, std::ratio<1, 1000000000> > >; FMT = toml::offset_datetime_format_info]' at /build/source/tests/test_value.cpp:303:33:
/build/source/include/toml11/value.hpp:1022:13: error: '((__vector(2) unsigned char*)((char*)&x_assign_different_type + offsetof(toml::value, toml::basic_value<toml::type_config>::<unnamed>)))[8]' may be used uninitialized [-Werror=maybe-uninitialized]
 1022 |             fmt = this->as_offset_datetime_fmt();
      |             ^~~
/build/source/tests/test_value.cpp: In function 'void test_ctors(T, U, FMT) [with toml::value_t TYPE = toml::value_t::offset_datetime; T = std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long int, std::ratio<1, 1000000000> > >; U = std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long int, std::ratio<1, 1000000000> > >; FMT = toml::offset_datetime_format_info]':
/build/source/tests/test_value.cpp:302:21: note: 'x_assign_different_type' declared here
  302 |         toml::value x_assign_different_type(true);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~
In member function 'toml::basic_value<TypeConcig>& toml::basic_value<TypeConcig>::operator=(std::chrono::_V2::system_clock::time_point) [with TypeConfig = toml::type_config]',
    inlined from 'void test_ctors(T, U, FMT) [with toml::value_t TYPE = toml::value_t::offset_datetime; T = std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long int, std::ratio<1, 1000000000> > >; U = std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long int, std::ratio<1, 1000000000> > >; FMT = toml::offset_datetime_format_info]' at /build/source/tests/test_value.cpp:303:33:
/build/source/include/toml11/value.hpp:1022:13: error: '((const toml::offset_datetime_format_info*)((char*)&x_assign_different_type + offsetof(toml::value, toml::basic_value<toml::type_config>::<unnamed>)))[1].toml::offset_datetime_format_info::subsecond_precision' may be used uninitialized [-Werror=maybe-uninitialized]
 1022 |             fmt = this->as_offset_datetime_fmt();
      |             ^~~
/build/source/tests/test_value.cpp: In function 'void test_ctors(T, U, FMT) [with toml::value_t TYPE = toml::value_t::offset_datetime; T = std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long int, std::ratio<1, 1000000000> > >; U = std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long int, std::ratio<1, 1000000000> > >; FMT = toml::offset_datetime_format_info]':
/build/source/tests/test_value.cpp:302:21: note: 'x_assign_different_type' declared here
  302 |         toml::value x_assign_different_type(true);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~
In member function 'toml::basic_value<TypeConcig>& toml::basic_value<TypeConcig>::operator=(offset_datetime_type) [with TypeConfig = toml::type_config]',
    inlined from 'void test_ctors(T, U, FMT) [with toml::value_t TYPE = toml::value_t::offset_datetime; T = toml::offset_datetime; U = toml::offset_datetime; FMT = toml::offset_datetime_format_info]' at /build/source/tests/test_value.cpp:303:33:
/build/source/include/toml11/value.hpp:987:13: error: '((__vector(2) unsigned char*)((char*)&x_assign_different_type + offsetof(toml::value, toml::basic_value<toml::type_config>::<unnamed>)))[8]' may be used uninitialized [-Werror=maybe-uninitialized]
  987 |             fmt = this->as_offset_datetime_fmt();
      |             ^~~
/build/source/tests/test_value.cpp: In function 'void test_ctors(T, U, FMT) [with toml::value_t TYPE = toml::value_t::offset_datetime; T = toml::offset_datetime; U = toml::offset_datetime; FMT = toml::offset_datetime_format_info]':
/build/source/tests/test_value.cpp:302:21: note: 'x_assign_different_type' declared here
  302 |         toml::value x_assign_different_type(true);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~
In member function 'toml::basic_value<TypeConcig>& toml::basic_value<TypeConcig>::operator=(offset_datetime_type) [with TypeConfig = toml::type_config]',
    inlined from 'void test_ctors(T, U, FMT) [with toml::value_t TYPE = toml::value_t::offset_datetime; T = toml::offset_datetime; U = toml::offset_datetime; FMT = toml::offset_datetime_format_info]' at /build/source/tests/test_value.cpp:303:33:
/build/source/include/toml11/value.hpp:987:13: error: '((const toml::offset_datetime_format_info*)((char*)&x_assign_different_type + offsetof(toml::value, toml::basic_value<toml::type_config>::<unnamed>)))[1].toml::offset_datetime_format_info::subsecond_precision' may be used uninitialized [-Werror=maybe-uninitialized]
  987 |             fmt = this->as_offset_datetime_fmt();
      |             ^~~
/build/source/tests/test_value.cpp: In function 'void test_ctors(T, U, FMT) [with toml::value_t TYPE = toml::value_t::offset_datetime; T = toml::offset_datetime; U = toml::offset_datetime; FMT = toml::offset_datetime_format_info]':
/build/source/tests/test_value.cpp:302:21: note: 'x_assign_different_type' declared here
  302 |         toml::value x_assign_different_type(true);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~
In member function 'toml::basic_value<TypeConcig>& toml::basic_value<TypeConcig>::operator=(const typename config_type::string_type::value_type*) [with TypeConfig = toml::type_config]',
    inlined from 'void DOCTEST_ANON_FUNC_37()' at /build/source/tests/test_value.cpp:560:29:
/build/source/include/toml11/value.hpp:678:13: error: '((__vector(2) unsigned char*)((char*)&x_from_non_string + offsetof(toml::value, toml::basic_value<toml::type_config>::<unnamed>)))[16]' may be used uninitialized [-Werror=maybe-uninitialized]
  678 |             fmt = this->as_string_fmt();
      |             ^~~
/build/source/tests/test_value.cpp: In function 'void DOCTEST_ANON_FUNC_37()':
/build/source/tests/test_value.cpp:559:21: note: 'x_from_non_string' declared here
  559 |         toml::value x_from_non_string(true);
      |                     ^~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
make[2]: *** [tests/CMakeFiles/test_value.dir/build.make:79: tests/CMakeFiles/test_value.dir/test_value.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:2468: tests/CMakeFiles/test_value.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```
</details>

If I've misjudged and this actually is a concern, or we want to fix this some other way, please feel free to correct me :)

(part of submitting some fixes to prepare for making gcc 16 the default later this release cycle: #537781)

## Things done

- Built on platform:
  - [x] x86_64-linux (both on this commit and with `default-gcc-version = 16;` in all-packages.nix)
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
