### PR TITLE
umami: 3.1.0 -> 3.2.0

### DIFF
--- a/pkgs/by-name/um/umami/package.nix
+++ b/pkgs/by-name/um/umami/package.nix
@@ -47,12 +47,12 @@ let
   # to guarantee compatibility.
   prisma-engines' = prisma-engines_7.overrideAttrs (
     finalAttrs: prevAttrs: {
-      version = "7.6.0";
+      version = "7.8.0";
       src = fetchFromGitHub {
         owner = "prisma";
         repo = "prisma-engines";
         tag = finalAttrs.version;
-        hash = "sha256-NMoAaiTa68i51lR6iMCyHyCAsFuuhPx2+tHFSSoqWqA=";
+        hash = "sha256-nquIcOmFz+ikD0x/YEPZ5NVKCFPCdR5MSCHldn+b9jI=";
       };
       cargoHash = "sha256-uiFvzxwVJXCW9LUDFRC6ZkzSa7LQk+9ZJcaJw8mrBX4=";
 
@@ -66,23 +66,23 @@ let
   );
   prisma' = (prisma_7.override { prisma-engines_7 = prisma-engines'; }).overrideAttrs (
     finalAttrs: prevAttrs: {
-      version = "7.6.0";
+      version = "7.8.0";
       src = fetchFromGitHub {
         owner = "prisma";
         repo = "prisma";
         tag = finalAttrs.version;
-        hash = "sha256-BesX2ySfgew6+9Q6fnhZ8gMnnxh4D4fefaA5BhehlHE=";
+        hash = "sha256-89q5433z54h3oGX+lEYDQykN2mNltGz4+LWlYSE75/E=";
       };
       pnpmDeps = prevAttrs.pnpmDeps.override {
         inherit (finalAttrs) src version;
-        hash = "sha256-ZOpNt+W5b1troicfkCi4wCCDtwhTB4VlPgxYMZetcs0=";
+        hash = "sha256-mrFU5SAF4QuTBJj5TP8tUkYDG4zchttjcQMLtx6OBnI=";
       };
     }
   );
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "umami";
-  version = "3.1.0";
+  version = "3.2.0";
 
   nativeBuildInputs = [
     makeWrapper
@@ -96,7 +96,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     owner = "umami-software";
     repo = "umami";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-EH3ebwTbajcNasn25ets2w068ZmCQRYUY2XON39J5HA=";
+    hash = "sha256-0nfCcaST06cTg43Rz1rCV8GYYDjQLP+6TrVRJF2/Yuk=";
   };
 
   # Umami uses next/font/google, which tries to download from Google Fonts at build time.
@@ -116,11 +116,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       src
       ;
     inherit pnpm;
-    fetcherVersion = 3;
-    hash = "sha256-QNWmCsVFh8xpsO4ZPTaKGszwuRaxTrWLMVh/6VV5oIw=";
+    fetcherVersion = 4;
+    hash = "sha256-6ho5xoVdqZdihThL5q8+RhVPfaSwu1y3+p9d8DnfO3o=";
   };
 
-  env.CYPRESS_INSTALL_BINARY = "0";
   env.NODE_ENV = "production";
   env.NEXT_TELEMETRY_DISABLED = "1";
 
@@ -144,7 +143,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   checkPhase = ''
     runHook preCheck
 
-    pnpm test
+    # Tests fail if NODE_ENV=production
+    NODE_ENV=development pnpm test
 
     runHook postCheck
   '';

--- a/pkgs/by-name/um/umami/sources.json
+++ b/pkgs/by-name/um/umami/sources.json
@@ -1,7 +1,7 @@
 {
   "geocities": {
-    "rev": "6a3ef689a4673ff2bf292548716e7cc6c5a2c903",
-    "date": "2026-04-16",
-    "hash": "sha256-GUUeFU1DKGL+NpzK1oJlsyB/VrFWe6Lj7U7yJXj8mNo="
+    "rev": "04017f13909e499135afea605a1e07427e845641",
+    "date": "2026-07-02",
+    "hash": "sha256-4IYGsxNGdzilI0mYXlwEo43auqNug307pYyPuilR3aw="
   }
 }


### PR DESCRIPTION
https://github.com/umami-software/umami/releases/tag/v3.2.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
