### PR TITLE
cockpit-dockermanager: init at 1.0.8.2

### DIFF
--- a/pkgs/by-name/co/cockpit-dockermanager/package.nix
+++ b/pkgs/by-name/co/cockpit-dockermanager/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "cockpit-dockermanager";
+  version = "1.0.8.2";
+
+  src = fetchFromGitHub {
+    owner = "chrisjbawden";
+    repo = "cockpit-dockermanager";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-NYRLlS9mk1OOlpX3L8ezl6Cvn2kP9+8YDLzuCb54pso=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/cockpit
+    cp -r $src/dockermanager $out/share/cockpit
+
+    runHook postInstall
+  '';
+
+  passthru.cockpitPath = [ ];
+
+  meta = {
+    description = "Cockpit plugin for managing docker containers";
+    homepage = "https://chrisjbawden.github.io/cockpit-dockermanager/";
+    changelog = "https://chrisjbawden.github.io/cockpit-dockermanager/";
+    maintainers = [ lib.maintainers.EpicEric ];
+    platforms = lib.platforms.linux;
+    license = [ lib.licenses.mit ];
+  };
+})


### PR DESCRIPTION
Plugin for cockpit to manage Docker containers: <https://github.com/chrisjbawden/cockpit-dockermanager>

Tested with the following config:

```nix
{ pkgs, ... }:
{
  services.cockpit = {
    enable = true;
    port = 9090;
    plugins = [
      pkgs.cockpit-dockermanager
    ];
    settings = {
      WebService = {
        AllowUnencrypted = true;
      };
    };
    allowed-origins = [
      "http://localhost:9090"
    ];
  };
}
```


<img width="1441" height="565" alt="2026-07-04T10-12-52" src="https://github.com/user-attachments/assets/5bbc4cbc-8474-4435-94bf-de3afbdcaa2c" />

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
