### PR TITLE
asn1c: 0.9.28 -> 0.9.29

### DIFF
--- a/pkgs/by-name/as/asn1c/package.nix
+++ b/pkgs/by-name/as/asn1c/package.nix
@@ -1,39 +1,64 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  autoreconfHook,
+  versionCheckHook,
+  fetchFromGitHub,
   perl,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "asn1c";
-  version = "0.9.28";
+  version = "0.9.29";
 
-  src = fetchurl {
-    url = "https://lionet.info/soft/asn1c-${finalAttrs.version}.tar.gz";
-    hash = "sha256-gAdEC2R+8t2ftz2THDOsEXZOavskN9vmOLtOX8gjhrk=";
+  src = fetchFromGitHub {
+    owner = "vlm";
+    repo = "asn1c";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ms4+tzlVdV0pVGhdBod8sepjHGS4OVxJb3HdrFKv9Cc=";
   };
 
   outputs = [
     "out"
     "doc"
     "man"
+
+    # for the one perl utility
+    "crfc2asn1"
+  ];
+
+  postPatch = ''
+    patchShebangs examples/crfc2asn1.pl
+  '';
+
+  nativeBuildInputs = [
+    autoreconfHook
+    versionCheckHook
   ];
 
   buildInputs = [ perl ];
 
-  preConfigure = ''
-    patchShebangs examples/crfc2asn1.pl
-  '';
+  enableParallelBuilding = true;
 
   postInstall = ''
     cp -r skeletons/standard-modules $out/share/asn1c
   '';
 
-  doCheck = true;
+  # Barely anyone uses this, so make it a split-output
+  # so we don't carry the dependency on perl into bin.
+  postFixup = ''
+    mkdir -p $crfc2asn1/bin
+    mv $out/bin/crfc2asn1.pl $crfc2asn1/bin/crfc2asn1
+  '';
+
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
-    homepage = "http://lionet.info/asn1c/compiler.html";
+    mainProgram = "asn1c";
+    homepage = "https://lionet.info/asn1c/compiler.html";
     description = "Open Source ASN.1 Compiler";
     license = lib.licenses.bsd2;
     platforms = lib.platforms.unix;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

First release in 8 years :confetti_ball: 

Security release: https://github.com/vlm/asn1c/releases/tag/v0.9.29

Compiled code seems like it mostly had memory leaks that were fixed and an XER crash; `unber` tool had a buffer overflow.

Move the crfc2asn1 output to a split output so we don't carry a runtime dependency on perl.

Use the github source instead of the tarball, which means we need autoreconfHook.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
