### PR TITLE
explo: init at 1.1.2

### DIFF
--- a/pkgs/by-name/ex/explo/package.nix
+++ b/pkgs/by-name/ex/explo/package.nix
@@ -1,0 +1,92 @@
+{
+  lib,
+  buildGoModule,
+  buildNpmPackage,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "explo";
+  version = "1.1.2";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "LumePart";
+    repo = "Explo";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-7FIDRNZn+Yh2c/oLU3Ggb4A9y+5q3vv17eVLmGR2Zeo=";
+  };
+
+  webui = buildNpmPackage {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      meta
+      ;
+
+    sourceRoot = "${finalAttrs.src.name}/src/web/frontend";
+
+    npmDepsHash = "sha256-N+i+VFHKJ9OxHyQKJ3vSw50N3tLjvFVPeG5aU0hLzqw=";
+
+    buildPhase = ''
+      runHook preBuild
+
+      npx vite build --outDir dist
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      cp -r dist/* $out
+
+      runHook postInstall
+    '';
+  };
+
+  vendorHash = "sha256-pa3WaVJU4WY/EyE3VttfEVOwwaxvkfxQj0wrwOmefYQ=";
+
+  ldflags = [
+    "-X explo/src/config.Version=${finalAttrs.version}"
+  ];
+
+  preBuild = ''
+    mkdir -p src/web/dist
+    cp -r ${finalAttrs.webui}/* src/web/dist
+  '';
+
+  postInstall = ''
+    mv $out/bin/main $out/bin/explo
+    mkdir -p $out/share/explo
+    cp src/downloader/youtube_music/search_ytmusic.py $out/share/explo/
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--subpackage"
+      "webui"
+    ];
+  };
+
+  meta = {
+    description = "Spotify's \"Discover Weekly\" for self-hosted music systems";
+    homepage = "https://github.com/LumePart/Explo/";
+    changelog = "https://github.com/LumePart/Explo/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      lilacious
+      arunoruto
+    ];
+    mainProgram = "explo";
+  };
+})


### PR DESCRIPTION
Supersedes #421299 

Adds my mentioned fixes for the derivation and updates it to the latest available versin. Should be automatically updated in the future :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
