### PR TITLE
qt6.qtwebengine: fix on darwin, cleanup

### DIFF
--- a/pkgs/development/libraries/qt-6/modules/qtwebengine/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwebengine/default.nix
@@ -7,7 +7,6 @@
   buildPackages,
   bison,
   coreutils,
-  fetchpatch2,
   flex,
   gperf,
   ninja,
@@ -119,77 +118,83 @@ qtModule {
     ./gn-object-sorted.patch
   ];
 
-  postPatch = ''
+  postPatch =
     # Patch Chromium build tools
-    (
-      cd src/3rdparty/chromium;
+    ''
+      (
+        cd src/3rdparty/chromium;
 
-      # Manually fix unsupported shebangs
-      substituteInPlace third_party/harfbuzz-ng/src/src/update-unicode-tables.make \
-        --replace "/usr/bin/env -S make -f" "/usr/bin/make -f" || true
-      substituteInPlace third_party/webgpu-cts/src/tools/run_deno \
-        --replace "/usr/bin/env -S deno" "/usr/bin/deno" || true
-      patchShebangs .
-    )
-
-    substituteInPlace cmake/Functions.cmake \
-      --replace "/bin/bash" "${buildPackages.bash}/bin/bash"
-
+        # Manually fix unsupported shebangs
+        substituteInPlace third_party/harfbuzz-ng/src/src/update-unicode-tables.make \
+          --replace "/usr/bin/env -S make -f" "/usr/bin/make -f" || true
+        substituteInPlace third_party/webgpu-cts/src/tools/run_deno \
+          --replace "/usr/bin/env -S deno" "/usr/bin/deno" || true
+        patchShebangs .
+      )
+    ''
+    + ''
+      substituteInPlace cmake/Functions.cmake \
+        --replace "/bin/bash" "${buildPackages.bash}/bin/bash"
+    ''
     # Patch library paths in sources
-    substituteInPlace src/core/web_engine_library_info.cpp \
-      --replace "QLibraryInfo::path(QLibraryInfo::DataPath)" "\"$out\"" \
-      --replace "QLibraryInfo::path(QLibraryInfo::TranslationsPath)" "\"$out/translations\"" \
-      --replace "QLibraryInfo::path(QLibraryInfo::LibraryExecutablesPath)" "\"$out/libexec\""
-
-    substituteInPlace configure.cmake src/gn/CMakeLists.txt \
-      --replace "AppleClang" "Clang"
-
+    + ''
+      substituteInPlace src/core/web_engine_library_info.cpp \
+        --replace "QLibraryInfo::path(QLibraryInfo::DataPath)" "\"$out\"" \
+        --replace "QLibraryInfo::path(QLibraryInfo::TranslationsPath)" "\"$out/translations\"" \
+        --replace "QLibraryInfo::path(QLibraryInfo::LibraryExecutablesPath)" "\"$out/libexec\""
+    ''
+    + ''
+      substituteInPlace configure.cmake src/gn/CMakeLists.txt \
+        --replace "AppleClang" "Clang"
+    ''
     # Disable metal shader compilation, Xcode only
-    substituteInPlace src/3rdparty/chromium/third_party/angle/src/libANGLE/renderer/metal/metal_backend.gni \
-      --replace-fail 'angle_has_build && !is_ios && target_os == host_os' "false"
-  ''
-  + lib.optionalString stdenv.hostPlatform.isLinux ''
-    sed -i -e '/lib_loader.*Load/s!"\(libudev\.so\)!"${lib.getLib systemd}/lib/\1!' \
-      src/3rdparty/chromium/device/udev_linux/udev?_loader.cc
+    + ''
+      substituteInPlace src/3rdparty/chromium/third_party/angle/src/libANGLE/renderer/metal/metal_backend.gni \
+        --replace-fail 'angle_has_build && !is_ios && target_os == host_os' "false"
+    ''
+    + lib.optionalString stdenv.hostPlatform.isLinux ''
+      sed -i -e '/lib_loader.*Load/s!"\(libudev\.so\)!"${lib.getLib systemd}/lib/\1!' \
+        src/3rdparty/chromium/device/udev_linux/udev?_loader.cc
 
-    sed -i -e '/libpci_loader.*Load/s!"\(libpci\.so\)!"${pciutils}/lib/\1!' \
-      src/3rdparty/chromium/gpu/config/gpu_info_collector_linux.cc
-  ''
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    substituteInPlace cmake/QtToolchainHelpers.cmake \
-      --replace-fail "/usr/bin/xcrun" "${xcbuild}/bin/xcrun"
-  '';
+      sed -i -e '/libpci_loader.*Load/s!"\(libpci\.so\)!"${pciutils}/lib/\1!' \
+        src/3rdparty/chromium/gpu/config/gpu_info_collector_linux.cc
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      substituteInPlace cmake/QtToolchainHelpers.cmake \
+        --replace-fail "/usr/bin/xcrun" "${xcbuild}/bin/xcrun"
+    '';
 
   cmakeFlags = [
-    "-DQT_FEATURE_qtpdf_build=ON"
-    "-DQT_FEATURE_qtpdf_widgets_build=ON"
-    "-DQT_FEATURE_qtpdf_quick_build=ON"
-    "-DQT_FEATURE_pdf_v8=ON"
-    "-DQT_FEATURE_pdf_xfa=ON"
-    "-DQT_FEATURE_pdf_xfa_bmp=ON"
-    "-DQT_FEATURE_pdf_xfa_gif=ON"
-    "-DQT_FEATURE_pdf_xfa_png=ON"
-    "-DQT_FEATURE_pdf_xfa_tiff=ON"
-    "-DQT_FEATURE_webengine_system_libevent=ON"
-    "-DQT_FEATURE_webengine_system_ffmpeg=ON"
+    (lib.cmakeBool "QT_FEATURE_qtpdf_build" true)
+    (lib.cmakeBool "QT_FEATURE_qtpdf_widgets_build" true)
+    (lib.cmakeBool "QT_FEATURE_qtpdf_quick_build" true)
+    (lib.cmakeFeature "QT_FEATURE_pdf_v8" "ON")
+    (lib.cmakeFeature "QT_FEATURE_pdf_xfa" "ON")
+    (lib.cmakeFeature "QT_FEATURE_pdf_xfa_bmp" "ON")
+    (lib.cmakeFeature "QT_FEATURE_pdf_xfa_gif" "ON")
+    (lib.cmakeFeature "QT_FEATURE_pdf_xfa_png" "ON")
+    (lib.cmakeFeature "QT_FEATURE_pdf_xfa_tiff" "ON")
+    (lib.cmakeBool "QT_FEATURE_webengine_system_libevent" true)
+    (lib.cmakeBool "QT_FEATURE_webengine_system_ffmpeg" true)
     # android only. https://bugreports.qt.io/browse/QTBUG-100293
     # "-DQT_FEATURE_webengine_native_spellchecker=ON"
-    "-DQT_FEATURE_webengine_sanitizer=ON"
-    "-DQT_FEATURE_webengine_kerberos=ON"
+    (lib.cmakeBool "-DQT_FEATURE_webengine_sanitizer" true)
+    (lib.cmakeBool "-DQT_FEATURE_webengine_kerberos" true)
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
-    "-DQT_FEATURE_webengine_system_libxml=ON"
-    "-DQT_FEATURE_webengine_webrtc_pipewire=ON"
+    (lib.cmakeBool "-DQT_FEATURE_webengine_system_libxml" true)
+    (lib.cmakeBool "-DQT_FEATURE_webengine_webrtc_pipewire" true)
 
     # Appears not to work on some platforms
     # https://github.com/Homebrew/homebrew-core/issues/104008
-    "-DQT_FEATURE_webengine_system_icu=ON"
+    (lib.cmakeBool "-DQT_FEATURE_webengine_system_icu" true)
   ]
   ++ lib.optionals enableProprietaryCodecs [
-    "-DQT_FEATURE_webengine_proprietary_codecs=ON"
+    (lib.cmakeBool "-DQT_FEATURE_webengine_proprietary_codecs" true)
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    "-DCMAKE_OSX_DEPLOYMENT_TARGET=11.0" # Per Qt 6’s deployment target (why doesn’t the hook work?)
+    # Per Qt 6’s deployment target (why doesn’t the hook work?)
+    (lib.cmakeFeature "CMAKE_OSX_DEPLOYMENT_TARGET" "11.0")
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/libraries/qt-6/modules/qtwebengine/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwebengine/default.nix
@@ -159,10 +159,24 @@ qtModule {
       sed -i -e '/libpci_loader.*Load/s!"\(libpci\.so\)!"${pciutils}/lib/\1!' \
         src/3rdparty/chromium/gpu/config/gpu_info_collector_linux.cc
     ''
-    + lib.optionalString stdenv.hostPlatform.isDarwin ''
-      substituteInPlace cmake/QtToolchainHelpers.cmake \
-        --replace-fail "/usr/bin/xcrun" "${xcbuild}/bin/xcrun"
-    '';
+    + lib.optionalString stdenv.hostPlatform.isDarwin (
+      ''
+        substituteInPlace cmake/QtToolchainHelpers.cmake \
+          --replace-fail "/usr/bin/xcrun" "${xcbuild}/bin/xcrun"
+      ''
+      # Chromium's mac toolchain invokes `$clang_base_path/bin/clang++` directly,
+      # bypassing the cc-wrapper. Since the build uses the system libc++
+      # (use_custom_libcxx=false, use_libcxx=true), the raw clang cannot find the
+      # libc++ headers, which in nixpkgs live in a separate package and are only
+      # added by the wrapper. Point clang_base_path at the wrapped compiler so
+      # `-isystem .../c++/v1` is injected, matching livekit-libwebrtc.
+      + ''
+        substituteInPlace cmake/QtToolchainHelpers.cmake \
+          --replace-fail \
+            'clang_base_path="''${QWELibClang_BASE_PATH}"' \
+            'clang_base_path="${stdenv.cc}"'
+      ''
+    );
 
   cmakeFlags = [
     (lib.cmakeBool "QT_FEATURE_qtpdf_build" true)

--- a/pkgs/development/python-modules/qtconsole/default.nix
+++ b/pkgs/development/python-modules/qtconsole/default.nix
@@ -23,6 +23,7 @@ buildPythonPackage (finalAttrs: {
   pname = "qtconsole";
   version = "5.7.2";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "jupyter";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **qtwebengine: cleanup**
- **python3Packages.qtconsole: enable __structuredAttrs**
- **qtwebengine: fix on darwin**

---

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
