### PR TITLE
gpclient: keep nixpkgs-update opt-out visible

### DIFF
--- a/pkgs/by-name/gp/gpclient/package.nix
+++ b/pkgs/by-name/gp/gpclient/package.nix
@@ -41,10 +41,14 @@ rustPlatform.buildRustPackage {
   # nixpkgs-update: no auto update
   inherit (gpauth)
     cargoHash
-    meta
     src
     version
     ;
+
+  meta = gpauth.meta // {
+    # Re-anchor meta.position here so nixpkgs-update sees the opt-out above.
+    inherit (gpauth.meta) description;
+  };
 
   buildAndTestSubdir = "apps/gpclient";
 


### PR DESCRIPTION
In 344a3c2437 we attempted to disable bot updates on gpclient. But it
didn't work because of a quirk in bot logic.

Re-inherit the description locally so meta.position points at gpclient
while preserving the inherited metadata text.

Precedent: https://github.com/NixOS/nixpkgs/commit/fab23265d6c6678e49a0526d6111ac8a9c26fdc9

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
