### PR TITLE
ocamlPackages.js_of_ocaml: 6.4.0 → 6.4.1

### DIFF
--- a/pkgs/development/tools/ocaml/js_of_ocaml/compiler.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/compiler.nix
@@ -12,7 +12,7 @@
   sedlex,
   version ?
     if lib.versionAtLeast ocaml.version "4.13" then
-      "6.4.0"
+      "6.4.1"
     else if lib.versionAtLeast ocaml.version "4.11" then
       "6.0.1"
     else
@@ -27,7 +27,7 @@ buildDunePackage {
     url = "https://github.com/ocsigen/js_of_ocaml/releases/download/${version}/js_of_ocaml-${version}.tbz";
     hash =
       {
-        "6.4.0" = "sha256-euIqflpsaqFKjiaV+mLGbzLLINsX8bRdwh6XAJNCFR8=";
+        "6.4.1" = "sha256-5Zu//K76ujGRYgVWUUt/U7sySeP4gaBw1yckI03/2Bk=";
         "6.3.2" = "sha256-qTr8llTsNGRwH7zg3M86i+uVCKyxLGBFd2vyzxBsq8A=";
         "6.2.0" = "sha256-fMZBd40bFyo1KogzPuDoxiE2WgrPzZuH44v9243Spdo=";
         "6.1.1" = "sha256-0x2kGq5hwCqqi01QTk6TcFIz0wPNgaB7tKxe7bA9YBQ=";


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
