### PR TITLE
whisper: init at 0.128.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14093,6 +14093,12 @@
     githubId = 6544084;
     name = "Kai Harries";
   };
+  kakooch = {
+    email = "kaveh@kaveh.org";
+    github = "kakooch";
+    githubId = 2082821;
+    name = "Kaveh Ranjbar";
+  };
   kalbasit = {
     email = "wael.nasreddine@gmail.com";
     matrix = "@kalbasit:matrix.org";

--- a/pkgs/by-name/wh/whisper/package.nix
+++ b/pkgs/by-name/wh/whisper/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "whisper";
+  version = "0.128.0";
+
+  src = fetchFromGitHub {
+    owner = "whisper-sec";
+    repo = "whisper-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-wcdwr6ROEqo6Vl5eH8LQc9f3yQHSj+70A6RmoOB4Seg=";
+  };
+
+  vendorHash = "sha256-6uJxbARrRD/QaTMymqrM4PziAgH/VrWSW3BbWJabH0Q=";
+
+  subPackages = [ "cmd/whisper" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=github.com/whisper-sec/whisper-cli/internal/cli.Version=${finalAttrs.version}"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Give your agent a real, routable IPv6 identity on the Whisper network";
+    homepage = "https://whisper.online";
+    changelog = "https://github.com/whisper-sec/whisper-cli/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "whisper";
+    maintainers = with lib.maintainers; [ kakooch ];
+  };
+})

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -2357,7 +2357,6 @@ mapAliases {
   welkin = throw "welkin was removed as it is unmaintained upstream"; # Added 2026-01-01
   whalebird = throw "'whalebird' has been removed because it was using an EOL electron version"; # Added 2026-03-20
   whatsapp-for-linux = throw "'whatsapp-for-linux' has been removed because it was unmaintained and archived upstream. Consider using 'karere' instead"; # Converted to throw 2025-10-27
-  whisper = throw "'whisper' was removed as it is unmaintained upstream and vendored insecure outdated libraries"; # Added 2026-05-01
   wifi-password = throw "'wifi-password' has been removed as it was unmaintained upstream"; # Added 2025-08-29
   win-pvdrivers = throw "'win-pvdrivers' has been removed as it was subject to the Xen build machine compromise (XSN-01) and has open security vulnerabilities (XSA-468)"; # Added 2025-08-29
   win-virtio = throw "'win-virtio' has been renamed to/replaced by 'virtio-win'"; # Converted to throw 2025-10-27


### PR DESCRIPTION
Adds the `whisper` CLI, a small Go command-line client for the Whisper network. `whisper` gives an agent a routable IPv6 identity and helps it resolve and connect; the command talks to a public HTTPS control API and needs no local daemon.

- Homepage: https://whisper.online
- Source: https://github.com/whisper-sec/whisper-cli (MIT)
- Upstream release: https://github.com/whisper-sec/whisper-cli/releases/tag/v0.128.0

### Notes for reviewers

- **Reclaims the `whisper` attribute.** A previous, unrelated `whisper` package was removed on 2026-05-01 and left a throw-alias in `pkgs/top-level/aliases.nix`. This PR removes that stale alias so the name can be used by this new, actively-maintained package. The two projects are unrelated; the binary this package installs is named `whisper`, so `whisper` is the natural attribute name.
- **New maintainer.** Adds `kakooch` (the upstream author) to `maintainers/maintainer-list.nix` and lists them as the package maintainer.
- The version is stamped at build time via `ldflags` (`-X .../internal/cli.Version=${version}`), so `whisper --version` matches the release tag. This is enforced at build time by `versionCheckHook`.
- `subPackages = [ "cmd/whisper" ]` builds only the CLI entrypoint.

### Automation/AI disclosure (per the Automation/AI policy)

This package and this pull request summary were prepared with the assistance of Claude Code (Opus 4.8) and reviewed by the maintainer before submission. The commit carries the required `Assisted-by: Claude Code (Opus 4.8)` trailer. Output was verified rather than taken on trust: the package builds locally, `whisper --version` prints `0.128.0`, and `nixpkgs-vet` validates the by-name structure (see below).

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage]. <!-- new leaf package with no reverse dependencies: ran `nix-build -A whisper` (full build + versionCheckHook) and `nixpkgs-vet` (Validated successfully) instead -->
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. <!-- ./result/bin/whisper --version → "whisper version 0.128.0" -->
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
