### PR TITLE
seafile-client: 9.0.15 -> 9.0.20

### DIFF
--- a/pkgs/by-name/se/seafile-client/package.nix
+++ b/pkgs/by-name/se/seafile-client/package.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "seafile-client";
-  version = "9.0.15";
+  version = "9.0.20";
 
   src = fetchFromGitHub {
     owner = "haiwen";
     repo = "seafile-client";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-BV1+9/+ryZB1BQyRJ5JaIU6bbOi4h8vt+V+FQIfUJp8=";
+    hash = "sha256-0idZCoTsuC32DolSLFDknQjvGWHGd4DQPCUyqocuuKA=";
   };
 
   patches = [

--- a/pkgs/by-name/se/seafile-client/package.nix
+++ b/pkgs/by-name/se/seafile-client/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchpatch,
   fetchFromGitHub,
+  nix-update-script,
   pkg-config,
   cmake,
   qt6,
@@ -72,4 +73,5 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     mainProgram = "seafile-applet";
   };
+  passthru.updateScript = nix-update-script { };
 })


### PR DESCRIPTION
Changelog: https://manual.seafile.com/latest/changelog/client-changelog/#9019-20260625

Contains a fix for an SQL injection vulnerability.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
