### PR TITLE
immich: 2.7.5 -> 3.0.1

### DIFF
--- a/nixos/tests/web-apps/immich.nix
+++ b/nixos/tests/web-apps/immich.nix
@@ -8,7 +8,7 @@
       # These tests need a little more juice
       virtualisation = {
         cores = 2;
-        memorySize = 2048;
+        memorySize = 4096;
         diskSize = 4096;
       };
 

--- a/pkgs/by-name/im/immich-cli/package.nix
+++ b/pkgs/by-name/im/immich-cli/package.nix
@@ -12,12 +12,6 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "immich-cli";
   inherit (immich) version src pnpmDeps;
 
-  postPatch = ''
-    local -r cli_version="$(jq -r .version cli/package.json)"
-    test "$cli_version" = ${finalAttrs.version} \
-      || (echo "error: update immich-cli version to $cli_version" && exit 1)
-  '';
-
   nativeBuildInputs = [
     jq
     makeWrapper
@@ -29,8 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildPhase = ''
     runHook preBuild
 
-    pnpm --filter @immich/sdk build
-    pnpm --filter @immich/cli build
+    pnpm --filter @immich/cli... build
 
     runHook postBuild
   '';

--- a/pkgs/by-name/im/immich-machine-learning/package.nix
+++ b/pkgs/by-name/im/immich-machine-learning/package.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  fetchpatch2,
   immich,
   python3,
   nixosTests,
@@ -16,15 +15,6 @@ python.pkgs.buildPythonApplication rec {
   inherit (immich) version;
   src = "${immich.src}/machine-learning";
   pyproject = true;
-
-  patches = [
-    (fetchpatch2 {
-      name = "fix_tests_with_openvino_ep.patch";
-      relative = "machine-learning";
-      url = "https://github.com/immich-app/immich/commit/7f611d90317d75ac3d75adf428f367376171e106.patch?full_index=1";
-      hash = "sha256-dntL5AZS3VIp7++yUec4HWIdtwltrnIePNFPJaiZdy4=";
-    })
-  ];
 
   pythonRelaxDeps = [
     "huggingface-hub"

--- a/pkgs/by-name/im/immich/package.nix
+++ b/pkgs/by-name/im/immich/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   fetchPnpmDeps,
   pnpmConfigHook,
-  pnpm_10,
+  pnpm_11,
   python3,
   nodejs,
   node-gyp,
@@ -37,7 +37,7 @@
   buildPackages,
 }:
 let
-  pnpm = pnpm_10;
+  pnpm = pnpm_11;
 
   esbuild' = buildPackages.esbuild.override {
     buildGoModule =
@@ -45,12 +45,12 @@ let
       buildPackages.buildGoModule (
         args
         // rec {
-          version = "0.25.5";
+          version = "0.28.1";
           src = fetchFromGitHub {
             owner = "evanw";
             repo = "esbuild";
             tag = "v${version}";
-            hash = "sha256-jemGZkWmN1x2+ZzJ5cLp3MoXO0oDKjtZTmZS9Be/TDw=";
+            hash = "sha256-V+HKaWGAIs24ynFFIS9fQ0EAJJdNmlAMeL1sgDEAqWM=";
           };
           vendorHash = "sha256-+BfxCyg0KkDQpHt/wycy/8CTG6YBA/VJvJFhhzUnSiQ=";
         }
@@ -115,20 +115,20 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "immich";
-  version = "2.7.5";
+  version = "3.0.1";
 
   src = fetchFromGitHub {
     owner = "immich-app";
     repo = "immich";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-EC1IXM7KObAWfwG5KEao5VDp79d8WGNEI7E89lLOJ44=";
+    hash = "sha256-Z18SEjUdFP2/grQtHFI6J7CVcAMalshPt3Sd4tGXsDw=";
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     inherit pnpm;
-    fetcherVersion = 3;
-    hash = "sha256-FEesjbhxP7ydFfNshF3iFIk9N3Z53jrEZ9DRBjgEfs0=";
+    fetcherVersion = 4;
+    hash = "sha256-kCMFAPWcv2/qqVUoR5pbRxmkGg3mLPrpm8ce7R+9VYM=";
   };
 
   postPatch = ''
@@ -174,7 +174,7 @@ stdenv.mkDerivation (finalAttrs: {
     # If exiftool-vendored.pl isn't found, exiftool is searched for on the PATH
     rm node_modules/.pnpm/node_modules/exiftool-vendored.pl
 
-    pnpm --filter immich build
+    pnpm --filter immich... build
 
     runHook postBuild
   '';
@@ -196,8 +196,8 @@ stdenv.mkDerivation (finalAttrs: {
       -o -name '*.target.mk' \
     \) -exec rm -r {} +
 
-    mkdir -p "$packageOut/build"
-    ln -s '${finalAttrs.passthru.plugins}' "$packageOut/build/corePlugin"
+    mkdir -p "$packageOut/build/plugins"
+    ln -s '${finalAttrs.passthru.plugin-core}' "$packageOut/build/plugins/immich-plugin-core"
     ln -s '${finalAttrs.passthru.web}' "$packageOut/build/www"
     ln -s '${geodata}' "$packageOut/build/geodata"
 
@@ -231,8 +231,8 @@ stdenv.mkDerivation (finalAttrs: {
       immich = finalAttrs.finalPackage;
     };
 
-    plugins = stdenv.mkDerivation {
-      pname = "immich-plugins";
+    plugin-core = stdenv.mkDerivation {
+      pname = "immich-plugin-core";
       inherit (finalAttrs) version src pnpmDeps;
 
       nativeBuildInputs = [
@@ -246,7 +246,7 @@ stdenv.mkDerivation (finalAttrs: {
       buildPhase = ''
         runHook preBuild
 
-        pnpm --filter plugins build
+        pnpm --filter @immich/plugin-core... build
 
         runHook postBuild
       '';
@@ -254,7 +254,7 @@ stdenv.mkDerivation (finalAttrs: {
       installPhase = ''
         runHook preInstall
 
-        cd plugins
+        cd packages/plugin-core
         mkdir $out
         cp -r dist manifest.json $out
 
@@ -275,8 +275,7 @@ stdenv.mkDerivation (finalAttrs: {
       buildPhase = ''
         runHook preBuild
 
-        pnpm --filter @immich/sdk build
-        pnpm --filter immich-web build
+        pnpm --filter immich-web... build
 
         runHook postBuild
       '';


### PR DESCRIPTION
supersede #537930

release notes: 
- https://github.com/immich-app/immich/releases/tag/v3.0.0
-  https://github.com/immich-app/immich/releases/tag/v3.0.1

been running this since ~26th during the first rc, seems fine.

closes https://github.com/NixOS/nixpkgs/issues/524881
closes https://github.com/NixOS/nixpkgs/issues/537902
closes https://github.com/NixOS/nixpkgs/pull/537930

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
