### PR TITLE
python3Packages.nibabel: 5.3.3 -> 5.4.2

### DIFF
--- a/pkgs/development/python-modules/nibabel/default.nix
+++ b/pkgs/development/python-modules/nibabel/default.nix
@@ -76,6 +76,8 @@ buildPythonPackage (finalAttrs: {
   ]
   ++ finalAttrs.passthru.optional-dependencies.all;
 
+  pythonImportsCheck = [ "nibabel" ];
+
   meta = {
     homepage = "https://nipy.org/nibabel";
     changelog = "https://github.com/nipy/nibabel/blob/${finalAttrs.version}/Changelog";

--- a/pkgs/development/python-modules/nibabel/default.nix
+++ b/pkgs/development/python-modules/nibabel/default.nix
@@ -2,8 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch2,
-  pythonAtLeast,
   pythonOlder,
 
   # build-system
@@ -17,6 +15,9 @@
   typing-extensions,
 
   # optional-dependencies
+  backports-zstd,
+  indexed-gzip,
+  matplotlib,
   pydicom,
   pillow,
   h5py,
@@ -27,27 +28,20 @@
   pytest-doctestplus,
   pytest-httpserver,
   pytest-xdist,
-  pytest7CheckHook,
+  pytestCheckHook,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "nibabel";
-  version = "5.3.3";
+  version = "5.4.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "nipy";
     repo = "nibabel";
     tag = finalAttrs.version;
-    hash = "sha256-Kdz7kCY5QnA9OiV/FPW1RerjP1GGLn+YaTwFpA0dJAM=";
+    hash = "sha256-QzkmSI0JGdIXLc3XSPZrGrBYSq98tLFrozNNopR/ytg=";
   };
-
-  patches = [
-    (fetchpatch2 {
-      url = "https://github.com/nipy/nibabel/commit/3f40a3bc0c4bd996734576a15785ad0f769a963a.patch?full_index=1";
-      hash = "sha256-URsxgP6Sd5IIOX20GtAYtWBWOhw+Hiuhgu1oa8o8NXk=";
-    })
-  ];
 
   build-system = [
     hatch-vcs
@@ -62,14 +56,14 @@ buildPythonPackage (finalAttrs: {
   ++ lib.optionals (pythonOlder "3.13") [ typing-extensions ];
 
   optional-dependencies = lib.fix (self: {
-    all = self.dicom ++ self.dicomfs ++ self.minc2 ++ self.spm ++ self.zstd;
+    all = self.dicomfs ++ self.indexed_gzip ++ self.minc2 ++ self.spm ++ self.zstd;
     dicom = [ pydicom ];
     dicomfs = [ pillow ] ++ self.dicom;
+    indexed_gzip = [ indexed-gzip ];
     minc2 = [ h5py ];
     spm = [ scipy ];
-    zstd = [
-      # TODO: pyzstd
-    ];
+    viewers = [ matplotlib ];
+    zstd = lib.optionals (pythonOlder "3.14") [ backports-zstd ];
   });
 
   nativeCheckInputs = [
@@ -78,14 +72,9 @@ buildPythonPackage (finalAttrs: {
     pytest-doctestplus
     pytest-httpserver
     pytest-xdist
-    pytest7CheckHook
+    pytestCheckHook
   ]
   ++ finalAttrs.passthru.optional-dependencies.all;
-
-  disabledTests = lib.optionals (pythonAtLeast "3.14") [
-    # https://github.com/nipy/nibabel/issues/1390
-    "test_deprecator_maker"
-  ];
 
   meta = {
     homepage = "https://nipy.org/nibabel";


### PR DESCRIPTION
Fixes the build of `python3Packages.nibabel` on `staging-next`.

Hydra: https://hydra.nixos.org/build/334112702

Changelog: https://github.com/nipy/nibabel/blob/5.4.2/Changelog
Diff: https://github.com/nipy/nibabel/compare/5.3.3...5.4.2

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — `python3{13,14}Packages.nibabel`
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
