### PR TITLE
umple: use headless jre

### DIFF
--- a/pkgs/by-name/um/umple/package.nix
+++ b/pkgs/by-name/um/umple/package.nix
@@ -8,7 +8,7 @@
   installShellFiles,
   makeBinaryWrapper,
   opentxl,
-  jre,
+  jre_headless,
 }:
 let
   versions = lib.importJSON ./versions.json;
@@ -112,7 +112,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     done
     # Create wrappers
     for file in *.jar; do
-      makeWrapper ${lib.getExe jre} "$out/bin/''${file%.jar}" \
+      makeWrapper ${lib.getExe jre_headless} "$out/bin/''${file%.jar}" \
         --add-flags "-jar $out/share/java/$file"
     done
     popd


### PR DESCRIPTION
Umple doesn't use any graphical libraries, so wrapping it with the headless JRE makes more sense and reduces closure size.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
