### PR TITLE
Symmetric mkRocqDerivation / mkCoqDerivation

### DIFF
--- a/pkgs/build-support/coq/default.nix
+++ b/pkgs/build-support/coq/default.nix
@@ -157,27 +157,11 @@ let
   append-version = p: n: p + display-pkg n "" coqPackages.${n}.version + "-";
   prefix-name = foldl append-version "" namePrefix;
   useDune = args.useDune or (useDuneifVersion fetched.version);
-  coqlib-flags =
-    switch coq.coq-version
-      [
-        {
-          case = v: versions.isLe "8.6" v && v != "dev";
-          out = [ "COQLIB=$(out)/lib/coq/${coq.coq-version}/" ];
-        }
-      ]
-      [
-        "COQLIBINSTALL=$(out)/lib/coq/${coq.coq-version}/user-contrib"
-        "COQPLUGININSTALL=$(OCAMLFIND_DESTDIR)"
-      ];
-  docdir-flags =
-    switch coq.coq-version
-      [
-        {
-          case = v: versions.isLe "8.6" v && v != "dev";
-          out = [ "DOCDIR=$(out)/share/coq/${coq.coq-version}/" ];
-        }
-      ]
-      [ "COQDOCINSTALL=$(out)/share/coq/${coq.coq-version}/user-contrib" ];
+  coqlib-flags = [
+    "COQLIBINSTALL=$(out)/lib/coq/${coq.coq-version}/user-contrib"
+    "COQPLUGININSTALL=$(OCAMLFIND_DESTDIR)"
+  ];
+  docdir-flags = [ "COQDOCINSTALL=$(out)/share/coq/${coq.coq-version}/user-contrib" ];
 in
 
 stdenv.mkDerivation (

--- a/pkgs/build-support/coq/default.nix
+++ b/pkgs/build-support/coq/default.nix
@@ -41,7 +41,7 @@ in
   pname,
   version ? null,
   fetcher ? null,
-  owner ? "coq-community",
+  owner ? "rocq-community",
   domain ? "github.com",
   repo ? pname,
   defaultVersion ? null,

--- a/pkgs/build-support/coq/default.nix
+++ b/pkgs/build-support/coq/default.nix
@@ -98,7 +98,6 @@ let
       "dropAttrs"
       "dropDerivationAttrs"
       "keepAttrs"
-      "enableParallelBuilding"
     ]
     ++ dropAttrs
   ) keepAttrs;
@@ -202,10 +201,7 @@ stdenv.mkDerivation (
         );
       buildInputs =
         args.overrideBuildInputs or ([ coq ] ++ (args.buildInputs or [ ]) ++ extraBuildInputs);
-      enableParallelBuilding =
-        lib.warnIf (args ? enableParallelBuilding && args.enableParallelBuilding == true)
-          "mkCoqDerivation: enableParallelBuilding is enabled by default; remove the explicit setting"
-          enableParallelBuilding;
+      inherit enableParallelBuilding;
 
       meta =
         (

--- a/pkgs/build-support/rocq/default.nix
+++ b/pkgs/build-support/rocq/default.nix
@@ -41,7 +41,7 @@ in
   pname,
   version ? null,
   fetcher ? null,
-  owner ? "coq-community",
+  owner ? "rocq-community",
   domain ? "github.com",
   repo ? pname,
   defaultVersion ? null,


### PR DESCRIPTION
This PR contains a bunch of small fixes and clean-ups that make the `mkCoqDerivation` and `mkRocqDerivation` symmetric. See commit log for details and justifications.

This is one small step that should help with implementing #537813.

I haven't tested it yet, but I would be surprised if any of these changes broke anything.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
