### PR TITLE
rkbin: 0-unstable-2025-06-13 -> 0-unstable-2025-12-30

### DIFF
--- a/pkgs/by-name/rk/rkbin/package.nix
+++ b/pkgs/by-name/rk/rkbin/package.nix
@@ -7,13 +7,13 @@
 
 stdenvNoCC.mkDerivation {
   pname = "rkbin";
-  version = "0-unstable-2025-06-13";
+  version = "0-unstable-2025-12-30";
 
   src = fetchFromGitHub {
     owner = "rockchip-linux";
     repo = "rkbin";
-    rev = "74213af1e952c4683d2e35952507133b61394862";
-    hash = "sha256-gNCZwJd9pjisk6vmvtRNyGSBFfAYOADTa5Nd6Zk+qEk=";
+    rev = "ecb4fcbe954edf38b3ae037d5de6d9f5bccf81f4";
+    hash = "sha256-U8d2cH6/TSXfBnLhh141A9wP/t6prFgwYMvwgXBf4vc=";
   };
 
   installPhase = ''
@@ -23,11 +23,11 @@ stdenvNoCC.mkDerivation {
   '';
 
   passthru = {
-    BL31_RK3568 = "${rkbin}/bin/rk35/rk3568_bl31_v1.45.elf";
-    BL31_RK3588 = "${rkbin}/bin/rk35/rk3588_bl31_v1.51.elf";
-    TPL_RK3566 = "${rkbin}/bin/rk35/rk3566_ddr_1056MHz_v1.23.bin";
-    TPL_RK3568 = "${rkbin}/bin/rk35/rk3568_ddr_1056MHz_v1.23.bin";
-    TPL_RK3588 = "${rkbin}/bin/rk35/rk3588_ddr_lp4_2112MHz_lp5_2400MHz_v1.19.bin";
+    BL31_RK3568 = "${rkbin}/bin/rk35/rk3568_bl31_v1.46.elf";
+    BL31_RK3588 = "${rkbin}/bin/rk35/rk3588_bl31_v1.54.elf";
+    TPL_RK3566 = "${rkbin}/bin/rk35/rk3566_ddr_1056MHz_v1.25.bin";
+    TPL_RK3568 = "${rkbin}/bin/rk35/rk3568_ddr_1056MHz_v1.25.bin";
+    TPL_RK3588 = "${rkbin}/bin/rk35/rk3588_ddr_lp4_2112MHz_lp5_2400MHz_v1.21.bin";
   };
 
   meta = {


### PR DESCRIPTION
Updated to the latest unstable.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
