### PR TITLE
nixos/sabnzbd: add secretValues option

### DIFF
--- a/nixos/modules/services/networking/sabnzbd/default.nix
+++ b/nixos/modules/services/networking/sabnzbd/default.nix
@@ -117,6 +117,28 @@ in
         default = [ ];
       };
 
+      secretValues = mkOption {
+        type = with types; attrsOf path;
+        description = ''
+          Attrset of patterns in the settings that should be replaced at
+          runtime, just before the service starts, with values read from the
+          given files. The files must be readable by the service user.
+
+          Compared to the secretFiles option, secretValues allows having the
+          full settings structure in Nix, and only externalizing the secret
+          values themselves.
+        '';
+        default = { };
+        example = lib.literalExpression ''
+          {
+            "@my_server_password@" = "/run/secrets/my_server_password";
+            "@my_server_username@" = "/run/secrets/my_server_username";
+            "@sabnzbd_api_key@" = "/run/secrets/sabnzbd_api_key";
+            "@sabnzbd_nzb_key@" = "/run/secrets/sabnzbd_nzb_key";
+          }
+        '';
+      };
+
       allowConfigWrite = mkOption {
         type = types.bool;
         description = ''
@@ -500,6 +522,12 @@ in
             ${./config_merge.py} \
             "''${files[@]}" \
             > "$tmpfile"
+
+          ${lib.concatStringsSep "\n" (
+            lib.mapAttrsToList (n: v: ''
+              "${lib.getExe pkgs.replace-secret}" "${n}" "${v}" "$tmpfile"
+            '') cfg.secretValues
+          )}
 
           install -D \
             -m ${if cfg.allowConfigWrite then "600" else "400"} \

--- a/nixos/tests/sabnzbd-module.nix
+++ b/nixos/tests/sabnzbd-module.nix
@@ -105,6 +105,26 @@ in
       };
     };
 
+  nodes.with_secret_values =
+    { pkgs, ... }:
+    {
+      config = {
+        services.sabnzbd = {
+          enable = true;
+          settings = {
+            misc.api_key = "@api_key@";
+            misc.nzb_key = "@nzb_key@";
+          };
+          secretValues = {
+            # Just for testing; don't use world readable files from the Nix
+            # store in production!
+            "@api_key@" = builtins.toFile "api_key" "dummyapikey";
+            "@nzb_key@" = builtins.toFile "nzb_key" "dummynzbkey";
+          };
+        };
+      };
+    };
+
   testScript = ''
     def wait_for_up(m):
       m.wait_for_unit("sabnzbd.service")
@@ -113,9 +133,12 @@ in
     wait_for_up(machine)
     wait_for_up(with_writeable_config)
     wait_for_up(with_raw_config_file)
+    wait_for_up(with_secret_values)
 
     machine.succeed("do_test")
     with_writeable_config.succeed("do_test")
     with_raw_config_file.succeed("do_test_2")
+    with_secret_values.succeed("grep dummyapikey /var/lib/sabnzbd/sabnzbd.ini")
+    with_secret_values.succeed("grep dummynzbkey /var/lib/sabnzbd/sabnzbd.ini")
   '';
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add a new option to the nixos/sabnzbd module: secretValues.

It's a more fine grained alternative to secretFiles.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
