### PR TITLE
captive-browser: 0-unstable-2021-08-01 -> 0-unstable-2025-11-05

### DIFF
--- a/nixos/modules/programs/captive-browser.nix
+++ b/nixos/modules/programs/captive-browser.nix
@@ -21,8 +21,6 @@ let
     types
     ;
 
-  requiresSetcapWrapper = config.boot.kernelPackages.kernelOlder "5.7" && cfg.bindInterface;
-
   browserDefault =
     chromium:
     concatStringsSep " " [
@@ -144,12 +142,5 @@ in
         else
           throw "programs.captive-browser.dhcp-dns must be set"
       );
-
-    security.wrappers.captive-browser = mkIf requiresSetcapWrapper {
-      owner = "root";
-      group = "root";
-      capabilities = "cap_net_raw+p";
-      source = "${captive-browser-configured}/bin/captive-browser";
-    };
   };
 }

--- a/nixos/modules/programs/captive-browser.nix
+++ b/nixos/modules/programs/captive-browser.nix
@@ -28,11 +28,20 @@ let
       "${chromium}/bin/chromium"
       "--user-data-dir=\${XDG_DATA_HOME:-$HOME/.local/share}/chromium-captive"
       ''--proxy-server="socks5://$PROXY"''
-      ''--host-resolver-rules="MAP * ~NOTFOUND , EXCLUDE localhost"''
+      ''--proxy-bypass-list="<-loopback>"''
       "--no-first-run"
       "--new-window"
       "--incognito"
       "-no-default-browser-check"
+      "--no-crash-upload"
+      "--disable-extensions"
+      "--disable-sync"
+      "--disable-background-networking"
+      "--disable-client-side-phishing-detection"
+      "--disable-component-update"
+      "--disable-translate"
+      "--disable-web-resources"
+      "--safebrowsing-disable-auto-update"
       "http://cache.nixos.org/"
     ];
 

--- a/pkgs/by-name/ca/captive-browser/package.nix
+++ b/pkgs/by-name/ca/captive-browser/package.nix
@@ -2,34 +2,25 @@
   lib,
   fetchFromGitHub,
   buildGoModule,
-  fetchpatch,
 }:
 
-buildGoModule {
+buildGoModule (finalAttrs: {
   pname = "captive-browser";
-  version = "0-unstable-2021-08-01";
+  version = "0-unstable-2025-11-05";
 
   src = fetchFromGitHub {
-    owner = "FiloSottile";
+    owner = "pacoorozco";
     repo = "captive-browser";
-    rev = "9c707dc32afc6e4146e19b43a3406329c64b6f3c";
-    sha256 = "sha256-65lPo5tpE0M/VyyvlzlcVSuHX4AhhVuqK0UF4BIAH/Y=";
+    rev = "ca6f74e132ecf298c87936d4c946fd551aefbbf7";
+    sha256 = "sha256-wojx28GFg9whfkNxUbOVDVNHp8M7SLsmRBTP/Jh8nLQ=";
   };
 
-  vendorHash = "sha256-2MFdQ2GIDAdLPuwAiGPO9wU3mm2BDXdyTwoVA1xVlcQ=";
-  deleteVendor = true;
-
-  patches = [
-    # Add go modules support
-    (fetchpatch {
-      url = "https://github.com/FiloSottile/captive-browser/commit/ef50837778ef4eaf38b19887e79c8b6fa830c342.patch";
-      hash = "sha256-w+jDFeO94pMu4ir+G5CzqYlXxYOm9+YfyzbU3sbTyiY=";
-    })
-  ];
+  vendorHash = "sha256-8FMFgCJUTalJ45GR5UnyXqN6s0gVFtiy6zjugbngDYQ=";
 
   ldflags = [
     "-s"
     "-w"
+    "-X main.Version=${finalAttrs.version}"
   ];
 
   meta = {
@@ -38,4 +29,4 @@ buildGoModule {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ ma27 ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Please review commit-by-commit.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
