### PR TITLE
nixos/ntfs: install userspace utils for the new NTFS (NTFSPLUS) driver

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -85,6 +85,8 @@
 
 - `security.polkit.settings` added for RFC42 style configuration of the polkitd daemon.
 
+- `boot.supportedFilesystems.ntfs` installs `ntfsprogs-plus` instead of `ntfs3g` on kernel version 7.1 and later, unless `boot.supportedFilesystems.ntfs-3g` is explicitly enabled.
+
 - The `programs.fuse` module, which provides the `fusermount3` executable and the `/etc/fuse.conf` config file, is now opt-in. The obligation to enable it has been shifted to its various consumers (e.g. gvfs, flatpak, appimage, sshfs). This can break fuse consumers at runtime, that don't explicitly declare that dependency with a module, e.g the mounting functionality in various backup tools (borg, restic, rclone, ...).
 
 - `services.plausible` can now again seed an initial admin user declaratively via [`services.plausible.adminUser.email`](#opt-services.plausible.adminUser.email).

--- a/nixos/modules/tasks/filesystems/ntfs.nix
+++ b/nixos/modules/tasks/filesystems/ntfs.nix
@@ -4,15 +4,24 @@
   pkgs,
   ...
 }:
-
-with lib;
-
+let
+  ntfsEnabled = config.boot.supportedFilesystems.ntfs or false;
+  ntfs3gEnabled = config.boot.supportedFilesystems.ntfs-3g or false;
+  ntfsPlusSupported = config.boot.kernelPackages.kernelAtLeast "7.1";
+  initrdSupport = config.boot.initrd.supportedFilesystems.ntfs or false;
+in
 {
-  config =
-    mkIf (config.boot.supportedFilesystems.ntfs or config.boot.supportedFilesystems.ntfs-3g or false)
-      {
+  config = lib.mkMerge [
+    (lib.mkIf (ntfsEnabled && ntfsPlusSupported && !ntfs3gEnabled) {
+      system.fsPackages = [ pkgs.ntfsprogs-plus ];
 
-        system.fsPackages = [ pkgs.ntfs3g ];
+      boot.initrd.availableKernelModules = lib.optionals initrdSupport [ "ntfs" ];
+    })
 
-      };
+    (lib.mkIf (ntfs3gEnabled || (ntfsEnabled && !ntfsPlusSupported)) {
+      system.fsPackages = [ pkgs.ntfs3g ];
+
+      boot.initrd.availableKernelModules = lib.optionals initrdSupport [ "ntfs3" ];
+    })
+  ];
 }


### PR DESCRIPTION
Replaces #521502.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
