### PR TITLE
scx.rustscheds: 1.1.1 -> 1.1.2

### DIFF
--- a/nixos/tests/scx/default.nix
+++ b/nixos/tests/scx/default.nix
@@ -13,13 +13,19 @@
     specialisation = {
       beerland.configuration.services.scx.scheduler = "scx_beerland";
       bpfland.configuration.services.scx.scheduler = "scx_bpfland";
+      cake.configuration.services.scx.scheduler = "scx_cake";
+      chaos.configuration.services.scx.scheduler = "scx_chaos";
       cosmos.configuration.services.scx.scheduler = "scx_cosmos";
       flash.configuration.services.scx.scheduler = "scx_flash";
+      flow.configuration.services.scx.scheduler = "scx_flow";
+      forge.configuration.services.scx.scheduler = "scx_forge";
       lavd.configuration.services.scx.scheduler = "scx_lavd";
       p2dq.configuration.services.scx.scheduler = "scx_p2dq";
+      pandemonium.configuration.services.scx.scheduler = "scx_pandemonium";
       rlfifo.configuration.services.scx.scheduler = "scx_rlfifo";
       rustland.configuration.services.scx.scheduler = "scx_rustland";
       rusty.configuration.services.scx.scheduler = "scx_rusty";
+      tickless.configuration.services.scx.scheduler = "scx_tickless";
     };
   };
 
@@ -27,13 +33,19 @@
     specialisation = [
       "beerland",
       "bpfland",
+      "cake",
+      "chaos",
       "cosmos",
       "flash",
+      "flow",
+      "forge",
       "lavd",
       "p2dq",
+      "pandemonium",
       "rlfifo",
       "rustland",
       "rusty",
+      "tickless",
     ]
 
     def activate_specialisation(name: str):

--- a/nixos/tests/scx/default.nix
+++ b/nixos/tests/scx/default.nix
@@ -15,14 +15,11 @@
       bpfland.configuration.services.scx.scheduler = "scx_bpfland";
       cosmos.configuration.services.scx.scheduler = "scx_cosmos";
       flash.configuration.services.scx.scheduler = "scx_flash";
-      flatcg.configuration.services.scx.scheduler = "scx_flatcg";
       lavd.configuration.services.scx.scheduler = "scx_lavd";
-      nest.configuration.services.scx.scheduler = "scx_nest";
       p2dq.configuration.services.scx.scheduler = "scx_p2dq";
       rlfifo.configuration.services.scx.scheduler = "scx_rlfifo";
       rustland.configuration.services.scx.scheduler = "scx_rustland";
       rusty.configuration.services.scx.scheduler = "scx_rusty";
-      simple.configuration.services.scx.scheduler = "scx_simple";
     };
   };
 
@@ -32,14 +29,11 @@
       "bpfland",
       "cosmos",
       "flash",
-      "flatcg",
       "lavd",
-      "nest",
       "p2dq",
       "rlfifo",
       "rustland",
       "rusty",
-      "simple"
     ]
 
     def activate_specialisation(name: str):

--- a/pkgs/os-specific/linux/scx/scx_rustscheds.nix
+++ b/pkgs/os-specific/linux/scx/scx_rustscheds.nix
@@ -11,30 +11,33 @@
   libseccomp,
   nix-update-script,
   nixosTests,
+  openssl,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "scx_rustscheds";
-  version = "1.1.1";
+  version = "1.1.2";
 
   src = fetchFromGitHub {
     owner = "sched-ext";
     repo = "scx";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-/EE1+mlbCQmeLqhbHM+k1JwrRw1Z1mOZmq/ffR1l4bg=";
+    hash = "sha256-igrmrfimVOEJnFxMr9ghN6lAHwEBSFLLVrB2MQ72PXI=";
   };
 
-  cargoHash = "sha256-1alU6Hl7wHM69JK1ZRWzhT843ROs0WhkBUuDDweZSvk=";
+  cargoHash = "sha256-CTEVdvw6aG/fFas2Fk3x9o4Sp2k3lHO/OLwUM8t9UjE=";
 
   nativeBuildInputs = [
     pkg-config
     rustPlatform.bindgenHook
     protobuf
   ];
+
   buildInputs = [
     elfutils
     zlib
     zstd
     libseccomp
+    openssl
   ];
 
   env = {
@@ -84,9 +87,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "scx_bpfland"
     "scx_cake"
     "scx_chaos"
+    "scx_characterize"
     "scx_cosmos"
     "scx_flash"
     "scx_flow"
+    "scx_forge"
     "scx_lavd"
     "scx_layered"
     "scx_mitosis"


### PR DESCRIPTION
Changelog: https://github.com/sched-ext/scx/releases/tag/v1.1.2
Diff: https://github.com/sched-ext/scx/compare/v1.1.1...v1.1.2

`1.1.2` includes two new binaries: `scx_forge` and `scx_characterize`, the later is not a scheduler.

I had to add `openssl` to the buildInputs since it failed to compile without it:
```
       >   Could not find directory of OpenSSL installation, and this `-sys` crate cannot
       >   proceed without this knowledge. If OpenSSL is installed and this crate had
       >   trouble finding it,  you can set the `OPENSSL_DIR` environment variable for the
       >   compilation process.
       >
       >   Make sure you also have the development packages of openssl installed.
       >   For example, `libssl-dev` on Ubuntu or `openssl-devel` on Fedora.
       >
       >   If you're in a situation where you think the directory *should* be found
       >   automatically, please open a bug at https://github.com/rust-openssl/rust-openssl
       >   and include information about your system as well as this message.
       >
       >   $HOST = x86_64-unknown-linux-gnu
       >   $TARGET = x86_64-unknown-linux-gnu
       >   openssl-sys = 0.9.116
       >
       >
       > warning: build failed, waiting for other jobs to finish...

```

While I was at it, I removed the cscheds for `nixosTests.scx` (mainly because `flatcg` was failing and also because they are not really maintained and are mostly here as examples), and added all the rustscheds (minus `layered` and `mitosis` since they both require a config to be run).
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test