### PR TITLE
nixos/matrix-authentication-service: make injecting secret files easier

### DIFF
--- a/nixos/modules/services/matrix/matrix-authentication-service.nix
+++ b/nixos/modules/services/matrix/matrix-authentication-service.nix
@@ -67,7 +67,19 @@ in
         [configuration reference](https://element-hq.github.io/matrix-authentication-service/usage/configuration.html)
         for possible values.
 
-        Secrets should be passed in by using the `extraConfigFiles` option.
+        Secrets can be injected as follows:
+
+        ```
+        systemd.services.matrix-authentication-service.serviceConfig.LoadCredential = [
+          "oidc_client_secret:/path/to/my/secret"
+        ];
+        services.matrix-authentication-service.settings.upstream_oauth2.providers = [{
+          client_secret_file = "\''${CREDENTIALS_DIRECTORY}/oidc_client_secret";
+        }];
+        ```
+        `
+        If there's no file-based option for a secret inside matrix-authentication-service,
+        use [](#opt-services.matrix-authentication-service.extraConfigFiles) instead.
       '';
       type = types.submodule {
         freeformType = format.type;
@@ -387,16 +399,18 @@ in
     systemd.services.matrix-authentication-service = rec {
       after = optional cfg.createDatabase "postgresql.service" ++ cfg.serviceDependencies;
       wants = after;
+      path = [ pkgs.envsubst ];
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
         DynamicUser = true;
-        ExecStartPre = ''
-          ${getExe cfg.package} config check \
-            ${concatMapStringsSep " " (x: "--config ${x}") ([ configFile ] ++ cfg.extraConfigFiles)}
+        ExecStartPre = pkgs.writeShellScript "mas-prepare" ''
+          envsubst -i ${configFile} > /run/matrix-authentication-service/config.yaml
+          ${getExe cfg.package} config check --config /run/matrix-authentication-service/config.yaml \
+            ${concatMapStringsSep " " (x: "--config ${x}") cfg.extraConfigFiles}
         '';
         ExecStart = ''
-          ${getExe cfg.package} server \
-            ${concatMapStringsSep " " (x: "--config ${x}") ([ configFile ] ++ cfg.extraConfigFiles)}
+          ${getExe cfg.package} server --config /run/matrix-authentication-service/config.yaml \
+            ${concatMapStringsSep " " (x: "--config ${x}") cfg.extraConfigFiles}
         '';
         Restart = "on-failure";
         RestartSec = "1s";
@@ -438,6 +452,7 @@ in
         # Working and state directories
         StateDirectory = "matrix-authentication-service";
         StateDirectoryMode = "0700";
+        RuntimeDirectory = "matrix-authentication-service";
         WorkingDirectory = "/var/lib/matrix-authentication-service";
       };
     };

--- a/nixos/tests/matrix/matrix-authentication-service.nix
+++ b/nixos/tests/matrix/matrix-authentication-service.nix
@@ -67,7 +67,7 @@ in
 
   name = "matrix-authentication-service-upstream";
   meta = {
-    teams = [ lib.teams.matrix ];
+    maintainers = lib.teams.matrix.members;
   };
 
   nodes = {
@@ -237,7 +237,7 @@ in
               {
                 id = masULID;
                 client_id = oidcClientID;
-                client_secret = oidcClientSecret;
+                client_secret_file = "\${CREDENTIALS_DIRECTORY}/oidc_client_secret";
                 issuer = "https://${dexDomain}:5556";
                 scope = "openid email profile";
                 token_endpoint_auth_method = "client_secret_post";
@@ -245,6 +245,9 @@ in
             ];
           };
         };
+        systemd.services.matrix-authentication-service.serviceConfig.SetCredential = [
+          "oidc_client_secret:${oidcClientSecret}"
+        ];
         services.postgresql.authentication = pkgs.lib.mkOverride 10 ''
           local all all trust
           host  all all 127.0.0.1/32 trust


### PR DESCRIPTION
I still think that #537261 is a bad idea since it effectively means that you'll need to put the entire OIDC configuration into a secret-file[1].

It is NOT WRONG to use the module-system to inject values into e.g. services, that's literally what it's for! In other words,

    systemd.services.matrix-authentication-service.serviceConfig.LoadCredential = [
      ...
    ];

is the way to go.

This also adds envsubst such that you can reference the credentials directory via $CREDENTIALS_DIRECTORY.

[1] unless you use sops templates, but that's not a standard NixOS
    solution


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
