### PR TITLE
python3Packages.xarray: 2026.04.0 -> unstable-2026-07-03

### DIFF
--- a/pkgs/development/python-modules/xarray/default.nix
+++ b/pkgs/development/python-modules/xarray/default.nix
@@ -39,7 +39,9 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "xarray";
-  version = "2026.04.0";
+  # 2026.04.0 is broken with numpy 2.5, no tagged release yet.
+  version = "unstable-2026-07-03";
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = "2026.04.0";
   pyproject = true;
   # Needed mainly for pytestFlags with spaces
   __structuredAttrs = true;
@@ -47,8 +49,8 @@ buildPythonPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "pydata";
     repo = "xarray";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-BsgL+Xo9fTMLLdz5AfScnKGuBa76cE85LuUzB4ZNLiY=";
+    rev = "030c9298839a6b69b5d7a76817c49699a4209e8f";
+    hash = "sha256-0F53lNbiwzZZqLdgN3itzhF7urOSRj78K8rKsWewM2k=";
   };
 
   postPatch = ''
@@ -129,7 +131,7 @@ buildPythonPackage (finalAttrs: {
   pythonImportsCheck = [ "xarray" ];
 
   meta = {
-    changelog = "https://github.com/pydata/xarray/blob/${finalAttrs.src.tag}/doc/whats-new.rst";
+    changelog = "https://github.com/pydata/xarray/blob/${finalAttrs.src.rev}/doc/whats-new.rst";
     description = "N-D labeled arrays and datasets in Python";
     homepage = "https://github.com/pydata/xarray";
     license = lib.licenses.asl20;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

xarray 2026.04.0 is broken with numpy 2.5, no tagged release yet, and there is too many changes to backport for proper 2.5 support

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
