### PR TITLE
lomiri.lomiri-telephony-service: Apply fixes for test flakiness & newer libnotify compat

### DIFF
--- a/pkgs/desktops/lomiri/services/lomiri-telephony-service/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-telephony-service/default.nix
@@ -2,13 +2,13 @@
   stdenv,
   lib,
   fetchFromGitLab,
+  fetchpatch,
   gitUpdater,
   nixosTests,
   runCommand,
   ayatana-indicator-messages,
   bash,
   cmake,
-  ctestCheckHook,
   dbus,
   dbus-glib,
   dbus-test-runner,
@@ -52,6 +52,31 @@ stdenv.mkDerivation (finalAttrs: {
     tag = finalAttrs.version;
     hash = "sha256-CNtJPMust7zCuoXw/CpaK4NVXijTXA3Xs4YMJiZyxes=";
   };
+
+  patches = [
+    # Fixes for test flakiness & newer libnotify compatibility
+    # Remove when version > 0.6.2
+    (fetchpatch {
+      name = "0001-lomiri-telephony-service-new-libnotify-needs-spec_version.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-telephony-service/-/commit/6b0b51a4fcfafcd10ae5fe4928d49c9f73f14d12.patch";
+      hash = "sha256-E9THrqE77GXBY8ftwrkwFzFCTSa/YpkaHiX4ivjH6mM=";
+    })
+    (fetchpatch {
+      name = "0002-lomiri-telephony-service-tests-depend-on-the-notification-mock.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-telephony-service/-/commit/8c5a3048492eb01354565f0892a61770eb27b957.patch";
+      hash = "sha256-nLN+Evyq4Yf9GN2wSSPXmzEzTPXHDl+Pl5FKOiwdDY8=";
+    })
+    (fetchpatch {
+      name = "0003-lomiri-telephony-service-approver-fix-race-condition-when-accepting-calls.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-telephony-service/-/commit/b3123f784ed692f9424c978e68867a8662d00083.patch";
+      hash = "sha256-/JEkoEEivFwFoNOrcdDleAGOjdUwS4SlUovMr9trNQQ=";
+    })
+    (fetchpatch {
+      name = "0004-lomiri-telephony-service-Robustness-fixes-for-tests.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-telephony-service/-/commit/e886fbdd016327634e935986f2b63b90833295be.patch";
+      hash = "sha256-Ie9kM7UHSjmORTOTNzZ1/qtM4ILkOnGjyQCXXo1PU88=";
+    })
+  ];
 
   postPatch = ''
     # Queries qmake for the QML installation path, which returns a reference to Qt5's build directory
@@ -112,7 +137,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   nativeCheckInputs = [
-    ctestCheckHook
     dbus-test-runner
     dconf
     gnome-keyring
@@ -138,25 +162,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   # Starts & talks to D-Bus services, breaks with parallelism
   enableParallelChecking = false;
-
-  disabledTests = [
-    # Flaky, randomly failing to launch properly & stuck until test timeout
-    # https://gitlab.com/ubports/development/core/lomiri-telephony-service/-/issues/70
-    "AccountEntryTest"
-    "AccountEntryFactoryTest"
-    "AuthHandlerTest"
-    "CallEntryTest"
-    "ChatManagerTest"
-    "HandlerTest"
-    "OfonoAccountEntryTest"
-    "PresenceRequestTest"
-    "TelepathyHelperSetupTest"
-
-    # Failing most of the time since libnotify 0.8.8
-    # https://gitlab.com/ubports/development/core/lomiri-telephony-service/-/issues/75
-    "ApproverTest"
-    "MessagingMenuTest"
-  ];
 
   preCheck = ''
     export QT_QPA_PLATFORM=minimal


### PR DESCRIPTION
Rebuilt this in a loop for some hours on my workstation, and didn't run into any failures. Hoping that OfBorg can trigger and give this an independent try, or someone else reviews this. Once it hits Hydra, I'll try to keep an eye on the build results there…

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
