### PR TITLE
sd-image-aarch64: support rpi5

### DIFF
--- a/nixos/modules/installer/sd-card/sd-image-aarch64.nix
+++ b/nixos/modules/installer/sd-card/sd-image-aarch64.nix
@@ -31,17 +31,25 @@
     populateFirmwareCommands =
       let
         configTxt = pkgs.writeText "config.txt" ''
-          [pi3]
-          kernel=u-boot-rpi3.bin
+          kernel=u-boot.bin
 
+          # Boot in 64-bit mode.
+          arm_64bit=1
+
+          # U-Boot needs this to work, regardless of whether UART is actually used or not.
+          # Look in arch/arm/mach-bcm283x/Kconfig in the U-Boot tree to see if this is still
+          # a requirement in the future.
+          enable_uart=1
+
+          # Prevent the firmware from smashing the framebuffer setup done by the mainline kernel
+          # when attempting to show low-voltage or overtemperature warnings.
+          avoid_warnings=1
+
+          [pi3]
           # Otherwise the serial output will be garbled.
           core_freq=250
 
-          [pi02]
-          kernel=u-boot-rpi3.bin
-
           [pi4]
-          kernel=u-boot-rpi4.bin
           enable_gic=1
           armstub=armstub8-gic.bin
 
@@ -58,28 +66,24 @@
           # (e.g. for USB device mode) or if USB support is not required.
           otg_mode=1
 
-          [all]
-          # Boot in 64-bit mode.
-          arm_64bit=1
+          [cm5]
+          dtoverlay=dwc2,dr_mode=host
 
-          # U-Boot needs this to work, regardless of whether UART is actually used or not.
-          # Look in arch/arm/mach-bcm283x/Kconfig in the U-Boot tree to see if this is still
-          # a requirement in the future.
-          enable_uart=1
-
-          # Prevent the firmware from smashing the framebuffer setup done by the mainline kernel
-          # when attempting to show low-voltage or overtemperature warnings.
-          avoid_warnings=1
+          [pi5]
+          # On some revisions of the RPi5, U-Boot interprets picks up
+          # ghost inputs from the uart, interrupting the boot process.
+          # https://bugzilla.opensuse.org/show_bug.cgi?id=1251192
+          enable_uart=0
         '';
       in
       ''
         (cd ${pkgs.raspberrypifw}/share/raspberrypi/boot && cp bootcode.bin fixup*.dat start*.elf $NIX_BUILD_TOP/firmware/)
+        cp ${pkgs.ubootRaspberryPiAarch64}/u-boot.bin firmware/u-boot.bin
 
         # Add the config
         cp ${configTxt} firmware/config.txt
 
         # Add pi3 specific files
-        cp ${pkgs.ubootRaspberryPi3_64bit}/u-boot.bin firmware/u-boot-rpi3.bin
         cp ${pkgs.raspberrypifw}/share/raspberrypi/boot/bcm2710-rpi-2-b.dtb firmware/
         cp ${pkgs.raspberrypifw}/share/raspberrypi/boot/bcm2710-rpi-3-b.dtb firmware/
         cp ${pkgs.raspberrypifw}/share/raspberrypi/boot/bcm2710-rpi-3-b-plus.dtb firmware/
@@ -88,12 +92,20 @@
         cp ${pkgs.raspberrypifw}/share/raspberrypi/boot/bcm2710-rpi-zero-2-w.dtb firmware/
 
         # Add pi4 specific files
-        cp ${pkgs.ubootRaspberryPi4_64bit}/u-boot.bin firmware/u-boot-rpi4.bin
         cp ${pkgs.raspberrypi-armstubs}/armstub8-gic.bin firmware/armstub8-gic.bin
         cp ${pkgs.raspberrypifw}/share/raspberrypi/boot/bcm2711-rpi-4-b.dtb firmware/
         cp ${pkgs.raspberrypifw}/share/raspberrypi/boot/bcm2711-rpi-400.dtb firmware/
         cp ${pkgs.raspberrypifw}/share/raspberrypi/boot/bcm2711-rpi-cm4.dtb firmware/
         cp ${pkgs.raspberrypifw}/share/raspberrypi/boot/bcm2711-rpi-cm4s.dtb firmware/
+
+        # Add pi5 specific files
+        cp ${pkgs.raspberrypifw}/share/raspberrypi/boot/bcm2712-d-rpi-5-b.dtb firmware/
+        cp ${pkgs.raspberrypifw}/share/raspberrypi/boot/bcm2712-rpi-5-b.dtb firmware/
+        cp ${pkgs.raspberrypifw}/share/raspberrypi/boot/bcm2712-rpi-500.dtb firmware/
+        cp ${pkgs.raspberrypifw}/share/raspberrypi/boot/bcm2712-rpi-cm5-cm4io.dtb firmware/
+        cp ${pkgs.raspberrypifw}/share/raspberrypi/boot/bcm2712-rpi-cm5-cm5io.dtb firmware/
+        cp ${pkgs.raspberrypifw}/share/raspberrypi/boot/bcm2712-rpi-cm5l-cm4io.dtb firmware/
+        cp ${pkgs.raspberrypifw}/share/raspberrypi/boot/bcm2712-rpi-cm5l-cm5io.dtb firmware/
       '';
     populateRootCommands = ''
       mkdir -p ./files/boot


### PR DESCRIPTION
## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
