### PR TITLE
mitm-cache: fetch: drop query

### DIFF
--- a/pkgs/by-name/mi/mitm-cache/fetch.nix
+++ b/pkgs/by-name/mi/mitm-cache/fetch.nix
@@ -19,15 +19,18 @@ let
 
   urlToPath =
     url:
-    if lib.hasPrefix "https://" url then
-      (
-        let
-          url' = lib.drop 2 (lib.splitString "/" url);
-        in
-        "https/${builtins.concatStringsSep "/" url'}"
-      )
-    else
-      builtins.replaceStrings [ "://" ] [ "/" ] url;
+    lib.elemAt (lib.splitString "?" (
+      if lib.hasPrefix "https://" url then
+        (
+          let
+            url' = lib.drop 2 (lib.splitString "/" url);
+          in
+          "https/${builtins.concatStringsSep "/" url'}"
+        )
+      else
+        builtins.replaceStrings [ "://" ] [ "/" ] url
+    )) 0;
+
   code = ''
     mkdir -p "$out"
     cd "$out"


### PR DESCRIPTION
mitm-cache ignores the query:
https://github.com/chayleaf/mitm-cache/blob/382b822/src/main.rs#L90

This fixes fetching URLs with query parameters.

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
