### PR TITLE
python3Packages.showit: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/showit/default.nix
+++ b/pkgs/development/python-modules/showit/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
   numpy,
   matplotlib,
   pytest,
@@ -10,7 +11,7 @@
 buildPythonPackage {
   pname = "showit";
   version = "1.1.4";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "freeman-lab";
@@ -19,7 +20,9 @@ buildPythonPackage {
     sha256 = "0xd8isrlwwxlgji90lly1sq4l2a37rqvhsmyhv7bd3aj1dyjmdr6";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     numpy
     matplotlib
   ];

--- a/pkgs/development/python-modules/showit/default.nix
+++ b/pkgs/development/python-modules/showit/default.nix
@@ -5,7 +5,7 @@
   setuptools,
   numpy,
   matplotlib,
-  pytest,
+  pytestCheckHook,
 }:
 
 buildPythonPackage {
@@ -13,11 +13,13 @@ buildPythonPackage {
   version = "1.1.4";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "freeman-lab";
     repo = "showit";
     rev = "ef76425797c71fbe3795b4302c49ab5be6b0bacb"; # no tags in repo
-    sha256 = "0xd8isrlwwxlgji90lly1sq4l2a37rqvhsmyhv7bd3aj1dyjmdr6";
+    hash = "sha256-JrcqfQtSjbbOhr5quHE+QwlKsA6eUpCifLRzTrOOqHU=";
   };
 
   build-system = [ setuptools ];
@@ -27,11 +29,9 @@ buildPythonPackage {
     matplotlib
   ];
 
-  nativeCheckInputs = [ pytest ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
-  checkPhase = ''
-    pytest test
-  '';
+  pythonImportsCheck = [ "showit" ];
 
   meta = {
     description = "Simple and sensible display of images";


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
