### PR TITLE
haskell.packages.ghc{96,98}.haskell-language-server: fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -228,13 +228,16 @@ in
           self.retrie
           self.floskell
           self.markdown-unlit
+          self.stan
+          self.trial
         ] super.haskell-language-server;
         hls-plugin-api = super.hls-plugin-api;
         hlint = self.hlint_3_8;
         lsp-types = super.lsp-types;
-        ormolu = self.ormolu_0_7_4_0;
+        ormolu = doJailbreak self.ormolu_0_7_4_0;
         retrie = doJailbreak (unmarkBroken super.retrie);
-        stylish-haskell = self.stylish-haskell_0_14_6_0;
+        stan = super.stan;
+        stylish-haskell = doJailbreak self.stylish-haskell_0_14_6_0;
       }
     )
     apply-refact
@@ -247,6 +250,7 @@ in
     lsp-types
     ormolu
     retrie
+    stan
     stylish-haskell
     ;
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -132,13 +132,16 @@ in
           self.retrie
           self.floskell
           self.markdown-unlit
+          self.stan
+          self.trial
         ] super.haskell-language-server;
         hls-plugin-api = super.hls-plugin-api;
         hlint = self.hlint_3_8;
         lsp-types = super.lsp-types;
-        ormolu = self.ormolu_0_7_4_0;
+        ormolu = doJailbreak self.ormolu_0_7_4_0;
         retrie = doJailbreak (unmarkBroken super.retrie);
-        stylish-haskell = self.stylish-haskell_0_14_6_0;
+        stan = super.stan;
+        stylish-haskell = doJailbreak self.stylish-haskell_0_14_6_0;
       }
     )
     apply-refact
@@ -151,6 +154,7 @@ in
     lsp-types
     ormolu
     retrie
+    stan
     stylish-haskell
     ;
 }


### PR DESCRIPTION
Jailbreaks are due to optparse-applicative.

## Things done

- Built on platform:
  - [x] x86_64-linux
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
