### PR TITLE
python3Packages.stix2: 3.0.1 -> 3.0.2, python3Packages.stix2-validator: 3.2.0 -> 3.3.1, python3Packages.stix2-patterns: 2.0.0 -> 2.1.2

### DIFF
--- a/pkgs/development/python-modules/stix2-patterns/default.nix
+++ b/pkgs/development/python-modules/stix2-patterns/default.nix
@@ -5,26 +5,24 @@
   fetchFromGitHub,
   pytestCheckHook,
   setuptools,
-  six,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "stix2-patterns";
-  version = "2.0.0";
+  version = "2.1.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "oasis-open";
     repo = "cti-pattern-validator";
-    tag = "v${version}";
-    hash = "sha256-lFgnvI5a7U7/Qj4Pqjr3mx4TNDnC2/Ru7tVG7VggR7Y=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ngRxUeT8ifFM4bpFRtS1ILtTz9lPXtyD8+0MYijWKoM=";
   };
 
   build-system = [ setuptools ];
 
   dependencies = [
     antlr4-python3-runtime
-    six
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
@@ -32,12 +30,11 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "stix2patterns" ];
 
   meta = {
-    broken = lib.versionAtLeast antlr4-python3-runtime.version "4.10";
     description = "Validate patterns used to express cyber observable content in STIX Indicators";
-    mainProgram = "validate-patterns";
     homepage = "https://github.com/oasis-open/cti-pattern-validator";
-    changelog = "https://github.com/oasis-open/cti-pattern-validator/blob/${version}/CHANGELOG.rst";
+    changelog = "https://github.com/oasis-open/cti-pattern-validator/blob/${finalAttrs.src.tag}/CHANGELOG.rst";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "validate-patterns";
   };
-}
+})

--- a/pkgs/development/python-modules/stix2-validator/default.nix
+++ b/pkgs/development/python-modules/stix2-validator/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "stix2-validator";
-  version = "3.2.0";
+  version = "3.3.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "oasis-open";
     repo = "cti-stix-validator";
     tag = "v${version}";
-    hash = "sha256-OI1SXILyCRGl1ZsoyYDl+/RsBhTP24eqECtW3uazS2k=";
+    hash = "sha256-w9SlRspt5tRLdqqEr6UJ+cmq3KM08cN9BqMvdSYay0Y=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/stix2-validator/default.nix
+++ b/pkgs/development/python-modules/stix2-validator/default.nix
@@ -12,7 +12,7 @@
   stix2-patterns,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "stix2-validator";
   version = "3.3.1";
   pyproject = true;
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "oasis-open";
     repo = "cti-stix-validator";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-w9SlRspt5tRLdqqEr6UJ+cmq3KM08cN9BqMvdSYay0Y=";
   };
 
@@ -45,8 +45,8 @@ buildPythonPackage rec {
   meta = {
     description = "Validator for STIX 2.0 JSON normative requirements and best practices";
     homepage = "https://github.com/oasis-open/cti-stix-validator/";
-    changelog = "https://github.com/oasis-open/cti-stix-validator/blob/${src.rev}/CHANGELOG";
+    changelog = "https://github.com/oasis-open/cti-stix-validator/blob/${finalAttrs.src.tag}/CHANGELOG";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/development/python-modules/stix2/default.nix
+++ b/pkgs/development/python-modules/stix2/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "stix2";
-  version = "3.0.1";
+  version = "3.0.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "oasis-open";
     repo = "cti-python-stix2";
     tag = "v${version}";
-    hash = "sha256-1bILZUZgPOWmFWRu4p/fmgi4QPEE1lFQH9mxoWd/saI=";
+    hash = "sha256-qm6VFufD9A4rSBHaDkqeYqOLRvE97SY0++o4ND0l3I0=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/stix2/default.nix
+++ b/pkgs/development/python-modules/stix2/default.nix
@@ -14,7 +14,7 @@
   taxii2-client,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "stix2";
   version = "3.0.2";
   pyproject = true;
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "oasis-open";
     repo = "cti-python-stix2";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-qm6VFufD9A4rSBHaDkqeYqOLRvE97SY0++o4ND0l3I0=";
   };
 
@@ -55,8 +55,8 @@ buildPythonPackage rec {
   meta = {
     description = "Produce and consume STIX 2 JSON content";
     homepage = "https://stix2.readthedocs.io/en/latest/";
-    changelog = "https://github.com/oasis-open/cti-python-stix2/blob/v${version}/CHANGELOG";
+    changelog = "https://github.com/oasis-open/cti-python-stix2/blob/${finalAttrs.src.tag}/CHANGELOG";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ PapayaJackal ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
