### PR TITLE
pkgs/top-level: Remove __allowFileset option

### DIFF
--- a/ci/eval/outpaths.nix
+++ b/ci/eval/outpaths.nix
@@ -83,8 +83,6 @@ let
             inHydra = true;
           }
           // extraNixpkgsConfig;
-
-          __allowFileset = false;
         };
       };
 

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -30,11 +30,11 @@ let
   # there’s nothing we can do about that within the constraints of the
   # Nix language.
   x86_64DarwinDeprecationWarning =
-    pristineLib.warn
+    lib.warn
       "Nixpkgs 26.05 will be the last release to support x86_64-darwin; see https://nixos.org/manual/nixpkgs/unstable/release-notes#x86_64-darwin-26.05"
       (x: x);
 
-  pristineLib = import ../../lib;
+  lib = import ../../lib;
 in
 
 {
@@ -48,10 +48,6 @@ in
 
   # Allow a configuration attribute set to be passed in as an argument.
   config ? { },
-
-  # Temporary hack to let Nixpkgs forbid internal use of `lib.fileset`
-  # until <https://github.com/NixOS/nix/issues/11503> is fixed.
-  __allowFileset ? true,
 
   # List of overlays layers used to extend Nixpkgs.
   overlays ? [ ],
@@ -68,31 +64,16 @@ in
   ...
 }@args:
 
+assert
+  args ? __allowFileset
+  -> throw "__allowFileset option was removed as it's no longer neeed, please remove it.";
+
 let # Rename the function arguments
   config0 = config;
   crossSystem0 = crossSystem;
 
 in
 let
-  lib =
-    if __allowFileset then
-      pristineLib
-    else
-      pristineLib.extend (
-        _: _: {
-          fileset = abort ''
-
-            The use of `lib.fileset` is currently forbidden in Nixpkgs due to the
-            upstream Nix bug <https://github.com/NixOS/nix/issues/11503>. This
-            causes difficult‐to‐debug errors when combined with chroot stores,
-            such as in the NixOS installer.
-
-            For packages that require source to be vendored inside Nixpkgs,
-            please use a subdirectory of the package instead.
-          '';
-        }
-      );
-
   inherit (lib) throwIfNot;
 
   checked =

--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -29,7 +29,6 @@
       allowUnfree = false;
       inHydra = true;
     };
-    __allowFileset = false;
   },
 }:
 

--- a/pkgs/top-level/release-cuda.nix
+++ b/pkgs/top-level/release-cuda.nix
@@ -34,8 +34,6 @@ in
       # Don't evaluate duplicate and/or deprecated attributes
       allowAliases = false;
     };
-
-    __allowFileset = false;
   },
   ...
 }@args:

--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -10,7 +10,6 @@
       allowUnfree = false;
       inHydra = true;
     };
-    __allowFileset = false;
   },
 }:
 

--- a/pkgs/top-level/release-python.nix
+++ b/pkgs/top-level/release-python.nix
@@ -16,8 +16,6 @@
       allowUnfree = false;
       inHydra = true;
     };
-
-    __allowFileset = false;
   },
 }:
 

--- a/pkgs/top-level/release-staging.nix
+++ b/pkgs/top-level/release-staging.nix
@@ -19,7 +19,6 @@
       allowUnfree = false;
       inHydra = true;
     };
-    __allowFileset = false;
   },
 }:
 

--- a/pkgs/top-level/release-unfree-redistributable.nix
+++ b/pkgs/top-level/release-unfree-redistributable.nix
@@ -37,8 +37,6 @@
       cudaSupport = true;
       inHydra = true;
     };
-
-    __allowFileset = false;
   },
   # We only build the full package set on infrequently releasing channels.
   full ? false,

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -49,8 +49,6 @@
         "kanidmWithSecretProvisioning_1_8-1.8.6"
       ];
     };
-
-    __allowFileset = false;
   },
 
   # This flag, if set to true, will inhibit the use of `mapTestOn`


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This options was created as a workaround for https://github.com/NixOS/nix/issues/11503. It is no longer needed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
