### PR TITLE
ldacbt: use Meson to build

### DIFF
--- a/pkgs/by-name/ld/ldacbt/make-byte-order-checks-portable.patch
+++ b/pkgs/by-name/ld/ldacbt/make-byte-order-checks-portable.patch
@@ -1,0 +1,55 @@
+diff --git a/src/ldacBT_internal.c b/src/ldacBT_internal.c
+index 94458854fe..ca9df42c72 100644
+--- a/src/ldacBT_internal.c
++++ b/src/ldacBT_internal.c
+@@ -241,7 +241,7 @@
+             char *p_pcm_8 = (char *)pbuff;
+             char *p_lch_8 = (char *)ap_pcm[0];
+             char *p_rch_8 = (char *)ap_pcm[1];
+-#if __BYTE_ORDER == __LITTLE_ENDIAN
++#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+             for (i = 0; i < nsmpl; i++) {
+                 *p_lch_8++ = p_pcm_8[0];
+                 *p_lch_8++ = p_pcm_8[1];
+@@ -252,24 +252,24 @@
+                 *p_rch_8++ = p_pcm_8[2];
+                 p_pcm_8+=3;
+             }
+-#else   /* __BYTE_ORDER */
++#else   /* __BYTE_ORDER__ */
+ #error unsupported byte order
+-#endif  /* #if __BYTE_ORDER == __LITTLE_ENDIAN */
++#endif  /* #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__ */
+         }
+         else if ( fmt == LDACBT_SMPL_FMT_S32 ){
+             char *p_pcm_8 = (char *)pbuff;
+             char *p_lch_8 = (char *)ap_pcm[0];
+             char *p_rch_8 = (char *)ap_pcm[1];
+-#if __BYTE_ORDER == __LITTLE_ENDIAN
++#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+             for (i = 0; i < nsmpl; i++) {
+                 *p_lch_8++ = p_pcm_8[0]; *p_lch_8++ = p_pcm_8[1]; *p_lch_8++ = p_pcm_8[2]; *p_lch_8++ = p_pcm_8[3];
+                 p_pcm_8+=4;
+                 *p_rch_8++ = p_pcm_8[0]; *p_rch_8++ = p_pcm_8[1]; *p_rch_8++ = p_pcm_8[2]; *p_rch_8++ = p_pcm_8[3];
+                 p_pcm_8+=4;
+             }
+-#else   /* __BYTE_ORDER */
++#else   /* __BYTE_ORDER__ */
+ #error unsupported byte order
+-#endif  /* #if __BYTE_ORDER == __LITTLE_ENDIAN */
++#endif  /* #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__ */
+         }
+         else if ( fmt == LDACBT_SMPL_FMT_F32 ){
+             float *p_pcm = (float *)pbuff;
+diff --git a/src/ldacBT_internal.h b/src/ldacBT_internal.h
+index 70dac607e7..170d14be7d 100644
+--- a/src/ldacBT_internal.h
++++ b/src/ldacBT_internal.h
+@@ -9,7 +9,6 @@
+ 
+ #include <stdlib.h>
+ #include <string.h>
+-#include <endian.h>
+ #ifdef ANDROID
+ #include <stdint.h>
+ #include <unistd.h>

--- a/pkgs/by-name/ld/ldacbt/meson.build
+++ b/pkgs/by-name/ld/ldacbt/meson.build
@@ -1,0 +1,52 @@
+project(
+  'ldacbt',
+  'c',
+  meson_version: '>=1.10.0',
+  version: files('VERSION'),
+)
+
+pkg = import('pkgconfig')
+
+cc = meson.get_compiler('c')
+dep_m = cc.find_library('m')
+
+lib = library(
+  'ldacBT',
+  'abr/src/ldacBT_abr.c',
+  'src/ldacBT.c',
+  'src/ldaclib.c',
+  include_directories: [
+    'abr/inc',
+    'inc',
+  ],
+  dependencies: [dep_m],
+  version: meson.project_version(),
+  install: true,
+)
+
+install_headers(
+  'abr/inc/ldacBT_abr.h',
+  'inc/ldacBT.h',
+  subdir: 'ldac',
+)
+
+pkg.generate(
+  lib,
+  name: 'ldacBT-enc',
+  description: 'LDAC Bluetooth encoder',
+  subdirs: 'ldac',
+)
+
+pkg.generate(
+  lib,
+  name: 'ldacBT-abr',
+  description: 'LDAC Bluetooth ABR library',
+  subdirs: 'ldac',
+)
+
+pkg.generate(
+  lib,
+  name: 'ldacBT-dec',
+  description: 'LDAC Bluetooth decoder',
+  subdirs: 'ldac',
+)

--- a/pkgs/by-name/ld/ldacbt/package.nix
+++ b/pkgs/by-name/ld/ldacbt/package.nix
@@ -5,7 +5,7 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  pname = "ldacBT";
+  pname = "ldacbt";
   version = "2.0.72";
 
   src = fetchFromGitHub {

--- a/pkgs/by-name/ld/ldacbt/package.nix
+++ b/pkgs/by-name/ld/ldacbt/package.nix
@@ -111,7 +111,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Sony LDAC Bluetooth decoder library (from AOSP via open-vela)";
     homepage = "https://github.com/open-vela/external_libldac";
     license = lib.licenses.asl20;
-    # LDAC bitstream format assumes LE; source has endian checks
+    # libldac code detects & #error's out on non-LE byte order
     platforms = lib.platforms.littleEndian;
     maintainers = with lib.maintainers; [ qweered ];
   };

--- a/pkgs/by-name/ld/ldacbt/package.nix
+++ b/pkgs/by-name/ld/ldacbt/package.nix
@@ -2,6 +2,8 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  meson,
+  ninja,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -24,87 +26,25 @@ stdenv.mkDerivation (finalAttrs: {
     ./0001-abr-drop-support-for-dynamic-loading-libldac.patch
   ];
 
-  env.NIX_CFLAGS_COMPILE = "-O2 -fPIC -fno-merge-constants -Wall -Iinc -Isrc -Iabr/inc";
+  nativeBuildInputs = [
+    meson
+    ninja
+  ];
 
-  # Verify finalAttrs.version matches LDACBT_LIB_VER_* in upstream source.
-  # Guards against silent version drift when the pinned commit changes.
-  preBuild = ''
+  mesonBuildType = "release";
+
+  # The upstream build system is tied to AOSP, so we use our own Meson
+  # definitions to replace it.
+  postPatch = ''
+    ln -s ${./meson.build} meson.build
+
     awk -v want=${finalAttrs.version} '
       /^#define LDACBT_LIB_VER_/ { v = v sep ($3+0); sep = "." }
       END {
         if (v != want) { print "version mismatch: package says " want ", source reports " v > "/dev/stderr"; exit 1 }
+        print v
       }
-    ' src/ldacBT_api.c
-  '';
-
-  # Upstream ships AOSP build files and a gcc/ makefile that only knows
-  # about the in-tree layout. Compile and link directly; the entire
-  # library is two umbrella translation units.
-  buildPhase = ''
-    runHook preBuild
-
-    soname=libldacBT.so.${lib.versions.major finalAttrs.version}
-    sofile=libldacBT.so.${finalAttrs.version}
-
-    $CC -shared -Wl,-soname,$soname src/ldaclib.c src/ldacBT.c abr/src/ldacBT_abr.c -lm -o $sofile
-
-    runHook postBuild
-  '';
-
-  installPhase = ''
-    runHook preInstall
-
-    install -Dm644 -t $out/lib $sofile
-    ln -s $sofile $out/lib/$soname
-    ln -s $sofile $out/lib/libldacBT.so
-
-    install -Dm644 inc/ldacBT.h $dev/include/ldac/ldacBT.h
-    install -Dm644 abr/inc/ldacBT_abr.h $dev/include/ldac/ldacBT_abr.h
-
-    mkdir -p $dev/lib/pkgconfig
-    cat > $dev/lib/pkgconfig/ldacBT-dec.pc <<EOF
-    prefix=$out
-    exec_prefix=\''${prefix}
-    libdir=$out/lib
-    includedir=$dev/include/ldac
-
-    Name: ldacBT-dec
-    Description: LDAC Bluetooth decoder
-    Version: ${finalAttrs.version}
-    Libs: -L\''${libdir} -lldacBT
-    Libs.private: -lm
-    Cflags: -I\''${includedir}
-    EOF
-
-    cat > $dev/lib/pkgconfig/ldacBT-enc.pc <<EOF
-    prefix=$out
-    exec_prefix=\''${prefix}
-    libdir=$out/lib
-    includedir=$dev/include/ldac
-
-    Name: ldacBT-enc
-    Description: LDAC Bluetooth encoder
-    Version: ${finalAttrs.version}
-    Libs: -L\''${libdir} -lldacBT
-    Libs.private: -lm
-    Cflags: -I\''${includedir}
-    EOF
-
-    cat > $dev/lib/pkgconfig/ldacBT-abr.pc <<EOF
-    prefix=$out
-    exec_prefix=\''${prefix}
-    libdir=$out/lib
-    includedir=$dev/include/ldac
-
-    Name: ldacBT-abr
-    Description: LDAC Bluetooth ABR library
-    Version: ${finalAttrs.version}
-    Libs: -L\''${libdir} -lldacBT
-    Libs.private: -lm
-    Cflags: -I\''${includedir}
-    EOF
-
-    runHook postInstall
+    ' src/ldacBT_api.c > VERSION
   '';
 
   meta = {

--- a/pkgs/by-name/ld/ldacbt/package.nix
+++ b/pkgs/by-name/ld/ldacbt/package.nix
@@ -24,6 +24,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./0001-abr-drop-support-for-dynamic-loading-libldac.patch
+
+    # Darwin doesn’t have `<endian.h>`; use the predefined GCC/Clang
+    # macros instead.
+    ./make-byte-order-checks-portable.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
