### PR TITLE
ungoogled-chromium: 149.0.7827.200-1 -> 150.0.7871.46-1

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -838,28 +838,28 @@
     }
   },
   "ungoogled-chromium": {
-    "version": "149.0.7827.200",
+    "version": "150.0.7871.46",
     "deps": {
       "depot_tools": {
-        "rev": "45dedc4c3b87c982fd846b3dc599b233ed3aff90",
-        "hash": "sha256-Ttklyw6IdNeMExlzeiQg/qsCkTmqVhUJ34MFgYmCWD4="
+        "rev": "f4fadaf6a5ba1bced9d3d9021060667b563bf583",
+        "hash": "sha256-3atvbwYnFTA40MonAxSQWkF58Jku7O7fUzelGPQvDyY="
       },
       "gn": {
-        "version": "0-unstable-2026-05-01",
-        "rev": "1740f5c25bcac5a650ee3d1c1ec22bfa25fcd756",
-        "hash": "sha256-oFs7fZAZEs/gQ7X1A4uigo9+Y+iEN9sMMQYwAjEuD04="
+        "version": "0-unstable-2026-05-27",
+        "rev": "3357c4f51b1a9e676378c695dd9c7e9911c35ee6",
+        "hash": "sha256-/1A+DkzAQj2zGPe/A/G0Z3VrYJXUxq4Hd/+d/o5p3G8="
       },
       "ungoogled-patches": {
-        "rev": "149.0.7827.200-1",
-        "hash": "sha256-D7c1ToAoUzAMpXoe60YPimRqe6/LRe0T95TduXUeTFo="
+        "rev": "150.0.7871.46-1",
+        "hash": "sha256-SuZTPUpv7onrHvDrwZO0Xo/mxLVcGUSxf2xb+OC//L8="
       },
       "npmHash": "sha256-pF0JtwFpPC4/fodbhSJnQKkczA9WlDg4VqEAy9aDVLg="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "c35c164b1b6d1adca9eddf914ed6d0d0743dba6a",
-        "hash": "sha256-b2gBRUzRjqVZEb/tWUL1JF6Afq5gHJ3aOM02My1FyYU=",
+        "rev": "5b586c06e0d27582900f17e2d59c5370d8d6e0bb",
+        "hash": "sha256-OAZNyZtR5WFWW42r74RSy9fT7Eb7CNZwzoIHhuoqR28=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -869,13 +869,13 @@
       },
       "src/third_party/compiler-rt/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/compiler-rt.git",
-        "rev": "0408cce08083f3d81379ed7d9f5bd26c03e1495b",
-        "hash": "sha256-kR5osTmp2girvNRVHzEKMZDCelgux9RrRuMoXMCRSGM="
+        "rev": "03641f7a5b05e48e318d64369057db577cafc594",
+        "hash": "sha256-KnWESGG6aI0S+fkJ3/T1x4QSiIYaOOvWUAm6l6l9iME="
       },
       "src/third_party/libc++/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxx.git",
-        "rev": "be1c391acca009d8d80535ce924e3d285451cdfa",
-        "hash": "sha256-zKb9PUiiBvhVhWnbQwR8uOFJ9gt3uYmfJ4M9ijpgKRc="
+        "rev": "5abc7f839700f0f17338434e1c1c6a8c87c00c11",
+        "hash": "sha256-vT1km7JgVpotDoNK+ae1gplSHcwrVNLsv/QAFUrDsIM="
       },
       "src/third_party/libc++abi/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxxabi.git",
@@ -884,13 +884,13 @@
       },
       "src/third_party/libunwind/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libunwind.git",
-        "rev": "71192be150bbe04d87bb5298512d464e38d2f654",
-        "hash": "sha256-PxXemxdWZoEavKDOovi67IVWEr2YW8YK2F0LXM3LZPw="
+        "rev": "d6c7a21e978f0adaa43accaad53bc64f0b64f6ec",
+        "hash": "sha256-EuaVSYiR7qrlYqBR0UqdWCvwdzJSn0RS2wC/lnP19AE="
       },
       "src/third_party/llvm-libc/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libc.git",
-        "rev": "deb95b5e48e875920a2eaae799c8dbcd76a6a4db",
-        "hash": "sha256-oAgIT3+vjBrX86jgi/Pb0SCyco0lozjBjXlrKm6i56M="
+        "rev": "6e5ec6f78d8b9f2e8a50fcc5692d1fc8b2964bde",
+        "hash": "sha256-qrkx8Z1fc088Ja32obIUPxDwklI7i1wdEw051UZ08u8="
       },
       "src/chrome/test/data/perf/canvas_bench": {
         "url": "https://chromium.googlesource.com/chromium/canvas_bench.git",
@@ -909,8 +909,8 @@
       },
       "src/docs/website": {
         "url": "https://chromium.googlesource.com/website.git",
-        "rev": "c9a9ad55e9ec9934244e58a5a8cab9a295526010",
-        "hash": "sha256-2GKWEnlExrTzoIYMxeP4n2klLLT/phB5ZVJ5Nj3/aoY="
+        "rev": "3da515a67f412be05ea1ea6b39832a69aef8f54e",
+        "hash": "sha256-wrkFsPX7jrsjD/Ow1gna/xLvk0E49m5GVxP1G7Vx7HM="
       },
       "src/media/cdm/api": {
         "url": "https://chromium.googlesource.com/chromium/cdm.git",
@@ -919,8 +919,8 @@
       },
       "src/net/third_party/quiche/src": {
         "url": "https://quiche.googlesource.com/quiche.git",
-        "rev": "fafc2fe9efc9f2e28a0815229fc14ca30c266ba8",
-        "hash": "sha256-4UmjE41MOFCBa3APDMyyJwkeV6LhHl5UsMxZpPRDsRY="
+        "rev": "997d654308b6a1a17435e472ef5190aecb12e3eb",
+        "hash": "sha256-xgDgW2foZZEWpr0ibSG21kf028FN07/1ecOqFCkNj/I="
       },
       "src/testing/libfuzzer/fuzzers/wasm_corpus": {
         "url": "https://chromium.googlesource.com/v8/fuzzer_wasm_corpus.git",
@@ -929,8 +929,8 @@
       },
       "src/third_party/angle": {
         "url": "https://chromium.googlesource.com/angle/angle.git",
-        "rev": "355cc61af2aadd8f0494800325b2bf9908138108",
-        "hash": "sha256-fgaCyO0oaz90aTaWMHH8ocySA0hXDHsPEl6vtMj4BY0="
+        "rev": "bbf3d8a4755268f016087be2f56099fa5a5f3f6e",
+        "hash": "sha256-8iuHtNgHumlMXeXj2k0ZPcvnTeJ00di298+789OjScs="
       },
       "src/third_party/angle/third_party/glmark2/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glmark2/glmark2",
@@ -944,13 +944,18 @@
       },
       "src/third_party/angle/third_party/VK-GL-CTS/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/VK-GL-CTS",
-        "rev": "3fe33a325af90c1c820b1e8109f11ea0f4b60c9b",
-        "hash": "sha256-JgOdlwtjC5HiCWBAaeM+Ffp9KlbI7+erT0ZRZBlWxXI="
+        "rev": "01471f4b3846c97eceb5b16b8acad950808791b2",
+        "hash": "sha256-SrL+G3osTtJGQslfCBEYbslb2kWtHRrwO87PHi+5o6E="
       },
       "src/third_party/anonymous_tokens/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/anonymous-tokens.git",
-        "rev": "208ea23596884f6d86476ea88b64e7931cdec08a",
-        "hash": "sha256-HLUX0mUzA3xcXbw71sIxFBNEkL8x86urcdJH2Yuuy04="
+        "rev": "92d1fdf881a932e7aa2a9b20e006136a659c7a20",
+        "hash": "sha256-llPt+UR8hY0yaJkYmq+A3ZfRRReuaXN09qpap6C28jc="
+      },
+      "src/third_party/aria-practices/src": {
+        "url": "https://chromium.googlesource.com/external/github.com/w3c/aria-practices.git",
+        "rev": "7b134ce6d19497cce8a67db4a9f59980baf853dc",
+        "hash": "sha256-POnvoO1KfzJj4CbcMPI0pUTRk5EtHLTOyKKmJCZdXOc="
       },
       "src/third_party/readability/src": {
         "url": "https://chromium.googlesource.com/external/github.com/mozilla/readability.git",
@@ -964,13 +969,13 @@
       },
       "src/third_party/dav1d/libdav1d": {
         "url": "https://chromium.googlesource.com/external/github.com/videolan/dav1d.git",
-        "rev": "5cfc3832687e3229117203905faf5425ac6bc0d7",
-        "hash": "sha256-MWDDrb8P5AIFszY0u5gCrK+kZlbYffIt9Y1b/thXL7I="
+        "rev": "62501cc7db378532d7e85ea434b70d57e1ba2cb0",
+        "hash": "sha256-5cpKTUnhR+QzQJR4KbAvdvqsWnT1fpH0g9MObv8Nx0c="
       },
       "src/third_party/dawn": {
         "url": "https://dawn.googlesource.com/dawn.git",
-        "rev": "54b4153cfef88e048f365f99b962478f0087dfe8",
-        "hash": "sha256-Bv30zz/pCNVzUl+mKCpusWc94poytv9ZFelZIcs+2B8="
+        "rev": "01249a97332468dbdd6cf5edb8dd7bae77875de5",
+        "hash": "sha256-tzomo+GTec2zixxk61gtlma/sjcBImgbLMwA+mIp1LM="
       },
       "src/third_party/dawn/third_party/glfw3/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glfw/glfw",
@@ -979,8 +984,8 @@
       },
       "src/third_party/dawn/third_party/directx-shader-compiler/src": {
         "url": "https://chromium.googlesource.com/external/github.com/microsoft/DirectXShaderCompiler",
-        "rev": "d73829d4e677ef00931e8e57de6d544396ab46cb",
-        "hash": "sha256-BIXNgVeF5x3BZWFWZ1Gz+zpNSOEl+hZWB0GgMEaNS2w="
+        "rev": "35c1b99e9e552267da5efaea07c003e322d65777",
+        "hash": "sha256-pzBk+jUp/FUV8ahHquE0942Qw/DjAUemSM9fxdFJ0JA="
       },
       "src/third_party/dawn/third_party/directx-headers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/microsoft/DirectX-Headers",
@@ -989,8 +994,8 @@
       },
       "src/third_party/dawn/third_party/OpenGL-Registry/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/OpenGL-Registry",
-        "rev": "9cb90ca4902d588bef3c830fbb1da484893bd5fb",
-        "hash": "sha256-mWVORjrbNFINr5WKAIDVnPs2T+96vkxWqZdJwp8oT9I="
+        "rev": "a30033d3e812c9bf10094f1010374a6b15e192eb",
+        "hash": "sha256-xLacUOSy783bCtv+wUnjVnNLwTQ3eLwUJtYXmELqekY="
       },
       "src/third_party/dawn/third_party/EGL-Registry/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/EGL-Registry",
@@ -999,8 +1004,8 @@
       },
       "src/third_party/dawn/third_party/webgpu-cts": {
         "url": "https://chromium.googlesource.com/external/github.com/gpuweb/cts",
-        "rev": "5c6b119c4fa0d9059c45f7637df1fe26fc80a6e4",
-        "hash": "sha256-9DAdS2u2YtrCFJu0KTuwRJjTUNexFxdmnn7LkwQ+KiQ="
+        "rev": "f08551b0fc4d6cfa5ba582a0235b571aa363102d",
+        "hash": "sha256-f5kWMnaod/Ved1Fz/vTkdL0ihSUnNM8XN5Ht3Vs1YpU="
       },
       "src/third_party/dawn/third_party/webgpu-headers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/webgpu-native/webgpu-headers",
@@ -1024,8 +1029,8 @@
       },
       "src/third_party/boringssl/src": {
         "url": "https://boringssl.googlesource.com/boringssl.git",
-        "rev": "65818adf16411ca394625f5747a1af28faf95d2c",
-        "hash": "sha256-tcTTzQnBp8Od1jdDMrFoCr9bnW0OCjGqUjH3QMnusmo="
+        "rev": "3a9254f16eda7a4c5d2260039ff23456a0a34de4",
+        "hash": "sha256-JuMnNppWhIFHYfk6ANIZLC7ABhqMseoV5LYV7slevBE="
       },
       "src/third_party/breakpad/breakpad": {
         "url": "https://chromium.googlesource.com/breakpad/breakpad.git",
@@ -1039,13 +1044,8 @@
       },
       "src/third_party/catapult": {
         "url": "https://chromium.googlesource.com/catapult.git",
-        "rev": "6e4188cabb4f37314ea41e9adfcb2cf9b64e2641",
-        "hash": "sha256-/kleYYllR22KjxHT2gTMGf6LEUZ1Ud7j593fIIAgqAA="
-      },
-      "src/third_party/catapult/third_party/webpagereplay": {
-        "url": "https://chromium.googlesource.com/webpagereplay.git",
-        "rev": "b7ac48f52cd298e966a76eb054412915c3e445d4",
-        "hash": "sha256-smtwB6vzLgCAePz0jNfrpm8TxrxBnBkigLxERhxUEvE="
+        "rev": "2852bb7e91e4995502ffb72b7ed21412ee157914",
+        "hash": "sha256-XYufVvzOXD4voZUWUvumQQqLNsx9sy0QmQzNzrgNEWg="
       },
       "src/third_party/ced/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/compact_enc_det.git",
@@ -1064,13 +1064,13 @@
       },
       "src/third_party/cpu_features/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/cpu_features.git",
-        "rev": "d3b2440fcfc25fe8e6d0d4a85f06d68e98312f5b",
-        "hash": "sha256-IBJc1sHHh4G3oTzQm1RAHHahsEECC+BDl14DHJ8M1Ys="
+        "rev": "81d13c49649f0714dd41fb56bb246398b6584085",
+        "hash": "sha256-TrC1WMLAhko57rAyDCiAC/IJ0unAqVhyjkh7gKibyi4="
       },
       "src/third_party/cpuinfo/src": {
         "url": "https://chromium.googlesource.com/external/github.com/pytorch/cpuinfo.git",
-        "rev": "3681f0ce1446167d01dfe125d6db96ba2ac31c3c",
-        "hash": "sha256-PhWbzQgZSUb3eVyx+JTSnxVOAC2WzL2Dw1I9/6LEIsw="
+        "rev": "ea6b9f1bb6e1001d8b21574d5bc78ddef62e499d",
+        "hash": "sha256-/QsOjDik0TnH3FnK7LOwsJkvX+O+2DRFX4eF3MxD3fc="
       },
       "src/third_party/crc32c/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/crc32c.git",
@@ -1079,28 +1079,28 @@
       },
       "src/third_party/cros_system_api": {
         "url": "https://chromium.googlesource.com/chromiumos/platform2/system_api.git",
-        "rev": "7ecd2b41460516ecd7b7d6e5c298db25e1436b6f",
-        "hash": "sha256-ehbAXv4DZStWDMC3iOjmWkAc4PhAamyI4C9bdXO7FfA="
+        "rev": "1c69e700a01a7fd3dd331f526c8a31ac1e5e49d0",
+        "hash": "sha256-qIwUs0KVU9xYFLN3UUayPLfz0ObA+EN6owKPW61J/5w="
       },
       "src/third_party/crossbench": {
         "url": "https://chromium.googlesource.com/crossbench.git",
-        "rev": "cecd70a5f49f777f603d38d11ac1f66c03c3e8af",
-        "hash": "sha256-zLwIY8fQVebkfN4KFMbitZODhmiN65JK2s9IG/5Cd+o="
+        "rev": "7d52b4ffbc319a7d5a0e0a0ebff744e5281d60c5",
+        "hash": "sha256-iwwvvIOuRMo/ZEu8Gk0lZaS4P5uGt8zpnYMChpZPcUo="
       },
       "src/third_party/crossbench-web-tests": {
         "url": "https://chromium.googlesource.com/chromium/web-tests.git",
-        "rev": "baf176aadedccc44329231d5dd40346874c2a63e",
-        "hash": "sha256-oY1/uGB6ykePIklWe35rmJWsnpu/wjkER4TJeP4TTdw="
+        "rev": "7b3de17542cc613aaddbfc72c6e12be37eed7b73",
+        "hash": "sha256-7ly4vaK+Pj4y91t6Q+igQ0890CqKyu9jNBhJnxbNGjI="
       },
       "src/third_party/depot_tools": {
         "url": "https://chromium.googlesource.com/chromium/tools/depot_tools.git",
-        "rev": "45dedc4c3b87c982fd846b3dc599b233ed3aff90",
-        "hash": "sha256-Ttklyw6IdNeMExlzeiQg/qsCkTmqVhUJ34MFgYmCWD4="
+        "rev": "f4fadaf6a5ba1bced9d3d9021060667b563bf583",
+        "hash": "sha256-3atvbwYnFTA40MonAxSQWkF58Jku7O7fUzelGPQvDyY="
       },
       "src/third_party/devtools-frontend/src": {
         "url": "https://chromium.googlesource.com/devtools/devtools-frontend",
-        "rev": "33c2f401a9c8ddad2159eb0ab83aa244a5247361",
-        "hash": "sha256-M9aULI+HECgA0ptAG47OPK0QuB+xzmb29iOtJ3whpB0="
+        "rev": "1d67dc0dafa344bbd6ca75c124e2d6d9d53074d8",
+        "hash": "sha256-VBXch2YwnKm+lMcZ5L0SlW+vAYeaSwgZvcOhg1TE5/A="
       },
       "src/third_party/dom_distiller_js/dist": {
         "url": "https://chromium.googlesource.com/chromium/dom-distiller/dist.git",
@@ -1114,8 +1114,8 @@
       },
       "src/third_party/eigen3/src": {
         "url": "https://chromium.googlesource.com/external/gitlab.com/libeigen/eigen.git",
-        "rev": "2cf9891537250255f50df5109ffe9e700e2a73de",
-        "hash": "sha256-1bu1Y9itHIKcwY5J0sF08DSyfElLHiZ6SRsNZkFjz8o="
+        "rev": "662ba79d796a2851b10cdafc6668e45b65b1120f",
+        "hash": "sha256-6bZFDeo7TqWNunkkQv8OJ+7/hfKwoIUtqZoXaeLp6M8="
       },
       "src/third_party/farmhash/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/farmhash.git",
@@ -1124,18 +1124,18 @@
       },
       "src/third_party/fast_float/src": {
         "url": "https://chromium.googlesource.com/external/github.com/fastfloat/fast_float.git",
-        "rev": "05087a303dad9c98768b33c829d398223a649bc6",
-        "hash": "sha256-ZQm8kDMYdwjKugc2vBG5mwTqXa01u6hODQc/Tai2I9A="
+        "rev": "cfd12ebcf1f82c4fd44a950b1815dd0549bc8d89",
+        "hash": "sha256-hzoB+Mmok3oe6B494uLc5ReWpUcB89zCGPYw4gvanK0="
       },
       "src/third_party/federated_compute/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google-parfait/federated-compute.git",
-        "rev": "3112513bf1a80872311e7718c5385f535a819b89",
-        "hash": "sha256-jnG3PCxjaYcClRgzOfIkHbbD3xU9TDLyQR3VZUwHIgU="
+        "rev": "8de5837b817f28abc54a387a9417631b905ba90a",
+        "hash": "sha256-GZYo0FjgW8XCplAi6jzzruwDlIzsWjNEVQuCwXBCPz8="
       },
       "src/third_party/ffmpeg": {
         "url": "https://chromium.googlesource.com/chromium/third_party/ffmpeg.git",
-        "rev": "f45bab87ce4c5fafc67fd53fcde777578d01bfa0",
-        "hash": "sha256-fsZSqmG6vFOPJYuBgG6OSWkzRu27B3mv/PqAP8s4ARk="
+        "rev": "ad41607c61898cf7150e0fb20fe4bbabd44922a3",
+        "hash": "sha256-41qpsOTedB51WMzzHXDiXA19OIzA7wG/Qgbz6IkmWpk="
       },
       "src/third_party/flac": {
         "url": "https://chromium.googlesource.com/chromium/deps/flac.git",
@@ -1164,8 +1164,8 @@
       },
       "src/third_party/freetype/src": {
         "url": "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git",
-        "rev": "b6bcd2177f72bb4842c7701d7b7f633bb3fc951a",
-        "hash": "sha256-TUz3yUD9HxqUMCOpLk74rEf8J0tMTh4ZCuD94AD4+q4="
+        "rev": "b08a2eb0dd37f4a6c886fa5b0ecf5b3e1d27aac7",
+        "hash": "sha256-xnYeUAJx5n8LSg04AknfiudonfmlUdlj8nzHzSZi65I="
       },
       "src/third_party/fxdiv/src": {
         "url": "https://chromium.googlesource.com/external/github.com/Maratyszcza/FXdiv.git",
@@ -1174,13 +1174,13 @@
       },
       "src/third_party/harfbuzz/src": {
         "url": "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git",
-        "rev": "e6741e2205309752839da60ff075b7fa2e7cddd3",
-        "hash": "sha256-XjUuY17fcZi+dIZFojq+eDsDVrBxtAWRydPdudt56+8="
+        "rev": "d639197ed529b05c27f38ebaab365a621d5edad5",
+        "hash": "sha256-uT4zK2hwHzEH6Nrd2rAeyzpQA1TmwtrdcujKYEUbLsY="
       },
       "src/third_party/ink/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/ink.git",
-        "rev": "a988417b6d0b1ea03fb0b40269fbc42313acc6fd",
-        "hash": "sha256-6O+N/ULn8sqsdgFw7VZ7TMjWvCAZbYo398PruPScU/k="
+        "rev": "0f9c6172b2ccc6b830ae313d522caf09e6933e06",
+        "hash": "sha256-LF+OcqNeg+KRuYmGuMZb4tmnr53sZHn/ZW1jg9ArPfc="
       },
       "src/third_party/instrumented_libs": {
         "url": "https://chromium.googlesource.com/chromium/third_party/instrumented_libraries.git",
@@ -1204,8 +1204,8 @@
       },
       "src/third_party/libgav1/src": {
         "url": "https://chromium.googlesource.com/codecs/libgav1.git",
-        "rev": "40f58ed32ff39071c3f2a51056dbc49a070af0dc",
-        "hash": "sha256-gisU0p0HDL7Po/ZXIIZVOTnxnOuVvSE/FYo9DaEUFfo="
+        "rev": "66ac17620652635392f6ab24065c77b035e281c9",
+        "hash": "sha256-6/zMaX2DPSKpsaqirhrgi3nL/88Qr2VXacmyL5IyJ3U="
       },
       "src/third_party/googletest/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/googletest.git",
@@ -1229,8 +1229,8 @@
       },
       "src/third_party/jsoncpp/source": {
         "url": "https://chromium.googlesource.com/external/github.com/open-source-parsers/jsoncpp.git",
-        "rev": "42e892d96e47b1f6e29844cc705e148ec4856448",
-        "hash": "sha256-bSLNcoYBz3QCt5VuTR056V9mU2PmBuYBa0W6hFg2m8Q="
+        "rev": "d4d072177213b117fb81d4cfda140de090616161",
+        "hash": "sha256-q+DOwkjRlHacgfWf5UVY02aqfnKK9M/1YRBX6aMce9g="
       },
       "src/third_party/leveldatabase/src": {
         "url": "https://chromium.googlesource.com/external/leveldb.git",
@@ -1244,8 +1244,8 @@
       },
       "src/third_party/fuzztest/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/fuzztest.git",
-        "rev": "e24a91020ab19c3d6f590bd0911b7acb492f81be",
-        "hash": "sha256-wFjuvJzGEaal+pIo5UtkdLHYTpoWxRE6Vf5OGLObGQk="
+        "rev": "da27bcae1a8902af1ae6a5c55d3674f22709bbf5",
+        "hash": "sha256-317zRhJPc0D9A58W8fdCGFmpNZ5vACfd/tlZOsp/Cvw="
       },
       "src/third_party/domato/src": {
         "url": "https://chromium.googlesource.com/external/github.com/googleprojectzero/domato.git",
@@ -1254,18 +1254,18 @@
       },
       "src/third_party/libaddressinput/src": {
         "url": "https://chromium.googlesource.com/external/libaddressinput.git",
-        "rev": "e20690c8d5178bb282641d5eb06ef0298ff4cbc5",
-        "hash": "sha256-rX7LQNUgk5ZljUrayD1a/SUrBrvpomW0Cs0KBw3lYu4="
+        "rev": "81eb9628382b07d371d8ea0b11badf7de3857fd5",
+        "hash": "sha256-6yDZpZ+CwxGqNO4+lZLFB6ESREeVku1BoOMtR+hKQ3I="
       },
       "src/third_party/libaom/source/libaom": {
         "url": "https://aomedia.googlesource.com/aom.git",
-        "rev": "33dba9e12a9f12e737eaa7c2624e8c580950a89a",
-        "hash": "sha256-01DbV0kQFg1yyFpVeo82KBoZHhizA7xnZ1qOuu4HTcs="
+        "rev": "137bcff61e73fdd2836dc04e8258bfb49cef595e",
+        "hash": "sha256-oDubKvgqMk3w0luM//rR3NnCOk1h/WVTyRkuCmYASrw="
       },
       "src/third_party/crabbyavif/src": {
         "url": "https://chromium.googlesource.com/external/github.com/webmproject/CrabbyAvif.git",
-        "rev": "c433c9a32320aed983e4106931596fbbae3f77ee",
-        "hash": "sha256-yw1cXB6s6biD2vj2K/3sVbKiaNK7bt+NkbQovbYlJ2Q="
+        "rev": "5e140b5abb9a91eb25b5ef66d29f6ee784ab7eab",
+        "hash": "sha256-tN+2YH2O9FTV50o4OVhKcKdwRwTI8NuNA0WqljUcrmo="
       },
       "src/third_party/nearby/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/nearby-connections.git",
@@ -1279,8 +1279,8 @@
       },
       "src/third_party/jetstream/main": {
         "url": "https://chromium.googlesource.com/external/github.com/WebKit/JetStream.git",
-        "rev": "de88e36ae91d5bd13126fa4cc4b0e0346d779842",
-        "hash": "sha256-ZpU0ONqIVmY2VR0MxqtYj8KPNlK0L21gLJuT/Ff7KI8="
+        "rev": "b7babdf323e64e69bd2f6c376189c15825f5c73a",
+        "hash": "sha256-s6UMdUYWZqk/MbhyCi2zdQNgni98gGsYxcuUh/5AUy0="
       },
       "src/third_party/jetstream/v2.2": {
         "url": "https://chromium.googlesource.com/external/github.com/WebKit/JetStream.git",
@@ -1319,8 +1319,8 @@
       },
       "src/third_party/cros-components/src": {
         "url": "https://chromium.googlesource.com/external/google3/cros_components.git",
-        "rev": "e580888fcc1c108e25c218ccf8b7a4372de18d57",
-        "hash": "sha256-p0Wfvhg/j8v9xL9Pueo7xPVHBKowOLI00AeIZXPQw4k="
+        "rev": "0abb2efaa3d16db861c9710b193c39e657ac3bdf",
+        "hash": "sha256-viuntf6umyLZwDR9BXG+ZOakp9f8rvpZYDBYAUkKzL4="
       },
       "src/third_party/libdrm/src": {
         "url": "https://chromium.googlesource.com/chromiumos/third_party/libdrm.git",
@@ -1329,8 +1329,8 @@
       },
       "src/third_party/expat/src": {
         "url": "https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git",
-        "rev": "f31adfd584b7f6c50bbf4d22eb928538ffc9145a",
-        "hash": "sha256-tLz4RejYQ/kFXhsWTduuGcinfUkqxYKPCpsou+WlvBc="
+        "rev": "9bdfbc77e3355405ceefbe59420abed953a5657e",
+        "hash": "sha256-veGg5/QjtBSmxYa8IyHF0NxEdJzlcJSZfzw8ay3ASVU="
       },
       "src/third_party/libipp/libipp": {
         "url": "https://chromium.googlesource.com/chromiumos/platform2/libipp.git",
@@ -1339,8 +1339,8 @@
       },
       "src/third_party/libjpeg_turbo": {
         "url": "https://chromium.googlesource.com/chromium/deps/libjpeg_turbo.git",
-        "rev": "d1f5f2393e0d51f840207342ae86e55a86443288",
-        "hash": "sha256-KGeB/lTjhm8DQBDZVSPENvZEGSHeLTkviJrYsFh5vEM="
+        "rev": "640f254ad0fa03f6b1f29f89b7dd9366f2f6e533",
+        "hash": "sha256-wor4RTF3/5BFL9EWcGEofY+M4HN2+/KJUaOY+u86K5Q="
       },
       "src/third_party/liblouis/src": {
         "url": "https://chromium.googlesource.com/external/liblouis-github.git",
@@ -1349,8 +1349,8 @@
       },
       "src/third_party/libphonenumber/src": {
         "url": "https://chromium.googlesource.com/external/libphonenumber.git",
-        "rev": "ade546d8856475d0493863ee270eb3be9628106b",
-        "hash": "sha256-cLtsM35Ir3iG3j8+Cy2McL1ysRB0Y1PXealAKl05Twg="
+        "rev": "c25558e39e2bcc9f26f7a2a1ef804324169eaf8f",
+        "hash": "sha256-Lr/gB5Em+TE092McPwJdOU0Ab4zyP4/2ZxlavMZMm+s="
       },
       "src/third_party/libprotobuf-mutator/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/libprotobuf-mutator.git",
@@ -1374,8 +1374,8 @@
       },
       "src/third_party/libvpx/source/libvpx": {
         "url": "https://chromium.googlesource.com/webm/libvpx.git",
-        "rev": "d1268a5f3f3553ad7735911c614e8548381ca3cd",
-        "hash": "sha256-6IZTDhtjVWiqTv+jUC6Wr/tSqvql3thi9+mt+M3ixt4="
+        "rev": "5f00413667d19ad683674524a9d03543d86d188b",
+        "hash": "sha256-uTteQ+z7t5KOtPuBoZazmonRHd8jGS1/YZAq+RAvhX4="
       },
       "src/third_party/libwebm/source": {
         "url": "https://chromium.googlesource.com/webm/libwebm.git",
@@ -1389,8 +1389,8 @@
       },
       "src/third_party/libyuv": {
         "url": "https://chromium.googlesource.com/libyuv/libyuv.git",
-        "rev": "644251f252a84bf8ce91ff0aca86a9b16b069ab8",
-        "hash": "sha256-DsoOY8bg0sPOF8tF67Gk7fRqdQzG1hc9fVMlZVjKWU4="
+        "rev": "3c5fa6ef272f6077d76816ee3d6a697ef1d6d272",
+        "hash": "sha256-FXFSC9dRb/KhSQdhJUqKEUpZbzU8ZpVnoSXtF/HPiJI="
       },
       "src/third_party/lss": {
         "url": "https://chromium.googlesource.com/linux-syscall-support.git",
@@ -1409,8 +1409,8 @@
       },
       "src/third_party/nasm": {
         "url": "https://chromium.googlesource.com/chromium/deps/nasm.git",
-        "rev": "358842b6b7dd69b2ed635bef17f941e030a05e5f",
-        "hash": "sha256-YwjwubijMZ9OvYeMUVMSunWZ2VCuqUFEOyv/MK/oojc="
+        "rev": "525a09a813be0f75b646ee93fc2a31c27b87d722",
+        "hash": "sha256-uC6bGxSdz1V2SXIQjMsDd6555b3gAPN1Y0ZQtWoqDww="
       },
       "src/third_party/neon_2_sse/src": {
         "url": "https://chromium.googlesource.com/external/github.com/intel/ARM_NEON_2_x86_SSE.git",
@@ -1424,8 +1424,8 @@
       },
       "src/third_party/openscreen/src": {
         "url": "https://chromium.googlesource.com/openscreen",
-        "rev": "684bcd767271a21f3e5d475b17a0fd862f16c65e",
-        "hash": "sha256-Yjz2E1/h+zp7L2x0zE0l+ktQIiSrJ4ZknXOhaVPKQVE="
+        "rev": "37ff938a93cb04c6b77e019b52328c8e9b320317",
+        "hash": "sha256-M57un/TVQPfTnKScVHS1VK1cUs8F/YPT3TwMVdo+mhM="
       },
       "src/third_party/openscreen/src/buildtools": {
         "url": "https://chromium.googlesource.com/chromium/src/buildtools",
@@ -1439,13 +1439,13 @@
       },
       "src/third_party/pdfium": {
         "url": "https://pdfium.googlesource.com/pdfium.git",
-        "rev": "be702d63baba7507bb1f6f6ff2d35be9c133c08c",
-        "hash": "sha256-hXqSJn1C0ISLWx68UicggiL8xzgQX2Y8l75vtpJgHeU="
+        "rev": "c052afb72a08d79a26bcf3103d11f344981b09f1",
+        "hash": "sha256-zqfErp0pDXHXIvRpZ1TJu2UGXNZjATRbPgQWTniKTJs="
       },
       "src/third_party/perfetto": {
         "url": "https://chromium.googlesource.com/external/github.com/google/perfetto.git",
-        "rev": "97c58a94bb6495c4e202467fb1c55eaa22b5670f",
-        "hash": "sha256-qtClkWAluLDRZn7yrHLU7qp9szP+/WsiG5JZZzRKd38="
+        "rev": "9ede949f025303868fa0c42418f122ac47312539",
+        "hash": "sha256-IRzEqgunO4Nfz+FkYir8G/Ht+Zsn6wpzncgkEFpsC+k="
       },
       "src/third_party/protobuf-javascript/src": {
         "url": "https://chromium.googlesource.com/external/github.com/protocolbuffers/protobuf-javascript",
@@ -1454,8 +1454,8 @@
       },
       "src/third_party/pthreadpool/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/pthreadpool.git",
-        "rev": "a56dcd79c699366e7ac6466792c3025883ff7704",
-        "hash": "sha256-WfyuPfII4eSmLskZV0TAcu4K6OyW38TjkDHm+VUx5eY="
+        "rev": "02460584c6092e527c8b89f7df4de143d70e801f",
+        "hash": "sha256-4EHJzZT+Gbhs8SkOhjSvDIPEqIQU93oJmtF3c/T+qjw="
       },
       "src/third_party/pyelftools": {
         "url": "https://chromium.googlesource.com/chromiumos/third_party/pyelftools.git",
@@ -1484,13 +1484,18 @@
       },
       "src/third_party/search_engines_data/resources": {
         "url": "https://chromium.googlesource.com/external/search_engines_data.git",
-        "rev": "2345fee6ce4ae24d9c365d5c0884ece593c55c67",
-        "hash": "sha256-5qkra6FURaMvEOk+ZKMRH1hc8ixEnk3u4rxNm0G8tuQ="
+        "rev": "1aab872af8d44dcf59362d7ba8255922f74fafde",
+        "hash": "sha256-5/XnNx6Pyk4KBb9krVo9u6i7LWNrsLLOIi4qhEY2PZc="
+      },
+      "src/third_party/sframe/src": {
+        "url": "https://chromium.googlesource.com/external/github.com/cisco/sframe",
+        "rev": "b14090904433bed0d4ec3f875b9b39f3e0555930",
+        "hash": "sha256-bw+6ycUpnFZJhtXFUzr7XTOljNrs+7oFdVY+LN0Rqek="
       },
       "src/third_party/skia": {
         "url": "https://skia.googlesource.com/skia.git",
-        "rev": "75c589e1f436688fca8f5b7f7a8affeafaa4f923",
-        "hash": "sha256-x0jEek7iJv7WBNdkOUPc5VvIYJw9QPzzTChFUofqErM="
+        "rev": "14d05ec761901b6e9e9193af8b347ab3a7f6fed0",
+        "hash": "sha256-KZGrztOKaT368KSCxiJAqnsgINpNODUlaXnH/maQNIA="
       },
       "src/third_party/smhasher/src": {
         "url": "https://chromium.googlesource.com/external/smhasher.git",
@@ -1504,13 +1509,13 @@
       },
       "src/third_party/sqlite/src": {
         "url": "https://chromium.googlesource.com/chromium/deps/sqlite.git",
-        "rev": "508ab21dc25702ed6690c4dd77da209a6bcd1239",
-        "hash": "sha256-SfvLfBKdPjFvZ7CzUeFMcyoHdCzQgNRQwZyzb6MRtJg="
+        "rev": "fc121d7d03cd6cbf499ec06a5112b263471b1181",
+        "hash": "sha256-hf9PxQhXEKT49GbkFYCvRPBT0Qu+hDnDpebI92yO1Oo="
       },
       "src/third_party/swiftshader": {
         "url": "https://swiftshader.googlesource.com/SwiftShader.git",
-        "rev": "f9d5d49a3c599a315e3493dc1e9b5309cffb3305",
-        "hash": "sha256-kBfqgXXJeEPT80mu6CJ2Bwmdv/y8jVzM6TedMXbzo4o="
+        "rev": "fce27a96526f54c6d31fdccf57629788e3712220",
+        "hash": "sha256-bmXZLpz3wv7eQWoqTjZmjwnnILWSIjZ8iqo8CeLk5fw="
       },
       "src/third_party/text-fragments-polyfill/src": {
         "url": "https://chromium.googlesource.com/external/github.com/GoogleChromeLabs/text-fragments-polyfill.git",
@@ -1519,23 +1524,23 @@
       },
       "src/third_party/tflite/src": {
         "url": "https://chromium.googlesource.com/external/github.com/tensorflow/tensorflow.git",
-        "rev": "2216f531fb72119745382c62f232acf9790f4b6e",
-        "hash": "sha256-zySLNPmug5HS5pwJ/lEMAWjjZSOuxdTgup7Y90k7NZI="
+        "rev": "999d49c10046e240cd5366d349d3a5f6af16a0d4",
+        "hash": "sha256-eSqaWXtzZ4Bi9ilaJYGdZamzUjmo+AtDZ9KeZhsc/fY="
       },
       "src/third_party/litert/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google-ai-edge/LiteRT.git",
-        "rev": "9b5418dd7a1a318eed20395743dcc868df17d8b0",
-        "hash": "sha256-80amwDPF3RrcoTaTQsunNmlvBGs6KCv369FW3J/Xcts="
+        "rev": "09b4b05203fd7a9402ffcce9cc736d887ff7e3fc",
+        "hash": "sha256-skMOzpsn67mmOAp7Mf6UrJdi2lbiQQ8b6kBy4Ik2ED8="
       },
       "src/third_party/vulkan-deps": {
         "url": "https://chromium.googlesource.com/vulkan-deps",
-        "rev": "d234b7b29748c07ef389279dd24f533ebd04cadc",
-        "hash": "sha256-w49HOjPixSI/C5IGlxQMj/Ol9f/Lr2zI2oMhQzzu1zk="
+        "rev": "669a28b1f31f89bfc46b74791f127bcc5e5b2f06",
+        "hash": "sha256-lsR+sh+XQP/wKgkBbie6Gp+kQNFnnC8TeNWpiWTdevw="
       },
       "src/third_party/glslang/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/glslang",
-        "rev": "458ff50a67cb69371850068a62b78f1990a1ff9a",
-        "hash": "sha256-2WauVjAEeZn16b4fE4ImKPX3wjDmeN92mqWi3NMiXSw="
+        "rev": "f6d9303ddaf2e879b9155f7186cd234f5a79079c",
+        "hash": "sha256-ru3QVyyyqxZRcvSpy9pYhHHhkjuLVhQbgOT/vQJ/oIw="
       },
       "src/third_party/spirv-cross/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Cross",
@@ -1544,43 +1549,43 @@
       },
       "src/third_party/spirv-headers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Headers",
-        "rev": "126038020c2bd47efaa942ccc364ca5353ffccde",
-        "hash": "sha256-QBX2M+ZSWgVvCx58NeDIdf6mIkdJbecDktBfUWGPvNc="
+        "rev": "1e770e7de8373a8dd49f23416cf7ca4001d01040",
+        "hash": "sha256-t8Shkoa90TJt1MbTOefnLaguW4eYKsRFO1Jd0AUc70Y="
       },
       "src/third_party/spirv-tools/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Tools",
-        "rev": "2ec8457ab33d539b6f1fecc998360c0b8b05ed4f",
-        "hash": "sha256-9TBb/gnDXgZRZXhF27KEQ0XQI5itRHKJQjLrkFDQq7Q="
+        "rev": "b38c4f83024546d4000b2db8e2294cf81b7f26e0",
+        "hash": "sha256-q5G4B75xBIXl1aG/vzbIDrc3Hs/MFoQ4nwh4ozb8hys="
       },
       "src/third_party/vulkan-headers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Headers",
-        "rev": "f6a6f7ab165cedbfa2a7d0c93fe27a2d01ce09c8",
-        "hash": "sha256-ZbjmxbRUiVJADNRWziCH0UIM09qKf+lm9PRnWOhZFhQ="
+        "rev": "015e25c3c91b70eb1a754d36fb14c4ba6ad9b0b9",
+        "hash": "sha256-pUxPwFGbOzP8ymTooeA1slFWEFsRoqUROSnndVtLiY8="
       },
       "src/third_party/vulkan-loader/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Loader",
-        "rev": "15a84652b94e465e9a7b25eb507193929863bc2f",
-        "hash": "sha256-pdC3YCM0Nzeabi5TPD+qR5PVdsxmWMnf2L9HsOcbv84="
+        "rev": "cf0cf82ea16c0ff0be75940f282540d6085b2d3b",
+        "hash": "sha256-uyoysS7lSBNDRfvcwPT+gQqhE20UxiYUEw1UXnYS3fY="
       },
       "src/third_party/vulkan-tools/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Tools",
-        "rev": "7c46da2b39036a80ce088576d5794bf39e667f56",
-        "hash": "sha256-nAyNVveeGg9sA0E37YiEPm+UdKsy48nAOjnUYHQnuqw="
+        "rev": "e3d18f90c0b8ef1f52539e0674a42f0adfe30381",
+        "hash": "sha256-Hs9N0FM3eWWjLm4BrDJoZIrsPDVFx0iRAJeQ4gHTM7o="
       },
       "src/third_party/vulkan-utility-libraries/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Utility-Libraries",
-        "rev": "2c909c1ab6f9c6caba39a84a4887186b3fafdead",
-        "hash": "sha256-k3xeKHQbd2rTQJsOZKXEMPrYjcHwoCC1N12F6AIP6Ho="
+        "rev": "8383c46b129c2b3a5f3833e602d946d2fcc57e39",
+        "hash": "sha256-ZBie5uDTVEehxRQW1GZY5Ki/bnp82LoW3jfMUFL0O9A="
       },
       "src/third_party/vulkan-validation-layers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-ValidationLayers",
-        "rev": "b105d8ea361af258abed65efb5a1565c031dcf1c",
-        "hash": "sha256-GgznBGYgnCFMNaqAOQ15dlw2dOFfSp3mAV2KokVLzgk="
+        "rev": "044eaba8a34a6e3bfb1d6aafac7c01068813a2b6",
+        "hash": "sha256-i3hochkK0LZPg8CsZMFkAL+8tf8QuuwtApAc4FDd0RM="
       },
       "src/third_party/vulkan_memory_allocator": {
         "url": "https://chromium.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git",
-        "rev": "cb0597213b0fcb999caa9ed08c2f88dc45eb7d50",
-        "hash": "sha256-yBCs3zfqs/60htsZAOscjcyKhVbAWE6znweuXcs1oKo="
+        "rev": "7e55b011e16182fc349149abbd3aaf3b1db46421",
+        "hash": "sha256-fOnFkcQDEGIe5yB507qnP9nA1LBBPFblncNiJ8JxAwI="
       },
       "src/third_party/wayland/src": {
         "url": "https://chromium.googlesource.com/external/anongit.freedesktop.org/git/wayland/wayland.git",
@@ -1614,18 +1619,23 @@
       },
       "src/third_party/webgpu-cts/src": {
         "url": "https://chromium.googlesource.com/external/github.com/gpuweb/cts.git",
-        "rev": "3b327ebc44f11212fd3872972a6dd394634fb9e3",
-        "hash": "sha256-RSZVKv2Z0pg2cGa3Elr2r5VZqdxlRJ+6mzm1Au1qg1I="
+        "rev": "b507bd117e53db86f2fb52d0d858d3ae7d684a85",
+        "hash": "sha256-6Y5Z0ErtsZdbuWTHa+PEiOxcZSbjBcnuOHbgtI1/+80="
       },
       "src/third_party/webpagereplay": {
         "url": "https://chromium.googlesource.com/webpagereplay.git",
-        "rev": "b7ac48f52cd298e966a76eb054412915c3e445d4",
-        "hash": "sha256-smtwB6vzLgCAePz0jNfrpm8TxrxBnBkigLxERhxUEvE="
+        "rev": "b2b856131e36c99e9de9c419fe8ca02f857082ba",
+        "hash": "sha256-+hcaP7C5Eh3SLl5B8mRgOVdM/tvnFnb/oqUIWPoe0NA="
+      },
+      "src/third_party/webpagereplay/third_party/clang-format/script": {
+        "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/clang/tools/clang-format.git",
+        "rev": "6eddfb5ec5f92127a531eda66c568d3a11e7ec11",
+        "hash": "sha256-Cm6BOOlEyD0kdYxMSmk6Fj1Dnfs3zCzXsm+BOXgBme0="
       },
       "src/third_party/webrtc": {
         "url": "https://webrtc.googlesource.com/src.git",
-        "rev": "28311abc149a9bb7e6761a3d54f362a8d77e6793",
-        "hash": "sha256-WuaxKrbISJ1nwyoj2sPAhGCNz33xEYSX1WlDiM+zxpw="
+        "rev": "1f975dfd761af6e5d76d28333191973b258d82a8",
+        "hash": "sha256-ucH+9HBkFyOKEItAWVoYmEzyU7h/UgWIvp/eC/JqGWU="
       },
       "src/third_party/wuffs/src": {
         "url": "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git",
@@ -1639,8 +1649,8 @@
       },
       "src/third_party/xnnpack/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/XNNPACK.git",
-        "rev": "2ad25fc09167df69c6c02eb8082a0b9658dd5e80",
-        "hash": "sha256-vBMGBXzJPCcsc2kMyGecjti68oZHWUwJKd7tkKub6kg="
+        "rev": "56ac34b3f45fae2eca1f32584f7f0b279be2cf1f",
+        "hash": "sha256-uw3r5g5rWamlFubBkXDb4KRx3hkOAoQyFo8l95GYGZI="
       },
       "src/third_party/libei/src": {
         "url": "https://chromium.googlesource.com/external/gitlab.freedesktop.org/libinput/libei.git",
@@ -1649,13 +1659,18 @@
       },
       "src/third_party/zstd/src": {
         "url": "https://chromium.googlesource.com/external/github.com/facebook/zstd.git",
-        "rev": "3ae099b48dfcfe02b1b3ba81ab85457f8a922e9f",
-        "hash": "sha256-futF0sM6z9HAl6AMJwUULBRByN92FTBjRIzYb2vBFGg="
+        "rev": "5233c58e6ca0b1c4c6b353ad79649191ed195bdc",
+        "hash": "sha256-vEl0s7Mjh+5rciOMxm99PNWiamtCk+sTN4lRYKCIZ+8="
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "933ce636c562cd54d68e7f7c93ab5cdffd685fca",
-        "hash": "sha256-zYArO6QS9nDIVWPINRVaDN1uX8X/wchBDeZHPZnwHYk="
+        "rev": "968f19a8970f8d91702d86f0ec1522f3909781b7",
+        "hash": "sha256-x3rCWvC3hEjyJq6PNThhZEp4oRF9Y1JJEPnZTqVNVrY="
+      },
+      "src/agents/shared": {
+        "url": "https://chromium.googlesource.com/chromium/agents.git",
+        "rev": "e75efa515896f6bf1dea92eaffbcf8ee711a65d8",
+        "hash": "sha256-z2GrzF8jDkdfBdq1HP3gTgQpoqjmhc80kEZBmlue0os="
       }
     }
   }


### PR DESCRIPTION
Same underlying changes as #537389

https://developer.chrome.com/blog/new-in-chrome-150

https://developer.chrome.com/release_notes/150

https://chromereleases.googleblog.com/2026/06/stable-channel-update-for-desktop_0175352312.html

This update includes 433 security fixes.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests] (`nixos/tests/chromium.nix`).
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
