### PR TITLE
waybar-lyric: 0.16.0 -> 0.17.0

### DIFF
--- a/pkgs/by-name/wa/waybar-lyric/package.nix
+++ b/pkgs/by-name/wa/waybar-lyric/package.nix
@@ -1,24 +1,27 @@
 {
   stdenv,
   lib,
+  ffmpeg,
+  makeWrapper,
   buildGoModule,
   fetchFromGitHub,
   versionCheckHook,
   nix-update-script,
   installShellFiles,
+  withEmbeddedLyric ? false,
 }:
 buildGoModule (finalAttrs: {
   pname = "waybar-lyric";
-  version = "0.16.0";
+  version = "0.17.0";
 
   src = fetchFromGitHub {
     owner = "Nadim147c";
     repo = "waybar-lyric";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-1kUAOR7p27pLMH7zlbj+tTlIh0f8JQuWhzQVWvOyKoo=";
+    hash = "sha256-5tMRAq37CZQYemXfJwmj9cj1gR5i9Zii9fqTPDCw45A=";
   };
 
-  vendorHash = "sha256-pzHNa/55n84VSFaWmgOtwWmmDLoNE6o8mgpFCz7r8FQ=";
+  vendorHash = "sha256-zVyUxpAqsWY3/dXlBhPX/o41UP5Afn38JauQsWUqLMk=";
 
   ldflags = [
     "-s"
@@ -26,13 +29,24 @@ buildGoModule (finalAttrs: {
     "-X main.Version=${finalAttrs.version}"
   ];
 
-  nativeBuildInputs = [ installShellFiles ];
-  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
-    installShellCompletion --cmd waybar-lyric \
-      --bash <($out/bin/waybar-lyric _carapace bash) \
-      --fish <($out/bin/waybar-lyric _carapace fish) \
-      --zsh <($out/bin/waybar-lyric _carapace zsh)
-  '';
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+  ];
+
+  propagatedBuildInputs = lib.optional withEmbeddedLyric ffmpeg;
+
+  postInstall =
+    lib.optionalString withEmbeddedLyric ''
+      wrapProgram $out/bin/waybar-lyric \
+        --prefix PATH : ${lib.makeBinPath finalAttrs.propagatedBuildInputs}
+    ''
+    + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      installShellCompletion --cmd waybar-lyric \
+        --bash <($out/bin/waybar-lyric _carapace bash) \
+        --fish <($out/bin/waybar-lyric _carapace fish) \
+        --zsh <($out/bin/waybar-lyric _carapace zsh)
+    '';
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];


### PR DESCRIPTION
## Things done

Release note: https://github.com/Nadim147c/waybar-lyric/releases/tag/v0.17.0.

> [!IMPORTANT]
> This release includes a feature that can extract embedded lyrics from audio
> files. But, I've set `withEmbeddedLyrics` to `false` by default. For this feature
> to work, the following conditions must be met:
>
> - The target `mpris` player must be playing a local song
> - The target `mpris` player must have xesam:url metadata
> - The url must have a `file://` scheme
> - Lyrics must be embedded into the audio file
>
> Since most players won't meet these conditions, and users might not want a
> full media toolkit (FFmpeg) installed just for a feature they may not use, I
> decided to set the default to false.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core"
        functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in
      `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and
      other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
