### PR TITLE
borgmatic: 2.1.5 -> 2.1.6, add changelog

### DIFF
--- a/pkgs/by-name/bo/borgmatic/package.nix
+++ b/pkgs/by-name/bo/borgmatic/package.nix
@@ -102,6 +102,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   meta = {
     description = "Simple, configuration-driven backup software for servers and workstations";
     homepage = "https://torsion.org/borgmatic/";
+    changelog = "https://projects.torsion.org/borgmatic-collective/borgmatic/src/tag/${finalAttrs.version}/NEWS";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.all;
     mainProgram = "borgmatic";

--- a/pkgs/by-name/bo/borgmatic/package.nix
+++ b/pkgs/by-name/bo/borgmatic/package.nix
@@ -15,7 +15,7 @@
 }:
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "borgmatic";
-  version = "2.1.5";
+  version = "2.1.6";
   pyproject = true;
 
   strictDeps = true;
@@ -23,7 +23,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
-    hash = "sha256-T0+E6opyfr7zxfP44OlNuhqsdQyi7OdIXiE5r310LaU=";
+    hash = "sha256-Mgx8PnGfTa5j6+53RVntPHa5EDJAY2NQC3fvmyRj24Y=";
   };
 
   passthru.updateScript = nix-update-script { };
@@ -33,13 +33,17 @@ python3Packages.buildPythonApplication (finalAttrs: {
     [
       flexmock
       pytestCheckHook
+      pytest-asyncio
       pytest-cov-stub
       pytest-timeout
     ]
-    ++ finalAttrs.passthru.optional-dependencies.apprise;
+    ++ finalAttrs.passthru.optional-dependencies.apprise
+    ++ finalAttrs.passthru.optional-dependencies.browse;
 
   # - test_borgmatic_version_matches_news_version
-  #   NEWS file not available on the pypi source
+  #   NEWS file is available on the pypi source, but the test requires a
+  #   borgmatic executable. Which it can't find in difference to all the
+  #   other tests.
   # - test_log_outputs_includes_error_output_in_exception
   #   TOCTOU race in log_outputs(): process.poll() returns None in
   #   raise_for_process_errors but non-None in the while-loop exit check,
@@ -51,6 +55,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   nativeBuildInputs = [ installShellFiles ];
 
+  build-system = [ python3Packages.setuptools ];
+
   dependencies = with python3Packages; [
     borgbackup
     colorama
@@ -58,11 +64,14 @@ python3Packages.buildPythonApplication (finalAttrs: {
     packaging
     requests
     ruamel-yaml
-    setuptools
   ];
 
   optional-dependencies = {
     apprise = [ python3Packages.apprise ];
+    browse = with python3Packages; [
+      binaryornot
+      textual
+    ];
   };
 
   postInstall =


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changes: https://projects.torsion.org/borgmatic-collective/borgmatic/src/tag/2.1.6/NEWS

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
