### PR TITLE
obliteratus: 0.1.2-unstable-2026-03-05 -> 0-unstable-2026-06-17

### DIFF
--- a/pkgs/by-name/ob/obliteratus/package.nix
+++ b/pkgs/by-name/ob/obliteratus/package.nix
@@ -1,26 +1,27 @@
 {
   lib,
-  python3,
+  stdenv,
+  python3Packages,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "obliteratus";
-  version = "0.1.2-unstable-2026-03-05";
+  version = "0-unstable-2026-06-17";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "elder-plinius";
     repo = "OBLITERATUS";
-    rev = "984ce140592a9385347934f9ca647413ba9fac76";
-    hash = "sha256-U5DcRC1/IEQRlBGLIfsCX48ZCxPkpzEhg8qIw3ytJps=";
+    rev = "a5a1ffa5849b442cf188b3c03fd4de71ddf5bdcc";
+    hash = "sha256-IxIpUlVlZRzXan53mCCsH8AYg/ajNofSm56iUO9XPrg=";
   };
 
-  __structuredAttrs = true;
+  build-system = with python3Packages; [ setuptools ];
 
-  build-system = with python3.pkgs; [ setuptools ];
-
-  dependencies = with python3.pkgs; [
+  dependencies = with python3Packages; [
     accelerate
     bitsandbytes
     datasets
@@ -37,18 +38,44 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     transformers
   ];
 
-  optional-dependencies = with python3.pkgs; {
+  optional-dependencies = with python3Packages; {
     spaces = [ gradio ];
   };
 
-  nativeCheckInputs = with python3.pkgs; [
+  pythonImportsCheck = [ "obliteratus" ];
+
+  nativeCheckInputs = with python3Packages; [
     pytest-cov-stub
     pytestCheckHook
   ];
-  # This increases the build time significantly
-  # ++ lib.flatten (builtins.attrValues finalAttrs.passthru.optional-dependencies);
 
-  pythonImportsCheck = [ "obliteratus" ];
+  disabledTestPaths = [
+    # These tests reference `obliteratus.models.loader._select_model_class`, which upstream
+    # removed/renamed without updating the tests or the benchmark script.
+    "tests/test_gemma4_hard_tier_bench.py"
+    "tests/test_gemma4_support.py"
+  ];
+
+  disabledTests = [
+    # Upstream tests that hardcode expectations the implementation has since outgrown
+    # (e.g. 512 prompts vs the current 842, a stale method set, changed pipeline defaults).
+    "test_default_values"
+    "test_informed_method_in_abliterate_methods"
+    "test_informed_method_standalone"
+    "test_inherits_base_pipeline"
+    "test_linear_cone_fewer_directions"
+    "test_methods_exist"
+    "test_prompt_count_512"
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+    # aarch64-linux fails cpuinfo test, because /sys/devices/system/cpu/ does not exist in the sandbox:
+    # RuntimeError: Failed to initialize cpuinfo!
+    "test_output_dtype_preserved"
+  ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
 
   meta = {
     description = "Ablation Suite for HuggingFace transformers";


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
