### PR TITLE
quester: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25212,6 +25212,12 @@
     githubId = 47693;
     name = "Jens Krause";
   };
+  sed4906 = {
+    email = "sed4906birdie@gmail.com";
+    github = "SED4906";
+    githubId = 37986786;
+    name = "Ron Ben Aroya";
+  };
   sedlund = {
     email = "scott+nixpkgs@teraton.com";
     github = "sedlund";

--- a/pkgs/by-name/qu/quester/package.nix
+++ b/pkgs/by-name/qu/quester/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  cmake,
+  fftw,
+  kdePackages,
+  libhwy,
+  libmpdclient,
+  projectm_3,
+  libpulseaudio,
+  pipewire,
+  pkg-config,
+  buildPackages,
+  fetchgit,
+  pkgsBuildTarget,
+  stdenv,
+}:
+
+stdenv.mkDerivation {
+  pname = "quester";
+  version = "0.1.0";
+
+  src = fetchgit {
+    url = "https://codeberg.org/anoraktrend/quester";
+    rev = "b7c600244e6d391398014ef9a44898e22659dd39";
+    hash = "sha256-IE0a1zvg+AzIt4T1vloItE+a+qdA2HCrKlIcMg6bwc8=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    kdePackages.wrapQtAppsHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    fftw
+    kdePackages.extra-cmake-modules
+    kdePackages.qtbase
+    kdePackages.qtdeclarative
+    kdePackages.qtmultimedia
+    libhwy
+    libmpdclient
+    projectm_3
+    libpulseaudio
+    pipewire
+    pkg-config
+  ];
+
+  postPatch = ''
+    sed -i '147,149d' CMakeLists.txt
+  '';
+
+  __structuredAttrs = true;
+
+  strictDeps = true;
+
+  enableParallelBuilding = true;
+
+  meta = {
+    homepage = "https://codeberg.org/anoraktrend/quester";
+    description = "A QML-based MPD Client.";
+    longDescription = ''
+      A modern, visually rich MPD client built with Qt 6 and QML
+
+      Quester is a desktop client for the Music Player Daemon (MPD). It provides a fluid user interface focused on album art and visual feedback. Built using C++ and Qt Quick (QML), it aims to offer a lightweight yet visually appealing way to browse and play your music library.
+    '';
+    license = lib.licenses.mit;
+    mainProgram = "quester";
+    maintainers = with lib.maintainers; [
+      sed4906
+    ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
https://codeberg.org/anoraktrend/quester/src/tag/0.1.0#about
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
