### PR TITLE
autosuspend: 10.1.0 -> 11.3.0

### DIFF
--- a/nixos/modules/services/misc/autosuspend.nix
+++ b/nixos/modules/services/misc/autosuspend.nix
@@ -246,6 +246,9 @@ in
   };
 
   meta = {
-    maintainers = with maintainers; [ xlambein ];
+    maintainers = with maintainers; [
+      xlambein
+      adamcstephens
+    ];
   };
 }

--- a/nixos/modules/services/misc/autosuspend.nix
+++ b/nixos/modules/services/misc/autosuspend.nix
@@ -240,7 +240,7 @@ in
       after = [ "network.target" ];
       path = flatten (attrValues (filterAttrs (n: _: hasCheck n) dependenciesForChecks));
       serviceConfig = {
-        ExecStart = "${autosuspend}/bin/autosuspend -l ${autosuspend}/etc/autosuspend-logging.conf -c ${autosuspend-conf} daemon";
+        ExecStart = "${autosuspend}/bin/autosuspend --logging ${autosuspend}/etc/autosuspend-logging.conf daemon --config ${autosuspend-conf}";
       };
     };
   };

--- a/pkgs/by-name/au/autosuspend/package.nix
+++ b/pkgs/by-name/au/autosuspend/package.nix
@@ -100,6 +100,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     maintainers = with lib.maintainers; [
       bzizou
       anthonyroussel
+      adamcstephens
     ];
     mainProgram = "autosuspend";
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/au/autosuspend/package.nix
+++ b/pkgs/by-name/au/autosuspend/package.nix
@@ -11,7 +11,7 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "autosuspend";
-  version = "10.1.0";
+  version = "11.3.0";
   pyproject = true;
 
   outputs = [
@@ -24,7 +24,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     owner = "languitar";
     repo = "autosuspend";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-4mByuJ75hd5TEoKxVglAHlYXZSlbAldMwnIianSw8O4=";
+    hash = "sha256-KG1Cv3Fmdf3VDdZR+k0SeA97g6R+oI6+NgtaWHWPVUQ=";
   };
 
   postPatch = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
