### PR TITLE
nagstamon: 3.16.2 -> 3.18.2

### DIFF
--- a/pkgs/by-name/na/nagstamon/package.nix
+++ b/pkgs/by-name/na/nagstamon/package.nix
@@ -7,14 +7,16 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "nagstamon";
-  version = "3.16.2";
+  version = "3.18.2";
   pyproject = true;
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "HenriWahl";
     repo = "Nagstamon";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-9w8ux+AeSg0vDhnk28/2eCE2zYLvAjD7mB0pJBMFs2I=";
+    hash = "sha256-ZA6gxV9zLKZ0g5v8CvnAuiYPhEDByz17kC54Idk9CYM=";
   };
 
   build-system = with python3Packages; [ setuptools ];
@@ -46,6 +48,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     requests
     requests-kerberos
     setuptools
+    tzlocal
   ];
 
   nativeCheckInputs = with python3Packages; [


### PR DESCRIPTION
Diff: https://github.com/HenriWahl/Nagstamon/compare/v3.16.2...v3.18.2

Changelog: https://github.com/HenriWahl/Nagstamon/releases/tag/v3.18.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
