### PR TITLE
stremio-linux-shell: 1.0.2 -> 1.1.2; install more files

### DIFF
--- a/pkgs/by-name/st/stremio-linux-shell/out-path.patch
+++ b/pkgs/by-name/st/stremio-linux-shell/out-path.patch
@@ -1,13 +1,22 @@
 diff --git a/build.rs b/build.rs
-index aa2bec5..f37a94d 100644
+index aa2bec5..d512a42 100644
 --- a/build.rs
 +++ b/build.rs
+@@ -26,7 +26,7 @@ fn setup_po() -> Result<()> {
+             && extension == "po"
+             && let Some(po_lang) = path.file_stem()
+         {
+-            let mo_dir = po_dir.join(po_lang).join("LC_MESSAGES");
++            let mo_dir = Path::new("@out@/share/locale").join(po_lang).join("LC_MESSAGES");
+ 
+             fs::create_dir_all(&mo_dir)?;
+ 
 @@ -46,7 +46,7 @@ fn setup_po() -> Result<()> {
  fn setup_schemas(filename: &str) -> Result<()> {
      println!("cargo:rerun-if-changed={DATA_DIR}");
  
 -    let out_dir = dirs::data_dir().expect("Failed to get data dir");
-+    let out_dir = std::path::PathBuf::from("@out@/share");
++    let out_dir = Path::new("@out@/share");
      let out_dir = out_dir.join("glib-2.0/schemas");
  
      fs::create_dir_all(&out_dir)?;

--- a/pkgs/by-name/st/stremio-linux-shell/out-path.patch
+++ b/pkgs/by-name/st/stremio-linux-shell/out-path.patch
@@ -1,0 +1,33 @@
+diff --git a/build.rs b/build.rs
+index aa2bec5..f37a94d 100644
+--- a/build.rs
++++ b/build.rs
+@@ -46,7 +46,7 @@ fn setup_po() -> Result<()> {
+ fn setup_schemas(filename: &str) -> Result<()> {
+     println!("cargo:rerun-if-changed={DATA_DIR}");
+ 
+-    let out_dir = dirs::data_dir().expect("Failed to get data dir");
++    let out_dir = std::path::PathBuf::from("@out@/share");
+     let out_dir = out_dir.join("glib-2.0/schemas");
+ 
+     fs::create_dir_all(&out_dir)?;
+diff --git a/data/com.stremio.Stremio.service b/data/com.stremio.Stremio.service
+index 7cfb139..7491969 100644
+--- a/data/com.stremio.Stremio.service
++++ b/data/com.stremio.Stremio.service
+@@ -1,3 +1,3 @@
+ [D-BUS Service]
+ Name=com.stremio.Stremio
+-Exec=/app/bin/stremio --gapplication-service
++Exec=@out@/bin/stremio --gapplication-service
+diff --git a/data/stremio.sh b/data/stremio.sh
+index 161bada..37373b0 100644
+--- a/data/stremio.sh
++++ b/data/stremio.sh
+@@ -5,4 +5,4 @@ if ls /dev/nvidia0 &>/dev/null 2>&1; then
+     export GSK_RENDERER=opengl
+ fi
+ 
+-exec /app/libexec/stremio/stremio "$@"
+\ No newline at end of file
++exec @out@/libexec/stremio/stremio "$@"

--- a/pkgs/by-name/st/stremio-linux-shell/package.nix
+++ b/pkgs/by-name/st/stremio-linux-shell/package.nix
@@ -68,9 +68,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
   postInstall = ''
     install -Dm644 data/icons/com.stremio.Stremio.svg $out/share/icons/hicolor/scalable/apps/com.stremio.Stremio.svg
     install -Dm644 data/com.stremio.Stremio.desktop $out/share/applications/com.stremio.Stremio.desktop
+    install -Dm644 data/com.stremio.Stremio.metainfo.xml $out/share/metainfo/com.stremio.Stremio.metainfo.xml
     install -Dm644 data/com.stremio.Stremio.service $out/share/dbus-1/services/com.stremio.Stremio.service
     install -Dm644 data/server.js $out/libexec/stremio/server.js
     install -Dm755 data/stremio.sh $out/bin/stremio
+    install -Dm644 LICENSE $out/share/licenses/stremio/LICENSE
 
     mv $out/bin/stremio-linux-shell $out/libexec/stremio/stremio
   '';

--- a/pkgs/by-name/st/stremio-linux-shell/package.nix
+++ b/pkgs/by-name/st/stremio-linux-shell/package.nix
@@ -116,7 +116,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
       fromSource
       obfuscatedCode # server.js
     ];
-    maintainers = with lib.maintainers; [ thunze ];
+    maintainers = with lib.maintainers; [
+      thunze
+      fazzi
+    ];
     platforms = lib.platforms.linux;
     mainProgram = "stremio";
   };

--- a/pkgs/by-name/st/stremio-linux-shell/package.nix
+++ b/pkgs/by-name/st/stremio-linux-shell/package.nix
@@ -26,7 +26,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "stremio-linux-shell";
-  version = "1.0.2";
+  version = "1.1.1";
 
   strictDeps = true;
   __structuredAttrs = true;
@@ -35,17 +35,18 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "Stremio";
     repo = "stremio-linux-shell";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-NbzUAv/L8xzdepqn677nlROumjlliZIHzPXIToHHeTU=";
+    hash = "sha256-L4axAO+Ky0QKC/WiGvpvSAsqld60znknxbSnSDCxPnY=";
   };
 
-  cargoHash = "sha256-yafkD7D0E+lbFV7MlLwQM4iWC8Glo/Tn2F+TFff6GoM=";
+  cargoHash = "sha256-fI3HplELOl0EG8JIZYnPi9Nm0K1F7eA13gIsP3AKTjQ=";
+
+  patches = [
+    ./out-path.patch
+  ];
 
   postPatch = ''
-    substituteInPlace data/com.stremio.Stremio.service \
-      --replace-fail "Exec=/app/bin/stremio" "Exec=$out/bin/stremio"
-
-    substituteInPlace data/stremio.sh \
-      --replace-fail "/app/libexec/stremio/stremio" "$out/libexec/stremio/stremio"
+    substituteInPlace data/com.stremio.Stremio.service data/stremio.sh build.rs \
+      --subst-var out
   '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/st/stremio-linux-shell/package.nix
+++ b/pkgs/by-name/st/stremio-linux-shell/package.nix
@@ -3,7 +3,7 @@
   rustPlatform,
   fetchFromGitHub,
   versionCheckHook,
-  gitUpdater,
+  nix-update-script,
 
   # nativeBuildInputs
   pkg-config,
@@ -93,7 +93,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   doInstallCheck = true;
 
   passthru = {
-    updateScript = gitUpdater { rev-prefix = "v"; };
+    updateScript = nix-update-script {
+      extraArgs = [ "--version-regex=^v([0-9.]+)$" ];
+    };
   };
 
   meta = {

--- a/pkgs/by-name/st/stremio-linux-shell/package.nix
+++ b/pkgs/by-name/st/stremio-linux-shell/package.nix
@@ -26,7 +26,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "stremio-linux-shell";
-  version = "1.1.1";
+  version = "1.1.2";
 
   strictDeps = true;
   __structuredAttrs = true;
@@ -35,10 +35,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "Stremio";
     repo = "stremio-linux-shell";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-L4axAO+Ky0QKC/WiGvpvSAsqld60znknxbSnSDCxPnY=";
+    hash = "sha256-jo+9KDX/a46jPTmYhiFNgp5fDKhoAsML/+m7u3ituEQ=";
   };
 
-  cargoHash = "sha256-fI3HplELOl0EG8JIZYnPi9Nm0K1F7eA13gIsP3AKTjQ=";
+  cargoHash = "sha256-hZ9neZD+aB7bth4UTsWJXIKGSbo/c3wZRtfOIp7LvwY=";
 
   patches = [
     ./out-path.patch


### PR DESCRIPTION
Changelog:

- https://github.com/Stremio/stremio-linux-shell/releases/tag/v1.0.3
- https://github.com/Stremio/stremio-linux-shell/releases/tag/v1.1.0
- https://github.com/Stremio/stremio-linux-shell/releases/tag/v1.1.1
- https://github.com/Stremio/stremio-linux-shell/releases/tag/v1.1.2

Diff: https://github.com/Stremio/stremio-linux-shell/compare/v1.0.2...v1.1.2

Additional changes:

- Install more files to match [upstream packaging](https://github.com/Stremio/stremio-linux-shell/blob/v1.1.1/flatpak/com.stremio.Stremio.Devel.json)
- Fix the update script (git-updater doesn't update `cargoHash`)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
