### PR TITLE
babashka: remove rlwrap

### DIFF
--- a/pkgs/by-name/ba/babashka/package.nix
+++ b/pkgs/by-name/ba/babashka/package.nix
@@ -1,22 +1,11 @@
 {
   stdenvNoCC,
-  lib,
   babashka-unwrapped,
   callPackage,
   makeWrapper,
   installShellFiles,
-  rlwrap,
   clojureToolsBabashka ? callPackage ./clojure-tools.nix { },
   jdkBabashka ? clojureToolsBabashka.jdk,
-
-  # rlwrap is a small utility to allow the editing of keyboard input, see
-  # https://book.babashka.org/#_repl
-  #
-  # NOTE In some cases, rlwrap prints some extra empty lines. That behavior can
-  # break some babashka scripts. For this reason, it is disabled by default. See:
-  # https://github.com/NixOS/nixpkgs/issues/246839
-  # https://github.com/NixOS/nixpkgs/pull/248207
-  withRlwrap ? false,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "babashka";
@@ -30,28 +19,20 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     installShellFiles
   ];
 
-  installPhase =
-    let
-      unwrapped-bin = "${babashka-unwrapped}/bin/bb";
-    in
-    ''
-      mkdir -p $out/clojure_tools
-      ln -s -t $out/clojure_tools ${clojureToolsBabashka}/*.edn
-      ln -s -t $out/clojure_tools ${clojureToolsBabashka}/libexec/*
+  installPhase = ''
+    mkdir -p $out/clojure_tools
+    ln -s -t $out/clojure_tools ${clojureToolsBabashka}/*.edn
+    ln -s -t $out/clojure_tools ${clojureToolsBabashka}/libexec/*
 
-      makeWrapper "${babashka-unwrapped}/bin/bb" "$out/bin/bb" \
-        --inherit-argv0 \
-        --set-default DEPS_CLJ_TOOLS_DIR $out/clojure_tools \
-        --set-default JAVA_HOME ${jdkBabashka}
+    makeWrapper "${babashka-unwrapped}/bin/bb" "$out/bin/bb" \
+      --inherit-argv0 \
+      --set-default DEPS_CLJ_TOOLS_DIR $out/clojure_tools \
+      --set-default JAVA_HOME ${jdkBabashka}
 
-      installShellCompletion --cmd bb --bash ${babashka-unwrapped}/share/bash-completion/completions/bb.bash
-      installShellCompletion --cmd bb --zsh ${babashka-unwrapped}/share/zsh/site-functions/_bb
-      installShellCompletion --cmd bb --fish ${babashka-unwrapped}/share/fish/vendor_completions.d/bb.fish
-    ''
-    + lib.optionalString withRlwrap ''
-      substituteInPlace $out/bin/bb \
-        --replace '"${unwrapped-bin}"' '"${rlwrap}/bin/rlwrap" "${unwrapped-bin}"'
-    '';
+    installShellCompletion --cmd bb --bash ${babashka-unwrapped}/share/bash-completion/completions/bb.bash
+    installShellCompletion --cmd bb --zsh ${babashka-unwrapped}/share/zsh/site-functions/_bb
+    installShellCompletion --cmd bb --fish ${babashka-unwrapped}/share/fish/vendor_completions.d/bb.fish
+  '';
 
   installCheckPhase = ''
     ${babashka-unwrapped.installCheckPhase}


### PR DESCRIPTION
Babashka now includes JLine, rlwrap is no longer needed.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
