### PR TITLE
immich: 2.7.5 -> 3.0.0

### DIFF
--- a/nixos/tests/web-apps/immich.nix
+++ b/nixos/tests/web-apps/immich.nix
@@ -5,10 +5,11 @@
   nodes.machine =
     { pkgs, ... }:
     {
-      # These tests need a little more juice
+      # These tests need a little more juice; the PEF raw thumbnail step OOMs
+      # at 2048 on immich 3.x.
       virtualisation = {
         cores = 2;
-        memorySize = 2048;
+        memorySize = 4096;
         diskSize = 4096;
       };
 

--- a/pkgs/by-name/im/immich-cli/package.nix
+++ b/pkgs/by-name/im/immich-cli/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   inherit (immich) version src pnpmDeps;
 
   postPatch = ''
-    local -r cli_version="$(jq -r .version cli/package.json)"
+    local -r cli_version="$(jq -r .version packages/cli/package.json)"
     test "$cli_version" = ${finalAttrs.version} \
       || (echo "error: update immich-cli version to $cli_version" && exit 1)
   '';

--- a/pkgs/by-name/im/immich-machine-learning/package.nix
+++ b/pkgs/by-name/im/immich-machine-learning/package.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  fetchpatch2,
   immich,
   python3,
   nixosTests,
@@ -16,15 +15,6 @@ python.pkgs.buildPythonApplication rec {
   inherit (immich) version;
   src = "${immich.src}/machine-learning";
   pyproject = true;
-
-  patches = [
-    (fetchpatch2 {
-      name = "fix_tests_with_openvino_ep.patch";
-      relative = "machine-learning";
-      url = "https://github.com/immich-app/immich/commit/7f611d90317d75ac3d75adf428f367376171e106.patch?full_index=1";
-      hash = "sha256-dntL5AZS3VIp7++yUec4HWIdtwltrnIePNFPJaiZdy4=";
-    })
-  ];
 
   pythonRelaxDeps = [
     "huggingface-hub"

--- a/pkgs/by-name/im/immich/package.nix
+++ b/pkgs/by-name/im/immich/package.nix
@@ -45,12 +45,12 @@ let
       buildPackages.buildGoModule (
         args
         // rec {
-          version = "0.25.5";
+          version = "0.28.1";
           src = fetchFromGitHub {
             owner = "evanw";
             repo = "esbuild";
             tag = "v${version}";
-            hash = "sha256-jemGZkWmN1x2+ZzJ5cLp3MoXO0oDKjtZTmZS9Be/TDw=";
+            hash = "sha256-V+HKaWGAIs24ynFFIS9fQ0EAJJdNmlAMeL1sgDEAqWM=";
           };
           vendorHash = "sha256-+BfxCyg0KkDQpHt/wycy/8CTG6YBA/VJvJFhhzUnSiQ=";
         }
@@ -115,20 +115,20 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "immich";
-  version = "2.7.5";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "immich-app";
     repo = "immich";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-EC1IXM7KObAWfwG5KEao5VDp79d8WGNEI7E89lLOJ44=";
+    hash = "sha256-YeqmmSE8Tjuf4MmAOBzdxPz9Ap02/iCgzAJ7ESwsBho=";
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     inherit pnpm;
     fetcherVersion = 3;
-    hash = "sha256-FEesjbhxP7ydFfNshF3iFIk9N3Z53jrEZ9DRBjgEfs0=";
+    hash = "sha256-/pWDkv9LV/TjkgncoGxCrho9Ru0iWLL/OgPuacnQAzo=";
   };
 
   postPatch = ''
@@ -174,7 +174,7 @@ stdenv.mkDerivation (finalAttrs: {
     # If exiftool-vendored.pl isn't found, exiftool is searched for on the PATH
     rm node_modules/.pnpm/node_modules/exiftool-vendored.pl
 
-    pnpm --filter immich build
+    pnpm --filter @immich/sdk --filter @immich/plugin-sdk --filter immich build
 
     runHook postBuild
   '';
@@ -196,8 +196,8 @@ stdenv.mkDerivation (finalAttrs: {
       -o -name '*.target.mk' \
     \) -exec rm -r {} +
 
-    mkdir -p "$packageOut/build"
-    ln -s '${finalAttrs.passthru.plugins}' "$packageOut/build/corePlugin"
+    mkdir -p "$packageOut/build/plugins"
+    ln -s '${finalAttrs.passthru.plugins}' "$packageOut/build/plugins/immich-plugin-core"
     ln -s '${finalAttrs.passthru.web}' "$packageOut/build/www"
     ln -s '${geodata}' "$packageOut/build/geodata"
 
@@ -246,7 +246,7 @@ stdenv.mkDerivation (finalAttrs: {
       buildPhase = ''
         runHook preBuild
 
-        pnpm --filter plugins build
+        pnpm --filter @immich/sdk --filter @immich/plugin-sdk --filter @immich/plugin-core build
 
         runHook postBuild
       '';
@@ -254,7 +254,7 @@ stdenv.mkDerivation (finalAttrs: {
       installPhase = ''
         runHook preInstall
 
-        cd plugins
+        cd packages/plugin-core
         mkdir $out
         cp -r dist manifest.json $out
 


### PR DESCRIPTION
## Description

Bumps Immich to [v3.0.0](https://github.com/immich-app/immich/releases/tag/v3.0.0) (released 2026-07-02).

v3 reorganised the pnpm workspace, which required corresponding changes to the derivations:

- **esbuild** bumped `0.25.5` → `0.28.1` — the plugin packages now pin `esbuild ^0.28`, and esbuild refuses to run when the JS wrapper and native binary versions differ.
- **`plugins` workspace split** into `@immich/plugin-core` + `@immich/plugin-sdk` under `packages/`. The server and plugin builds now also build `@immich/plugin-sdk`/`@immich/sdk`, and the built core plugin moved from `build/corePlugin` to `build/plugins/immich-plugin-core` to match upstream's Docker layout.
- **`immich-cli`**: the CLI moved from `cli/` to `packages/cli/`, so the version-consistency check path was updated.
- **`immich-machine-learning`**: dropped `fix_tests_with_openvino_ep.patch` — the upstream commit it backported (immich-app/immich@7f611d9) is now part of v3, so the patch no longer applies. The ML pytest suite passes without it.
- **immich NixOS test**: raised `memorySize` 2048 → 4096; the PEF raw thumbnail subtest OOM-panics at 2048 on 3.x.

Closes #537902

## Things done

- Built `immich`, `immich-cli`, and `immich-machine-learning` on `x86_64-linux`.
- Ran the NixOS VM tests: `nixosTests.immich` and `nixosTests.immich-vectorchord-reindex` (both pass).
- Verified the runtime layout: `server`/`immich-admin` binaries, `build/plugins/immich-plugin-core/{dist,manifest.json}` (incl. `plugin.wasm`), `build/www`, `build/geodata`.

- [x] Built on platform(s)
  - [x] x86_64-linux
- [x] For non-Linux: N/A
- [x] Ran nixpkgs-review / nixosTests where applicable (`nixosTests.immich`, `nixosTests.immich-vectorchord-reindex`)
- [x] Tested compilation of all packages that depend on this change (`immich`, `immich-cli`, `immich-machine-learning`)
- [x] Tested basic functionality of all binary files
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)
