### PR TITLE
antigravity-cli: fix updateScript version handling

### DIFF
--- a/pkgs/by-name/an/antigravity-cli/package.nix
+++ b/pkgs/by-name/an/antigravity-cli/package.nix
@@ -6,8 +6,9 @@
   versionCheckHook,
 }:
 let
-  wholeVersion = "1.0.12-6156052174077952"; # unfortunately this has dumb versioning
-  version = builtins.head (lib.splitString "-" wholeVersion);
+  version = "1.0.12";
+  buildId = "6156052174077952";
+  wholeVersion = "${version}-${buildId}";
 
   throwSystem = throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}";
 

--- a/pkgs/by-name/an/antigravity-cli/update.sh
+++ b/pkgs/by-name/an/antigravity-cli/update.sh
@@ -3,6 +3,7 @@
 
 set -euo pipefail
 
+packageFile=pkgs/by-name/an/antigravity-cli/package.nix
 baseUrl=https://storage.googleapis.com/antigravity-public/antigravity-cli
 
 currentVersion=$(nix-instantiate --eval --raw -E "with import ./. {}; antigravity-cli.version or (lib.getVersion antigravity-cli)")
@@ -15,8 +16,11 @@ fi
 
 # urls unfortunately include a weird buildid that make it hard to get
 latestWholeVersion=$(curl $baseUrl/$latestVersion/manifest.json | jq -r '.platforms."linux-x64".url' | cut -d/ -f6)
+latestBuildId=${latestWholeVersion#*-}
+currentBuildId=$(sed -n 's/.*buildId = "\([^"]*\)";.*/\1/p' "$packageFile")
 
-update-source-version --version-key=wholeVersion antigravity-cli $latestWholeVersion || true
+sed -i "s/buildId = \"$currentBuildId\";/buildId = \"$latestBuildId\";/" "$packageFile"
+update-source-version --version-key=version antigravity-cli $latestVersion || true
 
 for system in \
     x86_64-linux \
@@ -25,5 +29,5 @@ for system in \
     aarch64-darwin; do
     hash=$(nix store prefetch-file --json --hash-type sha256 \
       $(nix-instantiate --eval --raw -E "with import ./. {}; antigravity-cli.src.url" --system "$system") | jq -r '.hash')
-    update-source-version --version-key=wholeVersion antigravity-cli $latestWholeVersion $hash --system=$system --ignore-same-version
+    update-source-version --version-key=version antigravity-cli $latestVersion $hash --system=$system --ignore-same-version
 done


### PR DESCRIPTION
r-ryntm bot was [failing to update](https://nixpkgs-update-logs.nix-community.org/antigravity-cli/2026-06-30.log) as the version was not SemVar. This PR corrected that so that future runs will successfully update the package.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test