### PR TITLE
immich-kiosk: 0.31.0 -> 0.39.3

### DIFF
--- a/pkgs/by-name/im/immich-kiosk/package.nix
+++ b/pkgs/by-name/im/immich-kiosk/package.nix
@@ -3,68 +3,61 @@
   buildGoModule,
   fetchFromGitHub,
   nodejs,
-  pnpm_9,
-  fetchPnpmDeps,
-  pnpmConfigHook,
+  fetchNpmDeps,
+  npmHooks,
+  go-task,
 }:
+
 buildGoModule rec {
   pname = "immich-kiosk";
-  version = "0.31.0";
+  version = "0.39.3";
 
   src = fetchFromGitHub {
     owner = "damongolding";
     repo = "immich-kiosk";
     tag = "v${version}";
-    hash = "sha256-PHdHhhVy0RWMFzR4ZEyWLOiRYHROadLiPIdqkUZMTow=";
+    hash = "sha256-kdTEvH8MqL3oXe0QZlPTVpeByLpqAdNfPGfu5f2G6g0=";
   };
 
-  # Delete vendor directory to regenerate it consistently across platforms
   postPatch = ''
+    # Delete vendor directory to regenerate it consistently across platforms
     rm -rf vendor
+    # immich-kiosk bumps go at a faster cadence than nixpkgs
+    sed 's/^go 1\.26\.\d+$/go 1.26/' go.mod
   '';
-  vendorHash = "sha256-3M3fXwCkljfY8wjXf+PdcbqnkyPKaDCJWt9/nRA/+Dc=";
+  vendorHash = "sha256-y6Xl00G+mkhRKVGwMS0WCXZhQqqGGX5qY8PhMxtw7z8=";
   proxyVendor = true;
 
-  pnpmDeps = fetchPnpmDeps {
-    inherit
-      pname
-      version
-      src
-      ;
-    pnpm = pnpm_9;
+  npmDeps = fetchNpmDeps {
+    inherit src;
     sourceRoot = "${src.name}/frontend";
-    hash = "sha256-8iKug4zsX3u0vS68osKRW6iOP+A3OdjI3yxNPIJaQqM=";
-    fetcherVersion = 3;
+    hash = "sha256-lNON0/lxix2aczC0+m7Er5Te1+4fsSoLkk6Z2pYzQYQ=";
   };
-
   # Frontend is in a subdirectory
-  pnpmRoot = "frontend";
+  npmRoot = "frontend";
 
   nativeBuildInputs = [
     nodejs
-    pnpmConfigHook
-    pnpm_9
+    go-task
+    npmHooks.npmConfigHook
   ];
 
   # Generate templ templates during vendor hash calculation
-  # Don't run pnpm in this phase - filter out pnpmConfigHook
+  # Don't run npm in this phase - filter out npmConfigHook
   overrideModAttrs = oldAttrs: {
-    nativeBuildInputs = builtins.filter (drv: drv != pnpmConfigHook) (
+    nativeBuildInputs = builtins.filter (drv: drv != npmHooks.npmConfigHook) (
       oldAttrs.nativeBuildInputs or [ ]
     );
     preBuild = ''
-      go run github.com/a-h/templ/cmd/templ generate
+      go tool templ generate
     '';
   };
 
   # Generate templ templates and build frontend assets before Go build
   # Frontend assets are embedded into the binary via go:embed
   preBuild = ''
-    go run github.com/a-h/templ/cmd/templ generate
-
-    pushd frontend
-    pnpm build
-    popd
+    go tool templ generate
+    task frontend
   '';
 
   ldflags = [


### PR DESCRIPTION
Bumps immich-kiosk to 0.39.3. Build no longer depends on pnpm (#529285). Built and tested locally.

https://github.com/damongolding/immich-kiosk/compare/v0.31.0...v0.39.3

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
