### PR TITLE
glog: disable optimization-dependent stacktrace test

### DIFF
--- a/pkgs/by-name/gl/glog/package.nix
+++ b/pkgs/by-name/gl/glog/package.nix
@@ -69,18 +69,22 @@ stdenv.mkDerivation (finalAttrs: {
 
   checkPhase =
     let
-      excludedTests =
-        lib.optionals stdenv.hostPlatform.isDarwin [
-          "mock-log"
-        ]
-        ++ [
-          "logging" # works around segfaults for now
-        ]
-        ++ lib.optionals (stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isBigEndian) [
-          # CHECK_STREQ failed: symbol == "non_inline_func" ((/build/source/build/symbolize_unittest+0x1000b840) vs. non_inline_func)
-          # TestWithPCInsideNonInlineFunction doesn't use TEST(), so can't exclude via GTEST_FILTER
-          "symbolize"
-        ];
+      excludedTests = [
+        "logging" # works around segfaults for now
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isGnu [
+        # Test appears to make strong assumptions about compiler optimizations
+        # that appear to be broken under GCC 16.
+        "stacktrace"
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [
+        "mock-log"
+      ]
+      ++ lib.optionals (stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isBigEndian) [
+        # CHECK_STREQ failed: symbol == "non_inline_func" ((/build/source/build/symbolize_unittest+0x1000b840) vs. non_inline_func)
+        # TestWithPCInsideNonInlineFunction doesn't use TEST(), so can't exclude via GTEST_FILTER
+        "symbolize"
+      ];
       excludedTestsRegex = lib.optionalString (
         excludedTests != [ ]
       ) "(${lib.concatStringsSep "|" excludedTests})";


### PR DESCRIPTION
This test fails under GCC 16. It appears to be because it makes assumptions that certain compiler optimizations do not occur. It clearly is compiler-specific and tries to work around specific compiler optimizations upstream. In particular, an analysis of the test https://github.com/google/glog/blob/53d58e4531c7c90f71ddab503d915e027432447a/src/stacktrace_unittest.cc shows that it would be very plausible/correct for GCC to place labels such that the `INIT_ADDRESS_RANGE` macro has `start` and `end` labels that have the same address. While the functions are labeled NOINLINE, interprocedural analysis could *plausibly* produce this result.

<details>
<summary>Failure logs</summary>

```
Running phase: checkPhase
@nix { "action": "setPhase", "phase": "checkPhase" }
Test project /build/source/build
      Start  1: demangle
 1/22 Test  #1: demangle .........................***Not Run (Disabled)   0.00 sec
      Start  2: signalhandler
 2/22 Test  #2: signalhandler ....................   Passed    0.04 sec
      Start  3: stacktrace
 3/22 Test  #3: stacktrace .......................Subprocess aborted***Exception:   0.30 s>
F20260704 04:53:18.291560 140737352916608 stacktrace_unittest.cc:216] Check failed: (&expe>
    @     0x55555556386a  google::LogMessage::Fail()
    @     0x555555564c44  google::LogMessageFatal::~LogMessageFatal()
    @     0x55555556043d  CheckStackTrace(int) [clone .constprop.0]
    @     0x55555555d7c8  main
    @     0x7ffff782b305  __libc_start_call_main
    @     0x7ffff782b3b8  __libc_start_main_alias_2
    @     0x55555555f1e5  _start

      Start  4: symbolize
 4/22 Test  #4: symbolize ........................   Passed    0.01 sec
      Start  5: mock-log
 5/22 Test  #5: mock-log .........................   Passed    0.02 sec
      Start  6: cmake_package_config_init
 6/22 Test  #6: cmake_package_config_init ........   Passed    0.07 sec
      Start  7: cmake_package_config_generate
 7/22 Test  #7: cmake_package_config_generate ....   Passed    2.82 sec
      Start  8: cmake_package_config_build
 8/22 Test  #8: cmake_package_config_build .......   Passed    5.81 sec
      Start  9: cmake_package_config_cleanup
 9/22 Test  #9: cmake_package_config_cleanup .....   Passed    0.01 sec
      Start 10: cleanup_init
10/22 Test #10: cleanup_init .....................   Passed    0.01 sec
      Start 12: cleanup_immediately
11/22 Test #12: cleanup_immediately ..............   Passed    0.15 sec
      Start 13: cleanup_with_absolute_prefix
12/22 Test #13: cleanup_with_absolute_prefix .....   Passed    0.10 sec
      Start 14: cleanup_with_relative_prefix
13/22 Test #14: cleanup_with_relative_prefix .....   Passed    0.09 sec
      Start 11: cleanup_logdir
14/22 Test #11: cleanup_logdir ...................   Passed    0.04 sec
      Start 15: striplog0
15/22 Test #15: striplog0 ........................   Passed    0.02 sec
      Start 16: striplog2
16/22 Test #16: striplog2 ........................   Passed    0.03 sec
      Start 17: striplog10
17/22 Test #17: striplog10 .......................   Passed    0.01 sec
      Start 18: log_severity_constants
18/22 Test #18: log_severity_constants ...........   Passed    8.50 sec
      Start 19: log_severity_conversion
19/22 Test #19: log_severity_conversion ..........   Passed    7.70 sec
      Start 20: includes_vlog_is_on
20/22 Test #20: includes_vlog_is_on ..............   Passed    4.82 sec
      Start 21: dcheck_on
21/22 Test #21: dcheck_on ........................***Not Run (Disabled)   0.00 sec
      Start 22: dcheck_off
22/22 Test #22: dcheck_off .......................   Passed    8.75 sec

95% tests passed, 1 tests failed out of 20

Total Test time (real) =  39.37 sec

The following tests did not run:
          1 - demangle (Disabled)
         21 - dcheck_on (Disabled)

The following tests FAILED:
          3 - stacktrace (Subprocess aborted)
Errors while running CTest
```
</details>

We are not completely certain that this is the case, but it seems likely that this is not a genuine issue and just a questionable test.

Reformatting is just because it was confusing to us to have the unconditional case be the second entry instead of the first.

(part of submitting some fixes to prepare for making gcc 16 the default later this release cycle: https://github.com/NixOS/nixpkgs/pull/537781)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
