### PR TITLE
[Backport release-26.05] gpclient: 2.5.1 -> 2.6.4

### DIFF
--- a/pkgs/by-name/gp/gpauth/package.nix
+++ b/pkgs/by-name/gp/gpauth/package.nix
@@ -12,19 +12,19 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "gpauth";
-  version = "2.5.4";
+  version = "2.6.4";
 
   src = fetchFromGitHub {
     owner = "yuezk";
     repo = "GlobalProtect-openconnect";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-RDfxhf0t70Ex6MfgHAX2AaWcPAwTCvjm1bQkek+92zc=";
+    hash = "sha256-cFzQhogahw4/LXI6B9K2xxkMitbHfZg/3/00UORiGEE=";
     fetchSubmodules = true;
   };
 
   buildAndTestSubdir = "apps/gpauth";
 
-  cargoHash = "sha256-SY0PS5GxvVO1jaCNyLa3/l/v8/JT2R+4lM3W9kA7fVM=";
+  cargoHash = "sha256-9O9DHkn2ZG3SOnqjd5xYTNTTJ3w6yj0bs9Nl7m+rg64=";
 
   nativeBuildInputs = [
     perl

--- a/pkgs/by-name/gp/gpauth/package.nix
+++ b/pkgs/by-name/gp/gpauth/package.nix
@@ -12,19 +12,19 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "gpauth";
-  version = "2.5.1";
+  version = "2.5.4";
 
   src = fetchFromGitHub {
     owner = "yuezk";
     repo = "GlobalProtect-openconnect";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-rux2rToqs5GZEDTryPAkm62yGdhWfEqapTMQOGyqCRI=";
+    hash = "sha256-RDfxhf0t70Ex6MfgHAX2AaWcPAwTCvjm1bQkek+92zc=";
     fetchSubmodules = true;
   };
 
   buildAndTestSubdir = "apps/gpauth";
 
-  cargoHash = "sha256-xza7AfuOcSUkDyliGHUx9bEd+M94d23xVrVVvZo2nas=";
+  cargoHash = "sha256-SY0PS5GxvVO1jaCNyLa3/l/v8/JT2R+4lM3W9kA7fVM=";
 
   nativeBuildInputs = [
     perl

--- a/pkgs/by-name/gp/gpclient/package.nix
+++ b/pkgs/by-name/gp/gpclient/package.nix
@@ -6,21 +6,31 @@
   autoconf,
   automake,
   cairo,
+  coreutils,
+  gawk,
   glib,
   glib-networking,
+  gmp,
   gnutls,
+  gnugrep,
   gpauth,
   gtk3,
+  iproute2,
   libtool,
   libxml2,
   lz4,
   makeBinaryWrapper,
+  net-tools,
+  nettle,
+  openresolv,
   openssl,
   p11-kit,
   pango,
   perl,
   pkg-config,
-  vpnc-scripts,
+  systemd,
+  zlib,
+  withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
 }:
 
 rustPlatform.buildRustPackage {
@@ -48,14 +58,17 @@ rustPlatform.buildRustPackage {
   buildInputs = [
     glib
     glib-networking
+    gmp
+    gnutls
     gpauth
-    openssl
 
     # used for vendored openconnect
-    gnutls
     libxml2
     lz4
+    nettle
+    openssl
     p11-kit
+    zlib
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     atk
@@ -66,14 +79,17 @@ rustPlatform.buildRustPackage {
 
   postPatch = ''
     substituteInPlace crates/openconnect/src/vpn_utils.rs \
-      --replace-fail /etc/vpnc/vpnc-script ${vpnc-scripts}/bin/vpnc-script \
+      --replace-fail /usr/libexec/gpclient/vpnc-script $out/libexec/gpclient/vpnc-script \
       --replace-fail /usr/libexec/gpclient/hipreport.sh $out/libexec/gpclient/hipreport.sh
 
     substituteInPlace crates/common/src/constants.rs \
+      --replace-fail /usr/bin/gpauth ${gpauth}/bin/gpauth \
+      --replace-fail /opt/homebrew/bin/gpauth ${gpauth}/bin/gpauth \
+      --replace-fail /usr/local/bin/gpauth ${gpauth}/bin/gpauth \
       --replace-fail /usr/bin/gpclient $out/bin/gpclient \
       --replace-fail /usr/bin/gpservice $out/bin/gpservice \
-      --replace-fail /usr/bin/gpauth ${gpauth}/bin/gpauth \
-      --replace-fail /opt/homebrew/ $out/
+      --replace-fail /opt/homebrew/ $out/ \
+      --replace-fail /usr/local/ $out/
   '';
 
   postInstall = ''
@@ -81,6 +97,32 @@ rustPlatform.buildRustPackage {
 
     substituteInPlace $out/libexec/gpclient/hipreport.sh \
       --replace-fail /usr/bin/gpclient $out/bin/gpclient
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    substituteInPlace $out/libexec/gpclient/vpnc-script \
+      --replace-fail /sbin/resolvconf ${openresolv}/bin/resolvconf
+  ''
+  + lib.optionalString withSystemd ''
+    substituteInPlace $out/libexec/gpclient/vpnc-script \
+      --replace-fail /usr/bin/resolvectl ${systemd}/bin/resolvectl \
+      --replace-fail /usr/bin/busctl ${systemd}/bin/busctl
+  ''
+  + ''
+    wrapProgram "$out/libexec/gpclient/vpnc-script" \
+      --prefix PATH : "${
+        lib.makeBinPath (
+          [
+            coreutils
+            gawk
+            gnugrep
+            net-tools
+          ]
+          ++ lib.optionals stdenv.hostPlatform.isLinux [
+            iproute2
+            openresolv
+          ]
+        )
+      }"
   ''
   + lib.optionalString stdenv.hostPlatform.isLinux ''
     cp -r packaging/files/usr/lib $out/lib


### PR DESCRIPTION
- **gp{auth,client}: 2.5.1 -> 2.5.4**
- **gpauth: 2.5.4 -> 2.6.4**

Rationale for backport: no features dropped; new version adopts to the latest Palo Alto VPN server versions that changed authentication mechanism somewhat that broke some flows in the older versions.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
