### PR TITLE
ariang: Pin nodejs to version 22

### DIFF
--- a/pkgs/by-name/ar/ariang/package.nix
+++ b/pkgs/by-name/ar/ariang/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  nodejs_22,
   buildNpmPackage,
   copyDesktopItems,
   imagemagick,
@@ -18,6 +19,8 @@ buildNpmPackage rec {
     tag = version;
     hash = "sha256-u4MnjGMvnnb9EGHwK2QYpW7cuX1e1+6z2/1X1baR8iA=";
   };
+
+  nodejs = nodejs_22;
 
   npmDepsHash = "sha256-kxoSEdM8H7M9s6U2dtCdfuvqVROEk35jAkO7MgyVVRg=";
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Pinned nodejs version to 22 as suggested by @maxammann in https://github.com/NixOS/nixpkgs/issues/523144#issuecomment-4766865263

Closes https://github.com/NixOS/nixpkgs/issues/523144

There's basically no diff with the last working version I had:
```shell
❯ diff -r /nix/store/mibybp7vg33vgmiq7smbir7kjihb5y5n-ariang-1.3.13/ result
diff '--color=auto' -r /nix/store/mibybp7vg33vgmiq7smbir7kjihb5y5n-ariang-1.3.13/bin/ariang result/bin/ariang
1,2c1,2
< #! /nix/store/f15k3dpilmiyv6zgpib289rnjykgr1r4-bash-5.3p9/bin/bash -e
< exec "/nix/store/0xypmry8xznw2ciwc41zr83p80hb3aq8-xdg-utils-1.2.1/bin/xdg-open"  file:///nix/store/mibybp7vg33vgmiq7smbir7kjihb5y5n-ariang-1.3.13/share/ariang/index.html "$@" 
---
> #! /nix/store/gik3rh1vz2jlgnifb9dh6vc6sxwwz9jj-bash-5.3p9/bin/bash -e
> exec "/nix/store/0vk8rbf3l0j5qrihizh85kyplycw5kdv-xdg-utils-1.2.1/bin/xdg-open"  file:///nix/store/6c4m95hg31s6hbqhaz9gk0lnfy5mp11x-ariang-1.3.13/share/ariang/index.html "$@" 
```

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
