### PR TITLE
nixpkgs-vet: add Nixpkgs CI team as maintainers

### DIFF
--- a/pkgs/by-name/ni/nixpkgs-vet/package.nix
+++ b/pkgs/by-name/ni/nixpkgs-vet/package.nix
@@ -32,5 +32,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       philiptaron
       willbush
     ];
+    teams = [ lib.teams.ci ];
   };
 })


### PR DESCRIPTION
I noticed I wasn't getting pinged on nixpkgs-vet PRs. @NixOS/nixpkgs-ci are nominally the upstream maintainers, so it makes sense the team would also be package maintainers.

I kept explicit non-team maintainers as-is, even though some of them are also CI team members:
```shell
$ nix-instantiate --eval --strict --json -A nixpkgs-vet.meta.nonTeamMaintainers | jq --raw-output '.[] | .github'
mdaniels5757
philiptaron
willbush
```

```shell
$ nix-instantiate --eval --strict --json -A nixpkgs-vet.meta.maintainers | jq --raw-output '.[] | .github'
mdaniels5757
philiptaron
willbush
MattSturgeon
Mic92
zowoq
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
