### PR TITLE
croc: 10.4.5 -> 10.4.6

### DIFF
--- a/pkgs/by-name/cr/croc/package.nix
+++ b/pkgs/by-name/cr/croc/package.nix
@@ -11,16 +11,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "croc";
-  version = "10.4.5";
+  version = "10.4.6";
 
   src = fetchFromGitHub {
     owner = "schollz";
     repo = "croc";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-EbOjLR9xQMY2D+roK/Fv1so5FZwZ2RmNetLxq0WIw2g=";
+    hash = "sha256-+KG1PHUymeoAj92UAn/sitQF6xC1xwl+cdisxy2ZtPs=";
   };
 
-  vendorHash = "sha256-SVljsV7xxVVQsn1ii4ShnFVFQDAFSZJe14HJ/6TQi7c=";
+  vendorHash = "sha256-rwGunSDIgetBsk97LxQz0WHpzMDMMESHC1OhBWRuVjI=";
 
   subPackages = [ "." ];
 

--- a/pkgs/by-name/cr/croc/package.nix
+++ b/pkgs/by-name/cr/croc/package.nix
@@ -70,7 +70,6 @@ buildGoModule (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       equirosa
-      SuperSandro2000
       ryan4yin
       kaynetik
     ];

--- a/pkgs/by-name/cr/croc/package.nix
+++ b/pkgs/by-name/cr/croc/package.nix
@@ -72,6 +72,7 @@ buildGoModule (finalAttrs: {
       equirosa
       SuperSandro2000
       ryan4yin
+      kaynetik
     ];
     mainProgram = "croc";
   };


### PR DESCRIPTION
### Updates croc from 10.4.5 to 10.4.6

The `10.4.5` source hash started mismatching after upstream moved the `v10.4.5` git tag (reported in #537047, and independently in the r-ryantm auto-update -- FYI @NickCao ).

Rather than re-pinning the moved tag, this bumps to 10.4.6 to pull the `resume fix` (schollz/croc#1144) and avoid depending on a tag whose contents already proved unstable.
 Both `src.hash` and `vendorHash` are updated.

Changelog: https://github.com/schollz/croc/releases/tag/v10.4.6

Additional **WARNING**, this also introduces me (@kaynetik) as a maintainer, as I'd like to join you on this specific tool which I use every single day. 
In the past there was some reluctance towards me joining as maintainer on other packages, so if any of you do not wish to see me having elevated perms on `croc`, feel free to drop the separate commit for it. 🔥 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
