### PR TITLE
assimp: never treat warnings as fatal

### DIFF
--- a/pkgs/by-name/as/assimp/package.nix
+++ b/pkgs/by-name/as/assimp/package.nix
@@ -42,6 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "ASSIMP_BUILD_ASSIMP_TOOLS" true)
     (lib.cmakeBool "ASSIMP_BUILD_TESTS" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeBool "ASSIMP_WARNINGS_AS_ERRORS" false)
   ];
 
   # Some matrix tests fail on non-86_64-linux:


### PR DESCRIPTION
EDIT: see comment below.

gcc 16's stronger analysis for unused variables causes build failures in assimp, which were fixed upstream. we pull the patch to fix these until they've made it into a release. we could just silence the warning/pass `-Wno-error=unused-but-set-variable`, but it seems preferable to take the upstream change instead of potentially letting that flag calcify through future updates if it's not removed.

draft since this is stacked on top of #538296. both are needed to fix the build on gcc 16. the code here should be fine, though.

(part of submitting some fixes to prepare for making gcc 16 the default later this release cycle: https://github.com/NixOS/nixpkgs/pull/537781)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
