### PR TITLE
top-level/stage: abort lazily in internallyDisallowedAttrPathsOverlay

### DIFF
--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -319,15 +319,36 @@ let
     if config.attrPathsDisallowedForInternalUse == [ ] then
       { }
     else
+      let
+        # Abort only when this derivation, or one of its `outputs`, is instantiated.
+        # That is, when a `drvPath`, `outPath`, or `shellPath` is evaluated.
+        # Not to be confused with `lib.warnOnInstantiate`, which warns on much more than just instantiation.
+        abortOnInstantiate =
+          msg: drv:
+          let
+            paths = lib.filter (name: drv ? ${name}) [
+              "drvPath"
+              "outPath"
+              "shellPath"
+            ];
+          in
+          drv
+          // lib.genAttrs paths (name: abort msg drv.${name})
+          // lib.genAttrs (drv.outputs or [ ]) (name: abortOnInstantiate msg drv.${name})
+          // {
+            ${if lib.isFunction (drv.override or null) then "override" else null} =
+              args: abortOnInstantiate msg (drv.override args);
+            ${if lib.isFunction (drv.overrideAttrs or null) then "overrideAttrs" else null} =
+              args: abortOnInstantiate msg (drv.overrideAttrs args);
+          };
+      in
       lib.updateManyAttrsByPath (map (
         { attrPath, reason }:
         {
           path = attrPath;
-          update =
-            _:
-            abort "${lib.concatStringsSep "." attrPath} is disallowed from being used within Nixpkgs${
-              lib.optionalString (reason != null) ", because ${reason}"
-            }";
+          update = abortOnInstantiate "${lib.showAttrPath attrPath} is disallowed from being used within Nixpkgs${
+            lib.optionalString (reason != null) ", because ${reason}"
+          }";
         }
       ) config.attrPathsDisallowedForInternalUse) prev;
 


### PR DESCRIPTION
Followup to https://github.com/NixOS/nixpkgs/pull/533376#issuecomment-4861272438, I noticed in https://github.com/NixOS/nixpkgs/pull/522364 that inheriting a problematic package's `version` was enough to [trigger](https://github.com/NixOS/nixpkgs/actions/runs/28551752960/job/84650353939#step:7:443?pr=522364) the abort.

There's a debate to be had about what kinda relationships should require re-declaring dependencies' problems. My view is that depending on derivation outputs requires declaring a problem, while inheriting metadata from a problem-package could easily be inlined if/when that package is removed, so should not require declaring a problem.

---

~~Instead of replacing internally disallowed attrs entirely with an abort, we now lazily abort on access while preserving a small allowlist of metadata attributes.~~ **EDIT:** After discussion around the intended semantics of `lib.warnOnInstantiate`, I've changed the implementation to take a different approach.

Instead of replacing internally disallowed attrs with an immediate abort, we now abort lazily when a derivation (or one of its outputs) is instantiated. This preserves access to metadata and helper attributes while still preventing dependencies on the derivation's outputs.

Unlike `lib.warnOnInstantiate`, this only intercepts instantiation (i.e. evaluation of `drvPath`, `outPath`, `shellPath`, or an output's corresponding paths), rather than warning on most interactions with the derivation.

I also refactored the abort message to use `lib.showAttrPath` instead of `concatStringsSep "."`, which correctly formats attrpaths containing non-identifier segments.

<details>
<summary>Previous implementation</summary>

The original version of this PR preserved access to a small allowlist of attributes (`version`, `meta`, `passthru`, etc.) by wrapping derivations in a similar fashion to `lib.warnOnInstantiate`.

The current implementation instead preserves the entire derivation object and only aborts at instantiation time, which better matches the intended policy.

</details>

---

Tested in the repl:
```nix
nix-repl> pkgs = import ./. { config.attrPathsDisallowedForInternalUse = [ { attrPath = ["hello"]; reason = "hi!"; } ]; }

nix-repl> pkgs.mold-unwrapped.tests.wrapped
error:
       … while calling the 'derivationStrict' builtin
         at «nix-internal»/derivation-internal.nix:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'mold-wrapped-test'
         whose name attribute is located at /home/matt/nixpkgs/ci/pkgs/stdenv/generic/make-derivation.nix:651:11

       … while evaluating attribute 'buildCommand' of derivation 'mold-wrapped-test'
         at /home/matt/nixpkgs/ci/pkgs/build-support/trivial-builders/default.nix:81:17:
           80|         enableParallelBuilding = true;
           81|         inherit buildCommand name;
             |                 ^
           82|         passAsFile = [ "buildCommand" ] ++ (derivationArgs.passAsFile or [ ]);

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: evaluation aborted with the following error message: 'hello is disallowed from being used within Nixpkgs, because hi!'

nix-repl> pkgs.hello
error: attribute 'hello' missing
       at «string»:1:1:
            1| pkgs.hello
             | ^
       Did you mean one of jello, _3llo, bella, cell or delly?

nix-repl> pkgs.jello
«derivation /nix/store/0kvlydnamlcvxby6i2rmavl8xax37hbv-python3.13-jello-1.6.1.drv»
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
