### PR TITLE
python3Packages.shutilwhich: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/shutilwhich/default.nix
+++ b/pkgs/development/python-modules/shutilwhich/default.nix
@@ -2,13 +2,14 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
   pytest,
 }:
 
 buildPythonPackage rec {
   pname = "shutilwhich";
   version = "1.1.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mbr";
@@ -16,6 +17,8 @@ buildPythonPackage rec {
     rev = version;
     sha256 = "05fwcjn86w8wprck04iv1zccfi39skdf0lhwpb4b9gpvklyc9mj0";
   };
+
+  build-system = [ setuptools ];
 
   nativeCheckInputs = [ pytest ];
 

--- a/pkgs/development/python-modules/shutilwhich/default.nix
+++ b/pkgs/development/python-modules/shutilwhich/default.nix
@@ -3,28 +3,28 @@
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
-  pytest,
+  pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "shutilwhich";
   version = "1.1.0";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "mbr";
     repo = "shutilwhich";
-    rev = version;
-    sha256 = "05fwcjn86w8wprck04iv1zccfi39skdf0lhwpb4b9gpvklyc9mj0";
+    tag = finalAttrs.version;
+    hash = "sha256-QNbEPJ37vrTIuhxS4NrUaUTH2A87EjBZvhxxg6xk3BU=";
   };
 
   build-system = [ setuptools ];
 
-  nativeCheckInputs = [ pytest ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
-  checkPhase = ''
-    pytest -rs
-  '';
+  pythonImportsCheck = [ "shutilwhich" ];
 
   meta = {
     description = "Backport of shutil.which";
@@ -32,4 +32,4 @@ buildPythonPackage rec {
     homepage = "https://github.com/mbr/shutilwhich";
     maintainers = with lib.maintainers; [ multun ];
   };
-}
+})


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
