### PR TITLE
python3Packages.caido-server-auth: init at 0.1.2, python3Packages.caido-schema-proxy: init at 0.57.0, python3Packages.caido-sdk-client: init at 0.2.0

### DIFF
--- a/pkgs/development/python-modules/caido-schema-proxy/default.nix
+++ b/pkgs/development/python-modules/caido-schema-proxy/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  hatchling,
+  nix-update-script,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "caido-schema-proxy";
+  version = "0.57.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchPypi {
+    pname = "caido_schema_proxy";
+    inherit (finalAttrs) version;
+    hash = "sha256-5hholzMKrNuJZUZIvg+phProD8OZ/YB0ZSGReGa2IqU=";
+  };
+
+  build-system = [ hatchling ];
+
+  pythonImportsCheck = [ "caido_schema_proxy" ];
+
+  # Module has no tests
+  doCheck = false;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Caido Proxy API schemas (GraphQL and OpenAPI)";
+    homepage = "https://pypi.org/project/caido-schema-proxy";
+    license = lib.licenses.cc-by-40;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+})

--- a/pkgs/development/python-modules/caido-sdk-client/default.nix
+++ b/pkgs/development/python-modules/caido-sdk-client/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  caido-server-auth,
+  fetchPypi,
+  gql,
+  nix-update-script,
+  pydantic,
+  uv-build,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "caido-sdk-client";
+  version = "0.2.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchPypi {
+    pname = "caido_sdk_client";
+    inherit (finalAttrs) version;
+    hash = "sha256-OZiP4Hs/qcaa29SWYttmDXcH1g2SRRCbFiPe+Xs5usg=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.9.8,<0.10.0" "uv_build"
+  '';
+
+  build-system = [ uv-build ];
+
+  dependencies = [
+    caido-server-auth
+    gql
+    pydantic
+  ]
+  ++ gql.optional-dependencies.aiohttp
+  ++ gql.optional-dependencies.websockets;
+
+  pythonImportsCheck = [ "caido_sdk_client" ];
+
+  # Module has no tests
+  doCheck = false;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Client SDK for interacting with a Caido instance";
+    homepage = "https://pypi.org/project/caido-sdk-client";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+})

--- a/pkgs/development/python-modules/caido-server-auth/default.nix
+++ b/pkgs/development/python-modules/caido-server-auth/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  gql,
+  nix-update-script,
+  uv-build,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "caido-server-auth";
+  version = "0.1.2";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchPypi {
+    pname = "caido_server_auth";
+    inherit (finalAttrs) version;
+    hash = "sha256-6ywl6d4VBidgtoES9djprWPusTIlGLkMGgEZppp1JKQ=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.9.8,<0.10.0" "uv_build"
+  '';
+
+  build-system = [ uv-build ];
+
+  dependencies = [
+    gql
+  ]
+  ++ gql.optional-dependencies.aiohttp
+  ++ gql.optional-dependencies.websockets;
+
+  pythonImportsCheck = [ "caido_server_auth" ];
+
+  # Module has no tests
+  doCheck = false;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Authenticate with a Caido instance";
+    homepage = "https://github.com/caido-community/sdk-py/tree/main/packages/caido-server-auth";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2472,6 +2472,8 @@ self: super: with self; {
 
   caido-schema-proxy = callPackage ../development/python-modules/caido-schema-proxy { };
 
+  caido-sdk-client = callPackage ../development/python-modules/caido-sdk-client { };
+
   caido-server-auth = callPackage ../development/python-modules/caido-server-auth { };
 
   caio = callPackage ../development/python-modules/caio { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2470,6 +2470,8 @@ self: super: with self; {
     }
   );
 
+  caido-schema-proxy = callPackage ../development/python-modules/caido-schema-proxy { };
+
   caido-server-auth = callPackage ../development/python-modules/caido-server-auth { };
 
   caio = callPackage ../development/python-modules/caio { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2470,6 +2470,8 @@ self: super: with self; {
     }
   );
 
+  caido-server-auth = callPackage ../development/python-modules/caido-server-auth { };
+
   caio = callPackage ../development/python-modules/caio { };
 
   cairocffi = callPackage ../development/python-modules/cairocffi { };


### PR DESCRIPTION
Will be needed for `strix`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
