### PR TITLE
rekor-tiles: init at 2.3.0

### DIFF
--- a/pkgs/by-name/re/rekor-tiles/package.nix
+++ b/pkgs/by-name/re/rekor-tiles/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+}:
+buildGoModule (finalAttrs: {
+  pname = "rekor-tiles";
+  version = "2.3.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "sigstore";
+    repo = "rekor-tiles";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-YbW6SKxVT+mwAa72bI+z3W6q8ck3H9yXGEFeSEB+2LM=";
+  };
+  vendorHash = "sha256-YVN9vFXyVuDAzjLw8vvyBXcY+aRf/uZ2uKKRRhm2bLE=";
+
+  subPackages = [
+    "cmd/rekor-server/aws"
+    "cmd/rekor-server/gcp"
+    "cmd/rekor-server/gcpcloudsql"
+    "cmd/rekor-server/posix"
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X sigs.k8s.io/release-utils/version.gitVersion=v${finalAttrs.version}"
+    "-X sigs.k8s.io/release-utils/version.gitTreeState=clean"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+
+    for bin in aws gcp gcpcloudsql posix; do
+      mv "$GOPATH/bin/$bin" "$out/bin/rekor-server-$bin"
+    done
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/rekor-server-gcp";
+  versionCheckProgramArg = "version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = with lib; {
+    description = "(v2) Signature Transparency Log designed for ease of use, low cost, and minimal maintenance.";
+    homepage = "https://github.com/sigstore/rekor-tiles";
+    changelog = "https://github.com/sigstore/rekor-tiles/releases/tag/v${finalAttrs.version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ andrewzah ];
+  };
+})


### PR DESCRIPTION
* init [rekor-tiles](https://github.com/sigstore/rekor-tiles) at 2.3.0. This is rekor V2; [`rekor-cli` and `rekor-server`](https://github.com/sigstore/rekor#current-state-of-rekor-v1) are V1, which is in maintenance mode now.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
