### PR TITLE
stamp: init at 0-unstable-2026-07-14

### DIFF
--- a/pkgs/by-name/st/stamp/package.nix
+++ b/pkgs/by-name/st/stamp/package.nix
@@ -1,0 +1,66 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  desktop-file-utils,
+  libadwaita,
+  meson,
+  ninja,
+  pkg-config,
+  wrapGAppsHook4,
+  webkitgtk_6_0,
+  blueprint-compiler,
+  evolution-data-server-gtk4,
+  gst_all_1,
+  libportal-gtk4,
+  libpsl,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation {
+  pname = "stamp";
+  version = "0-unstable-2026-07-13";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "jbrummer";
+    repo = "stamp";
+    rev = "9bce220c9e094c4d616009ebc87499a68ffc14aa";
+    hash = "sha256-mplowqsBTT9ibLxD8pbaIeLSd1pindgXLSPKBjseul8=";
+  };
+
+  dontUseCmakeConfigure = true;
+
+  nativeBuildInputs = [
+    blueprint-compiler
+    desktop-file-utils
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    evolution-data-server-gtk4
+    gst_all_1.gstreamer
+    libadwaita
+    libportal-gtk4
+    libpsl
+    webkitgtk_6_0
+  ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch=main" ];
+  };
+
+  meta = {
+    description = "Modern GTK4 email client for the GNOME ecosystem";
+    homepage = "https://gitlab.gnome.org/jbrummer/stamp";
+    maintainers = with lib.maintainers; [ onny ];
+    license = with lib.licenses; [ gpl3Plus ];
+    platforms = lib.platforms.linux;
+    mainProgram = "stamp";
+  };
+}


### PR DESCRIPTION
Adding [stamp](https://gitlab.gnome.org/jbrummer/stamp), a modern GTK4 mail client

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
