### PR TITLE
orca-slicer: build with clang

### DIFF
--- a/pkgs/by-name/or/orca-slicer/package.nix
+++ b/pkgs/by-name/or/orca-slicer/package.nix
@@ -1,5 +1,5 @@
 {
-  stdenv,
+  clangStdenv,
   lib,
   binutils,
   fetchFromGitHub,
@@ -39,7 +39,7 @@
   wxwidgets_3_3,
   libx11,
   libnoise,
-  withSystemd ? stdenv.hostPlatform.isLinux,
+  withSystemd ? clangStdenv.hostPlatform.isLinux,
   withNvidiaGLWorkaround ? false,
 }:
 let
@@ -58,7 +58,10 @@ let
         ];
       });
 in
-stdenv.mkDerivation (finalAttrs: {
+# Build with clang even on Linux, because GCC uses absolutely obscene amounts of memory
+# on this particular code base (OOM with 32GB memory and --cores 16 on GCC, succeeds
+# with --cores 32 on clang).
+clangStdenv.mkDerivation (finalAttrs: {
   pname = "orca-slicer";
   version = "2.4.1";
 
@@ -152,32 +155,24 @@ stdenv.mkDerivation (finalAttrs: {
   env = {
     NLOPT = nlopt;
 
-    NIX_CFLAGS_COMPILE = toString (
-      [
-        "-Wno-ignored-attributes"
-        "-I${opencv.out}/include/opencv4"
-        "-Wno-error=incompatible-pointer-types"
-        "-Wno-template-id-cdtor"
-        "-Wno-uninitialized"
-        "-Wno-unused-result"
-        "-Wno-deprecated-declarations"
-        "-Wno-use-after-free"
-        "-Wno-format-overflow"
-        "-Wno-stringop-overflow"
-        "-DBOOST_ALLOW_DEPRECATED_HEADERS"
-        "-DBOOST_MATH_DISABLE_STD_FPCLASSIFY"
-        "-DBOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS"
-        "-DBOOST_MATH_DISABLE_FLOAT128"
-        "-DBOOST_MATH_NO_QUAD_SUPPORT"
-        "-DBOOST_MATH_MAX_FLOAT128_DIGITS=0"
-        "-DBOOST_CSTDFLOAT_NO_LIBQUADMATH_SUPPORT"
-        "-DBOOST_MATH_DISABLE_FLOAT128_BUILTIN_FPCLASSIFY"
-      ]
-      # Making it compatible with GCC 14+, see https://github.com/SoftFever/OrcaSlicer/pull/7710
-      ++ lib.optionals (stdenv.cc.isGNU && lib.versionAtLeast stdenv.cc.version "14") [
-        "-Wno-error=template-id-cdtor"
-      ]
-    );
+    NIX_CFLAGS_COMPILE = toString [
+      "-Wno-ignored-attributes"
+      "-I${opencv.out}/include/opencv4"
+      "-Wno-error=incompatible-pointer-types"
+      "-Wno-error=format-security"
+      "-Wno-uninitialized"
+      "-Wno-unused-result"
+      "-Wno-deprecated-declarations"
+      "-Wno-format-overflow"
+      "-DBOOST_ALLOW_DEPRECATED_HEADERS"
+      "-DBOOST_MATH_DISABLE_STD_FPCLASSIFY"
+      "-DBOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS"
+      "-DBOOST_MATH_DISABLE_FLOAT128"
+      "-DBOOST_MATH_NO_QUAD_SUPPORT"
+      "-DBOOST_MATH_MAX_FLOAT128_DIGITS=0"
+      "-DBOOST_CSTDFLOAT_NO_LIBQUADMATH_SUPPORT"
+      "-DBOOST_MATH_DISABLE_FLOAT128_BUILTIN_FPCLASSIFY"
+    ];
 
     NIX_LDFLAGS = toString [
       (lib.optionalString withSystemd "-ludev")


### PR DESCRIPTION
Same situation as prusa-slicer, older versions did some extremely cursed things clang categorically refused to accept, 2.4.x seems to be better.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
