### PR TITLE
cider-2: minor fixes and cleanup

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1997,6 +1997,12 @@
     githubId = 14838767;
     name = "Jacopo Scannella";
   };
+  antoineco = {
+    email = "hello@acotten.com";
+    github = "antoineco";
+    githubId = 3299086;
+    name = "Antoine Cotten";
+  };
   anton-4 = {
     name = "Anton";
     github = "Anton-4";

--- a/pkgs/by-name/ci/cider-2/package.nix
+++ b/pkgs/by-name/ci/cider-2/package.nix
@@ -72,8 +72,7 @@ stdenv.mkDerivation rec {
   postFixup = ''
     mv $out/share/applications/cider.desktop $out/share/applications/${pname}.desktop
     substituteInPlace $out/share/applications/${pname}.desktop \
-      --replace-warn 'Exec=cider' 'Exec=${pname}' \
-      --replace-warn 'Exec=/usr/lib/cider/Cider' 'Exec=${pname}'
+      --replace-fail Exec=cider Exec=${pname}
 
     install -Dm444 $out/share/pixmaps/cider.png \
       $out/share/icons/hicolor/256x256/apps/cider.png

--- a/pkgs/by-name/ci/cider-2/package.nix
+++ b/pkgs/by-name/ci/cider-2/package.nix
@@ -95,6 +95,7 @@ stdenv.mkDerivation rec {
     mainProgram = "cider-2";
     maintainers = with lib.maintainers; [
       amadejkastelic
+      antoineco
       l0r3v
     ];
     platforms = [ "x86_64-linux" ];

--- a/pkgs/by-name/ci/cider-2/package.nix
+++ b/pkgs/by-name/ci/cider-2/package.nix
@@ -8,13 +8,11 @@
 
   # Required dependencies for autoPatchelfHook
   alsa-lib,
-  asar,
   gtk3,
   libgbm,
   libGL,
   nspr,
   nss,
-  widevine-cdm,
 }:
 stdenv.mkDerivation rec {
   pname = "cider-2";
@@ -26,7 +24,6 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    asar
     dpkg
     autoPatchelfHook
     makeWrapper
@@ -57,16 +54,6 @@ stdenv.mkDerivation rec {
     chmod +x $out/lib/cider/Cider
 
     runHook postInstall
-  '';
-
-  postInstall = ''
-    ${lib.getExe asar} extract $out/lib/cider/resources/app.asar ./cider-build
-
-    ${lib.getExe asar} pack ./cider-build $out/lib/cider/resources/app.asar
-    rm -rf ./cider-build
-
-    # Install Widevine CDM for DRM support
-    ln -sf ${widevine-cdm}/share/google/chrome/WidevineCdm $out/lib/cider/
   '';
 
   postFixup = ''

--- a/pkgs/by-name/ci/cider-2/package.nix
+++ b/pkgs/by-name/ci/cider-2/package.nix
@@ -16,12 +16,12 @@
   nspr,
   nss,
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "cider-2";
   version = "4.0.9.1";
 
   src = fetchurl {
-    url = "https://repo.cider.sh/apt/pool/main/cider-v${version}-linux-x64.deb";
+    url = "https://repo.cider.sh/apt/pool/main/cider-v${finalAttrs.version}-linux-x64.deb";
     hash = "sha256-MsA6lK3PsyOEx938FgJFx8l9oqwoM3FzIK5goF73lTs=";
   };
 
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
 
     # The prefixes that follow LD_LIBRARY_PATH are typically injected via wrapGAppsHook3.
     # We append them manually instead to avoid a double-wrapping.
-    makeWrapper $out/lib/cider/Cider $out/bin/${pname} \
+    makeWrapper $out/lib/cider/Cider $out/bin/cider-2 \
       --add-flags "\$\{NIXOS_OZONE_WL:+\$\{WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true\}\}" \
       --add-flags "--no-sandbox --disable-gpu-sandbox" \
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libGL ]}" \
@@ -70,9 +70,9 @@ stdenv.mkDerivation rec {
   '';
 
   postFixup = ''
-    mv $out/share/applications/cider.desktop $out/share/applications/${pname}.desktop
-    substituteInPlace $out/share/applications/${pname}.desktop \
-      --replace-fail Exec=cider Exec=${pname}
+    mv $out/share/applications/cider.desktop $out/share/applications/cider-2.desktop
+    substituteInPlace $out/share/applications/cider-2.desktop \
+      --replace-fail Exec=cider Exec=cider-2
 
     install -Dm444 $out/share/pixmaps/cider.png \
       $out/share/icons/hicolor/256x256/apps/cider.png
@@ -94,4 +94,4 @@ stdenv.mkDerivation rec {
     ];
     platforms = [ "x86_64-linux" ];
   };
-}
+})

--- a/pkgs/by-name/ci/cider-2/package.nix
+++ b/pkgs/by-name/ci/cider-2/package.nix
@@ -5,6 +5,8 @@
   dpkg,
   autoPatchelfHook,
   makeWrapper,
+  gsettings-desktop-schemas,
+  dconf,
 
   # Required dependencies for autoPatchelfHook
   alsa-lib,
@@ -53,15 +55,21 @@ stdenv.mkDerivation rec {
 
     chmod +x $out/lib/cider/Cider
 
+    # The prefixes that follow LD_LIBRARY_PATH are typically injected via wrapGAppsHook3.
+    # We append them manually instead to avoid a double-wrapping.
+    makeWrapper $out/lib/cider/Cider $out/bin/${pname} \
+      --add-flags "\$\{NIXOS_OZONE_WL:+\$\{WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true\}\}" \
+      --add-flags "--no-sandbox --disable-gpu-sandbox" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libGL ]}" \
+      --prefix XDG_DATA_DIRS : "${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}" \
+      --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}" \
+      --prefix GIO_EXTRA_MODULES : "${dconf.lib}/lib/gio/modules" \
+      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
+
     runHook postInstall
   '';
 
   postFixup = ''
-    makeWrapper $out/lib/cider/Cider $out/bin/${pname} \
-      --add-flags "\$\{NIXOS_OZONE_WL:+\$\{WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true\}\}" \
-      --add-flags "--no-sandbox --disable-gpu-sandbox" \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libGL ]}"
-
     mv $out/share/applications/cider.desktop $out/share/applications/${pname}.desktop
     substituteInPlace $out/share/applications/${pname}.desktop \
       --replace-warn 'Exec=cider' 'Exec=${pname}' \
@@ -70,7 +78,7 @@ stdenv.mkDerivation rec {
     install -Dm444 $out/share/pixmaps/cider.png \
       $out/share/icons/hicolor/256x256/apps/cider.png
 
-    rm -r $out/share/pixmaps
+    rm -r $out/share/{pixmaps,lintian}
   '';
 
   passthru.updateScript = ./updater.sh;


### PR DESCRIPTION
I've submitted [a few contributions](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+author%3Aantoineco+) over the past months and care about Nixpkgs, therefore I would like to add myself as a maintainer and stamp my name on a few packages to speed up updates and reviews.

Also adds a few patches to the `cider-2` package (consolidation of 3 previously opened PRs):
- #538251
- #538334
- #538243

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
