### PR TITLE
dopamine: drop electron version pin

### DIFF
--- a/pkgs/by-name/do/dopamine/bump-better-sqlite3.patch
+++ b/pkgs/by-name/do/dopamine/bump-better-sqlite3.patch
@@ -1,0 +1,48 @@
+diff --git a/package-lock.json b/package-lock.json
+index 921ffcdc..f1a2aeeb 100644
+--- a/package-lock.json
++++ b/package-lock.json
+@@ -17,7 +17,7 @@
+                 "@electron/remote": "2.1.3",
+                 "@fortawesome/fontawesome-free": "^6.6.0",
+                 "angular-split": "14.1.0",
+-                "better-sqlite3": "12.5.0",
++                "better-sqlite3": "12.11.1",
+                 "cheerio": "1.0.0-rc.12",
+                 "discord-rpc": "4.0.1",
+                 "electron-log": "4.4.8",
+@@ -10353,9 +10353,9 @@
+             "license": "MIT"
+         },
+         "node_modules/better-sqlite3": {
+-            "version": "12.5.0",
+-            "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.5.0.tgz",
+-            "integrity": "sha512-WwCZ/5Diz7rsF29o27o0Gcc1Du+l7Zsv7SYtVPG0X3G/uUI1LqdxrQI7c9Hs2FWpqXXERjW9hp6g3/tH7DlVKg==",
++            "version": "12.11.1",
++            "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
++            "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
+             "hasInstallScript": true,
+             "license": "MIT",
+             "dependencies": {
+@@ -10363,7 +10363,7 @@
+                 "prebuild-install": "^7.1.1"
+             },
+             "engines": {
+-                "node": "20.x || 22.x || 23.x || 24.x || 25.x"
++                "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+             }
+         },
+         "node_modules/big.js": {
+diff --git a/package.json b/package.json
+index 2c07792f..9023e10c 100644
+--- a/package.json
++++ b/package.json
+@@ -98,7 +98,7 @@
+         "@electron/remote": "2.1.3",
+         "@fortawesome/fontawesome-free": "^6.6.0",
+         "angular-split": "14.1.0",
+-        "better-sqlite3": "12.5.0",
++        "better-sqlite3": "12.11.1",
+         "cheerio": "1.0.0-rc.12",
+         "discord-rpc": "4.0.1",
+         "electron-log": "4.4.8",

--- a/pkgs/by-name/do/dopamine/package.nix
+++ b/pkgs/by-name/do/dopamine/package.nix
@@ -3,30 +3,36 @@
   stdenv,
   fetchFromGitHub,
   buildNpmPackage,
-  electron_40,
+  electron,
   python3,
   xcodebuild,
+  applyPatches,
 }:
 buildNpmPackage (finalAttrs: {
   pname = "dopamine";
   version = "3.0.6";
 
-  src = fetchFromGitHub {
-    owner = "digimezzo";
-    repo = "dopamine";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-HTPWejm5Wi6yGJyS/f1RhjIluTz01ue8lAsnAcQY3IY=";
+  # needed to upgrade better-sqlite3 in npmConfigHook
+  src = applyPatches {
+    src = fetchFromGitHub {
+      owner = "digimezzo";
+      repo = "dopamine";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-HTPWejm5Wi6yGJyS/f1RhjIluTz01ue8lAsnAcQY3IY=";
+    };
+    patches = [
+      # register-scheme contains install scripts, but has no lockfile
+      ./remove-register-scheme.patch
+
+      # fixes node-addon-api errors with aarch64-darwin
+      ./update-node-addon-api.patch
+
+      # bump better-sqlite3 to work with electron 41
+      ./bump-better-sqlite3.patch
+    ];
   };
 
-  npmDepsHash = "sha256-JkGS0YmjsdUiOD48HcGXy/fPTP33JQAtJui0mQWicmc=";
-
-  patches = [
-    # register-scheme contains install scripts, but has no lockfile
-    ./remove-register-scheme.patch
-
-    # fixes node-addon-api errors with aarch64-darwin
-    ./update-node-addon-api.patch
-  ];
+  npmDepsHash = "sha256-9dQUqoLfzYXOgmE9j2lkew9b/1m4XOghT7roD82y+qg=";
 
   nativeBuildInputs = [
     (python3.withPackages (ps: with ps; [ distutils ]))
@@ -39,8 +45,8 @@ buildNpmPackage (finalAttrs: {
     runHook preBuild
 
     # needed for better-sqlite3 rebuild
-    export npm_config_nodedir="${electron_40.headers}"
-    export npm_config_target="${electron_40.version}"
+    export npm_config_nodedir="${electron.headers}"
+    export npm_config_target="${electron.version}"
 
     npm rebuild --verbose --no-progress --offline
 
@@ -57,7 +63,7 @@ buildNpmPackage (finalAttrs: {
     ${
       if stdenv.hostPlatform.isDarwin then
         ''
-          cp -r ${electron_40.dist}/Electron.app ./
+          cp -r ${electron.dist}/Electron.app ./
           find ./Electron.app -name 'Info.plist' -exec chmod +rw {} \;
 
           npm exec electron-builder -- \
@@ -65,7 +71,7 @@ buildNpmPackage (finalAttrs: {
             -c.npmRebuild=false \
             -c.mac.identity=null \
             -c.electronDist=./ \
-            -c.electronVersion=${electron_40.version} \
+            -c.electronVersion=${electron.version} \
             -c.extraMetadata.version=v${finalAttrs.version} \
             --config electron-builder.config.js
         ''
@@ -74,8 +80,8 @@ buildNpmPackage (finalAttrs: {
           npm exec electron-builder -- \
             --dir \
             -c.npmRebuild=false \
-            -c.electronDist=${electron_40.dist} \
-            -c.electronVersion=${electron_40.version} \
+            -c.electronDist=${electron.dist} \
+            -c.electronVersion=${electron.version} \
             -c.extraMetadata.version=v${finalAttrs.version} \
             --config electron-builder.config.js
         ''
@@ -99,7 +105,7 @@ buildNpmPackage (finalAttrs: {
           mkdir -p $out/share/dopamine
           cp -r release/linux*unpacked/{locales,resources{,.pak}} $out/share/dopamine
 
-          makeWrapper ${lib.getExe electron_40} $out/bin/dopamine \
+          makeWrapper ${lib.getExe electron} $out/bin/dopamine \
             --add-flags $out/share/dopamine/resources/app.asar \
             --inherit-argv0
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Upgraded electron version to default in nixpkgs.
Upstream still uses electron v38, I have opened an issue about it: https://github.com/digimezzo/dopamine/issues/1160. However, until it is fixed upstream, the patch added in this commit should be good enough.
Tracking issue for electron 40 EOL: https://github.com/NixOS/nixpkgs/issues/537847

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
