### PR TITLE
nixos/isso: add secret file option

### DIFF
--- a/nixos/modules/services/web-apps/isso.nix
+++ b/nixos/modules/services/web-apps/isso.nix
@@ -37,6 +37,8 @@ in
 
           See [Isso Server Configuration](https://posativ.org/isso/docs/configuration/server/)
           for supported values.
+          You can set secrets using the secretFile option with environment variables following
+          [the documentation](https://isso-comments.de/docs/reference/server-config/#environment-variables).
         '';
 
         type = types.submodule {
@@ -51,6 +53,16 @@ in
           }
         '';
       };
+
+      secretFile = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          A file containing secrets as environment variables that will be used in the configuration.
+          See [the documentation](https://isso-comments.de/docs/reference/server-config/#environment-variables) for details.
+        '';
+        example = "/run/secrets/isso.env";
+      };
     };
   };
 
@@ -64,6 +76,8 @@ in
       serviceConfig = {
         User = "isso";
         Group = "isso";
+
+        EnvironmentFile = mkIf (cfg.secretFile != null) [ cfg.secretFile ];
 
         DynamicUser = true;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added a secret file option to the isso service. This was currently lacking meaning secrets had to be defined in the normal nix config, which would leak them into the nix store. I took some inspiration from the listmonk option with the same name <https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/mail/listmonk.nix>. I tested it locally on my server and it works, see the testing branch here: <https://github.com/MartV0/homelab/compare/isso-secret-file>. This is my first ever nix pull request so any feedback is more than welcome.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
