### PR TITLE
pikpaktui: init at 0.0.56

### DIFF
--- a/pkgs/by-name/pi/pikpaktui/package.nix
+++ b/pkgs/by-name/pi/pikpaktui/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "pikpaktui";
+  version = "0.0.56";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Bengerthelorf";
+    repo = "pikpaktui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-LUOVfjNutjtXk4omjSoJNA+b2sACnXZsRNlUB7oWD60=";
+  };
+
+  cargoHash = "sha256-lTLZm+gPH4qYfZSsZ4YXcz5Zd8U7JYX+b9U2wwm08ew=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  env.OPENSSL_NO_VENDOR = 1;
+
+  buildInputs = [ openssl ];
+
+  __darwinAllowLocalNetworking = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--use-github-releases" ]; };
+
+  meta = {
+    description = "TUI and CLI client for PikPak cloud storage";
+    homepage = "https://app.snaix.homes/pikpaktui/";
+    downloadPage = "https://github.com/Bengerthelorf/pikpaktui/releases";
+    license = lib.licenses.asl20;
+    mainProgram = "pikpaktui";
+    maintainers = with lib.maintainers; [ chillcicada ];
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
