### PR TITLE
doc/styles: distinct colors for admonitions

### DIFF
--- a/doc/style.css
+++ b/doc/style.css
@@ -350,21 +350,33 @@ div.appendix .important > :last-child {
 }
 
 div.book .note,
-div.book .tip,
-div.book .important,
-div.appendix .note,
-div.appendix .tip,
-div.appendix .important {
+div.appendix .note {
   color: var(--note-text-color);
   background: var(--note-background);
 }
 
+div.book .tip,
+div.appendix .tip {
+  color: var(--tip-text-color);
+  background: var(--tip-background);
+}
+
+div.book .important,
+div.appendix .important {
+  color: var(--important-text-color);
+  background: var(--important-background);
+}
+
 div.book .warning,
-div.book .caution,
-div.appendix .warning,
-div.appendix .caution {
+div.appendix .warning {
   color: var(--warning-text-color);
-  background-color: var(--warning-background);
+  background: var(--warning-background);
+}
+
+div.book .caution,
+div.appendix .caution {
+  color: var(--caution-text-color);
+  background: var(--caution-background);
 }
 
 div.book .section,
@@ -461,10 +473,21 @@ div.appendix .variablelist .term {
   --link-color: #405d99;
   --heading-color: #6586c8;
   --small-heading-color: #6a6a6a;
-  --note-text-color: #5277c3;
-  --note-background: #f2f8fd;
-  --warning-text-color: #cc3900;
-  --warning-background: #fff5e1;
+  /* NOTE */
+  --note-text-color: #0065d2;
+  --note-background: #e4f5ff;
+  /* TIP */
+  --tip-text-color: #188000;
+  --tip-background: #e8fae3;
+  /* IMPORTANT */
+  --important-text-color: #8a3db8;
+  --important-background: #fbedff;
+  /* WARNING */
+  --warning-text-color: #aa4a00;
+  --warning-background: #fff0db;
+  /* CAUTION */
+  --caution-text-color: #be222a;
+  --caution-background: #ffebe8;
   --codeblock-background: #f2f8fd;
   --codeblock-text-color: #000;
 }
@@ -475,18 +498,33 @@ div.appendix .variablelist .term {
     --main-text-color: #fff;
     --link-color: #6586c8;
     --small-heading-color: #fff;
-    --note-background: none;
-    --warning-background: none;
+    /* NOTE */
+    --note-text-color: #66c6ff;
+    --note-background: #1e2f44;
+    /* TIP */
+    --tip-text-color: #80e05f;
+    --tip-background: #22331d;
+    /* IMPORTANT */
+    --important-text-color: #ea9dff;
+    --important-background: #35273f;
+    /* WARNING */
+    --warning-text-color: #ffaa00;
+    --warning-background: #3c2a13;
+    /* CAUTION */
+    --caution-text-color: #ff8c84;
+    --caution-background: #422522;
     --codeblock-background: #393939;
     --codeblock-text-color: #fff;
   }
 
   div.book .note,
   div.book .tip,
-  div.appendix .note,
-  div.appendix .tip,
+  div.book .important,
   div.book .warning,
   div.book .caution,
+  div.appendix .note,
+  div.appendix .tip,
+  div.appendix .important,
   div.appendix .warning,
   div.appendix .caution {
     border: 2px solid;

--- a/doc/style.css
+++ b/doc/style.css
@@ -216,11 +216,7 @@ h3 {
   color: var(--heading-color);
 }
 
-.note h3,
-.tip h3,
-.warning h3,
-.caution h3,
-.important h3 {
+:is(.note, .tip, .warning, .caution, .important) h3 {
   font-size: 120%;
 }
 
@@ -290,16 +286,7 @@ div.appendix .programlisting {
   color: var(--codeblock-text-color);
 }
 
-div.book .note,
-div.book .tip,
-div.book .warning,
-div.book .caution,
-div.book .important,
-div.appendix .note,
-div.appendix .tip,
-div.appendix .warning,
-div.appendix .caution,
-div.appendix .important {
+:is(.note, .tip, .warning, .caution, .important) {
   margin-bottom: 1rem;
   border-radius: 0.5rem;
   padding: 1.5rem;
@@ -307,74 +294,42 @@ div.appendix .important {
   background: #f4f4f4;
 }
 
-div.book .note > .title,
-div.book .tip > .title,
-div.book .warning > .title,
-div.book .caution > .title,
-div.book .important > .title,
-div.appendix .note > .title,
-div.appendix .tip > .title,
-div.appendix .warning > .title,
-div.appendix .caution > .title,
-div.appendix .important > .title {
+:is(.note, .tip, .warning, .caution, .important) > .title {
   font-weight: 800;
   line-height: 110%;
   color: inherit;
   margin-bottom: 0;
 }
 
-div.book .note > :first-child,
-div.book .tip > :first-child,
-div.book .warning > :first-child,
-div.book .caution > :first-child,
-div.book .important > :first-child,
-div.appendix .note > :first-child,
-div.appendix .tip > :first-child,
-div.appendix .warning > :first-child,
-div.appendix .caution > :first-child,
-div.appendix .important > :first-child {
+:is(.note, .tip, .warning, .caution, .important) > :first-child {
   margin-top: 0;
 }
 
-div.book .note > :last-child,
-div.book .tip > :last-child,
-div.book .warning > :last-child,
-div.book .caution > :last-child,
-div.book .important > :last-child,
-div.appendix .note > :last-child,
-div.appendix .tip > :last-child,
-div.appendix .warning > :last-child,
-div.appendix .caution > :last-child,
-div.appendix .important > :last-child {
+:is(.note, .tip, .warning, .caution, .important) > :last-child {
   margin-bottom: 0;
 }
 
-div.book .note,
-div.appendix .note {
+.note {
   color: var(--note-text-color);
   background: var(--note-background);
 }
 
-div.book .tip,
-div.appendix .tip {
+.tip {
   color: var(--tip-text-color);
   background: var(--tip-background);
 }
 
-div.book .important,
-div.appendix .important {
+.important {
   color: var(--important-text-color);
   background: var(--important-background);
 }
 
-div.book .warning,
-div.appendix .warning {
+.warning {
   color: var(--warning-text-color);
   background: var(--warning-background);
 }
 
-div.book .caution,
-div.appendix .caution {
+.caution {
   color: var(--caution-text-color);
   background: var(--caution-background);
 }
@@ -517,16 +472,7 @@ div.appendix .variablelist .term {
     --codeblock-text-color: #fff;
   }
 
-  div.book .note,
-  div.book .tip,
-  div.book .important,
-  div.book .warning,
-  div.book .caution,
-  div.appendix .note,
-  div.appendix .tip,
-  div.appendix .important,
-  div.appendix .warning,
-  div.appendix .caution {
+  :is(.note, .tip, .warning, .caution, .important) {
     border: 2px solid;
     font-weight: 400;
   }


### PR DESCRIPTION
Made sure every text-background pair passes WCAG-AA https://webaim.org/resources/contrastchecker/

Second commit cleans up .css, there is no point in those excessive css selectors.
The only point would be the ability to embed the .css into other websites, but it already leaks into globals (html,body, etc.)


List of all:

<img width="1208" height="586" alt="image" src="https://github.com/user-attachments/assets/db7205b9-fb56-4132-bcc8-a4fa7f6bd038" />


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
