### PR TITLE
framework-control: add updateScript

### DIFF
--- a/pkgs/by-name/fr/framework-control/package.nix
+++ b/pkgs/by-name/fr/framework-control/package.nix
@@ -7,6 +7,7 @@
   fetchNpmDeps,
   makeDesktopItem,
   copyDesktopItems,
+  nix-update-script,
   controlPort ? 30912,
 }:
 
@@ -74,6 +75,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     install -Dm644 web/public/assets/logo.png \
       $out/share/icons/hicolor/256x256/apps/framework-control.png
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Lightweight control surface for Framework laptops";


### PR DESCRIPTION
Adds `passthru.updateScript` (`nix-update-script`) to `framework-control` so that r-ryantm / nixpkgs-update can open update PRs automatically. The package has three hashes that need to stay in sync on every release (`src` hash, `cargoHash`, and a `fetchNpmDeps` hash), which `nix-update` handles correctly.

This is a `passthru`-only change — the built derivation is unchanged. The version intentionally stays at 0.5.2 even though 0.5.3 is out: as maintainer I'd like the bot to pick up the pending update using this script.

Verified end to end: ran `nix-update framework-control --version 0.5.3` in my checkout — it updated all three hashes correctly and the resulting 0.5.3 package built and ran fine on x86_64-linux. The bump was then reverted so this PR only adds the script.

*Disclosure per the automation/AI policy: this change was prepared with the assistance of an AI agent; I reviewed and tested it myself.*

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test