### PR TITLE
librevna: init at 1.6.5

### DIFF
--- a/pkgs/by-name/li/librevna/package.nix
+++ b/pkgs/by-name/li/librevna/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  git,
+  udev,
+  qt6,
+  libusb1,
+  copyDesktopItems,
+  makeDesktopItem,
+}:
+
+stdenv.mkDerivation {
+  pname = "librevna";
+  version = "1.6.5";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "jankae";
+    repo = "LibreVNA";
+    rev = "5fee370d4e56c30efaa0c6040a504bd01a63cc90";
+    hash = "sha256-uPVnjhbFXP1Z+pJuWDX4xqQGcmbJI8ElHq8fVXN0Qcc=";
+  };
+
+  nativeBuildInputs = [
+    git
+    qt6.qmake
+    qt6.wrapQtAppsHook
+    qt6.qtsvg
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    udev
+    qt6.qtbase
+    libusb1
+  ];
+
+  preConfigure = ''
+    cd Software/PC_Application/LibreVNA-GUI
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 LibreVNA-GUI $out/bin/LibreVNA-GUI
+    install -Dm644 ../51-vna.rules $out/lib/udev/rules.d/51-vna.rules
+    install -Dm644 resources/librevna.svg $out/share/icons/hicolor/scalable/apps/librevna.svg
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "librevna";
+      desktopName = "LibreVNA GUI";
+      comment = "Vector Network Analyzer for LibreVNA board";
+      exec = "LibreVNA-GUI";
+      icon = "librevna";
+      terminal = false;
+      categories = [
+        "Science"
+        "Engineering"
+        "Electronics"
+      ];
+    })
+  ];
+
+  meta = {
+    description = "GUI application for the LibreVNA vector network analyzer";
+    homepage = "https://github.com/jankae/LibreVNA";
+    maintainers = [ ];
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

``librevna`` is a package and command-line utility for controlling LibreVNA vector network analyzers and spectrum analyzers.

Homepage: https://github.com/jankae/LibreVNA/tree/master

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
