### PR TITLE
bashmount: add runtime dependencies

### DIFF
--- a/pkgs/by-name/ba/bashmount/package.nix
+++ b/pkgs/by-name/ba/bashmount/package.nix
@@ -2,6 +2,15 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  makeWrapper,
+  coreutils,
+  cryptsetup,
+  eject,
+  gnugrep,
+  gnused,
+  less,
+  udisks,
+  util-linux,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -14,6 +23,8 @@ stdenv.mkDerivation (finalAttrs: {
     tag = finalAttrs.version;
     sha256 = "1irw47s6i1qwxd20cymzlfw5sv579cw877l27j3p66qfhgadwxrl";
   };
+
+  nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
     mkdir -p $out/bin
@@ -29,6 +40,22 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/share/doc/bashmount
     cp COPYING $out/share/doc/bashmount
     cp NEWS    $out/share/doc/bashmount
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/bashmount \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          cryptsetup
+          eject
+          gnugrep
+          gnused
+          less
+          udisks
+          util-linux
+        ]
+      }
   '';
 
   meta = {


### PR DESCRIPTION
bashmount requires various other binaries to be installed to be fully functional. This PR declares them as deps.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
