### PR TITLE
openmodelica: 1.27.0: re-add after removal of stale package

### DIFF
--- a/pkgs/by-name/op/openmodelica/README.md
+++ b/pkgs/by-name/op/openmodelica/README.md
@@ -1,0 +1,19 @@
+# OpenModelica packaging notes
+
+Use the package-local update script to refresh the OpenModelica source and the
+release-pinned Modelica Standard Library sources together:
+
+```sh
+./pkgs/by-name/op/openmodelica/update.py --version 1.28.0 --in-place
+```
+
+For local testing against an unreleased upstream revision, ask it to print an
+override instead of editing `package.nix`:
+
+```sh
+./pkgs/by-name/op/openmodelica/update.py --rev master --print-override
+```
+
+The script updates or prints `srcRev`, `srcHash`, and
+`passthru.modelicaStandardLibrarySources`. The library revisions come from the
+selected OpenModelica source's `libraries/install-index.json`.

--- a/pkgs/by-name/op/openmodelica/package.nix
+++ b/pkgs/by-name/op/openmodelica/package.nix
@@ -1,0 +1,288 @@
+{
+  lib,
+  stdenv,
+  autoconf,
+  fetchFromGitHub,
+  blas,
+  boost,
+  bison,
+  cmake,
+  curl,
+  expat,
+  flex,
+  gfortran,
+  gettext,
+  jdk_headless,
+  lapack,
+  libffi,
+  libGL,
+  libuuid,
+  makeShellWrapper,
+  ninja,
+  openscenegraph,
+  pkg-config,
+  python3,
+  qt6,
+  readline,
+  xdg-utils,
+  zstd,
+}:
+stdenv.mkDerivation (
+  finalAttrs:
+  let
+    wrapperPath = lib.makeBinPath [
+      gfortran
+      stdenv.cc
+      xdg-utils
+    ];
+    wrapperLibraryPath = lib.makeLibraryPath [
+      blas
+      lapack
+      stdenv.cc.cc
+      stdenv.cc.cc.lib
+    ];
+    wrapperLdLibraryPath = lib.concatStringsSep ":" [
+      "${placeholder "out"}/lib/omc"
+      "${placeholder "out"}/lib/omc/cpp"
+      "${placeholder "out"}/lib/omc/omsicpp"
+      (lib.makeLibraryPath [ stdenv.cc.cc.lib ])
+    ];
+    modelicaStandardLibrary = lib.mapAttrs (
+      _: source:
+      fetchFromGitHub {
+        owner = "OpenModelica";
+        repo = "OpenModelica-ModelicaStandardLibrary";
+        inherit (source) rev hash;
+      }
+    ) finalAttrs.passthru.modelicaStandardLibrarySources;
+    modelicaStandardLibrarySourceMap = builtins.toJSON (
+      lib.mapAttrs' (
+        name: source: lib.nameValuePair source.rev "${modelicaStandardLibrary.${name}}"
+      ) finalAttrs.passthru.modelicaStandardLibrarySources
+    );
+  in
+  {
+    pname = "openmodelica";
+    version = "1.27.0";
+    srcRev = "v${finalAttrs.version}";
+    srcHash = "sha256-fq7+9iBAz7JrvXTMaj1pxPal5haLgka62uocLsBhwnE=";
+
+    src = fetchFromGitHub {
+      owner = "OpenModelica";
+      repo = "OpenModelica";
+      rev = finalAttrs.srcRev;
+      hash = finalAttrs.srcHash;
+      fetchSubmodules = true;
+    };
+
+    postPatch = ''
+      echo "v${finalAttrs.version}" > OMVERSION.txt
+      echo "v${finalAttrs.version}" > version.txt
+      echo "v${finalAttrs.version}" > OMSimulator/version.txt
+    '';
+
+    nativeBuildInputs = [
+      autoconf
+      bison
+      cmake
+      flex
+      gfortran
+      jdk_headless
+      makeShellWrapper
+      ninja
+      pkg-config
+      python3
+      qt6.qttools
+      qt6.wrapQtAppsHook
+    ];
+
+    buildInputs = [
+      blas
+      boost
+      curl
+      expat
+      gettext
+      lapack
+      libffi
+      libGL
+      libuuid
+      openscenegraph
+      qt6.qt5compat
+      qt6.qtbase
+      qt6.qthttpserver
+      qt6.qtsvg
+      qt6.qtwebengine
+      readline
+      stdenv.cc.cc
+      stdenv.cc.cc.lib
+      zstd
+    ];
+
+    cmakeFlags = [
+      (lib.cmakeBool "OM_USE_CCACHE" false)
+      (lib.cmakeFeature "OM_QT_MAJOR_VERSION" "6")
+      (lib.cmakeBool "OM_ENABLE_GUI_CLIENTS" true)
+      (lib.cmakeBool "OM_OMEDIT_ENABLE_TESTS" false)
+      (lib.cmakeBool "OM_OMS_ENABLE_TESTSUITE" false)
+      (lib.cmakeBool "OM_OMC_ENABLE_FORTRAN" true)
+      (lib.cmakeBool "OM_OMC_ENABLE_MOO" true)
+      (lib.cmakeBool "OM_OMC_ENABLE_OPTIMIZATION" true)
+      (lib.cmakeBool "OM_OMC_ENABLE_PRIMME" true)
+      (lib.cmakeBool "OM_OMC_ENABLE_COLPACK" true)
+      (lib.cmakeBool "OM_OMC_ENABLE_CPP_RUNTIME" true)
+      (lib.cmakeBool "OM_OMC_USE_LAPACK" true)
+      (lib.cmakeBool "OM_OMC_USE_CORBA" false)
+      (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
+    ];
+
+    env = {
+      NIX_CFLAGS_COMPILE = toString [
+        "-Wno-error=implicit-function-declaration"
+        "-Wno-error=incompatible-pointer-types"
+      ];
+      NIX_LDFLAGS = toString [
+        "-L${stdenv.cc.cc.lib}/lib"
+        "-rpath"
+        "${stdenv.cc.cc.lib}/lib"
+      ];
+    };
+
+    qtWrapperArgs = [
+      "--prefix"
+      "PATH"
+      ":"
+      wrapperPath
+      "--prefix"
+      "LIBRARY_PATH"
+      ":"
+      wrapperLibraryPath
+      "--prefix"
+      "LD_LIBRARY_PATH"
+      ":"
+      wrapperLdLibraryPath
+    ];
+
+    postInstall = ''
+      if [ -d "$out/lib/omc/pkgconfig" ]; then
+        find "$out/lib/omc/pkgconfig" -name '*.pc' -exec sed -i \
+          -e 's|''${prefix}//nix/store/|/nix/store/|g' \
+          -e 's|''${exec_prefix}//nix/store/|/nix/store/|g' \
+          {} +
+      fi
+
+      export libraryIndex=../libraries/install-index.json
+      export modelicaStandardLibrarySourceMap=${lib.escapeShellArg modelicaStandardLibrarySourceMap}
+      install -Dm444 "$libraryIndex" "$out/lib/omlibrary/index.json"
+
+      python3 <<'PY'
+      import json
+      import os
+      import shutil
+      from pathlib import Path
+
+      sources = {
+          revision: Path(path)
+          for revision, path in json.loads(os.environ["modelicaStandardLibrarySourceMap"]).items()
+      }
+      out = Path(os.environ["out"])
+      library_root = out / "lib" / "omlibrary"
+      with open(os.environ["libraryIndex"], encoding="utf-8") as handle:
+          index = json.load(handle)
+
+      for name, package in index["libs"].items():
+          for version, metadata in package["versions"].items():
+              source_path = sources[metadata["sha"]] / metadata["path"]
+              target = library_root / f"{name} {version}"
+              target.mkdir(parents=True, exist_ok=True)
+
+              if source_path.is_dir():
+                  shutil.copytree(source_path, target, dirs_exist_ok=True, symlinks=True)
+              else:
+                  shutil.copy2(source_path, target / "package.mo")
+
+              target.chmod(target.stat().st_mode | 0o200)
+              metadata_path = target / "openmodelica.metadata.json"
+              if metadata_path.exists():
+                  metadata_path.chmod(metadata_path.stat().st_mode | 0o200)
+
+              with open(metadata_path, "w", encoding="utf-8") as handle:
+                  json.dump(metadata, handle, separators=(",", ":"))
+                  handle.write("\n")
+      PY
+    '';
+
+    postFixup = ''
+      openModelicaLibraryPath='export OPENMODELICALIBRARY="${placeholder "out"}/lib/omlibrary:''${HOME}/.openmodelica/libraries''${OPENMODELICALIBRARY:+:}''${OPENMODELICALIBRARY}''${MODELICAPATH:+:}''${MODELICAPATH}"'
+
+      wrapProgramShell $out/bin/omc \
+        --run "$openModelicaLibraryPath" \
+        --prefix PATH : "${wrapperPath}" \
+        --prefix LIBRARY_PATH : "${wrapperLibraryPath}" \
+        --prefix LD_LIBRARY_PATH : "${wrapperLdLibraryPath}"
+
+      if [ -x "$out/bin/OMEdit" ]; then
+        wrapProgramShell $out/bin/OMEdit \
+          --run "$openModelicaLibraryPath"
+      fi
+
+      if [ -x "$out/bin/OMShell-terminal" ]; then
+        wrapProgramShell $out/bin/OMShell-terminal \
+          --run "$openModelicaLibraryPath" \
+          --prefix LD_LIBRARY_PATH : "${wrapperLdLibraryPath}"
+      fi
+    '';
+
+    doInstallCheck = true;
+    installCheckPhase = ''
+      runHook preInstallCheck
+
+      $out/bin/omc --version
+      $out/bin/OMSimulator --version
+      cat > load-modelica.mos <<'EOF'
+      loadModel(Modelica);
+      getErrorString();
+      EOF
+      $out/bin/omc load-modelica.mos | tee load-modelica.out
+      grep -qx true load-modelica.out
+
+      runHook postInstallCheck
+    '';
+
+    passthru = {
+      updateScript = ./update.py;
+
+      modelicaStandardLibrarySources = {
+        v3_2_3 = {
+          rev = "efd981a1176f124938d6d6759f7c09e0fbf55ddf";
+          hash = "sha256-9xKkWUS/Q52UKzhFGTZe/0bfaG89PLqsMSwTmjeZ/lo=";
+        };
+        v4_0_0 = {
+          rev = "96032134c36668898e1693e69bd9f81aa38de3dd";
+          hash = "sha256-WDwGfkaVJ2eQw0Air9Jk6cuxiBc7kN9kuWy+CpGrIv8=";
+        };
+        v4_1_0 = {
+          rev = "7a4bf7de77a3986e8eb1e88cbb515d646f78f834";
+          hash = "sha256-2DZv76oRZztiIfVH4WSEsrVJRpzd8qqOEZTRTOj1Kx0=";
+        };
+      };
+    };
+
+    meta = {
+      description = "Modelica-based modeling and simulation environment";
+      longDescription = ''
+        OpenModelica is an open-source Modelica-based modeling and simulation
+        environment. This package builds the compiler, simulation runtimes,
+        Modelica libraries, OMSimulator, OMEdit, OMPlot, OMShell, OMNotebook,
+        and related Qt 6 GUI clients from the upstream release.
+      '';
+      homepage = "https://openmodelica.org/";
+      changelog = "https://github.com/OpenModelica/OpenModelica/releases/tag/v${finalAttrs.version}";
+      license = lib.licenses.gpl3Only;
+      maintainers = with lib.maintainers; [
+        ppenguin
+      ];
+      mainProgram = "omc";
+      platforms = lib.platforms.linux;
+    };
+  }
+)

--- a/pkgs/by-name/op/openmodelica/update.py
+++ b/pkgs/by-name/op/openmodelica/update.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i python3 -p python3 git nix-prefetch-github
+import argparse
+import datetime as dt
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+OWNER = "OpenModelica"
+MAIN_REPO = "OpenModelica"
+MSL_REPO = "OpenModelica-ModelicaStandardLibrary"
+PACKAGE_NIX = Path(__file__).with_name("package.nix")
+
+
+def run(command, *, cwd=None):
+    try:
+        result = subprocess.run(
+            command,
+            cwd=cwd,
+            check=True,
+            encoding="utf-8",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except subprocess.CalledProcessError as error:
+        if error.stderr:
+            print(error.stderr, file=sys.stderr, end="")
+        raise
+    return result.stdout
+
+
+def prefetch_github(repo, rev, *, fetch_submodules=False):
+    command = [
+        "nix-prefetch-github",
+        OWNER,
+        repo,
+        "--rev",
+        rev,
+        "--json",
+    ]
+    if fetch_submodules:
+        command.append("--fetch-submodules")
+
+    print(f"prefetching {OWNER}/{repo}@{rev}", file=sys.stderr)
+    data = json.loads(run(command))
+    hash_value = data.get("hash") or data.get("sha256")
+    if not hash_value:
+        raise RuntimeError(f"nix-prefetch-github did not return a hash for {repo}@{rev}")
+    return {
+        "rev": data.get("rev", rev),
+        "hash": hash_value,
+    }
+
+
+def nix_string(value):
+    return json.dumps(value)
+
+
+def realise_fetch_from_github(repo, rev, hash_value, *, fetch_submodules=False):
+    expr = """
+let
+  pkgs = import ./. {};
+in
+  pkgs.fetchFromGitHub {
+    owner = %s;
+    repo = %s;
+    rev = %s;
+    hash = %s;
+    fetchSubmodules = %s;
+  }
+""" % (
+        nix_string(OWNER),
+        nix_string(repo),
+        nix_string(rev),
+        nix_string(hash_value),
+        "true" if fetch_submodules else "false",
+    )
+    path = run(
+        [
+            "nix",
+            "build",
+            "--impure",
+            "--no-link",
+            "--print-out-paths",
+            "--expr",
+            expr,
+        ],
+        cwd=PACKAGE_NIX.parents[4],
+    ).strip()
+    if not path:
+        raise RuntimeError(f"could not realise source for {OWNER}/{repo}@{rev}")
+    return Path(path)
+
+
+def resolve_rev(rev):
+    if re.fullmatch(r"[0-9a-f]{40}", rev):
+        return rev
+
+    url = f"https://github.com/{OWNER}/{MAIN_REPO}.git"
+    candidates = [
+        rev,
+        f"refs/heads/{rev}",
+        f"refs/tags/{rev}^{{}}",
+        f"refs/tags/{rev}",
+    ]
+    for candidate in candidates:
+        output = run(["git", "ls-remote", url, candidate]).splitlines()
+        if output:
+            return output[0].split()[0]
+
+    raise RuntimeError(f"could not resolve {rev!r} in {url}")
+
+
+def library_attr_name(name, version, used_names):
+    base_version = version.split("+", 1)[0]
+    base = "v" + re.sub(r"[^A-Za-z0-9]+", "_", base_version).strip("_")
+    if not re.match(r"^[A-Za-z_]", base):
+        base = f"{name}_{base}"
+    attr = base
+    suffix = 2
+    while attr in used_names:
+        attr = f"{base}_{suffix}"
+        suffix += 1
+    used_names.add(attr)
+    return attr
+
+
+def read_standard_library_revisions(openmodelica_source):
+    index_path = openmodelica_source / "libraries" / "install-index.json"
+    with index_path.open(encoding="utf-8") as handle:
+        index = json.load(handle)
+
+    by_rev = {}
+    for package_name, package in index["libs"].items():
+        for version, metadata in package["versions"].items():
+            by_rev.setdefault(metadata["sha"], []).append((package_name, version))
+
+    used_names = set()
+    revisions = []
+    for rev, packages in by_rev.items():
+        modelica_package = next(
+            ((name, version) for name, version in packages if name == "Modelica"),
+            packages[0],
+        )
+        name, version = modelica_package
+        revisions.append(
+            {
+                "attr": library_attr_name(name, version, used_names),
+                "rev": rev,
+                "label": f"{name} {version}",
+            }
+        )
+
+    return sorted(revisions, key=lambda item: item["attr"])
+
+
+def format_library_sources(sources, base_indent="        "):
+    lines = []
+    for source in sources:
+        lines.extend(
+            [
+                f"{base_indent}{source['attr']} = {{",
+                f"{base_indent}  rev = {nix_string(source['rev'])};",
+                f"{base_indent}  hash = {nix_string(source['hash'])};",
+                f"{base_indent}}};",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def collect_sources(main_rev):
+    main = prefetch_github(MAIN_REPO, main_rev, fetch_submodules=True)
+    source_path = realise_fetch_from_github(
+        MAIN_REPO,
+        main_rev,
+        main["hash"],
+        fetch_submodules=True,
+    )
+    library_revisions = read_standard_library_revisions(source_path)
+    for source in library_revisions:
+        prefetched = prefetch_github(MSL_REPO, source["rev"])
+        source["hash"] = prefetched["hash"]
+    return main, library_revisions
+
+
+def replace_once(text, pattern, replacement):
+    updated, count = re.subn(pattern, replacement, text, count=1, flags=re.S)
+    if count != 1:
+        raise RuntimeError(f"expected to replace exactly one match for {pattern!r}")
+    return updated
+
+
+def update_package(version, src_rev_expression, src_hash, library_sources):
+    text = PACKAGE_NIX.read_text(encoding="utf-8")
+    text = replace_once(text, r'version = "[^"]+";', f"version = {nix_string(version)};")
+    text = replace_once(text, r'srcRev = "[^"]+";', f"srcRev = {src_rev_expression};")
+    text = replace_once(text, r'srcHash = "[^"]+";', f"srcHash = {nix_string(src_hash)};")
+    text = replace_once(
+        text,
+        r"(modelicaStandardLibrarySources = \{\n).*?(\n      \};)",
+        r"\1" + format_library_sources(library_sources) + r"\2",
+    )
+    PACKAGE_NIX.write_text(text, encoding="utf-8")
+
+    nixfmt = shutil.which("nixfmt")
+    if nixfmt:
+        run([nixfmt, str(PACKAGE_NIX)])
+
+
+def print_override(version, src_rev, src_hash, library_sources):
+    print("openmodelica.overrideAttrs (old: {")
+    print(f"  version = {nix_string(version)};")
+    print(f"  srcRev = {nix_string(src_rev)};")
+    print(f"  srcHash = {nix_string(src_hash)};")
+    print("  passthru = old.passthru // {")
+    print("    modelicaStandardLibrarySources = {")
+    print(format_library_sources(library_sources, base_indent="      "))
+    print("    };")
+    print("  };")
+    print("})")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Update or override the nixpkgs OpenModelica package."
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--version", help="OpenModelica release version, for example 1.28.0")
+    source.add_argument("--rev", help="OpenModelica git revision, branch, tag, or HEAD")
+    output = parser.add_mutually_exclusive_group(required=True)
+    output.add_argument("--in-place", action="store_true", help="edit package.nix")
+    output.add_argument(
+        "--print-override",
+        action="store_true",
+        help="print an overrideAttrs snippet instead of editing package.nix",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    if args.in_place and args.rev:
+        raise SystemExit("--in-place updates are only supported for release --version updates")
+
+    if args.version:
+        version = args.version
+        src_rev = f"v{version}"
+        prefetch_rev = src_rev
+    else:
+        version = f"unstable-{dt.date.today().isoformat()}"
+        src_rev = resolve_rev(args.rev)
+        prefetch_rev = src_rev
+
+    main_source, library_sources = collect_sources(prefetch_rev)
+
+    if args.in_place:
+        update_package(version, '"v${finalAttrs.version}"', main_source["hash"], library_sources)
+    else:
+        print_override(version, src_rev, main_source["hash"], library_sources)
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1715,7 +1715,6 @@ mapAliases {
   openjdk24_headless = throw "OpenJDK 24 was removed as it has reached its end of life"; # Added 2025-10-04
   openjfx23 = throw "OpenJFX 23 was removed as it has reached its end of life"; # Added 2025-11-04
   openjfx24 = throw "OpenJFX 24 was removed as it has reached its end of life"; # Added 2025-10-04
-  openmodelica = throw "'openmodelica' has been removed as it was unmaintained in nixpkgs and depends on insecure&unmtaintained qtwebkit"; # Added 2026-04-26
   openmw-tes3mp = throw "'openmw-tes3mp' has been removed due to lack of maintenance upstream"; # Added 2025-08-30
   openssl_3_0 = throw "'openssl_3_0' has been renamed to/replaced by 'openssl_3'"; # Converted to throw 2025-10-27
   opensycl = throw "'opensycl' has been renamed to/replaced by 'adaptivecpp'"; # Converted to throw 2025-10-27


### PR DESCRIPTION
In April OpenModelica was removed because it was stale and unmaintained. This re-adds a (arguably better maintainable) package.

Disclaimer: the packaging was largely AI-authored, due to band width constraints on the part of the author, but manually checked and basic tested.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
