### PR TITLE
ibus: disable Python 2 bindings

### DIFF
--- a/pkgs/by-name/ib/ibus/package.nix
+++ b/pkgs/by-name/ib/ibus/package.nix
@@ -128,6 +128,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-python=${python3BuildEnv.interpreter}"
     (lib.enableFeature (!libOnly && dconf != null) "dconf")
     (lib.enableFeature (!libOnly && libnotify != null) "libnotify")
+    "--disable-python2"
     (lib.enableFeature withWayland "wayland")
     (lib.enableFeature enableUI "ui")
     (lib.enableFeature (!libOnly) "gtk3")


### PR DESCRIPTION
Disable ibus' Python 2 binding path explicitly.

IBus 1.5.33 defaults `--enable-python2`; if `python2` is not found, upstream `configure.ac` falls back to `PYTHON2=$PYTHON`. In nixpkgs that means the Python 2 and Python 3 pygobject override installs both target the Python 3 output path and can race over `gi/overrides/IBus.py` during parallel install.

This keeps parallel builds enabled and removes the duplicate install target instead of serializing the whole package or the pygobject directory.

Local validation:
- `nix build -L .#ibus .#ibusMinimal`
- `nix fmt -- pkgs/by-name/ib/ibus/package.nix`
- `./ci/nixpkgs-vet.sh master https://github.com/NixOS/nixpkgs.git`

nixpkgs-review-gha is running: https://github.com/caniko/nixpkgs-review-gha/actions/runs/28678522360

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test