### PR TITLE
apfel-llm: 1.7.0 -> 1.8.3

### DIFF
--- a/pkgs/by-name/ap/apfel-llm/package.nix
+++ b/pkgs/by-name/ap/apfel-llm/package.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "apfel-llm";
-  version = "1.7.0";
+  version = "1.8.3";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   # Building from source requires swift 6.3.0 while nixpkgs only has 5.10.1
   src = fetchurl {
     url = "https://github.com/Arthur-Ficial/apfel/releases/download/v${finalAttrs.version}/apfel-${finalAttrs.version}-arm64-macos.tar.gz";
-    hash = "sha256-q0DvI+D52Rz/LWQDX/oVRWJqeepJY8+CLOWrZT4yInk=";
+    hash = "sha256-1AA86f5+Poo5YCrtxT1rAPGBctQbNa5hdAZmI008/yU=";
   };
 
   sourceRoot = ".";


### PR DESCRIPTION
Bumps apfel-llm `1.7.0` -> `1.8.3`.

Release notes: https://github.com/Arthur-Ficial/apfel/releases/tag/v1.8.3

Opened by the package maintainer (I maintain apfel-llm). r-ryantm cannot auto-update this package: it is `meta.platforms = [ "aarch64-darwin" ]` only, so the bot's x86_64-linux worker refuses to evaluate it and never opens a PR (its log: https://nixpkgs-update-logs.nix-community.org/apfel-llm/ - "Refusing to evaluate ... hostPlatform.system = x86_64-linux"). The merge bot's "opened by r-ryantm or a committer" precondition is therefore unsatisfiable here, so a committer merge is appreciated whenever one has a moment. Only `pkgs/by-name` is touched.

## Things done

- Built on platform:
  - [x] aarch64-darwin
- [x] Tested basic functionality of all binary files (`./result/bin/apfel --version` -> `apfel v1.8.3`, via `versionCheckHook`)
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy] (disclosure below).

## Automation/AI disclosure

The version + SRI-hash bump is produced by a deterministic update script equivalent to this package's `passthru.updateScript` (`nix-update-script`) and yields the identical diff - exempt as standard update-script automation. It was build-verified on aarch64-darwin before opening (`nix-build -A apfel-llm`). This PR was opened by the apfel project's release automation and the PR summary was assisted by an AI agent (Claude Code, Claude Opus 4.8); the package maintainer is the responsible person in the loop and is accountable for this change.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy