### PR TITLE
python3Packages.qemu{,-qmp}: fix build / bin imports

### DIFF
--- a/pkgs/development/python-modules/qemu-qmp/default.nix
+++ b/pkgs/development/python-modules/qemu-qmp/default.nix
@@ -4,6 +4,10 @@
   fetchFromGitLab,
   setuptools,
   setuptools-scm,
+  tuiSupport ? false,
+  urwid,
+  urwid-readline,
+  pygments,
 }:
 
 buildPythonPackage rec {
@@ -23,7 +27,25 @@ buildPythonPackage rec {
     setuptools-scm
   ];
 
+  propagatedBuildInputs =
+    [ ]
+    ++ lib.optionals tuiSupport [
+      pygments
+      urwid
+      urwid-readline
+    ];
+
+  # Make sure all binaries have their necessary inputs
+  checkPhase = ''
+    for bin in $out/bin/*; do
+      $bin --help
+    done
+  '';
   pythonImportsCheck = [ "qemu.qmp" ];
+
+  preFixup = lib.optionalString (!tuiSupport) ''
+    rm $out/bin/qmp-tui
+  '';
 
   meta = {
     description = "Asyncio library for communicating with QEMU Monitor Protocol (“QMP”) servers";

--- a/pkgs/development/python-modules/qemu/default.nix
+++ b/pkgs/development/python-modules/qemu/default.nix
@@ -2,13 +2,10 @@
   lib,
   buildPythonPackage,
   qemu,
+  qemu-qmp,
   setuptools,
   fuseSupport ? false,
   fusepy,
-  tuiSupport ? false,
-  urwid,
-  urwid-readline,
-  pygments,
 }:
 
 buildPythonPackage {
@@ -33,14 +30,7 @@ buildPythonPackage {
 
   buildInputs = [ setuptools ];
 
-  propagatedBuildInputs =
-    [ ]
-    ++ lib.optionals fuseSupport [ fusepy ]
-    ++ lib.optionals tuiSupport [
-      urwid
-      urwid-readline
-      pygments
-    ];
+  propagatedBuildInputs = [ qemu-qmp ] ++ lib.optionals fuseSupport [ fusepy ];
 
   # Project requires avocado-framework for testing, therefore replacing check phase
   checkPhase = ''
@@ -51,13 +41,9 @@ buildPythonPackage {
 
   pythonImportsCheck = [ "qemu" ];
 
-  preFixup =
-    (lib.optionalString (!tuiSupport) ''
-      rm $out/bin/qmp-tui
-    '')
-    + (lib.optionalString (!fuseSupport) ''
-      rm $out/bin/qom-fuse
-    '');
+  preFixup = lib.optionalString (!fuseSupport) ''
+    rm $out/bin/qom-fuse
+  '';
 
   meta = {
     homepage = "https://www.qemu.org/";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9295,7 +9295,6 @@ with pkgs;
   qemu-python-utils = python3Packages.toPythonApplication (
     python3Packages.qemu.override {
       fuseSupport = true;
-      tuiSupport = true;
     }
   );
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This fixes the build for the qemu python package and makes sure that all bins in the qemu-qmp package work. It seems that the qmp-tui related stuff got moved to qmp.

That being said, I don't use any of this, so I'm not sure if it really works or anybody still wants it (considering it's been broken for a month with no issue reported).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
