### PR TITLE
lib.platforms: move primary systems to the beginning of the list

### DIFF
--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -14,12 +14,15 @@ let
   inherit (lib.attrsets) matchAttrs;
 
   all = [
+    # our primary systems. at the top of the list for fastest matching
+    # inside check-meta
+    "x86_64-linux"
+    "aarch64-darwin"
+    "aarch64-linux"
+
     # Cygwin
     "i686-cygwin"
     "x86_64-cygwin"
-
-    # Darwin
-    "aarch64-darwin"
 
     # FreeBSD
     "i686-freebsd"
@@ -37,8 +40,7 @@ let
     # JS
     "javascript-ghcjs"
 
-    # Linux
-    "aarch64-linux"
+    # Linux (excluding the primary two at the top)
     "arc-linux"
     "armv5tel-linux"
     "armv6l-linux"
@@ -61,7 +63,6 @@ let
     "riscv64-linux"
     "s390-linux"
     "s390x-linux"
-    "x86_64-linux"
 
     # MMIXware
     "mmix-mmixware"


### PR DESCRIPTION
The final `lib.platforms` lists are constructed via filtering this list. When a derivation defines `meta.platforms`, it's checked to ensure that the current platform is supported. Before, any package that defined `platforms = lib.platforms.linux` (of which there's ~6000) would have to iterate through all these elements to find x86_64-linux:

```nix
nix-repl> lib.platforms.linux
[
  "aarch64-linux"
  "arc-linux"
  "armv5tel-linux"
  "armv6l-linux"
  "armv7a-linux"
  "armv7l-linux"
  "i686-linux"
  "loongarch64-linux"
  "m68k-linux"
  "sh4-linux"
  "microblaze-linux"
  "microblazeel-linux"
  "mips-linux"
  "mips64-linux"
  "mips64el-linux"
  "mipsel-linux"
  "powerpc-linux"
  "powerpc64-linux"
  "powerpc64le-linux"
  "riscv32-linux"
  "riscv64-linux"
  "s390-linux"
  "s390x-linux"
  "x86_64-linux"
]
```

Don't even get me started on `lib.platforms.all`, of which there's 3k uses. Now, the likely systems will be first. This will probably make a very small real-time difference, but it makes me happier.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
