### PR TITLE
pcsc-cyberjack: add udev rules

### DIFF
--- a/pkgs/by-name/pc/pcsc-cyberjack/package.nix
+++ b/pkgs/by-name/pc/pcsc-cyberjack/package.nix
@@ -6,12 +6,43 @@
   pkg-config,
   libusb1,
   pcsclite,
+  writeText,
 }:
 
 let
   version = "3.99.5";
   suffix = "SP15";
   tarBall = "${version}final.${suffix}";
+  # source: https://salsa.debian.org/debian/pcsc-cyberjack/-/blob/master/debian/libifd-cyberjack6.udev?ref_type=heads
+  udevRules = writeText "pcsc-cyberjack.rules" ''
+    # If not adding the device, go away
+    ACTION!="add", GOTO="cyberjack_rules_end"
+    SUBSYSTEM!="usb", GOTO="cyberjack_rules_end"
+    ENV{DEVTYPE}!="usb_device", GOTO="cyberjack_rules_end"
+
+    ATTR{idVendor}=="0c4b", ATTR{idProduct}=="0100", MODE="660", GROUP="pcscd"
+    ATTR{idVendor}=="0c4b", ATTR{idProduct}=="0300", MODE="660", GROUP="pcscd"
+    ATTR{idVendor}=="0c4b", ATTR{idProduct}=="0400", MODE="660", GROUP="pcscd"
+    ATTR{idVendor}=="0c4b", ATTR{idProduct}=="0401", MODE="660", GROUP="pcscd"
+    ATTR{idVendor}=="0c4b", ATTR{idProduct}=="0412", MODE="660", GROUP="pcscd"
+    ATTR{idVendor}=="0c4b", ATTR{idProduct}=="0485", MODE="660", GROUP="pcscd"
+    ATTR{idVendor}=="0c4b", ATTR{idProduct}=="0500", MODE="660", GROUP="pcscd"
+    ATTR{idVendor}=="0c4b", ATTR{idProduct}=="0501", MODE="660", GROUP="pcscd"
+    ATTR{idVendor}=="0c4b", ATTR{idProduct}=="0502", MODE="660", GROUP="pcscd"
+    ATTR{idVendor}=="0c4b", ATTR{idProduct}=="0503", MODE="660", GROUP="pcscd"
+    ATTR{idVendor}=="0c4b", ATTR{idProduct}=="0504", MODE="660", GROUP="pcscd"
+    ATTR{idVendor}=="0c4b", ATTR{idProduct}=="0505", MODE="660", GROUP="pcscd"
+    ATTR{idVendor}=="0c4b", ATTR{idProduct}=="0506", MODE="660", GROUP="pcscd"
+    ATTR{idVendor}=="0c4b", ATTR{idProduct}=="0507", MODE="660", GROUP="pcscd"
+    ATTR{idVendor}=="0c4b", ATTR{idProduct}=="0525", MODE="660", GROUP="pcscd"
+    ATTR{idVendor}=="0c4b", ATTR{idProduct}=="0580", MODE="660", GROUP="pcscd"
+    ATTR{idVendor}=="0c4b", ATTR{idProduct}=="2000", MODE="660", GROUP="pcscd"
+    ATTR{idVendor}=="0c4b", ATTR{idProduct}=="0551", MODE="660", GROUP="pcscd"
+    ATTR{idVendor}=="0c4b", ATTR{idProduct}=="2002", MODE="660", GROUP="pcscd"
+
+    # All done
+    LABEL="cyberjack_rules_end"
+  '';
 
 in
 stdenv.mkDerivation rec {
@@ -47,7 +78,12 @@ stdenv.mkDerivation rec {
     "--bindir=${placeholder "tools"}/bin"
   ];
 
-  postInstall = "make -C tools/cjflash install";
+  postInstall = ''
+    make -C tools/cjflash install
+
+    mkdir -p $out/lib/udev/rules.d
+    ln -s "${udevRules}" $out/lib/udev/rules.d/90-pcsc-cyberjack.rules
+  '';
 
   meta = {
     description = "REINER SCT cyberJack USB chipcard reader user space driver";


### PR DESCRIPTION
pcscd runs as user/group pcscd, so those udev rules are needed for it to work. With these rules, pkgs.pcsc-cyberjack can be added to services.udev.packages to get the necessary rules.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
