### PR TITLE
home-assistant-custom-components.versatile_thermostat: 9.3.3 -> 10.0.2

### DIFF
--- a/pkgs/development/python-modules/vtherm-api/default.nix
+++ b/pkgs/development/python-modules/vtherm-api/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  home-assistant,
+  pythonOlder,
+  pytest-asyncio,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "vtherm-api";
+  version = "0.3.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.14";
+
+  src = fetchFromGitHub {
+    owner = "jmcollin78";
+    repo = "vtherm_api";
+    tag = finalAttrs.version;
+    hash = "sha256-8YE9+Y+R6TvBKssRPvDLSdVzonDawWgg01Ngk94eMzM=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ home-assistant ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "vtherm_api" ];
+
+  meta = {
+    changelog = "https://github.com/jmcollin78/vtherm_api/releases/tag/${finalAttrs.version}";
+    description = "API for Versatile Thermostat Home Assistant integrations";
+    homepage = "https://github.com/jmcollin78/vtherm_api";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ geri1701 ];
+  };
+})

--- a/pkgs/servers/home-assistant/custom-components/versatile_thermostat/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/versatile_thermostat/package.nix
@@ -4,24 +4,26 @@
   lib,
   numpy,
   scipy,
+  vtherm-api,
   gitUpdater,
 }:
 
 buildHomeAssistantComponent rec {
   owner = "jmcollin78";
   domain = "versatile_thermostat";
-  version = "9.3.3";
+  version = "10.0.2";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = domain;
     tag = version;
-    hash = "sha256-TiaJFFx3nEUYHVB5Ka71MaP8pngcPSdHxt920NSCQ8c=";
+    hash = "sha256-WnhOsvBhIyumWkEiX2Id2fz4GQQTZxBOLPtR6zHqsXw=";
   };
 
   dependencies = [
     numpy
     scipy
+    vtherm-api
   ];
 
   passthru.updateScript = gitUpdater { ignoredVersions = "(Alpha|Beta|alpha|beta).*"; };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21558,6 +21558,8 @@ self: super: with self; {
 
   vt-py = callPackage ../development/python-modules/vt-py { };
 
+  vtherm-api = callPackage ../development/python-modules/vtherm-api { };
+
   vtjp = callPackage ../development/python-modules/vtjp { };
 
   vtk = toPythonModule (


### PR DESCRIPTION
Updates `home-assistant-custom-components.versatile_thermostat` to 10.0.2 and adds `python314Packages.vtherm-api` 0.3.0 for the new `vtherm_api>=0.3.0` component requirement.

Changelog: https://github.com/jmcollin78/versatile_thermostat/releases/tag/10.0.2
Closes #528004

Assisted-by: pi coding agent / Mika (OpenAI GPT-5.5)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
