### PR TITLE
lact: 0.9.0 -> 0.9.1

### DIFF
--- a/pkgs/by-name/la/lact/package.nix
+++ b/pkgs/by-name/la/lact/package.nix
@@ -10,6 +10,7 @@
   gdk-pixbuf,
   gtk4,
   libadwaita,
+  libdisplay-info,
   libdrm,
   ocl-icd,
   vulkan-loader,
@@ -25,16 +26,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "lact";
-  version = "0.9.0";
+  version = "0.9.1";
 
   src = fetchFromGitHub {
     owner = "ilya-zlobintsev";
     repo = "LACT";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-c5GJf8AYgaAN3O6AVSEbJybEYb6lSHf7R24/1PKYhyM=";
+    hash = "sha256-/b5Cfexi/RtE3DkON5J3dc4aEX6aLZvIcAhsg6Kdv7M=";
   };
 
-  cargoHash = "sha256-Y+XdCmaDXdP7x22bYm//Ov7+IzlCr8GpFOgCXGFCfbA=";
+  cargoHash = "sha256-XV37VRbCaxySMgEqXmIA0TUpI9uR+6jGOzdMlEfWxDw=";
 
   nativeBuildInputs = [
     pkg-config
@@ -47,12 +48,18 @@ rustPlatform.buildRustPackage (finalAttrs: {
     gdk-pixbuf
     gtk4
     libadwaita
+    libdisplay-info
     libdrm
     ocl-icd
     vulkan-loader
     vulkan-tools
     hwdata
     fuse3
+  ];
+
+  checkFlags = [
+    # Requires /dev/fuse, which is unavailable in the Nix build sandbox.
+    "--skip=tests::apply_settings"
   ];
 
   # we do this here so that the binary is usable during integration tests


### PR DESCRIPTION
Update `lact` from 0.9.0 to 0.9.1.

Changes:

* Updated `version`, `src.hash`, and `cargoHash`.
* Added `libdisplay-info`, which is a new upstream dependency in 0.9.1.
* Skipped `tests::apply_settings` because it requires `/dev/fuse`, which is unavailable in the Nix build sandbox.

Upstream changelog: https://github.com/ilya-zlobintsev/LACT/releases/tag/v0.9.1

## Things done

* Built on platform:

  * [x] x86_64-linux
  * [ ] aarch64-linux
  * [ ] aarch64-darwin
* Tested, as applicable:

  * [x] [[NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests)] in [[nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)].
  * [x] [[Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)] at `passthru.tests`.
  * [ ] Tests in [[lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests)] or [[pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)] for functions and "core" functionality.
* [ ] Ran `nixpkgs-review` on this PR. See [[nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)].
* [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
* Nixpkgs Release Notes

  * [ ] Package update: when the change is major or breaking.
* NixOS Release Notes

  * [ ] Module addition: when adding a new NixOS module.
  * [ ] Module update: when the change is significant.
* [x] Fits [[CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)], [[pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md)], [[maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md)] and other READMEs.
* [x] Follows the [[automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy)].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test