### PR TITLE
python3Packages.swi-tools: init at 1.6

### DIFF
--- a/pkgs/development/python-modules/swi-tools/default.nix
+++ b/pkgs/development/python-modules/swi-tools/default.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  versionCheckHook,
+  hatchling,
+  cryptography,
+  jsonschema,
+  pyparsing,
+  pyyaml,
+  typer,
+  zip,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "swi-tools";
+  version = "1.6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "aristanetworks";
+    repo = "swi-tools";
+    # master branch is at 1.6, they don't have a v1.6 branch/tag
+    rev = "6db86f5983426d272e541a61e0add79b3fec5b1e";
+    hash = "sha256-enWxDrTFWxJCwHF8NjH2UvZ/cxJnldF5nxm+Xzmu4xY=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    cryptography
+    jsonschema
+    pyparsing
+    pyyaml
+    typer
+    zip
+  ];
+
+  # verify.py uses importlib.resources.files(__name__) but __name__ is
+  # "switools.verify" (a module, not a package).  The cert lives in the
+  # "switools" package directory, so we need to reference that instead.
+  postPatch = ''
+    substituteInPlace src/switools/verify.py \
+      --replace-fail 'import importlib' 'import importlib, importlib.resources' \
+      --replace-fail 'importlib.resources.files(__name__)' 'importlib.resources.files("switools")'
+  '';
+
+  # Importing verify triggers the importlib.resources cert load,
+  # so this catches the exact bug we patched above.
+  pythonImportsCheck = [
+    "switools"
+    "switools.verify"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    zip
+    versionCheckHook
+  ];
+
+  meta = {
+    description = "Scripts for operating on an Arista SWI or SWIX";
+    homepage = "https://github.com/aristanetworks/swi-tools";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jherland ];
+    mainProgram = "swi-tools";
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19455,6 +19455,8 @@ self: super: with self; {
 
   swh-web-client = callPackage ../development/python-modules/swh-web-client { };
 
+  swi-tools = callPackage ../development/python-modules/swi-tools { };
+
   swift = callPackage ../development/python-modules/swift { };
 
   swifter = callPackage ../development/python-modules/swifter { };


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
