### PR TITLE
tomato-c: 0-unstable-2024-04-19 -> 0-unstable-2025-11-11

### DIFF
--- a/pkgs/by-name/to/tomato-c/package.nix
+++ b/pkgs/by-name/to/tomato-c/package.nix
@@ -11,25 +11,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tomato-c";
-  version = "0-unstable-2024-04-19";
+  version = "0-unstable-2025-11-11";
 
   src = fetchFromGitHub {
     owner = "gabrielzschmitz";
     repo = "Tomato.C";
-    rev = "b3b85764362a7c120f3312f5b618102a4eac9f01";
-    hash = "sha256-7i+vn1dAK+bAGpBlKTnSBUpyJyRiPc7AiUF/tz+RyTI=";
+    rev = "590224cbbf0f53f09d33080c4e83797a11ad02d1";
+    hash = "sha256-TVvCqWWjfFHcFOMEO9frfrs9638cOjkV8yvqavdzdmI=";
   };
-
-  postPatch = ''
-    substituteInPlace Makefile \
-      --replace-fail "sudo " ""
-    substituteInPlace notify.c \
-      --replace-fail "/usr/local" "${placeholder "out"}"
-    substituteInPlace util.c \
-      --replace-fail "/usr/local" "${placeholder "out"}"
-    substituteInPlace tomato.desktop \
-      --replace-fail "/usr/local" "${placeholder "out"}"
-  '';
 
   nativeBuildInputs = [
     makeWrapper

--- a/pkgs/by-name/to/tomato-c/package.nix
+++ b/pkgs/by-name/to/tomato-c/package.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/gabrielzschmitz/Tomato.C";
     description = "Pomodoro timer written in pure C";
     license = with lib.licenses; [ gpl3Plus ];
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ _3JlOy-PYCCKUi ];
     mainProgram = "tomato";
     platforms = lib.platforms.unix;
   };


### PR DESCRIPTION
1. updated from `0-unstable-2024-04-19` to `0-unstable-2025-11-11`
2. adopted package

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
