### PR TITLE
python3Packages.facenet-pytorch: cleanup, fix

### DIFF
--- a/pkgs/development/python-modules/facenet-pytorch/default.nix
+++ b/pkgs/development/python-modules/facenet-pytorch/default.nix
@@ -1,34 +1,50 @@
 {
-  buildPythonPackage,
-  fetchPypi,
-  pillow,
-  torchvision,
   lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  pillow,
+  requests,
+  torchvision,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "facenet-pytorch";
   version = "2.5.3";
-  format = "setuptools";
+  pyproject = true;
+  __structuredAttrs = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-mMxbQqSPg3wCPrkvKlcc1KxqRmh8XnG56ZtJEIcnPis=";
+  src = fetchFromGitHub {
+    owner = "timesler";
+    repo = "facenet-pytorch";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-3YVyqKgVLD5aePwyVQA8kOiqx32kqg9lxU2uwPWGkCU=";
   };
 
-  doCheck = false; # pypi version doesn't ship with tests
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    pillow
+    requests
+    torchvision
+  ];
 
   pythonImportsCheck = [ "facenet_pytorch" ];
 
-  propagatedBuildInputs = [
-    pillow
-    torchvision
-  ];
+  # The only tests require internet access
+  doCheck = false;
 
   meta = {
     description = "Pretrained Pytorch face detection (MTCNN) and facial recognition (InceptionResnet) models";
     homepage = "https://github.com/timesler/facenet-pytorch";
+    changelog = "https://github.com/timesler/facenet-pytorch/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})


### PR DESCRIPTION
## Things done

Preparation for #536976.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
