### PR TITLE
hypr*: Enable separateDebugInfo

### DIFF
--- a/pkgs/applications/window-managers/hyprwm/xdg-desktop-portal-hyprland/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/xdg-desktop-portal-hyprland/default.nix
@@ -68,6 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeBuildType = if debug then "Debug" else "RelWithDebInfo";
 
   dontStrip = debug;
+  separateDebugInfo = !debug;
 
   dontWrapQtApps = true;
 

--- a/pkgs/by-name/aq/aquamarine/package.nix
+++ b/pkgs/by-name/aq/aquamarine/package.nix
@@ -63,6 +63,7 @@ gcc15Stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeBuildType = "RelWithDebInfo";
+  separateDebugInfo = true;
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/hy/hyprcursor/package.nix
+++ b/pkgs/by-name/hy/hyprcursor/package.nix
@@ -43,6 +43,9 @@ gcc15Stdenv.mkDerivation (finalAttrs: {
     "lib"
   ];
 
+  cmakeBuildType = "RelWithDebInfo";
+  separateDebugInfo = true;
+
   passthru.updateScript = nix-update-script { };
 
   meta = {

--- a/pkgs/by-name/hy/hyprgraphics/package.nix
+++ b/pkgs/by-name/hy/hyprgraphics/package.nix
@@ -59,6 +59,9 @@ gcc15Stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
 
+  cmakeBuildType = "RelWithDebInfo";
+  separateDebugInfo = true;
+
   passthru = {
     updateScript = nix-update-script { };
   };

--- a/pkgs/by-name/hy/hypridle/package.nix
+++ b/pkgs/by-name/hy/hypridle/package.nix
@@ -45,6 +45,9 @@ gcc15Stdenv.mkDerivation (finalAttrs: {
     wayland-protocols
   ];
 
+  cmakeBuildType = "RelWithDebInfo";
+  separateDebugInfo = true;
+
   passthru = {
     updateScript = nix-update-script { };
   };

--- a/pkgs/by-name/hy/hyprland-qtutils/package.nix
+++ b/pkgs/by-name/hy/hyprland-qtutils/package.nix
@@ -51,6 +51,9 @@ gcc15Stdenv.mkDerivation (finalAttrs: {
     qtWrapperArgs+=(--prefix PATH : "${makeBinPath [ pciutils ]}")
   '';
 
+  cmakeBuildType = "RelWithDebInfo";
+  separateDebugInfo = true;
+
   meta = {
     description = "Hyprland QT/qml utility apps";
     homepage = "https://github.com/hyprwm/hyprland-qtutils";

--- a/pkgs/by-name/hy/hyprland/package.nix
+++ b/pkgs/by-name/hy/hyprland/package.nix
@@ -185,6 +185,7 @@ customStdenv.mkDerivation (finalAttrs: {
   cmakeBuildType = if debug then "Debug" else "RelWithDebInfo";
 
   dontStrip = debug;
+  separateDebugInfo = !debug;
   strictDeps = true;
 
   cmakeFlags = mapAttrsToList cmakeBool {

--- a/pkgs/by-name/hy/hyprlang/package.nix
+++ b/pkgs/by-name/hy/hyprlang/package.nix
@@ -34,6 +34,9 @@ gcc15Stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
 
+  cmakeBuildType = "RelWithDebInfo";
+  separateDebugInfo = true;
+
   meta = {
     homepage = "https://github.com/hyprwm/hyprlang";
     description = "Official implementation library for the hypr config language";

--- a/pkgs/by-name/hy/hyprlock/package.nix
+++ b/pkgs/by-name/hy/hyprlock/package.nix
@@ -72,6 +72,9 @@ gcc15Stdenv.mkDerivation (finalAttrs: {
     ln -s $out/share/hypr/hyprlock.conf $out/etc/xdg/hypr/hyprlock.conf
   '';
 
+  cmakeBuildType = "RelWithDebInfo";
+  separateDebugInfo = true;
+
   passthru.updateScript = nix-update-script { };
 
   meta = {

--- a/pkgs/by-name/hy/hyprpaper/package.nix
+++ b/pkgs/by-name/hy/hyprpaper/package.nix
@@ -88,6 +88,9 @@ gcc15Stdenv.mkDerivation (finalAttrs: {
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
 
+  cmakeBuildType = "RelWithDebInfo";
+  separateDebugInfo = true;
+
   meta = {
     inherit (finalAttrs.src.meta) homepage;
     description = "Blazing fast wayland wallpaper utility";

--- a/pkgs/by-name/hy/hyprpicker/package.nix
+++ b/pkgs/by-name/hy/hyprpicker/package.nix
@@ -29,7 +29,10 @@ gcc15Stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-ABumeksE8Bvtdb6g4vJ2jA9BLlYHnXU86VAuKJhBPoY=";
   };
 
-  cmakeBuildType = if debug then "Debug" else "Release";
+  cmakeBuildType = if debug then "Debug" else "RelWithDebInfo";
+
+  dontStrip = debug;
+  separateDebugInfo = !debug;
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/hy/hyprsunset/package.nix
+++ b/pkgs/by-name/hy/hyprsunset/package.nix
@@ -46,6 +46,9 @@ gcc15Stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
+  cmakeBuildType = "RelWithDebInfo";
+  separateDebugInfo = true;
+
   passthru = {
     updateScript = nix-update-script { };
   };

--- a/pkgs/by-name/hy/hyprutils/package.nix
+++ b/pkgs/by-name/hy/hyprutils/package.nix
@@ -34,6 +34,7 @@ gcc15Stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeBuildType = "RelWithDebInfo";
+  separateDebugInfo = true;
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/hy/hyprwire/package.nix
+++ b/pkgs/by-name/hy/hyprwire/package.nix
@@ -31,6 +31,9 @@ gcc15Stdenv.mkDerivation (finalAttrs: {
     pugixml
   ];
 
+  cmakeBuildType = "RelWithDebInfo";
+  separateDebugInfo = true;
+
   meta = {
     inherit (finalAttrs.src.meta) homepage;
     description = "A fast and consistent wire protocol for IPC ";


### PR DESCRIPTION
This enables a .debug output for hyprland, its dependencies (e.g. aquamarine and hyprutils), hyprlock, and other hypr* packages. This way if Hyprland or other hypr* applications crash, debug symbols can be pulled to diagnose the core dump.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

I've verified that the .debug output is created and gdb can load its symbols for the Hyprland binary. I also confirmed that the .debug output is populated with symbols for each of the packages this PR enables separateDebugInfo for.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `3be1d06f6d7f0a5dec618f98384f08430a968ee3`

---
### `x86_64-linux`
<details>
  <summary>:x: 4 packages failed to build: <i>(I've confirmed all of these also fail to build without this PR)</i></summary>
  <ul>
    <li>hyprlandPlugins.hypr-darkwindow</li>
    <li>hyprlandPlugins.hyprgrass</li>
    <li>hyprlandPlugins.hyprsplit</li>
    <li>hyprlandPlugins.imgborders</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 37 packages built:</summary>
  <ul>
    <li>aquamarine</li>
    <li>grimblast</li>
    <li>hdrop</li>
    <li>hyprcursor</li>
    <li>hyprgraphics</li>
    <li>hypridle</li>
    <li>hyprland</li>
    <li>hyprland-qt-support</li>
    <li>hyprland-qtutils</li>
    <li>hyprlandPlugins.borders-plus-plus</li>
    <li>hyprlandPlugins.csgo-vulkan-fix</li>
    <li>hyprlandPlugins.hy3</li>
    <li>hyprlandPlugins.hypr-dynamic-cursors</li>
    <li>hyprlandPlugins.hyprbars</li>
    <li>hyprlandPlugins.hyprfocus</li>
    <li>hyprlandPlugins.hyprspace</li>
    <li>hyprlang</li>
    <li>hyprlauncher</li>
    <li>hyprlock</li>
    <li>hyprmagnifier</li>
    <li>hyprmoncfg</li>
    <li>hyprpanel</li>
    <li>hyprpaper</li>
    <li>hyprpicker</li>
    <li>hyprpolkitagent</li>
    <li>hyprpwcenter</li>
    <li>hyprshade</li>
    <li>hyprshell</li>
    <li>hyprshot</li>
    <li>hyprshutdown</li>
    <li>hyprsunset</li>
    <li>hyprsysteminfo</li>
    <li>hyprtoolkit</li>
    <li>hyprutils</li>
    <li>hyprwire</li>
    <li>nwg-panel</li>
    <li>xdg-desktop-portal-hyprland</li>
  </ul>
</details>

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
