### PR TITLE
codecov-cli: fix bug due to wrong relaxed dependency

### DIFF
--- a/pkgs/by-name/co/codecov-cli/package.nix
+++ b/pkgs/by-name/co/codecov-cli/package.nix
@@ -2,7 +2,20 @@
   lib,
   python3Packages,
   fetchFromGitHub,
+  fetchPypi,
 }:
+let
+  # Due to bug:
+  # https://github.com/codecov/codecov-cli/issues/721
+  click_8_2 = python3Packages.click.overridePythonAttrs (old: rec {
+    version = "8.2.1";
+    src = fetchPypi {
+      pname = "click";
+      inherit version;
+      hash = "sha256-J8SRzAXZaNJx1aHbE+O1oYRjbZ2TDxSMULA48NBkYgI=";
+    };
+  });
+in
 
 python3Packages.buildPythonApplication rec {
   pname = "codecov-cli";
@@ -21,12 +34,11 @@ python3Packages.buildPythonApplication rec {
   build-system = with python3Packages; [ setuptools ];
 
   pythonRelaxDeps = [
-    "click"
     "responses"
   ];
 
   dependencies = with python3Packages; [
-    click
+    click_8_2
     ijson
     pyyaml
     responses


### PR DESCRIPTION
The bug https://github.com/codecov/codecov-cli/issues/721 makes the executable unusable.

Its due to wrongly relaxed dependency.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
