### PR TITLE
qst: init at 0.10.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10096,6 +10096,12 @@
     githubId = 19275558;
     name = "Julien Girard-Satabin";
   };
+  GitanElyon = {
+    email = "gitanelyon@gmail.com";
+    github = "GitanElyon";
+    githubId = 157924085;
+    name = "Gitan Elyon Mandell-Balogh";
+  };
   GKasparov = {
     email = "mizozahr@gmail.com";
     github = "GKasparov";

--- a/pkgs/by-name/qs/qst/package.nix
+++ b/pkgs/by-name/qs/qst/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  rustPlatform,
+  fetchCrate,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "qst";
+  version = "0.10.0";
+  __structuredAttrs = true;
+
+  src = fetchCrate {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-IgSgozX1HHp3oK8iFUEOxJ0XWiXrKaj9N3i8yrPq/zs=";
+  };
+
+  cargoHash = "sha256-FyHO5rA2Wh8ztPOd5qpTKQJEjAjtEdEkVY923kXuYsY=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A Community Driven CLI Quick Script Tool";
+    homepage = "https://github.com/GitanElyon/qst";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GitanElyon ];
+    mainProgram = "qst";
+  };
+})


### PR DESCRIPTION
Initial package addition for `qst`, a community-driven CLI quick script tool written in Rust. I have also added myself to the maintainer list. The home page can be found at https://github.com/GitanElyon/qst.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
