### PR TITLE
go-ios: 1.0.207 -> 1.2.0

### DIFF
--- a/pkgs/by-name/go/go-ios/package.nix
+++ b/pkgs/by-name/go/go-ios/package.nix
@@ -7,33 +7,42 @@
   pkg-config,
   libusb1,
   iproute2,
-  net-tools,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "go-ios";
-  version = "1.0.207";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "danielpaulus";
     repo = "go-ios";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-2GjUrt1F8MrPOITCsuWHHsi/85pfzbLeY+WbPfLYDY4=";
+    sha256 = "sha256-5fMsHSwJUH/JBaZXyB11rHCNOqzHF3MYI9gg29hj0O4=";
   };
 
   proxyVendor = true;
-  vendorHash = "sha256-/aVaTC9lfoXQvhDVQm31HmXBnDYYOv6RH69Nm3I/K7s=";
+  vendorHash = "sha256-Bl9nlRnclqVgFF6mS6DX6oS+1c26DoISqDBY2rMS2yw=";
 
   excludedPackages = [
     "restapi"
+    "test/e2e"
   ];
 
-  postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''
+  ldflags = [
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  postPatch = ''
+    substituteInPlace main.go \
+      --replace-fail 'const version = ' 'var version = '
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
     substituteInPlace ncm/linux_commands.go \
       --replace-fail "ip " "${lib.getExe' iproute2 "ip"} "
-
-    substituteInPlace ios/tunnel/tunnel.go \
-      --replace-fail "ifconfig" "${lib.getExe' net-tools "ifconfig"}"
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace ios/tunnel/tunnel_darwin.go \
+      --replace-fail "ifconfig" "/sbin/ifconfig"
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Things done
Updated to latest version + fixed substitutes for linux/darwin + fixed the version being "local-build"

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
