### PR TITLE
teleport_18: 18.9.1 -> 18.9.2

### DIFF
--- a/pkgs/by-name/te/teleport_18/package.nix
+++ b/pkgs/by-name/te/teleport_18/package.nix
@@ -1,19 +1,19 @@
 {
   buildTeleport,
   buildGo125Module,
-  wasm-bindgen-cli_0_2_99,
+  wasm-bindgen-cli_0_2_122,
   withRdpClient ? true,
   extPatches ? [ ],
 }:
 
 buildTeleport {
-  version = "18.9.1";
-  hash = "sha256-FIPExc8tMoPXfWc7pQjwQRkxmiQEOxdkYgWS0GejQuk=";
-  vendorHash = "sha256-BlQhypAoK85ID0pgmXbUboks88qjSg3p5E8qxyTIc9M=";
-  pnpmHash = "sha256-ZGbuBMPwC3u/2qDTVLH2InOGVc94Vq0i3AKHMsOwq3k=";
-  cargoHash = "sha256-KbmacTEOElmboHMK6YxWGC0brlDsX7kcvpaOOZmuops=";
+  version = "18.9.2";
+  hash = "sha256-w6qCH57L2rwClbSpZeG01eekzj3JRNijwSdfl+wx8v8=";
+  vendorHash = "sha256-LJmpFHvFsBsneq1Cl3vvqxBGB94gSjaikNDZtQfwNjM=";
+  pnpmHash = "sha256-8tKVv5SPJlS89EsHhF8qpThkh4n47qRBbHDCgX17Cdg=";
+  cargoHash = "sha256-+B5fGIzCpiYmqVcM4iy+PTIdtvuvtufQiXMHNzHTDlQ=";
 
-  wasm-bindgen-cli = wasm-bindgen-cli_0_2_99;
+  wasm-bindgen-cli = wasm-bindgen-cli_0_2_122;
   buildGoModule = buildGo125Module;
   inherit withRdpClient extPatches;
 }

--- a/pkgs/by-name/wa/wasm-bindgen-cli_0_2_122/package.nix
+++ b/pkgs/by-name/wa/wasm-bindgen-cli_0_2_122/package.nix
@@ -1,0 +1,19 @@
+{
+  buildWasmBindgenCli,
+  fetchCrate,
+  rustPlatform,
+}:
+
+buildWasmBindgenCli rec {
+  src = fetchCrate {
+    pname = "wasm-bindgen-cli";
+    version = "0.2.122";
+    hash = "sha256-vO4RSxi/sMWxmsEs3GuljdMfIRSu75A+Q+c5wgYToRU=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit src;
+    inherit (src) pname version;
+    hash = "sha256-Inup6vvJSG5ghNyeDPyZbfZo4d0LsMG2OJfStoaeDBs=";
+  };
+}


### PR DESCRIPTION
## Summary

- Update `teleport_18` from 18.9.1 to 18.9.2 (latest stable release, changelog: https://github.com/gravitational/teleport/releases/tag/v18.9.2).
- Add a new pinned `wasm-bindgen-cli_0_2_122` package, required because teleport 18.9.2's `Cargo.lock` pins `wasm-bindgen` to 0.2.122, and `wasm-pack` requires the CLI version to exactly match the crate version used in the build.

Closes #525751

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. (`nixosTests.teleport.minimal_18` and `nixosTests.teleport.basic_18` both pass)
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (`teleport version` reports `Teleport v18.9.2`)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Assisted-by: Claude Code (claude-sonnet-5)