### PR TITLE
electron_43: init at 43.1.0, electron-{bin,chromedriver}: drop x86_64-darwin support

### DIFF
--- a/pkgs/by-name/gc/gclient2nix/gclient2nix.py
+++ b/pkgs/by-name/gc/gclient2nix/gclient2nix.py
@@ -60,7 +60,14 @@ class Repo:
         )
 
         deps_file = self.get_file("DEPS")
-        evaluated = gclient_eval.Parse(deps_file, vars_override=repo_vars, filename="DEPS")
+        evaluated = gclient_eval.Parse(
+            deps_file,
+            filename="DEPS",
+            vars_override=repo_vars,
+            # KeyError: "host_cpu was used as a variable, but was not declared in the vars dict (file 'DEPS', line 114)"
+            # https://chromium.googlesource.com/webpagereplay.git/+/b2b856131e36c99e9de9c419fe8ca02f857082ba/DEPS#114
+            builtin_vars= {"host_cpu": "*host_cpu_placeholder*"} if path == "src/third_party/webpagereplay" else None,
+        )
 
         repo_vars = dict(evaluated.get("vars", {})) | repo_vars
 

--- a/pkgs/by-name/gc/gclient2nix/package.nix
+++ b/pkgs/by-name/gc/gclient2nix/package.nix
@@ -69,8 +69,8 @@ runCommand "gclient2nix"
     # substitutions
     depot_tools_checkout = fetchgit {
       url = "https://chromium.googlesource.com/chromium/tools/depot_tools";
-      rev = "977d597d75def6781f890cdce459969a9568ea07";
-      hash = "sha256-OCIay+a+DHvKKIbDMSjTf6CbHHVfp8k0n1AO3E4yx1U=";
+      rev = "1b1b01fa912786b88a79f3504176a275183839b5";
+      hash = "sha256-SRPeosetXYUklafhcuqsJiIKfItUJACG70m4Z5pBQiU=";
     };
 
     passthru = {

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -38,5 +38,16 @@
             "x86_64-linux": "3a729b020acb04aefac2c9b4b29c65b37dd7126a14a04d1ef29acb256d3edbd1"
         },
         "version": "42.5.1"
+    },
+    "43": {
+        "hashes": {
+            "aarch64-darwin": "2ee24f768c41bc2ed9bd580d7797b185dffb550dafca59c2cd08b51965bcda3a",
+            "aarch64-linux": "78799ae4fdc7969acb152aa0f33f39bd5eaca2de3eafe817a13487b872abe43c",
+            "armv7l-linux": "1f32ac165dd1d01f1dcb8bfb881503369c7b739dd292034ef61e2ea75b852a2c",
+            "headers": "1xqgvsj7pq2j5yvg0yxa4l5l276dmj9zlpxmvy2g993bdypxj8zi",
+            "x86_64-darwin": "c84cd358a6c58ee9d6ce26ced694ab3b750109e9f29145ff5a639db64037f1de",
+            "x86_64-linux": "be56b5b8451bda585b56e6a6a67757da2cb7ead59f036b6000431a51c0e0c79b"
+        },
+        "version": "43.1.0"
     }
 }

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -45,7 +45,6 @@
             "aarch64-linux": "78799ae4fdc7969acb152aa0f33f39bd5eaca2de3eafe817a13487b872abe43c",
             "armv7l-linux": "1f32ac165dd1d01f1dcb8bfb881503369c7b739dd292034ef61e2ea75b852a2c",
             "headers": "1xqgvsj7pq2j5yvg0yxa4l5l276dmj9zlpxmvy2g993bdypxj8zi",
-            "x86_64-darwin": "c84cd358a6c58ee9d6ce26ced694ab3b750109e9f29145ff5a639db64037f1de",
             "x86_64-linux": "be56b5b8451bda585b56e6a6a67757da2cb7ead59f036b6000431a51c0e0c79b"
         },
         "version": "43.1.0"

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -45,7 +45,6 @@
             "aarch64-linux": "7bdc6d18aafb3aa434374998bbfccdd2087b9495745dd134c06e5f74eafa95d5",
             "armv7l-linux": "77a395bb4f4046fb43de81e9eac4b3f5d7d0f5911f2262bcd110bfe2ad1f3076",
             "headers": "1xqgvsj7pq2j5yvg0yxa4l5l276dmj9zlpxmvy2g993bdypxj8zi",
-            "x86_64-darwin": "1450a8af80b7d4c66a4b85779090ce80e1e1b52dacef5dd89322a10b07fe4848",
             "x86_64-linux": "e946ae6cad7dc279431e841e0bc19ba4e0dc16a82c5a9c1f7c4d9f3925e5b39a"
         },
         "version": "43.1.0"

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -38,5 +38,16 @@
             "x86_64-linux": "e0db56b8781035a48aae7fefdac311abb8993a7f6e72009e7adfb70926565bf0"
         },
         "version": "42.5.1"
+    },
+    "43": {
+        "hashes": {
+            "aarch64-darwin": "733c8fd5b80e761739cc776c1c6777115bd39cf86d825e895d996734ee3f3515",
+            "aarch64-linux": "7bdc6d18aafb3aa434374998bbfccdd2087b9495745dd134c06e5f74eafa95d5",
+            "armv7l-linux": "77a395bb4f4046fb43de81e9eac4b3f5d7d0f5911f2262bcd110bfe2ad1f3076",
+            "headers": "1xqgvsj7pq2j5yvg0yxa4l5l276dmj9zlpxmvy2g993bdypxj8zi",
+            "x86_64-darwin": "1450a8af80b7d4c66a4b85779090ce80e1e1b52dacef5dd89322a10b07fe4848",
+            "x86_64-linux": "e946ae6cad7dc279431e841e0bc19ba4e0dc16a82c5a9c1f7c4d9f3925e5b39a"
+        },
+        "version": "43.1.0"
     }
 }

--- a/pkgs/development/tools/electron/common.nix
+++ b/pkgs/development/tools/electron/common.nix
@@ -225,16 +225,20 @@ in
     allow_runtime_configurable_key_storage = true;
     enable_cet_shadow_stack = false;
     is_cfi = false;
-    v8_builtins_profiling_log_file = "";
     enable_dangling_raw_ptr_checks = false;
-    dawn_use_built_dxc = false;
+    enable_dangling_raw_ptr_feature_flag = false;
     v8_enable_private_mapping_fork_optimization = true;
     v8_expose_public_symbols = true;
-    enable_dangling_raw_ptr_feature_flag = false;
-    clang_unsafe_buffers_paths = "";
-    enterprise_cloud_content_analysis = false;
     enable_linux_installer = false;
     enable_pdf_save_to_drive = false;
+  }
+  // lib.optionalAttrs (lib.versionOlder info.version "43") {
+    enterprise_cloud_content_analysis = false;
+  }
+  // lib.optionalAttrs (lib.versionAtLeast info.version "43") {
+    node_openssl_path = "//third_party/boringssl";
+  }
+  // {
 
     # other
     enable_widevine = false;

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -2818,5 +2818,1435 @@
         "modules": "146",
         "node": "24.17.0",
         "version": "42.5.1"
+    },
+    "43": {
+        "chrome": "150.0.7871.47",
+        "chromium": {
+            "deps": {
+                "gn": {
+                    "hash": "sha256-/1A+DkzAQj2zGPe/A/G0Z3VrYJXUxq4Hd/+d/o5p3G8=",
+                    "rev": "3357c4f51b1a9e676378c695dd9c7e9911c35ee6",
+                    "version": "0-unstable-2026-05-27"
+                }
+            },
+            "version": "150.0.7871.47"
+        },
+        "chromium_npm_hash": "sha256-pF0JtwFpPC4/fodbhSJnQKkczA9WlDg4VqEAy9aDVLg=",
+        "deps": {
+            "src": {
+                "args": {
+                    "hash": "sha256-LYI9szAqoiJLIu1CUJYRBLdvBrNafaOXQQiYdbp5PRY=",
+                    "postFetch": "rm -rf $(find $out/third_party/blink/web_tests ! -name BUILD.gn -mindepth 1 -maxdepth 1); rm -r $out/content/test/data; rm -rf $out/courgette/testdata; rm -r $out/extensions/test/data; rm -r $out/media/test/data; ",
+                    "tag": "150.0.7871.47",
+                    "url": "https://chromium.googlesource.com/chromium/src.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/agents/shared": {
+                "args": {
+                    "hash": "sha256-z2GrzF8jDkdfBdq1HP3gTgQpoqjmhc80kEZBmlue0os=",
+                    "rev": "e75efa515896f6bf1dea92eaffbcf8ee711a65d8",
+                    "url": "https://chromium.googlesource.com/chromium/agents.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/chrome/test/data/perf/canvas_bench": {
+                "args": {
+                    "hash": "sha256-svOuyBGKloBLM11xLlWCDsB4PpRjdKTBdW2UEW4JQjM=",
+                    "rev": "a7b40ea5ae0239517d78845a5fc9b12976bfc732",
+                    "url": "https://chromium.googlesource.com/chromium/canvas_bench.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/chrome/test/data/perf/frame_rate/content": {
+                "args": {
+                    "hash": "sha256-t4kcuvH0rkPBkcdiMsoNQaRwU09eU+oSvyHDiAHrKXo=",
+                    "rev": "c10272c88463efeef6bb19c9ec07c42bc8fe22b9",
+                    "url": "https://chromium.googlesource.com/chromium/frame_rate/content.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/chrome/test/data/xr/webvr_info": {
+                "args": {
+                    "hash": "sha256-BsAPwc4oEWri0TlqhyxqFNqKdfgVSrB0vQyISmYY4eg=",
+                    "rev": "c58ae99b9ff9e2aa4c524633519570bf33536248",
+                    "url": "https://chromium.googlesource.com/external/github.com/toji/webvr.info.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/docs/website": {
+                "args": {
+                    "hash": "sha256-wrkFsPX7jrsjD/Ow1gna/xLvk0E49m5GVxP1G7Vx7HM=",
+                    "rev": "3da515a67f412be05ea1ea6b39832a69aef8f54e",
+                    "url": "https://chromium.googlesource.com/website.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/electron": {
+                "args": {
+                    "hash": "sha256-HgGRcv5ixKQOQrblfgg0VZ3xTPqxvMV1m6PpK3qxMcI=",
+                    "owner": "electron",
+                    "repo": "electron",
+                    "tag": "v43.1.0"
+                },
+                "fetcher": "fetchFromGitHub"
+            },
+            "src/media/cdm/api": {
+                "args": {
+                    "hash": "sha256-GsaRxLnsz1jrFZ3m5tv65d1dioG23uJnmfa+WD7XcFc=",
+                    "rev": "33c977516b3dfe5b065bc298aa74175e1999ab51",
+                    "url": "https://chromium.googlesource.com/chromium/cdm.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/net/third_party/quiche/src": {
+                "args": {
+                    "hash": "sha256-xgDgW2foZZEWpr0ibSG21kf028FN07/1ecOqFCkNj/I=",
+                    "rev": "997d654308b6a1a17435e472ef5190aecb12e3eb",
+                    "url": "https://quiche.googlesource.com/quiche.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/testing/libfuzzer/fuzzers/wasm_corpus": {
+                "args": {
+                    "hash": "sha256-gItDOfNqm1tHlmelz3l2GGdiKi9adu1EpPP6U7+8EQY=",
+                    "rev": "1df5e50a45db9518a56ebb42cb020a94a090258b",
+                    "url": "https://chromium.googlesource.com/v8/fuzzer_wasm_corpus.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/angle": {
+                "args": {
+                    "hash": "sha256-8iuHtNgHumlMXeXj2k0ZPcvnTeJ00di298+789OjScs=",
+                    "rev": "bbf3d8a4755268f016087be2f56099fa5a5f3f6e",
+                    "url": "https://chromium.googlesource.com/angle/angle.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/angle/third_party/VK-GL-CTS/src": {
+                "args": {
+                    "hash": "sha256-SrL+G3osTtJGQslfCBEYbslb2kWtHRrwO87PHi+5o6E=",
+                    "rev": "01471f4b3846c97eceb5b16b8acad950808791b2",
+                    "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/VK-GL-CTS"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/angle/third_party/glmark2/src": {
+                "args": {
+                    "hash": "sha256-VebUALLFKwEa4+oE+jF8mBSzhJd6aflphPmcK1Em8bw=",
+                    "rev": "6edcf02205fd1e8979dc3f3964257a81959b80c8",
+                    "url": "https://chromium.googlesource.com/external/github.com/glmark2/glmark2"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/angle/third_party/rapidjson/src": {
+                "args": {
+                    "hash": "sha256-oHHLYRDMb7Y/k0CwsdsxPC5lglr2IChQi0AiOMiFn78=",
+                    "rev": "24b5e7a8b27f42fa16b96fc70aade9106cf7102f",
+                    "url": "https://chromium.googlesource.com/external/github.com/Tencent/rapidjson"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/anonymous_tokens/src": {
+                "args": {
+                    "hash": "sha256-llPt+UR8hY0yaJkYmq+A3ZfRRReuaXN09qpap6C28jc=",
+                    "rev": "92d1fdf881a932e7aa2a9b20e006136a659c7a20",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/anonymous-tokens.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/aria-practices/src": {
+                "args": {
+                    "hash": "sha256-POnvoO1KfzJj4CbcMPI0pUTRk5EtHLTOyKKmJCZdXOc=",
+                    "rev": "7b134ce6d19497cce8a67db4a9f59980baf853dc",
+                    "url": "https://chromium.googlesource.com/external/github.com/w3c/aria-practices.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/boringssl/src": {
+                "args": {
+                    "hash": "sha256-JuMnNppWhIFHYfk6ANIZLC7ABhqMseoV5LYV7slevBE=",
+                    "rev": "3a9254f16eda7a4c5d2260039ff23456a0a34de4",
+                    "url": "https://boringssl.googlesource.com/boringssl.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/breakpad/breakpad": {
+                "args": {
+                    "hash": "sha256-NplvLz9oET6mhTuBkHH6pZc8qdfhqI7g69eZRCyae0A=",
+                    "rev": "8ef5673404a3bbc192b0997e1c2df559cc5bd79d",
+                    "url": "https://chromium.googlesource.com/breakpad/breakpad.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/cast_core/public/src": {
+                "args": {
+                    "hash": "sha256-yQxm1GMMne80bLl1P7OAN3bJLz1qRNAvou2/5MKp2ig=",
+                    "rev": "f5ee589bdaea60418f670fa176be15ccb9a34942",
+                    "url": "https://chromium.googlesource.com/cast_core/public"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/catapult": {
+                "args": {
+                    "hash": "sha256-XYufVvzOXD4voZUWUvumQQqLNsx9sy0QmQzNzrgNEWg=",
+                    "rev": "2852bb7e91e4995502ffb72b7ed21412ee157914",
+                    "url": "https://chromium.googlesource.com/catapult.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/ced/src": {
+                "args": {
+                    "hash": "sha256-ySG74Rj2i2c/PltEgHVEDq+N8yd9gZmxNktc56zIUiY=",
+                    "rev": "ba412eaaacd3186085babcd901679a48863c7dd5",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/compact_enc_det.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/clang-format/script": {
+                "args": {
+                    "hash": "sha256-Cm6BOOlEyD0kdYxMSmk6Fj1Dnfs3zCzXsm+BOXgBme0=",
+                    "rev": "6eddfb5ec5f92127a531eda66c568d3a11e7ec11",
+                    "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/clang/tools/clang-format.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/cld_3/src": {
+                "args": {
+                    "hash": "sha256-C3MOMBUy9jgkT9BAi/Fgm2UH4cxRuwSBEcRl3hzM2Ss=",
+                    "rev": "b48dc46512566f5a2d41118c8c1116c4f96dc661",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/cld_3.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/colorama/src": {
+                "args": {
+                    "hash": "sha256-6ZTdPYSHdQOLYMSnE+Tp7PgsVTs3U2awGu9Qb4Rg/tk=",
+                    "rev": "3de9f013df4b470069d03d250224062e8cf15c49",
+                    "url": "https://chromium.googlesource.com/external/colorama.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/compiler-rt/src": {
+                "args": {
+                    "hash": "sha256-KnWESGG6aI0S+fkJ3/T1x4QSiIYaOOvWUAm6l6l9iME=",
+                    "rev": "03641f7a5b05e48e318d64369057db577cafc594",
+                    "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/compiler-rt.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/content_analysis_sdk/src": {
+                "args": {
+                    "hash": "sha256-f5Jmk1MiGjaRdLun+v/GKVl8Yv9hOZMTQUSxgiJalcY=",
+                    "rev": "9a408736204513e0e95dd2ab3c08de0d95963efc",
+                    "url": "https://chromium.googlesource.com/external/github.com/chromium/content_analysis_sdk.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/cpu_features/src": {
+                "args": {
+                    "hash": "sha256-TrC1WMLAhko57rAyDCiAC/IJ0unAqVhyjkh7gKibyi4=",
+                    "rev": "81d13c49649f0714dd41fb56bb246398b6584085",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/cpu_features.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/cpuinfo/src": {
+                "args": {
+                    "hash": "sha256-/QsOjDik0TnH3FnK7LOwsJkvX+O+2DRFX4eF3MxD3fc=",
+                    "rev": "ea6b9f1bb6e1001d8b21574d5bc78ddef62e499d",
+                    "url": "https://chromium.googlesource.com/external/github.com/pytorch/cpuinfo.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/crabbyavif/src": {
+                "args": {
+                    "hash": "sha256-tN+2YH2O9FTV50o4OVhKcKdwRwTI8NuNA0WqljUcrmo=",
+                    "rev": "5e140b5abb9a91eb25b5ef66d29f6ee784ab7eab",
+                    "url": "https://chromium.googlesource.com/external/github.com/webmproject/CrabbyAvif.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/crc32c/src": {
+                "args": {
+                    "hash": "sha256-KBraGaO5LmmPP+p8RuDogGldbTWdNDK+WzF4Q09keuE=",
+                    "rev": "d3d60ac6e0f16780bcfcc825385e1d338801a558",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/crc32c.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/cros-components/src": {
+                "args": {
+                    "hash": "sha256-viuntf6umyLZwDR9BXG+ZOakp9f8rvpZYDBYAUkKzL4=",
+                    "rev": "0abb2efaa3d16db861c9710b193c39e657ac3bdf",
+                    "url": "https://chromium.googlesource.com/external/google3/cros_components.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/cros_system_api": {
+                "args": {
+                    "hash": "sha256-qIwUs0KVU9xYFLN3UUayPLfz0ObA+EN6owKPW61J/5w=",
+                    "rev": "1c69e700a01a7fd3dd331f526c8a31ac1e5e49d0",
+                    "url": "https://chromium.googlesource.com/chromiumos/platform2/system_api.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/crossbench": {
+                "args": {
+                    "hash": "sha256-iwwvvIOuRMo/ZEu8Gk0lZaS4P5uGt8zpnYMChpZPcUo=",
+                    "rev": "7d52b4ffbc319a7d5a0e0a0ebff744e5281d60c5",
+                    "url": "https://chromium.googlesource.com/crossbench.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/crossbench-web-tests": {
+                "args": {
+                    "hash": "sha256-7ly4vaK+Pj4y91t6Q+igQ0890CqKyu9jNBhJnxbNGjI=",
+                    "rev": "7b3de17542cc613aaddbfc72c6e12be37eed7b73",
+                    "url": "https://chromium.googlesource.com/chromium/web-tests.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/dav1d/libdav1d": {
+                "args": {
+                    "hash": "sha256-5cpKTUnhR+QzQJR4KbAvdvqsWnT1fpH0g9MObv8Nx0c=",
+                    "rev": "62501cc7db378532d7e85ea434b70d57e1ba2cb0",
+                    "url": "https://chromium.googlesource.com/external/github.com/videolan/dav1d.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/dawn": {
+                "args": {
+                    "hash": "sha256-tzomo+GTec2zixxk61gtlma/sjcBImgbLMwA+mIp1LM=",
+                    "rev": "01249a97332468dbdd6cf5edb8dd7bae77875de5",
+                    "url": "https://dawn.googlesource.com/dawn.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/dawn/third_party/EGL-Registry/src": {
+                "args": {
+                    "hash": "sha256-csSV8Yp0p0UIrodbX5793uO5iZMjQfy+0D2wPif2+Fw=",
+                    "rev": "3d7796b3721d93976b6bfe536aa97bbc4bce8667",
+                    "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/EGL-Registry"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/dawn/third_party/OpenGL-Registry/src": {
+                "args": {
+                    "hash": "sha256-xLacUOSy783bCtv+wUnjVnNLwTQ3eLwUJtYXmELqekY=",
+                    "rev": "a30033d3e812c9bf10094f1010374a6b15e192eb",
+                    "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/OpenGL-Registry"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/dawn/third_party/directx-headers/src": {
+                "args": {
+                    "hash": "sha256-0Miw1Cy/jmOo7bLFBOHuTRDV04cSeyvUEyPkpVsX9DA=",
+                    "rev": "980971e835876dc0cde415e8f9bc646e64667bf7",
+                    "url": "https://chromium.googlesource.com/external/github.com/microsoft/DirectX-Headers"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/dawn/third_party/directx-shader-compiler/src": {
+                "args": {
+                    "hash": "sha256-pzBk+jUp/FUV8ahHquE0942Qw/DjAUemSM9fxdFJ0JA=",
+                    "rev": "35c1b99e9e552267da5efaea07c003e322d65777",
+                    "url": "https://chromium.googlesource.com/external/github.com/microsoft/DirectXShaderCompiler"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/dawn/third_party/glfw3/src": {
+                "args": {
+                    "hash": "sha256-uVJOf+D3bgS/CyEL1y52gvkml6VUTtNPMTU6X5/XyS4=",
+                    "rev": "b00e6a8a88ad1b60c0a045e696301deb92c9a13e",
+                    "url": "https://chromium.googlesource.com/external/github.com/glfw/glfw"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/dawn/third_party/webgpu-cts": {
+                "args": {
+                    "hash": "sha256-f5kWMnaod/Ved1Fz/vTkdL0ihSUnNM8XN5Ht3Vs1YpU=",
+                    "rev": "f08551b0fc4d6cfa5ba582a0235b571aa363102d",
+                    "url": "https://chromium.googlesource.com/external/github.com/gpuweb/cts"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/dawn/third_party/webgpu-headers/src": {
+                "args": {
+                    "hash": "sha256-tFn3OChLKsYz52Vml7WVgqyrK7SI6WR1Z2C2vvFfakI=",
+                    "rev": "dc16b3e531cf4f31be54236d1a3e988ba5f295a2",
+                    "url": "https://chromium.googlesource.com/external/github.com/webgpu-native/webgpu-headers"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/depot_tools": {
+                "args": {
+                    "hash": "sha256-3atvbwYnFTA40MonAxSQWkF58Jku7O7fUzelGPQvDyY=",
+                    "rev": "f4fadaf6a5ba1bced9d3d9021060667b563bf583",
+                    "url": "https://chromium.googlesource.com/chromium/tools/depot_tools.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/devtools-frontend/src": {
+                "args": {
+                    "hash": "sha256-VBXch2YwnKm+lMcZ5L0SlW+vAYeaSwgZvcOhg1TE5/A=",
+                    "rev": "1d67dc0dafa344bbd6ca75c124e2d6d9d53074d8",
+                    "url": "https://chromium.googlesource.com/devtools/devtools-frontend"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/dom_distiller_js/dist": {
+                "args": {
+                    "hash": "sha256-yuEBD2XQlV3FGI/i7lTmJbCqzeBiuG1Qow8wvsppGJw=",
+                    "rev": "199de96b345ada7c6e7e6ba3d2fa7a6911b8767d",
+                    "url": "https://chromium.googlesource.com/chromium/dom-distiller/dist.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/domato/src": {
+                "args": {
+                    "hash": "sha256-fYxoA0fxKe9U23j+Jp0MWj4m7RfsRpM0XjF6/yOhX1I=",
+                    "rev": "053714bccbda79cf76dac3fee48ab2b27f21925e",
+                    "url": "https://chromium.googlesource.com/external/github.com/googleprojectzero/domato.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/dragonbox/src": {
+                "args": {
+                    "hash": "sha256-j6swuGgYGfiFcK3iqd4EKTeU92rZHKTbF5T1fcak/ko=",
+                    "rev": "beeeef91cf6fef89a4d4ba5e95d47ca64ccb3a44",
+                    "url": "https://chromium.googlesource.com/external/github.com/jk-jeon/dragonbox.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/eigen3/src": {
+                "args": {
+                    "hash": "sha256-6bZFDeo7TqWNunkkQv8OJ+7/hfKwoIUtqZoXaeLp6M8=",
+                    "rev": "662ba79d796a2851b10cdafc6668e45b65b1120f",
+                    "url": "https://chromium.googlesource.com/external/gitlab.com/libeigen/eigen.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/electron_node": {
+                "args": {
+                    "hash": "sha256-jlyRCBNU4YV5NKwsibJFcp7dRerfDlNFoCjWU1H1aqE=",
+                    "owner": "nodejs",
+                    "repo": "node",
+                    "tag": "v24.18.0"
+                },
+                "fetcher": "fetchFromGitHub"
+            },
+            "src/third_party/emoji-segmenter/src": {
+                "args": {
+                    "hash": "sha256-KdQdKBBipEBRT8UmNGao6yCB4m2CU8/SrMVvcXlb5qE=",
+                    "rev": "955936be8b391e00835257059607d7c5b72ce744",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/emoji-segmenter.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/engflow-reclient-configs": {
+                "args": {
+                    "hash": "sha256-aZXYPj9KYBiZnljqOLlWJWS396Fg3EhjiQLZmkwCBsY=",
+                    "owner": "EngFlow",
+                    "repo": "reclient-configs",
+                    "rev": "955335c30a752e9ef7bff375baab5e0819b6c00d"
+                },
+                "fetcher": "fetchFromGitHub"
+            },
+            "src/third_party/expat/src": {
+                "args": {
+                    "hash": "sha256-veGg5/QjtBSmxYa8IyHF0NxEdJzlcJSZfzw8ay3ASVU=",
+                    "rev": "9bdfbc77e3355405ceefbe59420abed953a5657e",
+                    "url": "https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/farmhash/src": {
+                "args": {
+                    "hash": "sha256-5n58VEUxa/K//jAfZqG4cXyfxrp50ogWDNYcgiXVHdc=",
+                    "rev": "816a4ae622e964763ca0862d9dbd19324a1eaf45",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/farmhash.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/fast_float/src": {
+                "args": {
+                    "hash": "sha256-hzoB+Mmok3oe6B494uLc5ReWpUcB89zCGPYw4gvanK0=",
+                    "rev": "cfd12ebcf1f82c4fd44a950b1815dd0549bc8d89",
+                    "url": "https://chromium.googlesource.com/external/github.com/fastfloat/fast_float.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/federated_compute/src": {
+                "args": {
+                    "hash": "sha256-GZYo0FjgW8XCplAi6jzzruwDlIzsWjNEVQuCwXBCPz8=",
+                    "rev": "8de5837b817f28abc54a387a9417631b905ba90a",
+                    "url": "https://chromium.googlesource.com/external/github.com/google-parfait/federated-compute.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/ffmpeg": {
+                "args": {
+                    "hash": "sha256-41qpsOTedB51WMzzHXDiXA19OIzA7wG/Qgbz6IkmWpk=",
+                    "rev": "ad41607c61898cf7150e0fb20fe4bbabd44922a3",
+                    "url": "https://chromium.googlesource.com/chromium/third_party/ffmpeg.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/flac": {
+                "args": {
+                    "hash": "sha256-LZFAJf8mF14XvXYvvBoLHGied2P7o23LUxszDpZLe8E=",
+                    "rev": "e7108e2ed031547c3759217819a032065c820d73",
+                    "url": "https://chromium.googlesource.com/chromium/deps/flac.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/flatbuffers/src": {
+                "args": {
+                    "hash": "sha256-gV1hn1iHI7knFEXy3Oii97mLRZYJUBiBlTh6/sqOoXg=",
+                    "rev": "a86afae9399bbe631d1ea0783f8816e780e236cc",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/flatbuffers.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/fontconfig/src": {
+                "args": {
+                    "hash": "sha256-Oo4ewK86dbEkO5EXyGWvdmsPHa8Wk1BHQah784vIem0=",
+                    "rev": "d62c2ab268d1679335daa8fb0ea6970f35224a76",
+                    "url": "https://chromium.googlesource.com/external/fontconfig.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/fp16/src": {
+                "args": {
+                    "hash": "sha256-CR7h1d9RFE86l6btk4N8vbQxy0KQDxSMvckbiO87JEg=",
+                    "rev": "3d2de1816307bac63c16a297e8c4dc501b4076df",
+                    "url": "https://chromium.googlesource.com/external/github.com/Maratyszcza/FP16.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/freetype/src": {
+                "args": {
+                    "hash": "sha256-xnYeUAJx5n8LSg04AknfiudonfmlUdlj8nzHzSZi65I=",
+                    "rev": "b08a2eb0dd37f4a6c886fa5b0ecf5b3e1d27aac7",
+                    "url": "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/fuzztest/src": {
+                "args": {
+                    "hash": "sha256-317zRhJPc0D9A58W8fdCGFmpNZ5vACfd/tlZOsp/Cvw=",
+                    "rev": "da27bcae1a8902af1ae6a5c55d3674f22709bbf5",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/fuzztest.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/fxdiv/src": {
+                "args": {
+                    "hash": "sha256-LjX5kivfHbqCIA5pF9qUvswG1gjOFo3CMpX0VR+Cn38=",
+                    "rev": "63058eff77e11aa15bf531df5dd34395ec3017c8",
+                    "url": "https://chromium.googlesource.com/external/github.com/Maratyszcza/FXdiv.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/gemmlowp/src": {
+                "args": {
+                    "hash": "sha256-e6AeRhZioIiTG5R+IA9g2GBqI4o74wijJYmqINLOtQs=",
+                    "rev": "16e8662c34917be0065110bfcd9cc27d30f52fdf",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/gemmlowp.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/glslang/src": {
+                "args": {
+                    "hash": "sha256-ru3QVyyyqxZRcvSpy9pYhHHhkjuLVhQbgOT/vQJ/oIw=",
+                    "rev": "f6d9303ddaf2e879b9155f7186cd234f5a79079c",
+                    "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/glslang"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/google_benchmark/src": {
+                "args": {
+                    "hash": "sha256-M8QkA8+bckoRjlcVneYXNetmPEWEvmWy/mca5JA40Ho=",
+                    "rev": "8abf1e701fbd88c8170f48fe0558247e2e5f8e7d",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/benchmark.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/googletest/src": {
+                "args": {
+                    "hash": "sha256-gJhv3DQQSP5BQ6GmDobq42/Gkx4AbOg/ZS80bM0WpEw=",
+                    "rev": "4fe3307fb2d9f86d19777c7eb0e4809e9694dde7",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/googletest.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/harfbuzz/src": {
+                "args": {
+                    "hash": "sha256-uT4zK2hwHzEH6Nrd2rAeyzpQA1TmwtrdcujKYEUbLsY=",
+                    "rev": "d639197ed529b05c27f38ebaab365a621d5edad5",
+                    "url": "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/highway/src": {
+                "args": {
+                    "hash": "sha256-YUYZO9KLffczjwIz3mBBceD6oM1giLCFLDHgDCevdRA=",
+                    "rev": "2607d3b5b0113992fe84d3848859eae13b3b52c1",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/highway.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/hunspell_dictionaries": {
+                "args": {
+                    "hash": "sha256-mYDPXa64IOKLMNiBiMqDrQMR7gDPI+vdyVc+M7E+ddc=",
+                    "rev": "cccf64a8acc951afe3f47fee023908e55699bc58",
+                    "url": "https://chromium.googlesource.com/chromium/deps/hunspell_dictionaries.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/icu": {
+                "args": {
+                    "hash": "sha256-rNErsn11FZUh8GXAl7jK+NyLHIKrQR3LuoM1qFFGtmM=",
+                    "rev": "3859e64eed5d34544b27fbcab0ac1685ce83df3c",
+                    "url": "https://chromium.googlesource.com/chromium/deps/icu.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/ink/src": {
+                "args": {
+                    "hash": "sha256-LF+OcqNeg+KRuYmGuMZb4tmnr53sZHn/ZW1jg9ArPfc=",
+                    "rev": "0f9c6172b2ccc6b830ae313d522caf09e6933e06",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/ink.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/instrumented_libs": {
+                "args": {
+                    "hash": "sha256-5cb9qhSEzb941pF5HH0Br+x9wEH7MiGwQttvErb2mZo=",
+                    "rev": "e8cb570a9a2ee9128e2214c73417ad2a3c47780b",
+                    "url": "https://chromium.googlesource.com/chromium/third_party/instrumented_libraries.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/jetstream/main": {
+                "args": {
+                    "hash": "sha256-s6UMdUYWZqk/MbhyCi2zdQNgni98gGsYxcuUh/5AUy0=",
+                    "rev": "b7babdf323e64e69bd2f6c376189c15825f5c73a",
+                    "url": "https://chromium.googlesource.com/external/github.com/WebKit/JetStream.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/jetstream/v2.2": {
+                "args": {
+                    "hash": "sha256-zucA2tqNOsvjhwYQKZ5bFUC73ZF/Fu7KpBflSelvixw=",
+                    "rev": "2145cedef4ca2777b792cb0059d3400ee2a6153c",
+                    "url": "https://chromium.googlesource.com/external/github.com/WebKit/JetStream.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/jsoncpp/source": {
+                "args": {
+                    "hash": "sha256-q+DOwkjRlHacgfWf5UVY02aqfnKK9M/1YRBX6aMce9g=",
+                    "rev": "d4d072177213b117fb81d4cfda140de090616161",
+                    "url": "https://chromium.googlesource.com/external/github.com/open-source-parsers/jsoncpp.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/leveldatabase/src": {
+                "args": {
+                    "hash": "sha256-a1fcVI9Vsm1qE17Fnx5UxwOy4ZFMMJ0OKwNs/gZHYQI=",
+                    "rev": "7ee830d02b623e8ffe0b95d59a74db1e58da04c5",
+                    "url": "https://chromium.googlesource.com/external/leveldb.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libFuzzer/src": {
+                "args": {
+                    "hash": "sha256-TDi1OvYClJKmEDikanKVTmy8uxUXJ95nuVKo5u+uFPM=",
+                    "rev": "bea408a6e01f0f7e6c82a43121fe3af4506c932e",
+                    "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/compiler-rt/lib/fuzzer.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libaddressinput/src": {
+                "args": {
+                    "hash": "sha256-6yDZpZ+CwxGqNO4+lZLFB6ESREeVku1BoOMtR+hKQ3I=",
+                    "rev": "81eb9628382b07d371d8ea0b11badf7de3857fd5",
+                    "url": "https://chromium.googlesource.com/external/libaddressinput.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libaom/source/libaom": {
+                "args": {
+                    "hash": "sha256-oDubKvgqMk3w0luM//rR3NnCOk1h/WVTyRkuCmYASrw=",
+                    "rev": "137bcff61e73fdd2836dc04e8258bfb49cef595e",
+                    "url": "https://aomedia.googlesource.com/aom.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libc++/src": {
+                "args": {
+                    "hash": "sha256-vT1km7JgVpotDoNK+ae1gplSHcwrVNLsv/QAFUrDsIM=",
+                    "rev": "5abc7f839700f0f17338434e1c1c6a8c87c00c11",
+                    "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxx.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libc++abi/src": {
+                "args": {
+                    "hash": "sha256-L5CUvhpOLS+NBNGssCv0pY9rsDFuAI0LlPjXQRfy62A=",
+                    "rev": "8f11bb1d4438d0239d0dfc1bd9456a9f31629dda",
+                    "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxxabi.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libdrm/src": {
+                "args": {
+                    "hash": "sha256-kOaTjBeo4IsfWEk/JBTNId5ikrnpoc9DEjIl7DUd2yE=",
+                    "rev": "369990d9660a387f618d0eedc341eb285016243b",
+                    "url": "https://chromium.googlesource.com/chromiumos/third_party/libdrm.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libei/src": {
+                "args": {
+                    "hash": "sha256-lSrIC93Cke90/Xc8dqd3e/TU32tflYHYqc5fE8wglBI=",
+                    "rev": "5d6d8e6590df210b75559a889baa9459c68d9366",
+                    "url": "https://chromium.googlesource.com/external/gitlab.freedesktop.org/libinput/libei.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libgav1/src": {
+                "args": {
+                    "hash": "sha256-6/zMaX2DPSKpsaqirhrgi3nL/88Qr2VXacmyL5IyJ3U=",
+                    "rev": "66ac17620652635392f6ab24065c77b035e281c9",
+                    "url": "https://chromium.googlesource.com/codecs/libgav1.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libipp/libipp": {
+                "args": {
+                    "hash": "sha256-GzLVt6RIN+FgOpcK61ya5lvdIIhQRciAb/ISIirWogY=",
+                    "rev": "4be5f77f672a3a9f1bbf3c935fb0ea8b3f86ce61",
+                    "url": "https://chromium.googlesource.com/chromiumos/platform2/libipp.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libjpeg_turbo": {
+                "args": {
+                    "hash": "sha256-wor4RTF3/5BFL9EWcGEofY+M4HN2+/KJUaOY+u86K5Q=",
+                    "rev": "640f254ad0fa03f6b1f29f89b7dd9366f2f6e533",
+                    "url": "https://chromium.googlesource.com/chromium/deps/libjpeg_turbo.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/liblouis/src": {
+                "args": {
+                    "hash": "sha256-EI/uaHXe0NlqdEw764q0SjerThYEVLRogUlmrsZwXnY=",
+                    "rev": "9700847afb92cb35969bdfcbbfbbb74b9c7b3376",
+                    "url": "https://chromium.googlesource.com/external/liblouis-github.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libpfm4/src": {
+                "args": {
+                    "hash": "sha256-t4LMG38GksMEM5DktyJ0qLUX1biXErQ57MaMtd7hoeo=",
+                    "rev": "977a25bb3dfe45f653a6cee71ffaae9a92fc3095",
+                    "url": "https://chromium.googlesource.com/external/git.code.sf.net/p/perfmon2/libpfm4.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libphonenumber/src": {
+                "args": {
+                    "hash": "sha256-Lr/gB5Em+TE092McPwJdOU0Ab4zyP4/2ZxlavMZMm+s=",
+                    "rev": "c25558e39e2bcc9f26f7a2a1ef804324169eaf8f",
+                    "url": "https://chromium.googlesource.com/external/libphonenumber.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libprotobuf-mutator/src": {
+                "args": {
+                    "hash": "sha256-Su1SPr/GEFi7/N8/HrFkVbGfWH0vYdcJ5/on8zLMcyU=",
+                    "rev": "c1c950eae0440c3808f2b8bd7c57d0c6a42c1a90",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/libprotobuf-mutator.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libsrtp": {
+                "args": {
+                    "hash": "sha256-6tIbthIcUw58AgaNzvSenZPp/e5vHVTp5K2bpPF+Zg0=",
+                    "rev": "cd5d177bf1fde755ddb4c7f0d9ff7693f8b49e5e",
+                    "url": "https://chromium.googlesource.com/chromium/deps/libsrtp.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libsync/src": {
+                "args": {
+                    "hash": "sha256-aI7Exie3AmTy8R/Ua5lua0lCwMO1k4wMS6cxulU6iD8=",
+                    "rev": "d29ac04dc81e6b072c091c5b1342a282765ea250",
+                    "url": "https://chromium.googlesource.com/aosp/platform/system/core/libsync.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libunwind/src": {
+                "args": {
+                    "hash": "sha256-EuaVSYiR7qrlYqBR0UqdWCvwdzJSn0RS2wC/lnP19AE=",
+                    "rev": "d6c7a21e978f0adaa43accaad53bc64f0b64f6ec",
+                    "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libunwind.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libva-fake-driver/src": {
+                "args": {
+                    "hash": "sha256-em/8rNqwv6szlxyji7mnYr3nObSW/x3OzEEnkiLuqpI=",
+                    "rev": "a9bcab9cd6b15d4e3634ca44d5e5f7652c612194",
+                    "url": "https://chromium.googlesource.com/chromiumos/platform/libva-fake-driver.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libvpx/source/libvpx": {
+                "args": {
+                    "hash": "sha256-uTteQ+z7t5KOtPuBoZazmonRHd8jGS1/YZAq+RAvhX4=",
+                    "rev": "5f00413667d19ad683674524a9d03543d86d188b",
+                    "url": "https://chromium.googlesource.com/webm/libvpx.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libwebm/source": {
+                "args": {
+                    "hash": "sha256-zXPuisCv2KkGQq23qTNhHeXpyCClUIeyjHra08DHJIw=",
+                    "rev": "6184f4484a826724b5293837134ab9492261b941",
+                    "url": "https://chromium.googlesource.com/webm/libwebm.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libwebp/src": {
+                "args": {
+                    "hash": "sha256-a7F97BEnwpdx9W8OsVnz+NfIYW+J1XVDSi38KsIZIfI=",
+                    "rev": "c00d83f6642e7838a12bb03bca94237f03cc2e00",
+                    "url": "https://chromium.googlesource.com/webm/libwebp.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/libyuv": {
+                "args": {
+                    "hash": "sha256-FXFSC9dRb/KhSQdhJUqKEUpZbzU8ZpVnoSXtF/HPiJI=",
+                    "rev": "3c5fa6ef272f6077d76816ee3d6a697ef1d6d272",
+                    "url": "https://chromium.googlesource.com/libyuv/libyuv.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/litert/src": {
+                "args": {
+                    "hash": "sha256-skMOzpsn67mmOAp7Mf6UrJdi2lbiQQ8b6kBy4Ik2ED8=",
+                    "rev": "09b4b05203fd7a9402ffcce9cc736d887ff7e3fc",
+                    "url": "https://chromium.googlesource.com/external/github.com/google-ai-edge/LiteRT.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/llvm-libc/src": {
+                "args": {
+                    "hash": "sha256-qrkx8Z1fc088Ja32obIUPxDwklI7i1wdEw051UZ08u8=",
+                    "rev": "6e5ec6f78d8b9f2e8a50fcc5692d1fc8b2964bde",
+                    "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libc.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/lss": {
+                "args": {
+                    "hash": "sha256-89CdA7vBYudbko0nAIyHcpHMXqFZHC05kwRIUmeEWGo=",
+                    "rev": "29164a80da4d41134950d76d55199ea33fbb9613",
+                    "url": "https://chromium.googlesource.com/linux-syscall-support.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/material_color_utilities/src": {
+                "args": {
+                    "hash": "sha256-Y85XU+z9W6tvmDNHJ/dXQnUKXvvDkO3nH/kUJRLqbc4=",
+                    "rev": "13434b50dcb64a482cc91191f8cf6151d90f5465",
+                    "url": "https://chromium.googlesource.com/external/github.com/material-foundation/material-color-utilities.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/minigbm/src": {
+                "args": {
+                    "hash": "sha256-9HwvjTETerbQ7YKXH9kUB2eWa8PxGWMAJfx1jAluhrs=",
+                    "rev": "3018207f4d89395cc271278fb9a6558b660885f5",
+                    "url": "https://chromium.googlesource.com/chromiumos/platform/minigbm.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/nan": {
+                "args": {
+                    "hash": "sha256-Tq6whJBeGlJhF7/ctFOEgb1W12Tu/HGNTC5ujQtk+Qk=",
+                    "owner": "nodejs",
+                    "repo": "nan",
+                    "rev": "675cefebca42410733da8a454c8d9391fcebfbc2"
+                },
+                "fetcher": "fetchFromGitHub"
+            },
+            "src/third_party/nasm": {
+                "args": {
+                    "hash": "sha256-uC6bGxSdz1V2SXIQjMsDd6555b3gAPN1Y0ZQtWoqDww=",
+                    "rev": "525a09a813be0f75b646ee93fc2a31c27b87d722",
+                    "url": "https://chromium.googlesource.com/chromium/deps/nasm.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/nearby/src": {
+                "args": {
+                    "hash": "sha256-Mwuo2RlKweqZPkDw4OcJDD+QNRiXVysSyzLdjHsG1mA=",
+                    "rev": "0bad8b0c9877f92eeeb550654f1ea51a71a085e4",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/nearby-connections.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/neon_2_sse/src": {
+                "args": {
+                    "hash": "sha256-ydHSMPJS+axvW7KIR/9SLWNFq/lP67dpg9Yt7shLCng=",
+                    "rev": "ed59be8546632d5126ff69c87122ae5de20ffe4f",
+                    "url": "https://chromium.googlesource.com/external/github.com/intel/ARM_NEON_2_x86_SSE.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/nlohmann_json/src": {
+                "args": {
+                    "hash": "sha256-t+ygFLws+E4D0Avia7swt4wruaDFaAT6shN6tl92q8k=",
+                    "rev": "75d9166a68355d2cd5a98bfd1a75a3a3dae8f071",
+                    "url": "https://chromium.googlesource.com/external/github.com/nlohmann/json.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/oak/src": {
+                "args": {
+                    "hash": "sha256-+ouwII+i5CbWoJ3NAxQPmczofzkPwtZTtjIPaXyyXt8=",
+                    "rev": "96c00a6c99ac382f3f3a8f376bc7a70890d1adaa",
+                    "url": "https://chromium.googlesource.com/external/github.com/project-oak/oak.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/openh264/src": {
+                "args": {
+                    "hash": "sha256-tf0lnxATCkoq+xRti6gK6J47HwioAYWnpEsLGSA5Xdg=",
+                    "rev": "652bdb7719f30b52b08e506645a7322ff1b2cc6f",
+                    "url": "https://chromium.googlesource.com/external/github.com/cisco/openh264"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/openscreen/src": {
+                "args": {
+                    "hash": "sha256-M57un/TVQPfTnKScVHS1VK1cUs8F/YPT3TwMVdo+mhM=",
+                    "rev": "37ff938a93cb04c6b77e019b52328c8e9b320317",
+                    "url": "https://chromium.googlesource.com/openscreen"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/openscreen/src/buildtools": {
+                "args": {
+                    "hash": "sha256-sWkgWY2rXVQK83WBVaZxCupQsS/8BtlgagNBQywScPE=",
+                    "rev": "eca5f0685c48ed59ff06077cb18cee00934249dd",
+                    "url": "https://chromium.googlesource.com/chromium/src/buildtools"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/openscreen/src/third_party/tinycbor/src": {
+                "args": {
+                    "hash": "sha256-fMKBFUSKmODQyg4hKIa1hwnEKIV6WBbY1Gb8DOSnaHA=",
+                    "rev": "d393c16f3eb30d0c47e6f9d92db62272f0ec4dc7",
+                    "url": "https://chromium.googlesource.com/external/github.com/intel/tinycbor.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/ots/src": {
+                "args": {
+                    "hash": "sha256-kiUXrXsaGOzPkKh0dVmU1I13WHt0Stzj7QLMqHN9FbU=",
+                    "rev": "46bea9879127d0ff1c6601b078e2ce98e83fcd33",
+                    "url": "https://chromium.googlesource.com/external/github.com/khaledhosny/ots.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/pdfium": {
+                "args": {
+                    "hash": "sha256-zqfErp0pDXHXIvRpZ1TJu2UGXNZjATRbPgQWTniKTJs=",
+                    "rev": "c052afb72a08d79a26bcf3103d11f344981b09f1",
+                    "url": "https://pdfium.googlesource.com/pdfium.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/perfetto": {
+                "args": {
+                    "hash": "sha256-IRzEqgunO4Nfz+FkYir8G/Ht+Zsn6wpzncgkEFpsC+k=",
+                    "rev": "9ede949f025303868fa0c42418f122ac47312539",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/perfetto.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/protobuf-javascript/src": {
+                "args": {
+                    "hash": "sha256-1o6N9+1wsQSu1B4w5LlGlwzIUmuPCIYHPqwOyt234ZM=",
+                    "rev": "e6d763860001ba1a76a63adcff5efb12b1c96024",
+                    "url": "https://chromium.googlesource.com/external/github.com/protocolbuffers/protobuf-javascript"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/pthreadpool/src": {
+                "args": {
+                    "hash": "sha256-4EHJzZT+Gbhs8SkOhjSvDIPEqIQU93oJmtF3c/T+qjw=",
+                    "rev": "02460584c6092e527c8b89f7df4de143d70e801f",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/pthreadpool.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/pyelftools": {
+                "args": {
+                    "hash": "sha256-rEnt08K90/Psfa+SQgTUG3YGrhp4/udXG9VKIwPM7pk=",
+                    "rev": "8047437615d66d3267ac0134834b80e70639d572",
+                    "url": "https://chromium.googlesource.com/chromiumos/third_party/pyelftools.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/pywebsocket3/src": {
+                "args": {
+                    "hash": "sha256-WEqqu2/7fLqcf/2/IcD7/FewRSZ6jTgVlVBvnihthYQ=",
+                    "rev": "50602a14f1b6da17e0b619833a13addc6ea78bc2",
+                    "url": "https://chromium.googlesource.com/external/github.com/GoogleChromeLabs/pywebsocket3.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/quic_trace/src": {
+                "args": {
+                    "hash": "sha256-JmK7nmHg/BfXvFNG2oMpOV83EF+LwVLdwL6qX5FGREs=",
+                    "rev": "352288a06d2c83ae68b5a402b2219f4678be9f39",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/quic-trace.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/re2/src": {
+                "args": {
+                    "hash": "sha256-oEU+dz8ax1S36+f9OysjB0GnQj8mjZx1VsZ/UgckdDI=",
+                    "rev": "972a15cedd008d846f1a39b2e88ce48d7f166cbd",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/re2.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/readability/src": {
+                "args": {
+                    "hash": "sha256-lFsHXk4kEkzIbHgJiLTgeiKqiGOErzUwADo8WSZlnec=",
+                    "rev": "d7949dc47dd9ed9ee1d3b34ffdcf3bce28cde435",
+                    "url": "https://chromium.googlesource.com/external/github.com/mozilla/readability.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/ruy/src": {
+                "args": {
+                    "hash": "sha256-4To1BMUgzj2/sV7USN9W0CgHnpRmaktEspfhwWWeVBc=",
+                    "rev": "2af88863614a8298689cc52b1a47b3fcad7be835",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/ruy.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/search_engines_data/resources": {
+                "args": {
+                    "hash": "sha256-5/XnNx6Pyk4KBb9krVo9u6i7LWNrsLLOIi4qhEY2PZc=",
+                    "rev": "1aab872af8d44dcf59362d7ba8255922f74fafde",
+                    "url": "https://chromium.googlesource.com/external/search_engines_data.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/securemessage/src": {
+                "args": {
+                    "hash": "sha256-GS4ccnuiqxMs/LVYAtvSlVAYFp4a5GoZsxcriTX3k78=",
+                    "rev": "fa07beb12babc3b25e0c5b1f38c16aa8cb6b8f84",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/securemessage.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/sframe/src": {
+                "args": {
+                    "hash": "sha256-bw+6ycUpnFZJhtXFUzr7XTOljNrs+7oFdVY+LN0Rqek=",
+                    "rev": "b14090904433bed0d4ec3f875b9b39f3e0555930",
+                    "url": "https://chromium.googlesource.com/external/github.com/cisco/sframe"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/skia": {
+                "args": {
+                    "hash": "sha256-KZGrztOKaT368KSCxiJAqnsgINpNODUlaXnH/maQNIA=",
+                    "rev": "14d05ec761901b6e9e9193af8b347ab3a7f6fed0",
+                    "url": "https://skia.googlesource.com/skia.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/smhasher/src": {
+                "args": {
+                    "hash": "sha256-OgZQwkQcVgRMf62ROGuY+3zQhBoWuUSP4naTmSKdq8s=",
+                    "rev": "0ff96f7835817a27d0487325b6c16033e2992eb5",
+                    "url": "https://chromium.googlesource.com/external/smhasher.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/snappy/src": {
+                "args": {
+                    "hash": "sha256-jUwnjbaqXz7fgI2TPRK7SlUPQUVzcpjp4ZlFbEzwA+o=",
+                    "rev": "32ded457c0b1fe78ceb8397632c416568d6714a0",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/snappy.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/speedometer/main": {
+                "args": {
+                    "hash": "sha256-oF8ELo2qmkgaTpNzBLaC3A6gyf2iFv+FQNPGwdGqzVU=",
+                    "rev": "e2e2538900938c5d6819e9456bf33d48f806c96c",
+                    "url": "https://chromium.googlesource.com/external/github.com/WebKit/Speedometer.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/speedometer/v2.0": {
+                "args": {
+                    "hash": "sha256-p7WUS8gZUaS+LOm7pNmRkwgxjx+V8R6yy7bbaEHaIs4=",
+                    "rev": "732af0dfe867f8815e662ac637357e55f285dbbb",
+                    "url": "https://chromium.googlesource.com/external/github.com/WebKit/Speedometer.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/speedometer/v2.1": {
+                "args": {
+                    "hash": "sha256-0z5tZlz32fYh9I1ALqfLm2WWO8HiRBwt0hcmgKQhaeM=",
+                    "rev": "8bf7946e39e47c875c00767177197aea5727e84a",
+                    "url": "https://chromium.googlesource.com/external/github.com/WebKit/Speedometer.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/speedometer/v3.0": {
+                "args": {
+                    "hash": "sha256-qMQ4naX+4uUu3vtzzinjkhxX9/dNoTwj6vWCu4FdQmU=",
+                    "rev": "8d67f28d0281ac4330f283495b7f48286654ad7d",
+                    "url": "https://chromium.googlesource.com/external/github.com/WebKit/Speedometer.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/speedometer/v3.1": {
+                "args": {
+                    "hash": "sha256-G89mrrgRaANT1vqzhKPQKemHbz56YwR+oku7rlRoCHw=",
+                    "rev": "1386415be8fef2f6b6bbdbe1828872471c5d802a",
+                    "url": "https://chromium.googlesource.com/external/github.com/WebKit/Speedometer.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/spirv-cross/src": {
+                "args": {
+                    "hash": "sha256-H43M9DXfEuyKuvo6rjb5k0KEbYOSFodbPJh8ZKY4PQg=",
+                    "rev": "b8fcf307f1f347089e3c46eb4451d27f32ebc8d3",
+                    "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Cross"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/spirv-headers/src": {
+                "args": {
+                    "hash": "sha256-t8Shkoa90TJt1MbTOefnLaguW4eYKsRFO1Jd0AUc70Y=",
+                    "rev": "1e770e7de8373a8dd49f23416cf7ca4001d01040",
+                    "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Headers"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/spirv-tools/src": {
+                "args": {
+                    "hash": "sha256-q5G4B75xBIXl1aG/vzbIDrc3Hs/MFoQ4nwh4ozb8hys=",
+                    "rev": "b38c4f83024546d4000b2db8e2294cf81b7f26e0",
+                    "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Tools"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/sqlite/src": {
+                "args": {
+                    "hash": "sha256-hf9PxQhXEKT49GbkFYCvRPBT0Qu+hDnDpebI92yO1Oo=",
+                    "rev": "fc121d7d03cd6cbf499ec06a5112b263471b1181",
+                    "url": "https://chromium.googlesource.com/chromium/deps/sqlite.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/squirrel.mac": {
+                "args": {
+                    "hash": "sha256-4GfKQg0u3c9GI+jl3ixESNqWXQJKRMi+00QT0s2Shqw=",
+                    "owner": "Squirrel",
+                    "repo": "Squirrel.Mac",
+                    "rev": "0e5d146ba13101a1302d59ea6e6e0b3cace4ae38"
+                },
+                "fetcher": "fetchFromGitHub"
+            },
+            "src/third_party/squirrel.mac/vendor/Mantle": {
+                "args": {
+                    "hash": "sha256-ykR4JFDJyajpzubzptjrxC9WUbGBTma5YLaBiPB6y0s=",
+                    "owner": "Mantle",
+                    "repo": "Mantle",
+                    "rev": "2a8e2123a3931038179ee06105c9e6ec336b12ea"
+                },
+                "fetcher": "fetchFromGitHub"
+            },
+            "src/third_party/squirrel.mac/vendor/ReactiveObjC": {
+                "args": {
+                    "hash": "sha256-/MCqC1oFe3N9TsmfVLgl+deR6qHU6ZFQQjudb9zB5Mo=",
+                    "owner": "ReactiveCocoa",
+                    "repo": "ReactiveObjC",
+                    "rev": "74ab5baccc6f7202c8ac69a8d1e152c29dc1ea76"
+                },
+                "fetcher": "fetchFromGitHub"
+            },
+            "src/third_party/swiftshader": {
+                "args": {
+                    "hash": "sha256-bmXZLpz3wv7eQWoqTjZmjwnnILWSIjZ8iqo8CeLk5fw=",
+                    "rev": "fce27a96526f54c6d31fdccf57629788e3712220",
+                    "url": "https://swiftshader.googlesource.com/SwiftShader.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/text-fragments-polyfill/src": {
+                "args": {
+                    "hash": "sha256-4rW2u1cQAF4iPWHAt1FvVXIpz2pmI901rEPks/w/iFA=",
+                    "rev": "c036420683f672d685e27415de0a5f5e85bdc23f",
+                    "url": "https://chromium.googlesource.com/external/github.com/GoogleChromeLabs/text-fragments-polyfill.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/tflite/src": {
+                "args": {
+                    "hash": "sha256-eSqaWXtzZ4Bi9ilaJYGdZamzUjmo+AtDZ9KeZhsc/fY=",
+                    "rev": "999d49c10046e240cd5366d349d3a5f6af16a0d4",
+                    "url": "https://chromium.googlesource.com/external/github.com/tensorflow/tensorflow.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/ukey2/src": {
+                "args": {
+                    "hash": "sha256-aaLs6ZS+CdBlCJ6ZhsmdAPFxiBIij6oufsDcNeRSV1E=",
+                    "rev": "0275885d8e6038c39b8a8ca55e75d1d4d1727f47",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/ukey2.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/vulkan-deps": {
+                "args": {
+                    "hash": "sha256-lsR+sh+XQP/wKgkBbie6Gp+kQNFnnC8TeNWpiWTdevw=",
+                    "rev": "669a28b1f31f89bfc46b74791f127bcc5e5b2f06",
+                    "url": "https://chromium.googlesource.com/vulkan-deps"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/vulkan-headers/src": {
+                "args": {
+                    "hash": "sha256-pUxPwFGbOzP8ymTooeA1slFWEFsRoqUROSnndVtLiY8=",
+                    "rev": "015e25c3c91b70eb1a754d36fb14c4ba6ad9b0b9",
+                    "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Headers"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/vulkan-loader/src": {
+                "args": {
+                    "hash": "sha256-uyoysS7lSBNDRfvcwPT+gQqhE20UxiYUEw1UXnYS3fY=",
+                    "rev": "cf0cf82ea16c0ff0be75940f282540d6085b2d3b",
+                    "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Loader"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/vulkan-tools/src": {
+                "args": {
+                    "hash": "sha256-Hs9N0FM3eWWjLm4BrDJoZIrsPDVFx0iRAJeQ4gHTM7o=",
+                    "rev": "e3d18f90c0b8ef1f52539e0674a42f0adfe30381",
+                    "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Tools"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/vulkan-utility-libraries/src": {
+                "args": {
+                    "hash": "sha256-ZBie5uDTVEehxRQW1GZY5Ki/bnp82LoW3jfMUFL0O9A=",
+                    "rev": "8383c46b129c2b3a5f3833e602d946d2fcc57e39",
+                    "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Utility-Libraries"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/vulkan-validation-layers/src": {
+                "args": {
+                    "hash": "sha256-i3hochkK0LZPg8CsZMFkAL+8tf8QuuwtApAc4FDd0RM=",
+                    "rev": "044eaba8a34a6e3bfb1d6aafac7c01068813a2b6",
+                    "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-ValidationLayers"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/vulkan_memory_allocator": {
+                "args": {
+                    "hash": "sha256-fOnFkcQDEGIe5yB507qnP9nA1LBBPFblncNiJ8JxAwI=",
+                    "rev": "7e55b011e16182fc349149abbd3aaf3b1db46421",
+                    "url": "https://chromium.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/wayland-protocols/gtk": {
+                "args": {
+                    "hash": "sha256-75XNnLkF5Lt1LMRGT+T61k0/mLa3kkynfN+QWvZ0LiQ=",
+                    "rev": "40ebed3a03aef096addc0af09fec4ec529d882a0",
+                    "url": "https://chromium.googlesource.com/external/github.com/GNOME/gtk.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/wayland-protocols/kde": {
+                "args": {
+                    "hash": "sha256-Dmcp/2ms/k7NxPPmPkp0YNfM9z2Es1ZO0uX10bc7N2Y=",
+                    "rev": "0b07950714b3a36c9b9f71fc025fc7783e82926e",
+                    "url": "https://chromium.googlesource.com/external/github.com/KDE/plasma-wayland-protocols.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/wayland-protocols/src": {
+                "args": {
+                    "hash": "sha256-tdpEK7soY0aKSk6VD4nulH7ORubX8RfjXYmNAd/cWKY=",
+                    "rev": "efbc060534be948b63e1f395d69b583eebba3235",
+                    "url": "https://chromium.googlesource.com/external/anongit.freedesktop.org/git/wayland/wayland-protocols.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/wayland/src": {
+                "args": {
+                    "hash": "sha256-5iG0HaPXJCEo027TuyXlJQNGluTaAPlvwQDFbiYOEJQ=",
+                    "rev": "736d12ac67c20c60dc406dc49bb06be878501f86",
+                    "url": "https://chromium.googlesource.com/external/anongit.freedesktop.org/git/wayland/wayland.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/webdriver/pylib": {
+                "args": {
+                    "hash": "sha256-k5qx4xyO83jPtHaMh6aMigMJ3hsytFdFQOcZLmwPEYo=",
+                    "rev": "1e954903022e9386b9acf452c24f4458dd4c4fc1",
+                    "url": "https://chromium.googlesource.com/external/github.com/SeleniumHQ/selenium/py.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/webgl/src": {
+                "args": {
+                    "hash": "sha256-Aax2hr/9Zq6Avk+TMU1OMBLGshUL6hyRTX6eoOQesqM=",
+                    "rev": "216b10fafd3f6a900c715a8c758a4c7f9883b030",
+                    "url": "https://chromium.googlesource.com/external/khronosgroup/webgl.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/webgpu-cts/src": {
+                "args": {
+                    "hash": "sha256-6Y5Z0ErtsZdbuWTHa+PEiOxcZSbjBcnuOHbgtI1/+80=",
+                    "rev": "b507bd117e53db86f2fb52d0d858d3ae7d684a85",
+                    "url": "https://chromium.googlesource.com/external/github.com/gpuweb/cts.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/webpagereplay": {
+                "args": {
+                    "hash": "sha256-+hcaP7C5Eh3SLl5B8mRgOVdM/tvnFnb/oqUIWPoe0NA=",
+                    "rev": "b2b856131e36c99e9de9c419fe8ca02f857082ba",
+                    "url": "https://chromium.googlesource.com/webpagereplay.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/webpagereplay/third_party/clang-format/script": {
+                "args": {
+                    "hash": "sha256-Cm6BOOlEyD0kdYxMSmk6Fj1Dnfs3zCzXsm+BOXgBme0=",
+                    "rev": "6eddfb5ec5f92127a531eda66c568d3a11e7ec11",
+                    "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/clang/tools/clang-format.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/webrtc": {
+                "args": {
+                    "hash": "sha256-ucH+9HBkFyOKEItAWVoYmEzyU7h/UgWIvp/eC/JqGWU=",
+                    "rev": "1f975dfd761af6e5d76d28333191973b258d82a8",
+                    "url": "https://webrtc.googlesource.com/src.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/weston/src": {
+                "args": {
+                    "hash": "sha256-PySen9syu0OshtlHAZw666FeSQXdnsV8nlW9RmxgapM=",
+                    "rev": "b65be9e699847c975440108a42f05412cc7fddac",
+                    "url": "https://chromium.googlesource.com/external/anongit.freedesktop.org/git/wayland/weston.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/wuffs/src": {
+                "args": {
+                    "hash": "sha256-V7inWJqH7Q4Ac/ZB//7XHrpgfAYUPBxWBerBem6Q/Kk=",
+                    "rev": "50869df0ea703b4f41b238bfe26aec6ec9c86889",
+                    "url": "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/xnnpack/src": {
+                "args": {
+                    "hash": "sha256-uw3r5g5rWamlFubBkXDb4KRx3hkOAoQyFo8l95GYGZI=",
+                    "rev": "56ac34b3f45fae2eca1f32584f7f0b279be2cf1f",
+                    "url": "https://chromium.googlesource.com/external/github.com/google/XNNPACK.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/third_party/zstd/src": {
+                "args": {
+                    "hash": "sha256-vEl0s7Mjh+5rciOMxm99PNWiamtCk+sTN4lRYKCIZ+8=",
+                    "rev": "5233c58e6ca0b1c4c6b353ad79649191ed195bdc",
+                    "url": "https://chromium.googlesource.com/external/github.com/facebook/zstd.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            },
+            "src/v8": {
+                "args": {
+                    "hash": "sha256-x3rCWvC3hEjyJq6PNThhZEp4oRF9Y1JJEPnZTqVNVrY=",
+                    "rev": "968f19a8970f8d91702d86f0ec1522f3909781b7",
+                    "url": "https://chromium.googlesource.com/v8/v8.git"
+                },
+                "fetcher": "fetchFromGitiles"
+            }
+        },
+        "electron_yarn_data": {
+            "hash": "sha256-Y2TE5iMVUgXqqKojb90yzcCfFAhEy7STB53yYQQanPM=",
+            "missing_hashes": {
+                "@oxfmt/binding-android-arm-eabi@npm:0.42.0": "42c08d87ce491086843070241f8777fa2cb968f4a08f67b3f6c33a8f67e0b3eac50eae146daede743e90e3bc32326951c5188814eea02e9c3e4a9764a4b492ba",
+                "@oxfmt/binding-android-arm64@npm:0.42.0": "73e6609498d05c655c6a435af9f3e4f341137c260c7ae27fbb0377573574ca5200bd9f187aa90d442879733bbd0c4e91ae023c3b4579c9a57413a0b2922c023a",
+                "@oxfmt/binding-darwin-arm64@npm:0.42.0": "ed0f486a5085942727e255a9c14bfd99756d4af3ad2c2e702bfb7ab682fc9041d5327f3e89dc4dbfc9a09a6c884dbc9a79a46c720435c5ad2f2fe3f48bb9c3ac",
+                "@oxfmt/binding-darwin-x64@npm:0.42.0": "b607e67171aa33717f7fe80d9d5c8ca816ff30dbbd2b41c4b129977c749c62a4bb1f6829aa95c564d15246c98689ba153fc003a09a1549e2f3316810b35463be",
+                "@oxfmt/binding-freebsd-x64@npm:0.42.0": "c038e53f42083a56d548bd2b89765d1b36150c874e83a41631dfa039fe4fd999475a4a5a99414e43fe44654abdbdfb78c17f53fb482ba3bdc9d22f5641931a41",
+                "@oxfmt/binding-linux-arm-gnueabihf@npm:0.42.0": "79d0b84f3281c7935eb153a53b7032fbb159357580cbcac721096d87ceb124e40863c0b7786ff1b94ad2cdc9b1beabe37e972e1b959423af028e6dea0fc8e0b6",
+                "@oxfmt/binding-linux-arm-musleabihf@npm:0.42.0": "c67dfa0553ba44f0585c3bba85efcbbd42b63b59f177302693fa83cc7b6fe6a6f2509c972cae9b367eb7cd36e8578209657ac4928cf329bf816fa4bfc578d2c1",
+                "@oxfmt/binding-linux-arm64-gnu@npm:0.42.0": "f8507b36f7f2673a4d6db227ed2e98f94d30f81275820d0d25e5e6b0b9b20c7f4cc32b646ae02aac0068b90ba3d47bcbd85ad789b27f028b8ea07e168ec731ce",
+                "@oxfmt/binding-linux-arm64-musl@npm:0.42.0": "c4d0406e36248b4a8ddd62ac2d7c1b6648d23fb2b1eee471e3965d6c411b2dedfc681d227adcff50bbff5f786727bef31420610564691887cdecb50d7f1f7587",
+                "@oxfmt/binding-linux-ppc64-gnu@npm:0.42.0": "12b0eb3cff0807f898dd2e47de5712c8b57d2373108135e87f1de69902204c0527b383753983388f32e48749c479ce0f6247fbc927a2e035b2fb1f6c31ae5df7",
+                "@oxfmt/binding-linux-riscv64-gnu@npm:0.42.0": "aff4c5104769388174a69f5f4ad418f33e86ff1286117072e2200b7217aa9d30375ffb4deeabd728aac7975ed5e79832ac725725df9ff2ea6f819aef5e166353",
+                "@oxfmt/binding-linux-riscv64-musl@npm:0.42.0": "710b0b9fc2d999a66b2c9e656e40e74e71d820d8670d5ee64dc36d373f1132a0c3ddcbedba6130f832b9e8abbb0988ab95de7a6ddd4657007f05fea4a3631835",
+                "@oxfmt/binding-linux-s390x-gnu@npm:0.42.0": "8fc8ee6c1ea3369d3f7ec2f6dbe3fe846663c8e10a0ea976b1b2e150117359580d7efc904f5da0ead2f59066b1e17076aa09c1c4f2544071c29b623ada15da70",
+                "@oxfmt/binding-linux-x64-gnu@npm:0.42.0": "d46d962752e0e2978cbd9b552a0d4bebde69fa9581512dfda33e7bc645c849e2787ef6a4e2ae825e7d2abf68b895c90c4a351387d2f0d2ba336e990c54e245f0",
+                "@oxfmt/binding-linux-x64-musl@npm:0.42.0": "e757b0b12ccf6e7355e2a3123fa0bea0908e1f220b7bb3601c18203bc78f1157be8364af9df3ca56f9c0bb123aeecbf058df31a9ee12612e1149b9c6228dc6f9",
+                "@oxfmt/binding-openharmony-arm64@npm:0.42.0": "fe85007d6e7e7c1b6662a9756267de459fc7213af9ddf6f0494397d9d666a452d4a1a6f6fe6ce288d8dd4763d07b52b4534cc177bdf0e5613559f144b78e8fbb",
+                "@oxfmt/binding-win32-arm64-msvc@npm:0.42.0": "04bd529ea236c23d8dc73d95acd365612ab489b0e6a4bdd976302b933b92dcc11d4d1629e2294036f16c1e1f5120140547f65060a9e2dc8adbb21f790e2eca39",
+                "@oxfmt/binding-win32-ia32-msvc@npm:0.42.0": "9775afa164de049416abf481f062b8c670cd27a70d82a0868fa61749f741e777a76eb0a57a9ef276f158a35741d90a856a492777a0a9f17c9ac01ead32935fe3",
+                "@oxfmt/binding-win32-x64-msvc@npm:0.42.0": "5c38197ac6f874c2622b68a531b9fc9a221de05aa09c40717bba775f658680ebf964db7aa41c12271f90261bf50713cd4ebb2c10f12bf33cf2103fb9d67a88bb",
+                "@oxlint/binding-android-arm-eabi@npm:1.57.0": "3860b1c5a2096817da9c18cbbc24f8b56f4b6b0cefdea19e0cc0f278055aac85d891fa9d70e02f551532bf45f6a79bb3ebc63d1c2e1dff724134a9bc398f8060",
+                "@oxlint/binding-android-arm64@npm:1.57.0": "fb40a768d5608e9b41c35f16cac2e57571cbcbf1b872bc145f60a7e1fd7a478c3806e3a330579e167f8877411fe362561a103976e41cbd1e46fb02d7d0d97611",
+                "@oxlint/binding-darwin-arm64@npm:1.57.0": "fd75b91d3db274782afec0b1dee319a01b864f11e0a4af1808de23762403000d13f7921c7889302c75d945b09005a44cdf17e3ad345c1ef2842403ac28f0dfb0",
+                "@oxlint/binding-darwin-x64@npm:1.57.0": "75e2e5423ccc82f61def946317c774f951e0a1443cd9c4c1550e0941da9a645a7acd3ed344c65b50288d4842a3a523a6cd9838a28d452d20c7a041fd1b15fe3a",
+                "@oxlint/binding-freebsd-x64@npm:1.57.0": "ad0f737171b8d60a1bcfeeb1736f0ecb751ebbfd915ad7e27d5ad25a858419be541a0854fc573be01752def42b9a3864d0aa11176b574571bb44350307ad2f59",
+                "@oxlint/binding-linux-arm-gnueabihf@npm:1.57.0": "a912a546bab5831bb5ae6e697e67b33f86fc48caaf1615df9ff3234818299845cf27dacecbe17ec679a757eb6354e5e15002c632ba43f76fc890060bebd45d1b",
+                "@oxlint/binding-linux-arm-musleabihf@npm:1.57.0": "e15e5c951193afd936f155db38b9dd48f9cf0e7de8eaf07acf957c4b5b47e79c2f668d4c47310bf28efb2af5640a5a7d3d6700c723c748efefa7e72c8660b1a3",
+                "@oxlint/binding-linux-arm64-gnu@npm:1.57.0": "c167c4bcfe4067703c626264b973dd2195192615aa4bb1ef07d918c8cd128cb1d3504ba991dbd78daee29e6bf5997704c87004e93a379231377c7f7b5c505e55",
+                "@oxlint/binding-linux-arm64-musl@npm:1.57.0": "d0a60e2aa7d491baf85450fb9c0053598da5cc884b9b4e0ed557baa813bcead8e9470259c5f390e412ba173932a0b2703f0b17b06b494ce480fc25ded8074461",
+                "@oxlint/binding-linux-ppc64-gnu@npm:1.57.0": "7798e0a7e8c71f6f3e2f495fdf1109f08d4c2a7357fa19c7f9111b9510f1417175afb00845e39692e5fa4b510cc56d3e8f76bf3f0372f651d19d587b623cdab8",
+                "@oxlint/binding-linux-riscv64-gnu@npm:1.57.0": "8cc0cb3eaf2ff0716e52ce8743e5cc7e952b25150a5e75fcb9b5d7a4f82a99295ce7a3ca9a0bf6694e917c629621e01e465d816379acb264c5f2f4e860d44e24",
+                "@oxlint/binding-linux-riscv64-musl@npm:1.57.0": "1de23e270049060ef5cc1824de2aafbd7129d07c13052c109bd7de62f8bf29ab91bbcf8c15cbbc6ba6aa382b90e1bae456d5160bc8518adb7973cdcd99625127",
+                "@oxlint/binding-linux-s390x-gnu@npm:1.57.0": "35791cd14a661de5605587c81b5f4d9715de92a2f888b4e5fb1ea85626b59c1b53306feadd9020652598e0ff7db8ec31d0d43f8e647a8e1c38361d1bfdc5f288",
+                "@oxlint/binding-linux-x64-gnu@npm:1.57.0": "a55364f9d86efa12f38c54f01b02d1310600245a10cdd27a1ec9b0bfc98522a686feb6b15b1a2ef70c7676eb7b3dc7efa5e2e252313496fc910be368d4c05ee3",
+                "@oxlint/binding-linux-x64-musl@npm:1.57.0": "f6862ffcbd14261528f9a3237d8f52752b745822b54d1c4c6c937830e3712e7b2b8d00aa07838bfc7024f2648d9f3b85c3fa05f6a78c40b5f259e618dbfbeb68",
+                "@oxlint/binding-openharmony-arm64@npm:1.57.0": "1420c753028b583ce4ea00edb14f47def68d675492ef8611e98ffe0cf0a0749cc368b8619d4760d38e02c15b06bda32eafce907f6bcefa997db4fbff3a900be7",
+                "@oxlint/binding-win32-arm64-msvc@npm:1.57.0": "2bb5a9f09e1f95e7bf4a9f76af29ba7623d3a83f35e9201cd2f45375ae891c77ddb87a09dcbf2f2416fd3d6e24f34582618da307ed65f8435b943672cb8be5aa",
+                "@oxlint/binding-win32-ia32-msvc@npm:1.57.0": "a2f8f3387866a6d371c50ec4d3aa2043e420bfe1cd523053083f68a33ee651fc9948485060b4e8827d603695b04d492cfa5ef8cdd1fb760cc34dd7674fe13a0b",
+                "@oxlint/binding-win32-x64-msvc@npm:1.57.0": "380591b6937dc483e2db3edf5ace4aa48a06d1d17d419ded224df8465b20840fea8f9d1b1aef38dfa89622eb9d7991592d80b15ceb871b5c09ef9b85197c0de4"
+            }
+        },
+        "modules": "148",
+        "node": "24.18.0",
+        "version": "43.1.0"
     }
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4862,12 +4862,14 @@ with pkgs;
           src = electron-source.electron_42;
           bin = electron_42-bin;
         };
+        electron_43 = electron-source-electron_43;
       }
     )
     electron_39
     electron_40
     electron_41
     electron_42
+    electron_43
     ;
   electron = electron_41;
   electron-bin = electron_41-bin;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4826,6 +4826,7 @@ with pkgs;
     electron_40-bin
     electron_41-bin
     electron_42-bin
+    electron_43-bin
     ;
 
   inherit (callPackages ../development/tools/electron/chromedriver { })
@@ -4833,6 +4834,7 @@ with pkgs;
     electron-chromedriver_40
     electron-chromedriver_41
     electron-chromedriver_42
+    electron-chromedriver_43
     ;
 
   inherit
@@ -4862,7 +4864,10 @@ with pkgs;
           src = electron-source.electron_42;
           bin = electron_42-bin;
         };
-        electron_43 = electron-source-electron_43;
+        electron_43 = getElectronPkg {
+          src = electron-source.electron_43;
+          bin = electron_43-bin;
+        };
       }
     )
     electron_39


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Thanks to emilylange for the `host_cpu` fix.

Changelog: https://github.com/electron/electron/releases/tag/v43.0.0

Synced `gnFlags` with https://github.com/electron/electron/blob/v43.1.0/build/args/all.gn and removed all flags that are no longer in use by either electron 41, 42, 43.

- `v8_builtins_profiling_log_file` was removed in https://github.com/electron/electron/commit/29750dda082501f5b728f58fb57765813d59a193 (and backported for all electron versions)
- `dawn_use_built_dxc` was removed in https://github.com/electron/electron/commit/9b740594fbdd0a205a1c2062c27184bb691a0b05
- `clang_unsafe_buffers_paths` was removed in https://github.com/electron/electron/commit/041ada15867b4ed24193f2023747f275806bcf10
- `enterprise_cloud_content_analysis` was removed in https://github.com/electron/electron/commit/76c5257fea58dad31de77d85861f88c0cc6aa954
- `node_openssl_path` using boringssl was added in version 43 https://github.com/electron/electron/commit/e4a5c5a3b9532e1ac1bfa561f0ee95b4ee64363a

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
