### PR TITLE
freqle: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13443,6 +13443,12 @@
     name = "Jonas Wunderlich";
     matrix = "@matrix:03j.de";
   };
+  jonascarpay = {
+    name = "Jonas Carpay";
+    email = "jonascarpay@gmail.com";
+    github = "jonascarpay";
+    githubId = 3593851;
+  };
   jonasfranke = {
     name = "Jonas Franke";
     email = "info@jonasfranke.xyz";

--- a/pkgs/by-name/fr/freqle/package.nix
+++ b/pkgs/by-name/fr/freqle/package.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  rustPlatform,
+  fetchCrate,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "freqle";
+  version = "0.1.0";
+  __structuredAttrs = true;
+  src = fetchCrate {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-1LL1C9jYPjboGgz0z7AdWeMZR7DApCDlQ8Cj7I+iADY=";
+  };
+  cargoHash = "sha256-VeI2jyq7EXpjIT4e6nuTXj8z5ANoZyfxd27k/4ZaY7k=";
+
+  meta = {
+    description = "Simple CLI frecency history";
+    homepage = "https://github.com/jonascarpay/freqle";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jonascarpay ];
+    mainProgram = "freqle";
+  };
+
+})


### PR DESCRIPTION
Adds `freqle` to nixpkgs.

This is a rewrite of another tool I wrote, but never upstreamed.
The original had a handful of loyal users and was very stable, but users complained that it was too hard to install.
So, I rewrote it in Rust, made it easier to make a static build, and decided to upstream.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
