### PR TITLE
plakar: 1.0.6 -> 1.1.4

### DIFF
--- a/pkgs/by-name/pl/plakar/package.nix
+++ b/pkgs/by-name/pl/plakar/package.nix
@@ -8,7 +8,7 @@
 }:
 buildGo125Module (finalAttrs: {
   pname = "plakar";
-  version = "1.1.3";
+  version = "1.1.4";
 
   # to avoid having all the Test(Get|Set|Validate)Service.* tests fail on darwin
   __darwinAllowLocalNetworking = true;
@@ -17,10 +17,10 @@ buildGo125Module (finalAttrs: {
     owner = "PlakarKorp";
     repo = "plakar";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-AQyE8VtTdkuevBVMLDfhN1h6/DirdhLgPu+76QfRUas=";
+    hash = "sha256-Urj1BG3XGhSroaa9pl9NGiKj38J1P+H9sA7noGwIhdc=";
   };
 
-  vendorHash = "sha256-nueFE6Ka1dq4Rt+Qs9YJU9N+yYfEyA8jkVGC4vKLjSI=";
+  vendorHash = "sha256-aqHjSTVVxBbaHAZZNQaFbftN0Hbl/+7wgk5uFM664po=";
 
   buildInputs = [
     fuse

--- a/pkgs/by-name/pl/plakar/package.nix
+++ b/pkgs/by-name/pl/plakar/package.nix
@@ -8,16 +8,19 @@
 }:
 buildGo125Module (finalAttrs: {
   pname = "plakar";
-  version = "1.0.6";
+  version = "1.1.3";
+
+  # to avoid having all the Test(Get|Set|Validate)Service.* tests fail on darwin
+  __darwinAllowLocalNetworking = true;
 
   src = fetchFromGitHub {
     owner = "PlakarKorp";
     repo = "plakar";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-X8m2dXMb+cxWBbKm0MhhY2pNSBTUONyHoPnGlDG9jOg=";
+    hash = "sha256-AQyE8VtTdkuevBVMLDfhN1h6/DirdhLgPu+76QfRUas=";
   };
 
-  vendorHash = "sha256-6MdwUJTu9QvqZ3iGEg39L5B5mce7JssFTF3ZmoTuH3M=";
+  vendorHash = "sha256-nueFE6Ka1dq4Rt+Qs9YJU9N+yYfEyA8jkVGC4vKLjSI=";
 
   buildInputs = [
     fuse
@@ -30,8 +33,8 @@ buildGo125Module (finalAttrs: {
   checkFlags =
     let
       skippedTests = [
-        # mount: fusermount: exec: "fusermount": executable file not found in $PATH
-        "TestExecuteCmdMountDefault"
+        # hangs even outside Nix, so probably an upstream issue:
+        "TestRebuildStateVersionMismatch"
       ]
       ++ lib.optionals stdenv.hostPlatform.isDarwin [
         "TestBTreeScanMemory"

--- a/pkgs/by-name/pl/plakar/package.nix
+++ b/pkgs/by-name/pl/plakar/package.nix
@@ -53,6 +53,7 @@ buildGo125Module (finalAttrs: {
     maintainers = with lib.maintainers; [
       heph2
       qbit
+      nadir-ishiguro
     ];
   };
 })


### PR DESCRIPTION
Manual backport of  #532041 and #537620

  Done:

  - don't skip test "TestExecuteCmdMountDefault"
  - skip test "TestRebuildStateVersionMismatch"
  - add `__darwinAllowLocalNetworking = true;` to avoid having all the Test(Get|Set|Validate)Service.* tests fail on Darwin
  - add nadir-ishiguro to maintainers

  Changelogs:

  - https://github.com/PlakarKorp/plakar/releases/tag/v1.1.4
  - https://github.com/PlakarKorp/plakar/releases/tag/v1.1.3
  - https://github.com/PlakarKorp/plakar/releases/tag/v1.1.2
  - https://github.com/PlakarKorp/plakar/releases/tag/v1.1.1
  - https://github.com/PlakarKorp/plakar/releases/tag/v1.1.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
