### PR TITLE
cups3: Init Module and Packages

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1486,6 +1486,7 @@
   ./services/networking/zerotierone.nix
   ./services/networking/znc/default.nix
   ./services/printing/cups-pdf.nix
+  ./services/printing/cups-v3.nix
   ./services/printing/cupsd.nix
   ./services/printing/ipp-usb.nix
   ./services/scheduling/atd.nix

--- a/nixos/modules/services/printing/cups-v3.nix
+++ b/nixos/modules/services/printing/cups-v3.nix
@@ -1,0 +1,542 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.cups-v3;
+
+  cupsLocalDaemon = lib.getExe' cfg.package "cupslocald";
+  cupsSharingDaemon = lib.getExe' cfg.sharing.package "cups-sharingd";
+  ippUsbDaemon = lib.getExe cfg.ipp-usb.package;
+
+  commonSandbox = {
+    ProtectSystem = "strict";
+    ProtectHome = true;
+    PrivateTmp = true;
+    PrivateDevices = true;
+    PrivateIPC = true;
+    ProtectKernelTunables = true;
+    ProtectKernelModules = true;
+    ProtectKernelLogs = true;
+    ProtectControlGroups = true;
+    ProtectHostname = true;
+    ProtectClock = true;
+    RestrictNamespaces = true;
+    RestrictRealtime = true;
+    RestrictSUIDSGID = true;
+    LockPersonality = true;
+    MemoryDenyWriteExecute = true;
+    NoNewPrivileges = true;
+    SystemCallArchitectures = "native";
+    SystemCallFilter = [
+      "@system-service"
+      "~@privileged"
+      "~@mount"
+    ];
+    SystemCallErrorNumber = "EPERM";
+  };
+
+in
+{
+
+  # ==========================================================================
+  # Options
+  # ==========================================================================
+
+  options.services.cups-v3 = {
+
+    enable = lib.mkEnableOption "CUPS 3.0 decoupled printing subsystem";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.cups-local;
+      defaultText = lib.literalExpression "pkgs.cups-local";
+      description = "The cups-local package providing cupslocald and the lp/lpr/lpstat/cancel tools.";
+    };
+
+    libcupsPackage = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.libcups3;
+      defaultText = lib.literalExpression "pkgs.libcups3";
+      description = "The libcups3 package. Provides the IPP utility programs and the pkg-config entry that pappl2 and cups-local build against.";
+    };
+
+    localMode = lib.mkOption {
+      type = lib.types.enum [
+        "system"
+        "user"
+      ];
+      default = "system";
+      description = ''
+        Whether to run cupslocald as a single system service or as a per-user
+        instance under each user's systemd session.
+
+        "system" runs as cups3:cups3 and is suitable for multi-user or headless hosts.
+        "user" starts automatically with the login session. Requires lingering
+        if the user needs printing without an active session (loginctl enable-linger).
+      '';
+    };
+
+    logLevel = lib.mkOption {
+      type = lib.types.enum [
+        "none"
+        "error"
+        "warn"
+        "info"
+        "debug"
+        "debug2"
+      ];
+      default = "warn";
+      description = "Log verbosity for cupslocald.";
+    };
+
+    extraEnvironment = lib.mkOption {
+      type = with lib.types; attrsOf str;
+      default = { };
+      example = lib.literalExpression ''{ CUPS_DEBUG_LEVEL = "5"; }'';
+      description = "Additional environment variables for the cupslocald service. System mode only.";
+    };
+
+    sharing = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Enable cups-sharingd, the system-wide network print server component of CUPS 3.
+
+          As of June 2026 the upstream repo contains only a build skeleton with no daemon
+          source. pkgs.cups-sharing is marked broken. Leave this false until that changes.
+        '';
+      };
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.cups-sharing;
+        defaultText = lib.literalExpression "pkgs.cups-sharing";
+        description = "The cups-sharing package.";
+      };
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 631;
+        description = ''
+          TCP port for the cups-sharingd IPP listener. Ports below 1024
+          are handled automatically via AmbientCapabilities.
+        '';
+      };
+
+      openFirewall = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Open the sharing port in the NixOS firewall.";
+      };
+    };
+
+    ipp-usb = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Enable ipp-usb for IPP-over-USB printers and scanners. Requires avahi.enable = true for loopback DNS-SD.";
+      };
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.ipp-usb3;
+        defaultText = lib.literalExpression "pkgs.ipp-usb3";
+        description = "The ipp-usb package.";
+      };
+
+      scanning = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Enable SANE + sane-airscan so USB IPP-Everywhere devices with an eSCL scan unit are usable for scanning, not just printing.";
+      };
+    };
+
+    avahi = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Enable Avahi for mDNS/DNS-SD driverless printer discovery. Set false to manage Avahi yourself; this module will not touch it.";
+      };
+    };
+  };
+
+  # ==========================================================================
+  # Implementation
+  # ==========================================================================
+
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+
+      # -------------------------------------------------------------------------
+      # Assertions
+      # -------------------------------------------------------------------------
+      {
+        assertions = [
+          {
+            assertion = !(cfg.localMode == "user" && cfg.sharing.enable);
+            message = ''
+              services.cups-v3: localMode = "user" and sharing.enable = true
+              are incompatible.  cups-sharing is a system-wide daemon and cannot
+              operate on a per-user spool.  Set localMode = "system".
+            '';
+          }
+          {
+            assertion = !(cfg.ipp-usb.enable && !cfg.avahi.enable);
+            message = ''
+              services.cups-v3: ipp-usb.enable = true requires avahi.enable = true
+              (ipp-usb self-advertises each bridged USB device over loopback
+              DNS-SD, which is how driverless discovery finds it).  Either set
+              avahi.enable = true or disable ipp-usb and manage it yourself.
+            '';
+          }
+        ];
+      }
+
+      # -------------------------------------------------------------------------
+      # System user for system-mode cupslocald.
+      # lp group gives /dev/usb/lp* access as a fallback; driverless rarely needs it.
+      # -------------------------------------------------------------------------
+      {
+        users.groups.cups3 = { };
+
+        users.users.cups3 = {
+          isSystemUser = true;
+          group = "cups3";
+          extraGroups = [
+            "lp"
+          ];
+          description = "CUPS 3.0 local spooler daemon user";
+          home = "/var/lib/cups3";
+          createHome = false;
+        };
+      }
+
+      # -------------------------------------------------------------------------
+      # Pre-create persistent dirs via tmpfiles.
+      # /run/cups3/ and /var/lib/cups3/ are also created by RuntimeDirectory=/
+      # StateDirectory= in each unit, but /etc/cups3/ has no owning service so
+      # it must come from here.
+      # -------------------------------------------------------------------------
+      {
+        systemd.tmpfiles.rules = [
+          "d /etc/cups3              0755 root  root  - -"
+          "d /var/lib/cups3          0750 cups3 cups3 - -"
+          "d /var/lib/cups3/sharing  0750 root  root  - -"
+        ];
+      }
+
+      # -------------------------------------------------------------------------
+      # cups-local: SYSTEM MODE
+      # -------------------------------------------------------------------------
+      (lib.mkIf (cfg.localMode == "system") {
+
+        # Desktop apps (Firefox, GTK/Qt print dialogs, etc.) link against
+        # libcups3 with no idea the server lives on a unix socket instead of
+        # the classic localhost:631 - without this they fall back to
+        # localhost:631, which nothing listens on (cups-sharing is disabled),
+        # and print dialogs hang indefinitely on "Getting printer information"
+        # instead of failing fast. This requires libcups3 to be built with
+        # --sysconfdir=/etc so it actually reads this file.
+        environment.etc."cups/client.conf".text = ''
+          ServerName /run/cups3/cups.sock
+        '';
+
+        # Socket unit owns the VFS lifecycle; service pulls it via Requires=.
+        systemd.sockets.cups-local = {
+          description = "CUPS 3.0 Local Print Spooler Socket";
+          wantedBy = [ "sockets.target" ];
+          socketConfig = {
+            ListenStream = "/run/cups3/cups.sock";
+            SocketMode = "0666";
+            RemoveOnStop = true;
+          };
+        };
+
+        systemd.services.cups-local = {
+          description = "CUPS 3.0 Local Print Spooler (cupslocald)";
+          documentation = [ "https://openprinting.github.io/cups/cups3.html" ];
+          wantedBy = [ "multi-user.target" ];
+          requires = [ "cups-local.socket" ];
+          after = [
+            "network.target"
+            "dbus.service"
+            "cups-local.socket"
+          ]
+          ++ lib.optional cfg.avahi.enable "avahi-daemon.service";
+          wants = lib.optional cfg.avahi.enable "avahi-daemon.service";
+          path = [
+            cfg.libcupsPackage
+            pkgs.poppler-utils
+          ];
+
+          environment = lib.mkMerge [
+            {
+              CUPS_SERVER = "/run/cups3/cups.sock";
+            }
+            cfg.extraEnvironment
+          ];
+
+          serviceConfig = lib.mkMerge [
+            commonSandbox
+            {
+              Type = "simple";
+              ExecStart = lib.escapeShellArgs [
+                cupsLocalDaemon
+                "-S"
+                "/run/cups3/cups.sock"
+                "-s"
+                "/var/lib/cups3/cups-locald.state"
+                "-L"
+                cfg.logLevel
+                "-d"
+                "/var/lib/cups3"
+              ];
+
+              Restart = "always";
+              RestartSec = "0";
+
+              User = "cups3";
+              Group = "cups3";
+
+              SupplementaryGroups = [ "avahi" ];
+
+              PrivateNetwork = lib.mkForce false;
+              RuntimeDirectory = "cups3";
+              RuntimeDirectoryMode = "0755";
+              StateDirectory = "cups3";
+              StateDirectoryMode = "0750";
+
+              ReadOnlyPaths = [
+                "/etc/cups3"
+                "${cfg.package}"
+                "${cfg.libcupsPackage}"
+              ];
+              ReadWritePaths = lib.optional cfg.avahi.enable "/run/avahi-daemon";
+
+              CapabilityBoundingSet = "";
+              AmbientCapabilities = "";
+
+              RestrictAddressFamilies = "AF_INET AF_INET6 AF_UNIX AF_NETLINK";
+
+              LimitNOFILE = 4096;
+              SyslogIdentifier = "cups-local";
+            }
+          ];
+        };
+        services.dbus.packages = [ cfg.package ];
+
+        environment.systemPackages = [
+          cfg.package
+          cfg.libcupsPackage
+        ];
+      })
+
+      # -------------------------------------------------------------------------
+      # cups-local: USER MODE
+      # Per-user cupslocald under systemd --user, auto-started via default.target.
+      # We define the unit ourselves because the packaged cupslocald.service
+      # ExecStart still points at sbin/ before postInstall moves it to bin/.
+      # -------------------------------------------------------------------------
+      (lib.mkIf (cfg.localMode == "user") {
+
+        systemd.user.services.cups-local = {
+          description = "CUPS 3.0 Local Print Spooler (per-user cupslocald)";
+          documentation = [ "https://openprinting.github.io/cups/cups3.html" ];
+          wantedBy = [ "default.target" ];
+          after = [ "dbus.socket" ];
+
+          environment = {
+            CUPS_SERVER = "%t/cups3/cups.sock";
+          };
+
+          serviceConfig = {
+            Type = "simple";
+            ExecStart = lib.escapeShellArgs [
+              cupsLocalDaemon
+              "-S"
+              "%t/cups3/cups.sock"
+              "-s"
+              "%S/cups3/cups-locald.state"
+              "-L"
+              cfg.logLevel
+              "-d"
+              "%S/cups3"
+            ];
+            Restart = "on-failure";
+            RestartSec = "10s";
+            RuntimeDirectory = "cups3";
+            RuntimeDirectoryMode = "0700";
+            StateDirectory = "cups3";
+            StateDirectoryMode = "0700";
+            PrivateTmp = true;
+            NoNewPrivileges = true;
+            RestrictNamespaces = true;
+            RestrictRealtime = true;
+            LockPersonality = true;
+            SystemCallArchitectures = "native";
+            SystemCallFilter = "@system-service ~@privileged ~@mount";
+            SystemCallErrorNumber = "EPERM";
+            CapabilityBoundingSet = "";
+            RestrictAddressFamilies = "AF_INET AF_INET6 AF_UNIX AF_NETLINK";
+
+            SyslogIdentifier = "cups-local";
+          };
+        };
+      })
+
+      # -------------------------------------------------------------------------
+      # cups-sharing: SYSTEM-WIDE NETWORK SERVER
+      # Structurally complete but non-functional until upstream ships daemon source
+      # and pkgs.cups-sharing is un-broken.
+      # -------------------------------------------------------------------------
+      (lib.mkIf cfg.sharing.enable {
+
+        systemd.services.cups-sharing = {
+          description = "CUPS 3.0 Network Sharing Server (cups-sharingd)";
+          documentation = [ "https://openprinting.github.io/cups/cups3.html" ];
+          wantedBy = [ "multi-user.target" ];
+          after = [
+            "network-online.target"
+            "dbus.service"
+            "cups-local.service"
+          ]
+          ++ lib.optional cfg.avahi.enable "avahi-daemon.service";
+          wants = [ "network-online.target" ] ++ lib.optional cfg.avahi.enable "avahi-daemon.service";
+
+          environment = {
+            PATH = lib.mkForce (
+              lib.makeBinPath [
+                cfg.libcupsPackage
+                cfg.sharing.package
+              ]
+            );
+            CUPS_LOGLEVEL = cfg.logLevel;
+            CUPS_SERVER = "localhost:631";
+            CUPS_SHARING_DATADIR = "${cfg.sharing.package}/share/cups-sharing";
+          };
+
+          serviceConfig = lib.mkMerge [
+            commonSandbox
+            {
+              Type = "simple";
+              ExecStart = cupsSharingDaemon;
+              Restart = "on-failure";
+              RestartSec = "15s";
+              User = "root";
+              Group = "root";
+              RuntimeDirectory = "cups3";
+              RuntimeDirectoryMode = "0750";
+              StateDirectory = "cups3 cups3/sharing";
+              StateDirectoryMode = "0750";
+              ConfigurationDirectory = "cups3";
+              ConfigurationDirectoryMode = "0750";
+
+              CapabilityBoundingSet = lib.concatStringsSep " " [
+                "CAP_NET_BIND_SERVICE"
+                "CAP_CHOWN"
+                "CAP_FOWNER"
+                "CAP_SETUID"
+                "CAP_SETGID"
+                "CAP_DAC_READ_SEARCH"
+              ];
+              AmbientCapabilities = lib.optionalString (cfg.sharing.port < 1024) "CAP_NET_BIND_SERVICE";
+
+              MemoryDenyWriteExecute = true;
+
+              RestrictAddressFamilies = "AF_INET AF_INET6 AF_UNIX AF_NETLINK";
+              ReadOnlyPaths = [
+                "${cfg.sharing.package}"
+                "${cfg.libcupsPackage}"
+              ];
+              ReadWritePaths = [
+                "/run/cups3"
+                "/var/lib/cups3"
+              ]
+              ++ lib.optional cfg.avahi.enable "/run/avahi-daemon";
+
+              LimitNOFILE = 65536;
+              SyslogIdentifier = "cups-sharing";
+            }
+          ];
+        };
+
+        networking.firewall.allowedTCPPorts = lib.optional cfg.sharing.openFirewall cfg.sharing.port;
+      })
+
+      # -------------------------------------------------------------------------
+      # Avahi: mDNS/DNS-SD for driverless IPP Everywhere discovery.
+      # nssmdns4/6 enable .local resolution in glibc NSS for IPP URIs.
+      # -------------------------------------------------------------------------
+      (lib.mkIf cfg.avahi.enable {
+        services.avahi = {
+          enable = true;
+          nssmdns4 = true;
+          nssmdns6 = true;
+          allowPointToPoint = true;
+
+          publish = {
+            enable = true;
+            addresses = true;
+            workstation = false;
+            userServices = true;
+          };
+        };
+      })
+
+      # -------------------------------------------------------------------------
+      # ipp-usb: IPP-over-USB bridge.
+      # ipp-usb bridges each USB device to
+      # a loopback HTTP/IPP port and self-advertises via DNS-SD, so
+      # driverless discovery (Avahi -> cups-local) picks it up the same way
+      # it would a real network printer. Requires avahi.enable = true,
+      # enforced by an assertion above.
+      # -------------------------------------------------------------------------
+      (lib.mkIf cfg.ipp-usb.enable {
+        systemd.services.ipp-usb = {
+          description = "Daemon for IPP over USB printer/scanner support";
+          after = [ "avahi-daemon.service" ];
+          wants = [ "avahi-daemon.service" ];
+
+          serviceConfig = lib.mkMerge [
+            commonSandbox
+            {
+              Type = "simple";
+              ExecStart = ippUsbDaemon;
+              Restart = "on-failure";
+              StateDirectory = "ipp-usb";
+              LogsDirectory = "ipp-usb";
+              ProtectHome = true;
+              PrivateUsers = true;
+              PrivateMounts = true;
+              RemoveIPC = true;
+              ProtectProc = "noaccess";
+              PrivateDevices = lib.mkForce false;
+              ProtectClock = lib.mkForce false;
+              CapabilityBoundingSet = "";
+              AmbientCapabilities = "";
+              RestrictAddressFamilies = [
+                "AF_UNIX"
+                "AF_NETLINK"
+                "AF_INET"
+                "AF_INET6"
+              ];
+            }
+          ];
+        };
+
+        services.udev.packages = [ cfg.ipp-usb.package ];
+      })
+
+      (lib.mkIf (cfg.ipp-usb.enable && cfg.ipp-usb.scanning) {
+        hardware.sane.enable = true;
+        hardware.sane.extraBackends = [ pkgs.sane-airscan ];
+      })
+
+    ]
+  );
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -459,6 +459,7 @@ in
   cross-seed = runTest ./cross-seed.nix;
   cryptpad = runTest ./cryptpad.nix;
   cups-pdf = runTest ./cups-pdf.nix;
+  cups-v3 = handleTest ./cups-v3.nix { };
   curl-impersonate = runTest ./curl-impersonate.nix;
   custom-ca = import ./custom-ca.nix { inherit pkgs runTest; };
   cyrus-imap = runTest ./cyrus-imap.nix;

--- a/nixos/tests/cups-v3.nix
+++ b/nixos/tests/cups-v3.nix
@@ -1,0 +1,54 @@
+{ pkgs, ... }:
+pkgs.testers.nixosTest {
+  name = "cups-v3-basic";
+
+  nodes.machine = { ... }: {
+    imports = [ ../modules/services/printing/cups-v3.nix ];
+    services.printing.enable = false;
+    services.cups-v3 = {
+      enable = true;
+      localMode = "system";
+      logLevel = "debug";
+      sharing.enable = false;
+    };
+  };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("cups-local.service")
+    machine.wait_for_file("/run/cups3/cups.sock")
+
+    # Legacy socket must be absent (services.printing.enable = false)
+    machine.fail("test -S /run/cups/cups.sock")
+
+    # Directories provisioned correctly
+    machine.succeed("test -d /etc/cups3")
+    machine.succeed("test -d /var/lib/cups3")
+    machine.succeed("stat -c '%U' /var/lib/cups3 | grep -qx cups3")
+    machine.succeed("stat -c '%a' /run/cups3 | grep -qx '755'")
+
+    # Service identity
+    machine.succeed(
+        "systemctl show cups-local.service --property=User "
+        "| grep -qx 'User=cups3'"
+    )
+
+    # Binaries on PATH
+    for b in ["lp", "lpstat", "cancel", "cupslocald"]:
+        machine.succeed(f"command -v {b}")
+
+    # No legacy CUPS running
+    machine.fail("systemctl is-active cups.service")
+
+    # ipp-usb
+    machine.succeed(
+        "systemctl show ipp-usb.service --property=LoadState "
+        "| grep -qx 'LoadState=loaded'"
+    )
+    machine.fail("systemctl is-active ipp-usb.service")
+    machine.succeed("test -e /etc/udev/rules.d/71-ipp-usb.rules")
+
+    # Scanning support (services.cups-v3.ipp-usb.scanning, default true)
+    machine.succeed("command -v scanimage")
+  '';
+}

--- a/pkgs/by-name/cu/cups-local/package.nix
+++ b/pkgs/by-name/cu/cups-local/package.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  makeWrapper,
+  libcups3,
+  pappl2,
+  poppler-utils,
+  dbus,
+  systemd,
+  withDBus ? true,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cups-local";
+  version = "3.0b1-unstable-2026-07-01";
+
+  src = fetchFromGitHub {
+    owner = "nick-linux8";
+    repo = "cups-local";
+    rev = "f4b84ea6ea7e5109df7b9c487c78029590e5cd21";
+    hash = "sha256-X/FH6GOPOV95pwyqesTZYH0R/WQgsQ32jgnpEqF00SU=";
+  };
+
+  __structuredAttrs = true;
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    libcups3
+    pappl2
+    poppler-utils
+  ]
+  # configure.ac requires BOTH together for HAVE_DBUS
+  ++ lib.optionals withDBus [
+    dbus
+    systemd
+  ];
+
+  strictDeps = true;
+
+  configureFlags = [
+    "--prefix=${placeholder "out"}"
+  ]
+  ++ lib.optionals (!withDBus) [ "--disable-dbus" ];
+
+  installFlags = [
+    "DBUSDIR=${placeholder "out"}/share/dbus-1"
+    "SYSTEMDDIR=${placeholder "out"}/lib/systemd"
+  ];
+
+  # Needed to link pow@@GLIBC_2.29 in drivers.o
+  env = {
+    NIX_LDFLAGS = "-lm";
+  };
+
+  postInstall = ''
+    mkdir -p $out/bin
+    mv $out/sbin/cupslocald $out/bin/cupslocald
+    mv $out/sbin/lpadmin    $out/bin/lpadmin
+    rmdir $out/sbin 2>/dev/null || true
+
+    wrapProgram "$out/bin/cupslocald" \
+     --prefix PATH : "${lib.makeBinPath [ poppler-utils ]}"
+
+  '';
+
+  meta = {
+    description = "Unprivileged per-user local print spooler and lp/lpr/lpstat/cancel commands for CUPS 3.0 (alpha quality upstream)";
+    homepage = "https://github.com/OpenPrinting/cups-local";
+    license = with lib.licenses; [
+      asl20
+    ];
+    maintainers = with lib.maintainers; [
+      nick-linux
+    ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/cu/cups-sharing/package.nix
+++ b/pkgs/by-name/cu/cups-sharing/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  libcups3,
+  pappl2,
+}:
+
+# As of June 22 2026, OpenPrinting/cups-sharing contains only the autotools
+# skeleton (configure.ac, Makedefs.in, top-level Makefile) there is
+# no daemon, commands, or man directory
+# Upstream's own language breakdown is M4/Shell/Makefile only; no C sources
+# have landed. configure+make below succeed against what exists today, but
+# produce no actual "Sharing Server" there is nothing yet to build one
+# from. This is a scaffold to extend once upstream lands real source, not a
+# usable package.
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cups-sharing";
+  version = "unstable-2026-06-18";
+
+  src = fetchFromGitHub {
+    owner = "OpenPrinting";
+    repo = "cups-sharing";
+    rev = "87d744e666841e42700d037858c841dda25aa378";
+    hash = "sha256-uH++IOG9zfc1oGUYB8LacR5TJlR0r6NX9PtFH2gQZS8=";
+  };
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libcups3
+    pappl2
+  ];
+
+  strictDeps = true;
+
+  # Intercept the infinite recursion loop in the upstream skeleton Makefile
+  dontBuild = true;
+
+  # Create a dummy binary/scaffold output so that systemd and the environment path declarations do not crash on a missing $out/bin binpath
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/cups-sharing
+    echo "#!/bin/sh" > $out/bin/cups-sharingd
+    echo "echo 'cups-sharing scaffold wrapper'" >> $out/bin/cups-sharingd
+    chmod +x $out/bin/cups-sharingd
+
+    runHook postInstall
+  '';
+  configureFlags = [
+    "--prefix=${placeholder "out"}"
+  ];
+
+  enableParallelBuilding = false;
+
+  meta = {
+    description = "Sharing server for CUPS 3.0 upstream currently ships only the build skeleton, no daemon source (alpha)";
+    homepage = "https://github.com/OpenPrinting/cups-sharing";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      nick-linux
+    ];
+    platforms = lib.platforms.linux;
+    broken = true;
+  };
+})

--- a/pkgs/by-name/ip/ipp-usb3/package.nix
+++ b/pkgs/by-name/ip/ipp-usb3/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  pkg-config,
+  libusb1,
+  avahi,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "ipp-usb";
+  version = "0.9.34";
+
+  src = fetchFromGitHub {
+    owner = "OpenPrinting";
+    repo = "ipp-usb";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-4xZf8Q1MfQcB13vHRdb8dQyZWrwnJzubdi+zln1lRc8=";
+  };
+
+  __structuredAttrs = true;
+
+  vendorHash = null;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libusb1
+    avahi
+  ];
+
+  strictDeps = true;
+
+  env.CGO_ENABLED = "1";
+
+  postInstall = ''
+    install -Dm444 ipp-usb.conf -t "$out/share/ipp-usb"
+    install -Dm444 ipp-usb.8 -t "$out/share/man/man8"
+    cp -r ipp-usb-quirks "$out/share/ipp-usb/quirks"
+
+    install -Dm444 systemd-udev/*.rules -t "$out/lib/udev/rules.d"
+    install -Dm444 systemd-udev/*.service -t "$out/lib/systemd/system"
+  '';
+
+  meta = {
+    description = "HTTP reverse proxy exposing IPP-over-USB printers/scanners as local IPP/eSCL services";
+    homepage = "https://github.com/OpenPrinting/ipp-usb";
+    license = lib.licenses.bsd2;
+    mainProgram = "ipp-usb";
+    maintainers = with lib.maintainers; [
+      nick-linux
+    ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/li/libcups3/package.nix
+++ b/pkgs/by-name/li/libcups3/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  zlib,
+  gnutls,
+  avahi,
+  libpng,
+  libiconv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libcups3";
+  version = "3.0.2";
+
+  src = fetchFromGitHub {
+    owner = "nick-linux8";
+    repo = "libcups";
+    rev = "09d7031cb04d2a950619b63959a4db95623bb63f";
+    # PDFio is a required git submodule; upstream explicitly documents the
+    # GitHub zip archive as broken because it omits it.
+    fetchSubmodules = true;
+    hash = "sha256-S6V7QeEuTBGsH2g9tmKTb6hBr1Tnf6L9gp3kgJ1ZZPM=";
+  };
+
+  __structuredAttrs = true;
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  # Without this, the generic builder's default --sysconfdir=$out/etc gets
+  # compiled into CUPS_SERVERROOT, so client.conf lookups resolve to an
+  # immutable store path instead of the real /etc/cups - meaning no
+  # libcups3-linked app (Firefox, GTK print dialogs, etc.) can ever be
+  # pointed at the cups-local socket via client.conf.
+  configureFlags = [ "--sysconfdir=/etc" ];
+
+  buildInputs = [
+    zlib.dev
+    gnutls
+    avahi
+    libpng.dev
+  ]
+  ++ lib.optional (!stdenv.hostPlatform.isLinux) libiconv;
+
+  strictDeps = true;
+
+  env = {
+    NIX_LDFLAGS = "-lpng16";
+  };
+
+  postPatch = ''
+    sed -i '/test -x \/usr\/sbin\/ldconfig/d' cups/Makefile
+  '';
+
+  postConfigure = ''
+    if [ -f pdfio/pdfio.pc ]; then
+      sed -i '/^Requires.*libpng/d; /^Requires.*zlib/d' pdfio/pdfio.pc
+    fi
+  '';
+
+  meta = {
+    description = "OpenPrinting CUPS 3.x library and IPP/HTTP client tools";
+    homepage = "https://github.com/OpenPrinting/libcups";
+    changelog = "https://github.com/OpenPrinting/libcups/blob/v${finalAttrs.version}/CHANGES.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      nick-linux
+    ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/pa/pappl2/package.nix
+++ b/pkgs/by-name/pa/pappl2/package.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  libcups3,
+  avahi,
+  zlib,
+  libjpeg,
+  libpng,
+  libusb1,
+  pam,
+  openssl,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pappl";
+  version = "2.0b1-unstable-2026-07-01";
+
+  src = fetchFromGitHub {
+    owner = "nick-linux8";
+    repo = "pappl";
+    rev = "72f5138a00b986d98c0335ad6965d0fa514e530a";
+    hash = "sha256-Zks9RlNis6LW87XfsGnG/lCzErMtCmtbRrY+AOgKDqU=";
+  };
+
+  __structuredAttrs = true;
+
+  outputs = [
+    "out"
+    "dev"
+    "lib"
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    libcups3
+    avahi
+    zlib
+    libjpeg
+    libpng
+    libusb1
+    openssl
+  ]
+  ++ lib.optional stdenv.hostPlatform.isLinux pam;
+
+  strictDeps = true;
+
+  configureFlags = [
+    "--prefix=${placeholder "out"}"
+    "--with-papplstatedir=/var/lib"
+    "--with-papplsockdir=/run"
+  ]
+  ++ lib.optionals (!stdenv.hostPlatform.isLinux) [ "--disable-libpam" ];
+
+  postFixup = ''
+    pc="$dev/lib/pkgconfig/pappl2.pc"
+    if [ -f "$pc" ]; then
+      # Requires: line exists but is empty — replace it in place
+      sed -i 's/^Requires:[[:space:]]*$/Requires: cups3/' "$pc"
+      echo "patched pappl2.pc:"
+      cat "$pc"
+    fi
+  '';
+
+  meta = {
+    description = "PAPPL printer application framework, built as pappl2 against libcups3";
+    homepage = "https://github.com/michaelrsweet/pappl";
+    license = with lib.licenses; [
+      asl20
+    ];
+    maintainers = with lib.maintainers; [
+      nick-linux
+    ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This adds the "decoupled" CUPS 3.0 printing stack (cups-local, libcups3, pappl2,
ipp-usb3, cups-sharing) as an alternative to the monolithic cupsd module, along
with a NixOS module and test. Everything is fully operational on my home setup running the module/packages locally, therefore it is ready for PR and further discussions/reviews.

## Motivation

The current services.printing (cupsd) module has known vulnerabilities rooted in
its architecture: one large privileged process handling everything. CUPS 3.0's
decoupled design uses separate, sandboxable daemons instead, and this adds it
as an opt-in alternative for users who want it. This follows a discussion in the Security Matrix channel in which we discussed the need for early opt in testing for such a suite.

## What's included

- libcups3: client library
- pappl2: printer application framework
- cups-local: local print spooler daemon (cupslocald)
- ipp-usb3: USB to IPP bridge
- cups-sharing: currently a skeleton only, not functional upstream yet (see below)
- nixos/modules/services/printing/cups-v3.nix: new module, services.cups-v3
- nixos/tests/cups-v3.nix

## Why some of these point at my fork instead of upstream

libcups3, pappl2, and cups-local currently point at my personal forks
(nick-linux8/<repo>/patches) instead of OpenPrinting upstream. Getting real end to end
printing working surfaced several genuine bugs in the upstream code, not
NixOS packaging issues. Just a few examples:

- a media size dimension swap in cups-local's driver callback
- pappl framing print job bodies with a fixed Content-Length instead of
  chunked transfer encoding, which is the correct approach for a streamed
  body of unknown length and matches how reference IPP clients already
  behave
- a race in cups-local's stdout/stderr pipe draining loop that could report
  a job as completed while it had actually sent 0 bytes to the device

Patches for all of these are in my forks and confirmed against real hardware.
I intend to upstream them to OpenPrinting and re-point these packages at
upstream once merged there. This PR isn't blocked on that happening first.

cups-sharing isn't included as a working component since its upstream
implementation isn't functional yet. I avoided depending on it by fixing
libcups3's cupsConnectDest() to reconnect over the local domain socket
directly for localhost destinations, instead of falling through to a TCP
connect on port 631, which nothing listens on in this decoupled setup. Name
based printing (lp -d, lpstat, etc.) works without cups-sharing as a result.

## AI Usage
I used Claude Sonnet 5 to perform research and identify best practices for the module, since influence was just research I was not sure about a commit trailer since I cross referenced with the documentation myself and wrote/own the code as my own, it's purpose was to speed up the process of digging through documentation for my review... And to summarize this PR(feeling lazy)

People who showed interest:
@LordGrimmauld @doronbehar @K900 @Skyb0rg007 @kuflierl @MagicRB @mweinelt 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
