### PR TITLE
kingfisher: init at 1.102.0

### DIFF
--- a/pkgs/by-name/ki/kingfisher/package.nix
+++ b/pkgs/by-name/ki/kingfisher/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  boost,
+  cmake,
+  fetchFromGitHub,
+  libgit2,
+  nix-update-script,
+  openssl,
+  pkg-config,
+  rust-jemalloc-sys,
+  rustPlatform,
+  sqlite,
+  versionCheckHook,
+  zlib,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "kingfisher";
+  version = "1.102.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "mongodb";
+    repo = "kingfisher";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ksTpxjBGYfZIFx93O0Wa+Z4qbLdur+5oETWHiH6BiNM=";
+  };
+
+  cargoHash = "sha256-+m7rDZvR1nJmNj1IPydQdMq+/Xl7yVdrUO42BxRmkQY=";
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    boost
+    libgit2
+    openssl
+    rust-jemalloc-sys
+    sqlite
+    zlib
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  env = {
+    LIBSQLITE3_SYS_USE_PKG_CONFIG = true;
+  };
+
+  doInstallCheck = true;
+
+  # Integration tests exceed memory limits and can crash
+  doCheck = false;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Tool to detect leaked secrets and perform live validation";
+    homepage = "https://github.com/mongodb/kingfisher";
+    changelog = "https://github.com/mongodb/kingfisher/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "kingfisher";
+  };
+})


### PR DESCRIPTION
Tool to detect leaked secrets and perform live validation

https://github.com/mongodb/kingfisher

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
