### PR TITLE
taisei: 1.4.4 -> 1.4.5

### DIFF
--- a/pkgs/by-name/ta/taisei/package.nix
+++ b/pkgs/by-name/ta/taisei/package.nix
@@ -19,6 +19,7 @@
   glslang,
   libogg,
   makeBinaryWrapper,
+  gettext,
 
   # Runtime depends
   sdl3,
@@ -29,19 +30,20 @@
   zlib,
   zstd,
   spirv-cross,
+  libunibreak,
 
   gamemodeSupport ? stdenv.hostPlatform.isLinux,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "taisei";
-  version = "1.4.4";
+  version = "1.4.5";
 
   src = fetchFromGitHub {
     owner = "taisei-project";
     repo = "taisei";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Cs66kyNSVjUZUH+ddZGjFwSUQtwqX4uuGQh+ZLv6N6o=";
+    hash = "sha256-xjEfSrtxZBBWUU8nv0fyNAofHSGVTeO3CBR/BhKSGHg=";
     fetchSubmodules = true;
   };
 
@@ -51,11 +53,11 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
     pkg-config
     python3Packages.python
-    python3Packages.zstandard
     shaderc
     makeWrapper
     makeBinaryWrapper
     cmake
+    gettext
   ];
 
   buildInputs = [
@@ -70,6 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
     openssl
     mimalloc
     libogg
+    libunibreak
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     glslang
@@ -81,7 +84,6 @@ stdenv.mkDerivation (finalAttrs: {
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin " -Dsincos=__builtin_sincos";
 
   mesonFlags = [
-    (lib.mesonEnable "vfs_zip" false)
     (lib.mesonEnable "shader_transpiler_dxbc" false)
     (lib.mesonEnable "package_data" false)
     (lib.mesonBool "b_lto" false)


### PR DESCRIPTION
Changelog: https://github.com/taisei-project/taisei/releases/tag/v1.4.5
Diff: https://github.com/taisei-project/taisei/compare/v1.4.4...v1.4.5
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
