### PR TITLE
haskellPackages.lambdabot: remove ncfavier as maintainer

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -383,7 +383,6 @@ package-maintainers:
     - Agda
     - agda2hs
     - irc-client
-    - lambdabot
     - shake
   nomeata:
     - cabal-plan-bounds

--- a/pkgs/development/haskell-modules/hackage-packages.nix
+++ b/pkgs/development/haskell-modules/hackage-packages.nix
@@ -418693,7 +418693,6 @@ self: {
       description = "Lambdabot is a development tool and advanced IRC bot";
       license = "GPL";
       mainProgram = "lambdabot";
-      maintainers = [ lib.maintainers.ncfavier ];
     }
   ) { };
 


### PR DESCRIPTION
I am no longer interested in maintaining this.