### PR TITLE
tcl-9_0: 9.0.3 -> 9.0.4

### DIFF
--- a/pkgs/development/interpreters/tcl/9.0.nix
+++ b/pkgs/development/interpreters/tcl/9.0.nix
@@ -4,13 +4,13 @@ callPackage ./generic.nix (
   args
   // rec {
     release = "9.0";
-    version = "${release}.3";
+    version = "${release}.4";
 
     # Note: when updating, the hash in pkgs/development/libraries/tk/9.0.nix must also be updated!
 
     src = fetchzip {
       url = "mirror://sourceforge/tcl/tcl${version}-src.tar.gz";
-      hash = "sha256-qKh2QYRy+dcX3tk6DS23YfrKfiN9V8RMU1es999KBE0=";
+      hash = "sha256-2yfj4ddGX/QT601NKG5y30LToMBu3jomFGnNUdzRaNw=";
     };
   }
 )

--- a/pkgs/development/interpreters/tcl/generic.nix
+++ b/pkgs/development/interpreters/tcl/generic.nix
@@ -90,6 +90,9 @@ let
       ]
       ++ lib.optional stdenv.hostPlatform.is64bit "--enable-64bit";
 
+    # https://core.tcl-lang.org/thread/tktview/30e201c7111a438e2fe6aadc9d733b954874cbb9
+    env = lib.optionalAttrs (lib.versionAtLeast version "9.0") { ZIPFS_BUILD = 0; };
+
     buildFlags = lib.optionals stdenv.hostPlatform.isStatic [
       # Don't use the default Make target for static,
       # since it builds shared libraries for bundled packages.

--- a/pkgs/development/libraries/tk/9.0.nix
+++ b/pkgs/development/libraries/tk/9.0.nix
@@ -11,7 +11,7 @@ callPackage ./generic.nix (
 
     src = fetchzip {
       url = "mirror://sourceforge/tcl/tk${tcl.version}-src.tar.gz";
-      hash = "sha256-ssgvJdgXCtBPfnPvX9AR9uo4zGbzRGsCjOowxe5cfjM=";
+      hash = "sha256-G0V6SWe2PF/EEg2qI41c0AAVMYLcCdJtnKlkRxbs5HQ=";
     };
 
     patches = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
