### PR TITLE
xclock: 1.1.1 -> 1.2.0

### DIFF
--- a/pkgs/by-name/xc/xclock/package.nix
+++ b/pkgs/by-name/xc/xclock/package.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
       mit
     ];
     mainProgram = "xclock";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ booxter ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/xc/xclock/package.nix
+++ b/pkgs/by-name/xc/xclock/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitLab,
-  fetchpatch,
   meson,
   ninja,
   pkg-config,
@@ -19,7 +18,7 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "xclock";
-  version = "1.1.1";
+  version = "1.2.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
@@ -27,16 +26,8 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "app";
     repo = "xclock";
     tag = "xclock-${finalAttrs.version}";
-    hash = "sha256-ZgUb+iVO45Az/C+2YJ1TXxcTLk3zQjM1GGv2E69WNfo=";
+    hash = "sha256-sytAl9vXBdxjTM0NnAgRNK34yqn/6zJeCQ/9bH3xaOc=";
   };
-
-  patches = [
-    # meson build system patch
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/xorg/app/xclock/-/commit/28e10bd26ac7e02fe8a4fb8016bb115f8d664032.patch";
-      hash = "sha256-KdrS7VneJqwVPB+TRJoMmtR03Ju3PvvUMYfXz5tII6k=";
-    })
-  ];
 
   strictDeps = true;
 

--- a/pkgs/by-name/xc/xclock/package.nix
+++ b/pkgs/by-name/xc/xclock/package.nix
@@ -5,6 +5,7 @@
   meson,
   ninja,
   pkg-config,
+  versionCheckHook,
   wrapWithXFileSearchPathHook,
   libx11,
   libxaw,
@@ -52,6 +53,10 @@ stdenv.mkDerivation (finalAttrs: {
   mesonFlags = [
     (lib.mesonOption "appdefaultdir" "${placeholder "out"}/share/X11/app-defaults")
   ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "-version";
+  doInstallCheck = true;
 
   passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=xclock-(.*)" ]; };
 


### PR DESCRIPTION
Diff: https://gitlab.freedesktop.org/xorg/app/xclock/-/compare/xclock-1.1.1...xclock-1.2.0

Among other changes, it fixes darwin with this patch:

https://gitlab.freedesktop.org/xorg/app/xclock/-/commit/fd4b44ea3b122cb15181242c4aa9ffc6b2674ca7


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
