### PR TITLE
nixos/yggdrasil: Fix stray 0-byte /private-key file

### DIFF
--- a/nixos/modules/services/networking/yggdrasil.nix
+++ b/nixos/modules/services/networking/yggdrasil.nix
@@ -33,17 +33,11 @@ let
     else
       null;
 
-  # Build base configuration with systemd credential path override
   baseSettings =
     cfg.settings
-    // (
-      if effectiveKeyPath != null then
-        {
-          PrivateKeyPath = "/private-key";
-        }
-      else
-        { }
-    );
+    // lib.optionalAttrs (effectiveKeyPath != null) {
+      PrivateKeyPath = "/run/credentials/yggdrasil.service/private-key";
+    };
 
   # Remove null values that yggdrasil doesn't expect
   cleanSettings = lib.filterAttrs (n: v: v != null) baseSettings;
@@ -327,7 +321,6 @@ in
           StateDirectory = "yggdrasil";
           RuntimeDirectory = "yggdrasil";
           RuntimeDirectoryMode = "0750";
-          BindReadOnlyPaths = lib.optional (effectiveKeyPath != null) "%d/private-key:/private-key";
           LoadCredential = lib.optional (effectiveKeyPath != null) "private-key:${effectiveKeyPath}";
 
           AmbientCapabilities = "CAP_NET_ADMIN CAP_NET_BIND_SERVICE";


### PR DESCRIPTION
The module bind-mounted the LoadCredential-provided key onto a /private-key target at the filesystem. systemd must create that target inode before overlaying the credential; the mount lives in the unit's namespace but the inode write hits the host filesystem, so a 0-byte /private-key file leaks onto the host and persists after the unit stops.

Point PrivateKeyPath directly at the credential (/run/credentials/yggdrasil.service/private-key) and drop BindReadOnlyPaths. The DynamicUser can read the credentials dir, so the bind was never needed.

Fixes #531972

Assisted-by: Oh My Pi (claude-opus-4-8)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
