### PR TITLE
﻿music-assistant: 2.9.4 -> 2.9.6; go-librespot: init at 0.7.4

### DIFF
--- a/nixos/modules/services/audio/music-assistant.nix
+++ b/nixos/modules/services/audio/music-assistant.nix
@@ -146,8 +146,11 @@ in
         ++ lib.optionals (lib.elem "airplay_receiver" cfg.providers) [
           shairport-sync
         ]
-        ++ lib.optionals (lib.elem "spotify" cfg.providers || lib.elem "spotify_connect" cfg.providers) [
+        ++ lib.optionals (lib.elem "spotify" cfg.providers) [
           librespot-ma
+        ]
+        ++ lib.optionals (lib.elem "spotify_connect" cfg.providers) [
+          go-librespot
         ]
         ++ lib.optionals (lib.elem "snapcast" cfg.providers) [
           snapcast

--- a/pkgs/by-name/go/go-librespot/package.nix
+++ b/pkgs/by-name/go/go-librespot/package.nix
@@ -1,0 +1,60 @@
+{
+  alsa-lib,
+  buildGoModule,
+  fetchFromGitHub,
+  flac,
+  lib,
+  libogg,
+  libvorbis,
+  pkg-config,
+  stdenv,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "go-librespot";
+  version = "0.7.4";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "devgianlu";
+    repo = "go-librespot";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-TJQMfZRuWDu83QZeCU+EQ90WX6gT5+nXbYRIqfvXRp8=";
+  };
+
+  vendorHash = "sha256-kCzzybOEP4Tp7OGFZBjIP1FgcQ9u+lgO3931gbaG9hA=";
+
+  subPackages = [ "cmd/daemon" ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    flac
+    libogg
+    libvorbis
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    alsa-lib
+  ];
+
+  ldflags = [
+    "-s"
+    "-X github.com/devgianlu/go-librespot.version=v${finalAttrs.version}"
+  ];
+
+  postInstall = ''
+    mv $out/bin/daemon $out/bin/go-librespot
+  '';
+
+  meta = {
+    description = "Yet another open source Spotify client, written in Go";
+    mainProgram = "go-librespot";
+    homepage = "https://github.com/devgianlu/go-librespot";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      sweenu
+      emilylange
+    ];
+  };
+})

--- a/pkgs/by-name/mu/music-assistant/package.nix
+++ b/pkgs/by-name/mu/music-assistant/package.nix
@@ -40,7 +40,7 @@ assert
 
 pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "music-assistant";
-  version = "2.9.4";
+  version = "2.9.6";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -48,7 +48,7 @@ pythonPackages.buildPythonApplication (finalAttrs: {
     owner = "music-assistant";
     repo = "server";
     tag = finalAttrs.version;
-    hash = "sha256-PiSBghhlxknijRqghkO8wn1CB2XqaJrjrvGNvZUlNbo=";
+    hash = "sha256-lEbWQi6iUvqL2MXk/ZqkdX4Ou5pFWIVi6qfSyWCs8uQ=";
   };
 
   patches = [
@@ -146,6 +146,7 @@ pythonPackages.buildPythonApplication (finalAttrs: {
       gql
       ifaddr
       librosa
+      markdownify
       mashumaro
       modern-colorthief
       music-assistant-frontend

--- a/pkgs/by-name/mu/music-assistant/providers.nix
+++ b/pkgs/by-name/mu/music-assistant/providers.nix
@@ -1,7 +1,7 @@
 # Do not edit manually, run ./update-providers.py
 
 {
-  version = "2.9.4";
+  version = "2.9.6";
   builtins = [
     "builtin"
     "coverartarchive"
@@ -272,10 +272,8 @@
       ps: with ps; [
         pkce
       ];
-    spotify_connect =
-      ps: with ps; [
-        pkce
-      ];
+    spotify_connect = ps: [
+    ];
     squeezelite =
       ps: with ps; [
         aioslimproto

--- a/pkgs/development/python-modules/markdownify/default.nix
+++ b/pkgs/development/python-modules/markdownify/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "markdownify";
-  version = "1.2.2";
+  version = "1.2.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "matthewwithanm";
     repo = "python-markdownify";
     tag = finalAttrs.version;
-    hash = "sha256-r6nah7QavrMjIHd5hByhy90OoTDb2iIhFZ+YV0h61fU=";
+    hash = "sha256-zhkWkEFdDLVvA0xgFOG2PDXCTLZy+DWweuiiSVNUU80=";
   };
 
   build-system = [


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
