### PR TITLE
nixos/emptty: init module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -622,6 +622,7 @@
   ./services/display-managers/cosmic-greeter.nix
   ./services/display-managers/default.nix
   ./services/display-managers/dms-greeter.nix
+  ./services/display-managers/emptty.nix
   ./services/display-managers/gdm.nix
   ./services/display-managers/generic.nix
   ./services/display-managers/greetd.nix

--- a/nixos/modules/services/display-managers/emptty.nix
+++ b/nixos/modules/services/display-managers/emptty.nix
@@ -1,0 +1,132 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  dmcfg = config.services.displayManager;
+  cfg = config.services.displayManager.emptty;
+  desktops = config.services.displayManager.sessionData.desktops;
+
+  emptty = cfg.package.override { x11Support = cfg.x11Support; };
+
+  settingsFormat = pkgs.formats.keyValue { };
+in
+{
+  options = {
+    services.displayManager.emptty = {
+      enable = lib.mkEnableOption "emptty as the display manager";
+      x11Support = lib.mkOption {
+        description = "Whether to enable support for X11";
+        type = lib.types.bool;
+        default = config.services.xserver.enable;
+        defaultText = "services.xserver.enable";
+      };
+
+      package = lib.mkPackageOption pkgs "emptty" { };
+
+      settings = lib.mkOption {
+        type = lib.types.submodule {
+          freeformType = settingsFormat.type;
+        };
+        default = { };
+        description = ''
+          Configuration for emptty, provided as a Nix attribute set and automatically
+          serialized to simple key-value pair.
+          See [emptty configuration documentation](https://github.com/tvrzna/emptty/blob/master/README.md) for available options.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = dmcfg.autoLogin.enable -> dmcfg.sessionData.autologinSession != null;
+        message = ''
+          emptty auto-login requires that services.displayManager.defaultSession is set.
+        '';
+      }
+    ];
+
+    security.pam.services = {
+      emptty = {
+        unixAuth = true;
+        startSession = true;
+        enableGnomeKeyring = lib.mkDefault config.services.gnome.gnome-keyring.enable;
+        rules.auth.autologin = {
+          enable = dmcfg.autoLogin.enable;
+          order = config.security.pam.services.emptty.rules.auth.unix.order - 10;
+          control = "sufficient";
+          modulePath = "${config.security.pam.package}/lib/security/pam_succeed_if.so";
+          settings.quiet = true;
+          args = [
+            "user"
+            "="
+            dmcfg.autoLogin.user
+          ];
+        };
+      };
+    };
+
+    environment.systemPackages = [ emptty ];
+
+    services = {
+      dbus.packages = [ emptty ];
+      xserver = {
+        display = null;
+      };
+      displayManager = {
+        enable = true;
+        generic = {
+          enable = true;
+          execCmd = "exec ${lib.getExe emptty} --daemon --config ${settingsFormat.generate "config" cfg.settings}";
+        };
+        emptty = {
+          settings = {
+            TTY_NUMBER = 1;
+            SWITCH_TTY = lib.mkDefault true;
+            AUTO_SELECTION = lib.mkDefault true;
+            XORG_ARGS = toString config.services.xserver.displayManager.xserverArgs;
+            XORG_SESSIONS_PATH = "${desktops}/share/xsessions";
+            WAYLAND_SESSIONS_PATH = "${desktops}/share/wayland-sessions";
+          }
+          // lib.optionalAttrs (dmcfg.defaultSession != null) {
+            DEFAULT_SESSION = dmcfg.defaultSession;
+          }
+          // lib.optionalAttrs dmcfg.autoLogin.enable {
+            AUTOLOGIN = true;
+            DEFAULT_USER = dmcfg.autoLogin.user;
+            AUTOLOGIN_SESSION = dmcfg.sessionData.autologinSession;
+          };
+        };
+      };
+    };
+
+    systemd.services.display-manager = {
+      path = [ "/run/current-system/sw" ];
+      unitConfig = {
+        Wants = [ "systemd-user-sessions.service" ];
+        After = [
+          "systemd-user-sessions.service"
+          "plymouth-quit-wait.service"
+        ];
+      };
+      serviceConfig = {
+        Type = "idle";
+        StandardInput = "tty";
+        TTYPath = "/dev/tty${toString cfg.settings.TTY_NUMBER or 1}";
+        TTYReset = "yes";
+        TTYVHangup = "yes";
+        TTYVTDisallocate = true;
+        KillMode = "process";
+        IgnoreSIGPIPE = "no";
+        SendSIGHUP = "yes";
+        LogDirectory = "emptty";
+        CacheDirectory = "emptty";
+      };
+      restartIfChanged = false;
+    };
+  };
+}

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -840,6 +840,7 @@ in
             || dmConf.sx.enable
             || dmConf.startx.enable
             || config.services.greetd.enable
+            || config.services.displayManager.emptty.enable
             || config.services.displayManager.ly.enable
             || config.services.displayManager.lemurs.enable
             || config.services.displayManager.plasma-login-manager.enable

--- a/pkgs/by-name/em/emptty/package.nix
+++ b/pkgs/by-name/em/emptty/package.nix
@@ -2,9 +2,12 @@
   buildGoModule,
   fetchFromGitHub,
   lib,
-  libx11,
   pam,
   stdenv,
+  util-linux,
+  x11Support ? true,
+  xauth,
+  xorg-server,
 }:
 
 buildGoModule (finalAttrs: {
@@ -20,10 +23,16 @@ buildGoModule (finalAttrs: {
 
   buildInputs = [
     pam
-    libx11
   ];
 
   vendorHash = "sha256-PLyemAUcCz9H7+nAxftki3G7rQoEeyPzY3YUEj2RFn4=";
+
+  postPatch = lib.optionalString x11Support ''
+    substituteInPlace src/session_xorg.go \
+      --replace-fail '/usr/bin/mcookie' '${lib.getExe' util-linux "mcookie"}' \
+      --replace-fail '/usr/bin/xauth' '${lib.getExe xauth}' \
+      --replace-fail '/usr/bin/Xorg' '${lib.getExe' xorg-server "Xorg"}'
+  '';
 
   meta = {
     description = "Dead simple CLI Display Manager on TTY";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Added a NixOS module for [emptty](https://github.com/tvrzna/emptty) display manager.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
