### PR TITLE
idevicerestore: 1.0.0-unstable-2025-10-02 -> 1.0.0-unstable-2026-07-26

### DIFF
--- a/pkgs/by-name/id/idevicerestore/package.nix
+++ b/pkgs/by-name/id/idevicerestore/package.nix
@@ -61,7 +61,10 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.lgpl21Plus;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ nh2 ];
+    maintainers = with lib.maintainers; [
+      flokli
+      nh2
+    ];
     mainProgram = "idevicerestore";
   };
 })

--- a/pkgs/by-name/id/idevicerestore/package.nix
+++ b/pkgs/by-name/id/idevicerestore/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "idevicerestore";
-  version = "1.0.0-unstable-2025-10-02";
+  version = "1.0.0-unstable-2026-07-26";
 
   src = fetchFromGitHub {
     owner = "libimobiledevice";
     repo = "idevicerestore";
-    rev = "f4d0f7e83105cc362527566315abee07b0840848";
-    hash = "sha256-fqTVAHTxamk2lIllr7ZNHOJ1YTJHM4JpVQylMV33CJI=";
+    rev = "45145e9fdc8458022c61a4b87bd029b866d5bcdc";
+    hash = "sha256-0W0DEnO8eZx2G3JKjp7SilLH8vmpfkiJxrwkudyf5rM=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Changelog:

 - 45145e9 restore: Add support for restoring macOS 27 IPSWs via DFU
 - 405fcd1 asr: Increase timeouts for slow devices
 - 6163635 logger: fix crash and undefined behavior in logger_dump_hex with zero-length buffers
 - 74e3bd9 endianness.h: Default to little endian
 - a499b62 configure: Bump libimobiledevice and libirecovery version requirements


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
