### PR TITLE
nsakura: init at 0.1.0

### DIFF
--- a/pkgs/by-name/ns/nsakura/lock.json
+++ b/pkgs/by-name/ns/nsakura/lock.json
@@ -1,0 +1,17 @@
+{
+  "depends": [
+    {
+      "method": "fetchzip",
+      "path": "/nix/store/k3sxzm7qnkgnwkrfd8hc3gkwzbayb1h1-source",
+      "rev": "99a120f7f69868b94f5d35ce7e21dd12535de70c",
+      "sha256": "0hiic5yjsaw6sgl1jzmfpm5g6a5ckzmd29c3pzg30glchn2g94sk",
+      "url": "https://github.com/johnnovak/illwill/archive/99a120f7f69868b94f5d35ce7e21dd12535de70c.tar.gz",
+      "ref": "v0.4.1",
+      "packages": [
+        "illwill"
+      ],
+      "srcDir": ""
+    }
+  ]
+}
+

--- a/pkgs/by-name/ns/nsakura/package.nix
+++ b/pkgs/by-name/ns/nsakura/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  buildNimPackage,
+  fetchFromGitHub,
+}:
+buildNimPackage rec {
+  pname = "nsakura";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "KornelHajto";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-/PAcHS0Yxhwp76FlyQXvBmlcSvaOsLtBEbgAKmmASIg=";
+  };
+
+  lockFile = ./lock.json;
+
+  meta = with lib; {
+    homepage = "https://github.com/KornelHajto/nsakura";
+    description = "Terminal cherry blossom screensaver";
+    license = lib.licenses.mit;
+    mainProgram = "nsakura";
+    maintainers = with lib.maintainers; [ yarn ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
https://github.com/KornelHajto/nsakura
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
