### PR TITLE
bendsql: init at 0.34.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18912,6 +18912,11 @@
     githubId = 45770;
     name = "Mitsuhiro Nakamura";
   };
+  mnixry = {
+    github = "mnixry";
+    githubId = 32300164;
+    name = "Mix";
+  };
   MNThomson = {
     github = "MNThomson";
     githubId = 73045936;

--- a/pkgs/by-name/be/bendsql/package.nix
+++ b/pkgs/by-name/be/bendsql/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  rustPlatform,
+  fetchCrate,
+  pkg-config,
+  sqlite,
+  versionCheckHook,
+  nix-update-script,
+  testers,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "bendsql";
+  version = "0.34.2";
+
+  src = fetchCrate {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-TSHUts54DfgWMTHuCUzjRdDVx6QXpOm+5Lhli6rlnqQ=";
+  };
+
+  cargoHash = "sha256-ST2ybXxXMd5MRFaITEoFRw0/yx+dOkff6vVm3mW87A4=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ sqlite ];
+
+  env = {
+    BENDSQL_BUILD_INFO = "nixpkgs";
+    LIBSQLITE3_SYS_USE_PKG_CONFIG = "1";
+  };
+
+  postPatch = ''
+    substituteInPlace build.rs \
+      --replace-fail "BuildBuilder::default().build_timestamp(true).build()?" \
+                     "BuildBuilder::default().build_timestamp(false).build()?"
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  passthru = {
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      command = "bendsql --version";
+    };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Native command-line client for Databend";
+    mainProgram = "bendsql";
+    homepage = "https://github.com/databendlabs/bendsql";
+    changelog = "https://github.com/databendlabs/bendsql/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ mnixry ];
+  };
+})


### PR DESCRIPTION
Add `bendsql` 0.34.0, Databend's native command-line client. Packaged from crates.io with `rustPlatform.buildRustPackage`, using nixpkgs SQLite instead of bundled SQLite.

Assisted-by: OpenAI Codex

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
