### PR TITLE
opentofu-mcp-server: 1.0.0 -> 1.0.0-unstable-2026-06-09, pnpm_8 -> pnpm_10

### DIFF
--- a/pkgs/by-name/op/opentofu-mcp-server/package.nix
+++ b/pkgs/by-name/op/opentofu-mcp-server/package.nix
@@ -4,15 +4,15 @@
   fetchFromGitHub,
   fetchPnpmDeps,
   nodejs,
-  nix-update-script,
-  pnpm_8,
+  pnpm_10,
   pnpmConfigHook,
   makeWrapper,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "opentofu-mcp-server";
-  version = "1.0.0";
+  version = "1.0.0-unstable-2026-06-09";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -20,20 +20,20 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "opentofu";
     repo = "opentofu-mcp-server";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-qgjAnoduzAjvxgbgG8QW53CMF3/bW0NQhDbVv3ebntw=";
+    rev = "59ee379fff12389a25e75dc26768f8602e505a91";
+    hash = "sha256-pPeqlJ/M7ylD7bniVbw/HqsFkZywHISmzpqsQG0VhoU=";
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    fetcherVersion = 3;
-    pnpm = pnpm_8;
-    hash = "sha256-8U+yGjUtgpASLU5LewUMRFT0uxz45trw27+HH/h+sdA=";
+    fetcherVersion = 4;
+    pnpm = pnpm_10;
+    hash = "sha256-N9+sbSsae1wOmHkOQ1+Km97w7T+BLuZKdskWZs8c4kw=";
   };
 
   nativeBuildInputs = [
     nodejs
-    pnpm_8
+    pnpm_10
     pnpmConfigHook
     makeWrapper
   ];
@@ -54,12 +54,14 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
 
   meta = {
     description = "OpenTofu MCP server for accessing the OpenTofu Registry";
     homepage = "https://github.com/opentofu/opentofu-mcp-server";
-    changelog = "https://github.com/opentofu/opentofu-mcp-server/releases/tag/${finalAttrs.src.tag}";
+    changelog = "https://github.com/opentofu/opentofu-mcp-server/commits/main";
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [ eana ];
     mainProgram = "opentofu-mcp-server";


### PR DESCRIPTION
`opentofu-mcp-server` was pinned to `v1.0.0` which ships a `lockfileVersion: '6.0'` lockfile (pnpm 8 format). pnpm 8 is EOL as of 2025-04-30 (nixpkgs issue #529286). pnpm 9/10/11 all reject that lockfile format, so a straight version swap was not possible.

Upstream `main` already has `lockfileVersion: '9.0'` (pnpm 10 compatible) and `package.json` version `1.0.1`, but no tag has been cut yet. This PR bumps to an unstable snapshot of `main` at `59ee379` (2026-06-09) and migrates to `pnpm_10` + `fetcherVersion = 4`, resolving both #529286 and #529285. `unstableGitUpdater` is used so the package will auto-track `main` until upstream tags `v1.0.1`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
