### PR TITLE
protobufc: unpin standard version to fix build with gcc 16

### DIFF
--- a/pkgs/by-name/pr/protobufc/package.nix
+++ b/pkgs/by-name/pr/protobufc/package.nix
@@ -36,6 +36,21 @@ stdenv.mkDerivation (finalAttrs: {
     zlib
   ];
 
+  # The upstream macro is vendored from a very old autoconf archive:
+  # https://github.com/protobuf-c/protobuf-c/commit/42612b4ba4b11d48b76e3643fa6d42f617e661b6
+  # and the build system appears to arbitrarily require C++17 specifically:
+  # https://github.com/protobuf-c/protobuf-c/blob/4719fdd7760624388c2c5b9d6759eb6a47490626/configure.ac#L72
+  # However, the default standard version used by GCC continues to increase
+  # (e.g. C++20 for GCC 16), and so protobuf-c's dependencies do as well. In
+  # particular, abseil-cpp has headers that protobuf-c includes and are
+  # sensitive to the standard version. While we could override the standard
+  # version used by these dependents, it is simpler to drop the requirement and
+  # allow the compiler default standard to be used.
+  postPatch = ''
+    substituteInPlace configure.ac --replace-fail \
+      "AX_CXX_COMPILE_STDCXX(17, noext, mandatory)" ""
+  '';
+
   env.PROTOC = lib.getExe buildPackages.protobuf_33;
 
   meta = {


### PR DESCRIPTION
protobufc pins a specific version of the C++ standard and does so using an ancient vendored macro from the autoconf archive. this causes a failure to build on gcc 16, as it defaults to C++20 and protobufc uses C++17. this particularly causes problems with abseil, which has headers which depend on the C++ standard to compile. accordingly, to avoid having to manually specify and update a version each time the default standard version updates, we unpin it completely and allow the compiler to choose what it uses by default.

alternatively, we could override the abseil that ends up in protobufc by way of protobuf_33 to use the C++17 standard instead. this would work, but this seems more fragile and subject to compiler version churn. it is also our understanding that mixing and matching versions of standards in dependents can be messy, and using the default seems the least likely to cause problems.

however, i don't really know C++ all that well, especially not the intricacies of standard versions. if i should switch to the override, or handle this some completely different way, i'd be happy to switch to that / have this be superseded. thanks!

(part of submitting some fixes to prepare for making gcc 16 the default later this release cycle: https://github.com/NixOS/nixpkgs/pull/537781)

## Things done

- Built on platform:
  - [x] x86_64-linux (both on this commit and with `default-gcc-version = 16;` in all-packages.nix)
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
