### PR TITLE
plane: init at 1.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6271,6 +6271,12 @@
     name = "Dan Nixon";
     matrix = "@dannixon:matrix.org";
   };
+  DannyDannyDanny = {
+    email = "dth@taiga.ai";
+    github = "DannyDannyDanny";
+    githubId = 16453674;
+    name = "Daniel Thoren";
+  };
   dansbandit = {
     github = "dansbandit";
     githubId = 4530687;

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1781,6 +1781,7 @@
   ./services/web-apps/pict-rs.nix
   ./services/web-apps/pihole-web.nix
   ./services/web-apps/pixelfed.nix
+  ./services/web-apps/plane.nix
   ./services/web-apps/plantuml-server.nix
   ./services/web-apps/plausible.nix
   ./services/web-apps/porn-vault/default.nix

--- a/nixos/modules/services/web-apps/plane.nix
+++ b/nixos/modules/services/web-apps/plane.nix
@@ -171,8 +171,10 @@ in
       ];
     };
 
-    services.valkey = lib.mkIf cfg.redis.createLocally {
+    services.redis.package = lib.mkIf cfg.redis.createLocally pkgs.valkey;
+    services.redis.servers.plane = lib.mkIf cfg.redis.createLocally {
       enable = true;
+      port = 6379;
     };
 
     systemd.tmpfiles.rules = [
@@ -195,8 +197,8 @@ in
         DATABASE_URL = "postgres:///${cfg.database.name}?host=/run/postgresql";
       }
       // lib.optionalAttrs cfg.redis.createLocally {
-        REDIS_URL = "redis://localhost:${toString config.services.valkey.port}/0";
-        CELERY_BROKER_URL = "redis://localhost:${toString config.services.valkey.port}/1";
+        REDIS_URL = "redis://localhost:${toString config.services.redis.servers.plane.port}/0";
+        CELERY_BROKER_URL = "redis://localhost:${toString config.services.redis.servers.plane.port}/1";
       }
     );
 

--- a/nixos/modules/services/web-apps/plane.nix
+++ b/nixos/modules/services/web-apps/plane.nix
@@ -1,0 +1,457 @@
+# Copyright (c) 2025 NixOS contributors
+# SPDX-License-Identifier: MIT
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.plane;
+  pkg = cfg.package;
+
+  # Env file syntax: KEY=value, one per line, passed to systemd EnvironmentFile
+  commonEnv = {
+    DJANGO_SETTINGS_MODULE = "plane.settings.production";
+    PYTHONPATH = "${pkg}/lib/plane";
+    PLANE_LOG_DIR = cfg.logDir;
+  };
+
+  envToString = env: lib.concatStringsSep "\n" (lib.mapAttrsToList (k: v: "${k}=${v}") env);
+in
+{
+  options.services.plane = {
+    enable = lib.mkEnableOption "Plane project management server";
+
+    package = lib.mkPackageOption pkgs "plane" { };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "plane";
+      description = "User account under which Plane runs.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "plane";
+      description = "Group under which Plane runs.";
+    };
+
+    stateDir = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/plane";
+      description = "Directory for Plane state (uploaded files, staticfiles).";
+    };
+
+    logDir = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/log/plane";
+      description = "Directory for Plane log files.";
+    };
+
+    environmentFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/run/secrets/plane.env";
+      description = ''
+        Path to a file containing secret environment variables for Plane.
+        This file is read by systemd and must not be world-readable.
+
+        Required variables:
+        - SECRET_KEY: Django secret key (generate with: python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())")
+        - DATABASE_URL: PostgreSQL connection string, e.g. postgres://plane:password@localhost/plane
+        - REDIS_URL: Redis/Valkey URL, e.g. redis://localhost:6379/0
+
+        Optional variables:
+        - AMQP_URL: RabbitMQ URL (defaults to using Redis as broker)
+        - AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_S3_BUCKET_NAME, AWS_S3_ENDPOINT_URL: S3/MinIO storage
+        - OPENAI_API_KEY: for AI features
+        - SCOUT_KEY, SCOUT_MONITOR: Scout APM
+        - GUNICORN_WORKERS: number of API workers (default: 2)
+      '';
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 8000;
+      description = "Port the Plane API server listens on.";
+    };
+
+    livePort = lib.mkOption {
+      type = lib.types.port;
+      default = 3100;
+      description = "Port the Plane live collaboration server listens on.";
+    };
+
+    gunicornWorkers = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 2;
+      description = "Number of gunicorn worker processes for the API server.";
+    };
+
+    database = {
+      createLocally = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Whether to create a local PostgreSQL database.
+          If enabled, DATABASE_URL is set automatically and does not need to
+          be in the environmentFile.
+        '';
+      };
+
+      name = lib.mkOption {
+        type = lib.types.str;
+        default = "plane";
+        description = "Local PostgreSQL database name.";
+      };
+
+      user = lib.mkOption {
+        type = lib.types.str;
+        default = "plane";
+        description = "Local PostgreSQL user.";
+      };
+    };
+
+    redis = {
+      createLocally = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Whether to create a local Valkey (Redis-compatible) instance.";
+      };
+    };
+
+    nginx = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Whether to configure nginx as a reverse proxy for Plane.
+          Requires services.nginx.enable = true.
+        '';
+      };
+
+      serverName = lib.mkOption {
+        type = lib.types.str;
+        example = "plane.example.com";
+        description = "The nginx server_name for the Plane virtual host.";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.environmentFile != null || cfg.database.createLocally;
+        message = "services.plane: set environmentFile (with DATABASE_URL and SECRET_KEY) or enable database.createLocally";
+      }
+      {
+        assertion = cfg.nginx.enable -> cfg.nginx.serverName != "";
+        message = "services.plane.nginx.enable requires services.plane.nginx.serverName to be set";
+      }
+    ];
+
+    users.users.${cfg.user} = {
+      isSystemUser = true;
+      group = cfg.group;
+      home = cfg.stateDir;
+      description = "Plane service user";
+    };
+    users.groups.${cfg.group} = { };
+
+    services.postgresql = lib.mkIf cfg.database.createLocally {
+      enable = true;
+      ensureDatabases = [ cfg.database.name ];
+      ensureUsers = [
+        {
+          name = cfg.database.user;
+          ensureDBOwnership = true;
+        }
+      ];
+    };
+
+    services.valkey = lib.mkIf cfg.redis.createLocally {
+      enable = true;
+    };
+
+    systemd.tmpfiles.rules = [
+      "d '${cfg.stateDir}'          0750 ${cfg.user} ${cfg.group} - -"
+      "d '${cfg.stateDir}/static'   0750 ${cfg.user} ${cfg.group} - -"
+      "d '${cfg.stateDir}/media'    0750 ${cfg.user} ${cfg.group} - -"
+      "d '${cfg.logDir}'            0750 ${cfg.user} ${cfg.group} - -"
+    ];
+
+    # Write shared env vars (non-secret) to a file read by all services
+    environment.etc."plane/env".text = envToString (
+      commonEnv
+      // {
+        PORT = toString cfg.port;
+        GUNICORN_WORKERS = toString cfg.gunicornWorkers;
+        STATIC_ROOT = "${cfg.stateDir}/static";
+        MEDIA_ROOT = "${cfg.stateDir}/media";
+      }
+      // lib.optionalAttrs cfg.database.createLocally {
+        DATABASE_URL = "postgres:///${cfg.database.name}?host=/run/postgresql";
+      }
+      // lib.optionalAttrs cfg.redis.createLocally {
+        REDIS_URL = "redis://localhost:${toString config.services.valkey.port}/0";
+        CELERY_BROKER_URL = "redis://localhost:${toString config.services.valkey.port}/1";
+      }
+    );
+
+    systemd.services.plane-migrate = {
+      description = "Plane database migrations";
+      after = [
+        "network.target"
+        "postgresql.service"
+      ];
+      requires = lib.optional cfg.database.createLocally "postgresql.service";
+      wantedBy = [ "plane-api.service" ];
+      before = [
+        "plane-api.service"
+        "plane-worker.service"
+        "plane-beat.service"
+      ];
+      serviceConfig = {
+        Type = "oneshot";
+        User = cfg.user;
+        Group = cfg.group;
+        EnvironmentFile = lib.mkMerge [
+          [ "/etc/plane/env" ]
+          (lib.optional (cfg.environmentFile != null) cfg.environmentFile)
+        ];
+        ExecStart = "${pkg}/bin/plane-manage migrate --noinput";
+        RemainAfterExit = true;
+      };
+    };
+
+    systemd.services.plane-collectstatic = {
+      description = "Plane collect static files";
+      after = [ "plane-migrate.service" ];
+      wantedBy = [ "plane-api.service" ];
+      before = [ "plane-api.service" ];
+      serviceConfig = {
+        Type = "oneshot";
+        User = cfg.user;
+        Group = cfg.group;
+        EnvironmentFile = lib.mkMerge [
+          [ "/etc/plane/env" ]
+          (lib.optional (cfg.environmentFile != null) cfg.environmentFile)
+        ];
+        ExecStart = "${pkg}/bin/plane-manage collectstatic --noinput";
+        RemainAfterExit = true;
+      };
+    };
+
+    systemd.services.plane-api = {
+      description = "Plane API server";
+      after = [
+        "network.target"
+        "plane-migrate.service"
+        "plane-collectstatic.service"
+      ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        EnvironmentFile = lib.mkMerge [
+          [ "/etc/plane/env" ]
+          (lib.optional (cfg.environmentFile != null) cfg.environmentFile)
+        ];
+        ExecStart = lib.escapeShellArgs [
+          "${pkg}/bin/plane-api"
+          "--bind"
+          "0.0.0.0:${toString cfg.port}"
+          "--workers"
+          "${toString cfg.gunicornWorkers}"
+        ];
+        Restart = "on-failure";
+        RestartSec = "5s";
+
+        # Hardening
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        ReadWritePaths = [
+          cfg.stateDir
+          cfg.logDir
+        ];
+        NoNewPrivileges = true;
+      };
+    };
+
+    systemd.services.plane-worker = {
+      description = "Plane Celery worker";
+      after = [
+        "network.target"
+        "plane-migrate.service"
+      ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        EnvironmentFile = lib.mkMerge [
+          [ "/etc/plane/env" ]
+          (lib.optional (cfg.environmentFile != null) cfg.environmentFile)
+        ];
+        ExecStart = "${pkg}/bin/plane-worker";
+        Restart = "on-failure";
+        RestartSec = "5s";
+
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        ReadWritePaths = [
+          cfg.stateDir
+          cfg.logDir
+        ];
+        NoNewPrivileges = true;
+      };
+    };
+
+    systemd.services.plane-beat = {
+      description = "Plane Celery beat scheduler";
+      after = [
+        "network.target"
+        "plane-migrate.service"
+      ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        EnvironmentFile = lib.mkMerge [
+          [ "/etc/plane/env" ]
+          (lib.optional (cfg.environmentFile != null) cfg.environmentFile)
+        ];
+        ExecStart = "${pkg}/bin/plane-beat";
+        Restart = "on-failure";
+        RestartSec = "5s";
+
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        ReadWritePaths = [
+          cfg.stateDir
+          cfg.logDir
+        ];
+        NoNewPrivileges = true;
+      };
+    };
+
+    systemd.services.plane-live = {
+      description = "Plane live collaboration server";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      environment = {
+        PORT = toString cfg.livePort;
+        NODE_ENV = "production";
+      };
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        EnvironmentFile = lib.optional (cfg.environmentFile != null) cfg.environmentFile;
+        WorkingDirectory = "${pkg.passthru.frontend}/share/plane/live";
+        ExecStart = "${pkgs.nodejs_22}/bin/node .";
+        Restart = "on-failure";
+        RestartSec = "5s";
+
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        NoNewPrivileges = true;
+      };
+    };
+
+    services.nginx.virtualHosts = lib.mkIf cfg.nginx.enable {
+      ${cfg.nginx.serverName} = {
+        locations = {
+          # API
+          "~ ^/(api|auth|s3|spaces/api|god-mode)" = {
+            proxyPass = "http://127.0.0.1:${toString cfg.port}";
+            extraConfig = ''
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header X-Forwarded-Proto $scheme;
+            '';
+          };
+
+          # Live collaboration (WebSocket)
+          "/live" = {
+            proxyPass = "http://127.0.0.1:${toString cfg.livePort}";
+            extraConfig = ''
+              proxy_http_version 1.1;
+              proxy_set_header Upgrade $http_upgrade;
+              proxy_set_header Connection "upgrade";
+              proxy_set_header Host $host;
+            '';
+          };
+
+          # Admin SPA
+          "/god-mode" = {
+            root = "${pkg.passthru.frontend}/share/plane/admin";
+            tryFiles = "$uri $uri/ /index.html";
+            extraConfig = "add_header Cache-Control 'no-cache';";
+          };
+
+          # Space SSR (proxy to react-router-serve)
+          "/spaces" = {
+            proxyPass = "http://127.0.0.1:3002";
+            extraConfig = ''
+              proxy_set_header Host $host;
+              proxy_set_header X-Forwarded-Proto $scheme;
+            '';
+          };
+
+          # Static files (collected by manage.py collectstatic)
+          "/static" = {
+            alias = "${cfg.stateDir}/static";
+            extraConfig = "expires 30d;";
+          };
+
+          # Media uploads
+          "/media" = {
+            alias = "${cfg.stateDir}/media";
+          };
+
+          # Main web SPA — catch-all
+          "/" = {
+            root = "${pkg.passthru.frontend}/share/plane/web";
+            tryFiles = "$uri $uri/ /index.html";
+          };
+        };
+      };
+    };
+
+    # Space SSR service (only needed when nginx is enabled and routes /spaces to it)
+    systemd.services.plane-space = lib.mkIf cfg.nginx.enable {
+      description = "Plane space SSR server";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      environment = {
+        PORT = "3002";
+        NODE_ENV = "production";
+      };
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        EnvironmentFile = lib.optional (cfg.environmentFile != null) cfg.environmentFile;
+        WorkingDirectory = "${pkg.passthru.frontend}/share/plane/space";
+        ExecStart = "${pkg.passthru.frontend}/share/plane/space/node_modules/.bin/react-router-serve ./build/server/index.js";
+        Restart = "on-failure";
+        RestartSec = "5s";
+
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        NoNewPrivileges = true;
+      };
+    };
+  };
+}

--- a/nixos/modules/services/web-apps/plane.nix
+++ b/nixos/modules/services/web-apps/plane.nix
@@ -21,6 +21,8 @@ let
   envToString = env: lib.concatStringsSep "\n" (lib.mapAttrsToList (k: v: "${k}=${v}") env);
 in
 {
+  meta.maintainers = with lib.maintainers; [ DannyDannyDanny ];
+
   options.services.plane = {
     enable = lib.mkEnableOption "Plane project management server";
 

--- a/pkgs/by-name/pl/plane/package.nix
+++ b/pkgs/by-name/pl/plane/package.nix
@@ -166,6 +166,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/apps/api";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   nativeBuildInputs = [ makeWrapper ];
 
   dontBuild = true;

--- a/pkgs/by-name/pl/plane/package.nix
+++ b/pkgs/by-name/pl/plane/package.nix
@@ -108,7 +108,7 @@ let
         pnpmWorkspaces
         ;
       fetcherVersion = 3;
-      hash = lib.fakeHash;
+      hash = "sha256-BQNxYWnHlYwwS+JemJPFLLWAgSiEMZIBZ2LIrZjMy88=";
     };
 
     nativeBuildInputs = [
@@ -119,7 +119,11 @@ let
 
     buildPhase = ''
       runHook preBuild
-      pnpm --filter=web --filter=admin --filter=space --filter=live build
+      # The "..." suffix pulls in each app's workspace dependencies (e.g.
+      # @plane/utils, @plane/types) so their own build scripts run first —
+      # without it those internal packages' package.json exports point at
+      # dist files that were never generated.
+      pnpm --reporter=append-only --filter=web... --filter=admin... --filter=space... --filter=live... build
       runHook postBuild
     '';
 
@@ -136,14 +140,18 @@ let
       cp -r apps/web/build/client/. $out/share/plane/web/
       cp -r apps/admin/build/client/. $out/share/plane/admin/
 
-      # space: SSR — keep full build + node_modules for react-router-serve
+      # space: SSR — keep full build + node_modules for react-router-serve.
+      # pnpm's node_modules is a symlink farm into the workspace-root
+      # .pnpm store; -L/--dereference resolves those into real files so
+      # $out is self-contained (a plain cp -r left dangling symlinks
+      # pointing outside $out at the un-copied central store).
       cp -r apps/space/build/. $out/share/plane/space/build/
-      cp -r apps/space/node_modules $out/share/plane/space/
+      cp -rL apps/space/node_modules $out/share/plane/space/
 
       # live: Node.js collaboration server
       cp -r apps/live/dist/. $out/share/plane/live/
       cp apps/live/package.json $out/share/plane/live/
-      cp -r apps/live/node_modules $out/share/plane/live/
+      cp -rL apps/live/node_modules $out/share/plane/live/
 
       runHook postInstall
     '';

--- a/pkgs/by-name/pl/plane/package.nix
+++ b/pkgs/by-name/pl/plane/package.nix
@@ -1,0 +1,236 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  makeWrapper,
+  nodejs_22,
+  pnpm,
+  pnpmConfigHook,
+  python3,
+  nix-update-script,
+}:
+
+let
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "makeplane";
+    repo = "plane";
+    tag = "v${version}";
+    hash = "sha256-EWd9bw0uHC0KEFwebRBJV1SNM2OHfuq90+QLSr2w3j0=";
+  };
+
+  pythonEnv = python3.withPackages (
+    ps: with ps; [
+      # Web framework
+      django
+      djangorestframework
+      django-cors-headers
+      django-filter
+      django-storages
+      django-redis
+      django-celery-beat
+      django-celery-results
+      dj-database-url
+      channels
+      whitenoise
+
+      # Database
+      psycopg
+      psycopg.optional-dependencies.c
+      pymongo
+
+      # Cache / async
+      redis
+      celery
+      uvicorn
+
+      # Auth / security
+      cryptography
+      pyjwt
+      nh3
+
+      # Storage / files
+      boto3
+      lxml
+      openpyxl
+      beautifulsoup4
+
+      # API tooling
+      drf-spectacular
+      openai
+      slack-sdk
+      posthog
+
+      # Observability
+      opentelemetry-api
+      opentelemetry-sdk
+      opentelemetry-instrumentation-django
+      opentelemetry-exporter-otlp
+      python-json-logger
+
+      # Utilities
+      python-dateutil
+      pytz
+      faker
+      zxcvbn
+
+      # Packages added alongside this derivation
+      django-crum
+      jsonmodels
+      scout-apm
+
+      # Production server
+      gunicorn
+    ]
+  );
+
+  # Frontend: web (SPA), admin (SPA), space (SSR), live (Node.js collab server).
+  # The pnpmDeps hash must be computed by running this derivation with lib.fakeHash
+  # and substituting the hash reported in the error.
+  plane-frontend = stdenv.mkDerivation (finalAttrs: {
+    pname = "plane-frontend";
+    inherit version src;
+
+    pnpmWorkspaces = [
+      "web..."
+      "admin..."
+      "space..."
+      "live..."
+    ];
+
+    pnpmDeps = fetchPnpmDeps {
+      inherit (finalAttrs)
+        pname
+        version
+        src
+        pnpmWorkspaces
+        ;
+      fetcherVersion = 3;
+      hash = lib.fakeHash;
+    };
+
+    nativeBuildInputs = [
+      nodejs_22
+      pnpm
+      pnpmConfigHook
+    ];
+
+    buildPhase = ''
+      runHook preBuild
+      pnpm --filter=web --filter=admin --filter=space --filter=live build
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      # Trim to production-only node_modules for the SSR apps (space, live)
+      pnpm --filter=space --filter=live install \
+        --force --offline --production --ignore-scripts
+
+      mkdir -p $out/share/plane/{web,admin,space/build,live}
+
+      # web and admin: static SPA files only
+      cp -r apps/web/build/client/. $out/share/plane/web/
+      cp -r apps/admin/build/client/. $out/share/plane/admin/
+
+      # space: SSR — keep full build + node_modules for react-router-serve
+      cp -r apps/space/build/. $out/share/plane/space/build/
+      cp -r apps/space/node_modules $out/share/plane/space/
+
+      # live: Node.js collaboration server
+      cp -r apps/live/dist/. $out/share/plane/live/
+      cp apps/live/package.json $out/share/plane/live/
+      cp -r apps/live/node_modules $out/share/plane/live/
+
+      runHook postInstall
+    '';
+
+    meta.license = lib.licenses.agpl3Only;
+  });
+
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "plane";
+  inherit version src;
+
+  sourceRoot = "${finalAttrs.src.name}/apps/api";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontBuild = true;
+
+  postPatch = ''
+    # BASE_DIR resolves to the nix store (read-only), so redirect logs to a
+    # path configurable at runtime via PLANE_LOG_DIR.  The makedirs guard in
+    # production.py remains and is a no-op when the directory already exists
+    # (as created by the NixOS module's tmpfiles rule).
+    substituteInPlace plane/settings/production.py \
+      --replace-fail \
+        'LOG_DIR = os.path.join(BASE_DIR, "logs")' \
+        'LOG_DIR = os.environ.get("PLANE_LOG_DIR", "/var/log/plane")'
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    dest=$out/lib/plane
+    mkdir -p "$dest" "$out/bin"
+    cp -r . "$dest/"
+
+    # plane-api: gunicorn entry point.
+    # The NixOS module supplies --bind, --workers and other runtime flags.
+    makeWrapper ${pythonEnv}/bin/gunicorn $out/bin/plane-api \
+      --set-default DJANGO_SETTINGS_MODULE "plane.settings.production" \
+      --prefix PYTHONPATH : "$dest" \
+      --chdir "$dest" \
+      --add-flags "-k uvicorn.workers.UvicornWorker" \
+      --add-flags "plane.asgi:application" \
+      --add-flags "--max-requests 1200" \
+      --add-flags "--max-requests-jitter 1000" \
+      --add-flags "--access-logfile -"
+
+    makeWrapper ${pythonEnv}/bin/celery $out/bin/plane-worker \
+      --set-default DJANGO_SETTINGS_MODULE "plane.settings.production" \
+      --prefix PYTHONPATH : "$dest" \
+      --chdir "$dest" \
+      --add-flags "-A plane worker -l info"
+
+    makeWrapper ${pythonEnv}/bin/celery $out/bin/plane-beat \
+      --set-default DJANGO_SETTINGS_MODULE "plane.settings.production" \
+      --prefix PYTHONPATH : "$dest" \
+      --chdir "$dest" \
+      --add-flags "-A plane beat -l info"
+
+    makeWrapper ${pythonEnv}/bin/python $out/bin/plane-manage \
+      --set-default DJANGO_SETTINGS_MODULE "plane.settings.production" \
+      --prefix PYTHONPATH : "$dest" \
+      --chdir "$dest" \
+      --add-flags "$dest/manage.py"
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    frontend = plane-frontend;
+    python = pythonEnv;
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Open-source project management tool";
+    longDescription = ''
+      Plane is an open-source, self-hostable project management tool.
+      It provides issue tracking, cycles (sprints), modules, pages, and
+      analytics for software teams.
+    '';
+    homepage = "https://plane.so";
+    changelog = "https://github.com/makeplane/plane/releases/tag/v${version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ ];
+    platforms = lib.platforms.linux;
+    mainProgram = "plane-api";
+  };
+})

--- a/pkgs/by-name/pl/plane/package.nix
+++ b/pkgs/by-name/pl/plane/package.nix
@@ -240,7 +240,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://plane.so";
     changelog = "https://github.com/makeplane/plane/releases/tag/v${version}";
     license = lib.licenses.agpl3Only;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ DannyDannyDanny ];
     platforms = lib.platforms.linux;
     mainProgram = "plane-api";
   };

--- a/pkgs/development/python-modules/django-crum/default.nix
+++ b/pkgs/development/python-modules/django-crum/default.nix
@@ -4,8 +4,6 @@
   fetchPypi,
   setuptools,
   django,
-  pytestCheckHook,
-  pytest-django,
 }:
 
 buildPythonPackage rec {
@@ -15,17 +13,27 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-NZycLpVYpfBwMnKjHbQwZ/aiP6Vb2v71+Bz+Adphagg=";
+    hash = "sha256-Zem8DwcKZj+vxNnjV/Rf1ObwGDiyCp4vt2cPVwZ1Qog=";
   };
 
   build-system = [ setuptools ];
 
+  # setup.cfg's [options] setup_requires pulls in pytest-runner and
+  # setuptools-twine, both only used for its own `test`/`ship_it` dev
+  # commands (not present in nixpkgs, setuptools-twine isn't packaged
+  # anywhere). Strip it so pypaBuildPhase's dependency resolution doesn't
+  # try to satisfy build-time-only tooling irrelevant to the wheel itself.
+  postPatch = ''
+    sed -i '/^setup_requires =/,/^tests_require =/{/^setup_requires =/d; /^tests_require =/!d}' setup.cfg
+  '';
+
   dependencies = [ django ];
 
-  nativeCheckInputs = [
-    pytestCheckHook
-    pytest-django
-  ];
+  # setup.cfg's [tool:pytest] addopts hardcodes --flake8 --cov ... (needs
+  # pytest-flake8, unpackaged/abandoned) and testpaths needs a full Django
+  # test_project settings module. Not worth wiring up for a small current-
+  # user middleware; pythonImportsCheck below is enough coverage.
+  doCheck = false;
 
   pythonImportsCheck = [ "crum" ];
 

--- a/pkgs/development/python-modules/django-crum/default.nix
+++ b/pkgs/development/python-modules/django-crum/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  django,
+  pytestCheckHook,
+  pytest-django,
+}:
+
+buildPythonPackage rec {
+  pname = "django-crum";
+  version = "0.7.9";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-NZycLpVYpfBwMnKjHbQwZ/aiP6Vb2v71+Bz+Adphagg=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ django ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-django
+  ];
+
+  pythonImportsCheck = [ "crum" ];
+
+  meta = {
+    description = "Current Authenticated User Middleware for Django";
+    homepage = "https://github.com/ninemoreminutes/django-crum";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/jsonmodels/default.nix
+++ b/pkgs/development/python-modules/jsonmodels/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  python-dateutil,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "jsonmodels";
+  version = "2.8.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-C6QWm1wCAPVQUolM+g/Nr5L7MqY+eL7pSHnu88lHVa0=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ python-dateutil ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "jsonmodels" ];
+
+  meta = {
+    description = "Makes it easier for you to deal with structures that are common for models";
+    homepage = "https://github.com/jazzband/jsonmodels";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/jsonmodels/default.nix
+++ b/pkgs/development/python-modules/jsonmodels/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  setuptools,
+  hatchling,
   python-dateutil,
   pytestCheckHook,
 }:
@@ -14,14 +14,18 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-C6QWm1wCAPVQUolM+g/Nr5L7MqY+eL7pSHnu88lHVa0=";
+    hash = "sha256-nDeuWPBBclK3Q+4fqF/JN9lpbhZSCCT2siHxn2Lwj5w=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [ hatchling ];
 
   dependencies = [ python-dateutil ];
 
   nativeCheckInputs = [ pytestCheckHook ];
+
+  # test_project.py is dev/release tooling (imports `invoke`, an
+  # unpackaged task runner), not a test of the library itself.
+  disabledTestPaths = [ "tests/test_project.py" ];
 
   pythonImportsCheck = [ "jsonmodels" ];
 

--- a/pkgs/development/python-modules/scout-apm/default.nix
+++ b/pkgs/development/python-modules/scout-apm/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  asgiref,
+  psutil,
+  urllib3,
+  certifi,
+  wrapt,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "scout-apm";
+  version = "3.5.3";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "scout_apm";
+    inherit version;
+    hash = "sha256-ZsGyw7WnvmepG7FbfTQm6NawBWB9b4ZHRjoaRhXaUj4=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    asgiref
+    certifi
+    psutil
+    urllib3
+    wrapt
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTestPaths = [
+    "tests/integration"
+  ];
+
+  pythonImportsCheck = [ "scout_apm" ];
+
+  meta = {
+    description = "Scout Application Performance Monitoring Agent";
+    homepage = "https://github.com/scoutapp/scout_apm_python";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/scout-apm/default.nix
+++ b/pkgs/development/python-modules/scout-apm/default.nix
@@ -8,7 +8,6 @@
   urllib3,
   certifi,
   wrapt,
-  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -19,7 +18,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "scout_apm";
     inherit version;
-    hash = "sha256-ZsGyw7WnvmepG7FbfTQm6NawBWB9b4ZHRjoaRhXaUj4=";
+    hash = "sha256-VOV16V9fmpjAlZigkuwD/I11dpB8U8XiBjKj8F4QNHk=";
   };
 
   build-system = [ setuptools ];
@@ -32,11 +31,8 @@ buildPythonPackage rec {
     wrapt
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
-
-  disabledTestPaths = [
-    "tests/integration"
-  ];
+  # The PyPI sdist doesn't ship a tests/ directory at all.
+  doCheck = false;
 
   pythonImportsCheck = [ "scout_apm" ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4543,6 +4543,8 @@ self: super: with self; {
 
   django-crossdomainmedia = callPackage ../development/python-modules/django-crossdomainmedia { };
 
+  django-crum = callPackage ../development/python-modules/django-crum { };
+
   django-csp = callPackage ../development/python-modules/django-csp { };
 
   django-cte = callPackage ../development/python-modules/django-cte { };
@@ -8551,6 +8553,8 @@ self: super: with self; {
   jsonrpclib-pelix = callPackage ../development/python-modules/jsonrpclib-pelix { };
 
   jsons = callPackage ../development/python-modules/jsons { };
+
+  jsonmodels = callPackage ../development/python-modules/jsonmodels { };
 
   jsonschema = callPackage ../development/python-modules/jsonschema { };
 
@@ -18257,6 +18261,8 @@ self: super: with self; {
   scooby = callPackage ../development/python-modules/scooby { };
 
   scour = callPackage ../development/python-modules/scour { };
+
+  scout-apm = callPackage ../development/python-modules/scout-apm { };
 
   scp = callPackage ../development/python-modules/scp { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8526,6 +8526,8 @@ self: super: with self; {
 
   jsonmerge = callPackage ../development/python-modules/jsonmerge { };
 
+  jsonmodels = callPackage ../development/python-modules/jsonmodels { };
+
   jsonnet = callPackage ../development/python-modules/jsonnet { };
 
   jsonpatch = callPackage ../development/python-modules/jsonpatch { };
@@ -8553,8 +8555,6 @@ self: super: with self; {
   jsonrpclib-pelix = callPackage ../development/python-modules/jsonrpclib-pelix { };
 
   jsons = callPackage ../development/python-modules/jsons { };
-
-  jsonmodels = callPackage ../development/python-modules/jsonmodels { };
 
   jsonschema = callPackage ../development/python-modules/jsonschema { };
 


### PR DESCRIPTION
Packages [Plane](https://plane.so), an open-source, self-hostable project management tool (Linear/Jira alike): issue tracking, cycles, modules, pages, analytics.

## Summary

- `pkgs/by-name/pl/plane/package.nix`: Python API (Django + gunicorn/uvicorn) plus a `passthru.frontend` derivation building the pnpm/Turborepo frontend (web, admin, space, live apps).
- `nixos/modules/services/web-apps/plane.nix`: `services.plane` module — systemd services for API/worker/beat/frontend, optional local PostgreSQL and Valkey, an nginx virtual host.
- Three new Python dependencies: `django-crum`, `jsonmodels`, `scout-apm`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

~~I don't yet have a production deployment old enough to volunteer as a package maintainer with full confidence, but I'm running this module myself and happy to be added and to follow up on review feedback.~~

**Update:** added myself (`DannyDannyDanny`) as maintainer for both the package and the module.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
