### PR TITLE
treewide: follow some GitHub redirects for `fetchFromGitHub`

### DIFF
--- a/pkgs/by-name/ef/effitask/package.nix
+++ b/pkgs/by-name/ef/effitask/package.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "1.4.2";
 
   src = fetchFromGitHub {
-    owner = "sanpii";
+    owner = "todotxt-rs";
     repo = "effitask";
     rev = finalAttrs.version;
     sha256 = "sha256-6BA/TCCqVh5rtgGkUgk8nIqUzozipC5rrkbXMDWYpdQ=";
@@ -45,7 +45,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       Or use it as standalone program by defining some environment variables
       like described in the projects readme.
     '';
-    homepage = "https://github.com/sanpii/effitask";
+    homepage = "https://github.com/todotxt-rs/effitask";
     maintainers = with lib.maintainers; [ davidak ];
     license = with lib.licenses; [ mit ];
     mainProgram = "effitask";

--- a/pkgs/by-name/ek/eksctl/package.nix
+++ b/pkgs/by-name/ek/eksctl/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
   version = "0.226.0";
 
   src = fetchFromGitHub {
-    owner = "weaveworks";
+    owner = "eksctl-io";
     repo = "eksctl";
     rev = finalAttrs.version;
     hash = "sha256-XjiM4o4xJPY+ZFtvWi5K99tQaZwNxiCla/jUeQQo+5E=";
@@ -46,7 +46,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "CLI for Amazon EKS";
-    homepage = "https://github.com/weaveworks/eksctl";
+    homepage = "https://github.com/eksctl-io/eksctl";
     changelog = "https://github.com/eksctl-io/eksctl/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/el/elfcat/package.nix
+++ b/pkgs/by-name/el/elfcat/package.nix
@@ -9,7 +9,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.1.10";
 
   src = fetchFromGitHub {
-    owner = "ruslashev";
+    owner = "rbakbashev";
     repo = "elfcat";
     rev = finalAttrs.version;
     sha256 = "sha256-8jyOYV455APlf8F6HmgyvgfNGddMzrcGhj7yFQT6qvg=";
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "ELF visualizer, generates HTML files from ELF binaries";
-    homepage = "https://github.com/ruslashev/elfcat";
+    homepage = "https://github.com/rbakbashev/elfcat";
     license = lib.licenses.zlib;
     maintainers = with lib.maintainers; [ moni ];
     mainProgram = "elfcat";

--- a/pkgs/by-name/em/embree/package.nix
+++ b/pkgs/by-name/em/embree/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "4.4.1";
 
   src = fetchFromGitHub {
-    owner = "embree";
+    owner = "RenderKit";
     repo = "embree";
     tag = "v${finalAttrs.version}";
     hash = "sha256-ZJItp33XUmaTk5s4AbM/uzWGxSdGh5scdZAZDBYy28M=";

--- a/pkgs/by-name/em/emissary/package.nix
+++ b/pkgs/by-name/em/emissary/package.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.3.1";
 
   src = fetchFromGitHub {
-    owner = "altonen";
+    owner = "eepnet";
     repo = "emissary";
     tag = "v${finalAttrs.version}";
     hash = "sha256-fLhvMzdxXAuEB99NgIfTLxYezIIZVaC8Z6snK9UUEl0=";
@@ -30,10 +30,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   __darwinAllowLocalNetworking = true;
 
   meta = {
-    changelog = "https://github.com/altonen/emissary/releases/tag/${finalAttrs.version}";
+    changelog = "https://github.com/eepnet/emissary/releases/tag/${finalAttrs.version}";
     description = "Rust implementation of the I2P protocol stack";
     homepage = "https://altonen.github.io/emissary/";
-    license = lib.licenses.mit; # https://github.com/altonen/emissary/blob/master/LICENSE (found an apache2 as well but thats for https://github.com/altonen/emissary/commit/c4a1c849ebfceba892adce53f512f1f099721de2)
+    license = lib.licenses.mit; # https://github.com/eepnet/emissary/blob/master/LICENSE (found an apache2 as well but thats for https://github.com/eepnet/emissary/commit/c4a1c849ebfceba892adce53f512f1f099721de2)
     mainProgram = "emissary-cli";
     maintainers = [ lib.maintainers.N4CH723HR3R ];
   };

--- a/pkgs/by-name/en/ente-auth/package.nix
+++ b/pkgs/by-name/en/ente-auth/package.nix
@@ -20,7 +20,7 @@ flutter.buildFlutterApplication rec {
   version = "4.4.17";
 
   src = fetchFromGitHub {
-    owner = "ente-io";
+    owner = "ente";
     repo = "ente";
     sparseCheckout = [ "mobile" ];
     tag = "auth-v${version}";
@@ -94,8 +94,8 @@ flutter.buildFlutterApplication rec {
     "--dart-define=app.flavor=independent"
   ];
 
-  # Based on https://github.com/ente-io/ente/blob/main/auth/linux/packaging/rpm/make_config.yaml
-  # and https://github.com/ente-io/ente/blob/main/auth/linux/packaging/enteauth.appdata.xml
+  # Based on https://github.com/ente/ente/blob/main/auth/linux/packaging/rpm/make_config.yaml
+  # and https://github.com/ente/ente/blob/main/auth/linux/packaging/enteauth.appdata.xml
   desktopItems = [
     (makeDesktopItem {
       name = desktopId;
@@ -138,7 +138,7 @@ flutter.buildFlutterApplication rec {
       Ente's 2FA app. An end-to-end encrypted, cross platform and free app for storing your 2FA codes with cloud backups. Works offline. You can even use it without signing up for an account if you don't want the cloud backups or multi-device sync.
     '';
     homepage = "https://ente.io/auth/";
-    changelog = "https://github.com/ente-io/ente/releases/tag/auth-v${version}";
+    changelog = "https://github.com/ente/ente/releases/tag/auth-v${version}";
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [
       niklaskorz

--- a/pkgs/by-name/en/ente-cli/package.nix
+++ b/pkgs/by-name/en/ente-cli/package.nix
@@ -13,7 +13,7 @@ buildGoModule (finalAttrs: {
   version = "0.2.3";
 
   src = fetchFromGitHub {
-    owner = "ente-io";
+    owner = "ente";
     repo = "ente";
     tag = "cli-v${finalAttrs.version}";
     hash = "sha256-qKMFoNtD5gH0Y+asD0LR5d3mxGpr2qVWXIUzJTSezeI=";
@@ -83,8 +83,8 @@ buildGoModule (finalAttrs: {
     longDescription = ''
       The Ente CLI is a Command Line Utility for exporting data from Ente. It also does a few more things, for example, you can use it to decrypting the export from Ente Auth.
     '';
-    homepage = "https://github.com/ente-io/ente/tree/main/cli#readme";
-    changelog = "https://github.com/ente-io/ente/releases/tag/cli-v${finalAttrs.version}";
+    homepage = "https://github.com/ente/ente/tree/main/cli#readme";
+    changelog = "https://github.com/ente/ente/releases/tag/cli-v${finalAttrs.version}";
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [ zi3m5f ];
     mainProgram = "ente";

--- a/pkgs/by-name/en/ente-desktop/package.nix
+++ b/pkgs/by-name/en/ente-desktop/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.7.24";
 
   src = fetchFromGitHub {
-    owner = "ente-io";
+    owner = "ente";
     repo = "ente";
     fetchSubmodules = true;
     sparseCheckout = [
@@ -169,7 +169,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   # The desktop item properties should be kept in sync with data from upstream:
-  # https://github.com/ente-io/ente/blob/main/desktop/electron-builder.yml
+  # https://github.com/ente/ente/blob/main/desktop/electron-builder.yml
   desktopItems = lib.optionals (!stdenv.hostPlatform.isDarwin) [
     (makeDesktopItem {
       name = "ente-desktop";

--- a/pkgs/by-name/en/ente-web/package.nix
+++ b/pkgs/by-name/en/ente-web/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.3.36";
 
   src = fetchFromGitHub {
-    owner = "ente-io";
+    owner = "ente";
     repo = "ente";
     sparseCheckout = [
       "rust"
@@ -72,7 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
     wasm-pack
   ];
 
-  # See: https://github.com/ente-io/ente/blob/main/web/apps/photos/.env
+  # See: https://github.com/ente/ente/blob/main/web/apps/photos/.env
   env = extraBuildEnv;
 
   postPatch =
@@ -163,7 +163,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Ente application web frontends";
     homepage = "https://ente.io/";
-    changelog = "https://github.com/ente-io/ente/releases";
+    changelog = "https://github.com/ente/ente/releases";
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [
       pinpox

--- a/pkgs/by-name/es/esshader/package.nix
+++ b/pkgs/by-name/es/esshader/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   version = "0-unstable-2020-08-09";
 
   src = fetchFromGitHub {
-    owner = "cmcsun";
+    owner = "chrismcfee";
     repo = "esshader";
     rev = "506eb02f3de52d3d1f4d81ac9ee145655216dee5";
     sha256 = "sha256-euxJw7CqOwi6Ndzalps37kDr5oOIL3tZICCfmxsujfk=";
@@ -40,7 +40,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Offline ShaderToy-compatible GLSL shader viewer using OpenGL ES 2.0";
-    homepage = "https://github.com/cmcsun/esshader";
+    homepage = "https://github.com/chrismcfee/esshader";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ astro ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/et/etherpad-lite/package.nix
+++ b/pkgs/by-name/et/etherpad-lite/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "ether";
-    repo = "etherpad-lite";
+    repo = "etherpad";
     tag = "v${finalAttrs.version}";
     hash = "sha256-8DCgbfp3ttpMTXS9SNkN1R63LZHaklsNHViRhmWVFuk=";
   };
@@ -86,7 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
       It provides full data export capabilities, and runs on your server, under your control.
     '';
     homepage = "https://etherpad.org/";
-    changelog = "https://github.com/ether/etherpad-lite/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/ether/etherpad/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     maintainers = with lib.maintainers; [
       erdnaxe
       f2k1de

--- a/pkgs/by-name/ev/evcxr/package.nix
+++ b/pkgs/by-name/ev/evcxr/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.21.1";
 
   src = fetchFromGitHub {
-    owner = "google";
+    owner = "evcxr";
     repo = "evcxr";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-8dV+NNtU4HFerrgRyc1kO+MSsMTJJItTtJylEIN014g=";
@@ -91,7 +91,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Evaluation context for Rust";
-    homepage = "https://github.com/google/evcxr";
+    homepage = "https://github.com/evcxr/evcxr";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       protoben

--- a/pkgs/by-name/ev/eventstore/package.nix
+++ b/pkgs/by-name/ev/eventstore/package.nix
@@ -19,8 +19,8 @@ buildDotnetModule rec {
   version = "24.10.6";
 
   src = fetchFromGitHub {
-    owner = "EventStore";
-    repo = "EventStore";
+    owner = "kurrent-io";
+    repo = "KurrentDB";
     tag = "v${version}";
     hash = "sha256-8/sagvMyJ1/onGMuJ28QLWI5M8dBDWyGOcZKUv3PJsQ=";
     leaveDotGit = true;

--- a/pkgs/by-name/ex/expected-lite/package.nix
+++ b/pkgs/by-name/ex/expected-lite/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.10.0";
 
   src = fetchFromGitHub {
-    owner = "martinmoene";
+    owner = "nonstd-lite";
     repo = "expected-lite";
     rev = "v${finalAttrs.version}";
     hash = "sha256-nxwdymBNbd+RuL8rKi2Fx2gC68TnJe7WnoN0O01lecQ=";
@@ -28,8 +28,8 @@ stdenv.mkDerivation (finalAttrs: {
     description = ''
       Expected objects in C++11 and later in a single-file header-only library
     '';
-    homepage = "https://github.com/martinmoene/expected-lite";
-    changelog = "https://github.com/martinmoene/expected-lite/blob/${finalAttrs.src.rev}/CHANGES.txt";
+    homepage = "https://github.com/nonstd-lite/expected-lite";
+    changelog = "https://github.com/nonstd-lite/expected-lite/blob/${finalAttrs.src.rev}/CHANGES.txt";
     license = lib.licenses.boost;
     maintainers = with lib.maintainers; [ azahi ];
   };

--- a/pkgs/by-name/fa/faba-icon-theme/package.nix
+++ b/pkgs/by-name/fa/faba-icon-theme/package.nix
@@ -16,7 +16,7 @@ stdenvNoCC.mkDerivation rec {
   version = "4.3";
 
   src = fetchFromGitHub {
-    owner = "moka-project";
+    owner = "snwh";
     repo = "faba-icon-theme";
     rev = "v${version}";
     sha256 = "0xh6ppr73p76z60ym49b4d0liwdc96w41cc5p07d48hxjsa6qd6n";

--- a/pkgs/by-name/fc/fcitx5-tokyonight/package.nix
+++ b/pkgs/by-name/fc/fcitx5-tokyonight/package.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation {
   version = "0-unstable-2024-01-28";
 
   src = fetchFromGitHub {
-    owner = "ch3n9w";
+    owner = "ch4xer";
     repo = "fcitx5-Tokyonight";
     rev = "f7454ab387d6b071ee12ff7ee819f0c7030fdf2c";
     hash = "sha256-swOy0kDZUdqtC2sPSZEBLnHSs8dpQ/QfFMObI6BARfo=";
@@ -36,7 +36,7 @@ stdenvNoCC.mkDerivation {
 
   meta = {
     description = "Fcitx5 theme based on Tokyo Night color";
-    homepage = "https://github.com/ch3n9w/fcitx5-Tokyonight";
+    homepage = "https://github.com/ch4xer/fcitx5-Tokyonight";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ Guanran928 ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/fc/fcppt/package.nix
+++ b/pkgs/by-name/fc/fcppt/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "5.0.0";
 
   src = fetchFromGitHub {
-    owner = "freundlich";
+    owner = "cpreh";
     repo = "fcppt";
     rev = finalAttrs.version;
     hash = "sha256-8dBG6LdSngsutBboqb3WVVg3ylayoUYDOJV6p/ZFkoE=";

--- a/pkgs/by-name/fe/feather-tk/package.nix
+++ b/pkgs/by-name/fe/feather-tk/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.4.0";
 
   src = fetchFromGitHub {
-    owner = "darbyjohnston";
+    owner = "grizzlypeak3d";
     repo = "feather-tk";
     tag = finalAttrs.version;
     hash = "sha256-hcV99y14o3YFUtKDLEKaR7MxBB3pBdd3sferrYvtvYw=";
@@ -90,12 +90,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Lightweight toolkit for building cross-platform applications";
-    homepage = "https://github.com/darbyjohnston/feather-tk";
+    homepage = "https://github.com/grizzlypeak3d/feather-tk";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ liberodark ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
     badPlatforms = [
-      # Broken on darwin with latest SDK, see https://github.com/darbyjohnston/feather-tk/issues/1
+      # Broken on darwin with latest SDK, see https://github.com/grizzlypeak3d/feather-tk/issues/1
       lib.systems.inspect.patterns.isDarwin
     ];
   };

--- a/pkgs/by-name/fe/ferrishot/package.nix
+++ b/pkgs/by-name/fe/ferrishot/package.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "nik-rev";
-    repo = "ferrishot";
+    repo = "peashot";
     tag = "v${finalAttrs.version}";
     hash = "sha256-QnIHLkxqL/4s6jgIbGmzR5tqCjH7yJcfpx0AhdxqVKc=";
   };
@@ -60,8 +60,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Screenshot app written in Rust";
-    homepage = "https://github.com/nik-rev/ferrishot";
-    changelog = "https://github.com/nik-rev/ferrishot/blob/v${finalAttrs.version}/CHANGELOG.md";
+    homepage = "https://github.com/nik-rev/peashot";
+    changelog = "https://github.com/nik-rev/peashot/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ GaetanLepage ];
     mainProgram = "ferrishot";

--- a/pkgs/by-name/fe/fet-sh/package.nix
+++ b/pkgs/by-name/fe/fet-sh/package.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation rec {
   version = "1.9";
 
   src = fetchFromGitHub {
-    owner = "6gk";
+    owner = "eepykate";
     repo = "fet.sh";
     rev = "v${version}";
     sha256 = "sha256-xhX2nVteC3T3IjQh++mYlm0btDJQbyQa6b8sGualV0E=";
@@ -25,7 +25,7 @@ stdenvNoCC.mkDerivation rec {
 
   meta = {
     description = "Fetch written in posix shell without any external commands";
-    homepage = "https://github.com/6gk/fet.sh";
+    homepage = "https://github.com/eepykate/fet.sh";
     license = lib.licenses.isc;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ elkowar ];

--- a/pkgs/by-name/fi/findup/package.nix
+++ b/pkgs/by-name/fi/findup/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.0.0";
 
   src = fetchFromGitHub {
-    owner = "booniepepper";
+    owner = "so-dang-cool";
     repo = "findup";
     tag = "v${finalAttrs.version}";
     hash = "sha256-6/rQ4xNfzJQwJgrpvFRuirqlx6fVn7sLXfVRFsG3fUw=";
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
 
   meta = {
-    homepage = "https://github.com/booniepepper/findup";
+    homepage = "https://github.com/so-dang-cool/findup";
     description = "Search parent directories for sentinel files";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ booniepepper ];

--- a/pkgs/by-name/fl/flintlock/package.nix
+++ b/pkgs/by-name/fl/flintlock/package.nix
@@ -14,7 +14,7 @@ buildGoModule (finalAttrs: {
   version = "0.8.1";
 
   src = fetchFromGitHub {
-    owner = "weaveworks";
+    owner = "liquidmetal-dev";
     repo = "flintlock";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-Kbk94sqj0aPsVonPsiu8kbjhIOURB1kX9Lt3NURL+jk=";

--- a/pkgs/by-name/fl/fluxcd-operator-mcp/package.nix
+++ b/pkgs/by-name/fl/fluxcd-operator-mcp/package.nix
@@ -13,7 +13,7 @@ buildGoModule (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "controlplaneio-fluxcd";
-    repo = "fluxcd-operator";
+    repo = "flux-operator";
     tag = "v${finalAttrs.version}";
     hash = "sha256-l+IJtFmVR3WZaFW4aaYjirTqj+X1FGLAVgbA21MHO1k=";
   };

--- a/pkgs/by-name/fl/fluxcd-operator/package.nix
+++ b/pkgs/by-name/fl/fluxcd-operator/package.nix
@@ -13,7 +13,7 @@ buildGoModule (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "controlplaneio-fluxcd";
-    repo = "fluxcd-operator";
+    repo = "flux-operator";
     tag = "v${finalAttrs.version}";
     hash = "sha256-l+IJtFmVR3WZaFW4aaYjirTqj+X1FGLAVgbA21MHO1k=";
   };

--- a/pkgs/by-name/fl/flye/package.nix
+++ b/pkgs/by-name/fl/flye/package.nix
@@ -17,7 +17,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "fenderglass";
+    owner = "mikolmogorov";
     repo = "flye";
     tag = finalAttrs.version;
     hash = "sha256-ZdrAxPKY3+HJ388tGCdpDcvW70mJ5wd4uOUkuufyqK8=";

--- a/pkgs/by-name/fo/fooyin/package.nix
+++ b/pkgs/by-name/fo/fooyin/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.9.2";
 
   src = fetchFromGitHub {
-    owner = "ludouzi";
+    owner = "fooyin";
     repo = "fooyin";
     tag = "v" + finalAttrs.version;
     hash = "sha256-sQ1zsQ/6OHGPkofiKhusCrpW2XnO+PpMvH1M2OG5Huw=";

--- a/pkgs/by-name/fo/foxmarks/package.nix
+++ b/pkgs/by-name/fo/foxmarks/package.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "2.1.1";
 
   src = fetchFromGitHub {
-    owner = "zer0-x";
+    owner = "zefr0x";
     repo = "foxmarks";
     rev = "v${finalAttrs.version}";
     hash = "sha256-6lJ9acVo444RMxc3wUakBz4zT74oNUpwoP69rdf2mmE=";
@@ -22,8 +22,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "CLI read-only interface for Mozilla Firefox's bookmarks";
-    homepage = "https://github.com/zer0-x/foxmarks";
-    changelog = "https://github.com/zer0-x/foxmarks/blob/v${finalAttrs.version}/CHANGELOG.md";
+    homepage = "https://github.com/zefr0x/foxmarks";
+    changelog = "https://github.com/zefr0x/foxmarks/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ loicreynier ];
   };

--- a/pkgs/by-name/fp/fprettify/package.nix
+++ b/pkgs/by-name/fp/fprettify/package.nix
@@ -10,7 +10,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "pseewald";
+    owner = "fortran-lang";
     repo = "fprettify";
     rev = "v${finalAttrs.version}";
     sha256 = "17v52rylmsy3m3j5fcb972flazykz2rvczqfh8mxvikvd6454zyj";

--- a/pkgs/by-name/fr/freebayes/package.nix
+++ b/pkgs/by-name/fr/freebayes/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     name = "freebayes-${finalAttrs.version}-src";
-    owner = "ekg";
+    owner = "freebayes";
     repo = "freebayes";
     tag = "v${finalAttrs.version}";
     sha256 = "035nriknjqq8gvil81vvsmvqwi35v80q8h1cw24vd1gdyn1x7bys";
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Bayesian haplotype-based polymorphism discovery and genotyping";
     license = lib.licenses.mit;
-    homepage = "https://github.com/ekg/freebayes";
+    homepage = "https://github.com/freebayes/freebayes";
     maintainers = with lib.maintainers; [ jdagilliland ];
     platforms = [ "x86_64-linux" ];
   };

--- a/pkgs/by-name/fr/frescobaldi/package.nix
+++ b/pkgs/by-name/fr/frescobaldi/package.nix
@@ -13,7 +13,7 @@ python3Packages.buildPythonApplication rec {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "wbsoft";
+    owner = "frescobaldi";
     repo = "frescobaldi";
     tag = "v${version}";
     hash = "sha256-IgvjKj0+8oNbuZ91n4O16kGXBS7rS63HQUNQnJcOis8=";

--- a/pkgs/by-name/fs/fsql/package.nix
+++ b/pkgs/by-name/fs/fsql/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "0.5.2";
 
   src = fetchFromGitHub {
-    owner = "kshvmdn";
+    owner = "kashav";
     repo = "fsql";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-U6TPszqsZvoz+9GIB0wNYMRJqIDLOp/BZO3/k8FC0Gs=";
@@ -24,7 +24,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Search through your filesystem with SQL-esque queries";
-    homepage = "https://github.com/kshvmdn/fsql";
+    homepage = "https://github.com/kashav/fsql";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ pSub ];
     mainProgram = "fsql";

--- a/pkgs/by-name/fs/fsrx/package.nix
+++ b/pkgs/by-name/fs/fsrx/package.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "1.0.2";
 
   src = fetchFromGitHub {
-    owner = "thatvegandev";
+    owner = "jrnxf";
     repo = "fsrx";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-hzfpjunP20WCt3erYu7AO7A3nz+UMKdFzWUA5jASbVA=";
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Flow state reader in the terminal";
-    homepage = "https://github.com/thatvegandev/fsrx";
+    homepage = "https://github.com/jrnxf/fsrx";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ MoritzBoehme ];
     mainProgram = "fsrx";

--- a/pkgs/by-name/fw/fwup/package.nix
+++ b/pkgs/by-name/fw/fwup/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.15.1";
 
   src = fetchFromGitHub {
-    owner = "fhunleth";
+    owner = "fwup-home";
     repo = "fwup";
     tag = "v${finalAttrs.version}";
     hash = "sha256-SIRDVlC/g+rq5m4Ind7dqPzjdCjAxRK/kAdXt6byL/8=";
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     changelog = "https://github.com/fwup-home/fwup/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     description = "Configurable embedded Linux firmware update creator and runner";
-    homepage = "https://github.com/fhunleth/fwup";
+    homepage = "https://github.com/fwup-home/fwup";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.georgewhewell ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/ga/galaxy-buds-client/package.nix
+++ b/pkgs/by-name/ga/galaxy-buds-client/package.nix
@@ -22,7 +22,7 @@ buildDotnetModule rec {
   version = "5.2.1";
 
   src = fetchFromGitHub {
-    owner = "ThePBone";
+    owner = "timschneeb";
     repo = "GalaxyBudsClient";
     tag = version;
     hash = "sha256-jPVrSkf6Bybwc5glkxId5VeWkwLBoTjOzM3CCgO6h9I=";
@@ -85,7 +85,7 @@ buildDotnetModule rec {
 
   meta = {
     description = "Unofficial Galaxy Buds Manager";
-    homepage = "https://github.com/ThePBone/GalaxyBudsClient";
+    homepage = "https://github.com/timschneeb/GalaxyBudsClient";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ icy-thought ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/ge/gemget/package.nix
+++ b/pkgs/by-name/ge/gemget/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "1.9.0";
 
   src = fetchFromGitHub {
-    owner = "makeworld-the-better-one";
+    owner = "makew0rld";
     repo = "gemget";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-P5+yRaf2HioKOclJMMm8bJ8/BtBbNEeYU57TceZVqQ8=";
@@ -19,7 +19,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Command line downloader for the Gemini protocol";
-    homepage = "https://github.com/makeworld-the-better-one/gemget";
+    homepage = "https://github.com/makew0rld/gemget";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ amfl ];
     mainProgram = "gemget";

--- a/pkgs/by-name/gi/git-annex-remote-rclone/package.nix
+++ b/pkgs/by-name/gi/git-annex-remote-rclone/package.nix
@@ -11,7 +11,7 @@ stdenvNoCC.mkDerivation rec {
   version = "0.8";
 
   src = fetchFromGitHub {
-    owner = "DanielDent";
+    owner = "git-annex-remote-rclone";
     repo = "git-annex-remote-rclone";
     rev = "v${version}";
     sha256 = "sha256-B6x67XXE4BHd3x7a8pQlqPPmpy0c62ziDAldB4QpqQ4=";
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation rec {
   '';
 
   meta = {
-    homepage = "https://github.com/DanielDent/git-annex-remote-rclone";
+    homepage = "https://github.com/git-annex-remote-rclone/git-annex-remote-rclone";
     description = "Use rclone supported cloud storage providers with git-annex";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.all;

--- a/pkgs/by-name/gi/git-bug-migration/package.nix
+++ b/pkgs/by-name/gi/git-bug-migration/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "0.3.4";
 
   src = fetchFromGitHub {
-    owner = "MichaelMure";
+    owner = "git-bug";
     repo = "git-bug-migration";
     rev = "v${finalAttrs.version}";
     hash = "sha256-IOBgrU3C0ZHD2wx9LRVgKEJzDlUj6z2UXlHGU3tdTdQ=";
@@ -32,7 +32,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Tool for upgrading repositories using git-bug to new versions";
-    homepage = "https://github.com/MichaelMure/git-bug-migration";
+    homepage = "https://github.com/git-bug/git-bug-migration";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       DeeUnderscore

--- a/pkgs/by-name/gi/git-graph/package.nix
+++ b/pkgs/by-name/gi/git-graph/package.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.7.0";
 
   src = fetchFromGitHub {
-    owner = "mlange-42";
+    owner = "git-bahn";
     repo = "git-graph";
     tag = "v${finalAttrs.version}";
     hash = "sha256-9GFwxWYDnH3kKDWpxgh7ciSLB1Zr2zExxIrIrhycmZY=";
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Command line tool to show clear git graphs arranged for your branching model";
-    homepage = "https://github.com/mlange-42/git-graph";
+    homepage = "https://github.com/git-bahn/git-graph";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       cafkafk

--- a/pkgs/by-name/gi/git-igitt/package.nix
+++ b/pkgs/by-name/gi/git-igitt/package.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.1.21";
 
   src = fetchFromGitHub {
-    owner = "mlange-42";
+    owner = "git-bahn";
     repo = "git-igitt";
     rev = "v${finalAttrs.version}";
     hash = "sha256-5AVKBew+HShWFZwm4xRmRSL76N2c84Yi97jgcqsslxM=";
@@ -38,7 +38,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Interactive, cross-platform Git terminal application with clear git graphs arranged for your branching model";
-    homepage = "https://github.com/mlange-42/git-igitt";
+    homepage = "https://github.com/git-bahn/git-igitt";
     license = lib.licenses.mit;
     sourceProvenance = [ lib.sourceTypes.fromSource ];
     maintainers = [ lib.maintainers.pinage404 ];

--- a/pkgs/by-name/gi/git-quick-stats/package.nix
+++ b/pkgs/by-name/gi/git-quick-stats/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     repo = "git-quick-stats";
-    owner = "arzzen";
+    owner = "git-quick-stats";
     rev = finalAttrs.version;
     sha256 = "sha256-YVvlrlNRDDci7fH9LW4NxZcIkakVgvKe9FhJ2gCfoXg=";
   };
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
 
   meta = {
-    homepage = "https://github.com/arzzen/git-quick-stats";
+    homepage = "https://github.com/git-quick-stats/git-quick-stats";
     description = "Simple and efficient way to access various statistics in git repository";
     platforms = lib.platforms.all;
     maintainers = [ lib.maintainers.kmein ];

--- a/pkgs/by-name/gi/git-repo/package.nix
+++ b/pkgs/by-name/gi/git-repo/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.59";
 
   src = fetchFromGitHub {
-    owner = "android";
+    owner = "aosp-mirror";
     repo = "tools_repo";
     rev = "v${finalAttrs.version}";
     hash = "sha256-5ffk5B4ZA/Wy2bQNahFaXPFRSZdKz5t6TaGbN00mfxo=";

--- a/pkgs/by-name/gi/gitflow/package.nix
+++ b/pkgs/by-name/gi/gitflow/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "petervanderdoes";
-    repo = "gitflow";
+    repo = "gitflow-avh";
     rev = finalAttrs.version;
     sha256 = "sha256-kHirHG/bfsU6tKyQ0khNSTyChhzHfzib+HyA3LOtBI8=";
   };
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    homepage = "https://github.com/petervanderdoes/gitflow";
+    homepage = "https://github.com/petervanderdoes/gitflow-avh";
     description = "Extend git with the Gitflow branching model";
     mainProgram = "git-flow";
     longDescription = ''

--- a/pkgs/by-name/gi/gitqlient/package.nix
+++ b/pkgs/by-name/gi/gitqlient/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.6.3-unstable-2025-09-11"; # cmake does not install correctly on tagged release
 
   src = fetchFromGitHub {
-    owner = "francescmm";
+    owner = "francescmaestre";
     repo = "gitqlient";
     rev = "faa3e2c19205123944bb88427a569c6f1b4366a1";
     fetchSubmodules = true;

--- a/pkgs/by-name/gl/glabels-qt/package.nix
+++ b/pkgs/by-name/gl/glabels-qt/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   version = "unstable-2025-12-03";
 
   src = fetchFromGitHub {
-    owner = "jimevins";
+    owner = "j-evins";
     repo = "glabels-qt";
     tag = "3.99-master602";
     hash = "sha256-7MQufoU1GBvmZd8FRn331/PwmwQMuZeuFKQqViRI754=";
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "GLabels Label Designer (Qt/C++)";
-    homepage = "https://github.com/jimevins/glabels-qt";
+    homepage = "https://github.com/j-evins/glabels-qt";
     license = lib.licenses.gpl3Only;
     maintainers = [ lib.maintainers.matthewcroughan ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/gl/glava/package.nix
+++ b/pkgs/by-name/gl/glava/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.6.3";
 
   src = fetchFromGitHub {
-    owner = "wacossusca34";
+    owner = "jarcode-foss";
     repo = "glava";
     rev = "v${finalAttrs.version}";
     sha256 = "0kqkjxmpqkmgby05lsf6c6iwm45n33jk5qy6gi3zvjx4q4yzal1i";
@@ -96,7 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
       OpenGL audio spectrum visualizer
     '';
     mainProgram = "glava";
-    homepage = "https://github.com/wacossusca34/glava";
+    homepage = "https://github.com/jarcode-foss/glava";
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/gm/gmap/package.nix
+++ b/pkgs/by-name/gm/gmap/package.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.3.3";
 
   src = fetchFromGitHub {
-    owner = "seeyebe";
+    owner = "marawny";
     repo = "gmap";
     tag = finalAttrs.version;
     hash = "sha256-+klVySOgI/M57f98Cx3omkEBx/NcaWD4FuIW6cz1aN8=";
@@ -41,8 +41,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
       Built for developers who live in the CLI and want quick,
       powerful insights.
     '';
-    homepage = "https://github.com/seeyebe/gmap";
-    changelog = "https://github.com/seeyebe/gmap/releases/tag/${finalAttrs.src.tag}";
+    homepage = "https://github.com/marawny/gmap";
+    changelog = "https://github.com/marawny/gmap/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ yiyu ];
     mainProgram = "gmap";

--- a/pkgs/by-name/gn/gnome-inform7/package.nix
+++ b/pkgs/by-name/gn/gnome-inform7/package.nix
@@ -104,7 +104,7 @@ stdenv.mkDerivation {
   version = "unstable-2021-04-06";
   src = fetchFromGitHub {
     owner = "ptomato";
-    repo = "gnome-inform7";
+    repo = "inform7-ide";
     # build from revision in the GTK3 branch as mainline requires webkit-1.0
     rev = "c37e045c159692aae2e4e79b917e5f96cfefa66a";
     sha256 = "Q4xoITs3AYXhvpWaABRAvJaUWTtUl8lYQ1k9zX7FrNw=";
@@ -143,7 +143,7 @@ stdenv.mkDerivation {
     longDescription = ''
       This version of Inform 7 for the Gnome platform was created by Philip Chimento, based on a design by Graham Nelson and Andrew Hunter.
     '';
-    homepage = "https://github.com/ptomato/gnome-inform7";
+    homepage = "https://github.com/ptomato/inform7-ide";
     license = lib.licenses.gpl3Only;
     maintainers = [ lib.maintainers.fitzgibbon ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/gn/gnome-pomodoro/package.nix
+++ b/pkgs/by-name/gn/gnome-pomodoro/package.nix
@@ -27,8 +27,8 @@ stdenv.mkDerivation rec {
   version = "0.28.1";
 
   src = fetchFromGitHub {
-    owner = "gnome-pomodoro";
-    repo = "gnome-pomodoro";
+    owner = "focustimerhq";
+    repo = "FocusTimer";
     rev = version;
     hash = "sha256-1G0Sv6uR4rE+/TZqEM57mCdBaXoJNpC0cznY4pnPEa4=";
   };

--- a/pkgs/by-name/go/go-autoconfig/package.nix
+++ b/pkgs/by-name/go/go-autoconfig/package.nix
@@ -9,7 +9,7 @@ buildGoModule {
   version = "unstable-2022-08-03";
 
   src = fetchFromGitHub {
-    owner = "L11R";
+    owner = "savely-krasovsky";
     repo = "go-autoconfig";
     rev = "b1b182202da82cc881dccd715564853395d4f76a";
     sha256 = "sha256-Rbg6Ghp5NdcLSLSIhwwFFMKmZPWsboDyHCG6ePqSSZA=";
@@ -23,7 +23,7 @@ buildGoModule {
 
   meta = {
     description = "IMAP/SMTP autodiscover feature for Thunderbird, Apple Mail and Microsoft Outlook";
-    homepage = "https://github.com/L11R/go-autoconfig";
+    homepage = "https://github.com/savely-krasovsky/go-autoconfig";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ onny ];
     mainProgram = "go-autoconfig";

--- a/pkgs/by-name/go/go-dnscollector/package.nix
+++ b/pkgs/by-name/go/go-dnscollector/package.nix
@@ -10,7 +10,7 @@ buildGoModule (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "dmachard";
-    repo = "go-dnscollector";
+    repo = "DNS-collector";
     tag = "v${finalAttrs.version}";
     hash = "sha256-Gm5PXEEgw98NnsfKN8JxhyTqEL9KSA6L2CgRTRJirdY=";
   };
@@ -21,7 +21,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Ingesting, pipelining, and enhancing your DNS logs with usage indicators, security analysis, and additional metadata";
-    homepage = "https://github.com/dmachard/go-dnscollector";
+    homepage = "https://github.com/dmachard/DNS-collector";
     changelog = "https://github.com/dmachard/DNS-collector/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ shift ];


### PR DESCRIPTION
This PR updates some `fetchFromGitHub` calls and corresponding `github.com/<owner>/<repo>` links in the same location to point directly to canonical repositories instead of redirecting URLs.

This doesn't update all `fetchFromGitHub` redirects since that would produce a diff too large for maintainers to review.

**Motivation:**
This avoids silent failures if upstream redirects ever change or disappear, and improves reliability and reproducibility of fetches.

**How:**
Changes were generated using [this script](https://git.kybe.xyz/2kybe3/nixpkgs-github-redirect).

**How to verify:**
You can verify that all modified package sources still build using the following script with a `changed.txt` file containing the changed package list.

<details>
  <summary>Verify script</summary>

```bash
#!/usr/bin/env bash

out="result.txt"
: > "$out"

while read -r pkg; do
    echo "=== $pkg ==="

    output=$(nix build "./nixpkgs#$pkg.src" -L -v --rebuild --no-link --print-out-paths)
    status=$?

    if [ $status -eq 0 ]; then
        echo "$pkg: success | $output" | tee -a "$out"
    else
        echo "$pkg: failed" | tee -a "$out"
    fi
done < ./changed.txt
```
</details>

<details>
  <summary>Changed Packages</summary>

```
effitask
eksctl
elfcat
emissary
embree
ente-auth
ente-cli
ente-desktop
ente-web
esshader
etherpad-lite
evcxr
eventstore
expected-lite
faba-icon-theme
fcitx5-tokyonight
fcppt
ferrishot
feather-tk
fet-sh
findup
flintlock
fluxcd-operator
fluxcd-operator-mcp
fooyin
flye
foxmarks
freebayes
fprettify
fsql
frescobaldi
fsrx
fwup
galaxy-buds-client
gemget
git-annex-remote-rclone
git-bug-migration
git-graph
git-quick-stats
git-igitt
gitRepo
gitflow
gitqlient
glabels-qt
glava
gmap
gnome-inform7
gnome-pomodoro
go-dnscollector
go-autoconfig
```
</details>

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
