### PR TITLE
puredns: init at 2.1.1

### DIFF
--- a/pkgs/by-name/pu/puredns/package.nix
+++ b/pkgs/by-name/pu/puredns/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  fetchpatch2,
+  makeWrapper,
+  massdns,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "puredns";
+  version = "2.1.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "d3mondev";
+    repo = "puredns";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-3I4ZRj0bM6VfdnaG7pG9E4Qw4dpxlX4xJbsOIZu01i0=";
+  };
+
+  vendorHash = "sha256-JB0Xojjh2STXwrpZxCvTgvp80ZLtL0jhhzTsiYOWtIM=";
+
+  overrideModAttrs = _: { patches = finalAttrs.patches; };
+
+  patches = [
+    # https://github.com/d3mondev/puredns/pull/71
+    (fetchpatch2 {
+      name = "bump-go.patch";
+      url = "https://github.com/d3mondev/puredns/commit/4c58955c5d9450b9aecad2213c253a6eb2670c33.patch?full_index=1";
+      hash = "sha256-CzlfN4ld065O7OVI5vILeyvv+jWBbAeweVgkeL80UDY=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    makeWrapper
+    massdns
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  ldflags = [ "-s" ];
+
+  postFixup = ''
+    wrapProgram $out/bin/puredns --prefix PATH : "${lib.makeBinPath [ massdns ]}"
+  '';
+
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Domain resolver and subdomain bruteforcing tool";
+    homepage = "https://github.com/d3mondev/puredns";
+    changelog = "https://github.com/d3mondev/puredns/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "puredns";
+  };
+})


### PR DESCRIPTION
Domain resolver and subdomain bruteforcing tool

https://github.com/d3mondev/puredns

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
