### PR TITLE
veryl: 0.20.1 -> 0.20.2

### DIFF
--- a/pkgs/by-name/ve/veryl/package.nix
+++ b/pkgs/by-name/ve/veryl/package.nix
@@ -5,22 +5,24 @@
   pkg-config,
   installShellFiles,
   dbus,
+  writableTmpDirAsHomeHook,
+  git,
   stdenv,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "veryl";
-  version = "0.20.1";
+  version = "0.20.2";
 
   src = fetchFromGitHub {
     owner = "veryl-lang";
     repo = "veryl";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-jY8CeuRjtRtyQl07ezl/PUILvMABFJn9Q6AH11C4M/0=";
+    hash = "sha256-ldibFrtU/lEL4a0QIhVKx8A0noZF2qyH9iExYNZedoU=";
     fetchSubmodules = true;
   };
 
-  cargoHash = "sha256-j6lJlGqtQf/mRYKDUi3nttbPWfI7CyE1tlksGhrnrEM=";
+  cargoHash = "sha256-mpI3Eo5fkP66Ywr/anQ3ajPrVuuK6Ku7qJ/jpVPHE6Q=";
 
   nativeBuildInputs = [
     pkg-config
@@ -37,6 +39,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --fish <($out/bin/veryl metadata --completion fish) \
       --zsh <($out/bin/veryl metadata --completion zsh)
   '';
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+    git
+  ];
 
   checkFlags = [
     # takes over an hour


### PR DESCRIPTION
Diff: https://github.com/veryl-lang/veryl/compare/v0.20.1...v0.20.2

Changelog: https://github.com/veryl-lang/veryl/releases/tag/v0.20.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
