### PR TITLE
fetchurl/mirrors: add mirrors for https://kernel.org/pub

### DIFF
--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -122,6 +122,17 @@
     "https://cdn.kernel.org/pub/"
     "http://linux-kernel.uio.no/pub/"
     "ftp://ftp.funet.fi/pub/mirrors/ftp.kernel.org/pub/"
+    "https://mirrors.mit.edu/kernel/"
+    "https://ftp.metu.edu.tr/pub/mirrors/ftp.kernel.org/pub/"
+    "https://ftp.iij.ad.jp/pub/"
+    "https://mirror.yandex.ru/pub/"
+    "https://mirror.math.princeton.edu/pub/kernel/"
+    "https://ftp.cvut.cz/pub/"
+    "https://ftp.iitm.ac.in/kernel/"
+    "https://ftp.riken.jp/Linux/kernel.org/"
+    "https://mirrors.hust.edu.cn/kernel.org/"
+    "https://mirrors.ustc.edu.cn/kernel.org/"
+    "https://mirror.nju.edu.cn/kernel.org/"
   ];
 
   # MySQL


### PR DESCRIPTION
Upstream kernel tarballs are deleted: https://lwn.net/Articles/1081015/ and still restoring by now
Many mirrors including currently listed ones are automatically syncing with upstream so they get affected too.

These mirrors are found by searching `inurl:pub/linux/kernel`, `inurl:linux/kernel/v6.x` and https://mirrors.cernet.edu.cn/list/kernel
then filtered out mirrors that has no `/software` tree as there's 3 usages in nixpkgs: https://github.com/search?q=repo%3ANixOS%2Fnixpkgs%20%22mirror%3A%2F%2Fkernel%2Fsoftware%22&type=code

| latest | mirror tree of kernel tarballs |
|--------|--------------------------------|
|6.1.149 |https://mirrors.mit.edu/kernel/linux/kernel/|
|nothing |https://ftp.metu.edu.tr/pub/mirrors/ftp.kernel.org/pub/linux/kernel/|
|5.19.17 |https://ftp.iij.ad.jp/pub/linux/kernel/linux/kernel/|
|6.1.158 |https://mirror.yandex.ru/pub/linux/kernel/|
|6.1.159 |https://mirror.math.princeton.edu/pub/kernel/linux/kernel/|
|5.19.17 |https://ftp.cvut.cz/pub/linux/kernel/|
|5.19.17 |https://bog.iitm.ac.in/kernel/linux/kernel/|
|5.15.210|https://ftp.riken.jp/Linux/kernel.org/linux/kernel/|
|6.19.14 |https://mirrors.hust.edu.cn/kernel.org/linux/kernel/|
|6.19.14 |https://mirrors.ustc.edu.cn/kernel.org/linux/kernel/|
|nothing |https://mirror.nju.edu.cn/kernel.org/linux/kernel/|

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
