### PR TITLE
webrtc-audio-processing: explicitly specify C++17 for abseil-cpp

### DIFF
--- a/pkgs/by-name/we/webrtc-audio-processing/package.nix
+++ b/pkgs/by-name/we/webrtc-audio-processing/package.nix
@@ -46,7 +46,11 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   propagatedBuildInputs = [
-    abseil-cpp
+    # webrtc-audio-processing specifies C++17, so abseil must match. Otherwise,
+    # abseil exposes a different (incompatible) interface based on the default
+    # C++ standard of the compiler.
+    # https://gitlab.freedesktop.org/pulseaudio/webrtc-audio-processing/-/blob/d0569cfa50c1858ee279d77b3fc8870be6902441/meson.build#L7
+    (abseil-cpp.override { cxxStandard = "17"; })
   ];
 
   mesonFlags =


### PR DESCRIPTION
abseil exposes different interfaces depending on what is available in `std` in a given C++ standard. gcc 16 defaults to C++20, thus causing the default abseil-cpp to expose a different interface than the one webrtc-audio-processing (built with C++17) expects. this leads to a great deal of "error: 'partial_ordering' has not been declared in 'std'" and similar originating from abseil's types/compare.h. thus, we explicitly override abseil to specify the desired C++ standard.

or at least, that's my best guess at understanding what's going on as someone who doesn't know C++ :). it does fix the build with gcc 16. i think this is a reasonable fix, but i'm not 100% sure.

(part of submitting some fixes to prepare for making gcc 16 the default later this release cycle: https://github.com/NixOS/nixpkgs/pull/537781)

## Things done

- Built on platform:
  - [x] x86_64-linux (both on this commit and with `default-gcc-version = 16;` in all-packages.nix)
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
