### PR TITLE
liquid-dsp: 1.6.0 -> 1.8.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11486,6 +11486,13 @@
     githubId = 72767437;
     name = "Ian Holloway";
   };
+  iank = {
+    email = "iank@iank.org";
+    github = "iank";
+    githubId = 109598;
+    name = "Ian Kilgore";
+    keys = [ { fingerprint = "21F7 244E 095F 619E 8E3E  1EB4 9F3A 4AAB 4D90 D879"; } ];
+  };
   ianliu = {
     email = "ian.liu88@gmail.com";
     github = "ianliu";

--- a/pkgs/development/libraries/liquid-dsp/default.nix
+++ b/pkgs/development/libraries/liquid-dsp/default.nix
@@ -38,6 +38,8 @@ stdenv.mkDerivation rec {
     ./include-stdarg.patch
   ];
 
+  doCheck = true;
+
   meta = {
     homepage = "https://liquidsdr.org/";
     description = "Digital signal processing library for software-defined radios";

--- a/pkgs/development/libraries/liquid-dsp/default.nix
+++ b/pkgs/development/libraries/liquid-dsp/default.nix
@@ -43,5 +43,6 @@ stdenv.mkDerivation rec {
     description = "Digital signal processing library for software-defined radios";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ iank ];
   };
 }

--- a/pkgs/development/libraries/liquid-dsp/default.nix
+++ b/pkgs/development/libraries/liquid-dsp/default.nix
@@ -1,42 +1,41 @@
 {
   lib,
   stdenv,
+  cmake,
   fetchFromGitHub,
   autoreconfHook,
-  cctools,
   autoSignDarwinBinariesHook,
   fixDarwinDylibNames,
 }:
 
 stdenv.mkDerivation rec {
   pname = "liquid-dsp";
-  version = "1.6.0";
+  version = "1.8.0";
 
   src = fetchFromGitHub {
     owner = "jgaeddert";
     repo = "liquid-dsp";
     rev = "v${version}";
-    sha256 = "sha256-3UKAwhYaYZ42+d+wiW/AB6x5TSOel8d++d3HeZqAg/8=";
+    sha256 = "sha256-IvWtoXuuIvpJfY4cyRUsPHgax2/aytYShSdxEStiPYI=";
   };
 
-  configureFlags =
-    lib.optionals stdenv.hostPlatform.isDarwin [
-      "LIBTOOL=${cctools}/bin/libtool"
-    ]
-    ++ [
-      # Prevent native cpu arch from leaking into binaries. This might lead to
-      # poor performance, but having portable and working executables is more
-      # important.
-      (lib.enableFeature true "simdoverride")
-    ];
+  cmakeFlags = [
+    # Prevent native cpu arch from leaking into binaries.
+    (lib.cmakeBool "ENABLE_SIMD" false)
+    (lib.cmakeBool "FIND_SIMD" false)
+  ];
 
   nativeBuildInputs = [
-    autoreconfHook
+    cmake
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    cctools
     autoSignDarwinBinariesHook
     fixDarwinDylibNames
+  ];
+
+  patches = [
+    ./fix-cmake-pc-paths.patch
+    ./include-stdarg.patch
   ];
 
   meta = {

--- a/pkgs/development/libraries/liquid-dsp/fix-cmake-pc-paths.patch
+++ b/pkgs/development/libraries/liquid-dsp/fix-cmake-pc-paths.patch
@@ -1,0 +1,29 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 07c123889..a6640515c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -564,6 +564,9 @@ if (fftw3f_FOUND)
+     string(APPEND LIQUID_PC_LIBS_PRIVATE " -lfftw3f")
+ endif()
+ 
++cmake_path(APPEND libdir_for_pc_file "\${prefix}" "${CMAKE_INSTALL_LIBDIR}")
++cmake_path(APPEND includedir_for_pc_file "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
++
+ configure_file(
+     cmake/liquid-dsp.pc.in
+     ${CMAKE_CURRENT_BINARY_DIR}/liquid-dsp.pc
+diff --git a/cmake/liquid-dsp.pc.in b/cmake/liquid-dsp.pc.in
+index 93597a7e4..06de85dee 100644
+--- a/cmake/liquid-dsp.pc.in
++++ b/cmake/liquid-dsp.pc.in
+@@ -2,8 +2,8 @@
+ 
+ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=${prefix}
+-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
++libdir=@libdir_for_pc_file@
++includedir=@includedir_for_pc_file@
+ 
+ Name: liquid-dsp
+ Description: Software-defined radio digital signal processing library

--- a/pkgs/development/libraries/liquid-dsp/include-stdarg.patch
+++ b/pkgs/development/libraries/liquid-dsp/include-stdarg.patch
@@ -1,0 +1,12 @@
+diff --git a/include/liquid.h b/include/liquid.h
+index 290778b50..52d898d07 100644
+--- a/include/liquid.h
++++ b/include/liquid.h
+@@ -34,6 +34,7 @@ extern "C" {
+ #include <stdlib.h>
+ #include <stdio.h>
+ #include <time.h>
++#include <stdarg.h>
+ 
+ // compile-time short file path: use __FILE_NAME__ if available (Clang 9+, GCC 12+)
+ #ifdef __FILE_NAME__


### PR DESCRIPTION
Updates liquid-dsp 1.6.0 to 1.8.0.

Needed a patch to the cmake .pc file generation; I submitted that upstream: https://github.com/jgaeddert/liquid-dsp/pull/450

Not sure if I did the right thing to address the build failure in fm-tune.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
