### PR TITLE
lib.warnOnInstantiate: only warn when instantiating

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -38,6 +38,8 @@
   Additionally, the kernel module tree used inside the VM has been split out of the `kernel` argument into a new `kernelModules` argument (defaulting to `kernel`).
   Callers that overrode `kernel` with a module tree (e.g. from `pkgs.aggregateModules`) to make extra modules available must now pass it via `kernelModules` instead, keeping `kernel` pointing at a bootable kernel derivation.
 
+- `lib.warnOnInstantiate` now only warns when evaluating a `drvPath` or output path, like `outPath`.
+
 - The ARMv5 Linux kernel build now uses a standard configuration and generates a standard compressed image instead of the deprecated legacy U‐Boot image format.
   `lib.systems.{examples,platforms}.{sheevaplug,pogoplug4}` have been unified into `lib.systems.examples.armv5tel-multiplatform`.
   Note that there is no official support for ARMv5 and it is not possible to build even a simple NixOS configuration out of the box.

--- a/lib/derivations.nix
+++ b/lib/derivations.nix
@@ -14,6 +14,7 @@ let
     ;
 
   inherit (lib.trivial)
+    isFunction
     warn
     ;
 
@@ -274,10 +275,8 @@ in
     drv
     // genAttrs paths (name: warn msg drv.${name})
     // genAttrs (drv.outputs or [ ]) (name: warnOnInstantiate msg drv.${name})
-    // (
-      if drv ? overrideAttrs && builtins.isFunction drv.overrideAttrs then
-        { overrideAttrs = x: lib.derivations.warnOnInstantiate msg (drv.overrideAttrs x); }
-      else
-        { }
-    );
+    // {
+      ${if isFunction (drv.overrideAttrs or null) then "overrideAttrs" else null} =
+        args: warnOnInstantiate msg (drv.overrideAttrs args);
+    };
 }

--- a/lib/derivations.nix
+++ b/lib/derivations.nix
@@ -2,10 +2,23 @@
 
 let
   inherit (lib)
-    genAttrs
     isString
-    mapAttrs
-    removeAttrs
+    ;
+
+  inherit (lib.attrsets)
+    genAttrs
+    ;
+
+  inherit (lib.lists)
+    filter
+    ;
+
+  inherit (lib.trivial)
+    warn
+    ;
+
+  inherit (lib.derivations)
+    warnOnInstantiate
     ;
 
   showMaybeAttrPosPre =
@@ -221,9 +234,7 @@ in
   /**
     Wrap a derivation such that instantiating it produces a warning.
 
-    All attributes will be wrapped with `lib.warn` except from `.meta`, `.name`,
-    and `.type` which are used by `nix search`, and `.outputName` which avoids
-    double warnings with `nix-instantiate` and `nix-build`.
+    The `drvPath`, `outPath`, and `shellPath` attributes will be wrapped with `lib.warn` in the derivation and its outputs.
 
     # Inputs
 
@@ -254,15 +265,15 @@ in
   warnOnInstantiate =
     msg: drv:
     let
-      drvToWrap = removeAttrs drv [
-        "meta"
-        "name"
-        "type"
-        "outputName"
+      paths = filter (name: drv ? ${name}) [
+        "drvPath"
+        "outPath"
+        "shellPath"
       ];
     in
     drv
-    // mapAttrs (_: lib.warn msg) drvToWrap
+    // genAttrs paths (name: warn msg drv.${name})
+    // genAttrs (drv.outputs or [ ]) (name: warnOnInstantiate msg drv.${name})
     // (
       if drv ? overrideAttrs && builtins.isFunction drv.overrideAttrs then
         { overrideAttrs = x: lib.derivations.warnOnInstantiate msg (drv.overrideAttrs x); }


### PR DESCRIPTION
TL;DR: make `lib.warnOnInstantiate` do what it says on the tin.

Historically, `lib.warnOnInstantiate` was essentially a "lazy warn" with a few explicit exceptions:
- `meta`
- `name`
- `type`
- `outputName`

That approximated an "on instantiate" behaviour, but we can do better without paying any real performance or complexity cost.

"Instantiation" happens when `drvPath` is used, but a dependency on a derivation also happens when its `outPath` is used, so for practical purposes this is effectively also instantiation. The same applies to a derivation's outputs, which also have `drvPath` and `outPath`.

This refactor flips the logic from a fragile blacklist to a precise whitelist, based on how derivations are _actually_ instantiated:

1. Derivation path attrs (`drvPath`, `outPath`, `shellPath`).
2. Recursively wrap output attrs listed in `drv.outputs` (`drv.out`, `drv.dev`, `drv.man`, etc) with `warnOnInstantiate`. This catches users targeting specific multi-output paths (like `nix-build -A pkg.dev` or `"${pkg.dev}"`).

Also, while I'm here I applied some cleanup to the `overrideAttrs` wrapping.

1. There should be no behaviour changes for intended use-cases of `warnOnInstantiate`.
2. However, it is now possible to evaluate metadata, passthrus, etc without triggering a warning.
   Reflecting what the function claims to do.

### Tests

As there is no test-coverage for `warnOnInstantiate`, and I felt like adapting `lib/tests/debug.sh` to cover it would bloat this PR too much, I asked a LLM to generate a one-off sanity check script based on me grepping for `warnOnInstantiate` usage:

<details><summary>Script</summary>

```bash
#!/usr/bin/env bash
set -euo pipefail

NIX_PATH=nixpkgs=$(pwd)
export NIX_PATH

work="$(mktemp -d)"
trap 'rm -rf "$work"' EXIT

die() {
  echo >&2 -e "❌ Test case failed: $1"
  exit 1
}

# Evaluates an expression and asserts it produces NO stderr
expectNoWarning() {
  local expr=$1
  local desc=$2

  if ! nix-instantiate --eval --strict --json --expr "$expr" 2>"$work/stderr" >/dev/null; then
    die "Evaluation failed for $desc\nExpr: $expr"
  fi

  if [[ -s "$work/stderr" ]]; then
    die "Unexpected warning/error captured on stderr for $desc:\n$(cat "$work/stderr")"
  fi
}

# Evaluates an expression and asserts it produces the expected warning substring
expectWarning() {
  local expr=$1
  local desc=$2
  local expected_substring=$3

  if ! nix-instantiate --eval --expr "$expr" 2>"$work/stderr" >/dev/null; then
    die "Evaluation failed for $desc\nExpr: $expr"
  fi

  if [[ ! "$(<"$work/stderr")" =~ $expected_substring ]]; then
    die "Expected warning message containing '$expected_substring' was missing for $desc!\nGot instead:\n$(cat "$work/stderr")"
  fi
}

echo "=================================================="
echo " Running warnOnInstantiate Multi-Output Matrix    "
echo "=================================================="

# Define the packages we want to test on-the-fly
TARGET_PACKAGES=("hello" "git")

for pkg in "${TARGET_PACKAGES[@]}"; do
  echo "👉 Testing dynamically wrapped package: pkgs.$pkg"

  # Base expression that wraps the target package cleanly
  BASE_EXPR="let pkgs = import <nixpkgs> {}; wrapped = pkgs.lib.warnOnInstantiate \"TEST_WARN_FOR_$pkg\" pkgs.$pkg; in"

  # 1. Test Top-Level Passthru vs Instantiation
  expectNoWarning "$BASE_EXPR wrapped.name" "Top-level metadata (.name)"
  expectNoWarning "$BASE_EXPR wrapped.meta" "Top-level metadata (.meta)"
  expectWarning   "$BASE_EXPR wrapped.outPath" "Top-level instantiation (.outPath)" "TEST_WARN_FOR_$pkg"
  expectWarning   "$BASE_EXPR wrapped.drvPath" "Top-level instantiation (.drvPath)" "TEST_WARN_FOR_$pkg"

  # 2. Extract outputs of the package to test child projections dynamically
  outputs=( $(nix-instantiate --eval --json -A "$pkg.outputs" | jq --raw-output .[]) )

  for output in "${outputs[@]}"; do
    echo "   -> Verifying output projection: .$output"

    # Nested output metadata should be silent
    expectNoWarning "$BASE_EXPR wrapped.${output}.name" "Output projection metadata (.$output.name)"
    expectNoWarning "$BASE_EXPR wrapped.${output}.type" "Output projection metadata (.$output.type)"

    # Nested output path evaluation should trigger the warning
    expectWarning   "$BASE_EXPR wrapped.${output}.outPath" "Output projection path (.$output.outPath)" "TEST_WARN_FOR_$pkg"
  done

  echo "   ✅ pkgs.$pkg behaves perfectly!"
  echo "--------------------------------------------------"
done

echo "=================================================="
echo " 🎉 SUCCESS: All multi-output checks passed!     "
echo "=================================================="
```

</details>

<details><summary>Output</summary>

```
$ ./test-warn.sh
==================================================
 Running warnOnInstantiate Multi-Output Matrix
==================================================
👉 Testing dynamically wrapped package: pkgs.hello
   -> Verifying output projection: .out
   ✅ pkgs.hello behaves perfectly!
--------------------------------------------------
👉 Testing dynamically wrapped package: pkgs.git
   -> Verifying output projection: .out
   -> Verifying output projection: .doc
   -> Verifying output projection: .debug
   ✅ pkgs.git behaves perfectly!
--------------------------------------------------
==================================================
 🎉 SUCCESS: All multi-output checks passed!
==================================================
```

</details>

### Prior discussion

@k900 [on matrix](https://matrix.to/#/!CTCrFzsBPYmDLmrja4:0upti.me/$lwsM_PScGyRPF9RjCmRe4LWmUgVjIHHmDg3itcyTp-A?via=nixos.org&via=matrix.org&via=tchncs.de)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Major `lib` change
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
