### PR TITLE
pastebinit: 1.6.2 -> 1.8.0

### DIFF
--- a/pkgs/by-name/pa/pastebinit/package.nix
+++ b/pkgs/by-name/pa/pastebinit/package.nix
@@ -9,14 +9,14 @@
   callPackage,
 }:
 stdenv.mkDerivation rec {
-  version = "1.6.2";
+  version = "1.8.0";
   pname = "pastebinit";
 
   src = fetchFromGitHub {
     owner = "pastebinit";
     repo = "pastebinit";
     rev = version;
-    hash = "sha256-vuAWkHlQM6QTWarThpSbY0qrxzej0GvLU0jT2JOS/qc=";
+    hash = "sha256-+2vcpLueYUMrOJvSPo7Uxk3PWHR2MB0z1YtGeqJMsSM=";
   };
 
   patches = [

--- a/pkgs/by-name/pa/pastebinit/use-drv-etc.patch
+++ b/pkgs/by-name/pa/pastebinit/use-drv-etc.patch
@@ -1,13 +1,13 @@
 diff --git a/pastebinit b/pastebinit
-index 4e5f9ce..fe06bd3 100755
+index 90575d8..3d1d6d0 100755
 --- a/pastebinit
 +++ b/pastebinit
-@@ -91,7 +91,7 @@ try:
-         # Files found later override files found earlier.
-         pastebind = {}
-         confdirs = []
--        for confdir in ['/usr/share', '/usr/local/share'] \
-+        for confdir in ['@etc@', '/usr/share', '/usr/local/share'] \
-                 + list(reversed(os.environ.get('XDG_DATA_DIRS', '').split(':'))) \
-                 + list(reversed(os.environ.get('XDG_CONFIG_DIRS', '').split(':'))) \
-                 + ['/etc', '/usr/local/etc',
+@@ -76,7 +76,7 @@ def preloadPastebins():
+     # Files found later override files found earlier.
+     pastebind = {}
+     confdirs = []
+-    for confdir in ['/usr/share', '/usr/local/share'] \
++    for confdir in ['@etc@', '/usr/share', '/usr/local/share'] \
+             + list(reversed(os.environ.get('XDG_DATA_DIRS', '').split(':'))) \
+             + list(reversed(os.environ.get('XDG_CONFIG_DIRS', '').split(':'))) \
+             + ['/etc', '/usr/local/etc',


### PR DESCRIPTION
tested. sadly currently the default pastebin (bpa.st) seems to return 400 errors, but that's an upstream issue. dpaste.com does seem to work.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
