### PR TITLE
dnst: 0.2.0-alpha2 -> 0.2.0-alpha3

### DIFF
--- a/pkgs/by-name/dn/dnst/package.nix
+++ b/pkgs/by-name/dn/dnst/package.nix
@@ -39,7 +39,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     installManPage doc/manual/build/man/*.1
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=unstable" ];
+  };
 
   meta = {
     description = "Toolset to assist DNS operators with zone and nameserver maintenance";

--- a/pkgs/by-name/dn/dnst/package.nix
+++ b/pkgs/by-name/dn/dnst/package.nix
@@ -10,14 +10,14 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "dnst";
-  version = "0.2.0-alpha2";
+  version = "0.2.0-alpha3";
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "NLnetLabs";
     repo = "dnst";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-OpyOnBddbIdnJLchY5y2oMqK5JSXCTF8cC5KstJ7pnc=";
+    hash = "sha256-6Sgj2OZptG/bMsuYdGfaaY62qh4uUyxdbit6vpWWm9w=";
   };
 
   nativeBuildInputs = [
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
   buildInputs = [ openssl ];
 
-  cargoHash = "sha256-y048tMh5wBjAB7I8FK3pETn0j9S/h893JZb9sbOBdbo=";
+  cargoHash = "sha256-8pzf4GeBJbqIZf6KAqROEAvFAqtf6XLODWhS3RVfpAQ=";
 
   postInstall = ''
     mkdir -p $out/libexec


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Updates dnst to the newest git tag, and adds `--version=unstable` so that nix-update will pick up future unstable releases. I plan to remove this once `dnst` hits 1.0.

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
