### PR TITLE
rocq-core: update repo, build coq-core and coqide-server

### DIFF
--- a/pkgs/applications/science/logic/rocq-core/default.nix
+++ b/pkgs/applications/science/logic/rocq-core/default.nix
@@ -44,8 +44,8 @@ let
       {
         inherit release releaseRev;
         location = {
-          owner = "coq";
-          repo = "coq";
+          owner = "rocq-prover";
+          repo = "rocq";
         };
       }
       args.version;
@@ -130,7 +130,11 @@ let
     };
 
     nativeBuildInputs = [ pkg-config ] ++ ocamlNativeBuildInputs;
-    buildInputs = [ ncurses ];
+    buildInputs = [
+      ncurses
+      ocamlPackages.camlzip
+      ocamlPackages.yojson
+    ];
 
     propagatedBuildInputs = ocamlPropagatedBuildInputs;
 
@@ -157,22 +161,18 @@ let
 
     prefixKey = "-prefix ";
 
+    buildFlags = [ "world" ];
+
     enableParallelBuilding = true;
 
     createFindlibDestdir = true;
 
-    buildPhase = ''
-      runHook preBuild
-      make dunestrap
-      dune build -p rocq-runtime,rocq-core -j $NIX_BUILD_CORES
-      runHook postBuild
-    '';
-
     installPhase = ''
       runHook preInstall
-      dune install --prefix $out rocq-runtime rocq-core
+      dune install --prefix $out rocq-runtime rocq-core coqide-server
       ln -s $out/lib/rocq-runtime $OCAMLFIND_DESTDIR/rocq-runtime
       ln -s $out/lib/rocq-core $OCAMLFIND_DESTDIR/rocq-core
+      ln -s $out/lib/coqide-server $OCAMLFIND_DESTDIR/coqide-server
       runHook postInstall
     '';
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Updates the rocq repo from https://github.com/coq/coq to https://github.com/rocq-prover/rocq.
Also builds the coq-core and coqide-server packages: coqide-server includes coqidetop which is used by the [Coqtail](https://github.com/whonore/Coqtail) vim plugin.

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
