### PR TITLE
namecoind: 28.0 -> 31.0

### DIFF
--- a/pkgs/by-name/na/namecoind/package.nix
+++ b/pkgs/by-name/na/namecoind/package.nix
@@ -5,11 +5,12 @@
   python3,
   boost,
   libevent,
-  autoreconfHook,
   db4,
   miniupnpc,
   sqlite,
   pkg-config,
+  cmake,
+  ninja,
   util-linux,
   hexdump,
   zeromq,
@@ -20,18 +21,20 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "namecoind";
-  version = "28.0";
+  version = "31.0";
 
   src = fetchFromGitHub {
     owner = "namecoin";
     repo = "namecoin-core";
     tag = "nc${finalAttrs.version}";
-    hash = "sha256-r6rVgPrKz7nZ07oXw7KmVhGF4jVn6L+R9YHded+3E9k=";
+    fetchSubmodules = true;
+    hash = "sha256-jgkyLWJr7+wFTOazxkS8fJV4544dyIOAZf2zorL7KXY=";
   };
 
   nativeBuildInputs = [
-    autoreconfHook
     pkg-config
+    cmake
+    ninja
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [ util-linux ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ hexdump ]
@@ -42,37 +45,36 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     boost
     libevent
-    db4
     miniupnpc
     zeromq
     zlib
   ]
   ++ lib.optionals withWallet [ sqlite ]
-  # building with db48 (for legacy descriptor wallet support) is broken on Darwin
   ++ lib.optionals (withWallet && !stdenv.hostPlatform.isDarwin) [ db4 ];
 
   enableParallelBuilding = true;
 
-  configureFlags = [
-    "--with-boost-libdir=${boost.out}/lib"
-    "--disable-bench"
-    "--disable-gui-tests"
+  cmakeFlags = [
+    "-DBOOST_ROOT=${boost.out}"
+    "-DBUILD_BENCH=OFF"
+    "-DBUILD_TESTS=OFF"
+    "-DBUILD_GUI=OFF"
+    "-DENABLE_IPC=OFF"
   ]
   ++ lib.optionals (!withWallet) [
-    "--disable-wallet"
+    "-DENABLE_WALLET=OFF"
   ];
 
   nativeCheckInputs = [ python3 ];
 
   doCheck = true;
-
   checkFlags = [ "LC_ALL=en_US.UTF-8" ];
 
   meta = {
     description = "Decentralized open source information registration and transfer system based on the Bitcoin cryptocurrency";
     homepage = "https://namecoin.org";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.lukas-sgx ];
     platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
