### PR TITLE
hacksguard: init at 0.1

### DIFF
--- a/pkgs/by-name/ha/hacksguard/package.nix
+++ b/pkgs/by-name/ha/hacksguard/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  pkg-config,
+  rustPlatform,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "hacksguard";
+  version = "0.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Rhacknarok";
+    repo = "hacksguard";
+    tag = finalAttrs.version;
+    hash = "sha256-kS8VF1zD4VV9rSLz4euvNwtOUFWLeW2isAjgjw/iay0=";
+  };
+
+  cargoHash = "sha256-7Wt2cFKwWT82P2uxOy/lGEWZcCUSu0BNr9JdgRLwBnw=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Multi-threaded TUI malware analysis tool";
+    homepage = "https://github.com/Rhacknarok/hacksguard";
+    changelog = "https://github.com/Rhacknarok/hacksguard/releases/tag/${finalAttrs.src.tag}";
+    # https://github.com/Rhacknarok/hacksguard/issues/1
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "hacksguard";
+  };
+})


### PR DESCRIPTION
Multi-threaded TUI malware analysis tool

https://github.com/Rhacknarok/hacksguard

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
