### PR TITLE
nixos/nordvpn: init module

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -1891,6 +1891,9 @@
   "sec-kubernetes": [
     "index.html#sec-kubernetes"
   ],
+  "module-services-nordvpn": [
+    "index.html#module-services-nordvpn"
+  ],
   "ch-running": [
     "index.html#ch-running"
   ],

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -54,6 +54,8 @@
 
 - [OO7](https://github.com/linux-credentials/oo7) is a desktop-agnostic Secret Service provider. Available as [services.oo7](#opt-services.oo7.enable)
 
+- [NordVPN](https://github.com/NordSecurity/nordvpn-linux), a NordVPN client for linux. Available as [services.nordvpn](options.html#opt-services.nordvpn.enable).
+
 ## Backward Incompatibilities {#sec-release-26.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1341,6 +1341,7 @@
   ./services/networking/nncp.nix
   ./services/networking/nntp-proxy.nix
   ./services/networking/nomad.nix
+  ./services/networking/nordvpn.nix
   ./services/networking/nsd.nix
   ./services/networking/ntopng.nix
   ./services/networking/ntp/chrony.nix

--- a/nixos/modules/services/networking/nordvpn.md
+++ b/nixos/modules/services/networking/nordvpn.md
@@ -1,0 +1,65 @@
+# NordVPN {#module-services-nordvpn}
+
+*Source:* {file}`modules/services/networking/nordvpn.nix`
+
+*Upstream documentation:* <https://github.com/NordSecurity/nordvpn-linux>
+
+NordVPN offers a paid virtual private network (VPN) service.
+The service operates as closed-source,
+but the Linux client uses open-source code licensed under GPLv3.
+A minimal configuration in NixOS appears as follows:
+
+```nix
+{
+  services.nordvpn.enable = true;
+  networking.firewall.enable = true;
+  networking.firewall.checkReversePath = "loose";
+}
+```
+
+When using a firewall, set `networking.firewall.checkReversePath` to `"loose"` or `false`.
+NordVPN includes a `kill-switch` feature that blocks all packets not associated with the VPN connection.
+
+Additionally, add your user to the `nordvpn` group.
+
+```nix
+{
+  users.users.yourUser = {
+    #..
+    extraGroups = [
+      #..
+      "nordvpn"
+    ];
+  };
+}
+```
+
+If you prefer to use your own user and group, you can do so using
+
+```nix
+{
+  services.nordvpn.user = "SOME-USER";
+  services.nordvpn.group = "SOME-GROUP";
+}
+```
+
+NordVPN provides several useful CLI commands, including:
+
+```bash
+nordvpn login  # Log in using an OAuth URL
+nordvpn login --token <token>  # Log in with a token obtained from your NordVPN account
+nordvpn c  # Connect to the VPN
+nordvpn c ie  # Connect to a NordVPN server in Ireland
+nordvpn d  # Disconnect from the VPN
+nordvpn set technology openvpn  # Switch to OpenVPN technology
+nordvpn c  # Reconnect after changing technology
+```
+
+Additionally, if you prefer to use the friendly GUI,
+
+```bash
+nordvpn-gui
+```
+
+**Disclaimer:** NixOS currently does not support meshnet.
+Contributions welcome!

--- a/nixos/modules/services/networking/nordvpn.nix
+++ b/nixos/modules/services/networking/nordvpn.nix
@@ -1,0 +1,171 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.nordvpn;
+  defaultUser = "nordvpn";
+  defaultGroup = "nordvpn";
+
+  nordvpn =
+    let
+      cli = cfg.package.cli.overrideAttrs (old: {
+        preBuild =
+          let
+            extraPreBuild = lib.optionalString (cfg.group != defaultGroup) ''
+              substituteInPlace internal/permissions.go \
+                --replace-fail \
+                      'string{"nordvpn"}' \
+                      'string{"${cfg.group}"}'
+
+              substituteInPlace internal/constants.go \
+                  --replace-fail \
+                      'NordvpnGroup = "nordvpn"' \
+                      'NordvpnGroup = "${cfg.group}"'
+            '';
+          in
+          extraPreBuild + (old.preBuild or "");
+
+        # postFixup wraps nordvpnd so that it can find binaries that it calls.
+        # here, instead, use systemd to update the path to those binaries.
+        postFixup = "";
+      });
+    in
+    pkgs.symlinkJoin {
+      inherit (cfg.package) pname version meta;
+      paths = [
+        cli
+        cfg.package.gui
+      ];
+    };
+in
+{
+  options.services.nordvpn = {
+    enable = lib.mkEnableOption "Enable NordVPN";
+    package = lib.mkPackageOption pkgs "nordvpn" { };
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = defaultUser;
+      description = ''
+        The User that owns the `nordvpnd` systemd process.
+        If overriding the default, a user with the same name must exist.
+      '';
+    };
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = defaultGroup;
+      description = ''
+        The Group that owns the `nordvpnd` systemd process.
+        If overriding the default, a group with the same name must exist.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+
+    # create the default user if that's the one used
+    users.users = lib.mkIf (cfg.user == defaultUser) {
+      ${defaultUser} = {
+        description = "User that runs `nordvpnd`.";
+        group = cfg.group;
+        isSystemUser = true;
+      };
+    };
+
+    # create the default group if that's the one used
+    users.groups = lib.mkIf (cfg.group == defaultGroup) {
+      ${defaultGroup} = { };
+    };
+
+    # nordvpnd uses resolved to configure dns
+    services.resolved.enable = true;
+
+    # policy that allows nordvpnd to configure dns
+    security.polkit = {
+      enable = true;
+      extraConfig = ''
+        polkit.addRule(function(action, subject) {
+          if (action.id == "org.freedesktop.resolve1.set-dns-servers"
+              && subject.isInGroup("${cfg.group}")) {
+            return polkit.Result.YES;
+          }
+        });
+      '';
+    };
+
+    environment.systemPackages = [
+      nordvpn
+    ];
+
+    systemd.services.nordvpnd = {
+      after = [ "network-online.target" ];
+      description = "NordVPN daemon.";
+      path = (
+        with pkgs;
+        [
+          e2fsprogs
+          iproute2
+          libxslt
+          nftables
+          procps
+          wireguard-tools
+        ]
+        ++ [ nordvpn ]
+      );
+      serviceConfig = {
+        # nordvpnd needs CAP_NET_ADMIN to configure network interfaces
+        AmbientCapabilities = "CAP_NET_ADMIN";
+        CapabilityBoundingSet = "CAP_NET_ADMIN";
+        ExecStart = lib.getExe' nordvpn "nordvpnd";
+        Group = cfg.group;
+        KillMode = "process";
+        NonBlocking = true;
+        Requires = "nordvpnd.socket";
+        Restart = "on-failure";
+        RestartSec = 5;
+        RuntimeDirectory = "nordvpn";
+        RuntimeDirectoryMode = "0750";
+        StateDirectory = "nordvpn";
+        StateDirectoryMode = "0750";
+        User = cfg.user;
+      };
+      wantedBy = [ "default.target" ];
+      wants = [ "network-online.target" ];
+    };
+
+    systemd.sockets.nordvpnd = {
+      description = "NordVPN Daemon Socket";
+      listenStreams = [ "/run/nordvpn/nordvpnd.sock" ];
+      partOf = [ "nordvpnd.service" ];
+      socketConfig = {
+        DirectoryMode = "0750";
+        NoDelay = true;
+        SocketGroup = cfg.group;
+        SocketMode = "0770";
+        SocketUser = cfg.user;
+      };
+      wantedBy = [ "sockets.target" ];
+    };
+
+    systemd.user.services.norduserd = {
+      after = [ "network-online.target" ];
+      description = "NordUserD Service";
+      serviceConfig = {
+        ExecStart = lib.getExe' nordvpn "norduserd";
+        NonBlocking = true;
+        Restart = "on-failure";
+        RestartSec = 5;
+      };
+      wantedBy = [ "graphical-session.target" ];
+      wants = [ "network-online.target" ];
+    };
+
+  };
+
+  meta = {
+    doc = ./nordvpn.md;
+    maintainers = with lib.maintainers; [ different-error ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1205,6 +1205,7 @@ in
   nominatim = runTest ./nominatim.nix;
   non-default-filesystems = handleTest ./non-default-filesystems.nix { };
   non-switchable-system = runTest ./non-switchable-system.nix;
+  nordvpn = runTest ./nordvpn.nix;
   noto-fonts = runTest ./noto-fonts.nix;
   noto-fonts-cjk-qt-default-weight = runTest ./noto-fonts-cjk-qt-default-weight.nix;
   novacomd = handleTestOn [ "x86_64-linux" ] ./novacomd.nix { };

--- a/nixos/tests/nordvpn.nix
+++ b/nixos/tests/nordvpn.nix
@@ -1,0 +1,129 @@
+{ lib, ... }:
+{
+  name = "nordvpn";
+  meta.maintainers = with lib.maintainers; [ different-error ];
+  nodes =
+    let
+      commonConfig = user: {
+        # norduserd reads DBUS_SESSION_BUS_ADDRESS which the
+        # desktopManager sets on user session creation (i.e. login)
+        services.xserver.enable = true;
+        services.desktopManager.plasma6.enable = true;
+        services.displayManager.gdm.enable = true;
+        services.displayManager.autoLogin = {
+          enable = true;
+          user = user;
+        };
+      };
+    in
+    {
+      nada = { ... }: { };
+      basic =
+        { ... }:
+        lib.recursiveUpdate {
+          users.users.alice = {
+            extraGroups = [ "nordvpn" ];
+            isNormalUser = true;
+          };
+          # default: run nordvpnd as nordvpn:nordvpn
+          services.nordvpn.enable = true;
+        } (commonConfig "alice");
+      userOnly =
+        { ... }:
+        lib.recursiveUpdate {
+          users.users.kanye = {
+            extraGroups = [ "nordvpn" ];
+            isNormalUser = true;
+          };
+          # run nordvpnd as kanye:nordvpn
+          services.nordvpn = {
+            enable = true;
+            user = "kanye";
+          };
+        } (commonConfig "kanye");
+      groupOnly =
+        { ... }:
+        lib.recursiveUpdate {
+          users.users.alice = {
+            extraGroups = [ "kanye" ];
+            isNormalUser = true;
+          };
+          users.groups.kanye = { };
+          # run nordvpnd as nordvpn:kanye
+          services.nordvpn = {
+            enable = true;
+            group = "kanye";
+          };
+        } (commonConfig "alice");
+      userAndGroup =
+        { ... }:
+        lib.recursiveUpdate {
+          users.users.kanye = {
+            group = "kanye";
+            isNormalUser = true;
+          };
+          users.groups.kanye = { };
+          # run nordvpnd as kanye:kanye
+          services.nordvpn = {
+            enable = true;
+            group = "kanye";
+            user = "kanye";
+          };
+        } (commonConfig "kanye");
+    };
+
+  testScript = ''
+    class UserGroupTestCase:
+      def __init__(self, machine, user, has_nordvpn_usr, has_nordvpn_gp):
+        self.machine = machine
+        self.user = user
+        self.has_nordvpn_usr = has_nordvpn_usr
+        self.has_nordvpn_gp = has_nordvpn_gp
+
+      def run(self):
+        self.machine.start()
+        self.verify_nordvpn_user()
+        self.verify_nordvpn_group()
+        self.verify_services()
+        self.machine.shutdown()
+
+      def verify_nordvpn_user(self):
+          if self.has_nordvpn_usr:
+            self.machine.succeed("id nordvpn")
+          else:
+            self.machine.fail("id nordvpn")
+
+      def verify_nordvpn_group(self):
+        group_str = self.machine.succeed(f"sudo -u {self.user} groups")
+        groups = [x.strip() for x in group_str.split(" ")]
+        if self.has_nordvpn_gp:
+          assert "nordvpn" in groups, f"nordvpn is not in {groups} but should be"
+        else:
+          assert "nordvpn" not in groups, f"nordvpn is in {groups} but should not be"
+
+      def verify_services(self):
+        self.machine.wait_for_unit("nordvpnd", timeout=60)
+        self.machine.wait_for_unit("norduserd", self.user, timeout=90)
+        # verify can talk to nordvpnd. give nordvpnd at most 5s to initialize.
+        self.machine.wait_until_succeeds("nordvpn status", timeout=5)
+        self.machine.succeed("nordvpn status")
+
+    test_cases = [
+      UserGroupTestCase(basic, "alice", has_nordvpn_usr=True,  has_nordvpn_gp=True),
+      UserGroupTestCase(userOnly, "kanye", has_nordvpn_usr=False, has_nordvpn_gp=True),
+      UserGroupTestCase(groupOnly, "alice", has_nordvpn_usr=True,  has_nordvpn_gp=False),
+      UserGroupTestCase(userAndGroup, "kanye", has_nordvpn_usr=False, has_nordvpn_gp=False),
+    ]
+
+    # NADA
+    nada.start()
+    nada.wait_for_unit("multi-user.target", timeout=60)
+    nada.fail("nordvpnd")
+    nada.fail("nordvpn")
+    nada.fail("norduserd")
+    nada.shutdown()
+
+    for test_case in test_cases:
+      test_case.run()
+  '';
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

AI disclaimer: I wrote most of the code before Claude, but may have used Claude for feedback.

Other relevant prs: [previous module pr](https://github.com/NixOS/nixpkgs/pull/406725), [package pr](https://github.com/NixOS/nixpkgs/pull/477174).

I use the following configuration.nix file for building the vm:
```nix
{
  pkgs,
  ...
}:

{
  imports = [
    ./hardware-configuration.nix
  ];

  boot.loader.systemd-boot.enable = true;
  boot.loader.efi.canTouchEfiVariables = true;
  networking.firewall.enable = true;
  networking.firewall.checkReversePath = "loose";

  services.xserver.enable = true;
  services.displayManager.gdm.enable = true;
  services.desktopManager.plasma6.enable = true;

  environment.etc.hosts.mode = "0644";

  services.nordvpn = {
    enable = true;
    group = "alice";
  };

  virtualisation.vmVariant = {
    virtualisation = {
      memorySize = 8192;
      cores = 3;
    };
  };
  users.groups.alice = { };
  users.users.alice = {
    isNormalUser = true;
    password = "alice";
    group = "alice";
    extraGroups = [
      "wheel"
      "nordvpn"
    ];
    shell = pkgs.bash;
    home = "/home/alice";
    createHome = true;
    packages = with pkgs; [
      tree
      tmux
      dunst
      libnotify
      socat
      vim
      appimage-run
      firefox
      #nordvpn
    ];
  };
  system.stateVersion = "24.11"; # Did you read the comment?
}
```

```
nixos-rebuild build-vm -I nixpkgs=/path/to/nixpkgs -I nixos-config=/path/to/configuration.nix
```