### PR TITLE
vtk: fix build with gdal-3.13; vtk_9_6: 9.6.0 -> 9.6.2; python3Packages.vtk: drop wslink; vtk: propagate qttools;

### DIFF
--- a/pkgs/by-name/pa/parmmg/package.nix
+++ b/pkgs/by-name/pa/parmmg/package.nix
@@ -10,10 +10,13 @@
   metis,
   mmg,
   scotch,
-  vtk-full,
+  vtk,
   withVtk ? true,
   testers,
 }:
+let
+  vtk-mpi = vtk.override { mpiSupport = true; };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "parmmg";
   version = "1.5.0";
@@ -53,10 +56,10 @@ stdenv.mkDerivation (finalAttrs: {
     scotch
     (mmg.override {
       inherit withVtk;
-      vtk = vtk-full;
+      vtk = vtk-mpi;
     })
   ]
-  ++ lib.optional withVtk vtk-full;
+  ++ lib.optional withVtk vtk-mpi;
 
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))

--- a/pkgs/development/libraries/vtk/default.nix
+++ b/pkgs/development/libraries/vtk/default.nix
@@ -19,8 +19,8 @@ in
   };
 
   vtk_9_6 = mkVtk {
-    version = "9.6.0";
-    sourceSha256 = "sha256-130YBpT6r9yBZXi5pTZR9nkOeZYVgRv7uRAYZho7uPI=";
+    version = "9.6.2";
+    sourceSha256 = "sha256-rtEs7BKpYJF5v2YykHAmZifKZCRKEIVqRSsqF/+wSh0=";
     patches = [
       (fetchpatch {
         name = "fix-gdal-3.13-const-conversion.patch";

--- a/pkgs/development/libraries/vtk/default.nix
+++ b/pkgs/development/libraries/vtk/default.nix
@@ -1,6 +1,6 @@
 {
   callPackage,
-  fetchpatch2,
+  fetchpatch,
 }:
 let
   mkVtk = initArgs: callPackage (import ./generic.nix initArgs) { };
@@ -9,10 +9,24 @@ in
   vtk_9_5 = mkVtk {
     version = "9.5.2";
     sourceSha256 = "sha256-zuZLmNJw/3MC2vHvE0WN/11awey0XUdyODX399ViyYk=";
+    patches = [
+      (fetchpatch {
+        name = "fix-gdal-3.13-const-conversion.patch";
+        url = "https://github.com/Kitware/VTK/commit/2395603fdddc40c29efc64c632ae98225ca2a58e.patch";
+        hash = "sha256-Gcnt1JXWPkhfNLhtk9SXYqx/0cLkjO4xiRfR8YiaY8I=";
+      })
+    ];
   };
 
   vtk_9_6 = mkVtk {
     version = "9.6.0";
     sourceSha256 = "sha256-130YBpT6r9yBZXi5pTZR9nkOeZYVgRv7uRAYZho7uPI=";
+    patches = [
+      (fetchpatch {
+        name = "fix-gdal-3.13-const-conversion.patch";
+        url = "https://github.com/Kitware/VTK/commit/2395603fdddc40c29efc64c632ae98225ca2a58e.patch";
+        hash = "sha256-Gcnt1JXWPkhfNLhtk9SXYqx/0cLkjO4xiRfR8YiaY8I=";
+      })
+    ];
   };
 }

--- a/pkgs/development/libraries/vtk/generic.nix
+++ b/pkgs/development/libraries/vtk/generic.nix
@@ -169,7 +169,6 @@ stdenv.mkDerivation (finalAttrs: {
     libxrender
     libxcursor
   ]
-  ++ lib.optional withQt6 qt6.qttools
   ++ lib.optional mpiSupport mpi
   ++ lib.optional pythonSupport tk;
 
@@ -219,6 +218,7 @@ stdenv.mkDerivation (finalAttrs: {
     libx11
     gl2ps
   ]
+  ++ lib.optionals withQt6 [ qt6.qttools ]
   # create meta package providing dist-info for python3Pacakges.vtk that common cmake build does not do
   ++ lib.optionals pythonSupport [
     (python3Packages.mkPythonMetaPackage {
@@ -319,7 +319,6 @@ stdenv.mkDerivation (finalAttrs: {
         package = finalAttrs.finalPackage;
 
         nativeBuildInputs = lib.optionals withQt6 [
-          qt6.qttools
           qt6.wrapQtAppsHook
         ];
       };

--- a/pkgs/development/libraries/vtk/generic.nix
+++ b/pkgs/development/libraries/vtk/generic.nix
@@ -227,7 +227,6 @@ stdenv.mkDerivation (finalAttrs: {
         with python3Packages;
         [
           numpy
-          wslink
           matplotlib
         ]
         ++ lib.optional mpiSupport (mpi4py.override { inherit mpi; });

--- a/pkgs/development/libraries/vtk/generic.nix
+++ b/pkgs/development/libraries/vtk/generic.nix
@@ -218,6 +218,9 @@ stdenv.mkDerivation (finalAttrs: {
     libx11
     gl2ps
   ]
+  ++ lib.optionals ((lib.versionAtLeast finalAttrs.version "9.6.0") && stdenv.hostPlatform.isLinux) [
+    libxcursor
+  ]
   ++ lib.optionals withQt6 [ qt6.qttools ]
   # create meta package providing dist-info for python3Pacakges.vtk that common cmake build does not do
   ++ lib.optionals pythonSupport [


### PR DESCRIPTION
see also

fix build with gdal-3.13: https://gitlab.archlinux.org/archlinux/packaging/packages/vtk/-/commit/f40ada914dd594276d0c7ead63e8e33bc47105a2
do not propagate wslink: https://github.com/Kitware/wslink/pull/165#issuecomment-3769609059
propagate qttools: https://github.com/NixOS/nixpkgs/pull/536748
propagate libxcursor: https://github.com/NixOS/nixpkgs/pull/501661


some clean up before we bump vtk = vtk_9_6

nixpkgs-reviewing on my poor aarch64-linux machine.

Closes #542507 
Closes #542757

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
