### PR TITLE
oxvg: init at 0.0.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28847,6 +28847,12 @@
     github = "TyberiusPrime";
     githubId = 1257580;
   };
+  tyceherrman = {
+    email = "Tyce.Herrman@pm.me";
+    github = "TyceHerrman";
+    githubId = 22066434;
+    name = "Tyce Herrman";
+  };
   tye-exe = {
     name = "Tye";
     email = "nixpkgs-fr@tye-home.xyz";

--- a/pkgs/by-name/ox/oxvg/package.nix
+++ b/pkgs/by-name/ox/oxvg/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  fetchCrate,
+  nix-update-script,
+  rustPlatform,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "oxvg";
+  version = "0.0.5";
+  __structuredAttrs = true;
+
+  src = fetchCrate {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-I52L0cbj7BYdHVVhJEdhT28DRTg/f7eWpN0qGxfSdhQ=";
+  };
+
+  cargoHash = "sha256-+dfM2/SjUTwNAoKC7cjw2Ba1RNp6BwmbR1TxXtp9W4E=";
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Vector image toolchain";
+    homepage = "https://github.com/noahbald/oxvg";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tyceherrman ];
+    mainProgram = "oxvg";
+  };
+})


### PR DESCRIPTION
Add `oxvg`, a Rust CLI vector-graphics toolchain, using the published crates.io source for version 0.0.5.

Automation disclosure: this PR was prepared with assistance from OpenAI Codex (GPT-5). I reviewed the generated changes and verification output before submission.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Verification:

- `nix-instantiate -A oxvg .`
- `nix-build -A oxvg .`
- `./result/bin/oxvg --version`
- `./result/bin/oxvg --help`
- `nixpkgs-review rev HEAD` built `oxvg`
- `XDG_CACHE_HOME=/private/tmp/codex-nix-cache ./ci/nixpkgs-vet.sh master`

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
