### PR TITLE
revanity-go: init at 0-unstable-2026-03-30

### DIFF
--- a/pkgs/by-name/re/revanity-go/package.nix
+++ b/pkgs/by-name/re/revanity-go/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  libsodium,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "revanity-go";
+  version = "0-unstable-2026-03-30";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "ratspeak";
+    repo = "revanity-go";
+    rev = "0689c73bdc95fe14957f67075891cc6653f3568c";
+    hash = "sha256-utf9YcVCdWj78oDGxRSvTXRRXnUPLMypk77yBdOI24c=";
+  };
+
+  vendorHash = null;
+
+  buildInputs = [
+    libsodium
+  ];
+
+  ldflags = [ "-s" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Go implementation of Revanity, a Reticulum/LXMF vanity address generator";
+    homepage = "https://github.com/ratspeak/revanity-go";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ drupol ];
+    mainProgram = "revanity-go";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
