### PR TITLE
[staging-next] {jetbrains-mono, python313Packages.gftools,python313Packages.ttfautohint-py}: fix build

### DIFF
--- a/pkgs/by-name/je/jetbrains-mono/package.nix
+++ b/pkgs/by-name/je/jetbrains-mono/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
-  python3Packages,
+  python313Packages,
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -19,7 +19,8 @@ stdenvNoCC.mkDerivation rec {
   env."PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION" = "python";
 
   nativeBuildInputs = [
-    python3Packages.gftools
+    # Currently broken on 3.14
+    python313Packages.gftools
   ];
 
   buildPhase = ''

--- a/pkgs/development/python-modules/gftools/default.nix
+++ b/pkgs/development/python-modules/gftools/default.nix
@@ -158,7 +158,6 @@ buildPythonPackage rec {
     requests
     rich
     ruamel-yaml
-    setuptools
     skia-pathops
     statmake
     strictyaml

--- a/pkgs/development/python-modules/ttfautohint-py/default.nix
+++ b/pkgs/development/python-modules/ttfautohint-py/default.nix
@@ -36,10 +36,6 @@ buildPythonPackage rec {
     distutils
   ];
 
-  dependencies = [
-    setuptools # for pkg_resources
-  ];
-
   buildInputs = [ ttfautohint ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
-  `fs` is unsupported on Python 3.14 which breaks `gftools` on 3.14. -> switch `jetbrains-mono` to `python313Packages.gftools`
- `python313Packages.fs` now uses setuptools 80, which causes dependency issues for `python313Packages.gftools` and `python313Packages.ttfautohint-py` as they both had `setuptools` (82) in their `dependencies`. However, both removed `pkg_resources` from their source code, so this dependency is outdated and not required anymore.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - here: font files
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
