### PR TITLE
Openshell update and rework

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3944,6 +3944,12 @@
     githubId = 1743184;
     name = "Boris Babić";
   };
+  bornav = {
+    email = "borna.vincek1@gmail.com";
+    github = "bornav";
+    githubId = 51048565;
+    name = "Borna Vincek";
+  };
   bosu = {
     email = "boriss@gmail.com";
     github = "bosu";

--- a/pkgs/by-name/op/openshell/package.nix
+++ b/pkgs/by-name/op/openshell/package.nix
@@ -1,64 +1,147 @@
 {
   lib,
   stdenv,
-  fetchFromGitHub,
-  rustPlatform,
-  versionCheckHook,
-  cacert,
-  gitMinimal,
-  pkg-config,
-  z3,
+  fetchurl,
+  installShellFiles,
 }:
 
-rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "openshell";
-  version = "0.0.36";
+let
+  repo = "NVIDIA/OpenShell";
+  version = "0.0.76";
+  baseUrl = "https://github.com/${repo}/releases/download/v${version}";
 
-  src = fetchFromGitHub {
-    owner = "NVIDIA";
-    repo = "OpenShell";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-AnZliQrn5kwaVJw1LEorT+VPtIk2NIbVY0QISxfnORs=";
+  # ── Checksums ──────────────────────────────────────────────────────────
+  # Update these from the release checksum files:
+  #   openshell-checksums-sha256.txt
+  #   openshell-gateway-checksums-sha256.txt
+  #   openshell-sandbox-checksums-sha256.txt
+  checksums = {
+    main = {
+      x86_64-linux = "dacdc2a0dcc31b5006276b2d810399bd8482f87fecef47f2fee882e280ae11c4";
+      aarch64-linux = "174b2b8291b8c2825a4fbc6c9c6e9cf7f428ec566fcab5f34d4eca78012e052d";
+      aarch64-darwin = "f4a95d117569f515363fb61337d108cde4cae84e0f6b32bfc8821796d8979e3b";
+    };
+    gateway = {
+      x86_64-linux = "9de752d60bc3b2a5076c8378794f5921769708b27f2a026f6d9314379039a73d";
+      aarch64-linux = "e6d11b6dc3396bd97eaebbfd5a362573d0618fc24c64113e9e5ae6b7ab7e8e56";
+    };
+    sandbox = {
+      x86_64-linux = "fe199994d94e19bebe055168446ad674d8396465aa2e880aaa8ecf5c3db0a24c";
+      aarch64-linux = "c678fd85c7671ee9a2be1b1b74e9284e6f8b545b735db63b4747f49a5d204e11";
+    };
+    driver = {
+      x86_64-linux = "7be64f2009c2989b48a5ba515fec99f6bdd781a207303bf2025fb310807bf6e0";
+      aarch64-linux = "e3ff330edbeef1dc89d49c92548ba35b4599846a76ce6c2fbae1b6d2da4dfbd5";
+      aarch64-darwin = "c3326a40f11353d2cb908b8f0db1ffdf67804c66ae549405bfb96965446a5e56";
+    };
   };
 
-  cargoHash = "sha256-kmmzzph39KaAXkEbjOHMoTRltX2ttqxtHppb6apoSSs=";
+  # ── Architecture / platform mapping ────────────────────────────────────
+  archMap = {
+    x86_64-linux = "x86_64";
+    aarch64-linux = "aarch64";
+    aarch64-darwin = "aarch64";
+  };
+
+  platformMap = {
+    x86_64-linux = "x86_64-unknown-linux-musl";
+    aarch64-linux = "aarch64-unknown-linux-musl";
+    aarch64-darwin = "aarch64-apple-darwin";
+  };
+
+  platformGnuMap = {
+    x86_64-linux = "x86_64-unknown-linux-gnu";
+    aarch64-linux = "aarch64-unknown-linux-gnu";
+  };
+
+  # ── Asset name builders ────────────────────────────────────────────────
+  mainAsset = system: "openshell-${platformMap.${system}}.tar.gz";
+  gatewayAsset = system: "openshell-gateway-${platformGnuMap.${system}}.tar.gz";
+  sandboxAsset = system: "openshell-sandbox-${platformGnuMap.${system}}.tar.gz";
+  driverAsset =
+    system:
+    "openshell-driver-vm-${
+      if system == "aarch64-darwin" then
+        "aarch64-apple-darwin"
+      else
+        "${archMap.${system}}-unknown-linux-gnu"
+    }.tar.gz";
+
+  # ── Fetch helper ───────────────────────────────────────────────────────
+  fetchTarball =
+    system: name: url: sha256:
+    fetchurl {
+      inherit url sha256;
+      name = "openshell-${name}-v${version}";
+    };
+
+  # ── Install script per platform ────────────────────────────────────────
+  installScript =
+    system:
+    let
+      mainTarball = fetchTarball system "main" "${baseUrl}/${mainAsset system}" checksums.main.${system};
+      driverTarball =
+        fetchTarball system "driver" "${baseUrl}/${driverAsset system}"
+          checksums.driver.${system};
+      gatewayTarball =
+        fetchTarball system "gateway" "${baseUrl}/${gatewayAsset system}"
+          checksums.gateway.${system};
+      sandboxTarball =
+        fetchTarball system "sandbox" "${baseUrl}/${sandboxAsset system}"
+          checksums.sandbox.${system};
+      isLinux = lib.any (p: system == p) [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+    in
+    ''
+      mkdir -p $out/bin
+
+      # Extract main CLI binary
+      tar xzf "${mainTarball}" -C $out/bin
+
+      # Extract gateway binary (Linux only)
+      ${lib.optionalString isLinux ''
+        tar xzf "${gatewayTarball}" -C $out/bin
+      ''}
+
+      # Extract sandbox binary (Linux only)
+      ${lib.optionalString isLinux ''
+        tar xzf "${sandboxTarball}" -C $out/bin
+      ''}
+
+      # Extract driver-vm binary
+      tar xzf "${driverTarball}" -C $out/bin
+
+      # Ensure all binaries are executable
+      chmod +x $out/bin/openshell
+      chmod +x $out/bin/openshell-gateway
+      chmod +x $out/bin/openshell-sandbox
+      chmod +x $out/bin/openshell-driver-vm
+    '';
+
+in
+stdenv.mkDerivation {
+  pname = "openshell";
+  inherit version;
+
+  # No source needed — everything is fetched via fetchurl above.
+  # We use a dummy file and override unpackPhase to skip extraction.
+  src = builtins.toFile "noop" "";
+  dontUnpack = true;
 
   nativeBuildInputs = [
-    pkg-config
-    rustPlatform.bindgenHook
+    installShellFiles
   ];
 
-  buildInputs = [ z3 ];
+  installPhase = installScript stdenv.hostPlatform.system;
 
-  nativeCheckInputs = [
-    cacert
-    gitMinimal
-  ];
-
-  postPatch = ''
-    # fill in package version to Cargo
-    substituteInPlace Cargo.toml \
-      --replace-fail 'version = "0.0.0"' 'version = "${finalAttrs.version}"'
-    # only build openshell-cli crate
-    substituteInPlace Cargo.toml \
-      --replace-fail 'members = ["crates/*"]' 'members = ["crates/openshell-cli"]'
-  '';
-
-  env = {
-    # docker image tag baked in at compile time, must match binary version
-    OPENSHELL_IMAGE_TAG = finalAttrs.version;
-  };
-
-  doCheck = !stdenv.hostPlatform.isDarwin;
-
-  nativeInstallCheckInputs = [ versionCheckHook ];
-  doInstallCheck = true;
+  dontStrip = true;
 
   meta = {
-    changelog = "https://github.com/NVIDIA/OpenShell/releases/tag/v${finalAttrs.version}";
-    description = "The safe, private runtime for autonomous AI agents.";
+    changelog = "https://github.com/${repo}/releases/tag/v${version}";
+    description = "Safe, private runtime for autonomous AI agents";
     homepage = "https://docs.nvidia.com/openshell/index.html";
-    license = lib.licenses.asl20;
     longDescription = ''
       NVIDIA OpenShell is an open source runtime to build and deploy autonomous,
       self-evolving agents more safely. OpenShell sits between your agent and
@@ -66,8 +149,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
       see and do, and where inference goes. It enables claws to run in isolated
       sandboxes, with fine-grained control over privacy and security.
     '';
-    maintainers = with lib.maintainers; [ wishstudio ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      wishstudio
+      bornav
+    ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
     mainProgram = "openshell";
-    platforms = lib.platforms.all;
   };
-})
+}

--- a/pkgs/by-name/op/openshell/package.nix
+++ b/pkgs/by-name/op/openshell/package.nix
@@ -10,30 +10,14 @@ let
   version = "0.0.76";
   baseUrl = "https://github.com/${repo}/releases/download/v${version}";
 
-  # ── Checksums ──────────────────────────────────────────────────────────
-  # Update these from the release checksum files:
-  #   openshell-checksums-sha256.txt
-  #   openshell-gateway-checksums-sha256.txt
-  #   openshell-sandbox-checksums-sha256.txt
+  versionsData = builtins.fromJSON (builtins.readFile ./versions.json);
+  versionData = versionsData.${version} or (throw "No checksums found for version ${version}");
+
   checksums = {
-    main = {
-      x86_64-linux = "dacdc2a0dcc31b5006276b2d810399bd8482f87fecef47f2fee882e280ae11c4";
-      aarch64-linux = "174b2b8291b8c2825a4fbc6c9c6e9cf7f428ec566fcab5f34d4eca78012e052d";
-      aarch64-darwin = "f4a95d117569f515363fb61337d108cde4cae84e0f6b32bfc8821796d8979e3b";
-    };
-    gateway = {
-      x86_64-linux = "9de752d60bc3b2a5076c8378794f5921769708b27f2a026f6d9314379039a73d";
-      aarch64-linux = "e6d11b6dc3396bd97eaebbfd5a362573d0618fc24c64113e9e5ae6b7ab7e8e56";
-    };
-    sandbox = {
-      x86_64-linux = "fe199994d94e19bebe055168446ad674d8396465aa2e880aaa8ecf5c3db0a24c";
-      aarch64-linux = "c678fd85c7671ee9a2be1b1b74e9284e6f8b545b735db63b4747f49a5d204e11";
-    };
-    driver = {
-      x86_64-linux = "7be64f2009c2989b48a5ba515fec99f6bdd781a207303bf2025fb310807bf6e0";
-      aarch64-linux = "e3ff330edbeef1dc89d49c92548ba35b4599846a76ce6c2fbae1b6d2da4dfbd5";
-      aarch64-darwin = "c3326a40f11353d2cb908b8f0db1ffdf67804c66ae549405bfb96965446a5e56";
-    };
+    main = versionData.main or (throw "No main checksums for version ${version}");
+    gateway = versionData.gateway or { };
+    sandbox = versionData.sandbox or { };
+    driver = versionData.driver or (throw "No driver checksums for version ${version}");
   };
 
   # ── Architecture / platform mapping ────────────────────────────────────
@@ -124,6 +108,7 @@ in
 stdenv.mkDerivation {
   pname = "openshell";
   inherit version;
+  strictDeps = true;
 
   # No source needed — everything is fetched via fetchurl above.
   # We use a dummy file and override unpackPhase to skip extraction.
@@ -141,7 +126,6 @@ stdenv.mkDerivation {
   meta = {
     changelog = "https://github.com/${repo}/releases/tag/v${version}";
     description = "Safe, private runtime for autonomous AI agents";
-    homepage = "https://docs.nvidia.com/openshell/index.html";
     longDescription = ''
       NVIDIA OpenShell is an open source runtime to build and deploy autonomous,
       self-evolving agents more safely. OpenShell sits between your agent and
@@ -149,6 +133,7 @@ stdenv.mkDerivation {
       see and do, and where inference goes. It enables claws to run in isolated
       sandboxes, with fine-grained control over privacy and security.
     '';
+    homepage = "https://docs.nvidia.com/openshell/index.html";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       wishstudio

--- a/pkgs/by-name/op/openshell/update-checksums.sh
+++ b/pkgs/by-name/op/openshell/update-checksums.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="NVIDIA/OpenShell"
+BASE_URL="https://github.com/${REPO}/releases/download"
+VERSIONS_FILE="$(dirname "$0")/versions.json"
+
+usage() {
+  echo "Usage: $0 <version>"
+  echo ""
+  echo "Fetches SHA256 checksums from GitHub releases and updates versions.json."
+  exit 1
+}
+
+[[ $# -lt 1 ]] && usage
+
+VERSION="$1"
+echo "Fetching checksums for version ${VERSION}..."
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+checksum_files=(
+  "openshell-checksums-sha256.txt"
+  "openshell-gateway-checksums-sha256.txt"
+  "openshell-sandbox-checksums-sha256.txt"
+)
+
+for file in "${checksum_files[@]}"; do
+  url="${BASE_URL}/v${VERSION}/${file}"
+  echo "  Downloading ${file}..."
+  if ! curl -sL -o "${TMPDIR}/${file}" "$url"; then
+    echo "ERROR: Failed to download ${url}"
+    exit 1
+  fi
+done
+
+export VERSIONS_FILE VERSION TMPDIR
+
+# Use python3 to parse all checksum files and write JSON
+python3 -c '
+import json
+import os
+
+versions_file = os.environ["VERSIONS_FILE"]
+version = os.environ["VERSION"]
+tmpdir = os.environ["TMPDIR"]
+
+platform_map = {
+    "openshell-x86_64-unknown-linux-musl.tar.gz": ("main", "x86_64-linux"),
+    "openshell-aarch64-unknown-linux-musl.tar.gz": ("main", "aarch64-linux"),
+    "openshell-aarch64-apple-darwin.tar.gz": ("main", "aarch64-darwin"),
+    "openshell-driver-vm-x86_64-unknown-linux-gnu.tar.gz": ("driver", "x86_64-linux"),
+    "openshell-driver-vm-aarch64-unknown-linux-gnu.tar.gz": ("driver", "aarch64-linux"),
+    "openshell-driver-vm-aarch64-apple-darwin.tar.gz": ("driver", "aarch64-darwin"),
+    "openshell-gateway-x86_64-unknown-linux-gnu.tar.gz": ("gateway", "x86_64-linux"),
+    "openshell-gateway-aarch64-unknown-linux-gnu.tar.gz": ("gateway", "aarch64-linux"),
+    "openshell-sandbox-x86_64-unknown-linux-gnu.tar.gz": ("sandbox", "x86_64-linux"),
+    "openshell-sandbox-aarch64-unknown-linux-gnu.tar.gz": ("sandbox", "aarch64-linux"),
+}
+
+checksums = {}
+
+for checksum_file in ["openshell-checksums-sha256.txt", "openshell-gateway-checksums-sha256.txt", "openshell-sandbox-checksums-sha256.txt"]:
+    filepath = os.path.join(tmpdir, checksum_file)
+    if not os.path.exists(filepath):
+        continue
+    with open(filepath) as f:
+        for line in f:
+            parts = line.strip().split("  ", 1)
+            if len(parts) != 2:
+                continue
+            hash_val, filename = parts
+            if filename in platform_map:
+                category, platform = platform_map[filename]
+                checksums[(category, platform)] = hash_val
+
+if os.path.exists(versions_file):
+    with open(versions_file) as f:
+        data = json.load(f)
+else:
+    data = {}
+
+entry = {}
+for (category, platform), hash_val in sorted(checksums.items()):
+    if category not in entry:
+        entry[category] = {}
+    entry[category][platform] = hash_val
+
+data[version] = entry
+
+with open(versions_file, "w") as f:
+    json.dump(data, f, indent=2)
+    f.write("\n")
+
+print(f"  Written {len(checksums)} checksums to {versions_file}")
+'
+
+echo ""
+echo "Done! Update package.nix to version ${VERSION}."

--- a/pkgs/by-name/op/openshell/versions.json
+++ b/pkgs/by-name/op/openshell/versions.json
@@ -1,0 +1,22 @@
+{
+  "0.0.76": {
+    "main": {
+      "x86_64-linux": "dacdc2a0dcc31b5006276b2d810399bd8482f87fecef47f2fee882e280ae11c4",
+      "aarch64-linux": "174b2b8291b8c2825a4fbc6c9c6e9cf7f428ec566fcab5f34d4eca78012e052d",
+      "aarch64-darwin": "f4a95d117569f515363fb61337d108cde4cae84e0f6b32bfc8821796d8979e3b"
+    },
+    "gateway": {
+      "x86_64-linux": "9de752d60bc3b2a5076c8378794f5921769708b27f2a026f6d9314379039a73d",
+      "aarch64-linux": "e6d11b6dc3396bd97eaebbfd5a362573d0618fc24c64113e9e5ae6b7ab7e8e56"
+    },
+    "sandbox": {
+      "x86_64-linux": "fe199994d94e19bebe055168446ad674d8396465aa2e880aaa8ecf5c3db0a24c",
+      "aarch64-linux": "c678fd85c7671ee9a2be1b1b74e9284e6f8b545b735db63b4747f49a5d204e11"
+    },
+    "driver": {
+      "x86_64-linux": "7be64f2009c2989b48a5ba515fec99f6bdd781a207303bf2025fb310807bf6e0",
+      "aarch64-linux": "e3ff330edbeef1dc89d49c92548ba35b4599846a76ce6c2fbae1b6d2da4dfbd5",
+      "aarch64-darwin": "c3326a40f11353d2cb908b8f0db1ffdf67804c66ae549405bfb96965446a5e56"
+    }
+  }
+}


### PR DESCRIPTION
Updated package system from build from source to grab package from source and expose them
Added openshell-sandbox, openshell-gateway and openshell-driver-vm to the package

Moved away from compiling from source here for one main reason, we can compile the openshell base driver without issues, but the gateway, sandbox and vm-driver are using a complicated miso install pipeline, that references self build packages  that would be hard to port/maintain from nixpkgs, taking the ones that were gotten from the upstream seems like a better option

Im fine with reverting openshell base package to be build from source here, but i assume we would start having issues regarding validation when running them against gateways(assumption)

i left package changes as 2 commits, one with versions handled in the package.nix file and one as external versions.json file in case the external hashes are not something we want to go with so it can be dropped easily

added a shell script that would manage updating those hashes simpler in the future




## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
