### PR TITLE
nut: 2.8.4 -> 2.8.5

### DIFF
--- a/pkgs/by-name/nu/nut/CVE-2026-54161.patch
+++ b/pkgs/by-name/nu/nut/CVE-2026-54161.patch
@@ -1,0 +1,358 @@
+diff --git a/UPGRADING.adoc b/UPGRADING.adoc
+index e4beed637a..5d957ab0b7 100644
+--- a/UPGRADING.adoc
++++ b/UPGRADING.adoc
+@@ -46,6 +46,14 @@
+   if the requested value is larger than what is allowed (minus some reserve
+   for configuration files and other use-cases). [issue #3365]
+ 
++- Potentially a breaking change for existing deployments with `upsmon` and
++  `upssched` integration: the `CMDSCRIPT` and `NOTIFYCMD` definitions were
++  revised to mean an exact program name (possibly with spaces in the value),
++  not a shell scriptlet. Documentation in earlier NUT releases implied that
++  arguments could be passed here -- this is no longer true. If you need to
++  pass special arguments to a notification program, please write a small
++  script to do so and specify its path here. The `SHUTDOWNCMD` is still
++  a scriptlet, as far as specifying command arguments is concerned. [#3499]
+ 
+ Changes from 2.8.4 to 2.8.5
+ ---------------------------
+diff --git a/clients/upsmon.c b/clients/upsmon.c
+index 7124eb8813..ce47ad7951 100644
+--- a/clients/upsmon.c
++++ b/clients/upsmon.c
+@@ -238,25 +238,18 @@
+ 	pclose(wf);
+ #else	/* WIN32 */
+ #	define MESSAGE_CMD "message.exe"
+-	char	*command;
+-
+-	/* first +1 is for the space between message and text
+-	 * second +1 is for trailing 0
+-	 * +2 is for ""
+-	 */
+-	size_t	commandsz = strlen(MESSAGE_CMD) + 1 + 2 + strlen(text) + 1;
++	char	*argv[3];
++	int	ret;
+ 
+-	command = malloc (commandsz);
+-	if (command == NULL) {
+-		upslog_with_errno(LOG_NOTICE, "Not enough memory for wall");
+-		return;
+-	}
++	argv[0] = MESSAGE_CMD;
++	argv[1] = (char *)text;
++	argv[2] = NULL;
+ 
+-	snprintf(command, commandsz, "%s \"%s\"", MESSAGE_CMD, text);
+-	if (system(command) != 0) {
+-		upslog_with_errno(LOG_NOTICE, "Can't invoke wall");
++	upsdebugx(6, "%s: executing %s with message: %s", __func__, MESSAGE_CMD, NUT_STRARG(text));
++	ret = _spawnvp(_P_WAIT, MESSAGE_CMD, (const char * const *)argv);
++	if (ret != 0) {
++		upslog_with_errno(LOG_NOTICE, "Can't invoke wall (status: %d)", ret);
+ 	}
+-	free(command);
+ #endif	/* WIN32 */
+ }
+ 
+@@ -271,32 +264,37 @@
+ 
+ static unsigned __stdcall async_notify(LPVOID param)
+ {
+-	char	exec[LARGEBUF];
+-	char	notice[LARGEBUF];
++	char	*argv[3];
++	int	ret;
+ 
+ 	/* the following code is a copy of the content of the NOT WIN32 part of
+-	"notify" function below */
++	 * "notify" function below */
+ 
+ 	async_notify_t *data = (async_notify_t *)param;
+ 
+ 	if (flag_isset(data->flags, NOTIFY_WALL)) {
+-		snprintf(notice,LARGEBUF,"%s: %s", data->date, data->notice);
++		char	notice[LARGEBUF];
++
++		snprintf(notice, sizeof(notice), "%s: %s", data->date, data->notice);
+ 		wall(notice);
+ 	}
+ 
+ 	if (flag_isset(data->flags, NOTIFY_EXEC)) {
+ 		if (notifycmd != NULL) {
+-			snprintf(exec, sizeof(exec), "%s \"%s\"", notifycmd, data->notice);
+-
+-			upsdebugx(6, "%s: Calling NOTIFYCMD: %s", __func__, exec);
++			upsdebugx(6, "%s: Calling NOTIFYCMD: %s with notice: %s",
++				__func__, notifycmd, NUT_STRARG(data->notice));
+ 			if (data->upsname)
+ 				setenv("UPSNAME", data->upsname, 1);
+ 			else
+ 				setenv("UPSNAME", "", 1);
+ 
+ 			setenv("NOTIFYTYPE", data->ntype, 1);
+-			if (system(exec) == -1) {
+-				upslog_with_errno(LOG_ERR, "%s", __func__);
++			argv[0] = notifycmd;
++			argv[1] = data->notice;
++			argv[2] = NULL;
++			ret = _spawnvp(_P_WAIT, notifycmd, (const char * const *)argv);
++			if (ret == -1) {
++				upslog_with_errno(LOG_ERR, "%s: _spawnvp failed", __func__);
+ 			}
+ 		}
+ 	}
+@@ -314,12 +312,11 @@
+ 			const char *upsname)
+ {
+ #ifndef WIN32
+-	char	exec[LARGEBUF];
+ 	int	ret;
+ #endif	/* !WIN32 */
+ 
+ 	upsdebugx(6, "%s: sending notification for [%s]: type %s with flags 0x%04x: %s",
+-		__func__, upsname ? upsname : "upsmon itself", ntype, flags, notice);
++		__func__, upsname ? upsname : "upsmon itself", ntype, flags, NUT_STRARG(notice));
+ 
+ 	if (flag_isset(flags, NOTIFY_IGNORE)) {
+ 		upsdebugx(6, "%s: NOTIFY_IGNORE", __func__);
+@@ -328,7 +325,7 @@
+ 
+ 	if (flag_isset(flags, NOTIFY_SYSLOG)) {
+ 		upsdebugx(6, "%s: NOTIFY_SYSLOG (as LOG_NOTICE)", __func__);
+-		upslogx(LOG_NOTICE, "%s", notice);
++		upslogx(LOG_NOTICE, "%s", NUT_STRARG(notice));
+ 	}
+ 
+ #ifndef WIN32
+@@ -357,10 +354,10 @@
+ 
+ 	if (flag_isset(flags, NOTIFY_EXEC)) {
+ 		if (notifycmd != NULL) {
+-			upsdebugx(6, "%s (%schild): NOTIFY_EXEC: calling NOTIFYCMD as '%s \"%s\"'",
+-				__func__, use_pipe ? "grand" : "", notifycmd, notice);
++			char	*argv[3];
+ 
+-			snprintf(exec, sizeof(exec), "%s \"%s\"", notifycmd, notice);
++			upsdebugx(6, "%s (%schild): NOTIFY_EXEC: calling NOTIFYCMD as '%s' with notice: '%s'",
++				__func__, use_pipe ? "grand" : "", notifycmd, NUT_STRARG(notice));
+ 
+ 			if (upsname)
+ 				setenv("UPSNAME", upsname, 1);
+@@ -368,9 +365,13 @@
+ 				setenv("UPSNAME", "", 1);
+ 
+ 			setenv("NOTIFYTYPE", ntype, 1);
+-			if (system(exec) == -1) {
+-				upslog_with_errno(LOG_ERR, "%s", __func__);
+-			}
++			argv[0] = (char *)notifycmd;
++			argv[1] = (char *)notice;
++			argv[2] = NULL;
++			execvp(notifycmd, argv);
++			/* execvp() only returns on error */
++			upslog_with_errno(LOG_ERR, "%s: execvp(%s) failed", __func__, notifycmd);
++			exit(EXIT_FAILURE);
+ 		} else {
+ 			upsdebugx(6, "%s (%schild): NOTIFY_EXEC: no NOTIFYCMD was configured", __func__, use_pipe ? "grand" : "");
+ 		}
+diff --git a/clients/upssched.c b/clients/upssched.c
+index a2952ecff8..3d0ea84718 100644
+--- a/clients/upssched.c
++++ b/clients/upssched.c
+@@ -105,32 +105,71 @@
+ 
+ static void exec_cmd(const char *cmd)
+ {
+-	int	err;
+-	char	buf[LARGEBUF];
++#ifndef WIN32
++	int	waitstatus = 0;
++	pid_t	pid, waitret;
++#else
++	int	err = 0;
++#endif
++	char	*argv[3];
++
++	if (cmdscript == NULL) {
++		upslogx(LOG_ERR, "No CMDSCRIPT defined, cannot execute command: %s", NUT_STRARG(cmd));
++		return;
++	}
+ 
+-	snprintf(buf, sizeof(buf), "%s %s", cmdscript, cmd);
++	argv[0] = cmdscript;
++	argv[1] = (char *)cmd;
++	argv[2] = NULL;
++
++	upsdebugx(4, "%s: calling: %s %s", __func__, cmdscript, NUT_STRARG(cmd));
+ 
+-	upsdebugx(4, "%s: calling: %s", __func__, buf);
+-	err = system(buf);
+-	upsdebugx(3, "%s(%s): returned %d", __func__, buf, err);
+ #ifndef WIN32
+-	if (WIFEXITED(err)) {
+-		if (WEXITSTATUS(err)) {
+-			upslogx(LOG_INFO, "exec_cmd(%s) returned %d", buf, WEXITSTATUS(err));
++	pid = fork();
++	if (pid < 0) {
++		upslog_with_errno(LOG_ERR, "fork() failed in exec_cmd");
++		return;
++	}
++
++	if (pid == 0) {
++		/* child process */
++		execvp(cmdscript, argv);
++		/* execvp() only returns on error */
++		upslog_with_errno(LOG_ERR, "execvp(%s) failed", cmdscript);
++		exit(EXIT_FAILURE);
++	}
++
++	/* parent process - wait for child */
++	waitret = waitpid(pid, &waitstatus, 0);
++	if (waitret < 0) {
++		upslog_with_errno(LOG_ERR, "waitpid(%d) failed", (int)pid);
++		return;
++	}
++
++	if (WIFEXITED(waitstatus)) {
++		if (WEXITSTATUS(waitstatus)) {
++			upslogx(LOG_INFO, "exec_cmd(%s %s) returned %d",
++				cmdscript, NUT_STRARG(cmd), WEXITSTATUS(waitstatus));
+ 		}
+ 	} else {
+-		if (WIFSIGNALED(err)) {
+-			upslogx(LOG_WARNING, "exec_cmd(%s) terminated with signal %d", buf, WTERMSIG(err));
++		if (WIFSIGNALED(waitstatus)) {
++			upslogx(LOG_WARNING, "exec_cmd(%s %s) terminated with signal %d",
++				cmdscript, NUT_STRARG(cmd), WTERMSIG(waitstatus));
+ 		} else {
+-			upslogx(LOG_ERR, "Execute command failure: %s", buf);
++			upslogx(LOG_ERR, "Execute command failure: %s %s",
++				cmdscript, NUT_STRARG(cmd));
+ 		}
+ 	}
++
++	upsdebugx(3, "%s: returned status %d", __func__, waitstatus);
+ #else	/* WIN32 */
+-	if(err != -1) {
+-		upslogx(LOG_INFO, "Execute command \"%s\" OK", buf);
+-	}
+-	else {
+-		upslogx(LOG_ERR, "Execute command failure : %s", buf);
++	/* Use _spawnvp for Windows */
++	err = _spawnvp(_P_WAIT, cmdscript, (const char * const *)argv);
++	if (err != -1) {
++		upslogx(LOG_INFO, "Execute command \"%s %s\" OK", cmdscript, NUT_STRARG(cmd));
++		upsdebugx(3, "%s: returned status %d", __func__, err);
++	} else {
++		upslog_with_errno(LOG_ERR, "Execute command \"%s %s\" failure", cmdscript, NUT_STRARG(cmd));
+ 	}
+ #endif	/* WIN32 */
+ 
+diff --git a/conf/upsmon.conf.sample.in b/conf/upsmon.conf.sample.in
+index f07e7a4d40..94b6eed532 100644
+--- a/conf/upsmon.conf.sample.in
++++ b/conf/upsmon.conf.sample.in
+@@ -210,6 +210,9 @@
+ #
+ # upsmon calls this to send messages when things happen
+ #
++# The value is interpreted as a complete path to an externally stored
++# executable script (e.g. not an inline scriptlet) or program file without
++# further arguments (this is a change from NUT v2.8.5 and older releases).
+ # This command is called with the full text of the message (from NOTIFYMSG)
+ # as one argument.
+ #
+diff --git a/conf/upssched.conf.sample.in b/conf/upssched.conf.sample.in
+index bfb9b99f68..96cfa47fb4 100644
+--- a/conf/upssched.conf.sample.in
++++ b/conf/upssched.conf.sample.in
+@@ -21,6 +21,9 @@
+ # CMDSCRIPT <scriptname>
+ #
+ # This script gets called to invoke commands for timers that trigger.
++# The value is interpreted as a complete path to an externally stored
++# executable script (e.g. not an inline scriptlet) or program file without
++# further arguments (this is a change from NUT v2.8.5 and older releases).
+ # It is given a single argument - the <timername> in your
+ # AT ... START-TIMER defines.
+ #
+diff --git a/docs/man/upsmon.conf.txt b/docs/man/upsmon.conf.txt
+index 83fcf4df0d..e88f880977 100644
+--- a/docs/man/upsmon.conf.txt
++++ b/docs/man/upsmon.conf.txt
+@@ -230,10 +230,13 @@
+ Making this some sort of shell script might not be a bad idea.  For
+ more information and ideas, see docs/scheduling.txt
+ +
+-Remember, this command also needs to be one element in the configuration file,
+-so if your command has spaces, then wrap it in quotes.
++The value is interpreted as a complete path to an externally stored
++executable script (e.g. not an inline scriptlet) or program file without
++further arguments (this is a change from NUT v2.8.5 and older releases).
++Remember, this command also needs to be one element in the configuration
++file, so if your command path has spaces, then wrap it in quotes.
+ +
+-+NOTIFYCMD "/path/to/script --foo --bar"+
+++NOTIFYCMD "/path to/script"+
+ +
+ This script is run in the background--that is, upsmon forks before it
+ calls out to start it.  This means that your NOTIFYCMD may have multiple
+diff --git a/docs/man/upsmon.txt b/docs/man/upsmon.txt
+index 05c20e29c1..b9f6d53889 100644
+--- a/docs/man/upsmon.txt
++++ b/docs/man/upsmon.txt
+@@ -258,7 +258,12 @@
+  - `NOTIFYCMD "/usr/local/bin/notifyme"`
+ 
+ Remember to wrap the path in "double quotes" if it contains any spaces.
+-It should probably not rely on receiving any command-line arguments.
++It should not rely on receiving any command-line arguments: the value of
++this directive is interpreted as a complete path to an externally stored
++executable script (e.g. not an inline scriptlet) or program file without
++further arguments (this is a change from NUT v2.8.5 and older releases).
++If you need to pass special arguments to a notification program, please
++write a small script to do so and specify its path here.
+ 
+ The program you run as your NOTIFYCMD can use the environment variables
+ NOTIFYTYPE and UPSNAME to know what has happened and on which UPS.  It
+diff --git a/docs/man/upssched.conf.txt b/docs/man/upssched.conf.txt
+index b0d38f04c8..1dbe19692d 100644
+--- a/docs/man/upssched.conf.txt
++++ b/docs/man/upssched.conf.txt
+@@ -46,6 +46,10 @@
+ Required.  This must be above any AT lines.  This script is used to
+ invoke commands when your timers are triggered.  It receives a single
+ argument which is the name of the timer that caused it to trigger.
+++
++The value is interpreted as a complete path to an externally stored
++executable script (e.g. not an inline scriptlet) or program file without
++further arguments (this is a change from NUT v2.8.5 and older releases).
+ 
+ *PIPEFN* 'filename'::
+ Required.  This sets the file name of the socket which will be used for
+diff --git a/docs/man/upssched.txt b/docs/man/upssched.txt
+index 3b790fbb0f..0dbd2651e4 100644
+--- a/docs/man/upssched.txt
++++ b/docs/man/upssched.txt
+@@ -98,9 +98,16 @@
+ ---------------
+ 
+ To shut down the system early, define a timer that starts due to an ONBATT
+-condition.  When it triggers, make your CMDSCRIPT call your shutdown
+-routine.  It should finish by calling `upsmon -c fsd` so that upsmon gets
+-to shut down the slaves in a controlled manner.
++condition.  When it triggers, make your `CMDSCRIPT` call your shutdown
++routine, especially if you have to prioritize something to stop first,
++or have subsystems that can take longer to gracefully stop than the normal
++OS shutdown patience allows (some systems might `kill` remaining processes
++after a hard-coded timeout).
++
++Your `CMDSCRIPT` should finish by calling `upsmon -c fsd`, so that your
++primary instance of linkman:upsmon[8] gets to shut down the secondary
++systems in a controlled manner (note the primary instance would also run
++its local definition of `SHUTDOWNCMD` in the end).
+ 
+ Be sure you cancel the timer if power returns (ONLINE).
+ 

--- a/pkgs/by-name/nu/nut/package.nix
+++ b/pkgs/by-name/nu/nut/package.nix
@@ -14,6 +14,7 @@
   libusb1,
   makeWrapper,
   neon,
+  glib,
   net-snmp,
   openssl,
   pkg-config,
@@ -49,11 +50,11 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nut";
-  version = "2.8.4";
+  version = "2.8.5";
 
   src = fetchurl {
     url = "https://networkupstools.org/source/${lib.versions.majorMinor finalAttrs.version}/nut-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-ATC6gup58Euk80xSSahZQ5d+/ZhO199q7BpRjVo1lPg=";
+    sha256 = "sha256-GL8y5Z63ZLE9o8T6cDhJJtf6WEyzHS/n8TelcGM+7sE=";
   };
 
   patches = [
@@ -73,12 +74,15 @@ stdenv.mkDerivation (finalAttrs: {
       libmodbus = "${modbus}/lib";
       netsnmp = "${net-snmp.lib}/lib";
     })
+    # Vendored until https://github.com/networkupstools/nut/pull/3499 merges upstream
+    ./CVE-2026-54161.patch
   ];
 
   buildInputs = [
     avahi
     freeipmi
     gd
+    glib
     libtool
     libusb1
     modbus
@@ -109,6 +113,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-systemdsystemunitdir=$(out)/lib/systemd/system"
     "--with-systemdshutdowndir=$(out)/lib/systemd/system-shutdown"
     "--with-systemdtmpfilesdir=$(out)/lib/tmpfiles.d"
+    "--with-systemdsysusersdir=$(out)/lib/sysusers.d/"
     "--with-udev-dir=$(out)/etc/udev"
     "--with-user=nutmon"
     "--with-group=nutmon"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Release: https://github.com/networkupstools/nut/releases/tag/v2.8.5
https://github.com/networkupstools/nut/compare/v2.8.4...v2.8.5
Fixes: https://github.com/networkupstools/nut/security/advisories/GHSA-mjgp-j4gm-6qg5 per the reporter https://www.openwall.com/lists/oss-security/2026/07/01/10
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
