### PR TITLE
nixos/temporal-ui: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -36,6 +36,8 @@
 
 - [Matrix Authentication Service](https://github.com/element-hq/matrix-authentication-service) is an OAuth2.0 and OpenID Connect provider for Matrix homeservers (such as Synapse). It replaces standard password authentication with modern OpenID Connect flows, and can delegate authentication to upstream OIDC providers. Available as [services.matrix-authentication-service](#opt-services.matrix-authentication-service.enable).
 
+- [Temporal Web UI](https://github.com/temporalio/ui-server), the web frontend for a [Temporal](https://temporal.io) cluster. Available as [services.temporal-ui](#opt-services.temporal-ui.enable).
+
 ## Backward Incompatibilities {#sec-release-26.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -500,6 +500,7 @@
   ./services/cluster/patroni/default.nix
   ./services/cluster/rancher/default.nix
   ./services/cluster/spark/default.nix
+  ./services/cluster/temporal-ui/default.nix
   ./services/cluster/temporal/default.nix
   ./services/computing/boinc/client.nix
   ./services/computing/foldingathome/client.nix

--- a/nixos/modules/services/cluster/temporal-ui/default.nix
+++ b/nixos/modules/services/cluster/temporal-ui/default.nix
@@ -1,0 +1,132 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.temporal-ui;
+
+  settingsFormat = pkgs.formats.yaml { };
+
+  usingDefaultUserAndGroup = cfg.user == "temporal-ui" && cfg.group == "temporal-ui";
+in
+{
+  meta.maintainers = [ lib.maintainers.jpds ];
+
+  options.services.temporal-ui = {
+    enable = lib.mkEnableOption "Temporal Web UI";
+
+    package = lib.mkPackageOption pkgs "temporal-ui-server" { };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = settingsFormat.type;
+      };
+
+      default = { };
+
+      example = {
+        temporalGrpcAddress = "127.0.0.1:7233";
+        port = 8080;
+      };
+
+      description = ''
+        Temporal Web UI server configuration. `temporalGrpcAddress` must be
+        set to the address of the Temporal frontend service, see
+        [](#opt-services.temporal.settings).
+
+        See <https://github.com/temporalio/ui-server/blob/main/config/base.yaml>
+        for the full set of available options.
+      '';
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "temporal-ui";
+      description = ''
+        The user Temporal Web UI runs as. Should be left at default unless
+        you have very specific needs.
+      '';
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "temporal-ui";
+      description = ''
+        The group Temporal Web UI runs as. Should be left at default unless
+        you have very specific needs.
+      '';
+    };
+
+    restartIfChanged = lib.mkOption {
+      type = lib.types.bool;
+      description = ''
+        Automatically restart the service on config change.
+        This can be set to false to defer restarts on a server or cluster.
+        Please consider the security implications of inadvertently running an older version,
+        and the possibility of unexpected behavior caused by inconsistent versions across a cluster when disabling this option.
+      '';
+      default = true;
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.settings ? temporalGrpcAddress && cfg.settings.temporalGrpcAddress != "";
+        message = "services.temporal-ui.settings.temporalGrpcAddress must be set to the Temporal frontend gRPC address.";
+      }
+    ];
+
+    environment.etc."temporal-ui/config/base.yaml".source =
+      settingsFormat.generate "temporal-ui-base.yaml" cfg.settings;
+
+    systemd.services.temporal-ui-server = {
+      description = "Temporal Web UI server";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      inherit (cfg) restartIfChanged;
+      restartTriggers = [ config.environment.etc."temporal-ui/config/base.yaml".source ];
+      serviceConfig = {
+        ExecStart = ''
+          ${lib.getExe cfg.package} --root /etc/temporal-ui start
+        '';
+        User = cfg.user;
+        Group = cfg.group;
+        Restart = "on-failure";
+        DynamicUser = usingDefaultUserAndGroup;
+        CapabilityBoundingSet = [ "" ];
+        DevicePolicy = "closed";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectControlGroups = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RestrictAddressFamilies = [
+          "AF_NETLINK"
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service @resources"
+          "~@privileged"
+        ];
+      };
+    };
+  };
+}

--- a/nixos/tests/temporal.nix
+++ b/nixos/tests/temporal.nix
@@ -104,6 +104,12 @@
             enable = true;
             settings = {
               # Based on https://github.com/temporalio/temporal/blob/main/config/development-sqlite.yaml
+              global = {
+                membership = {
+                  maxJoinDuration = "30s";
+                  broadcastAddress = "0.0.0.0";
+                };
+              };
               log = {
                 stdout = true;
                 level = "info";
@@ -113,7 +119,7 @@
                   rpc = {
                     grpcPort = 7233;
                     membershipPort = 6933;
-                    bindOnLocalHost = true;
+                    bindOnIP = "0.0.0.0";
                     httpPort = 7243;
                   };
                 };
@@ -258,6 +264,93 @@
             };
           };
         };
+
+      temporal-ui =
+        { config, pkgs, ... }:
+        {
+          networking.useDHCP = false;
+          networking.firewall.allowedTCPPorts = [ 8080 ];
+
+          services.temporal-ui = {
+            enable = true;
+            settings = {
+              temporalGrpcAddress = "temporal:7233";
+              port = 8080;
+              enableUi = true;
+              defaultNamespace = "default";
+            };
+          };
+        };
+
+      browser =
+        {
+          config,
+          lib,
+          pkgs,
+          ...
+        }:
+        {
+          virtualisation.memorySize = 1024 * 2;
+
+          environment.systemPackages =
+            let
+              temporalUiSeleniumScript =
+                pkgs.writers.writePython3Bin "temporal-ui-selenium-script"
+                  {
+                    libraries = [ pkgs.python3Packages.selenium ];
+                  }
+                  ''
+                    from selenium import webdriver
+                    from selenium.webdriver.common.by import By
+                    from selenium.webdriver.firefox.options import Options
+                    from selenium.webdriver.support import expected_conditions as EC
+                    from selenium.webdriver.support.ui import WebDriverWait
+
+                    options = Options()
+                    options.add_argument("--headless")
+                    service = webdriver.FirefoxService(
+                      executable_path="${lib.getExe pkgs.geckodriver}")  # noqa: E501
+
+                    driver = webdriver.Firefox(options=options, service=service)
+                    driver.implicitly_wait(10)
+
+                    driver.get("http://temporal-ui:8080/")
+                    wait = WebDriverWait(driver, 60)
+
+                    # Navigate via the side nav's link text
+                    wait.until(EC.element_to_be_clickable(
+                      (By.LINK_TEXT, "Namespaces"))).click()
+                    wait.until(EC.url_contains("/namespaces"))
+
+                    wait.until(EC.element_to_be_clickable(
+                      (By.LINK_TEXT, "default"))).click()
+                    wait.until(EC.url_contains("/namespaces/default"))
+
+                    wait.until(EC.element_to_be_clickable(
+                      (By.LINK_TEXT, "Workflows"))).click()
+                    wait.until(EC.url_contains("/namespaces/default/workflows"))
+
+                    # Find by Workflow ID, not position or a generated class name
+                    row = wait.until(EC.presence_of_element_located((
+                      By.XPATH,
+                      "//tr[@data-testid='workflows-summary-configurable-table-row']"
+                      "[.//text()[contains(., 'hello-activity-workflow-id')]]",
+                    )))
+
+                    status = row.find_element(
+                      By.XPATH, ".//*[@data-testid='workflow-status']").text
+                    assert "Completed" in status, f"unexpected workflow status: {status!r}"
+
+                    driver.close()
+                  '';
+            in
+            [
+              pkgs.curl
+              pkgs.firefox-unwrapped
+              pkgs.geckodriver
+              temporalUiSeleniumScript
+            ];
+        };
     };
 
     testScript = ''
@@ -322,6 +415,25 @@
       temporal.log(temporal.succeed(
         "systemd-analyze security temporal.service | grep -v '✓'"
       ))
+
+      temporal_ui.wait_for_unit("temporal-ui-server")
+      temporal_ui.wait_for_open_port(8080)
+
+      temporal_ui.wait_until_succeeds(
+        "curl -sf http://localhost:8080/healthz | grep '\"OK\"'"
+      )
+
+      temporal_ui.log(temporal_ui.succeed(
+        "systemd-analyze security temporal-ui-server.service | grep -v '✓'"
+      ))
+
+      browser.systemctl("start network-online.target")
+      browser.wait_for_unit("network-online.target")
+
+      browser.succeed("curl -sSf http://temporal-ui:8080/healthz")
+
+      # Confirm the hello-workflow shows up as completed in the actual UI
+      browser.succeed("PYTHONUNBUFFERED=1 temporal-ui-selenium-script")
     '';
   }
 )

--- a/pkgs/by-name/te/temporal-ui-server/package.nix
+++ b/pkgs/by-name/te/temporal-ui-server/package.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   buildGoModule,
   nix-update-script,
+  nixosTests,
   versionCheckHook,
 }:
 
@@ -27,7 +28,12 @@ buildGoModule (finalAttrs: {
 
   doInstallCheck = true;
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = {
+      inherit (nixosTests) temporal;
+    };
+  };
 
   meta = {
     changelog = "https://github.com/temporalio/ui-server/releases/tag/${finalAttrs.src.tag}";


### PR DESCRIPTION
Adds a module for `temporal-ui` and adds it into the Temporal integration test.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [X] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
