### PR TITLE
maintainers: remove happy-river

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10684,12 +10684,6 @@
     githubId = 9850776;
     name = "Hans-Jörg Schurr";
   };
-  happy-river = {
-    email = "happyriver93@runbox.com";
-    github = "happy-river";
-    githubId = 54728477;
-    name = "Happy River";
-  };
   happyalu = {
     email = "alok@parlikar.com";
     github = "happyalu";

--- a/nixos/modules/services/web-apps/mastodon.nix
+++ b/nixos/modules/services/web-apps/mastodon.nix
@@ -1155,7 +1155,6 @@ in
   );
 
   meta.maintainers = with lib.maintainers; [
-    happy-river
     erictapen
   ];
 

--- a/pkgs/by-name/ma/mastodon/package.nix
+++ b/pkgs/by-name/ma/mastodon/package.nix
@@ -187,7 +187,6 @@ stdenv.mkDerivation rec {
       "aarch64-linux"
     ];
     maintainers = with lib.maintainers; [
-      happy-river
       erictapen
       izorkin
       ghuntley


### PR DESCRIPTION
## Reasons

- Last commented in [June 2025](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Ahappy-river)
- Hasn't created any PRs / Issues since [June 2025](https://github.com/NixOS/nixpkgs/issues?q=author%3Ahappy-river)
- About 5 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Ahappy-river%20-commenter%3Ahappy-river%20-author%3Ahappy-river%20-reviewed-by%3Ahappy-river%20created%3A%3E2025-06-01) PRs / Issues (the number is probably higher as they aren't in the NixOS org anymore)

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.
