### PR TITLE
nixos/moonlight-qt: add module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -12,6 +12,8 @@
 
 - [tranquil](https://tangled.org/tranquil.farm/tranquil-pds) is an ATProto PDS (personal data server) implementation in Rust. A featureful, spec conscious and community driven alternative to the Bluesky reference implementation PDS. Available as [services.tranquil-pds](#opt-services.tranquil-pds.enable).
 
+- [Moonlight Qt](https://moonlight-stream.org/), a client for playing your PC games on almost any device. Available as [programs.moonlight-qt](#opt-programs.moonlight-qt.enable).
+
 - [scx_loader](https://github.com/sched-ext/scx-loader), a system daemon and DBus-based loader for sched_ext schedulers. `scxctl` is the command-line client for interacting with the loader, allowing users to switch schedulers, modes, and arguments dynamically. Available as [services.scx-loader](#opt-services.scx-loader.enable)
 
 - [Nezha](https://github.com/nezhahq/nezha), a self-hosted, lightweight server and website monitoring and O&M tool. Available as [services.nezha](#opt-services.nezha.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -267,6 +267,7 @@
   ./programs/mininet.nix
   ./programs/minipro.nix
   ./programs/miriway.nix
+  ./programs/moonlight-qt.nix
   ./programs/mosh.nix
   ./programs/mouse-actions.nix
   ./programs/msmtp.nix

--- a/nixos/modules/programs/moonlight-qt.nix
+++ b/nixos/modules/programs/moonlight-qt.nix
@@ -1,0 +1,39 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.moonlight-qt;
+in
+{
+  options.programs.moonlight-qt = {
+    enable = lib.mkEnableOption "Moonlight Qt, a client for playing your PC games on almost any device";
+
+    package = lib.mkPackageOption pkgs "moonlight-qt" { };
+
+    capSysNice = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Add the CAP_SYS_NICE capability to Moonlight Qt so that it may raise
+        its scheduling priority.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    security.wrappers.moonlight = lib.mkIf cfg.capSysNice {
+      owner = "root";
+      group = "root";
+      source = lib.getExe cfg.package;
+      capabilities = "cap_sys_nice+ep";
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ aaravrav ];
+}

--- a/nixos/tests/sunshine.nix
+++ b/nixos/tests/sunshine.nix
@@ -40,9 +40,10 @@
         ./common/x11.nix
       ];
 
-      environment.systemPackages = with pkgs; [
-        moonlight-qt
-      ];
+      programs.moonlight-qt = {
+        enable = true;
+        capSysNice = true;
+      };
 
     };
 
@@ -52,6 +53,7 @@
     # start the tests, wait for sunshine to be up
     start_all()
     sunshine.wait_for_open_port(48010,"localhost")
+    moonlight.succeed("${pkgs.libcap}/bin/getcap \"$(command -v moonlight)\" | grep -q 'cap_sys_nice'")
 
     # set the admin username/password, restart sunshine
     sunshine.execute("sunshine --creds sunshine sunshine")


### PR DESCRIPTION
Adds a NixOS module for moonlight-qt with options:
- `enable`
- `package`
- `capSysNice`: creates a wrapper with `CAP_SYS_NICE`, allowing Moonlight to raise its scheduling priority without needing to change PAM/systemd priority limits

Adds a test which checks that the Moonlight wrapper has `CAP_SYS_NICE`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test