### PR TITLE
minikube: add kubectl symlink, add runHook, use writableTmpDirAsHomeHook

### DIFF
--- a/pkgs/by-name/mi/minikube/package.nix
+++ b/pkgs/by-name/mi/minikube/package.nix
@@ -69,6 +69,7 @@ buildGoModule (finalAttrs: {
     install out/minikube -Dt $out/bin
 
     wrapProgram $out/bin/minikube --set MINIKUBE_WANTUPDATENOTIFICATION false
+    ln -sv $out/bin/minikube $out/bin/kubectl
 
     for shell in bash zsh fish; do
       $out/bin/minikube completion $shell > minikube.$shell

--- a/pkgs/by-name/mi/minikube/package.nix
+++ b/pkgs/by-name/mi/minikube/package.nix
@@ -56,10 +56,16 @@ buildGoModule (finalAttrs: {
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ libvirt ];
 
   buildPhase = ''
+    runHook preBuild
+
     make COMMIT=${finalAttrs.src.rev}
+
+    runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
+
     install out/minikube -Dt $out/bin
 
     wrapProgram $out/bin/minikube --set MINIKUBE_WANTUPDATENOTIFICATION false
@@ -68,6 +74,8 @@ buildGoModule (finalAttrs: {
       $out/bin/minikube completion $shell > minikube.$shell
       installShellCompletion minikube.$shell
     done
+
+    runHook postInstall
   '';
 
   meta = {

--- a/pkgs/by-name/mi/minikube/package.nix
+++ b/pkgs/by-name/mi/minikube/package.nix
@@ -26,7 +26,7 @@ buildGoModule (finalAttrs: {
     owner = "kubernetes";
     repo = "minikube";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-1unwbu2pJviHXukQKalJLgrkHpjf0sRR2nCm2gKv2VU=";
+    hash = "sha256-1unwbu2pJviHXukQKalJLgrkHpjf0sRR2nCm2gKv2VU=";
   };
   postPatch = ''
     substituteInPlace Makefile \

--- a/pkgs/by-name/mi/minikube/package.nix
+++ b/pkgs/by-name/mi/minikube/package.nix
@@ -10,6 +10,7 @@
   withQemu ? false,
   qemu,
   makeWrapper,
+  writableTmpDirAsHomeHook,
   OVMF,
 }:
 
@@ -49,6 +50,7 @@ buildGoModule (finalAttrs: {
     pkg-config
     which
     makeWrapper
+    writableTmpDirAsHomeHook
   ];
 
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ libvirt ];
@@ -61,7 +63,6 @@ buildGoModule (finalAttrs: {
     install out/minikube -Dt $out/bin
 
     wrapProgram $out/bin/minikube --set MINIKUBE_WANTUPDATENOTIFICATION false
-    export HOME=$PWD
 
     for shell in bash zsh fish; do
       $out/bin/minikube completion $shell > minikube.$shell


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

* Add kubectl symlink as suggested by [official docs](https://minikube.sigs.k8s.io/docs/handbook/kubectl/); this improves kubectl shell completion use.
* Add `runHook` call for pre and post in `buildPhase` and `installPhase`
* Replace `export HOME=$PWD` with `writableTmpDirAsHomeHook` in `nativeBuildInputs`
* Use `src.hash` instead of `src.sha256`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
