### PR TITLE
lief: 0.17.0 -> 0.17.6

### DIFF
--- a/pkgs/by-name/li/lief/package.nix
+++ b/pkgs/by-name/li/lief/package.nix
@@ -20,13 +20,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "lief";
-  version = "0.17.0";
+  version = "0.17.6";
 
   src = fetchFromGitHub {
     owner = "lief-project";
     repo = "LIEF";
     tag = finalAttrs.version;
-    hash = "sha256-icwRW9iY/MiG/x3VHqRfAU2Yk4q2hXLJsfN5Lwx37gw=";
+    hash = "sha256-WcWKGIQIGngfzW+VnrZEnRPX2w4syNw+so2aqwSgecw=";
   };
 
   outputs = [


### PR DESCRIPTION
Bugfix-only update: https://github.com/lief-project/LIEF/releases/tag/0.17.6
(covers 0.17.1–0.17.6; no API changes)

Reason for contribution: 0.17.0 [corrupted elf binary section](https://github.com/lief-project/LIEF/issues/1315) of some of my musl PIE binaries

<details>
Notably fixes ELF corruption when writing patched binaries (DYN section
alignment in 0.17.2, PHDR/SHDR alignment + NOBITS handling in 0.17.6) —
verified by round-tripping an ELF with the python bindings:
parse → add section → write → binary still runs.
</details>

Testing and this PR summary were AI-assisted (Claude Code, Fable 5);
the change itself and final review are my own, as well as the intent for this contribution.

## nixpkgs-review (errors same as `master`)

```
--------- Report for 'x86_64-linux' ---------
2 packages marked as broken and skipped:
haskellPackages.llama-cpp-hs local-ai

2 packages failed to build:
tabby unblob

18 packages built:
blint chiri ghost grok-cli knot-resolver-manager_6 lief llama-cpp llama-cpp-rocm llama-cpp-vulkan nodejs-slim_26 nodejs_26 python313Packages.hatasm python313Packages.pex-entysec python314Packages.hatasm python314Packages.lief python314Packages.pex-entysec ramalama trueseeing
```

Verified reproducibillity of two errors on main:
```sh
git worktree add /tmp/master-check upstream/master
nix-build /tmp/master-check -A unblob -A tabby --no-out-link --keep-going
```
- tabby rust compilation
  > `recorder` escapes the associated function body here
- unblob
  > `OSError: [Errno 18] Invalid cross-device link: '/build/pytest-of-nixbld/pytest-0/test_all_handlers_filesystem_b0/sample.v2.none.bin_extract/16-5250324.btrfs_stream_extract/o258-7-0' -> '/build/pytest-of-nixbld/pytest-0/test_all_handlers_filesystem_b0/sample.v2.none.bin_extract/16-5250324.btrfs_stream_extract/data_samples/subdir'`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
