### PR TITLE
keka: 1.6.0 -> 1.6.7, add kinnrai to maintainers

### DIFF
--- a/pkgs/by-name/ke/keka/package.nix
+++ b/pkgs/by-name/ke/keka/package.nix
@@ -6,11 +6,11 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "keka";
-  version = "1.6.0";
+  version = "1.6.7";
 
   src = fetchzip {
     url = "https://github.com/aonez/Keka/releases/download/v${finalAttrs.version}/Keka-${finalAttrs.version}.zip";
-    hash = "sha256-E0KvDgjx86myZk5+QsydonDaT31CS+B1QGOUXCOaJxY=";
+    hash = "sha256-6zC8lQLkJ/Qppyo3XwK6fy4f/bLsIg0L+4GwFfiVlvg=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/by-name/ke/keka/package.nix
+++ b/pkgs/by-name/ke/keka/package.nix
@@ -31,7 +31,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://www.keka.io";
     license = lib.licenses.unfree;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    maintainers = with lib.maintainers; [ emilytrau ];
+    maintainers = with lib.maintainers; [
+      emilytrau
+      kinnrai
+    ];
     platforms = lib.platforms.darwin;
   };
 })


### PR DESCRIPTION
Version bump for `keka` and addition of myself to the maintainers to help keep it up to date.

Changelog: https://github.com/aonez/Keka/releases/tag/v1.6.7
Diff: https://github.com/aonez/Keka/compare/v1.6.0...v1.6.7

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
