### PR TITLE
nixos/softether: fix ExecStart failing on read-only /nix/store

### DIFF
--- a/nixos/modules/services/networking/softether.nix
+++ b/nixos/modules/services/networking/softether.nix
@@ -95,8 +95,8 @@ in
           wantedBy = [ "network.target" ];
           serviceConfig = {
             Type = "forking";
-            ExecStart = "${package}/bin/vpnserver start";
-            ExecStop = "${package}/bin/vpnserver stop";
+            ExecStart = "${cfg.dataDir}/vpnserver/vpnserver start";
+            ExecStop = "${cfg.dataDir}/vpnserver/vpnserver stop";
           };
           preStart = ''
             rm -rf ${cfg.dataDir}/vpnserver/vpnserver
@@ -116,8 +116,8 @@ in
           wantedBy = [ "network.target" ];
           serviceConfig = {
             Type = "forking";
-            ExecStart = "${package}/bin/vpnbridge start";
-            ExecStop = "${package}/bin/vpnbridge stop";
+            ExecStart = "${cfg.dataDir}/vpnbridge/vpnbridge start";
+            ExecStop = "${cfg.dataDir}/vpnbridge/vpnbridge stop";
           };
           preStart = ''
             rm -rf ${cfg.dataDir}/vpnbridge/vpnbridge
@@ -137,8 +137,8 @@ in
           wantedBy = [ "network.target" ];
           serviceConfig = {
             Type = "forking";
-            ExecStart = "${package}/bin/vpnclient start";
-            ExecStop = "${package}/bin/vpnclient stop";
+            ExecStart = "${cfg.dataDir}/vpnclient/vpnclient start";
+            ExecStop = "${cfg.dataDir}/vpnclient/vpnclient stop";
           };
           preStart = ''
             rm -rf ${cfg.dataDir}/vpnclient/vpnclient


### PR DESCRIPTION
Closes #485922

The softether binaries were being invoked from their nix store paths. Softether was unable to create state files into this read-only path resulting in startup failures like:

`Unable to create /nix/store/.../vpnclient/.VPN-...`

A writeable state directory is already setup in preStart, use the pre-existing symlinks in this directory to invoke the binaries instead.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
