### PR TITLE
chromium: enable AV1 hw decoder on aarch64

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -964,9 +964,11 @@ let
         ffmpeg_branding = "Chrome";
       }
       // lib.optionalAttrs stdenv.hostPlatform.isAarch64 {
-        # Enable v4l2 video decoder for hardware acceleratation on aarch64:
+        # Enable v4l2 video decoder for hardware acceleration on aarch64:
         use_vaapi = false;
         use_v4l2_codec = true;
+        # Chromium's Linux default enables this via VA-API, but aarch64 uses V4L2 here.
+        use_av1_hw_decoder = true;
       }
       // lib.optionalAttrs pulseSupport {
         use_pulseaudio = true;


### PR DESCRIPTION
## Description of changes

Enable Chromium's AV1 hardware decoder build flag on aarch64-linux, where nixpkgs already selects V4L2 video decoding instead of VA-API.

Chromium's upstream Linux default enables `use_av1_hw_decoder` through the VA-API path. On aarch64-linux we set `use_vaapi=false` and `use_v4l2_codec=true`, so AV1 V4L2 support needs the flag explicitly.

Arch Linux ARM enables the same V4L2 decoder path in its Chromium PKGBUILD:

https://github.com/archlinuxarm/PKGBUILDs/commit/dd4db472e49c3b7a8b623cf6eb36052ba0575505

## Things done

- Evaluated aarch64 Chromium GN flags and confirmed `use_vaapi=false`, `use_v4l2_codec=true`, `use_av1_hw_decoder=true`
- Tested on rockchip rk3588 boards, chrome://gpu;chrome://media-internal; cat /proc/interrupts both proved hardware decoding with av1 works

<img width="989" height="450" alt="image" src="https://github.com/user-attachments/assets/744235cb-656b-41c2-bf95-22bacc2c46d1" />

```command
qbisi@h89k ~ $ cat /proc/interrupts|grep video
149:      17708          0          0          0          0          0          0          0    GICv3 127 Level     fdc38100.video-codec
150:          0          0          0          0          0          0          0          0    GICv3 151 Level     fdb50000.video-codec
152:          0          0          0          0          0          0          0          0    GICv3 154 Level     fdba0000.video-codec
156:       5034          0          0          0          0          0          0          0    GICv3 140 Level     fdc70000.video-codec
```

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
