### PR TITLE
lime-juice: init at 0.2.3

### DIFF
--- a/pkgs/by-name/li/lime-juice/package.nix
+++ b/pkgs/by-name/li/lime-juice/package.nix
@@ -1,0 +1,46 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  gitUpdater,
+  testers,
+  cmake,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lime-juice";
+  version = "0.2.3";
+
+  src = fetchFromGitHub {
+    owner = "FuzionCD";
+    repo = "lime-juice";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-0KOzqpeQQleMkJUpWLHA5ZhqSxy8iD0Tj6gdCPM+itA=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  passthru = {
+    updateScript = gitUpdater {
+      rev-prefix = "v";
+    };
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      version = "v${finalAttrs.version}";
+    };
+  };
+
+  meta = {
+    description = "C++ port of Tomyun's 'Juice' de/recompiler for PC-98 games using the ADV engine";
+    homepage = "https://github.com/FuzionCD/lime-juice";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "juice";
+    maintainers = with lib.maintainers; [ OPNA2608 ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
https://github.com/FuzionCD/lime-juice

Have been using this over the past few months to mess with existing game translations, and start a game translation of my own. Will likely continue using this, and have seen other ppl in the relevant niche interest circles using this.

<img width="694" height="511" alt="image" src="https://github.com/user-attachments/assets/d8c2cc05-0f89-435b-8920-a1bf1fdc5ee1" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
