### PR TITLE
home-assistant-custom-lovelace-modules.weather-forecast-card: init at 1.0.0

### DIFF
--- a/pkgs/servers/home-assistant/custom-lovelace-modules/weather-forecast-card/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/weather-forecast-card/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  nodejs,
+  pnpm,
+  pnpmConfigHook,
+  stdenvNoCC,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "weather-forecast-card";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "troinine";
+    repo = "ha-weather-forecast-card";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-N3bE6HSXx6Vst6ZiMsJ490XBnlDQJDm+MoEunlLusnQ=";
+  };
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    inherit pnpm;
+    fetcherVersion = 4;
+    hash = "sha256-DDJpfkblo3E6YxWThs0rtkMabhRuDW2k5fszTo4Gud8=";
+  };
+
+  nativeBuildInputs = [
+    pnpmConfigHook
+    pnpm
+    nodejs
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm run build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out"
+    cp dist/* "$out"
+
+    runHook postInstall
+  '';
+
+  passthru.entrypoint = "weather-forecast-card.js";
+
+  meta = {
+    description = "Slightly improved weather forecast card for Home Assistant";
+    homepage = "https://github.com/troinine/ha-weather-forecast-card";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
