### PR TITLE
lib.meta-types: add binary either/both combinators

### DIFF
--- a/lib/meta-types.nix
+++ b/lib/meta-types.nix
@@ -160,6 +160,32 @@ lib.fix (self: {
       verify = v: all (func: func v) funcs;
     };
 
+  either =
+    t1: t2:
+    assert isTypeDef t1 && isTypeDef t2;
+    let
+      # Store the functions directly so we don't have to pay the cost of attrset lookups at runtime.
+      v1 = t1.verify;
+      v2 = t2.verify;
+    in
+    {
+      name = "either<${t1.name},${t2.name}>";
+      verify = v: v1 v || v2 v;
+    };
+
+  both =
+    t1: t2:
+    assert isTypeDef t1 && isTypeDef t2;
+    let
+      # Store the functions directly so we don't have to pay the cost of attrset lookups at runtime.
+      v1 = t1.verify;
+      v2 = t2.verify;
+    in
+    {
+      name = "both<${t1.name},${t2.name}>";
+      verify = v: v1 v && v2 v;
+    };
+
   not =
     t:
     assert isTypeDef t;

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -304,21 +304,18 @@ let
       types = import ../../../lib/meta-types.nix { inherit lib; };
       inherit (types)
         str
-        union
+        either
         int
         attrs
         any
         listOf
         bool
         record
-        intersection
+        both
         not
         derivation
         ;
-      platforms = listOf (union [
-        str
-        attrs
-      ]); # see lib.meta.platformMatch
+      platforms = listOf (either str attrs); # see lib.meta.platformMatch
     in
     record {
       # These keys are documented
@@ -326,31 +323,16 @@ let
       mainProgram = str;
       longDescription = str;
       branch = str;
-      homepage = union [
-        (listOf str)
-        str
-      ];
+      homepage = either str (listOf str);
       donationPage = str;
       downloadPage = str;
-      changelog = union [
-        (listOf str)
-        str
-      ];
+      changelog = either str (listOf str);
       license =
         let
           # TODO disallow `str` licenses, use a module
-          licenseType = union [
-            (intersection [
-              attrs
-              (not derivation)
-            ])
-            str
-          ];
+          licenseType = either (both attrs (not derivation)) str;
         in
-        union [
-          (listOf licenseType)
-          licenseType
-        ];
+        either licenseType (listOf licenseType);
       sourceProvenance = listOf attrs;
       maintainers = listOf attrs; # TODO use the maintainer type from lib/tests/maintainer-module.nix
       nonTeamMaintainers = listOf attrs; # TODO use the maintainer type from lib/tests/maintainer-module.nix


### PR DESCRIPTION
lib.meta-types: add binary either/both combinators

With `checkMeta = true` (the CI and Hydra configuration), the `meta-types` `verify` functions run for every meta attribute of every package. The `union`/`intersection` verifies were `v: any (func: func v) funcs`, which allocates a closure and calls the `any`/`all` primop on every single verification.

Every in-tree use has exactly two members, so this adds binary `either`/`both` combinators whose verify is simply `v: v1 v || v2 v` — no per-call closure allocation, no primop call, and short-circuit behavior is explicit — and switches the `check-meta.nix` call sites to them. `union`/`intersection` are kept for potential future use.

### How the types are actually used

The only `union`/`intersection` constructions in the tree are the six sites in `check-meta.nix`'s `metaType`, all 2-member. Instrumented counts of every `verify` invocation confirm it dynamically:

| workload | `union` calls | `intersection` calls | members |
|---|---:|---:|---|
| CI eval chunk (5000 attrs, `checkMeta = true`) | 1,331,231 | 17,433 | 100% 2-member |
| `hello` outPath, `checkMeta = true` | 10,194 | 261 | 100% 2-member |
| `hello` outPath, default config | 0 | 0 | — |
| NixOS minimal ISO toplevel | 0 | 0 | — |

So a binary interface fits the actual usage exactly, and workloads without `checkMeta` never call these at all.

### Results

Measured on one 5000-attr CI eval chunk (`ci/eval/chunk.nix` via `nix-env -qa --out-path --json --meta`, `checkMeta = true`), stats from `NIX_SHOW_STATS` (deterministic counters, identical across runs):

| metric | before | after | Δ |
|---|---:|---:|---:|
| function calls | 13.55 M | 12.14 M | **−10.4%** |
| primop calls | 6.49 M | 5.13 M | **−20.9%** |
| thunks | 18.13 M | 16.78 M | −7.5% |
| envs allocated | 14.74 M | 13.33 M | −9.6% |
| GC allocations | 2296 MB | 2252 MB | −1.9% |

CPU work as retired user instructions (`perf stat -e instructions:u`, pinned core, same checkout for both sides, alternated runs): **−2.81%** for the whole chunk eval, reproducible to ±0.05%.

NixOS evaluations are unaffected (they don't set `checkMeta`); this targets CI/Hydra-style package-set evals.

### Verification

- Full CI eval chunk output (`nix-env -qa --out-path --json --meta`, 5000 attrs): byte-identical before/after — no derivation or meta changes.
- `lib/tests/misc.nix` and `lib/tests/modules.sh` (407 tests): all pass.
- `meta-types.nix` is documented as internal and unstable, and `check-meta.nix` is its only consumer, so the interface change is contained.

Assisted-by: Claude Code (Claude Fable 5)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
