### PR TITLE
nixos/lib/testing: don't require kvm if only containers are specified

### DIFF
--- a/nixos/lib/testing/run.nix
+++ b/nixos/lib/testing/run.nix
@@ -35,8 +35,7 @@ let
     options = {
       devnet = mkOption {
         type = types.bool;
-        default =
-          builtins.length (lib.attrNames containers) > 0 && builtins.length (lib.attrNames nodes) > 0;
+        default = containers != { } && nodes != { };
         defaultText = lib.literalMD "`true` if both VMs and containers are present.";
         description = ''
           This heuristic setting that assumes that the majority of tests requires VMs and containers
@@ -52,7 +51,7 @@ let
       };
       uid-range = mkOption {
         type = types.bool;
-        default = builtins.length (lib.attrNames containers) > 0;
+        default = containers != { };
         defaultText = lib.literalMD "`true` if containers are present.";
         description = "Containers use systemd-nspawn, which requires pid 0 inside of the sandbox. `uid-range` enables that.";
       };

--- a/nixos/lib/testing/run.nix
+++ b/nixos/lib/testing/run.nix
@@ -57,8 +57,8 @@ let
       };
       kvm = mkOption {
         type = types.bool;
-        default = isLinux;
-        defaultText = lib.literalMD "`true` if built to run on Linux.";
+        default = isLinux && nodes != { };
+        defaultText = lib.literalMD "`true` if built to run on Linux and any virtual machines are specified.";
         description = "Whether Linux KVM virtualization is required when running this test. Can be disabled to allow emulated execution.";
       };
       apple-virt = mkOption {


### PR DESCRIPTION
Allows containers to be run on systems that don't have the `kvm` feature enabled, like VMs that don't support nested virt.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
