### PR TITLE
umple-lsp: init at 1.0.2

### DIFF
--- a/pkgs/by-name/um/umple-lsp/package-lock.json
+++ b/pkgs/by-name/um/umple-lsp/package-lock.json
@@ -1,0 +1,176 @@
+{
+  "name": "umple-lsp-monorepo",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "umple-lsp-monorepo",
+      "workspaces": [
+        "packages/tree-sitter-umple",
+        "packages/server"
+      ]
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
+      "integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/tree-sitter": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
+      "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.8.0"
+      }
+    },
+    "node_modules/tree-sitter-cli": {
+      "version": "0.26.10",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.26.10.tgz",
+      "integrity": "sha512-RTse32x5YWOrEtH7wos8ODt3yyB7SKgmGN70jC7R+WcnDA64vrpYU98+LnwrwdXMlxgr0LGQdezZz85DN8Wv0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "tree-sitter": "cli.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/tree-sitter-umple": {
+      "resolved": "packages/tree-sitter-umple",
+      "link": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/umple-lsp-server": {
+      "resolved": "packages/server",
+      "link": true
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/web-tree-sitter": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.3.tgz",
+      "integrity": "sha512-JIVgIKFS1w6lejxSntCtsS/QsE/ecTS00en809cMxMPxaor6MvUnQ+ovG8uTTTvQCFosSh4MeDdI5bSGw5SoBw==",
+      "license": "MIT"
+    },
+    "packages/server": {
+      "name": "umple-lsp-server",
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver": "^9.0.1",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "web-tree-sitter": "0.26.3"
+      },
+      "bin": {
+        "umple-lsp-server": "bin/umple-lsp-server"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.2",
+        "typescript": "^5.7.2"
+      }
+    },
+    "packages/tree-sitter-umple": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.5.0",
+        "node-gyp-build": "^4.8.4",
+        "tree-sitter": "^0.21.1"
+      },
+      "devDependencies": {
+        "tree-sitter-cli": "^0.26.3"
+      }
+    }
+  }
+}

--- a/pkgs/by-name/um/umple-lsp/package.nix
+++ b/pkgs/by-name/um/umple-lsp/package.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  pkgsCross,
+  buildNpmPackage,
+  fetchFromGitHub,
+  linkFarm,
+  versionCheckHook,
+  jre_headless,
+  nodejs,
+  tree-sitter,
+  umple,
+  withUmple ? true,
+}:
+let
+  # tree-sitter needs a wasi32 clang available at `bin/clang`
+  wasi32cc = lib.getExe pkgsCross.wasi32.stdenv.cc;
+  wasi-sdk = linkFarm "wasi-sdk" { "bin/clang" = wasi32cc; };
+in
+buildNpmPackage (finalAttrs: {
+  pname = "umple-lsp";
+  version = "1.0.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "umple";
+    repo = "umple-lsp";
+    # Upstream repo has no tags, so rev is derived from npm version info
+    # See ./update.sh
+    rev = "1771d55d7e00a720b97c0f2422971efa26e110f6";
+    hash = "sha256-44JLteH4q2toLBWQ1YmbFlDHqgF4JufCf8DJCczGayE=";
+  };
+
+  postPatch = ''
+    cp ${./package-lock.json} package-lock.json
+  '';
+
+  npmDepsHash = "sha256-0RUExwYu/N80cw3LGX4ieOCwSf1LkCICteKIllARhBc=";
+  npmFlags = [ "--ignore-scripts" ];
+  npmWorkspace = "packages/server";
+
+  nativeBuildInputs = [
+    nodejs
+    pkgsCross.wasi32.stdenv.cc.bintools
+    tree-sitter
+  ];
+
+  # Stop tree-sitter from trying to fetch its own wasi-sdk
+  env.TREE_SITTER_WASI_SDK_PATH = wasi-sdk;
+
+  dontNpmBuild = true;
+
+  # Same process as the `build-grammar` script from package.json
+  buildPhase = ''
+    runHook preBuild
+
+    cd packages/tree-sitter-umple
+    tree-sitter generate
+    tree-sitter build --wasm
+    cd -
+
+    npm run copy-wasm
+    node_modules/.bin/tsc -b
+
+    runHook postBuild
+  '';
+
+  makeWrapperArgs = [
+    "--prefix"
+    "PATH"
+    ":"
+    (lib.makeBinPath [ jre_headless ])
+  ]
+  ++ lib.optionals withUmple [
+    "--set-default"
+    "UMPLESYNC_JAR_PATH"
+    "${umple}/share/java/umplesync.jar"
+  ];
+
+  # Dangling symlinks are left from the npm workspace and aren't used
+  dontCheckForBrokenSymlinks = true;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Umple language server";
+    mainProgram = "umple-lsp-server";
+    homepage = "https://github.com/umple/umple-lsp";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ MysteryBlokHed ];
+  };
+})

--- a/pkgs/by-name/um/umple-lsp/update.sh
+++ b/pkgs/by-name/um/umple-lsp/update.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p common-updater-scripts curl git jq nix-update nodejs
+set -euo pipefail
+
+meta="$(curl -fsSL https://registry.npmjs.org/umple-lsp-server/latest)"
+latestVersion="$(echo "$meta" | jq -r .version)"
+revision="$(echo "$meta" | jq -r .gitHead)"
+
+if [[ -z "$latestVersion" || "$latestVersion" == "null" ]]; then
+  echo "No version from registry" >&2
+  exit 1
+fi
+
+if [[ -z "$revision" || "$revision" == "null" ]]; then
+  echo "No gitHead from registry" >&2
+  exit 1
+fi
+
+currentVersion=$(nix-instantiate --eval -E "with import ./. {}; umple-lsp.version or (lib.getVersion umple-lsp)" | tr -d '"')
+
+echo "Current version: $currentVersion"
+echo "Latest version: $latestVersion"
+
+if [[ "$currentVersion" = "$latestVersion" ]]; then
+  echo "Up-to-date."
+  exit
+fi
+
+echo "Updating to $latestVersion"
+
+# Update source version and use nix-update to handle the rest
+update-source-version umple-lsp "$latestVersion" --rev="$revision"
+nix-update umple-lsp --version=skip --generate-lockfile


### PR DESCRIPTION
Adds a package for the official [Umple](https://github.com/umple/umple) language server.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
