### PR TITLE
gcstar: 1.8.0 -> 1.8.1

### DIFF
--- a/pkgs/by-name/gc/gcstar/package.nix
+++ b/pkgs/by-name/gc/gcstar/package.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gcstar";
-  version = "1.8.0";
+  version = "1.8.1";
 
   src = fetchFromGitLab {
     owner = "Kerenoc";
     repo = "GCstar";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-37yjKI4l/nUzDnra1AGxDQxNafMsLi1bSifG6pz33zg=";
+    hash = "sha256-cVDOu1BH3WEHhaHa5d8usTrc5M8ZKaKCLNzsSIC+HsU=";
   };
 
   nativeBuildInputs = [ wrapGAppsHook3 ];
@@ -34,6 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
     JSON
     ImageExifTool
     librelative
+    LocaleCodes
     LWP
     LWPProtocolHttps
     MP3Info
@@ -44,6 +45,9 @@ stdenv.mkDerivation (finalAttrs: {
     XMLSimple
     XMLParser
   ];
+
+  # DateTime::Format::Strptime requires lang locale to be defined for correct date formatting.
+  env.LANG = "C.UTF-8";
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
Bumped version (changelog here: https://gitlab.com/GCstar/GCstar/-/blob/main/gcstar/CHANGELOG ) and adjusted perl dependencies. LocaleCodes perl package dependency was added and LANG env variable was set to C.UTF-8.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
