### PR TITLE
ostui: 1.3.3 -> 1.3.4

### DIFF
--- a/pkgs/by-name/os/ostui/package.nix
+++ b/pkgs/by-name/os/ostui/package.nix
@@ -8,24 +8,25 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "ostui";
-  version = "1.3.3";
+  version = "1.3.4";
 
   src = fetchFromSourcehut {
     owner = "~ser";
     repo = "ostui";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-Zm7j4s+GLILLnH+CjF8JsJB4APYeWV7TyCUkKLW2SGQ=";
+    hash = "sha256-+8YZiFV86SuTYQT+FTMo55dQy/W35hD+mcJp8MUz17s=";
   };
 
-  vendorHash = "sha256-yhoTwouYlv2VkCWmvwvvpbQmrFwzwpraf0EV2Tegq94=";
+  vendorHash = "sha256-cCyOG6nqlw2DPbA1dCuki5cpDy9LmZV/3YGyB3nCreI=";
 
-  nativeBuildInputs = [
-    pkg-config
-  ];
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ pkg-config ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ mpv-unwrapped ];
 
-  buildInputs = [
-    mpv-unwrapped
-  ];
+  postConfigure = lib.optionalString stdenv.hostPlatform.isLinux ''
+    substituteInPlace vendor/github.com/gen2brain/go-mpv/purego_linux.go \
+      --replace-warn '"libmpv.so"' '"${lib.getLib mpv-unwrapped}/lib/libmpv.so"' \
+      --replace-warn '"libmpv.so.2"' '"${lib.getLib mpv-unwrapped}/lib/libmpv.so.2"'
+  '';
 
   ldflags = [
     "-s"
@@ -33,9 +34,7 @@ buildGoModule (finalAttrs: {
     "-X main.Version=${finalAttrs.version}"
   ];
 
-  env = {
-    CGO_ENABLED = "1";
-  };
+  env.CGO_ENABLED = if stdenv.hostPlatform.isLinux then "0" else "1";
 
   doCheck = !stdenv.hostPlatform.isDarwin;
 


### PR DESCRIPTION
Upstream:
```
a07607a4 — Sean E. Russell
change: go-mpv v0.3.1 fixes several issues and ostui can now use nocgo; CI updated to use nocgo for Linux.
```

Note: This PR now also switches the build to use `nocgo` (`CGO_ENABLED = "0"`). Because the vendored `go-mpv` uses `purego` to dynamically load `libmpv` at runtime, `pkg-config` was dropped, and `postPatch` is used to point the `purego` bindings directly to the absolute path of `mpv-unwrapped` in the Nix store.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
