### PR TITLE
kbd-ergol: init at 0-unstable-2026-07-03

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -30426,6 +30426,13 @@
     github = "x807x";
     githubId = 86676478;
   };
+  xaltsc = {
+    email = "hey+dev@xaltsc.dev";
+    matrix = "@xaltsc:matrix.org";
+    name = "xaltsc";
+    github = "xaltsc";
+    githubId = 41400742;
+  };
   xanderio = {
     name = "Alexander Sieg";
     email = "alex@xanderio.de";

--- a/pkgs/by-name/kb/kbd-ergol/package.nix
+++ b/pkgs/by-name/kb/kbd-ergol/package.nix
@@ -1,0 +1,36 @@
+{
+  stdenv,
+  fetchFromCodeberg,
+  lib,
+  nix-update-script,
+}:
+stdenv.mkDerivation {
+  pname = "kbd-ergol";
+  version = "0-unstable-2026-07-03";
+
+  src = fetchFromCodeberg {
+    owner = "Alerymin";
+    repo = "kbd-ergol";
+    rev = "5111b8c90cee7daddb6c49115ba1ca665b2102ab";
+    hash = "sha256-kkxsTFNXGO8dly8r/EQyKL/JWZC4hUnq67rHChhwmkU=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  # console.nix expects keymaps to be under /share/keymaps
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace "/usr/share/kbd/" "$out/share/"
+  '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    description = "Ergo-L layout in keymap format for linux console";
+    homepage = "https://codeberg.org/Alerymin/kbd-ergol";
+    maintainers = with lib.maintainers; [ xaltsc ];
+    platforms = lib.platforms.linux;
+    license = lib.licenses.wtfpl;
+  };
+}


### PR DESCRIPTION
This package makes it possible to make [Ergo-L](https://ergol.org) keymaps available to the linux console (through the NixOS option `console.packages` for instance). Ergo-L has long been available on `xkb` but is noticeably absent from `kbd`, for various reasons, including technical difficulties in implementing the full layout within the framework of `kbd`.

The repo that is the source of this package, while not official (as much as things can be official within the Ergo-L project), is the one recommended by the community.

This package should be backported as far back as possible, I doubt there will be any conflicts.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`. (No binary, but tested that adding it to `console.packages` did enable `loadkeys` to use it).
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
