### PR TITLE
treewide: follow some GitHub redirects for `fetchFromGitHub`

### DIFF
--- a/pkgs/by-name/au/aube/package.nix
+++ b/pkgs/by-name/au/aube/package.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "1.9.1";
 
   src = fetchFromGitHub {
-    owner = "endevco";
+    owner = "jdx";
     repo = "aube";
     tag = "v${finalAttrs.version}";
     hash = "sha256-uwOEou6DH+bePNupYKmTc82xQV9T08bDmSPG9RU9yBk=";
@@ -40,8 +40,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Fast Node.js package manager";
-    homepage = "https://github.com/endevco/aube";
-    changelog = "https://github.com/endevco/aube/blob/v${finalAttrs.version}/CHANGELOG.md";
+    homepage = "https://github.com/jdx/aube";
+    changelog = "https://github.com/jdx/aube/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ chillcicada ];
     mainProgram = "aube";

--- a/pkgs/by-name/bu/burn-central-cli/package.nix
+++ b/pkgs/by-name/bu/burn-central-cli/package.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "tracel-ai";
-    repo = "burn-central-cli";
+    repo = "tracel-cli";
     tag = "v${finalAttrs.version}";
     hash = "sha256-1QXlN1cq5MKZAPgGx5mnf8Jy7o4CnKJDKi0sSith6n0=";
   };
@@ -45,8 +45,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
       with Burn Central, the centralized platform for experiment tracking,
       model sharing, and deployment for Burn users.
     '';
-    homepage = "https://github.com/tracel-ai/burn-central-cli";
-    changelog = "https://github.com/tracel-ai/burn-central-cli/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/tracel-ai/tracel-cli";
+    changelog = "https://github.com/tracel-ai/tracel-cli/releases/tag/v${finalAttrs.version}";
     license = with lib.licenses; [
       mit
       asl20

--- a/pkgs/by-name/cc/ccusage/package.nix
+++ b/pkgs/by-name/cc/ccusage/package.nix
@@ -31,7 +31,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "20.0.6";
 
   src = fetchFromGitHub {
-    owner = "ryoppippi";
+    owner = "ccusage";
     repo = "ccusage";
     tag = "v${finalAttrs.version}";
     hash = "sha256-uf/FlPprxx4jh74YwjmYMtoIHpTkKrWTLetbNoYiFv4=";
@@ -98,8 +98,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Analyze coding agent CLI token usage and costs from local data";
-    homepage = "https://github.com/ryoppippi/ccusage";
-    changelog = "https://github.com/ryoppippi/ccusage/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/ccusage/ccusage";
+    changelog = "https://github.com/ccusage/ccusage/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ thrix ];
     mainProgram = "ccusage";

--- a/pkgs/by-name/ce/cel-go/package.nix
+++ b/pkgs/by-name/ce/cel-go/package.nix
@@ -9,7 +9,7 @@ let
     version = "0.25.2";
 
     src = fetchFromGitHub {
-      owner = "google";
+      owner = "cel-expr";
       repo = "cel-spec";
       tag = "v${finalAttrs.version}";
       hash = "sha256-aNyBGUlpTqILCiQHo7BxaZShI6q9xgtRegywd+jQSlo=";
@@ -29,7 +29,7 @@ buildGoModule (finalAttrs: {
   version = "0.28.1";
 
   src = fetchFromGitHub {
-    owner = "google";
+    owner = "cel-expr";
     repo = "cel-go";
     tag = "v${finalAttrs.version}";
     hash = "sha256-fiFkoYVKdSdYkSMQxmC1SvEEGsalBasCl9tzsGSYwmw=";
@@ -68,9 +68,9 @@ buildGoModule (finalAttrs: {
   };
 
   meta = {
-    changelog = "https://github.com/google/cel-go/releases/tag/${finalAttrs.src.tag}";
+    changelog = "https://github.com/cel-expr/cel-go/releases/tag/${finalAttrs.src.tag}";
     description = "Fast, portable, non-Turing complete expression evaluation with gradual typing";
-    homepage = "https://github.com/google/cel-go";
+    homepage = "https://github.com/cel-expr/cel-go";
     license = lib.licenses.asl20;
     mainProgram = "cel-go";
     maintainers = with lib.maintainers; [ hythera ];

--- a/pkgs/by-name/cj/cjose/package.nix
+++ b/pkgs/by-name/cj/cjose/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.6.2.2";
 
   src = fetchFromGitHub {
-    owner = "zmartzone";
+    owner = "OpenIDC";
     repo = "cjose";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-vDvCxMpgCdteGvNxy2HCNRaxbhxOuTadL0nM2wkFHtk=";
@@ -47,8 +47,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
-    homepage = "https://github.com/zmartzone/cjose";
-    changelog = "https://github.com/zmartzone/cjose/blob/${finalAttrs.version}/CHANGELOG.md";
+    homepage = "https://github.com/OpenIDC/cjose";
+    changelog = "https://github.com/OpenIDC/cjose/blob/${finalAttrs.version}/CHANGELOG.md";
     description = "C library for Javascript Object Signing and Encryption. This is a maintained fork of the original project";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ midchildan ];

--- a/pkgs/by-name/cl/clarity-city/package.nix
+++ b/pkgs/by-name/cl/clarity-city/package.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   version = "1.0.0";
 
   src = fetchFromGitHub {
-    owner = "vmware";
+    owner = "vmware-archive";
     repo = "clarity-city";
     rev = "v${finalAttrs.version}";
     hash = "sha256-1POSdd2ICnyNNmGadIujezNK8qvARD0kkLR4yWjs5kA=";
@@ -29,7 +29,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Open source sans-serif typeface";
-    homepage = "https://github.com/vmware/clarity-city";
+    homepage = "https://github.com/vmware-archive/clarity-city";
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ sagikazarmark ];

--- a/pkgs/by-name/cl/classicube/package.nix
+++ b/pkgs/by-name/cl/classicube/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.3.8";
 
   src = fetchFromGitHub {
-    owner = "UnknownShadow200";
+    owner = "ClassiCube";
     repo = "ClassiCube";
     tag = finalAttrs.version;
     hash = "sha256-AF4cr3ZXCixwiihS+2ayrzVH5eYShkjlfF0myb2PbHM=";

--- a/pkgs/by-name/cl/clematis/package.nix
+++ b/pkgs/by-name/cl/clematis/package.nix
@@ -9,7 +9,7 @@ buildGoModule {
   version = "2022-04-16";
 
   src = fetchFromGitHub {
-    owner = "TorchedSammy";
+    owner = "sammy-ette";
     repo = "clematis";
     rev = "cbe74da084b9d3f6893f53721c27cd0f3a45fe93";
     sha256 = "sha256-TjoXHbY0vUQ2rhwdCJ/s/taRd9/MG0P9HaEw2BOIy/s=";
@@ -19,7 +19,7 @@ buildGoModule {
 
   meta = {
     description = "Discord rich presence for MPRIS music players";
-    homepage = "https://github.com/TorchedSammy/Clematis";
+    homepage = "https://github.com/sammy-ette/clematis";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ misterio77 ];

--- a/pkgs/by-name/cn/cnquery/package.nix
+++ b/pkgs/by-name/cn/cnquery/package.nix
@@ -10,7 +10,7 @@ buildGoModule rec {
 
   src = fetchFromGitHub {
     owner = "mondoohq";
-    repo = "cnquery";
+    repo = "mql";
     tag = "v${version}";
     hash = "sha256-CTg2jfpCLTYuRx5R+9Si0Ig1NT1ZGXMFbcPPa8CbMKY=";
   };
@@ -32,7 +32,7 @@ buildGoModule rec {
       accounts, Kubernetes, containers, services, VMs, APIs, and more.
     '';
     homepage = "https://mondoo.com/cnquery";
-    changelog = "https://github.com/mondoohq/cnquery/releases/tag/v${version}";
+    changelog = "https://github.com/mondoohq/mql/releases/tag/v${version}";
     license = lib.licenses.bsl11;
     maintainers = with lib.maintainers; [ mariuskimmina ];
   };

--- a/pkgs/by-name/co/cocogitto/package.nix
+++ b/pkgs/by-name/co/cocogitto/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "7.0.0";
 
   src = fetchFromGitHub {
-    owner = "oknozor";
+    owner = "cocogitto";
     repo = "cocogitto";
     tag = finalAttrs.version;
     hash = "sha256-Z+SXB6bDxyR+Bt3Pz6uF9+sZLjbiFNYeECVFZbx40h8=";

--- a/pkgs/by-name/co/cointop/package.nix
+++ b/pkgs/by-name/co/cointop/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "1.6.10";
 
   src = fetchFromGitHub {
-    owner = "miguelmota";
+    owner = "cointop-sh";
     repo = "cointop";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-NAw1uoBL/FnNLJ86L9aBCOY65aJn1DDGK0Cd0IO2kr0=";

--- a/pkgs/by-name/co/construct/package.nix
+++ b/pkgs/by-name/co/construct/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.1.0";
 
   src = fetchFromGitHub {
-    owner = "Thomas-de-Bock";
+    owner = "Thomas-995";
     repo = "construct";
     rev = finalAttrs.version;
     hash = "sha256-ENso0y7yEaXzGXzZOnlZ1L7+j/qayJL+f55/NYLz2ew=";
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Abstraction over x86 NASM Assembly";
     longDescription = "Construct adds features such as while loops, if statements, scoped macros and function-call syntax to NASM Assembly.";
-    homepage = "https://github.com/Thomas-de-Bock/construct";
+    homepage = "https://github.com/Thomas-995/construct";
     maintainers = with lib.maintainers; [ rucadi ];
     platforms = lib.platforms.all;
     license = lib.licenses.mit;

--- a/pkgs/by-name/co/cortex-tools/package.nix
+++ b/pkgs/by-name/co/cortex-tools/package.nix
@@ -13,7 +13,7 @@ buildGoModule (finalAttrs: {
   version = "0.11.3";
 
   src = fetchFromGitHub {
-    owner = "grafana";
+    owner = "grafana-cold-storage";
     repo = "cortex-tools";
     tag = "v${finalAttrs.version}";
     hash = "sha256-+GWUC+lnCn5Nw2WytSvW/UsIMmMelCCsnKdBCHuue24=";
@@ -31,7 +31,7 @@ buildGoModule (finalAttrs: {
   env.CGO_ENABLED = 0;
 
   ldflags = [
-    "-X github.com/grafana/cortex-tools/pkg/version.Version=${finalAttrs.src.tag}"
+    "-X github.com/grafana-cold-storage/cortex-tools/pkg/version.Version=${finalAttrs.src.tag}"
     "-s"
     "-w"
   ];
@@ -60,7 +60,7 @@ buildGoModule (finalAttrs: {
   versionCheckProgramArg = "version";
 
   meta = {
-    changelog = "https://github.com/grafana/cortex-tools/releases/tag/${finalAttrs.src.tag}";
+    changelog = "https://github.com/grafana-cold-storage/cortex-tools/releases/tag/${finalAttrs.src.tag}";
     description = "Tools used for interacting with Cortex, a Prometheus-compatible server";
     longDescription = ''
       Tools used for interacting with Cortex, a horizontally scalable, highly available, multi-tenant, long term Prometheus server:
@@ -70,7 +70,7 @@ buildGoModule (finalAttrs: {
       - logtool: Tool which parses Cortex query-frontend logs and formats them for easy analysis.
       - e2ealerting: Tool that helps measure how long an alert takes from scrape of sample to Alertmanager notification delivery.
     '';
-    homepage = "https://github.com/grafana/cortex-tools";
+    homepage = "https://github.com/grafana-cold-storage/cortex-tools";
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux ++ lib.platforms.windows ++ lib.platforms.darwin;
     maintainers = with lib.maintainers; [ videl ];

--- a/pkgs/by-name/co/cosmic-applibrary/package.nix
+++ b/pkgs/by-name/co/cosmic-applibrary/package.nix
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # nixpkgs-update: no auto update
   src = fetchFromGitHub {
     owner = "pop-os";
-    repo = "cosmic-applibrary";
+    repo = "cosmic-app-library";
     tag = "epoch-${finalAttrs.version}";
     hash = "sha256-TZncRQer4lXunUwdQ2xDP3DmF5B7UmfhSQvEwVodc98=";
   };
@@ -62,7 +62,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   meta = {
-    homepage = "https://github.com/pop-os/cosmic-applibrary";
+    homepage = "https://github.com/pop-os/cosmic-app-library";
     description = "Application Template for the COSMIC Desktop Environment";
     license = lib.licenses.gpl3Only;
     teams = [ lib.teams.cosmic ];

--- a/pkgs/by-name/co/coze/package.nix
+++ b/pkgs/by-name/co/coze/package.nix
@@ -10,7 +10,7 @@ buildGoModule (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "Cyphrme";
-    repo = "Coze_cli";
+    repo = "CozeCLI";
     rev = "v${finalAttrs.version}";
     hash = "sha256-/Cznx5Q0a9vVrC4oAoBmAkejT1505AQzzCW/wi3itv4=";
   };
@@ -24,7 +24,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "CLI client for Coze, a cryptographic JSON messaging specification";
     mainProgram = "coze";
-    homepage = "https://github.com/Cyphrme/coze_cli";
+    homepage = "https://github.com/Cyphrme/CozeCLI";
     license = with lib.licenses; [ bsd3 ];
     maintainers = with lib.maintainers; [ qbit ];
   };

--- a/pkgs/by-name/cp/cpuset/package.nix
+++ b/pkgs/by-name/cp/cpuset/package.nix
@@ -10,7 +10,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "lpechacek";
+    owner = "SUSE";
     repo = "cpuset";
     rev = "v${finalAttrs.version}";
     hash = "sha256-fW0SXNI10pb6FTn/2TOqxP9qlys0KL/H9m//NjslUaY=";

--- a/pkgs/by-name/cr/credhub-cli/package.nix
+++ b/pkgs/by-name/cr/credhub-cli/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "2.9.54";
 
   src = fetchFromGitHub {
-    owner = "cloudfoundry-incubator";
+    owner = "cloudfoundry";
     repo = "credhub-cli";
     rev = finalAttrs.version;
     sha256 = "sha256-qp7Oj207uu2P/Jt9O5tZM0ra9fMx+DfuHPaKr5z+ef0=";
@@ -40,7 +40,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Provides a command line interface to interact with CredHub servers";
-    homepage = "https://github.com/cloudfoundry-incubator/credhub-cli";
+    homepage = "https://github.com/cloudfoundry/credhub-cli";
     maintainers = with lib.maintainers; [ ris ];
     license = lib.licenses.asl20;
   };

--- a/pkgs/by-name/cr/crlfsuite/package.nix
+++ b/pkgs/by-name/cr/crlfsuite/package.nix
@@ -10,7 +10,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "Nefcore";
+    owner = "Raghavd3v";
     repo = "CRLFsuite";
     tag = "v${finalAttrs.version}";
     sha256 = "sha256-mK20PbVGhTEjhY5L6coCzSMIrG/PHHmNq30ZoJEs6uI=";
@@ -35,7 +35,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   meta = {
     description = "CRLF injection (HTTP Response Splitting) scanner";
     mainProgram = "crlfsuite";
-    homepage = "https://github.com/Nefcore/CRLFsuite";
+    homepage = "https://github.com/Raghavd3v/CRLFsuite";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       fab

--- a/pkgs/by-name/ct/ctodo/package.nix
+++ b/pkgs/by-name/ct/ctodo/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.3";
 
   src = fetchFromGitHub {
-    owner = "Acolarh";
+    owner = "nielssp";
     repo = "ctodo";
     rev = "v${finalAttrs.version}";
     sha256 = "0mqy5b35cbdwfpbs91ilsgz3wc4cky38xfz9pnr4q88q1vybigna";

--- a/pkgs/by-name/cu/cuetsy/package.nix
+++ b/pkgs/by-name/cu/cuetsy/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "0.1.11";
 
   src = fetchFromGitHub {
-    owner = "grafana";
+    owner = "grafana-cold-storage";
     repo = "cuetsy";
     rev = "v${finalAttrs.version}";
     hash = "sha256-dirzVR4j5K1+EHbeRi4rHwRxkyveySoM7qJzvOlGp+0=";
@@ -19,7 +19,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Experimental CUE->TypeScript exporter";
-    homepage = "https://github.com/grafana/cuetsy";
+    homepage = "https://github.com/grafana-cold-storage/cuetsy";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ bryanhonof ];
     mainProgram = "cuetsy";

--- a/pkgs/by-name/cu/cups-printers/package.nix
+++ b/pkgs/by-name/cu/cups-printers/package.nix
@@ -10,7 +10,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "audiusGmbH";
+    owner = "audius";
     repo = "cups-printers";
     tag = finalAttrs.version;
     hash = "sha256-Fne7V9dEZwdV6OsQPg2gzrz/wloAOOuwlx3CqXOyWBc=";

--- a/pkgs/by-name/da/dapper/package.nix
+++ b/pkgs/by-name/da/dapper/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "0.6.0";
 
   src = fetchFromGitHub {
-    owner = "rancher";
+    owner = "rancher-archives";
     repo = "dapper";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-V+lHnOmIWjI1qmoJ7+pp+cGmJAtSeY+r2I9zykswQzM=";
@@ -23,7 +23,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Docker build wrapper";
     mainProgram = "dapper";
-    homepage = "https://github.com/rancher/dapper";
+    homepage = "https://github.com/rancher-archives/dapper";
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ kuznero ];

--- a/pkgs/by-name/dd/ddosify/package.nix
+++ b/pkgs/by-name/dd/ddosify/package.nix
@@ -10,8 +10,8 @@ buildGoModule (finalAttrs: {
   version = "2.6.0";
 
   src = fetchFromGitHub {
-    owner = "ddosify";
-    repo = "ddosify";
+    owner = "getanteon";
+    repo = "anteon";
     tag = "selfhosted-${finalAttrs.version}";
     hash = "sha256-EPbpBCSaUVVhxGlj7gRqwHLuj5p6563iiARqkEjA6Rk=";
   };
@@ -41,7 +41,7 @@ buildGoModule (finalAttrs: {
     description = "High-performance load testing tool, written in Golang";
     mainProgram = "ddosify";
     homepage = "https://ddosify.com/";
-    changelog = "https://github.com/ddosify/ddosify/releases/tag/selfhosted-${finalAttrs.version}";
+    changelog = "https://github.com/getanteon/anteon/releases/tag/selfhosted-${finalAttrs.version}";
     license = lib.licenses.agpl3Plus;
     maintainers = [ ];
   };

--- a/pkgs/by-name/de/dehydrated/package.nix
+++ b/pkgs/by-name/de/dehydrated/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.7.2";
 
   src = fetchFromGitHub {
-    owner = "lukas2511";
+    owner = "dehydrated-io";
     repo = "dehydrated";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-xDDYqP6oxJt0NPgHtHV1xQKUxVc8JQxWekXwxezggtE=";

--- a/pkgs/by-name/de/desmume/package.nix
+++ b/pkgs/by-name/de/desmume/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.9.13";
 
   src = fetchFromGitHub {
-    owner = "TASVideos";
+    owner = "TASEmulators";
     repo = "desmume";
     rev = "release_${lib.replaceStrings [ "." ] [ "_" ] finalAttrs.version}";
     hash = "sha256-vmjKXa/iXLTwtqnG+ZUvOnOQPZROeMpfM5J3Jh/Ynfo=";
@@ -87,7 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
-    homepage = "https://www.github.com/TASVideos/desmume/";
+    homepage = "https://www.github.com/TASEmulators/desmume/";
     description = "Open-source Nintendo DS emulator";
     longDescription = ''
       DeSmuME is a freeware emulator for the NDS roms & Nintendo DS Lite games

--- a/pkgs/by-name/di/digitalbitbox/package.nix
+++ b/pkgs/by-name/di/digitalbitbox/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.0.0";
 
   src = fetchFromGitHub {
-    owner = "digitalbitbox";
+    owner = "BitBoxSwiss";
     repo = "dbb-app";
     tag = "v${finalAttrs.version}";
     hash = "sha256-ig3+TdYv277D9GVnkRSX6nc6D6qruUOw/IQdQCK6FoA=";

--- a/pkgs/by-name/di/discord-rpc/package.nix
+++ b/pkgs/by-name/di/discord-rpc/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.4.0";
 
   src = fetchFromGitHub {
-    owner = "discordapp";
+    owner = "discord";
     repo = "discord-rpc";
     rev = "v${finalAttrs.version}";
     sha256 = "04cxhqdv5r92lrpnhxf8702a8iackdf3sfk1050z7pijbijiql2a";
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Official library to interface with the Discord client";
-    homepage = "https://github.com/discordapp/discord-rpc";
+    homepage = "https://github.com/discord/discord-rpc";
     license = lib.licenses.mit;
     maintainers = [ ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/di/discord-sh/package.nix
+++ b/pkgs/by-name/di/discord-sh/package.nix
@@ -14,7 +14,7 @@ stdenvNoCC.mkDerivation rec {
   version = "2.0.1";
 
   src = fetchFromGitHub {
-    owner = "ChaoticWeg";
+    owner = "fieu";
     repo = "discord.sh";
     rev = "v${version}";
     sha256 = "sha256-z57uMbH6PI68aTMAjA8UIPEefV8sQRR4cS0eK6Ypxuk=";
@@ -61,7 +61,7 @@ stdenvNoCC.mkDerivation rec {
   meta = {
     description = "Write-only command-line Discord webhook integration written in 100% Bash script";
     mainProgram = "discord.sh";
-    homepage = "https://github.com/ChaoticWeg/discord.sh";
+    homepage = "https://github.com/fieu/discord.sh";
     license = lib.licenses.gpl3;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ matthewcroughan ];

--- a/pkgs/by-name/di/disktui/package.nix
+++ b/pkgs/by-name/di/disktui/package.nix
@@ -7,7 +7,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "disktui";
   version = "1.3.0";
   src = fetchFromGitHub {
-    owner = "Maciejonos";
+    owner = "mkbula";
     repo = "disktui";
     tag = "v${finalAttrs.version}";
     hash = "sha256-C0skZF7fP7Qx5o+q9bUitgnBB9tBh1J4JdGyn8oQ/Rc=";
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "TUI for disk management on Linux";
-    homepage = "https://github.com/Maciejonos/disktui";
+    homepage = "https://github.com/mkbula/disktui";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ Inarizxc ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/dj/djlint/package.nix
+++ b/pkgs/by-name/dj/djlint/package.nix
@@ -10,7 +10,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "Riverside-Healthcare";
+    owner = "djlint";
     repo = "djlint";
     tag = "v${finalAttrs.version}";
     hash = "sha256-1DXBDVe8Ae8joJOYwwlBZB8MVubDPVhh+TiJBpL2u2M=";
@@ -43,7 +43,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   meta = {
     description = "HTML Template Linter and Formatter. Django - Jinja - Nunjucks - Handlebars - GoLang";
     mainProgram = "djlint";
-    homepage = "https://github.com/Riverside-Healthcare/djlint";
+    homepage = "https://github.com/djlint/djLint";
     license = lib.licenses.gpl3Only;
     changelog = "https://github.com/djlint/djLint/blob/v${finalAttrs.version}/CHANGELOG.md";
     maintainers = with lib.maintainers; [ traxys ];

--- a/pkgs/by-name/dj/djv/package.nix
+++ b/pkgs/by-name/dj/djv/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.1.1";
 
   src = fetchFromGitHub {
-    owner = "darbyjohnston";
+    owner = "grizzlypeak3d";
     repo = "djv";
     tag = finalAttrs.version;
     hash = "sha256-/SakJ23mi/dz8eUt2UtcgfLtFZiCHy1ME+jWdNS8+Fw=";

--- a/pkgs/by-name/dm/dmrconfig/package.nix
+++ b/pkgs/by-name/dm/dmrconfig/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.1";
 
   src = fetchFromGitHub {
-    owner = "sergev";
+    owner = "OpenRTX";
     repo = "dmrconfig";
     rev = finalAttrs.version;
     sha256 = "1qwix75z749628w583fwp7m7kxbj0k3g159sxb7vgqxbadqqz1ab";
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     longDescription = ''
       DMRconfig is a utility for programming digital radios via USB programming cable.
     '';
-    homepage = "https://github.com/sergev/dmrconfig";
+    homepage = "https://github.com/OpenRTX/dmrconfig";
     license = lib.licenses.asl20;
     maintainers = [ ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/do/dogedns/package.nix
+++ b/pkgs/by-name/do/dogedns/package.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "Dj-Codeman";
-    repo = "doge";
+    repo = "dog_community";
     rev = "v${finalAttrs.version}";
     hash = "sha256-SeC/GZ1AeEqRzxWc4oJ6JOvXfn3/LRcQz9uWXXqdTqU=";
   };
@@ -53,7 +53,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Reviving a command-line DNS client";
-    homepage = "https://github.com/Dj-Codeman/doge";
+    homepage = "https://github.com/Dj-Codeman/dog_community";
     license = lib.licenses.eupl12;
     mainProgram = "doge";
     maintainers = with lib.maintainers; [ aktaboot ];

--- a/pkgs/by-name/do/doom-bcc/package.nix
+++ b/pkgs/by-name/do/doom-bcc/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   version = "unstable-2018-01-04";
 
   src = fetchFromGitHub {
-    owner = "wormt";
+    owner = "positively-charged";
     repo = "bcc";
     rev = "d58b44d9f18b28fd732c27113e5607a454506d19";
     sha256 = "1m83ip40ln61qrvb1fbgaqbld2xip9n3k817lwkk1936pml9zcrq";
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
   meta = {
     description = "Compiler for Doom/Hexen scripts (ACS, BCS)";
     mainProgram = "bcc";
-    homepage = "https://github.com/wormt/bcc";
+    homepage = "https://github.com/positively-charged/bcc";
     license = lib.licenses.mit;
   };
 }

--- a/pkgs/by-name/dr/dracut/package.nix
+++ b/pkgs/by-name/dr/dracut/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "dracut-ng";
-    repo = "dracut-ng";
+    repo = "dracut";
     tag = finalAttrs.version;
     hash = "sha256-2jdS7/LGuLSBBXv1R/o8yjgwdXl2l2wNbZWxq01wSb0";
   };

--- a/pkgs/by-name/dr/droidcam/package.nix
+++ b/pkgs/by-name/dr/droidcam/package.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.1.5";
 
   src = fetchFromGitHub {
-    owner = "aramg";
-    repo = "droidcam";
+    owner = "dev47apps";
+    repo = "droidcam-linux-client";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-22lRmtXumjR/83Fg1edBisM1GjNZvNUvPs1Yg7Na1xw=";
   };
@@ -62,7 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Linux client for DroidCam app";
-    homepage = "https://github.com/aramg/droidcam";
+    homepage = "https://github.com/dev47apps/droidcam-linux-client";
     license = lib.licenses.gpl2Only;
     maintainers = [ lib.maintainers.suhr ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/dr/drone/package.nix
+++ b/pkgs/by-name/dr/drone/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "harness";
-    repo = "drone";
+    repo = "harness";
     tag = "v${finalAttrs.version}";
     hash = "sha256-jKM+jET6dsMe5+QRDKIHA40OOHb/nZmli3owaDB7IvU=";
   };
@@ -28,7 +28,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Continuous Integration platform built on container technology";
     mainProgram = "drone-server";
-    homepage = "https://github.com/harness/drone";
+    homepage = "https://github.com/harness/harness";
     maintainers = with lib.maintainers; [
       vdemeester
       techknowlogick

--- a/pkgs/development/python-modules/deepdiff/default.nix
+++ b/pkgs/development/python-modules/deepdiff/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "seperman";
+    owner = "qlustered";
     repo = "deepdiff";
     tag = version;
     hash = "sha256-/XRPP8O2ykoXwOZ2ou/7Yoa1x7t45dCx6G3aq30o3Wc=";
@@ -89,8 +89,8 @@ buildPythonPackage rec {
   meta = {
     description = "Deep Difference and Search of any Python object/data";
     mainProgram = "deep";
-    homepage = "https://github.com/seperman/deepdiff";
-    changelog = "https://github.com/seperman/deepdiff/blob/${src.tag}/CHANGELOG.md";
+    homepage = "https://github.com/qlustered/deepdiff";
+    changelog = "https://github.com/qlustered/deepdiff/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       mic92

--- a/pkgs/development/python-modules/dodgy/default.nix
+++ b/pkgs/development/python-modules/dodgy/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "landscapeio";
+    owner = "prospector-dev";
     repo = "dodgy";
     rev = version;
     sha256 = "0ywwjpz0p6ls3hp1lndjr9ql6s5lkj7dgpll1h87w04kwan70j0x";
@@ -33,7 +33,7 @@ buildPythonPackage rec {
   meta = {
     description = "Looks at Python code to search for things which look \"dodgy\" such as passwords or diffs";
     mainProgram = "dodgy";
-    homepage = "https://github.com/landscapeio/dodgy";
+    homepage = "https://github.com/prospector-dev/dodgy";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ kamadorueda ];
   };

--- a/pkgs/development/python-modules/dvc/default.nix
+++ b/pkgs/development/python-modules/dvc/default.nix
@@ -68,7 +68,7 @@ buildPythonPackage (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "iterative";
+    owner = "treeverse";
     repo = "dvc";
     tag = finalAttrs.version;
     hash = "sha256-KzHaR7o3PUHMBrtSDWXvH7/YMPxSafPSGUnS9018XKg=";
@@ -162,7 +162,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Version Control System for Machine Learning Projects";
     homepage = "https://dvc.org";
-    changelog = "https://github.com/iterative/dvc/releases/tag/${finalAttrs.src.tag}";
+    changelog = "https://github.com/treeverse/dvc/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       cmcdragonkai


### PR DESCRIPTION
This PR updates some `fetchFromGitHub` calls and corresponding `github.com/<owner>/<repo>` links in the same location to point directly to canonical repositories instead of redirecting URLs.

This doesn't update all `fetchFromGitHub` redirects since that would produce a diff too large for maintainers to review.

**Motivation:**
This avoids silent failures if upstream redirects ever change or disappear, and improves reliability and reproducibility of fetches.

**How:**
Changes were generated using [this script](https://git.kybe.xyz/2kybe3/nixpkgs-github-redirect).

**How to verify:**
You can verify that all modified package sources still build using the following script with a `changed.txt` file containing the changed package list.

<details>
  <summary>Verify script</summary>

```bash
#!/usr/bin/env bash

out="result.txt"
: > "$out"

while read -r pkg; do
    echo "=== $pkg ==="

    output=$(nix build "./nixpkgs#$pkg.src" -L -v --rebuild --no-link --print-out-paths)
    status=$?

    if [ $status -eq 0 ]; then
        echo "$pkg: success | $output" | tee -a "$out"
    else
        echo "$pkg: failed" | tee -a "$out"
    fi
done < ./changed.txt
```
</details>

<details>
  <summary>Changed Packages</summary>

```
aube
burn-central-cli
cjose
cel-go
ccusage
clematis
classicube
cointop
cosmic-applibrary
cocogitto
clarity-city
coze
cpuset
cnquery
cuetsy
cups-printers
ddosify
cortex-tools
construct
ctodo
credhub-cli
crlfsuite
dehydrated
dapper
deepdiff
desmume
digitalbitbox
discord-rpc
disktui
discord-sh
dmrconfig
doom-bcc
dracut
djv
dogedns
drone
djlint
dodgy
droidcam
drone-oss
dvc
dvc-with-remotes
```
</details>

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
