### PR TITLE
folia-major: init at 0.5.26

### DIFF
--- a/pkgs/by-name/fo/folia-major/package.nix
+++ b/pkgs/by-name/fo/folia-major/package.nix
@@ -1,0 +1,115 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  nodejs,
+  npmHooks,
+  makeWrapper,
+  electron,
+  copyDesktopItems,
+  makeDesktopItem,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "folia-major";
+  version = "0.5.26";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "chthollyphile";
+    repo = "folia-major";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-0G7Mh34xW8kx3iP7V5u9qSqKdzqSsciVBW/g+0z7YVY=";
+  };
+
+  npmDeps = fetchNpmDeps {
+    inherit (finalAttrs) src;
+    hash = "sha256-ihFIXw9y2Ab+Z6CecBxFqcEGU4+sdy41hQoaknpCpb4=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    npmHooks.npmConfigHook
+    makeWrapper
+    copyDesktopItems
+  ];
+
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+    ELECTRON_DEV = "false";
+    ELECTRON = "true";
+  };
+
+  # workaround for https://github.com/electron/electron/issues/31121
+  postPatch = ''
+    substituteInPlace electron/main.cjs \
+      --replace-fail "process.resourcesPath" "'$out/lib/folia-major/resources'"
+
+    substituteInPlace vite.config.ts \
+      --replace-fail "git rev-parse --short HEAD" "echo unknown" \
+      --replace-fail "git rev-parse --abbrev-ref HEAD" "echo main"
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    npm run build
+    npm exec electron-builder -- \
+      --dir \
+      -c.electronDist=${electron.dist} \
+      -c.electronVersion=${electron.version}
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/folia-major
+    cp -r release/*-unpacked/{locales,resources{,.pak}} $out/lib/folia-major/
+
+    install -D build/icon.png $out/share/icons/hicolor/512x512/apps/folia-major.png
+
+    makeWrapper '${lib.getExe electron}' $out/bin/folia-major \
+      --add-flags $out/lib/folia-major/resources/app.asar \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true --wayland-text-input-version=3}}" \
+      --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
+      --set-default ELECTRON_IS_DEV 0 \
+      --inherit-argv0
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "folia-major";
+      desktopName = "Folia";
+      exec = "folia-major";
+      terminal = false;
+      type = "Application";
+      icon = "folia-major";
+      startupWMClass = "folia";
+      comment = "Lyrics Reimagine";
+      categories = [
+        "AudioVideo"
+        "Player"
+      ];
+    })
+  ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--use-github-releases" ]; };
+
+  meta = {
+    description = "Lyrics Reimagine desktop app";
+    homepage = "https://folia-site.vercel.app/";
+    downloadPage = "https://github.com/chthollyphile/folia-major/releases";
+    license = lib.licenses.agpl3Only;
+    mainProgram = "folia-major";
+    maintainers = with lib.maintainers; [ chillcicada ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
init [folia-major](https://github.com/chthollyphile/folia-major) at 0.5.26

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
