### PR TITLE
grub2_efi: apply patch for gcc 16

### DIFF
--- a/pkgs/by-name/gr/grub2/package.nix
+++ b/pkgs/by-name/gr/grub2/package.nix
@@ -583,6 +583,13 @@ stdenv.mkDerivation rec {
       url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=ac1512b872af8567b408518a7efa01607a0219ae";
       hash = "sha256-deyp6Yatlgv86bYMt7WcWhKg8J6StDPUEy4UPHqJYIc=";
     })
+    # Required to build grub2_efi with GCC 16, or fails with "error: 'regparm'
+    # attribute ignored [-Werror=attributes]"
+    (fetchpatch {
+      name = "gcc16_make_regparm_attribute_more_conditional.patch";
+      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=9922ed133c2c754ec9f37198da2b3e3e8a4fd5ff";
+      hash = "sha256-V2vffDxL/qQ14YN5scc3CFPBFBWvkh57dc5/hWd/6F4=";
+    })
   ];
 
   postPatch =


### PR DESCRIPTION
gcc 16 gains stricter analysis of whether attributes are ignored, leading to build failures of `grub2_efi` when built with -Werror. we could silence the error, but this was fixed in a trivial commit upstream that is obviously correct, so we pull it in: https://cgit.git.savannah.gnu.org/cgit/grub.git/commit/?id=9922ed133c2c754ec9f37198da2b3e3e8a4fd5ff

(part of submitting some fixes to prepare for making gcc 16 the default later this release cycle: #537781)

## Things done

- Built on platform:
  - [x] x86_64-linux (`grub2{,_efi,_xen,_light,_xen_pvh,_ieee1275}` on this commit, and `grub2{,_efi}` with `default-gcc-version = 16;` in `all-packages.nix`)
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. (`grub2.tests`)
  - [x] [Package tests] at `passthru.tests`. (`grub2.tests`)
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
