### PR TITLE
treewide: remove redundant SETUPTOOLS_SCM_PRETEND_VERSION setters

### DIFF
--- a/pkgs/by-name/dt/dtc/package.nix
+++ b/pkgs/by-name/dt/dtc/package.nix
@@ -49,8 +49,6 @@ stdenv.mkDerivation (finalAttrs: {
         }
       );
 
-  env.SETUPTOOLS_SCM_PRETEND_VERSION = finalAttrs.version;
-
   nativeBuildInputs = [
     meson
     ninja

--- a/pkgs/by-name/sa/savepagenow/package.nix
+++ b/pkgs/by-name/sa/savepagenow/package.nix
@@ -16,8 +16,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
     sha256 = "sha256-ztM1g71g8SN1LTyFF7sxaLhC3+nVsC9fJwfYPjkUsdE=";
   };
 
-  env.SETUPTOOLS_SCM_PRETEND_VERSION = finalAttrs.version;
-
   build-system = with python3Packages; [ setuptools-scm ];
 
   dependencies = with python3Packages; [

--- a/pkgs/by-name/sk/skypilot/package.nix
+++ b/pkgs/by-name/sk/skypilot/package.nix
@@ -46,8 +46,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
     writableTmpDirAsHomeHook
   ];
 
-  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
-
   postPatch = ''
     substituteInPlace sky/setup_files/dependencies.py --replace-fail 'casbin' 'pycasbin'
     substituteInPlace pyproject.toml --replace-fail 'buildkite-test-collector' ""

--- a/pkgs/development/python-modules/amd-aiter/default.nix
+++ b/pkgs/development/python-modules/amd-aiter/default.nix
@@ -90,7 +90,6 @@ buildPythonPackage (finalAttrs: {
     BUILD_TARGET = "rocm";
     PREBUILD_KERNELS = "0";
     ROCM_PATH = "${rocmPackages.clr}";
-    SETUPTOOLS_SCM_PRETEND_VERSION = finalAttrs.version;
   };
 
   build-system = [

--- a/pkgs/development/python-modules/cvxopt/default.nix
+++ b/pkgs/development/python-modules/cvxopt/default.nix
@@ -45,7 +45,6 @@ buildPythonPackage rec {
     CVXOPT_BUILD_DSDP = "0";
     CVXOPT_SUITESPARSE_LIB_DIR = "${lib.getLib suitesparse}/lib";
     CVXOPT_SUITESPARSE_INC_DIR = "${lib.getDev suitesparse}/include";
-    SETUPTOOLS_SCM_PRETEND_VERSION = version;
   }
   // lib.optionalAttrs withGsl {
     CVXOPT_BUILD_GSL = "1";

--- a/pkgs/development/python-modules/fastjet/default.nix
+++ b/pkgs/development/python-modules/fastjet/default.nix
@@ -76,8 +76,6 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
-
   meta = {
     description = "Jet-finding in the Scikit-HEP ecosystem";
     homepage = "https://github.com/scikit-hep/fastjet";

--- a/pkgs/development/python-modules/flash-attn-4/default.nix
+++ b/pkgs/development/python-modules/flash-attn-4/default.nix
@@ -36,8 +36,6 @@ buildPythonPackage (finalAttrs: {
   # The top-level setup.py builds the classic compiled flash-attn and excludes flash_attn.cute.
   sourceRoot = "${finalAttrs.src.name}/flash_attn/cute";
 
-  env.SETUPTOOLS_SCM_PRETEND_VERSION = finalAttrs.version;
-
   build-system = [
     setuptools
     setuptools-scm

--- a/pkgs/development/python-modules/formulaic/default.nix
+++ b/pkgs/development/python-modules/formulaic/default.nix
@@ -29,6 +29,7 @@ buildPythonPackage rec {
     hash = "sha256-C4IUuyxBbW2DUxF4at8/736ZMmVZrFRRp+RxrJfmLkY=";
   };
 
+  # project uses a version-file that is not present in tagged releases
   env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   build-system = [

--- a/pkgs/development/python-modules/geoarrow-c/default.nix
+++ b/pkgs/development/python-modules/geoarrow-c/default.nix
@@ -41,8 +41,6 @@ buildPythonPackage rec {
     rm -v ./bootstrap.py
   '';
 
-  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
-
   nativeCheckInputs = [
     pytestCheckHook
     pyarrow

--- a/pkgs/development/python-modules/geoarrow-pandas/default.nix
+++ b/pkgs/development/python-modules/geoarrow-pandas/default.nix
@@ -25,8 +25,6 @@ buildPythonPackage rec {
 
   build-system = [ setuptools-scm ];
 
-  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
-
   dependencies = [
     geoarrow-pyarrow
     geoarrow-types

--- a/pkgs/development/python-modules/geoarrow-pyarrow/default.nix
+++ b/pkgs/development/python-modules/geoarrow-pyarrow/default.nix
@@ -51,8 +51,6 @@ buildPythonPackage rec {
     pyarrow-hotfix
   ];
 
-  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
-
   nativeCheckInputs = [
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/geoarrow-types/default.nix
+++ b/pkgs/development/python-modules/geoarrow-types/default.nix
@@ -22,8 +22,6 @@ buildPythonPackage rec {
 
   build-system = [ setuptools-scm ];
 
-  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
-
   nativeCheckInputs = [
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/icalendar-compatibility/default.nix
+++ b/pkgs/development/python-modules/icalendar-compatibility/default.nix
@@ -46,8 +46,6 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "icalendar_compatibility" ];
 
-  # env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
-
   meta = {
     homepage = "https://icalendar-compatibility.readthedocs.io/en/latest/";
     changelog = "https://icalendar-compatibility.readthedocs.io/en/latest/changes.html";

--- a/pkgs/development/python-modules/linearmodels/default.nix
+++ b/pkgs/development/python-modules/linearmodels/default.nix
@@ -34,6 +34,10 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-/unFszNGaEPsoXDtaS3tsLnsX4A6e7Y88O8pDrf4nKc=";
   };
 
+  # tries to execute linearmodels/_build/git_version.py at build time
+  # which would require keeping the .git tree
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = finalAttrs.version;
+
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace-fail "setuptools_scm>=9.2.0,<10" "setuptools_scm"
@@ -45,8 +49,6 @@ buildPythonPackage (finalAttrs: {
     numpy
     setuptools-scm
   ];
-
-  env.SETUPTOOLS_SCM_PRETEND_VERSION = finalAttrs.version;
 
   dependencies = [
     formulaic

--- a/pkgs/development/python-modules/nipreps-versions/default.nix
+++ b/pkgs/development/python-modules/nipreps-versions/default.nix
@@ -20,8 +20,6 @@ buildPythonPackage rec {
     hash = "sha256-B2wtLurzgk59kTooH51a2dewK7aEyA0dAm64Wp+tqhM=";
   };
 
-  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
-
   nativeBuildInputs = [
     flit-scm
     setuptools-scm

--- a/pkgs/development/python-modules/niworkflows/default.nix
+++ b/pkgs/development/python-modules/niworkflows/default.nix
@@ -52,6 +52,9 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-AMUOiIL33kcJtlKT+L5QwcUh8mBBkf80uzOQZFKDauo=";
   };
 
+  # fails to determine the version automatically
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = finalAttrs.version;
+
   pythonRelaxDeps = [ "traits" ];
 
   build-system = [
@@ -83,8 +86,6 @@ buildPythonPackage (finalAttrs: {
     traits
     transforms3d
   ];
-
-  env.SETUPTOOLS_SCM_PRETEND_VERSION = finalAttrs.version;
 
   nativeCheckInputs = [
     pytest-cov-stub

--- a/pkgs/development/python-modules/pandera/default.nix
+++ b/pkgs/development/python-modules/pandera/default.nix
@@ -59,8 +59,6 @@ buildPythonPackage (finalAttrs: {
     setuptools-scm
   ];
 
-  env.SETUPTOOLS_SCM_PRETEND_VERSION = finalAttrs.version;
-
   dependencies = [
     packaging
     pydantic

--- a/pkgs/development/python-modules/pillow-jpls/default.nix
+++ b/pkgs/development/python-modules/pillow-jpls/default.nix
@@ -30,8 +30,6 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-Rc4/S8BrYoLdn7eHDBaoUt1Qy+h0TMAN5ixCAuRmfPU=";
   };
 
-  env.SETUPTOOLS_SCM_PRETEND_VERSION = finalAttrs.version;
-
   dontUseCmakeConfigure = true;
 
   postPatch = ''

--- a/pkgs/development/python-modules/pyfatfs/default.nix
+++ b/pkgs/development/python-modules/pyfatfs/default.nix
@@ -40,8 +40,6 @@ buildPythonPackage rec {
     pytest-mock
   ];
 
-  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
-
   passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 
   meta = {

--- a/pkgs/development/python-modules/riscv-model/default.nix
+++ b/pkgs/development/python-modules/riscv-model/default.nix
@@ -20,8 +20,6 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-H4N9Z8aK/xV5gCCdsL+oiR+XQfYtCfBRBGLqvuztX+o=";
   };
 
-  env.SETUPTOOLS_SCM_PRETEND_VERSION = finalAttrs.version;
-
   build-system = [
     setuptools
     setuptools-scm

--- a/pkgs/development/python-modules/trsfile/default.nix
+++ b/pkgs/development/python-modules/trsfile/default.nix
@@ -20,8 +20,6 @@ buildPythonPackage (finalAttrs: {
 
   pyproject = true;
 
-  env.SETUPTOOLS_SCM_PRETEND_VERSION = finalAttrs.version;
-
   build-system = [
     setuptools
     setuptools-scm


### PR DESCRIPTION
The setuptools-scm setup script sets the env var to the derivation version already.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x]  Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
