### PR TITLE
Revert "nixos/pipewire: minor refactor"

### DIFF
--- a/nixos/modules/services/desktops/pipewire/pipewire.nix
+++ b/nixos/modules/services/desktops/pipewire/pipewire.nix
@@ -11,10 +11,9 @@ let
   inherit (lib) maintainers teams;
   inherit (lib.attrsets)
     attrByPath
+    attrsToList
     concatMapAttrs
     filterAttrs
-    mapAttrs'
-    nameValuePair
     ;
   inherit (lib.lists) flatten optional optionals;
   inherit (lib.modules) mkIf mkRemovedOptionModule;
@@ -24,7 +23,7 @@ let
     mkOption
     mkPackageOption
     ;
-  inherit (lib.strings) hasPrefix optionalString;
+  inherit (lib.strings) concatMapStringsSep hasPrefix optionalString;
   inherit (lib.types)
     attrsOf
     bool
@@ -33,6 +32,17 @@ let
     ;
 
   json = pkgs.formats.json { };
+  mapToFiles =
+    location: config:
+    concatMapAttrs (name: value: {
+      "share/pipewire/${location}.conf.d/${name}.conf" = json.generate "${name}" value;
+    }) config;
+  extraConfigPkgFromFiles =
+    locations: filesSet:
+    pkgs.runCommand "pipewire-extra-config" { } ''
+      mkdir -p ${concatMapStringsSep " " (l: "$out/share/pipewire/${l}.conf.d") locations}
+      ${concatMapStringsSep ";" ({ name, value }: "ln -s ${value} $out/${name}") (attrsToList filesSet)}
+    '';
   cfg = config.services.pipewire;
   enable32BitAlsaPlugins =
     cfg.alsa.support32Bit && pkgs.stdenv.hostPlatform.isx86_64 && pkgs.pkgsi686Linux.pipewire != null;
@@ -48,14 +58,11 @@ let
 
   configPackages = cfg.configPackages;
 
-  extraConfigPkg = pkgs.linkFarm "pipewire-extra-config" (
-    concatMapAttrs (
-      location: config:
-      mapAttrs' (
-        name: value:
-        nameValuePair "share/pipewire/${location}.conf.d/${name}.conf" (json.generate name value)
-      ) config
-    ) cfg.extraConfig
+  extraConfigPkg = extraConfigPkgFromFiles [ "pipewire" "client" "jack" "pipewire-pulse" ] (
+    mapToFiles "pipewire" cfg.extraConfig.pipewire
+    // mapToFiles "client" cfg.extraConfig.client
+    // mapToFiles "jack" cfg.extraConfig.jack
+    // mapToFiles "pipewire-pulse" cfg.extraConfig.pipewire-pulse
   );
 
   configs = pkgs.buildEnv {


### PR DESCRIPTION
Broke things with deprecated options.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
