### PR TITLE
cpond: init at 0-unstable-2025-11-23

### DIFF
--- a/pkgs/by-name/cp/cpond/package.nix
+++ b/pkgs/by-name/cp/cpond/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  ncurses,
+}:
+stdenv.mkDerivation {
+  pname = "cpond";
+  version = "0-unstable-2025-11-23";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "ayuzur";
+    repo = "cpond";
+    rev = "b6d2827c73080b144ff07a70ec61757baff6a73b";
+    hash = "sha256-feRGJ2CIa82eEiGG65WwFlh6dhhIvhW70FJMObWvi1Q=";
+  };
+
+  buildInputs = [ ncurses ];
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail '$(eflags)$(ncursesw_macros)' '$(eflags) $(ncursesw_macros)'
+  ''
+  + lib.optionalString stdenv.isDarwin ''
+    substituteInPlace Makefile \
+      --replace-fail '-lncursesw' '-lncurses'
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp cpond $out/bin/
+  '';
+
+  meta = {
+    homepage = "https://github.com/ayuzur/cpond";
+    description = "Procedurally animated fish for your terminal";
+    license = lib.licenses.mit;
+    mainProgram = "cpond";
+    maintainers = with lib.maintainers; [ yarn ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
https://github.com/ayuzur/cpond
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
