### PR TITLE
gdash, tamatool: fixup build after splitting SDL2_ttf.dev

### DIFF
--- a/pkgs/by-name/gd/gdash/package.nix
+++ b/pkgs/by-name/gd/gdash/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
     SDL2_image
   ];
 
-  env.NIX_CFLAGS_COMPILE = " -I${SDL2_image}/include/SDL2";
+  env.NIX_CFLAGS_COMPILE = " -I${lib.getInclude SDL2_image}/include/SDL2";
 
   doCheck = true;
 

--- a/pkgs/by-name/ta/tamatool/package.nix
+++ b/pkgs/by-name/ta/tamatool/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-Clinux"
     "VERSION=${finalAttrs.version}"
     "CFLAGS+=-I${lib.getInclude SDL2}/include/SDL2"
-    "CFLAGS+=-I${SDL2_image}/include/SDL2"
+    "CFLAGS+=-I${lib.getInclude SDL2_image}/include/SDL2"
     "DIST_PATH=$(out)"
     "CC=${stdenv.cc.targetPrefix}cc"
   ];


### PR DESCRIPTION

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
