### PR TITLE
playwrite-mcp: fix mkdir to nix store #538295

### DIFF
--- a/pkgs/by-name/pl/playwright-mcp/package.nix
+++ b/pkgs/by-name/pl/playwright-mcp/package.nix
@@ -30,8 +30,11 @@ buildNpmPackage rec {
     ln -s ${playwright-test}/lib/node_modules/playwright "$pkg_dir/node_modules/playwright"
     ln -s ${playwright-test}/lib/node_modules/playwright-core "$pkg_dir/node_modules/playwright-core"
 
+    # playwright-mcp creates browser profile dirs (mcp-<browser>-<hash>) inside
+    # PLAYWRIGHT_BROWSERS_PATH at runtime, so redirect them to a writable cache dir.
     wrapProgram $out/bin/playwright-mcp \
       --set PLAYWRIGHT_BROWSERS_PATH ${playwright-driver.browsers} \
+      --run 'export PWMCP_PROFILES_DIR_FOR_TEST="''${PWMCP_PROFILES_DIR_FOR_TEST:-''${XDG_CACHE_HOME:-$HOME/.cache}/playwright-mcp-profiles}"' \
       --set-default PLAYWRIGHT_MCP_BROWSER chromium
   '';
 


### PR DESCRIPTION
I'm overriding the `PWMCP_PROFILES_DIR_FOR_TEST` env var so that it points to `$HOME/.cache/playwright-mcp-profiles`

https://github.com/microsoft/playwright/blob/e9a206539/packages/playwright-core/src/tools/mcp/browserFactory.ts#L196-L204

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
