### PR TITLE
codex-relay: init at 0.5.6

### DIFF
--- a/pkgs/by-name/co/codex-relay/package.nix
+++ b/pkgs/by-name/co/codex-relay/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "codex-relay";
+  version = "0.5.6";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "MetaFARS";
+    repo = "codex-relay";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JjrtQev2lujweV3dNiPC5ZV+LTPHX4BjWASfrI4/zy8=";
+  };
+
+  cargoHash = "sha256-Ihdm2GhUhxlZw61w01Nakod4ZIAdHeBv2rCCrMQrC7I=";
+
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = with lib; {
+    description = "Responses API ↔  Chat Completions translation bridge for Codex CLI";
+    longDescription = ''
+      A lightweight Rust proxy that translates the OpenAI Responses API
+      (used by Codex CLI) into the Chat Completions API, letting Codex work
+      with any OpenAI-compatible provider —  DeepSeek, Kimi, Qwen, Mistral,
+      Groq, xAI, OpenRouter, and more.
+    '';
+    homepage = "https://github.com/MetaFARS/codex-relay";
+    changelog = "https://github.com/MetaFARS/codex-relay/releases/tag/v${finalAttrs.version}";
+    license = licenses.mit;
+    mainProgram = "codex-relay";
+    maintainers = [ maintainers.andrewzah ];
+  };
+})


### PR DESCRIPTION
* init [codex-relay](https://github.com/MetaFARS/codex-relay) at v0.4.1

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
