### PR TITLE
kdePackages: Gear 26.04.2 -> 26.04.3

### DIFF
--- a/pkgs/kde/generated/sources/gear.json
+++ b/pkgs/kde/generated/sources/gear.json
@@ -1,1257 +1,1257 @@
 {
   "accessibility-inspector": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/accessibility-inspector-26.04.2.tar.xz",
-    "hash": "sha256-zIbBboKd0R8ZDvfTDUR1KeQh2MlA75bsfHPMVapM8sk="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/accessibility-inspector-26.04.3.tar.xz",
+    "hash": "sha256-wl3shPwpoESc4HEI7W4mQzQrMizXE7BlbTrBgbR8x38="
   },
   "akonadi": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/akonadi-26.04.2.tar.xz",
-    "hash": "sha256-zGZuQVLMgqOwc0vDTJpw774XP+Q6ZYLpBYslp0CvqGY="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/akonadi-26.04.3.tar.xz",
+    "hash": "sha256-GWwcJ8Ei0MpOwyDInvg1/sPsc9BCYXp28GflxknP6CQ="
   },
   "akonadi-calendar": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/akonadi-calendar-26.04.2.tar.xz",
-    "hash": "sha256-gwDqiUrNvddJb+/4cOz902hocQSjRC7YKr7wn1jndPo="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/akonadi-calendar-26.04.3.tar.xz",
+    "hash": "sha256-l2m7d2APQijNPSp0tO1Ia7yCDjbY7bOyA9+a/UgFx3k="
   },
   "akonadi-calendar-tools": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/akonadi-calendar-tools-26.04.2.tar.xz",
-    "hash": "sha256-DXTH+cvZPqTEZerqrqhfsZbffh1pJWW83J+dhArMnU4="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/akonadi-calendar-tools-26.04.3.tar.xz",
+    "hash": "sha256-/2m7TEtdZ4Qj/NsLrxbBFJ2vK4A8LEVl0JmcF2VIkns="
   },
   "akonadi-contacts": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/akonadi-contacts-26.04.2.tar.xz",
-    "hash": "sha256-GI8PtRx1bBM8A/lcMW8WuUfEkrSYceEdqifQlaUKjBU="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/akonadi-contacts-26.04.3.tar.xz",
+    "hash": "sha256-izGrIfEYsg/OKCaQTj8V4wCAppFDUZpUQoVgbPAxvN4="
   },
   "akonadi-import-wizard": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/akonadi-import-wizard-26.04.2.tar.xz",
-    "hash": "sha256-2HYUhh+RJ0Q7QEinbebyM69t7cYS+fYLBIP0fdt3Z8o="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/akonadi-import-wizard-26.04.3.tar.xz",
+    "hash": "sha256-g09tywscBuJtgS+k81w5nXhH2Kp650v7pgZPyN0GyRs="
   },
   "akonadi-mime": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/akonadi-mime-26.04.2.tar.xz",
-    "hash": "sha256-/K0qS0qz8t7sn48GlNEeliAJKzPgkjpHv0NFaaibrBQ="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/akonadi-mime-26.04.3.tar.xz",
+    "hash": "sha256-e617/AdnJjW6Dq1qtm8DHys6gAvgIdWwwGmZfNyD9Ys="
   },
   "akonadi-search": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/akonadi-search-26.04.2.tar.xz",
-    "hash": "sha256-FCzkbz2uJi9DJj+AoTulMnZ5EKOeRC/cS5JpOHCDnAQ="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/akonadi-search-26.04.3.tar.xz",
+    "hash": "sha256-hriiOB9kHpap3mHKEGBe/7C+c18TQvTCIF6vYL9HzA4="
   },
   "akonadiconsole": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/akonadiconsole-26.04.2.tar.xz",
-    "hash": "sha256-+j1XfEH+s8aoieVZCwQtE4P9gHK41zdLY0tSbg63kLA="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/akonadiconsole-26.04.3.tar.xz",
+    "hash": "sha256-0nCSqHr02i1eOhXrWnNJcIFDj2VFwthsLy1/8ttTZOU="
   },
   "akregator": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/akregator-26.04.2.tar.xz",
-    "hash": "sha256-KysWrS2LEnRd3EpEsoJQVCtgHh5BE5Z6hCU8n/hafno="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/akregator-26.04.3.tar.xz",
+    "hash": "sha256-xZ19aJnjSxqcWAic0TmDinviLjWP8DZTLIcAhxwYKRA="
   },
   "alligator": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/alligator-26.04.2.tar.xz",
-    "hash": "sha256-ZQLBdjxDvG5uednDE91npyuHo1cdeb/YYITaDeWRPUA="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/alligator-26.04.3.tar.xz",
+    "hash": "sha256-Ica6xnKQPEjJeMHxOq5a/Fj4RfdtVLjSwLrmbos/yqM="
   },
   "analitza": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/analitza-26.04.2.tar.xz",
-    "hash": "sha256-Zum830AFlaA9+txZtF44Cxpsvm+8NSKvDXcu31w17So="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/analitza-26.04.3.tar.xz",
+    "hash": "sha256-YVt8JEpbruC+UhTFO4zjfQpU5ppv1rhDjDDX/aRbB0Y="
   },
   "angelfish": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/angelfish-26.04.2.tar.xz",
-    "hash": "sha256-fpG3Iid8OQlUvW3Dnglc8+oxmpIvRzAR52W5zrshPQM="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/angelfish-26.04.3.tar.xz",
+    "hash": "sha256-EoPqXdp3FSZ7j2btC+ohT2nbgMvgEKyJuHliNR9S8Jk="
   },
   "arianna": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/arianna-26.04.2.tar.xz",
-    "hash": "sha256-xKCcvZY+2I8gQnqTVNJ+/zzeB1ulM2fN0sNipUynZtg="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/arianna-26.04.3.tar.xz",
+    "hash": "sha256-rTT7yQ/8XjZ2x9MW9AIJXO43OdLjgphd09oVjMCiOY4="
   },
   "ark": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/ark-26.04.2.tar.xz",
-    "hash": "sha256-uBxAVUhsmfTyH/IovxJIW8c+jmsAZO3uEEOhGtXR5VU="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/ark-26.04.3.tar.xz",
+    "hash": "sha256-gBj+xpZoqsNeWrfOTlHOBN5qt/VqOZYyKwFvQcMdWgE="
   },
   "artikulate": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/artikulate-26.04.2.tar.xz",
-    "hash": "sha256-vxNOGy3zWLoZEgrhJNo3Y2QvAAdCbsPnqXyB0rzGlMU="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/artikulate-26.04.3.tar.xz",
+    "hash": "sha256-IRaLDhbHzor3g/wo37MCSy4aEpXY1DbP1oTFchcQNdI="
   },
   "audex": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/audex-26.04.2.tar.xz",
-    "hash": "sha256-JzmJHBanjyPGEGc/kODzrrcKGL8zewHz3snKbjWk3xA="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/audex-26.04.3.tar.xz",
+    "hash": "sha256-yO3OPc76X7iw1LZoxe4gk1Iakjf9Y7qEy0JagQMTkzs="
   },
   "audiocd-kio": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/audiocd-kio-26.04.2.tar.xz",
-    "hash": "sha256-U6YITXxKrxJeNywMpb4JR0g7y9dcNSuX+9JM7eNtwtY="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/audiocd-kio-26.04.3.tar.xz",
+    "hash": "sha256-uopvJzEcoU+NHhwhNfqSXhB1xDxkY+ovZBsa895nBDA="
   },
   "audiotube": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/audiotube-26.04.2.tar.xz",
-    "hash": "sha256-rwSSFIJjRjUSFchgTnSrdECcyb8wBVZbKigPzVr+05M="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/audiotube-26.04.3.tar.xz",
+    "hash": "sha256-BLm2Qetv3NB8dymcHwxMSAOjYBTlzKjzJuKOOlox5Dw="
   },
   "baloo-widgets": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/baloo-widgets-26.04.2.tar.xz",
-    "hash": "sha256-fa8+aCG5mIwXGjFstUdZH7osrKeIGMLaHUCWA+qTwAo="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/baloo-widgets-26.04.3.tar.xz",
+    "hash": "sha256-+lKI0hbT7Z7QkmOF28CyZrYDF6YMIxptzK/0vNgQ2fw="
   },
   "blinken": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/blinken-26.04.2.tar.xz",
-    "hash": "sha256-/mGCsn+jHlsswldkTxzkDLuvUA3hYas0mP46sY4F//s="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/blinken-26.04.3.tar.xz",
+    "hash": "sha256-RT/AdcwBrqyYDs3zBkh0ppw1fUbGBFe8QvuXmpVnoLo="
   },
   "bomber": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/bomber-26.04.2.tar.xz",
-    "hash": "sha256-uppzi+IHGa/Ul2BjGSFj26E0iOKlq7dx5wlkjW3BKdI="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/bomber-26.04.3.tar.xz",
+    "hash": "sha256-GpHLCOi6rECe51hEMM7C3inhbT47pFAi74j8Ia8OBos="
   },
   "bovo": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/bovo-26.04.2.tar.xz",
-    "hash": "sha256-AIA/3oL8egCisOLWBqS97TEY25M/IOwM3UhMa5Cylho="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/bovo-26.04.3.tar.xz",
+    "hash": "sha256-uzjy+cPDaU07mGn10dl+2isWITdPWoXOKzCkrvpTVJ0="
   },
   "calendarsupport": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/calendarsupport-26.04.2.tar.xz",
-    "hash": "sha256-dyCnLz9BgIc9QHxWywdtsmgVjyqNINzQZqYV2CheNbk="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/calendarsupport-26.04.3.tar.xz",
+    "hash": "sha256-yw/mUxpIEczDaODD8dWRGPRSS8BRl2cHGIxVvOoMZDs="
   },
   "calindori": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/calindori-26.04.2.tar.xz",
-    "hash": "sha256-F2zNAowKmtxWQH+kFrjvwkZXcJ4eW2XD+UE/GjHdAA4="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/calindori-26.04.3.tar.xz",
+    "hash": "sha256-dnZHj6pnk+i9N8x/YyNJX8dAuIfDOx6qlfkix4YpzHk="
   },
   "calligra": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/calligra-26.04.2.tar.xz",
-    "hash": "sha256-y3hzcaViK4QBqxUTbR6/a5wM8O0yyEDDWgjyN01Z7rg="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/calligra-26.04.3.tar.xz",
+    "hash": "sha256-TH//mvkNelotPFaDsf3JNsYnRZzS8s20/Dg3gixSs0U="
   },
   "cantor": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/cantor-26.04.2.tar.xz",
-    "hash": "sha256-oSJNeArIZX36wPU7/GRarYvufwsr6543MhLJHdL03PY="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/cantor-26.04.3.tar.xz",
+    "hash": "sha256-8OlzRBAHC27LVN/gQoYkBbTvAdZVM8C+A4bRO5/fclA="
   },
   "colord-kde": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/colord-kde-26.04.2.tar.xz",
-    "hash": "sha256-FjHwPbFxKCbQ6G2VDcZQK4xJRrc6OyWgoS2xdHwCnOU="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/colord-kde-26.04.3.tar.xz",
+    "hash": "sha256-94iycCt1makIpi3Icb/JwVDUCUMwer3ePna0oKhsLyQ="
   },
   "dolphin": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/dolphin-26.04.2.tar.xz",
-    "hash": "sha256-x+kL64zhOuoJFJSufd+r3pmbEpeYallkA4KAEL7Fk0Y="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/dolphin-26.04.3.tar.xz",
+    "hash": "sha256-0YV5WH+EHKWlccNhS9oL7tblO/Xe1NRWAJ4YfLudC0Q="
   },
   "dolphin-plugins": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/dolphin-plugins-26.04.2.tar.xz",
-    "hash": "sha256-jFPOGbK5EPCH3kIYDANN2cCHWY07FFgVo+unEwBuIuc="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/dolphin-plugins-26.04.3.tar.xz",
+    "hash": "sha256-Nf6egixqYWCOoZTsm5SbScRLKzt3qHdFSEejBdeWMlI="
   },
   "dragon": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/dragon-26.04.2.tar.xz",
-    "hash": "sha256-V3jqTDBk4eho1V4hZv4990PEr/a14VOyShTxzngCgeM="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/dragon-26.04.3.tar.xz",
+    "hash": "sha256-Jj//WcfvWM/oh7+ufJU64iP84Uvk+FVlZbQ63HAmeZ4="
   },
   "elisa": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/elisa-26.04.2.tar.xz",
-    "hash": "sha256-xZBFZHFByPWOkiBn8D2xCZVnqERdOkwXIkH2O6ToNYI="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/elisa-26.04.3.tar.xz",
+    "hash": "sha256-Nh5PW/43PzQOGOgP41uNfBtsj2WXC4Z6LifoEQPOJdU="
   },
   "eventviews": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/eventviews-26.04.2.tar.xz",
-    "hash": "sha256-0dCxvBe6uIC9fpHBZw251BFI8ZscL5K387qMIS+PUUk="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/eventviews-26.04.3.tar.xz",
+    "hash": "sha256-hPw5AfMg9DW7/3yUhZ7rhPBWg50a7qxcY5CnXcxiTS8="
   },
   "falkon": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/falkon-26.04.2.tar.xz",
-    "hash": "sha256-j5puNlC27j4iZkz9eCBxSKt785xKQhGT9pzVu8zYGeI="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/falkon-26.04.3.tar.xz",
+    "hash": "sha256-3JJIVMqozOqleN6gg+RGMOxIzz0LT2OL18kse67KuQ8="
   },
   "ffmpegthumbs": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/ffmpegthumbs-26.04.2.tar.xz",
-    "hash": "sha256-hloZBLH2ZMcRiXZgPjj/ywpYc3gtQOtoQmh2ejA9jUg="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/ffmpegthumbs-26.04.3.tar.xz",
+    "hash": "sha256-ptehKlfyQRN4kgNBPUCkNVzkwK/1FjhOzSxUjOQvOJs="
   },
   "filelight": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/filelight-26.04.2.tar.xz",
-    "hash": "sha256-6Mj2hoFDY9MhEH/HDbHTTq7T11e7eXZ8Q+eXbAi9b/g="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/filelight-26.04.3.tar.xz",
+    "hash": "sha256-s/spRyU1Zr2kKhXBEczx3wz/cAPpDCms+gX1Csm8A/Y="
   },
   "francis": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/francis-26.04.2.tar.xz",
-    "hash": "sha256-XGqsqegcsr8XCZLVB7khrl8Tzh1l4hLQUvE8GxLegE8="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/francis-26.04.3.tar.xz",
+    "hash": "sha256-Ifgsk6jMto07t3gamnYHVV//njrkdlHrsKCL9JKpH2k="
   },
   "ghostwriter": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/ghostwriter-26.04.2.tar.xz",
-    "hash": "sha256-TTtuV1eYQ6HdUNCdNEZnwHsVEfTc+Cdk29Zh0oiJ1dw="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/ghostwriter-26.04.3.tar.xz",
+    "hash": "sha256-yUiSPZDIqz1cIqQmpKAu//Zjrq7sg2v1mp3Pmj44p78="
   },
   "granatier": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/granatier-26.04.2.tar.xz",
-    "hash": "sha256-//GAMg2If6Gh7CUnRjFvXXX/U/ulmfGduWqGdACjsKI="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/granatier-26.04.3.tar.xz",
+    "hash": "sha256-1hRTGI1rvrY2xpmwpaW/OyjbxMXf15nia9/ltxAPVU0="
   },
   "grantlee-editor": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/grantlee-editor-26.04.2.tar.xz",
-    "hash": "sha256-EoU2GfKo9D1NZgaO5YraK7ab/kRNVdrGoLhEhwrEgP0="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/grantlee-editor-26.04.3.tar.xz",
+    "hash": "sha256-Hh87CGxHAfcO9tcz7FdetNs4bBUlgqVOfm+zrrQa66Q="
   },
   "grantleetheme": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/grantleetheme-26.04.2.tar.xz",
-    "hash": "sha256-qRgwcZqLPk1SzsaVzT/CjwFCmDKB3PI/yWSiOOHTErc="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/grantleetheme-26.04.3.tar.xz",
+    "hash": "sha256-KPkzO4pzJ8ZcUTr72dmkEbeZ/1iDtMmqr8IqznnZRwI="
   },
   "gwenview": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/gwenview-26.04.2.tar.xz",
-    "hash": "sha256-FQtgF0Hx/POq5ej6bb0oroOv4+CRSh6RyE76VTEtmmk="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/gwenview-26.04.3.tar.xz",
+    "hash": "sha256-2r1I4XLPePS0LedCPeVu1HTSQauwgLTStjLF1NTo268="
   },
   "incidenceeditor": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/incidenceeditor-26.04.2.tar.xz",
-    "hash": "sha256-rT2k3VOkfwcsFuJ3/juEGtDj3d8pkGz5SS/vMu5+tmQ="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/incidenceeditor-26.04.3.tar.xz",
+    "hash": "sha256-oUNCu8RTEVOALXTTQF30WfRhFVRXH1WYJIEeUrKIbTY="
   },
   "isoimagewriter": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/isoimagewriter-26.04.2.tar.xz",
-    "hash": "sha256-snFmV4kYYWjqY12m+UFmAZjVm9vNQQRueDlH2AtboIg="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/isoimagewriter-26.04.3.tar.xz",
+    "hash": "sha256-xPiQRaDScgd7L9FgFhlUGeWMciivfUdnhCj9fxLB7jg="
   },
   "itinerary": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/itinerary-26.04.2.tar.xz",
-    "hash": "sha256-L0n9CqgQ4aW/4yFRgoF+nyQgrIzbmTgIiXdot04IIIM="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/itinerary-26.04.3.tar.xz",
+    "hash": "sha256-mtWpIozqUELik+Aai7YfZD6l7+bqTf3386Yr9PWwcpM="
   },
   "juk": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/juk-26.04.2.tar.xz",
-    "hash": "sha256-DTIaDMR7jUAkSfvXAeKjJPMklOrX9co3U6QIncbW3iA="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/juk-26.04.3.tar.xz",
+    "hash": "sha256-k5Y+x1EdhUR39UvM+mzFhMxpNbl3pJiFHPq2aUbouBM="
   },
   "k3b": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/k3b-26.04.2.tar.xz",
-    "hash": "sha256-CAwUTVN3CNyGQEXWKtxyAGzxvcYd8L63VEb8+5Dbwuo="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/k3b-26.04.3.tar.xz",
+    "hash": "sha256-1cruzKG2KnLWzZwJUmKUscXN5KJbuxR9p3Iaj8zyMX4="
   },
   "kaccounts-integration": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kaccounts-integration-26.04.2.tar.xz",
-    "hash": "sha256-f7u1uLAJWIsRS4T0xZE7PkKfsAT5rXzhu9hWRTDfnpY="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kaccounts-integration-26.04.3.tar.xz",
+    "hash": "sha256-79+fFPf6kXhj7/1HsMfr0LSWh+kgUEn/jLhoQF8WM0w="
   },
   "kaccounts-providers": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kaccounts-providers-26.04.2.tar.xz",
-    "hash": "sha256-DT8nj/rIivLbTHun2cq0YiouGduzn70UTx2qEHXK+KA="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kaccounts-providers-26.04.3.tar.xz",
+    "hash": "sha256-ezZOdaViBSky2LLo+uy3zYcWo15xd+QJ424+Yx4fZ3U="
   },
   "kaddressbook": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kaddressbook-26.04.2.tar.xz",
-    "hash": "sha256-z+Yjt0Jz98bKV23LalnKpgWqyswQCz/E4atUM/z4rHg="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kaddressbook-26.04.3.tar.xz",
+    "hash": "sha256-MA4xMgXW64Osm6E0+dMzdB6W7RUYNCzWPQagI07T2dw="
   },
   "kajongg": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kajongg-26.04.2.tar.xz",
-    "hash": "sha256-BvoChpuKIGPI0p086lrv1INF6l+tyCV7sESD+fKImGA="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kajongg-26.04.3.tar.xz",
+    "hash": "sha256-7RbN3MIsHTZqbcUGdO5ycdaK+ZlaKeltDVWf/FutHsI="
   },
   "kalarm": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kalarm-26.04.2.tar.xz",
-    "hash": "sha256-4d9FCuFDa2M4G3V2bSOyrwHyOV6O1tRfvfwWCxXpJTM="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kalarm-26.04.3.tar.xz",
+    "hash": "sha256-a76SrA6ajqQ6RshQ4zRLc13uYKhvX7jMZmoQsPEjxIA="
   },
   "kalgebra": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kalgebra-26.04.2.tar.xz",
-    "hash": "sha256-fDPRQ2+Orew9/ZqfNO1mXB4pirhAuSgjujrAG1ngM4c="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kalgebra-26.04.3.tar.xz",
+    "hash": "sha256-UZAbRAf7XWx65D307yJLBnIzmn04NKe8Rw/rLxabs7Y="
   },
   "kalk": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kalk-26.04.2.tar.xz",
-    "hash": "sha256-Z4IVoDO8E6MAdTBKTDRPJZ1cBy0Vr1efoKp0SW56n2M="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kalk-26.04.3.tar.xz",
+    "hash": "sha256-9WND+/nBmEg9pGN15/F/QLj5KCoC+YExxSrUZq3PWpI="
   },
   "kalm": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kalm-26.04.2.tar.xz",
-    "hash": "sha256-DxVBEhqH3dUYKld1RVCLCIai/H1zMC45+9up+/qII6Q="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kalm-26.04.3.tar.xz",
+    "hash": "sha256-6RqwjmvKsFYtTe+m25+710c2Bpk4L17BK5NuOQPyPVQ="
   },
   "kalzium": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kalzium-26.04.2.tar.xz",
-    "hash": "sha256-Gd6vgxqRFoueaiDerh1njBSaUxKpOR0mGvQO8sHroKY="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kalzium-26.04.3.tar.xz",
+    "hash": "sha256-15EUpC/DWClivshawth3IXcIqUkdUfcxsWbDbIftGiM="
   },
   "kamera": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kamera-26.04.2.tar.xz",
-    "hash": "sha256-cxZvC9Y4pAsEFxXhGsofrGBt+8ZUpBPvyo+GTAbwTq8="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kamera-26.04.3.tar.xz",
+    "hash": "sha256-a2lTgri/J97qGQxIspxj/+rkFvhNoBTeEFzI+Gt6euY="
   },
   "kamoso": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kamoso-26.04.2.tar.xz",
-    "hash": "sha256-StZL2moHQnky3yLwEV57paxYjzMztWkI5xhxchIoRI8="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kamoso-26.04.3.tar.xz",
+    "hash": "sha256-EcNhkjdk5dM9tSTiBLRbg9GoTSI7z2BcK9nItlPpy2Y="
   },
   "kanagram": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kanagram-26.04.2.tar.xz",
-    "hash": "sha256-c6HVBW/QDxN7rCNMthjSSo8+S9ox0D/sAIm7k94Gmrk="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kanagram-26.04.3.tar.xz",
+    "hash": "sha256-7wjqPtJAwqFj4rKr8aGfz72gecjwAPndHhT6tEhR/Q0="
   },
   "kapman": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kapman-26.04.2.tar.xz",
-    "hash": "sha256-wDNiqXm+H8TO0DzfeuTMFph8/XzL8r8fOxBU/RkQ+YI="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kapman-26.04.3.tar.xz",
+    "hash": "sha256-GAOtTPY+EDs2lwRwpml0FAw6f25gyP0d5PR9kwAEo28="
   },
   "kapptemplate": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kapptemplate-26.04.2.tar.xz",
-    "hash": "sha256-/QZU+GvV6HMecJt8CHFttAFo39HSs8Z256X9CR1rrp4="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kapptemplate-26.04.3.tar.xz",
+    "hash": "sha256-6Rel436Me5KDrzD80BdDOglm2dQjbkAh+Bes0nI6VCY="
   },
   "kasts": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kasts-26.04.2.tar.xz",
-    "hash": "sha256-+n+Ypo+FbZPU5HmrA0TCGbOu2Xee/xw838q0gyOmpJE="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kasts-26.04.3.tar.xz",
+    "hash": "sha256-CG5hodBblKUOJ7VBKwGzXIkVjCf/hgH51Z6UxS6TGl4="
   },
   "kate": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kate-26.04.2.tar.xz",
-    "hash": "sha256-8TilsCK2ygViuQO+p7KnlLtrsYuIqSd//K9Bi5tJAY0="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kate-26.04.3.tar.xz",
+    "hash": "sha256-y5VCbLoXD5lHYeUJ40LVI+U6YqgKJSJIs478voq/9iM="
   },
   "katomic": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/katomic-26.04.2.tar.xz",
-    "hash": "sha256-1JpCuHnxcGXZGPlIr6G6ejN/7k/wo6nvj4vI+vIJDKo="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/katomic-26.04.3.tar.xz",
+    "hash": "sha256-k2Jlp17sf4bGYeJ7ADUz2ohOd/You903aW0LmnbzqMs="
   },
   "kbackup": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kbackup-26.04.2.tar.xz",
-    "hash": "sha256-dcN8sZ7gs5sTj+gA2N5Eza1QZ0E/jmslHbJ3jFK1QLQ="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kbackup-26.04.3.tar.xz",
+    "hash": "sha256-ldQxOTgonlIKlLfvVMeOXVudGg/7YXrlu4YwAmfpoHU="
   },
   "kblackbox": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kblackbox-26.04.2.tar.xz",
-    "hash": "sha256-CvgC+4OvSFfthIBkDlpLyWAN88qQpoj5WCJjhW7ILeY="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kblackbox-26.04.3.tar.xz",
+    "hash": "sha256-OtYZnJdxdmK0Km2CqKjzMlQ3IZ4Gr/9DKluhYiExYK4="
   },
   "kblocks": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kblocks-26.04.2.tar.xz",
-    "hash": "sha256-sWqo9soTLP/k7NgAPegHwXhxEkWwMCHqWs00h4TsYmM="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kblocks-26.04.3.tar.xz",
+    "hash": "sha256-Uep+IsAGkEYHw0EW1xB+d631m3Z/K+f/QHP7xxfD5Wg="
   },
   "kbounce": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kbounce-26.04.2.tar.xz",
-    "hash": "sha256-2Br63kjzPuDrdBAf2BJjtNTxnVw6NnjZR6H7ysbRXo4="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kbounce-26.04.3.tar.xz",
+    "hash": "sha256-lnDl0Tm1JkPt9rAp4UeOOnAFIDhmOQoMtDhcZ5N+SNE="
   },
   "kbreakout": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kbreakout-26.04.2.tar.xz",
-    "hash": "sha256-sHA4aosOta4rb3vIYqzr1nDFDp7j+mSnEciDl+Ok5XA="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kbreakout-26.04.3.tar.xz",
+    "hash": "sha256-noExTm9qLR3XHPQkezvoqjPUcjz1RqMaV13TOGhNzJs="
   },
   "kbruch": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kbruch-26.04.2.tar.xz",
-    "hash": "sha256-r4FDC3A+3HAJGlB/kRzmY3e8cg7tPojngaTOi50ds0M="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kbruch-26.04.3.tar.xz",
+    "hash": "sha256-Pq4/mpnq10zVCfh9fJ6cbNkZd+yLbuaM8MgDcda14nM="
   },
   "kcachegrind": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kcachegrind-26.04.2.tar.xz",
-    "hash": "sha256-iaTufsiwdQBnzG4YJuqxhcuX3WsbnrzATlUosF47cHg="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kcachegrind-26.04.3.tar.xz",
+    "hash": "sha256-WgcUgq9MmZCB7KDaeYxFfbM8/HkcEzhZ6MmHfOvSJXc="
   },
   "kcalc": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kcalc-26.04.2.tar.xz",
-    "hash": "sha256-298p2xd02ITi1+5UPGuRnND1eNvVF6RJp5S/hUUJsw0="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kcalc-26.04.3.tar.xz",
+    "hash": "sha256-Rb1j43kervQhp+AXLOJvXfjaW+X10QUssjvnLiVoUgg="
   },
   "kcalutils": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kcalutils-26.04.2.tar.xz",
-    "hash": "sha256-UVww9zVyVeItuYhww3lWzDFd8U7LGKsPR4GyGfIf97w="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kcalutils-26.04.3.tar.xz",
+    "hash": "sha256-qCLRzIwrCK55RMaldPMvkavjobhq3s9w6L6ks1PeiPY="
   },
   "kcharselect": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kcharselect-26.04.2.tar.xz",
-    "hash": "sha256-Tk4QN9oX4zdKg2FQicuaUZNWdaLrJAn/Iq2Y91eP3W4="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kcharselect-26.04.3.tar.xz",
+    "hash": "sha256-N2oxvwPqLWojH9wBLHk/YI9IwBcuNUO4SkTg6bh6ZlE="
   },
   "kclock": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kclock-26.04.2.tar.xz",
-    "hash": "sha256-n1yZhGIxbfRWp+lBOwOTAAA/Qh5yrUCzs5PkP2yVhVg="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kclock-26.04.3.tar.xz",
+    "hash": "sha256-jcZK0w90hJQMG76tfFG7SivjseVucW2m8ZM04Po3Rbg="
   },
   "kcolorchooser": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kcolorchooser-26.04.2.tar.xz",
-    "hash": "sha256-xFQBhwdxylz7YMpHeZdcCNSQyJ3Qw3bTcWs5AP0z3G8="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kcolorchooser-26.04.3.tar.xz",
+    "hash": "sha256-6zny7tL8/diRuJomrVHApDXbQraP+aTZWSEdlm3mUbY="
   },
   "kcron": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kcron-26.04.2.tar.xz",
-    "hash": "sha256-BKNzJBjfHpjg1RdDrtVFK2iQFiCDGY7qqrgSibY7mhM="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kcron-26.04.3.tar.xz",
+    "hash": "sha256-0QiYCP94nbDVYVhRMXdToKRG9catuUfJ3dPwSW0l7ak="
   },
   "kde-dev-scripts": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kde-dev-scripts-26.04.2.tar.xz",
-    "hash": "sha256-tSvhG14XSbPsQKBk7N69JoLAqzXqNMnh8U/94IyTuNo="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kde-dev-scripts-26.04.3.tar.xz",
+    "hash": "sha256-RpejaLZsKSy30cipG46FHN0LYaTmS7+rBHH3XFGKTR8="
   },
   "kde-dev-utils": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kde-dev-utils-26.04.2.tar.xz",
-    "hash": "sha256-9JmmdrFl7rzDhEithfgZkRwfRi1PabwepzQ4CVo2IBA="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kde-dev-utils-26.04.3.tar.xz",
+    "hash": "sha256-/QPkpOl0kgYFPYG3HTo7Rwgd88Vwy47E9L8Y6OsootY="
   },
   "kde-inotify-survey": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kde-inotify-survey-26.04.2.tar.xz",
-    "hash": "sha256-zvhBJr+svzG97qQFvnrTo3zx9b5VTSDoK2HeHpETaIs="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kde-inotify-survey-26.04.3.tar.xz",
+    "hash": "sha256-bl9ijVuS2378qR+/8cFkfpRlS0PQnoYidqPMeM+SVZo="
   },
   "kdebugsettings": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kdebugsettings-26.04.2.tar.xz",
-    "hash": "sha256-1FnX0hjhnvnJ8EOb8OQJ1e/7kA77MNzIKf+b1JQzv3M="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kdebugsettings-26.04.3.tar.xz",
+    "hash": "sha256-E+5dv5L7udegN+evDU2OgoIZFUW+3EhDQ0ypo4yu3uk="
   },
   "kdeconnect-kde": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kdeconnect-kde-26.04.2.tar.xz",
-    "hash": "sha256-RaGXovLn5ADmz0LzUc+SygaAfxAj8XN48SijMUx/wXY="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kdeconnect-kde-26.04.3.tar.xz",
+    "hash": "sha256-UFtYtSYwpmKo9qLFDFjtod5md5diwx1epSR7SLulJWE="
   },
   "kdeedu-data": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kdeedu-data-26.04.2.tar.xz",
-    "hash": "sha256-vn4moU7JEFP0B3CatI7f/pxDfTdL6/DK3BDZ/TGylyI="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kdeedu-data-26.04.3.tar.xz",
+    "hash": "sha256-57f5CqI+5bK1lDADo3b5b6dVkXFst9maIrXvCAIPpRk="
   },
   "kdegraphics-mobipocket": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kdegraphics-mobipocket-26.04.2.tar.xz",
-    "hash": "sha256-EYgZOJ79LSVOTmWG/Qhv88QGEZnXeoc0kM0syMdh45o="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kdegraphics-mobipocket-26.04.3.tar.xz",
+    "hash": "sha256-Js8FjUQewaI3aKRwJpYKC3t3ykDcfeUciam01GOFH5I="
   },
   "kdegraphics-thumbnailers": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kdegraphics-thumbnailers-26.04.2.tar.xz",
-    "hash": "sha256-gtfYrmNFvc5Ws5Vi5nPGkySjJSujrldeYJS/gQyEpG8="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kdegraphics-thumbnailers-26.04.3.tar.xz",
+    "hash": "sha256-vUTEwT4i3Gk2bnbQWz1lYp0HUHo45bpC1gJndW1z7c8="
   },
   "kdenetwork-filesharing": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kdenetwork-filesharing-26.04.2.tar.xz",
-    "hash": "sha256-0FtDgI3Y3gyLNq1vdq9EetdSXJw3+8KWn3LfxKXEcSo="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kdenetwork-filesharing-26.04.3.tar.xz",
+    "hash": "sha256-9WNQIUPilGM6ad3Y/syb7ZGvbGiUyoMeYJN+32sFWDs="
   },
   "kdenlive": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kdenlive-26.04.2.tar.xz",
-    "hash": "sha256-Jy2/gfxLhdJw3tvji8V/03VAuBK6o/K0hTUDHyw3qxg="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kdenlive-26.04.3.tar.xz",
+    "hash": "sha256-yNvIj2wPtznjj6OEDzISoONqqdwnORG8Gevdsfg/Lk4="
   },
   "kdepim-addons": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kdepim-addons-26.04.2.tar.xz",
-    "hash": "sha256-7mlADOvS7ksuGfWlcbvK8SheVxchV1aFIVTAgJyBwD4="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kdepim-addons-26.04.3.tar.xz",
+    "hash": "sha256-A7LjertoM32SsZS8sMcu84BBzocmwKxPinx+0RUAdUY="
   },
   "kdepim-runtime": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kdepim-runtime-26.04.2.tar.xz",
-    "hash": "sha256-XhoTsWV50ly0pmJFqere88jXfth2aaVLtSFc10p7Jhc="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kdepim-runtime-26.04.3.tar.xz",
+    "hash": "sha256-SYdEIo8iUXZiT6+6soOBW2hyNR9tFbuTXi0CwaZE3UM="
   },
   "kdesdk-kio": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kdesdk-kio-26.04.2.tar.xz",
-    "hash": "sha256-IYAkMnZ6RiCFRL83oAgRzjNGPPOpN4yo7OC4jqrGeZQ="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kdesdk-kio-26.04.3.tar.xz",
+    "hash": "sha256-5zz/MLUEJAzgJXMmqjdq10c8vCXxlbuS84PHjdjKgmg="
   },
   "kdesdk-thumbnailers": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kdesdk-thumbnailers-26.04.2.tar.xz",
-    "hash": "sha256-Zg4s3j3HknWrTRJ2xSxHq+AFJbXlZzAe6VitTC3DxTc="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kdesdk-thumbnailers-26.04.3.tar.xz",
+    "hash": "sha256-IGPG314t0hbSRL0w6e73/JT66X8EIN3CDi3a+VghO6c="
   },
   "kdev-php": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kdev-php-26.04.2.tar.xz",
-    "hash": "sha256-rTNpN7bhSKhI1XlOowDn8oQmzzXQzqY/WnKMK5atmLk="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kdev-php-26.04.3.tar.xz",
+    "hash": "sha256-0l1Ow8IPptRWmrbwvraxi9M7NZFJVzSKHV6o4J9KFpM="
   },
   "kdev-python": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kdev-python-26.04.2.tar.xz",
-    "hash": "sha256-AC1TjWIGeJHnuoTI0i6tvi52nfP5oyBb6RfAaB1dVeA="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kdev-python-26.04.3.tar.xz",
+    "hash": "sha256-GtJuzP0cwotM9f+5GyUnObG5VNmpiURuHggJ7NqMWlI="
   },
   "kdevelop": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kdevelop-26.04.2.tar.xz",
-    "hash": "sha256-7WpcbUuaVbQzoaZttpcE4x10InnE52fZ0+jH3hqcXzc="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kdevelop-26.04.3.tar.xz",
+    "hash": "sha256-qUCoOwdSV4+wS3ALjSdAROI1Q6aIUMvESNvcuHSudfQ="
   },
   "kdf": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kdf-26.04.2.tar.xz",
-    "hash": "sha256-9ojym3Qh710GNcNHldd8Mtr7b4PRaDrh63FC/QNPfZc="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kdf-26.04.3.tar.xz",
+    "hash": "sha256-nVmBXLzH5hxzDfV5RBEgFHhbcC1scVpj4ZuicfsPy44="
   },
   "kdialog": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kdialog-26.04.2.tar.xz",
-    "hash": "sha256-Un7P1KmvGQePVfV1iXeCHbzvR6G0lrGhtoDWgSKK3m0="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kdialog-26.04.3.tar.xz",
+    "hash": "sha256-6LbdT1S2udAFGlAUrwaTMjJ3F8Dja7w2Qw7dy7dvIm4="
   },
   "kdiamond": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kdiamond-26.04.2.tar.xz",
-    "hash": "sha256-yAhVUCFiuFZ/pG9bZoO9c+qmJfuKm+uGpSSuQJWmsY4="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kdiamond-26.04.3.tar.xz",
+    "hash": "sha256-R/guXVT3kyLUrV62z5GKIfNKgzFu0sd4/l8L60yTep0="
   },
   "keditbookmarks": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/keditbookmarks-26.04.2.tar.xz",
-    "hash": "sha256-X+9YNcDn/arh4y3DQtN/LtQ4Xg21DJFjlThyuNr3lYE="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/keditbookmarks-26.04.3.tar.xz",
+    "hash": "sha256-Q00wYBIUsGRTZkSN6Tl+bw4BO63jtJyxr4RfanQcTdA="
   },
   "keysmith": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/keysmith-26.04.2.tar.xz",
-    "hash": "sha256-X01kNi8srfvLEYosiL1jJxB2nz38n7BflM1g9z2fqZ4="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/keysmith-26.04.3.tar.xz",
+    "hash": "sha256-z70ANRKulNwXeOZlXOqdd8+1yGC1vzAWAV+ChiBVc7U="
   },
   "kfind": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kfind-26.04.2.tar.xz",
-    "hash": "sha256-KQIRCJCp3ZagF+cfrpsMKK5TyUa5d/P/X1OzDokytVM="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kfind-26.04.3.tar.xz",
+    "hash": "sha256-Ibecg7YL0ULyDt8s84DDd8D8qio0tydAGQWraWIcJ9g="
   },
   "kfourinline": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kfourinline-26.04.2.tar.xz",
-    "hash": "sha256-H/GvKtKsONxYX8ZoKG2HU0zNIFN83OsBDx5JuC9vAyc="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kfourinline-26.04.3.tar.xz",
+    "hash": "sha256-CfHoD/OhHjfgp6J87PiG0NCzkFYKnakwK3kPdLNcGdY="
   },
   "kgeography": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kgeography-26.04.2.tar.xz",
-    "hash": "sha256-O9J/5Xfs5w3GPJQsVjXANcANd0MjbCWeSryS48Kajow="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kgeography-26.04.3.tar.xz",
+    "hash": "sha256-YQBEIw30gnGO2UdsZpBaUgDkDXjWSE6Iux1h73pNauI="
   },
   "kget": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kget-26.04.2.tar.xz",
-    "hash": "sha256-5GQyFN3DxD6to0XuszQYljyfiAkDoEENsjIEI1Ib5mk="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kget-26.04.3.tar.xz",
+    "hash": "sha256-WQ3Ln0D59bsSpnwbHGkNwp0YPJUtotdqqT+J2LicQdg="
   },
   "kgoldrunner": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kgoldrunner-26.04.2.tar.xz",
-    "hash": "sha256-4bLw5rBsnOrXKY3N28sX4OUNR0AEcG5EfbjgFE93SNQ="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kgoldrunner-26.04.3.tar.xz",
+    "hash": "sha256-GcCpBxsp9k3HBe8I4uH9b8QN9VNekYkXYvh9U0JepUg="
   },
   "kgpg": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kgpg-26.04.2.tar.xz",
-    "hash": "sha256-zXTzM5v+AZCPwpfYdwv6rnRgLdxaMbcLcN7b2DHZu78="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kgpg-26.04.3.tar.xz",
+    "hash": "sha256-71ORhRCkudMqXqUkyEy2YhLT9wBnv3IX70NVsIHrmwQ="
   },
   "kgraphviewer": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kgraphviewer-26.04.2.tar.xz",
-    "hash": "sha256-r64vDkvv3oElxVtSvmkInrsCtaH9YAdax1NsO/DQHH4="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kgraphviewer-26.04.3.tar.xz",
+    "hash": "sha256-0QJm9qmO4CNOXt8vPdsnKlCMtyZ5VT0AMP/ryz5Ambk="
   },
   "khangman": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/khangman-26.04.2.tar.xz",
-    "hash": "sha256-kt9EoX9MsM1ir57MFvYWabg/HCWfcJktMfw8dnOdB4w="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/khangman-26.04.3.tar.xz",
+    "hash": "sha256-xb4Kcz6RBoLQ1nptsyNr4sutQtoWw+fBp3CWqz0rgfA="
   },
   "khealthcertificate": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/khealthcertificate-26.04.2.tar.xz",
-    "hash": "sha256-YGHI7vRg/3VVofFeacXAPgCauQcGmhg76WCxgH9VdsM="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/khealthcertificate-26.04.3.tar.xz",
+    "hash": "sha256-tD12cQWj8ae7ilsbqJ/rhQQ5EDt8aFlJqe758b9BJEI="
   },
   "khelpcenter": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/khelpcenter-26.04.2.tar.xz",
-    "hash": "sha256-4/lbbI6qbX40eWUqdi3tdzhK+HR5YXMbQU+sNBTVl5k="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/khelpcenter-26.04.3.tar.xz",
+    "hash": "sha256-sRAaEM7mmcws/Ovdosf9DQtESZilCIaEWuBXrN3KbHk="
   },
   "kidentitymanagement": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kidentitymanagement-26.04.2.tar.xz",
-    "hash": "sha256-9dELwuIIY4ksCnjnB3kKVpHP3C3+feuqp0m/zi5L9/8="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kidentitymanagement-26.04.3.tar.xz",
+    "hash": "sha256-Q5nbOVc+WSGMqLwDsK330evd23z4f25vVTkKtPoO2q0="
   },
   "kig": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kig-26.04.2.tar.xz",
-    "hash": "sha256-CD1n7lWWvK0p81p8pZwHJhBQTPia/aYYwb26kifUNVs="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kig-26.04.3.tar.xz",
+    "hash": "sha256-41fl6JC9laGkTQ1b6LqO7IdF4BjdTlKR93i5YtHxXuA="
   },
   "kigo": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kigo-26.04.2.tar.xz",
-    "hash": "sha256-4niD0dwIV4ougNI0LshHgQBmv22W3gukosb7BMmrQMY="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kigo-26.04.3.tar.xz",
+    "hash": "sha256-colMjWI5rhgoQ6HPWWXWg6e86jCS9OyI5WAtLX8F208="
   },
   "killbots": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/killbots-26.04.2.tar.xz",
-    "hash": "sha256-9GnmuP7xvkSCD6fO6EOdfLG0iQmpUhZWph7XYGJdeBY="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/killbots-26.04.3.tar.xz",
+    "hash": "sha256-Z9KfgeuiE6OZ50YUjgxVcfxjIW2jL6w9S4eRlcLDevM="
   },
   "kimagemapeditor": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kimagemapeditor-26.04.2.tar.xz",
-    "hash": "sha256-XptLqnjAeZz4EGlTMq4HQN7qzAxVwYgJEL+UUSYHVn4="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kimagemapeditor-26.04.3.tar.xz",
+    "hash": "sha256-U/hnBkdbbCyspqD3fmGNYFSXrLuNuDRYZfOFbX/AGfw="
   },
   "kimap": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kimap-26.04.2.tar.xz",
-    "hash": "sha256-DNuMAYafgokTdfXHWH8C74p1HmgDGu2U49C0fzAfyag="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kimap-26.04.3.tar.xz",
+    "hash": "sha256-IIvfe1y5fCsuMo6X0Qe6wAvFNoWZi+vGS6HiAzw+fs8="
   },
   "kio-admin": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kio-admin-26.04.2.tar.xz",
-    "hash": "sha256-2OUmDClJDgffBMF3LtF4Lfwl09wmUKz9j44ExTanwDY="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kio-admin-26.04.3.tar.xz",
+    "hash": "sha256-s93giTYlv2hm5A5ClTRMZH1JaLP0dxHRWsHBNBluQBQ="
   },
   "kio-extras": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kio-extras-26.04.2.tar.xz",
-    "hash": "sha256-r0lBr2JPiDiR0zcBqgzkIW1t4RTbPkolAJnFLT1CrKo="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kio-extras-26.04.3.tar.xz",
+    "hash": "sha256-hEgHX97dHlrkO4ZTN/WsPKOQN3Jt0N6qBheX+oTTHWM="
   },
   "kio-gdrive": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kio-gdrive-26.04.2.tar.xz",
-    "hash": "sha256-af+43nK5fe7EmGdW1qLO5Qs/3AOFqIpys5J7utGKPjw="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kio-gdrive-26.04.3.tar.xz",
+    "hash": "sha256-J4H32SAYbJ5z+yafWWLuIiTRMIsZHMs9IPCBcirII4c="
   },
   "kio-zeroconf": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kio-zeroconf-26.04.2.tar.xz",
-    "hash": "sha256-kwh3ZOF3MTnjKrHdXoppthVDF/NNK8NxNF0uZ1d2nVY="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kio-zeroconf-26.04.3.tar.xz",
+    "hash": "sha256-gsCRgZrEIYi3AyE4BodZpWz2b8BvOpo/4Blfns+UPts="
   },
   "kirigami-gallery": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kirigami-gallery-26.04.2.tar.xz",
-    "hash": "sha256-cu86RlndTO5VcqYloBTmwqi0Bs6luzQkomOq/8L8u60="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kirigami-gallery-26.04.3.tar.xz",
+    "hash": "sha256-IWEZ4IjGPWxv7ntIse2UpwqbIXKZu63sRDUMnIGVAc0="
   },
   "kiriki": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kiriki-26.04.2.tar.xz",
-    "hash": "sha256-DMQUd1so2mF2ZfqQTZUMLZJmfd+U1MTa5cWjAllrvd0="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kiriki-26.04.3.tar.xz",
+    "hash": "sha256-Yi34Ly1JmlDsMVv/TClrG+gZ/LI0eYrC5amiMdOe2fE="
   },
   "kiten": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kiten-26.04.2.tar.xz",
-    "hash": "sha256-oE5quZzHjlmzjwgtT0QR6uPNEDlaeaK9EigF+P2Dr6A="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kiten-26.04.3.tar.xz",
+    "hash": "sha256-R6Kb03uK6+RrX3+gEaUR2+AlKBO80C/k/67/pk9EGM8="
   },
   "kitinerary": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kitinerary-26.04.2.tar.xz",
-    "hash": "sha256-hu6pg8lp+h/tK9wipG+ADAK2bFEgh9pvAHIyTSjm1cY="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kitinerary-26.04.3.tar.xz",
+    "hash": "sha256-KgcmUFCKlamWR9CtfSPmWNCSJwQSVz9fgZNyFJy0n4w="
   },
   "kjournald": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kjournald-26.04.2.tar.xz",
-    "hash": "sha256-aUe5HAvANonQWAOTPPXowmqoxd3qH8pOnwFsNmimTbc="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kjournald-26.04.3.tar.xz",
+    "hash": "sha256-apesdsAG3NDM2zOTOrccYRt5zJriBmbeuAdKisQ5k84="
   },
   "kjumpingcube": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kjumpingcube-26.04.2.tar.xz",
-    "hash": "sha256-EEjQ02MiWRUTtiEZG/CeLP962rsIvWal3HpV4LetV3U="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kjumpingcube-26.04.3.tar.xz",
+    "hash": "sha256-3Gy9ZuwRTYN5YhvjUspT9xJXAeDFw2Q0FwPnI+Tnfh0="
   },
   "kldap": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kldap-26.04.2.tar.xz",
-    "hash": "sha256-WYij4WDufF5O3/1EIiWkaFpVu+jYGnsSwpD7mAiZEg8="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kldap-26.04.3.tar.xz",
+    "hash": "sha256-UND2Z1wTMjAj/EMFzlFtN4hOJEIx/4Kwm+ADJObJvb4="
   },
   "kleopatra": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kleopatra-26.04.2.tar.xz",
-    "hash": "sha256-yvrseXXvKNVX/h8oDCxivq6G9MZCz5adfLycBeD/eu4="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kleopatra-26.04.3.tar.xz",
+    "hash": "sha256-Z9HDeGB23hnxAF0LPXX2tEz9ICenNhVlkJPhkrnfjhs="
   },
   "klettres": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/klettres-26.04.2.tar.xz",
-    "hash": "sha256-T2tnWBGcKGmUnRKIybNEvJfyffp0F5xacWeGCWKzrAI="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/klettres-26.04.3.tar.xz",
+    "hash": "sha256-flLYIV34zUfJG2T3DfR0ZYt4MlgGCqYef/+iWxsRUME="
   },
   "klickety": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/klickety-26.04.2.tar.xz",
-    "hash": "sha256-m3ESV2o64riEdk4r9qXgNlM6Bk+l/B2sKlm9UHMp9Os="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/klickety-26.04.3.tar.xz",
+    "hash": "sha256-xO6rXk4uzmypkpJU5q6iX/8bT19xPpabSuQflrWWOUE="
   },
   "klines": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/klines-26.04.2.tar.xz",
-    "hash": "sha256-puHneLLrihAIbD1SHS/tvkiOykk1TrQEJ4qIWTT9dq8="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/klines-26.04.3.tar.xz",
+    "hash": "sha256-lBJYP22tVY18nHn0SFc3J3wpW8Zu5YTLeKtvrKSERGc="
   },
   "kmag": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kmag-26.04.2.tar.xz",
-    "hash": "sha256-yJxe7oRLfUcdR33+5VP8ItcoQ/i0xFLZ4yLM4qutzf0="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kmag-26.04.3.tar.xz",
+    "hash": "sha256-QqAkWBnGcfPvI/gLHXVmYEXJgwuyhxFPxzs71wLQhew="
   },
   "kmahjongg": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kmahjongg-26.04.2.tar.xz",
-    "hash": "sha256-1sBj2iP15bbzS4Hgw73FKkMPczK+z/pOsapR5Y6HQNo="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kmahjongg-26.04.3.tar.xz",
+    "hash": "sha256-jkV1pQ03piWbfEOBxCQ9CgXWSEfGIMWvWMNKg65s44s="
   },
   "kmail": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kmail-26.04.2.tar.xz",
-    "hash": "sha256-jJGF1jTu6z8VESZDn9An9UqfEkqOhl+9prEQmTvTAPk="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kmail-26.04.3.tar.xz",
+    "hash": "sha256-er0sDoh3nxjv8167T3L2RH4lwNtoZ6Ht+UU2BSoa6VI="
   },
   "kmail-account-wizard": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kmail-account-wizard-26.04.2.tar.xz",
-    "hash": "sha256-WO+vOrVG0IJPBdOXJyVTVH38R7gYTvWZdtfTViD31l0="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kmail-account-wizard-26.04.3.tar.xz",
+    "hash": "sha256-a8VNtwV+X9ToP3HWgXqBvTY3ekHMc04Hn1XfNhnnBGE="
   },
   "kmailtransport": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kmailtransport-26.04.2.tar.xz",
-    "hash": "sha256-uKdPOkuU8ieOVwwpEH6AWZ5Io0w9ubxweAvtw+PyTns="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kmailtransport-26.04.3.tar.xz",
+    "hash": "sha256-/qfNEH3cIZnowQTroA64Rp/6rM1nzk5AOReXHSPkxnU="
   },
   "kmbox": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kmbox-26.04.2.tar.xz",
-    "hash": "sha256-J+eWYQt+eiJJtGc/2KJ7WcktWm/hqa+eNezWMIzejxU="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kmbox-26.04.3.tar.xz",
+    "hash": "sha256-/znWYW+dVqMYy7TgKb1Clg+KEVV5vc53heCvbx/l7lk="
   },
   "kmime": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kmime-26.04.2.tar.xz",
-    "hash": "sha256-dHNSL0LYRoTNcf51Scxmih/P2RcWpyhg3JvLqoVp7W0="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kmime-26.04.3.tar.xz",
+    "hash": "sha256-oRiw07OtLrs19zxnXP//V1zRs2/1h11Pn9S86IS7roo="
   },
   "kmines": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kmines-26.04.2.tar.xz",
-    "hash": "sha256-wBEcDgVePoiFO+gO5tP2JNOjodfv4EgQKAYy4C4P0DA="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kmines-26.04.3.tar.xz",
+    "hash": "sha256-obp7NdqLipv1HyJ4OEhbjZ0kJLPASNRTklb0/QsvyCU="
   },
   "kmix": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kmix-26.04.2.tar.xz",
-    "hash": "sha256-Xx0COY7IE8NQWng6KP9O7PW4BQrPvmzDtBQF/Y0/4WA="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kmix-26.04.3.tar.xz",
+    "hash": "sha256-a808fZoJP6k8nWz68aE7aR1z3pG5vOr33i8A3E1es60="
   },
   "kmousetool": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kmousetool-26.04.2.tar.xz",
-    "hash": "sha256-fxKPJcBT5nfIqMaecyML5dQE/XxzLXFf97LrCDWTw4U="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kmousetool-26.04.3.tar.xz",
+    "hash": "sha256-sTqQ7ukakfsCmWbxKGVvTkYSar9xG2FOdAgAh+BtD/8="
   },
   "kmouth": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kmouth-26.04.2.tar.xz",
-    "hash": "sha256-+xlK7VM3xApbuQkmZvZWcx0OK4a5Ku/zOhBg+crHfBE="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kmouth-26.04.3.tar.xz",
+    "hash": "sha256-pggQXdj1GcU9gf/IqeZXizHjELbJMzxC02lQe41f4cE="
   },
   "kmplot": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kmplot-26.04.2.tar.xz",
-    "hash": "sha256-oJ+spcQoUii/NjlGkfywVCIaN3bCm4ERUBTw80rNJxs="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kmplot-26.04.3.tar.xz",
+    "hash": "sha256-JZ9yzOlJzDFmJ18tImbbNDImPqLFp68OKpzztaLIoN4="
   },
   "knavalbattle": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/knavalbattle-26.04.2.tar.xz",
-    "hash": "sha256-87BzM/ED5jju53lRbv5M2jiGn7DdVUUI16Cy6WB42ik="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/knavalbattle-26.04.3.tar.xz",
+    "hash": "sha256-v3CkbNScx8Yy1tXp7W9KKFeDrhSDKAxUtafop1gjyYI="
   },
   "knetwalk": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/knetwalk-26.04.2.tar.xz",
-    "hash": "sha256-QiKPnUCwNG17QohTDAyFnfgX5kMWaNX8kG51OeMaXrY="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/knetwalk-26.04.3.tar.xz",
+    "hash": "sha256-/Ir7ctVFXdAWEEkx0nM1vr7+yW0emTaW5wURVyn7cO4="
   },
   "knights": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/knights-26.04.2.tar.xz",
-    "hash": "sha256-EuRoOUzgZsRz20R15BdmXkpSrg0ZmV/7LINZQX9jWAE="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/knights-26.04.3.tar.xz",
+    "hash": "sha256-YnIK2fABd+g2sWFvdsrapVoaEmNv1MfW2Uue4f6bTF0="
   },
   "koko": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/koko-26.04.2.tar.xz",
-    "hash": "sha256-IMl/gRVUhFWujyFVcLRFJ5+kIHF1alCbTG3CfkHUgjo="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/koko-26.04.3.tar.xz",
+    "hash": "sha256-/ZELgtDwjjw5rIo1iLWnhRbQcxxqNqfZMCZE4731WsQ="
   },
   "kolf": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kolf-26.04.2.tar.xz",
-    "hash": "sha256-PHJ2tCysw0b/4FuqELllGWj+q11y4me0X7WYipo6GUE="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kolf-26.04.3.tar.xz",
+    "hash": "sha256-+/Y3yItzUxGaPCLYbMTpe3FSg++qqUHN7MLHZ3EDLXM="
   },
   "kollision": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kollision-26.04.2.tar.xz",
-    "hash": "sha256-JiG7t9NL7p3D1szRvJDjFe7V4ut+5zy2Y1uDtLLqkyc="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kollision-26.04.3.tar.xz",
+    "hash": "sha256-qyMarIO7VRp2tdHBsRgmp+rXyCdFXZf7y+7uSBNmfJo="
   },
   "kolourpaint": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kolourpaint-26.04.2.tar.xz",
-    "hash": "sha256-m2XGNuMOCjdjUsZrtw3nT64rcyydJFMfzBe+hj8nEms="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kolourpaint-26.04.3.tar.xz",
+    "hash": "sha256-/s4QPFKSkCEsx6ZunyLolOsDTQRXkzKhfX9sDo7aYGk="
   },
   "kompare": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kompare-26.04.2.tar.xz",
-    "hash": "sha256-cTDuSS2msS8LM+cFtwUUzV6xEBm1eZyWN2+ZXKBS+jc="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kompare-26.04.3.tar.xz",
+    "hash": "sha256-/BKZs8/K2B7ISIpeol8Yn+fPcn75EkKXLMBOZjXVIAU="
   },
   "kongress": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kongress-26.04.2.tar.xz",
-    "hash": "sha256-9MP1uQ4oZHuEFZ6RkAyv4/+DL89hi/2hodUvS4uRN0U="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kongress-26.04.3.tar.xz",
+    "hash": "sha256-JY/kaQ9u6rM98keRKAXBPmb55JpMEYs9lWYhsevF9/8="
   },
   "konqueror": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/konqueror-26.04.2.tar.xz",
-    "hash": "sha256-qpo1+B+h8wqsHXe5AI0HT7BBsqfBIxnR+MmxlBN+V94="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/konqueror-26.04.3.tar.xz",
+    "hash": "sha256-xa1OcA+fQ/nGR+PAEdeRiRHPXA5NeBGHWWfLN6NGkuM="
   },
   "konquest": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/konquest-26.04.2.tar.xz",
-    "hash": "sha256-1QCfsH4ZVduIAbe6v1ItH4NVHmxf9DQ251CLa1Xx9VY="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/konquest-26.04.3.tar.xz",
+    "hash": "sha256-siTBCST4KcOkh1VEUkEGW4z4E21nAx3NqnLrS7GFUHc="
   },
   "konsole": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/konsole-26.04.2.tar.xz",
-    "hash": "sha256-2BppbWoxbQyPq+POzYN4P2Vu6XxwztiVE7P9FunSFqw="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/konsole-26.04.3.tar.xz",
+    "hash": "sha256-/lTQKXwkpSsuyOv0W/dbInNvZTAWY4RrjzU5BElD4aw="
   },
   "kontact": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kontact-26.04.2.tar.xz",
-    "hash": "sha256-fvWohJ98IfPCFGRmssbs204gptKMEffn8XDci/B+9Cg="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kontact-26.04.3.tar.xz",
+    "hash": "sha256-KO/Yl9RoJemrZrBQqAdmY9anSihv1KH4GD/BJpWy9NU="
   },
   "kontactinterface": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kontactinterface-26.04.2.tar.xz",
-    "hash": "sha256-wZABZw3qNvYYL2XnzdXWHFf4itOsWumUFgI9DRUef/g="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kontactinterface-26.04.3.tar.xz",
+    "hash": "sha256-7Geq1iPT2Av60RV6e+hj2Peg7tPoxiDFnFzX/ydrt2o="
   },
   "kontrast": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kontrast-26.04.2.tar.xz",
-    "hash": "sha256-PVXs3v9jUFkHEsQmmbKkY6lmZsq+6xTvYGVNphCPxqg="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kontrast-26.04.3.tar.xz",
+    "hash": "sha256-BK7aexYgXDzR9loOSpyZyM31iXrHJJTbVd7AG3Kce7M="
   },
   "konversation": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/konversation-26.04.2.tar.xz",
-    "hash": "sha256-/J7FxpfgBD6oaGgGjfd9e2xgqo7MlmTbOHO4UnDxofU="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/konversation-26.04.3.tar.xz",
+    "hash": "sha256-2ddwgNTYdW74zGdn2+flnvBV63Y4z0OxKe5dtiNX+nc="
   },
   "kopeninghours": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kopeninghours-26.04.2.tar.xz",
-    "hash": "sha256-AAGUYZAQXaBCEh2TvwEC1VTdShG9ybRHcYZAaY/MY/I="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kopeninghours-26.04.3.tar.xz",
+    "hash": "sha256-MJzeXZye4UGGf+5uylIIhjpvqxOxzdj4myhQ0W4BfvY="
   },
   "korganizer": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/korganizer-26.04.2.tar.xz",
-    "hash": "sha256-eLhWFU8IMFo4Fyw7RR/E7y8YUrICsQnyrfnz6Xr2daI="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/korganizer-26.04.3.tar.xz",
+    "hash": "sha256-iaEdRKpMRv4+PKZPKzj9gGz82yMmLGPMdkxearngTUg="
   },
   "kosmindoormap": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kosmindoormap-26.04.2.tar.xz",
-    "hash": "sha256-QYFD2SEptEITvm/khGp1urlM++ubpjZ2Z7KiBX0X8uY="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kosmindoormap-26.04.3.tar.xz",
+    "hash": "sha256-c6apMmslAl0CgsV1K84iPdMpL9WS9D1WbFEoYFXLZoo="
   },
   "kpat": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kpat-26.04.2.tar.xz",
-    "hash": "sha256-wK4Q8sEOJBM1HqecvIPZpW7Bw3xXBl3D1eSB03x2r9c="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kpat-26.04.3.tar.xz",
+    "hash": "sha256-Viq3QEO/t37FeXD3V/EH3tnY4/4TdIMkAJcgB3rXGcs="
   },
   "kpimtextedit": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kpimtextedit-26.04.2.tar.xz",
-    "hash": "sha256-2TfE5bwru+y4b5sx6G1a+xR4OoiwlmQPdKsTimnzDk4="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kpimtextedit-26.04.3.tar.xz",
+    "hash": "sha256-Te0ZCt66zdAk3RL3MKJtz5FZxdyyH4rxjNqXPHjKw7k="
   },
   "kpkpass": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kpkpass-26.04.2.tar.xz",
-    "hash": "sha256-deXWpZHTXttW/1oDeT1QvnxieQss/MuI1y7MaHQjI9A="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kpkpass-26.04.3.tar.xz",
+    "hash": "sha256-+wOwT6fZuQl/81cKRcoDqv1dpfM+rRflzuy3s+zFy4c="
   },
   "kpmcore": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kpmcore-26.04.2.tar.xz",
-    "hash": "sha256-OK2cG1IRWFjNeP52NV2Bu024StLDGwkzvPWPTIW1ECM="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kpmcore-26.04.3.tar.xz",
+    "hash": "sha256-CAGNlGX8yvn1bugXjyqjQZ1rz+9mcwi7VY44dRYhbm0="
   },
   "kpublictransport": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kpublictransport-26.04.2.tar.xz",
-    "hash": "sha256-lmn9wnEGf4KFHPeAT8YvwKWyKNSI+ekhejtl0Og5xrI="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kpublictransport-26.04.3.tar.xz",
+    "hash": "sha256-rqw+wPo5omz5us2How9djPKWgRbKmZAoc0mbbNRfmxc="
   },
   "kqtquickcharts": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kqtquickcharts-26.04.2.tar.xz",
-    "hash": "sha256-wpGQQWwyFeIS2TnnvVWbPLL+MXDtzzdL0bqhvd/6cF8="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kqtquickcharts-26.04.3.tar.xz",
+    "hash": "sha256-+LXzo3ofLF5sDx63SZF9ZCs0FQLBscW6Wwgu3oDyrvg="
   },
   "krdc": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/krdc-26.04.2.tar.xz",
-    "hash": "sha256-Ic6ht4l4sBcpDp33GCMUnaU06X9vlkyp1i3nZ/oeAfM="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/krdc-26.04.3.tar.xz",
+    "hash": "sha256-dM1+VfKgpyqCEQQxIr2q8dFf6Dk0Zrqle1k/6zrh/QQ="
   },
   "krecorder": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/krecorder-26.04.2.tar.xz",
-    "hash": "sha256-+PFvq8Cc6tgj1wesdvU5EfnOSEelGAkxIC61qWsvkhg="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/krecorder-26.04.3.tar.xz",
+    "hash": "sha256-r3peZ3cwBuJSYWyhZUBWVNZJCJeHvGRrST+RrSWAomA="
   },
   "kreversi": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kreversi-26.04.2.tar.xz",
-    "hash": "sha256-70QOmLJek9zWvtj4cCYMPUynDFMupnYkBTz9UySMnOE="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kreversi-26.04.3.tar.xz",
+    "hash": "sha256-QCwu5x7N1hYFQfif+d0UA1ynQwJcBCkslH62JNDwzlI="
   },
   "krfb": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/krfb-26.04.2.tar.xz",
-    "hash": "sha256-9xxqmV+24bBwhLuHcPfb0S2nbC8/6NfZ+R1wJO8ZnVw="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/krfb-26.04.3.tar.xz",
+    "hash": "sha256-+ioNTHBY//cpousE0qX0ajqRkqb0curD5mnHLWKrPPc="
   },
   "kruler": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kruler-26.04.2.tar.xz",
-    "hash": "sha256-Wka7DFJN2P4J5bwvkLb6giCDS/rXYSxyZe8M9BPxmss="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kruler-26.04.3.tar.xz",
+    "hash": "sha256-Y0sVTQXbUmpNBQJec1iwGSm3xZOGAkd/aICxnGunmhM="
   },
   "ksanecore": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/ksanecore-26.04.2.tar.xz",
-    "hash": "sha256-j4Sgj5hAVc7XoaIFG5ogRNFcCpUjEhpWrKZr/lqyadk="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/ksanecore-26.04.3.tar.xz",
+    "hash": "sha256-5cloQLoh56+m4GNbIcwRdVKJixRijZVV8qYAx3iEdH0="
   },
   "kshisen": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kshisen-26.04.2.tar.xz",
-    "hash": "sha256-ZN7ktjBYremruKVTccmfOPiMBIw9wMA2dPeuAF1T4UE="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kshisen-26.04.3.tar.xz",
+    "hash": "sha256-JHmnOuwaSu7EUcMeG1hY11cSNWFc0+PeXxNERaxc6FM="
   },
   "ksirk": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/ksirk-26.04.2.tar.xz",
-    "hash": "sha256-Csh3LK82NHFtGqaLP24P4/5kOW9Lo+qpx/UgOo2kAVA="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/ksirk-26.04.3.tar.xz",
+    "hash": "sha256-7hbq8MKGd6BRYo2aqPQmyJmdv3hGIGlmKsOhaVPIMj0="
   },
   "ksmtp": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/ksmtp-26.04.2.tar.xz",
-    "hash": "sha256-L6yssgCViNoig2ldmjUQSNR4kgrrkYjJMhZJhfx+9oY="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/ksmtp-26.04.3.tar.xz",
+    "hash": "sha256-bhvLEJSzj1NsiefBAFpJPCZ7JALzpPRWGBdpvy8wCZI="
   },
   "ksnakeduel": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/ksnakeduel-26.04.2.tar.xz",
-    "hash": "sha256-H73tTiD6QnlPumzzcw176Z5F4pwP0YX4ev7h7m4ffOE="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/ksnakeduel-26.04.3.tar.xz",
+    "hash": "sha256-UX1mouoNGVS0IF03NXzQPCEmrPjgQ9e5XD2fWYuUojE="
   },
   "kspaceduel": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kspaceduel-26.04.2.tar.xz",
-    "hash": "sha256-uGnKNs5xO8V3g3a4v7iX0XOVGw6Oa56fQPjHPJtZKjQ="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kspaceduel-26.04.3.tar.xz",
+    "hash": "sha256-gj+ISk1+9VjhrabWlWIG8ergaKsQV3uIBzjnOEr8YK8="
   },
   "ksquares": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/ksquares-26.04.2.tar.xz",
-    "hash": "sha256-Q2VINRUT2wOcd+MPri90bnALKt/fa851/Dbp7RdPJtM="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/ksquares-26.04.3.tar.xz",
+    "hash": "sha256-iiN+V9uiXpYLCxuGF7KsnliRUjpQEW5pAo68p+cdxBA="
   },
   "ksudoku": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/ksudoku-26.04.2.tar.xz",
-    "hash": "sha256-jbT5AcCs6PIZOP3xSaaeE/6049sxLMcCEsupXzRIddE="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/ksudoku-26.04.3.tar.xz",
+    "hash": "sha256-rfYPq6P7Co8FLl1J7zdzvfR86Vgf/0wdeQ308eG5oN8="
   },
   "ksystemlog": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/ksystemlog-26.04.2.tar.xz",
-    "hash": "sha256-AIFbUxi5FrpzPW6DBbZhi/5Mn7NzYUDfjuAk2sSFAJ8="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/ksystemlog-26.04.3.tar.xz",
+    "hash": "sha256-qTuEw5i+D4XuW01UIU8wb4byHBaPk3kceoCfYQjSjII="
   },
   "kteatime": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kteatime-26.04.2.tar.xz",
-    "hash": "sha256-38557HG4nvc/rZCYcLBKnzO1MLR2enPf8EEyYE3nHvc="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kteatime-26.04.3.tar.xz",
+    "hash": "sha256-Ar9G3QzHvsN8t3Jtt7VceDSuDlMpVb8jlHYJZH7Rbuk="
   },
   "ktimer": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/ktimer-26.04.2.tar.xz",
-    "hash": "sha256-q0Gl4W6C16kmGHu4AtOtdU43EgeRyKaVez5FWhgrN4k="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/ktimer-26.04.3.tar.xz",
+    "hash": "sha256-Fri3SIWREv7/OGAiu1s5kRmfNVUnLEawGTLewwKccBE="
   },
   "ktnef": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/ktnef-26.04.2.tar.xz",
-    "hash": "sha256-D7g48SXH6VLJXrTspaDdg7Urn8n1yRR231bDfgSx7lY="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/ktnef-26.04.3.tar.xz",
+    "hash": "sha256-CdRfvUB6uanssbRdIDcyp0YOJek6o7XzCx3xmPPwzig="
   },
   "ktorrent": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/ktorrent-26.04.2.tar.xz",
-    "hash": "sha256-vfXdz6uM2VLXcsWs2AGZLbDjM/GWd8joA7+oygamGRI="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/ktorrent-26.04.3.tar.xz",
+    "hash": "sha256-XTwUPisVensRshT6ldZ8Ti09NmWApi+WXH8QufFSP8k="
   },
   "ktouch": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/ktouch-26.04.2.tar.xz",
-    "hash": "sha256-/eRGO5Yj/xG0kmzjHUJxe6mX0UwLkCrmUGCmPWLCs6s="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/ktouch-26.04.3.tar.xz",
+    "hash": "sha256-00YGQt8945NOuUxB2TQjTVOnqvQpqPuVU1x1T25M1oo="
   },
   "ktrip": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/ktrip-26.04.2.tar.xz",
-    "hash": "sha256-SkDJjjRU3mkiR/GB3yTC460hbECP8iHIb2B1uxrw7KA="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/ktrip-26.04.3.tar.xz",
+    "hash": "sha256-mdWKm/K/H/TuNX4fkQ65lXGTUNL/i8xtb6JQRE8QHUI="
   },
   "ktuberling": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/ktuberling-26.04.2.tar.xz",
-    "hash": "sha256-8K12IFCtX170At7PkvTNuPKSX5Rlac9ZNqPKaLJ54iw="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/ktuberling-26.04.3.tar.xz",
+    "hash": "sha256-L94juBg3BxNtepshCEi8tPAXQlVYzNGHaPfLw/YuxUg="
   },
   "kturtle": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kturtle-26.04.2.tar.xz",
-    "hash": "sha256-QuMGli9Hlduoky4Axd/HDceJK2d5rZfhrJUIFsRMAjM="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kturtle-26.04.3.tar.xz",
+    "hash": "sha256-1XNu+tI0Smk27hg2fgzSwbD5jLtu2JEGFEoKfVBH7Pc="
   },
   "kubrick": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kubrick-26.04.2.tar.xz",
-    "hash": "sha256-g3P3nutbYV5DhQ0DbVomzZ6XDNMllbul5iotPpZIkjA="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kubrick-26.04.3.tar.xz",
+    "hash": "sha256-pvC2mvhZtMfHYjdcQHDtJy/fsiydT42Ro/qCgIOtKdA="
   },
   "kunifiedpush": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kunifiedpush-26.04.2.tar.xz",
-    "hash": "sha256-FbbHxGOVOw07Cujf3enepBrn6sd9A2ypXbb4fRqKj+E="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kunifiedpush-26.04.3.tar.xz",
+    "hash": "sha256-JHzMe8xCd+L8Y6dTw2fQyhDv47SRb2CkTZyi2kA8T+U="
   },
   "kwalletmanager": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kwalletmanager-26.04.2.tar.xz",
-    "hash": "sha256-lpMljfVrwI3A/BIs4263nuBEmNO+dwZjWvE088nr5eo="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kwalletmanager-26.04.3.tar.xz",
+    "hash": "sha256-44kl/1FMqPwhl2Kg2Ctikg9N9iyrAlr5UDX/WvQp30s="
   },
   "kwave": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kwave-26.04.2.tar.xz",
-    "hash": "sha256-r1ZdQPQJ9OCSpM9OcWneeShCFkFob9eObtLZNJHew+0="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kwave-26.04.3.tar.xz",
+    "hash": "sha256-7HgAMm1aSHgKWLu7k482Tv1Q37T6Pj1kZWUEpMi+V0I="
   },
   "kweather": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kweather-26.04.2.tar.xz",
-    "hash": "sha256-hA4M8ndOEhh6rOhzWQO3MzVbvsqdnGX6nrU/eVxLXRg="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kweather-26.04.3.tar.xz",
+    "hash": "sha256-PSLUAXQnFTM8JWb9s5AvgtVh7h519nf+lY6fFhz5Aho="
   },
   "kweathercore": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kweathercore-26.04.2.tar.xz",
-    "hash": "sha256-03C0WBmDWXsWo4P8ZyBhGMj2pn8PXWQh6X3Wt2laYNk="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kweathercore-26.04.3.tar.xz",
+    "hash": "sha256-W0awhBdX7kmP08Va09AdXj0/QNDIA5s7Lhap5Fndm0s="
   },
   "kwordquiz": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/kwordquiz-26.04.2.tar.xz",
-    "hash": "sha256-S9nqngXwCsKydkVzNa7l1Iwyt3VY5PgCxkMwVgR/Vd0="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/kwordquiz-26.04.3.tar.xz",
+    "hash": "sha256-CLETWdHQquFtyU+qKkE5XW/uRoOioKjR5DN+qV9l8+U="
   },
   "libgravatar": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/libgravatar-26.04.2.tar.xz",
-    "hash": "sha256-hL80vwWwgjU0uctAzviAOuLmVKnHql6CMpbtxKACvGw="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/libgravatar-26.04.3.tar.xz",
+    "hash": "sha256-TkasvSHCqBckf+pf9mqJ66srgkRm6JOefcVl8pndmoE="
   },
   "libkcddb": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/libkcddb-26.04.2.tar.xz",
-    "hash": "sha256-07jYO/VILMXtLVgwlglA+wOX/n/Pu6z4XIwraPdSo4s="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/libkcddb-26.04.3.tar.xz",
+    "hash": "sha256-xa8hq/yGQ4xXbISEb5XYlcEOm+nV9AusXfRQALmTw40="
   },
   "libkdcraw": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/libkdcraw-26.04.2.tar.xz",
-    "hash": "sha256-DOtOOueSHiX/njxKwGkzIVIfqMRV0/RBUtA7P/u6OR0="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/libkdcraw-26.04.3.tar.xz",
+    "hash": "sha256-e8Y1keH8E1IXeEmmmYAw3KL8qY6QKlUYav7FWt0yb08="
   },
   "libkdegames": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/libkdegames-26.04.2.tar.xz",
-    "hash": "sha256-r0TUayijRJtvgF0DFt3ORnQpZxneBADz46U6jcWfGQU="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/libkdegames-26.04.3.tar.xz",
+    "hash": "sha256-+5ohmcHX1a2CdYTtsGPdluQaqKk3mA1kHh/6Ei0ezMM="
   },
   "libkdepim": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/libkdepim-26.04.2.tar.xz",
-    "hash": "sha256-mu1jF5UQ39hCSDAZWVon1E+XoOPAXo6hDEwH+eUy7v0="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/libkdepim-26.04.3.tar.xz",
+    "hash": "sha256-CJ8bJIOaZrI06Yf563Gsqe/iDC6djdc4fyTBTL/ze/U="
   },
   "libkeduvocdocument": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/libkeduvocdocument-26.04.2.tar.xz",
-    "hash": "sha256-2h+jP5GKF35gv1H6WJdI2P9C/CMKerDVVdDrigHAn/c="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/libkeduvocdocument-26.04.3.tar.xz",
+    "hash": "sha256-AjybtpqY3biXvBXdDlJvmIF/IKy2zzQGioOC2FAAO2Q="
   },
   "libkexiv2": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/libkexiv2-26.04.2.tar.xz",
-    "hash": "sha256-/diyykczOSgWdrzNG+HWv33y92RIIsUqXLc6+FNahU4="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/libkexiv2-26.04.3.tar.xz",
+    "hash": "sha256-3V3b8QfdmlFFSug7BTfKgM4x5l2mScCo23ReNW0NAGQ="
   },
   "libkgapi": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/libkgapi-26.04.2.tar.xz",
-    "hash": "sha256-/1KquqOI6aV74lEMztsMUU7141wCwMwlYheh5Nh26/E="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/libkgapi-26.04.3.tar.xz",
+    "hash": "sha256-rUOnandM0hye2Jn76klZBC1mdHKW4eUh7CsxNxOxK+4="
   },
   "libkleo": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/libkleo-26.04.2.tar.xz",
-    "hash": "sha256-+i7jdJFBBQjbXrBbvS9le+CBJxuODnGDhJ6WVySaxJ8="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/libkleo-26.04.3.tar.xz",
+    "hash": "sha256-R3ciEb5hoxlHR0+HHhkPNjRKh97+x7yXpGjtahW1DAk="
   },
   "libkmahjongg": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/libkmahjongg-26.04.2.tar.xz",
-    "hash": "sha256-cYn64KgMPKufNLyT8XMwNhg+qRtLGw2nSFIvZTktNns="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/libkmahjongg-26.04.3.tar.xz",
+    "hash": "sha256-GRTHgBYNiRPdZJ/dGwdgtEVSPAm1cvRc6ZwIGW4px+g="
   },
   "libkomparediff2": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/libkomparediff2-26.04.2.tar.xz",
-    "hash": "sha256-Mf7RdY+A5WCFKtFbwk1ul3jBpZg+ovt+4AgXlaAXUBA="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/libkomparediff2-26.04.3.tar.xz",
+    "hash": "sha256-3XdSmpOsP5rv5XGWHo96sUxBbzFkpSTGWIKEvMGsgXs="
   },
   "libksane": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/libksane-26.04.2.tar.xz",
-    "hash": "sha256-kmbl4zOE2hzX3Ip/4jb/k46fB1vqmiBWCITvy3+xxjs="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/libksane-26.04.3.tar.xz",
+    "hash": "sha256-yobkkjKCYsxticGxMROe3ra04e6xW4T7qKFy/gmiX3A="
   },
   "libksieve": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/libksieve-26.04.2.tar.xz",
-    "hash": "sha256-u4eK7P4mFXJxjyWUq2ym3aGIy7BnK0sbJphBGZtNFFI="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/libksieve-26.04.3.tar.xz",
+    "hash": "sha256-tJtG+7Q8ikt8Tpo4M4mtk3GRlBQOfZENJfIWX2a5Gtk="
   },
   "libktorrent": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/libktorrent-26.04.2.tar.xz",
-    "hash": "sha256-pvW6wAgxgufg2aUDT/aLU4r7aw7oItZJgFk+ievBjjE="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/libktorrent-26.04.3.tar.xz",
+    "hash": "sha256-0FnT+CpPypKSzZfRE44wwitYddCppZOkIR0vAlUug2E="
   },
   "lokalize": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/lokalize-26.04.2.tar.xz",
-    "hash": "sha256-6yABo+Hvi1ItGnY6kILTM0weMPp4fe0Str6dB/gEKSo="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/lokalize-26.04.3.tar.xz",
+    "hash": "sha256-wjrEv17GMQCCOFX3L5xuRzBQKCNhsUYAcrsV0ZPs5d0="
   },
   "lskat": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/lskat-26.04.2.tar.xz",
-    "hash": "sha256-WzQgJgHUayH1DxRF+lNyO7hfphTt8er7bO/HReXViKQ="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/lskat-26.04.3.tar.xz",
+    "hash": "sha256-zGnNURQ2lLE+W1+YNQbboVyANkIMXBbXld5daYlyx1Y="
   },
   "mailcommon": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/mailcommon-26.04.2.tar.xz",
-    "hash": "sha256-tlF3667mRHodYM+5lOsqA+Ov1itgEFBM5F2ZQ5zMnMw="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/mailcommon-26.04.3.tar.xz",
+    "hash": "sha256-mqSGpl8xHE5rQBP6RGeA8IvIiWWHJODFHEeb352UWns="
   },
   "mailimporter": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/mailimporter-26.04.2.tar.xz",
-    "hash": "sha256-S6McHpHukXqW3qVT3MOMKoRz53oX6c5UO+trDUIXv5M="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/mailimporter-26.04.3.tar.xz",
+    "hash": "sha256-R/rOHo8LKtcVj2ofAzM4hWhIpVmfr1ooaIfGm+gRS2k="
   },
   "marble": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/marble-26.04.2.tar.xz",
-    "hash": "sha256-ix9LH7pyLEKFIVBCeAO7KPgA5cIX2aKoVJsSJkbvLUQ="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/marble-26.04.3.tar.xz",
+    "hash": "sha256-dSQrQBmy6HOrgtDl0BSSNnefTpkxeCvwzVxrZ7y2kgg="
   },
   "markdownpart": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/markdownpart-26.04.2.tar.xz",
-    "hash": "sha256-CUxMl8XmDvnpHMtJqZJqXITMna/W2jO+yDPx3ZaV3ro="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/markdownpart-26.04.3.tar.xz",
+    "hash": "sha256-VzuRaNu0GEBAxru9yTvSHptsQ2BsXeoj3aMN76Ne6rk="
   },
   "massif-visualizer": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/massif-visualizer-26.04.2.tar.xz",
-    "hash": "sha256-qeR1UnmmbCUvIfsnxTzqx1e9Xs8bwOml/CX2XHIcevE="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/massif-visualizer-26.04.3.tar.xz",
+    "hash": "sha256-Y0lrqIEPk413xWvJfBrOI71CKsZEBdaPCUsAFU0zReM="
   },
   "mbox-importer": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/mbox-importer-26.04.2.tar.xz",
-    "hash": "sha256-ZKDgIfZbQpvYX3p8JIqrPGS6CYsLc3CJGaDGjBznmE8="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/mbox-importer-26.04.3.tar.xz",
+    "hash": "sha256-96iiLas3InEXUWJZXKyMOKFkXFSwk1zAXcnfTqUARQg="
   },
   "merkuro": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/merkuro-26.04.2.tar.xz",
-    "hash": "sha256-tI49X6WeprRgZoC2sv+BYKBNvjIpy1LSZkmD+qPDRDs="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/merkuro-26.04.3.tar.xz",
+    "hash": "sha256-E21j7NQYBWnlArcf1aw/gVTuAVq9ZcD0BaA1F1wax/A="
   },
   "messagelib": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/messagelib-26.04.2.tar.xz",
-    "hash": "sha256-q/e/CNm/gvrXiG4ph38eJrdiNFAmxmfeVrT3DmkWb4U="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/messagelib-26.04.3.tar.xz",
+    "hash": "sha256-RbbnyTO8Y2iOv6ZDp1x/C42CdXepd7WXkx2a+bu8wc8="
   },
   "mimetreeparser": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/mimetreeparser-26.04.2.tar.xz",
-    "hash": "sha256-8VtiaCYSVYiOPphtZ7jznw1XFE6H2ZtG6Pq+eMrTANw="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/mimetreeparser-26.04.3.tar.xz",
+    "hash": "sha256-iHUEKTEOncYOH5Ytydfljhk26HjbVKpBy39cS0/FJNw="
   },
   "minuet": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/minuet-26.04.2.tar.xz",
-    "hash": "sha256-2HDko210jWAyaNaquQ8uAAW+t0O408/XqTzNZeJoLe4="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/minuet-26.04.3.tar.xz",
+    "hash": "sha256-L9vCH4AJAnQYG++ACxXmw1g8U1dowaWmapsAQX9kYrE="
   },
   "neochat": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/neochat-26.04.2.tar.xz",
-    "hash": "sha256-tzckswEh7X4tYfGCClhjmMhRB9Sfh2QbtfHEbAcBV4Y="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/neochat-26.04.3.tar.xz",
+    "hash": "sha256-eBMQaHi95ShvRcAFZHBIIXsuRkRMisLvdkgKLeiOfw8="
   },
   "okular": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/okular-26.04.2.tar.xz",
-    "hash": "sha256-1RzFvpb25JEYFgiwEVrzfSDuFbCAtuQsDADim54Fir4="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/okular-26.04.3.tar.xz",
+    "hash": "sha256-puSlcazTtwu2fuxHaDSwCfcQVAt5MJH1H3B7U7b6y8o="
   },
   "palapeli": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/palapeli-26.04.2.tar.xz",
-    "hash": "sha256-TSmXUquVZR88uGUftl4cwiYJHlP+E6KL1lks/ABUoG4="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/palapeli-26.04.3.tar.xz",
+    "hash": "sha256-Tm1njPjdOGbIKa4AbQG9B/LgRcA/VncifS4g/XuGrQU="
   },
   "parley": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/parley-26.04.2.tar.xz",
-    "hash": "sha256-EgdpDKSq9cx/4pmxIXOj0u7rVYgmuBVE2lKARy/dAPw="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/parley-26.04.3.tar.xz",
+    "hash": "sha256-zsu7Ew7yA7O8U7dYuwY1tMmEOpFAVtcmhVTjaTxYnLw="
   },
   "partitionmanager": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/partitionmanager-26.04.2.tar.xz",
-    "hash": "sha256-J+EPb5reOwjtqL4YB+HxRw1tsiGWQivgYiTJUcVZPLU="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/partitionmanager-26.04.3.tar.xz",
+    "hash": "sha256-4TrzXivHmR1Af3Cr3ELDq3o3ibKLsC4kGubO54mID20="
   },
   "picmi": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/picmi-26.04.2.tar.xz",
-    "hash": "sha256-OGtUL7e23yPhjOTIdrdZ8LdNOuZFJGneUOS2n4cntFU="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/picmi-26.04.3.tar.xz",
+    "hash": "sha256-KDcJFWI8co/IUZf/3KGMig2SuvN1h2VJ8s5pk7i3KKI="
   },
   "pim-data-exporter": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/pim-data-exporter-26.04.2.tar.xz",
-    "hash": "sha256-iWKMCASKSlEdG2CAUchRDvbr9+3Qh59yRb28m6eV9Zw="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/pim-data-exporter-26.04.3.tar.xz",
+    "hash": "sha256-LA7PuIMmf1wY/d4lTHcCwo+7XFedJjO/Yiwt5tUMlWA="
   },
   "pim-sieve-editor": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/pim-sieve-editor-26.04.2.tar.xz",
-    "hash": "sha256-THXRPLCvGoOMA4XqGosFo82f3wDrW9f8KQcgYDwNTsg="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/pim-sieve-editor-26.04.3.tar.xz",
+    "hash": "sha256-Ts0ldK3LiV/5AheLs/ZuAjPiSa87i88SkgG7JakxybY="
   },
   "pimcommon": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/pimcommon-26.04.2.tar.xz",
-    "hash": "sha256-o1WPtM9newf3OsPl8MdMF5yJi0VRFaYub0TLBkz+L2I="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/pimcommon-26.04.3.tar.xz",
+    "hash": "sha256-KgSm4lFNmN6pd+u0xvCRymu5lAQTbL7gAR8Z/7cRss8="
   },
   "plasma-camera": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/plasma-camera-26.04.2.tar.xz",
-    "hash": "sha256-tswN0npCMr3gPwDR/EtNrpGUTk1j5FotfETWpiDjEyY="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/plasma-camera-26.04.3.tar.xz",
+    "hash": "sha256-RLjyAzpa7Ul4uL3AFXsIyDMvt5AGQke+tKppSc3QD+k="
   },
   "plasma-phonebook": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/plasma-phonebook-26.04.2.tar.xz",
-    "hash": "sha256-g+jlwGK+BnhH9nipBuOXiL4fj0SM52Nflpbj0HNRAAM="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/plasma-phonebook-26.04.3.tar.xz",
+    "hash": "sha256-DOm2F4iU67Scv+2uumPCHh4n3ggR4D3a1Xw+ecy3xzA="
   },
   "plasma-settings": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/plasma-settings-26.04.2.tar.xz",
-    "hash": "sha256-E9baJLsPYYsWWdOp2cRCHbq0fBsCbSC5URD05I6ZRtw="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/plasma-settings-26.04.3.tar.xz",
+    "hash": "sha256-WYpfjyh4UUjH5SeAI5gBFmDb1y4cTFYo0pFnkGnQBTA="
   },
   "plasmatube": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/plasmatube-26.04.2.tar.xz",
-    "hash": "sha256-RLJhwrhYuYHA9jyrCqjaPPTy87yexdi8UTIk5tIzLeA="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/plasmatube-26.04.3.tar.xz",
+    "hash": "sha256-kamX5A98Idou0IEFDN3osAdiZie40ddMIK1rihfhpZc="
   },
   "poxml": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/poxml-26.04.2.tar.xz",
-    "hash": "sha256-DNFW4M8yB2lBMEvoXilIli6C20ELlDc6DOWzfAllpXE="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/poxml-26.04.3.tar.xz",
+    "hash": "sha256-w7PJcZ1Q5N3oH2fnXOI27xW56BGHII87OERwfM52xEg="
   },
   "qmlkonsole": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/qmlkonsole-26.04.2.tar.xz",
-    "hash": "sha256-Hyv+oz/4Lr5jNlT8bdqKS1K16Q4RRDlOKDX8uucOqGM="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/qmlkonsole-26.04.3.tar.xz",
+    "hash": "sha256-oK450RwMes0etcyk6jTkQO1Zr3xXD/lmTTqvjStShQA="
   },
   "qrca": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/qrca-26.04.2.tar.xz",
-    "hash": "sha256-xtP8UOILAEyKqYHkkh8RckRoG7q/zi5ofythLksvZCc="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/qrca-26.04.3.tar.xz",
+    "hash": "sha256-1n0vo7ptlu9z4DNczZlmHGzUeemb/8Hjsh3bI6whFI4="
   },
   "rocs": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/rocs-26.04.2.tar.xz",
-    "hash": "sha256-3uX5+w59eC5dM2F02txDCI9iNYOexbqp41LC6C6r0T0="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/rocs-26.04.3.tar.xz",
+    "hash": "sha256-YDt4OC/uFk3SDqKwMZ7GjOcFVscgqMCQCs3bMVipHd4="
   },
   "signon-kwallet-extension": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/signon-kwallet-extension-26.04.2.tar.xz",
-    "hash": "sha256-qHlfqCemmWuRwQDRDooMMCrn+McxxcxUDVD1pyOiiR8="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/signon-kwallet-extension-26.04.3.tar.xz",
+    "hash": "sha256-MpvZvFBQTra9fUMffbZyUoeDJVDWD3GJ740CAQknU8c="
   },
   "skanlite": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/skanlite-26.04.2.tar.xz",
-    "hash": "sha256-2zWLmbCXpb1L7sn6FgCA45D6Heh0iAHmYwKe00Sxqkc="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/skanlite-26.04.3.tar.xz",
+    "hash": "sha256-2sdXRRtDAZKgDu96kKrRT15Z2UYOn/X7FikiykdANBc="
   },
   "skanpage": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/skanpage-26.04.2.tar.xz",
-    "hash": "sha256-/TPs3Xb9qB0pOYq9SJKELI2Nmm42d/1Q3JWHb0JRnWk="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/skanpage-26.04.3.tar.xz",
+    "hash": "sha256-fkenR4d+6J1Qbv0wdNOShwuRcXSbe6YPWsof0a1UJKI="
   },
   "skladnik": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/skladnik-26.04.2.tar.xz",
-    "hash": "sha256-5fIC6VtA6Y1Bx3pI7f7p8atBqMaRnxK5eyc9LkxHT+s="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/skladnik-26.04.3.tar.xz",
+    "hash": "sha256-YrfxqDG9UMriUTdNsv6bwY4og1zIPX9iAiaPx5C4vLc="
   },
   "step": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/step-26.04.2.tar.xz",
-    "hash": "sha256-TrITD29TFt8bJdRMWHh6UnskpXsrD13LV35Fb0W4OT8="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/step-26.04.3.tar.xz",
+    "hash": "sha256-N6vDjX8ZMYQtK5EO4o+HiLQNigIakmxKG5t/Cu3QX6Q="
   },
   "svgpart": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/svgpart-26.04.2.tar.xz",
-    "hash": "sha256-H1N+dzUiX/NVzR+Q+OT9FJf0GHLIuHkEDXYJld4dR/c="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/svgpart-26.04.3.tar.xz",
+    "hash": "sha256-+8aNzfkQcxatJhJtisKts4Lk7muMAYT+sTAGhsOpxwI="
   },
   "sweeper": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/sweeper-26.04.2.tar.xz",
-    "hash": "sha256-+HuftvAJG+s0wim6DgXaGHGVXV8AO7KxCbCRqY3ODJc="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/sweeper-26.04.3.tar.xz",
+    "hash": "sha256-edr+IU58oSVuz8SrUdE9tGLddzbMZW2kCCLrALxyl80="
   },
   "telly-skout": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/telly-skout-26.04.2.tar.xz",
-    "hash": "sha256-UejUa+eLabpvGmU+Q24s2mhkPPgFGrT97TlTvffH2Bw="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/telly-skout-26.04.3.tar.xz",
+    "hash": "sha256-p3WlqmbTJlZihFButp6T6LUdrWPyt7VhQ9BlKZWFo4U="
   },
   "tokodon": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/tokodon-26.04.2.tar.xz",
-    "hash": "sha256-fsSiv25IJegUvTIw+uYghSzoHRY3BNy94r89GXmZPQs="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/tokodon-26.04.3.tar.xz",
+    "hash": "sha256-ecPqOQL/8gcF4/zaEE8Z9bDBuUx1Gg/umVBo8X/iUk8="
   },
   "umbrello": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/umbrello-26.04.2.tar.xz",
-    "hash": "sha256-/LPGSn8leA2YWqt21uzA5fpePB4UStHVq15Q7KcUtnA="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/umbrello-26.04.3.tar.xz",
+    "hash": "sha256-SPxi7bWL88Zcxdiej9SSf0QZAqFj5HpV/xttS37UDVY="
   },
   "yakuake": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/yakuake-26.04.2.tar.xz",
-    "hash": "sha256-3YUyBusyW5aGbPFNKAQIigmI2A/iI29SQPt6j09xZ28="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/yakuake-26.04.3.tar.xz",
+    "hash": "sha256-7VZ2pl7Znle3v9c/vTH5Pn9ajU3FRVHTwqZmj3i1tbI="
   },
   "zanshin": {
-    "version": "26.04.2",
-    "url": "mirror://kde/stable/release-service/26.04.2/src/zanshin-26.04.2.tar.xz",
-    "hash": "sha256-Q0VFGAIetXr28otft2Xy9+upNRbenDuW76cYFPynpk8="
+    "version": "26.04.3",
+    "url": "mirror://kde/stable/release-service/26.04.3/src/zanshin-26.04.3.tar.xz",
+    "hash": "sha256-qAXpoguCQMVS6j19FYZBkDe/Q6q5Q6sc1I8Aw7Xcl5I="
   }
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
