### PR TITLE
python3Packages.pyannote-audio: add undeclared pyyaml dependency

### DIFF
--- a/pkgs/development/python-modules/pyannote-audio/default.nix
+++ b/pkgs/development/python-modules/pyannote-audio/default.nix
@@ -24,6 +24,7 @@
   pyannote-pipeline,
   pyannoteai-sdk,
   pytorch-metric-learning,
+  pyyaml,
   safetensors,
   speechbrain,
   tensorboardx,
@@ -61,11 +62,6 @@ buildPythonPackage (finalAttrs: {
     hatch-vcs
   ];
 
-  pythonRelaxDeps = [
-    "torch"
-    "torchaudio"
-    "torchcodec"
-  ];
   dependencies = [
     asteroid-filterbanks
     einops
@@ -81,6 +77,7 @@ buildPythonPackage (finalAttrs: {
     pyannote-pipeline
     pyannoteai-sdk
     pytorch-metric-learning
+    pyyaml
     safetensors
     speechbrain
     tensorboardx


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

https://github.com/pyannote/pyannote-audio/blob/b749285c5cdd4636b2edc7f766f1352c8dde9369/src/pyannote/audio/core/pipeline.py#L36

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
