### PR TITLE
delta: generate latest shell completions

### DIFF
--- a/pkgs/by-name/de/delta/package.nix
+++ b/pkgs/by-name/de/delta/package.nix
@@ -44,7 +44,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   postInstall = ''
     installShellCompletion --cmd delta \
-      etc/completion/completion.{bash,fish,zsh}
+      --bash <($out/bin/delta --generate-completion bash) \
+      --fish <($out/bin/delta --generate-completion zsh) \
+      --zsh <($out/bin/delta --generate-completion fish)
   '';
 
   # test_env_parsing_with_pager_set_to_bat sets environment variables,


### PR DESCRIPTION
As per documentation the shell completions provided in the source GitHub might not be up-to-date.
https://dandavison.github.io/delta/tips-and-tricks/shell-completion.html

In particular the following changes are observed
```
$ diff /nix/store/9j9q32mcmb41dxc799sp5rygbghhwkg0-delta-0.19.2/share/bash-completion/completions/delta.bash <(delta --generate-completion bash)
22c22
<             opts="-n -s -w -h -V --blame-code-style --blame-format --blame-palette --blame-separator-format --blame-separator-style --blame-timestamp-format --blame-timestamp-output-format --color-only --config --commit-decoration-style --commit-regex --commit-style --dark --default-language --diff-highlight --diff-so-fancy --diff-stat-align-width --features --file-added-label --file-copied-label --file-decoration-style --file-modified-label --file-removed-label --file-renamed-label --file-style --file-transformation --generate-completion --grep-context-line-style --grep-file-style --grep-header-decoration-style --grep-header-file-style --grep-line-number-style --grep-output-type --grep-match-line-style --grep-match-word-style --grep-separator-symbol --hunk-header-decoration-style --hunk-header-file-style --hunk-header-line-number-style --hunk-header-style --hunk-label --hyperlinks --hyperlinks-commit-link-format --hyperlinks-file-link-format --inline-hint-style --inspect-raw-lines --keep-plus-minus-markers --light --line-buffer-size --line-fill-method --line-numbers --line-numbers-left-format --line-numbers-left-style --line-numbers-minus-style --line-numbers-plus-style --line-numbers-right-format --line-numbers-right-style --line-numbers-zero-style --list-languages --list-syntax-themes --map-styles --max-line-distance --max-line-length --merge-conflict-begin-symbol --merge-conflict-end-symbol --merge-conflict-ours-diff-header-decoration-style --merge-conflict-ours-diff-header-style --merge-conflict-theirs-diff-header-decoration-style --merge-conflict-theirs-diff-header-style --minus-empty-line-marker-style --minus-emph-style --minus-non-emph-style --minus-style --navigate --navigate-regex --no-gitconfig --pager --paging --parse-ansi --plus-emph-style --plus-empty-line-marker-style --plus-non-emph-style --plus-style --raw --relative-paths --right-arrow --show-colors --show-config --show-syntax-themes --show-themes --side-by-side --syntax-theme --tabs --true-color --whitespace-error-style --width --word-diff-regex --wrap-left-symbol --wrap-max-lines --wrap-right-percent --wrap-right-prefix-symbol --wrap-right-symbol --zero-style --24-bit-color --help --version [MINUS_FILE] [PLUS_FILE]"
---
>             opts="-@ -n -s -w -h -V --blame-code-style --blame-format --blame-palette --blame-separator-format --blame-separator-style --blame-timestamp-format --blame-timestamp-output-format --color-only --config --commit-decoration-style --commit-regex --commit-style --dark --default-language --detect-dark-light --diff-args --diff-highlight --diff-so-fancy --diff-stat-align-width --features --file-added-label --file-copied-label --file-decoration-style --file-modified-label --file-removed-label --file-renamed-label --file-style --file-transformation --generate-completion --grep-context-line-style --grep-file-style --grep-header-decoration-style --grep-header-file-style --grep-line-number-style --grep-output-type --grep-match-line-style --grep-match-word-style --grep-separator-symbol --hunk-header-decoration-style --hunk-header-file-style --hunk-header-line-number-style --hunk-header-style --hunk-label --hyperlinks --hyperlinks-commit-link-format --hyperlinks-file-link-format --inline-hint-style --inspect-raw-lines --keep-plus-minus-markers --light --line-buffer-size --line-fill-method --line-numbers --line-numbers-left-format --line-numbers-left-style --line-numbers-minus-style --line-numbers-plus-style --line-numbers-right-format --line-numbers-right-style --line-numbers-zero-style --list-languages --list-syntax-themes --map-styles --max-line-distance --max-syntax-highlighting-length --max-line-length --merge-conflict-begin-symbol --merge-conflict-end-symbol --merge-conflict-ours-diff-header-decoration-style --merge-conflict-ours-diff-header-style --merge-conflict-theirs-diff-header-decoration-style --merge-conflict-theirs-diff-header-style --minus-empty-line-marker-style --minus-emph-style --minus-non-emph-style --minus-style --navigate --navigate-regex --no-gitconfig --pager --paging --parse-ansi --plus-emph-style --plus-empty-line-marker-style --plus-non-emph-style --plus-style --raw --relative-paths --right-arrow --show-colors --show-config --show-syntax-themes --show-themes --side-by-side --syntax-theme --tabs --true-color --whitespace-error-style --width --word-diff-regex --wrap-left-symbol --wrap-max-lines --wrap-right-percent --wrap-right-prefix-symbol --wrap-right-symbol --zero-style --24-bit-color --help --version [MINUS_FILE] [PLUS_FILE]"
75a76,87
>                 --detect-dark-light)
>                     COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
>                     return 0
>                     ;;
>                 --diff-args)
>                     COMPREPLY=($(compgen -f "${cur}"))
>                     return 0
>                     ;;
>                 -@)
>                     COMPREPLY=($(compgen -f "${cur}"))
>                     return 0
>                     ;;
235a248,251
>                 --max-syntax-highlighting-length)
>                     COMPREPLY=($(compgen -f "${cur}"))
>                     return 0
>                     ;;
378,380c394,395
< # nosort isn't supported for bash less than < 4.4
< if [[ ${BASH_VERSINFO[0]} -lt 4 || ( ${BASH_VERSINFO[0]} -eq 4 && ${BASH_VERSINFO[1]} -lt 4 ) ]]; then
<     complete -F _delta -o bashdefault -o default delta
---
> if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
>     complete -F _delta -o nosort -o bashdefault -o default delta
382c397
<     complete -F _delta -o bashdefault -o default -o nosort delta
---
>     complete -F _delta -o bashdefault -o default delta
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
