### PR TITLE
assimp: devendor pugixml, rapidjson, and utf8cpp

### DIFF
--- a/pkgs/by-name/as/assimp/package.nix
+++ b/pkgs/by-name/as/assimp/package.nix
@@ -3,6 +3,9 @@
   stdenv,
   fetchFromGitHub,
   cmake,
+  pugixml,
+  rapidjson,
+  utf8cpp,
   zlib,
   nix-update-script,
 }:
@@ -23,6 +26,14 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-QWBi1pl5C76UtPhB6SmFipm9oEdnfhELMT3MqfV6oxg=";
   };
 
+  # assimp vendors many libraries that we have available in Nixpkgs, and offers no good way of pulling them from non-vendored sources.
+  # We thus patch the CMake declarations to do so.
+  # https://github.com/assimp/assimp/issues/5286
+  # also see:
+  # https://src.fedoraproject.org/rpms/assimp/blob/e0ca8c040bfd661b6d68551b6dc189ba33ffdac1/f/assimp-unbundle.patch
+  # https://salsa.debian.org/debian/assimp/-/tree/c60e93150d63590d671d9aab165cf259c71f5df9/debian/patches
+  patches = [ ./use-system-libraries.patch ];
+
   postPatch = ''
     # nix build sandbox does not set /var/tmp up:
     #   https://github.com/assimp/assimp/issues/6270
@@ -33,6 +44,9 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [
+    pugixml
+    rapidjson
+    utf8cpp
     zlib
   ];
 

--- a/pkgs/by-name/as/assimp/use-system-libraries.patch
+++ b/pkgs/by-name/as/assimp/use-system-libraries.patch
@@ -1,0 +1,86 @@
+diff --git a/code/CMakeLists.txt b/code/CMakeLists.txt
+index b7b08de3b7..1c07aee928 100644
+--- a/code/CMakeLists.txt
++++ b/code/CMakeLists.txt
+@@ -1117,13 +1117,7 @@
+   hunter_add_package(pugixml)
+   find_package(pugixml CONFIG REQUIRED)
+ ELSEIF(NOT TARGET pugixml::pugixml)
+-  SET( Pugixml_SRCS
+-    ../contrib/pugixml/src/pugiconfig.hpp
+-    ../contrib/pugixml/src/pugixml.cpp
+-    ../contrib/pugixml/src/pugixml.hpp
+-  )
+-  INCLUDE_DIRECTORIES("../contrib/pugixml/src")
+-  SOURCE_GROUP( Contrib\\Pugixml FILES ${Pugixml_SRCS})
++  find_package(pugixml REQUIRED)
+ ENDIF()
+ 
+ # utf8
+@@ -1131,7 +1125,7 @@
+   hunter_add_package(utf8)
+   find_package(utf8cpp CONFIG REQUIRED)
+ ELSE()
+-  INCLUDE_DIRECTORIES("../contrib/utf8cpp/source")
++  find_package(utf8cpp REQUIRED)
+ ENDIF()
+ 
+ # polyclipping
+@@ -1287,7 +1281,8 @@
+   hunter_add_package(RapidJSON)
+   find_package(RapidJSON CONFIG REQUIRED)
+ ELSE()
+-  INCLUDE_DIRECTORIES("../contrib/rapidjson/include")
++  find_package(RapidJSON CONFIG REQUIRED)
++  include_directories(${RapidJSON_INCLUDE_DIRS})
+   ADD_DEFINITIONS( -DRAPIDJSON_HAS_STDSTRING=1)
+   option( ASSIMP_RAPIDJSON_NO_MEMBER_ITERATOR "Suppress rapidjson warning on MSVC (NOTE: breaks android build)" ON )
+   if(ASSIMP_RAPIDJSON_NO_MEMBER_ITERATOR)
+@@ -1353,7 +1348,7 @@
+   ${ASSIMP_EXPORTER_SRCS}
+ 
+   ${FBX_COMMON_SRCS}
+-  
++
+   # Third-party libraries
+   ${unzip_compile_SRCS}
+   ${Poly2Tri_SRCS}
+@@ -1497,13 +1492,11 @@
+     target_link_libraries(assimp PRIVATE ${draco_LIBRARIES})
+   endif()
+ ELSE()
+-  TARGET_LINK_LIBRARIES(assimp ${ZLIB_LIBRARIES} ${OPENDDL_PARSER_LIBRARIES})
++  TARGET_LINK_LIBRARIES(assimp PRIVATE ${ZLIB_LIBRARIES} ${OPENDDL_PARSER_LIBRARIES})
+   if (ASSIMP_BUILD_DRACO)
+     target_link_libraries(assimp ${draco_LIBRARIES})
+   endif()
+-  if(TARGET pugixml::pugixml)
+-    target_link_libraries(assimp pugixml::pugixml)
+-  endif()
++  target_link_libraries(assimp PRIVATE pugixml utf8::cpp)
+ ENDIF()
+ 
+ if(ASSIMP_ANDROID_JNIIOSYSTEM)
+@@ -1608,7 +1601,7 @@
+ 
+ # Add RT-extension library for glTF importer with Open3DGC-compression.
+ IF (RT_FOUND AND ASSIMP_IMPORTER_GLTF_USE_OPEN3DGC)
+-  TARGET_LINK_LIBRARIES(assimp rt)
++  TARGET_LINK_LIBRARIES(assimp PRIVATE rt)
+ ENDIF ()
+ 
+ IF(ASSIMP_INSTALL)
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index 362a43be05..368b52b126 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -263,7 +263,8 @@
+   hunter_add_package(RapidJSON)
+   find_package(RapidJSON CONFIG REQUIRED)
+ ELSE()
+-  INCLUDE_DIRECTORIES("../contrib/rapidjson/include")
++  find_package(RapidJSON CONFIG REQUIRED)
++  include_directories(${RapidJSON_INCLUDE_DIRS})
+   ADD_DEFINITIONS( -DRAPIDJSON_HAS_STDSTRING=1)
+   option( ASSIMP_RAPIDJSON_NO_MEMBER_ITERATOR "Suppress rapidjson warning on MSVC (NOTE: breaks android build)" ON )
+   if(ASSIMP_RAPIDJSON_NO_MEMBER_ITERATOR)


### PR DESCRIPTION
assimp vendors a *lot* of its own libraries, which is generally an anti-pattern for distros as it leads to duplicate work, both for fixing any issues and build compute. unfortunately, assimp does not make it easy to pull in system libraries (there is an open issue for it, but little progress seems to have been made in a few years), so we patch the CMake declarations to use our own in the same way that Fedora and Debian already do. there are still some more vendored things in use (e.g. `gtest`), but we weren't able to get those working.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
