### PR TITLE
rustPlatform.fetchCargoVendor: improve overriding

### DIFF
--- a/pkgs/build-support/rust/fetch-cargo-vendor.nix
+++ b/pkgs/build-support/rust/fetch-cargo-vendor.nix
@@ -29,7 +29,8 @@ let
     git-lfs = null;
   };
 
-  removedArgs = [
+  # Arguments not overwritten by `args`
+  priorityArgs = [
     "name"
     "nativeBuildInputs"
   ];
@@ -92,7 +93,8 @@ let
       outputHash = if hash == "" then lib.fakeHash else hash;
       outputHashMode = "recursive";
     }
-    // removeAttrs args removedArgs
+    # Trick to avoid repetitive `{ <attrname> = args.<attrname> or ...; }`
+    // removeAttrs args priorityArgs
   );
 in
 runCommand "${name}-vendor"

--- a/pkgs/build-support/rust/fetch-cargo-vendor.nix
+++ b/pkgs/build-support/rust/fetch-cargo-vendor.nix
@@ -31,10 +31,7 @@ let
 
   removedArgs = [
     "name"
-    "pname"
-    "version"
     "nativeBuildInputs"
-    "hash"
   ];
 
   fetchCargoVendorUtil = writers.writePython3Bin "fetch-cargo-vendor-util" {

--- a/pkgs/build-support/rust/fetch-cargo-vendor.nix
+++ b/pkgs/build-support/rust/fetch-cargo-vendor.nix
@@ -92,8 +92,7 @@ let
       dontInstall = true;
       dontFixup = true;
 
-      outputHash = hash;
-      outputHashAlgo = if hash == "" then "sha256" else null;
+      outputHash = if hash == "" then lib.fakeHash else hash;
       outputHashMode = "recursive";
     }
     // removeAttrs args removedArgs

--- a/pkgs/build-support/rust/fetch-cargo-vendor.nix
+++ b/pkgs/build-support/rust/fetch-cargo-vendor.nix
@@ -49,6 +49,11 @@ let
   } (builtins.readFile ./fetch-cargo-vendor-util.py);
 in
 
+lib.extendMkDerivation {
+  constructDrv = stdenvNoCC.mkDerivation;
+
+  extendDrvArgs =
+    finalAttrs:
 {
   name ? if args ? pname && args ? version then "${args.pname}-${args.version}" else "cargo-deps",
   hash ? (throw "fetchCargoVendor requires a `hash` value to be set for ${name}"),
@@ -57,9 +62,6 @@ in
 }@args:
 
 # TODO: add asserts about pname version and name
-
-let
-  vendorStaging = stdenvNoCC.mkDerivation (
     {
       name = "${name}-vendor-staging";
 
@@ -94,10 +96,11 @@ let
       outputHashMode = "recursive";
     }
     # Trick to avoid repetitive `{ <attrname> = args.<attrname> or ...; }`
-    // removeAttrs args priorityArgs
-  );
-in
-runCommand "${name}-vendor"
+    // removeAttrs args priorityArgs;
+
+  transformDrv =
+    vendorStaging:
+runCommand "${lib.removeSuffix "-staging" vendorStaging.name}"
   {
     inherit vendorStaging;
     nativeBuildInputs = [
@@ -108,4 +111,5 @@ runCommand "${name}-vendor"
   }
   ''
     fetch-cargo-vendor-util create-vendor "$vendorStaging" "$out"
-  ''
+  '';
+}

--- a/pkgs/build-support/rust/fetch-cargo-vendor.nix
+++ b/pkgs/build-support/rust/fetch-cargo-vendor.nix
@@ -54,14 +54,18 @@ lib.extendMkDerivation {
 
   extendDrvArgs =
     finalAttrs:
-{
-  name ? if finalAttrs ? pname && finalAttrs ? version then "${finalAttrs.pname}-${finalAttrs.version}" else "cargo-deps",
-  hash ? (throw "fetchCargoVendor requires a `hash` value to be set for ${name}"),
-  nativeBuildInputs ? [ ],
-  ...
-}@args:
+    {
+      name ?
+        if finalAttrs ? pname && finalAttrs ? version then
+          "${finalAttrs.pname}-${finalAttrs.version}"
+        else
+          "cargo-deps",
+      hash ? (throw "fetchCargoVendor requires a `hash` value to be set for ${name}"),
+      nativeBuildInputs ? [ ],
+      ...
+    }@args:
 
-# TODO: add asserts about pname version and name
+    # TODO: add asserts about pname version and name
     {
       inherit
         hash
@@ -104,24 +108,23 @@ lib.extendMkDerivation {
 
   transformDrv =
     vendorStaging:
-    (
-runCommand "${lib.replaceString "-vendor-staging" "-vendor" vendorStaging.name}"
-  {
-    inherit vendorStaging;
-    nativeBuildInputs = [
-      fetchCargoVendorUtil
-      cargo
-      replaceWorkspaceValues
-    ];
-  }
-  ''
-    fetch-cargo-vendor-util create-vendor "$vendorStaging" "$out"
-  ''
-    # TODO(@ShamrockLee): Remove after converting to stdenvNoCC.mkDerivation
-    ).overrideAttrs (
-      finalAttrs: previousAttrs:
+    (runCommand "${lib.replaceString "-vendor-staging" "-vendor" vendorStaging.name}"
       {
-        name = lib.replaceString "-vendor-staging" "-vendor" finalAttrs.vendorStaging.name;
+        inherit vendorStaging;
+        nativeBuildInputs = [
+          fetchCargoVendorUtil
+          cargo
+          replaceWorkspaceValues
+        ];
       }
-    );
+      ''
+        fetch-cargo-vendor-util create-vendor "$vendorStaging" "$out"
+      ''
+      # TODO(@ShamrockLee): Remove after converting to stdenvNoCC.mkDerivation
+    ).overrideAttrs
+      (
+        finalAttrs: previousAttrs: {
+          name = lib.replaceString "-vendor-staging" "-vendor" finalAttrs.vendorStaging.name;
+        }
+      );
 }

--- a/pkgs/build-support/rust/fetch-cargo-vendor.nix
+++ b/pkgs/build-support/rust/fetch-cargo-vendor.nix
@@ -55,7 +55,7 @@ lib.extendMkDerivation {
   extendDrvArgs =
     finalAttrs:
 {
-  name ? if args ? pname && args ? version then "${args.pname}-${args.version}" else "cargo-deps",
+  name ? if finalAttrs ? pname && finalAttrs ? version then "${finalAttrs.pname}-${finalAttrs.version}" else "cargo-deps",
   hash ? (throw "fetchCargoVendor requires a `hash` value to be set for ${name}"),
   nativeBuildInputs ? [ ],
   ...
@@ -100,7 +100,8 @@ lib.extendMkDerivation {
 
   transformDrv =
     vendorStaging:
-runCommand "${lib.removeSuffix "-staging" vendorStaging.name}"
+    (
+runCommand "${lib.replaceString "-vendor-staging" "-vendor" vendorStaging.name}"
   {
     inherit vendorStaging;
     nativeBuildInputs = [
@@ -111,5 +112,12 @@ runCommand "${lib.removeSuffix "-staging" vendorStaging.name}"
   }
   ''
     fetch-cargo-vendor-util create-vendor "$vendorStaging" "$out"
-  '';
+  ''
+    # TODO(@ShamrockLee): Remove after converting to stdenvNoCC.mkDerivation
+    ).overrideAttrs (
+      finalAttrs: previousAttrs:
+      {
+        name = lib.replaceString "-vendor-staging" "-vendor" finalAttrs.vendorStaging.name;
+      }
+    );
 }

--- a/pkgs/build-support/rust/fetch-cargo-vendor.nix
+++ b/pkgs/build-support/rust/fetch-cargo-vendor.nix
@@ -63,6 +63,10 @@ lib.extendMkDerivation {
 
 # TODO: add asserts about pname version and name
     {
+      inherit
+        hash
+        ;
+
       name = "${name}-vendor-staging";
 
       impureEnvVars = lib.fetchers.proxyImpureEnvVars;
@@ -92,7 +96,7 @@ lib.extendMkDerivation {
       dontInstall = true;
       dontFixup = true;
 
-      outputHash = if hash == "" then lib.fakeHash else hash;
+      outputHash = if finalAttrs.hash == "" then lib.fakeHash else finalAttrs.hash;
       outputHashMode = "recursive";
     }
     # Trick to avoid repetitive `{ <attrname> = args.<attrname> or ...; }`


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Pass all arguments to `stdenv.mkDerivation` when constructing `vendorStaging`
- Simplify hash handling (no more `outputHashAlgo`) and make the `hash` argument overridable.
- Make all arguments `fetchCargoVendor` takes overridable with `overrideAttrs` by overriding the `vendorStaging` attribute of the result derivation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
