### PR TITLE
gcc: 15 -> 16

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -16,6 +16,8 @@
   +nixpkgs.url = "https://channels.nixos.org/nixos-26.05/nixexprs.tar.zst";
   ```
 
+- GCC has been updated from GCC 15 to GCC 16. This introduces some backwards-incompatible changes. Refer to the [upstream porting guide](https://gcc.gnu.org/gcc-16/porting_to.html) for details.
+
 - Emacs has been updated to 31.
   This introduces some backwards‐incompatible changes; see the NEWS for details.
   NEWS can be viewed from Emacs by typing `C-h n`, or by clicking `Help->Emacs News` from the menu bar.

--- a/pkgs/os-specific/linux/minimal-bootstrap/gcc/glibc.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gcc/glibc.nix
@@ -22,7 +22,7 @@
 }:
 let
   pname = "gcc";
-  version = "15.3.0";
+  version = "16.2.0";
   linkerName =
     {
       i686-linux = "ld-linux.so.2";
@@ -32,7 +32,7 @@ let
 
   src = fetchurl {
     url = "mirror://gnu/gcc/gcc-${version}/gcc-${version}.tar.xz";
-    hash = "sha256-+lnBvu+JlfJ8TXHB3yJ1hxiTFdPm+v8btDBuYbDFMOs=";
+    hash = "sha256-5nOOKVl/czJwcxqpBgDzf/3ARQed/CfsfoGSzIEIXD4=";
   };
 
   gmpVersion = "6.3.0";

--- a/pkgs/os-specific/linux/minimal-bootstrap/gcc/latest.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gcc/latest.nix
@@ -21,11 +21,11 @@
 }:
 let
   pname = "gcc";
-  version = "15.3.0";
+  version = "16.2.0";
 
   src = fetchurl {
     url = "mirror://gnu/gcc/gcc-${version}/gcc-${version}.tar.xz";
-    hash = "sha256-+lnBvu+JlfJ8TXHB3yJ1hxiTFdPm+v8btDBuYbDFMOs=";
+    hash = "sha256-5nOOKVl/czJwcxqpBgDzf/3ARQed/CfsfoGSzIEIXD4=";
   };
 
   gmpVersion = "6.3.0";

--- a/pkgs/stdenv/linux/stdenv-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/stdenv-bootstrap-tools.nix
@@ -135,6 +135,9 @@ stdenv.mkDerivation (finalAttrs: {
     cp -d ${bootGCC.lib}/lib/libstdc++.so* $out/lib
     cp -d ${bootGCC.out}/lib/libssp.a* $out/lib
     cp -d ${bootGCC.out}/lib/libssp_nonshared.a $out/lib
+    cp -d ${bootGCC.lib}/lib/libgcc_s_asneeded.so $out/lib
+    cp -d ${bootGCC.lib}/lib/libatomic_asneeded.so $out/lib
+    cp -d ${bootGCC.out}/lib/libatomic.a* $out/lib
     cp -rd ${bootGCC.out}/lib/gcc $out/lib
     chmod -R u+w $out/lib
     rm -f $out/lib/gcc/*/*/include*/linux
@@ -156,15 +159,6 @@ stdenv.mkDerivation (finalAttrs: {
     cp -d ${mpfr.out}/lib/libmpfr*.so* $out/lib
     cp -d ${libmpc.out}/lib/libmpc*.so* $out/lib
     cp -d ${zlib.out}/lib/libz.so* $out/lib
-
-  ''
-  + lib.optionalString (stdenv.hostPlatform.isRiscV) ''
-    # libatomic is required on RiscV platform for C/C++ atomics and pthread
-    # even though they may be translated into native instructions.
-    cp -d ${bootGCC.out}/lib/libatomic.a* $out/lib
-
-  ''
-  + ''
     cp -d ${bzip2.out}/lib/libbz2.so* $out/lib
 
     # Copy binutils.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3215,7 +3215,7 @@ with pkgs;
   gerbilPackages-unstable = pkgs.gerbil-support.gerbilPackages-unstable; # NB: don't recurseIntoAttrs for (unstable!) libraries
   glow-lang = pkgs.gerbilPackages-unstable.glow-lang;
 
-  default-gcc-version = 15;
+  default-gcc-version = 16;
   gcc = pkgs.${"gcc${toString default-gcc-version}"};
   gccFun = callPackage ../development/compilers/gcc;
   gcc-unwrapped = gcc.cc;


### PR DESCRIPTION
changes: https://gcc.gnu.org/gcc-16/changes.html
porting guide: https://gcc.gnu.org/gcc-16/porting_to.html

see https://github.com/NixOS/nixpkgs/pull/537781#issuecomment-5076411068 for a reasonably up-to-date triaging of current failures.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
