### PR TITLE
thorium-reader: 3.3.0 -> 3.4.0

### DIFF
--- a/pkgs/by-name/th/thorium-reader/package.nix
+++ b/pkgs/by-name/th/thorium-reader/package.nix
@@ -14,17 +14,34 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "thorium-reader";
-  version = "3.3.0";
+  version = "3.4.0";
   nodejs = nodejs_24;
-  npmDepsHash = "sha256-UR2MSqmdJ79Fz7qjQRkCAwx2jdMn8KLWPzNSnnsb5Ak=";
+  npmDepsHash = "sha256-IwdU77fRJJ7Ch5rWop3lFpf14XHklFDa8w6YJCFtJRU=";
   makeCacheWritable = true;
 
   src = fetchFromGitHub {
     owner = "edrlab";
     repo = "thorium-reader";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-2d5M9C/cLK2A8O3Ls0xEkT6H8tucVR7eivPi+82V7Zg=";
+    hash = "sha256-h285GM7DKKD34Wjw6E+zSSIGkUH/UOesLrYD2EdQ7+U=";
   };
+
+  # The upstream `build` script re-runs `npm i` inside `dist/` to populate
+  # `dist/node_modules` with the runtime subset declared in `src/package.json`.
+  # This is bad (not reproducible), so we strip that segment from the `build`
+  # script. This ends up not being an issue, since our build/install process
+  # copies relevant dependencies anyways.
+  patches = [ ./remove-dist-npm-install.patch ];
+
+  postBuild = ''
+    # copy node modules manually
+    cp -r node_modules dist/node_modules
+
+    # remove unnecessary npm deps
+    pushd dist
+    npm prune --production --ignore-scripts --offline --no-audit --no-fund
+    popd
+  '';
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
   # makeBinaryWrapper is required on Darwin since MacOS is confuses itself

--- a/pkgs/by-name/th/thorium-reader/remove-dist-npm-install.patch
+++ b/pkgs/by-name/th/thorium-reader/remove-dist-npm-install.patch
@@ -1,0 +1,13 @@
+diff --git a/package.json b/package.json
+index d838331..073dfff 100644
+--- a/package.json
++++ b/package.json
+@@ -25,7 +25,7 @@
+     "_NOT_NEEDED_electron-build_": "npm rebuild --runtime=electron --target=41.1.1 --disturl=https://electronjs.org/headers --build-from-source",
+     "_NOT_NEEDED_electron-build": "electron-rebuild --version=41.1.1 --disturl=https://electronjs.org/headers",
+     "_NOT_NEEDED_rmDupeReactReduxTypes": "rimraf \"./node_modules/@types/react-redux/node_modules/@types/react\"",
+-    "build": "cross-env NODE_ENV=production webpack --config webpack.config.js && ncp src/package.json dist/package.json && cd dist && rimraf node_modules && npm i --ignore-scripts --foreground-scripts && rimraf package-lock.json && cd ..",
++    "build": "cross-env NODE_ENV=production webpack --config webpack.config.js && ncp src/package.json dist/package.json",
+     "build:prod": "npm run lint && npm run build",
+     "build:dev:main": "webpack --config webpack.config.main.js",
+     "_NOT_NEEDED_build:dev:renderer:library": "webpack --config webpack.config.renderer-library.js",


### PR DESCRIPTION
Updated thorium reader. This requires a tiny patch to the "build" script in package.json, which has changed since the [last version](https://github.com/edrlab/thorium-reader/blob/c45e2ace2884a7e1f388af2710628d1d40a0d7af/package.json), and now, by default, includes, a `npm install` inside a subdirectory. This is bad for reasons of reproducibility and causes a nix build failure.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
