### PR TITLE
python3Packages.pynauty: init at 2.8.8.1

### DIFF
--- a/pkgs/development/python-modules/pynauty/default.nix
+++ b/pkgs/development/python-modules/pynauty/default.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  gnumake,
+  pytestCheckHook,
+  pythonOlder,
+  setuptools,
+  wheel,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pynauty";
+  version = "2.8.8.1";
+
+  __structuredAttrs = true;
+
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "pdobsan";
+    repo = "pynauty";
+    tag = finalAttrs.version;
+    hash = "sha256-VdAXNRRMNEos0t04ixQywUncj7ohSCqRDitT+kWywZo=";
+  };
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  nativeBuildInputs = [
+    gnumake
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlags = [
+    "--pyargs"
+    "pynauty"
+  ];
+
+  pythonImportsCheck = [
+    "pynauty"
+    "pynauty.nautywrap"
+  ];
+
+  meta = {
+    description = "Isomorphism testing and automorphisms of graphs";
+    homepage = "https://github.com/pdobsan/pynauty";
+    changelog = "https://github.com/pdobsan/pynauty/releases/tag/${finalAttrs.version}";
+    license = with lib.licenses; [
+      gpl3Plus
+      asl20
+    ];
+    maintainers = with lib.maintainers; [ kilianar ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15253,6 +15253,8 @@ self: super: with self; {
 
   pynanoleaf = callPackage ../development/python-modules/pynanoleaf { };
 
+  pynauty = callPackage ../development/python-modules/pynauty { };
+
   pync = callPackage ../development/python-modules/pync { inherit (pkgs) which; };
 
   pynecil = callPackage ../development/python-modules/pynecil { };


### PR DESCRIPTION
This PR adds [pynauty](https://github.com/pdobsan/pynauty/) to nixpkgs.

pynauty provides Python bindings for [nauty](https://pallini.di.uniroma1.it/), a library for computing graph automorphism groups and canonical labels.

https://github.com/pdobsan/pynauty/releases/tag/2.8.8.1

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
