### PR TITLE
mkdocs-build-plantml: 1.11.0 -> 2.1.0

### DIFF
--- a/pkgs/development/python-modules/mkdocs-build-plantuml/default.nix
+++ b/pkgs/development/python-modules/mkdocs-build-plantuml/default.nix
@@ -10,20 +10,20 @@
 
 buildPythonPackage rec {
   pname = "mkdocs-build-plantuml";
-  version = "1.11.0";
+  version = "2.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "christo-ph";
     repo = "mkdocs_build_plantuml";
     tag = version;
-    hash = "sha256-cbyxvWBIV+v81m+xGZZsUypkM1uuj4ADMUrAYlc/XBI=";
+    hash = "sha256-KTtZXeMZwbrx1M6Keu9BzT3GmarsVx9kEmn63rwHatI=";
   };
 
   # There's only one substitution, no patch is needed.
   postPatch = ''
     substituteInPlace mkdocs_build_plantuml_plugin/plantuml.py \
-      --replace-fail '/usr/local/bin/plantuml' '${lib.getExe pkgs.plantuml}'
+      --replace-fail "shutil.which('plantuml') or 'plantuml'" "'${lib.getExe pkgs.plantuml}'"
   '';
 
   build-system = [ setuptools ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update the Python package `mkdocs-build-plantuml`. Changelog: <https://github.com/christo-ph/mkdocs_build_plantuml/blob/master/CHANGELOG.md#210---2026-02-24>

Note the initial package creation in:

- #428250

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] ~Tested basic functionality of all binary files, usually in `./result/bin/`.~
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] ~Module update: when the change is significant.~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].


- [x] Tested on a local (private) project through `nix build .#manual --override-input nixpkgs /home/nixos/nixpkgs/`


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

This is another attempt after
- #537750