### PR TITLE
doc/fixed-point-arguments: add an example of wrapping with transformDrv and miscelaneous fixes

### DIFF
--- a/doc/build-helpers/fixed-point-arguments.chapter.md
+++ b/doc/build-helpers/fixed-point-arguments.chapter.md
@@ -23,7 +23,8 @@ See [recursive-sets](https://nix.dev/manual/nix/stable/language/syntax#recursive
 
 ## Define a build helper with `lib.extendMkDerivation` {#sec-build-helper-extendMkDerivation}
 
-Use [`lib.customisation.extendMkDerivation`](#function-library-lib.customisation.extendMkDerivation) to define a build helper with fixed-point support from an existing one. It takes an attribute overlay similar to [`<pkg>.overrideAttrs`](#sec-pkg-overrideAttrs).
+Use [`lib.customisation.extendMkDerivation`](#function-library-lib.customisation.extendMkDerivation) to define a build helper with fixed-point support from an existing one.
+Its argument `extendDrvArgs` takes an attribute overlay similar to [`<pkg>.overrideAttrs`](#sec-pkg-overrideAttrs).
 
 Besides overriding, `lib.extendMkDerivation` also supports `excludeDrvArgNames` to optionally exclude some arguments in the input fixed-point arguments from passing down to the base build helper (specified as `constructDrv`).
 

--- a/doc/build-helpers/fixed-point-arguments.chapter.md
+++ b/doc/build-helpers/fixed-point-arguments.chapter.md
@@ -74,3 +74,72 @@ To apply extra changes to the result derivation, pass `transformDrv` to `lib.ext
 ```nix
 lib.customisation.extendMkDerivation { transformDrv = drv: /...; }
 ```
+
+Construct a wrapper derivation around another derivation using `transformDrv`
+
+The wrapper has access to the original arguments
+
+:::{.example #ex-build-helpers-extendMkDerivation-transformDrv-wrapper}
+
+# Define a custom build helper that downloads and builds
+
+```nix
+{
+  lib,
+  stdenvNoCC,
+  cacert,
+  configure-example,
+  download-example,
+}:
+
+lib.extendMkDerivation {
+  constructDrv = stdenvNoCC.mkDerivation;
+
+  excludeDrvArgNames = [
+    "bar"
+  ];
+
+  extendDrvArgs =
+    finalAttrs:
+    {
+      bar,
+      foo,
+      hash ? "",
+      ...
+    }@args:
+    {
+      inherit hash;
+      nativeBuildInputs = args.nativeBuildInputs or [ ] ++ [
+        cacert
+        download-example
+      ];
+      buildPhase = ''
+        runHook preBuild
+        download-example --foo="$foo" --out="$out"
+        runHook postBuild
+      '';
+      impureEnvVars = lib.fetchers.proxyImpureEnvVars;
+      outputHash = if finalAttrs.hash != "" then finalAttrs.hash else lib.fakeHash;
+      outputHashFormat = "recursive";
+      passthru = args.passthru or { } // {
+        inherit bar;
+      };
+    };
+
+  transformDrv =
+    unwrapped:
+    stdenvNoCC.mkDerivation (finalAttrs: {
+      name = finalAttrs.src.name + "-wrapped";
+      src = unwrapped;
+      nativeBuildInputs = [
+        configure-example
+      ];
+      inherit (unwrapped) bar;
+      buildPhase = ''
+        runHook preBuild
+        configure-example --bar="$bar"
+        runHook postBuild
+      '';
+    });
+}
+```

--- a/doc/build-helpers/fixed-point-arguments.chapter.md
+++ b/doc/build-helpers/fixed-point-arguments.chapter.md
@@ -3,6 +3,10 @@
 `stdenv.mkDerivation` also accepts a [fixed-point function](#function-library-lib.fixedPoints.fix) instead of a plain attribute set:
 
 ```nix
+{
+  stdenv,
+  fetchurl,
+}:
 stdenv.mkDerivation (finalAttrs: {
   pname = "hello";
   version = "2.12";
@@ -37,6 +41,10 @@ Define a build helper named `mkLocalDerivation` that builds locally without usin
 Use `lib.extendMkDerivation`:
 
 ```nix
+{
+  lib,
+  stdenv,
+}:
 lib.extendMkDerivation {
   constructDrv = stdenv.mkDerivation;
   excludeDrvArgNames = [

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -108,6 +108,9 @@
   "ex-build-helpers-extendMkDerivation": [
     "index.html#ex-build-helpers-extendMkDerivation"
   ],
+  "ex-build-helpers-extendMkDerivation-transformDrv-wrapper": [
+    "index.html#ex-build-helpers-extendMkDerivation-transformDrv-wrapper"
+  ],
   "ex-first-package-go": [
     "index.html#ex-first-package-go"
   ],


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* State that`extendDrvArgs` takes the attribute overlay.
* Make all examples [`callPackage`-compatible](https://github.com/NixOS/nixpkgs/tree/master/doc/#callpackage-compatible-examples).
* Add an example usage of `transformDrv` to wrap the constructed derivation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
