### PR TITLE
moyu: init at 0.15.1

### DIFF
--- a/pkgs/by-name/mo/moyu/package.nix
+++ b/pkgs/by-name/mo/moyu/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  clang,
+  lld,
+  makeBinaryWrapper,
+  libopus,
+  alsa-lib,
+  udev,
+  wayland,
+  libxkbcommon,
+  libGL,
+  libx11,
+  libxcursor,
+  libxi,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "moyu";
+  version = "0.15.1";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Icemic";
+    repo = "moyu";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-GoCcFhUbWB5NBVKgqjejBGlyElbmeD4ry/dcbegb/1Y=";
+  };
+
+  cargoHash = "sha256-Jef2CjSuJISGHyrVpXkuG8PzP+C+xNDE3SlL8ldsiAo=";
+
+  nativeBuildInputs = [
+    pkg-config
+    clang # libquickjs-ng-sys
+    lld
+    rustPlatform.bindgenHook
+    makeBinaryWrapper
+  ];
+
+  buildInputs = [
+    libopus # audiopus_sys
+    alsa-lib
+    udev
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/${finalAttrs.meta.mainProgram} \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath (
+          finalAttrs.buildInputs
+          ++ [
+            wayland
+            libxkbcommon
+            libGL
+            libx11
+            libxcursor
+            libxi
+          ]
+        )
+      }
+  '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--use-github-releases" ]; };
+
+  meta = {
+    description = "Cross-platform visual novel engine";
+    homepage = "https://momoyu.ink/";
+    downloadPage = "https://github.com/Icemic/moyu/releases";
+    license = lib.licenses.mpl20;
+    mainProgram = "moyu";
+    maintainers = with lib.maintainers; [ chillcicada ];
+  };
+})


### PR DESCRIPTION
way to test this package (`git-lfs`, `nodejs` and `yarn-berry` are required):

```
git clone https://github.com/DeepSpaceMill/framework.git my-vn-project
cd my-vn-project
```

run `yarn install` to init the test project

run `yarn engine:update` to download the engine and replace the native engine by what you build. then run `yarn dev` start the development server, after that, run:

```
yarn engine:native
```

then you can preview it in the native window

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
