### PR TITLE
xmage: 1.4.58 -> 1.4.60

### DIFF
--- a/pkgs/by-name/xm/xmage/package.nix
+++ b/pkgs/by-name/xm/xmage/package.nix
@@ -5,14 +5,13 @@
   jdk8,
   unzrip,
 }:
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "xmage";
-  version = "1.4.58-dev_2025-10-06_20-40";
+  version = "1.4.60-dev_2026-06-28_13-19";
 
   src = fetchurl {
     url = "https://xmage.today/files/mage-full_${finalAttrs.version}.zip";
-    sha256 = "sha256-UOtxV+ykDIH+PLjLrC66Rut92IIw2iDHWwvJ2ytmUAs=";
+    sha256 = "sha256-n6g38rE19ZSyipoOp3cnLTsJirLRXeLF1ft7gvx3bVs=";
   };
 
   preferLocalBuild = true;
@@ -53,5 +52,4 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     homepage = "http://xmage.de/";
   };
-
 })


### PR DESCRIPTION
## Description
Updates xmage from `1.4.58-dev_2025-10-06_20-40` to `1.4.60-dev_2026-06-28_13-19`,
corresponding to upstream release [xmage_1.4.60V2](https://github.com/magefree/mage/releases/tag/xmage_1.4.60V2).

Release notes: https://github.com/magefree/mage/wiki/Release-1.4.60#release-1460v2-2026-06-28

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
