### PR TITLE
Update license of OCaml

### DIFF
--- a/pkgs/development/compilers/ocaml/generic.nix
+++ b/pkgs/development/compilers/ocaml/generic.nix
@@ -214,10 +214,7 @@ stdenv.mkDerivation (
     meta = {
       homepage = "https://ocaml.org/";
       branch = versionNoPatch;
-      license = with lib.licenses; [
-        qpl # compiler
-        lgpl2 # library
-      ];
+      license = lib.licenses.lgpl21;
       description = "OCaml is an industrial-strength programming language supporting functional, imperative and object-oriented styles";
 
       maintainers = [ lib.maintainers.georgyo ];


### PR DESCRIPTION
OCaml has switched away from QPL to LGPL2.1 around 10 years ago: https://github.com/ocaml/ocaml/commit/7fc2d214c4ee8853615fc3e5649f45e11d85378d at the 4.04 release.

Nixpkgs does not have such old versions so might as well set the version for all of them to `lgpl21`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
