### PR TITLE
openvpn: 2.6.19 -> 2.6.21

### DIFF
--- a/pkgs/tools/networking/openvpn/default.nix
+++ b/pkgs/tools/networking/openvpn/default.nix
@@ -23,11 +23,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "openvpn";
-  version = "2.6.19";
+  version = "2.6.21";
 
   src = fetchurl {
     url = "https://swupdate.openvpn.net/community/releases/openvpn-${finalAttrs.version}.tar.gz";
-    hash = "sha256-E3AlJvaHwYslQMGj8uGJGHuqplIR7c9/9ncvpp8FNs8=";
+    hash = "sha256-JMthheVEpHMj1nmLA9OfI2fZbyJ77pzRVD6O1Sgxmxc=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Updated to latest openvpn 2.6 version which fixes the below CVE's from the [2.6.20](https://community.openvpn.net/ReleaseHistory?__cf_chl_f_tk=s0RMevaFjpOzFxgeEjDt74cnPoIXxJq3P6w5eiBZg40-1783254095-1.0.1.1-PVpdIDrN7arGSd2ljgNrTdy8Y9ojBqhrhC319xeznQw#openvpn-2620-released-22-april-2026) and [2.6.21]( https://community.openvpn.net/ReleaseHistory?__cf_chl_f_tk=s0RMevaFjpOzFxgeEjDt74cnPoIXxJq3P6w5eiBZg40-1783254095-1.0.1.1-PVpdIDrN7arGSd2ljgNrTdy8Y9ojBqhrhC319xeznQw#openvpn-2621-released-1-july-2026) update:
- [CVE-2026-40215](https://www.cve.org/CVERecord?id=CVE-2026-40215)
- [CVE-2026-35058](https://www.cve.org/CVERecord?id=CVE-2026-35058):
- [CVE-2026-12996](https://www.cve.org/CVERecord?id=CVE-2026-12996)
- [CVE-2026-13117](https://www.cve.org/CVERecord?id=CVE-2026-13117)
- [CVE-2026-13122](https://www.cve.org/CVERecord?id=CVE-2026-13122)
- [CVE-2026-12932](https://www.cve.org/CVERecord?id=CVE-2026-12932)
- [CVE-2026-11771](https://www.cve.org/CVERecord?id=CVE-2026-11771)
- [CVE-2026-13698](https://www.cve.org/CVERecord?id=CVE-2026-13698)

Note:Have not had a chance to do much testing of the binary (other than the nix tests we have) yet.

Closes #529803
This is also in favor of #507810 as current tests use auth method that is deprecated in 2.7 .
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
