### PR TITLE
mdfried: move env variables into env for structuredAttrs

### DIFF
--- a/pkgs/by-name/md/mdfried/package.nix
+++ b/pkgs/by-name/md/mdfried/package.nix
@@ -59,8 +59,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     libiconv
   ];
 
-  CFLAGS_aarch64_apple_darwin = lib.optionalString stdenv.hostPlatform.isDarwin "-UTARGET_OS_MAC";
-  CXXFLAGS_aarch64_apple_darwin = lib.optionalString stdenv.hostPlatform.isDarwin "-UTARGET_OS_MAC";
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    CFLAGS_aarch64_apple_darwin = "-UTARGET_OS_MAC";
+    CXXFLAGS_aarch64_apple_darwin = "-UTARGET_OS_MAC";
+  };
 
   doCheck = true;
 


### PR DESCRIPTION
New instances of environment variables outside of env should not be introduced.

I cannot test for Darwin myself, but this looks correct? Should have no rebuild for Darwin.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
