### PR TITLE
various: fix more ld64 hardening build failures

### DIFF
--- a/pkgs/by-name/fl/fltk_1_3/package.nix
+++ b/pkgs/by-name/fl/fltk_1_3/package.nix
@@ -35,6 +35,8 @@
   withShared ? true,
 
   nix-update-script,
+  # TODO: Clean up on `staging`
+  llvmPackages,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -68,6 +70,10 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals withDocs [
     doxygen
     graphviz
+  ]
+  # TODO: Clean up on `staging`
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    llvmPackages.lld
   ];
 
   buildInputs =
@@ -139,6 +145,12 @@ stdenv.mkDerivation (finalAttrs: {
 
     # RPATH of binary /nix/store/.../bin/... contains a forbidden reference to /build/
     (lib.cmakeBool "CMAKE_SKIP_BUILD_RPATH" true)
+  ]
+  # Fix for ld64 hardening issue
+  #
+  # TODO: Clean up on `staging`
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    (lib.cmakeFeature "CMAKE_LINKER_TYPE" "LLD")
   ];
 
   preBuild = lib.optionalString (withCairo && withShared && stdenv.hostPlatform.isDarwin) ''

--- a/pkgs/by-name/fl/fltk_1_4/package.nix
+++ b/pkgs/by-name/fl/fltk_1_4/package.nix
@@ -46,6 +46,8 @@
   withExamples ? (stdenv.buildPlatform == stdenv.hostPlatform),
 
   nix-update-script,
+  # TODO: Clean up on `staging`
+  llvmPackages,
 }:
 
 # pango support depends on Xft
@@ -84,6 +86,10 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals withDocs [
     doxygen
     graphviz
+  ]
+  # TODO: Clean up on `staging`
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    llvmPackages.lld
   ];
 
   buildInputs =
@@ -169,6 +175,12 @@ stdenv.mkDerivation (finalAttrs: {
 
     # RPATH of binary /nix/store/.../bin/... contains a forbidden reference to /build/
     (lib.cmakeBool "CMAKE_SKIP_BUILD_RPATH" true)
+  ]
+  # Fix for ld64 hardening issue
+  #
+  # TODO: Clean up on `staging`
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    (lib.cmakeFeature "CMAKE_LINKER_TYPE" "LLD")
   ];
 
   postBuild = lib.optionalString withDocs ''

--- a/pkgs/by-name/gt/gtk-mac-integration/package.nix
+++ b/pkgs/by-name/gt/gtk-mac-integration/package.nix
@@ -9,6 +9,8 @@
   gtk ? gtk3,
   gtk3,
   gobject-introspection,
+  # TODO: Clean up on `staging`
+  llvmPackages,
 }:
 
 stdenv.mkDerivation rec {
@@ -28,6 +30,8 @@ stdenv.mkDerivation rec {
     pkg-config
     gtk-doc
     gobject-introspection
+    # TODO: Clean up on `staging`
+    llvmPackages.lld
   ];
   buildInputs = [ glib ];
   propagatedBuildInputs = [ gtk ];
@@ -35,6 +39,13 @@ stdenv.mkDerivation rec {
   preAutoreconf = ''
     gtkdocize
   '';
+
+  # Fix for ld64 hardening issue
+  #
+  # TODO: Clean up on `staging`
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    NIX_CFLAGS_LINK = "-fuse-ld=lld";
+  };
 
   meta = {
     description = "Provides integration for GTK applications into the Mac desktop";

--- a/pkgs/by-name/gt/gtk2/package.nix
+++ b/pkgs/by-name/gt/gtk2/package.nix
@@ -27,6 +27,8 @@
   gdktarget ? if stdenv.hostPlatform.isDarwin then "quartz" else "x11",
   cupsSupport ? config.gtk2.cups or stdenv.hostPlatform.isLinux,
   xineramaSupport ? stdenv.hostPlatform.isLinux,
+  # TODO: Clean up on `staging`
+  llvmPackages,
 }:
 
 let
@@ -56,13 +58,19 @@ stdenv.mkDerivation (finalAttrs: {
     gtkCleanImmodulesCache
   ];
 
-  nativeBuildInputs = finalAttrs.setupHooks ++ [
-    gdk-pixbuf
-    gettext
-    gobject-introspection
-    perl
-    pkg-config
-  ];
+  nativeBuildInputs =
+    finalAttrs.setupHooks
+    ++ [
+      gdk-pixbuf
+      gettext
+      gobject-introspection
+      perl
+      pkg-config
+    ]
+    # TODO: Clean up on `staging`
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      llvmPackages.lld
+    ];
 
   patches = [
     ./patches/2.0-immodules.cache.patch
@@ -120,12 +128,19 @@ stdenv.mkDerivation (finalAttrs: {
     "ac_cv_path_GDK_PIXBUF_CSOURCE=${buildPackages.gdk-pixbuf.dev}/bin/gdk-pixbuf-csource"
   ];
 
-  env = lib.optionalAttrs stdenv.cc.isGNU {
-    NIX_CFLAGS_COMPILE = toString [
-      "-Wno-error=implicit-int"
-      "-Wno-error=incompatible-pointer-types"
-    ];
-  };
+  env =
+    lib.optionalAttrs stdenv.cc.isGNU {
+      NIX_CFLAGS_COMPILE = toString [
+        "-Wno-error=implicit-int"
+        "-Wno-error=incompatible-pointer-types"
+      ];
+    }
+    # Fix for ld64 hardening issue
+    #
+    # TODO: Clean up on `staging`
+    // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+      NIX_CFLAGS_LINK = "-fuse-ld=lld";
+    };
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/mo/moltenvk/package.nix
+++ b/pkgs/by-name/mo/moltenvk/package.nix
@@ -17,6 +17,8 @@
   # but that’s not really a concern for nixpkgs, so use them by default.
   # See: https://github.com/KhronosGroup/MoltenVK/blob/main/README.md#metal_private_api
   enablePrivateAPIUsage ? true,
+  # TODO: Clean up on `staging`
+  llvmPackages,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -35,7 +37,11 @@ stdenv.mkDerivation (finalAttrs: {
     vulkan-headers
   ];
 
-  nativeBuildInputs = [ xcbuildHook ];
+  nativeBuildInputs = [
+    xcbuildHook
+    # TODO: Clean up on `staging`
+    llvmPackages.lld
+  ];
 
   outputs = [
     "out"
@@ -113,6 +119,11 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ lib.optional enablePrivateAPIUsage "-DMVK_USE_METAL_PRIVATE_API=1"
   );
+
+  # Fix for ld64 hardening issue
+  #
+  # TODO: Clean up on `staging`
+  env.NIX_CFLAGS_LINK = "-fuse-ld=lld";
 
   env.NIX_LDFLAGS = toString [
     "-lglslang"

--- a/pkgs/development/compilers/swift/compiler/default.nix
+++ b/pkgs/development/compilers/swift/compiler/default.nix
@@ -37,6 +37,8 @@
   DarwinTools,
   apple-sdk_14,
   darwinMinVersionHook,
+  # TODO: Clean up on `staging`
+  lld,
 }:
 
 let
@@ -252,6 +254,8 @@ stdenv.mkDerivation {
     DarwinTools # sw_vers
     fixDarwinDylibNames
     cctools.libtool
+    # TODO: Clean up on `staging`
+    lld
   ];
 
   buildInputs = [
@@ -562,6 +566,12 @@ stdenv.mkDerivation {
     #   Fixed in: https://github.com/apple/swift/commit/84083afef1de5931904d5c815d53856cdb3fb232
     cmakeFlags="
       -GNinja
+      ${
+        # Fix for ld64 hardening issue
+        #
+        # TODO: Clean up on staging
+        lib.optionalString stdenv.hostPlatform.isDarwin "-DCMAKE_LINKER_TYPE=LLD"
+      }
       -DBOOTSTRAPPING_MODE=BOOTSTRAPPING${lib.optionalString stdenv.hostPlatform.isDarwin "-WITH-HOSTLIBS"}
       -DSWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING=ON
       -DSWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY=ON

--- a/pkgs/development/compilers/swift/default.nix
+++ b/pkgs/development/compilers/swift/default.nix
@@ -15,7 +15,8 @@ let
     inherit stdenv;
 
     swift-unwrapped = callPackage ./compiler {
-      inherit (llvmPackages) stdenv;
+      # TODO: Clean up on `staging`
+      inherit (llvmPackages) stdenv lld;
       inherit (darwin) DarwinTools sigtool;
     };
 

--- a/pkgs/development/libraries/gstreamer/base/default.nix
+++ b/pkgs/development/libraries/gstreamer/base/default.nix
@@ -46,6 +46,8 @@
   hotdoc,
   directoryListingUpdater,
   apple-sdk_gstreamer,
+  # TODO: Clean up on `staging`
+  llvmPackages,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -87,6 +89,10 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals enableWayland [
     wayland-scanner
+  ]
+  # TODO: Clean up on `staging`
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    llvmPackages.lld
   ];
 
   buildInputs = [
@@ -158,6 +164,14 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional (!enableAlsa) "-Dalsa=disabled"
   ++ lib.optional (!enableCdparanoia) "-Dcdparanoia=disabled"
   ++ lib.optional stdenv.hostPlatform.isDarwin "-Ddrm=disabled";
+
+  # Fix for ld64 hardening issue
+  #
+  # TODO: Clean up on `staging`
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    CC_LD = "lld";
+    OBJC_LD = "lld";
+  };
 
   postPatch = ''
     patchShebangs \

--- a/pkgs/development/libraries/gstreamer/core/default.nix
+++ b/pkgs/development/libraries/gstreamer/core/default.nix
@@ -33,6 +33,8 @@
   hotdoc,
   directoryListingUpdater,
   apple-sdk_gstreamer,
+  # TODO: Clean up on `staging`
+  llvmPackages,
 }:
 
 let
@@ -84,6 +86,10 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals enableDocumentation [
     hotdoc
+  ]
+  # TODO: Clean up on `staging`
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    llvmPackages.lld
   ];
 
   buildInputs = [
@@ -116,6 +122,14 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonEnable "libunwind" withLibunwind)
     (lib.mesonEnable "libdw" (withLibunwind && hasElfutils))
   ];
+
+  # Fix for ld64 hardening issue
+  #
+  # TODO: Clean up on `staging`
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    CC_LD = "lld";
+    OBJC_LD = "lld";
+  };
 
   postPatch = ''
     patchShebangs \

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -66,6 +66,8 @@
   gst-plugins-good,
   directoryListingUpdater,
   apple-sdk_gstreamer,
+  # TODO: Clean up on `staging`
+  llvmPackages,
 }:
 
 let
@@ -137,6 +139,10 @@ stdenv.mkDerivation (finalAttrs: {
   )
   ++ lib.optionals enableWayland [
     wayland-protocols
+  ]
+  # TODO: Clean up on `staging`
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    llvmPackages.lld
   ];
 
   buildInputs = [
@@ -265,6 +271,13 @@ stdenv.mkDerivation (finalAttrs: {
       # linking error on Darwin
       # https://github.com/NixOS/nixpkgs/pull/70690#issuecomment-553694896
       "-lncurses";
+  }
+  // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    # Fix for ld64 hardening issue
+    #
+    # TODO: Clean up on `staging`
+    CC_LD = "lld";
+    OBJC_LD = "lld";
   };
 
   # fails 1 tests with "Unexpected critical/warning: g_object_set_is_valid_property: object class 'GstRtpStorage' has no property named ''"

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -20,6 +20,8 @@
   which,
   # darwin support
   xcbuild,
+  # TODO: Clean up on `staging`
+  llvmPackages,
 
   dbus,
   fontconfig,
@@ -192,6 +194,8 @@ stdenv.mkDerivation (
       ]
       ++ lib.optionals stdenv.hostPlatform.isDarwin [
         xcbuild
+        # TODO: Clean up on `staging`
+        llvmPackages.lld
       ];
 
     }
@@ -373,6 +377,12 @@ stdenv.mkDerivation (
         # if dependency paths contain the string "pq", which can occur in the hash.
         # To prevent these failures, we need to override PostgreSQL detection.
         PSQL_LIBS = "-L${libpq}/lib -lpq";
+      }
+      // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+        # Fix for ld64 hardening issue
+        #
+        # TODO: Clean up on `staging`
+        NIX_CFLAGS_LINK = "-fuse-ld=lld";
       };
 
       prefixKey = "-prefix ";

--- a/pkgs/tools/security/pinentry/mac.nix
+++ b/pkgs/tools/security/pinentry/mac.nix
@@ -10,6 +10,8 @@
   common-updater-scripts,
   writers,
   re-plistbuddy,
+  # TODO: Clean up on `staging`
+  llvmPackages,
 }:
 
 stdenv.mkDerivation rec {
@@ -47,6 +49,8 @@ stdenv.mkDerivation rec {
     makeBinaryWrapper
     texinfo
     re-plistbuddy
+    # TODO: Clean up on `staging`
+    llvmPackages.lld
   ];
 
   configureFlags = [
@@ -55,6 +59,11 @@ stdenv.mkDerivation rec {
     "--with-libgpg-error-prefix=${libgpg-error.dev}"
     "--with-libassuan-prefix=${libassuan.dev}"
   ];
+
+  # Fix for ld64 hardening issue
+  #
+  # TODO: Clean up on `staging`
+  env.NIX_CFLAGS_LINK = "-fuse-ld=lld";
 
   installPhase = ''
     mkdir -p $out/Applications $out/bin


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Continuation of #537396, see #537396 and #536363 for more info. Wasn't quite able to fix `swiftPackages.swift`, only the unwrapped version. There was something up with the wrapper ignoring `-fuse-ld=lld` which means that I need to figure something out.

Rebuilds are because the swift build script is weird and it was non-trivial and ugly to make the linux derivation be exactly the same.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
