### PR TITLE
ci/eval: add opt-in instruction counting using perf

### DIFF
--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -17,6 +17,7 @@
   busybox,
   jq,
   nix,
+  perf,
 }:
 
 {
@@ -92,6 +93,8 @@ let
       evalSystem ? builtins.currentSystem,
       # The path to the `result.json` file from `preEval`
       preEvalFile ? "${preEval { inherit evalSystem; }}/result.json",
+      # Output the number of assembly instructions executed during evaluation
+      countInstructions ? false,
     }:
     let
       singleChunk = writeShellScript "single-chunk" ''
@@ -147,13 +150,16 @@ let
     runCommand "nixpkgs-eval-${evalSystem}"
       {
         # Don't depend on -dev outputs to reduce closure size for CI.
-        nativeBuildInputs = map lib.getBin [
-          busybox
-          jq
-          nix
-        ];
+        nativeBuildInputs = map lib.getBin (
+          [
+            busybox
+            jq
+            nix
+          ]
+          ++ lib.optionals countInstructions [ perf ]
+        );
         env = {
-          inherit evalSystem chunkSize;
+          inherit evalSystem chunkSize countInstructions;
         };
         __structuredAttrs = true;
         unsafeDiscardReferences.out = true;
@@ -203,9 +209,23 @@ let
 
           mkdir -p "$chunkOutputDir"/{result,stats,timestats,stderr}
 
-          seq -w 0 "$seq_end" |
-            xargs -I{} -P"$cores" \
-            ${singleChunk} "$chunkSize" {} "$evalSystem" "$chunkOutputDir" "$preEvalFile"
+          runAllChunks() {
+            seq -w 0 "$seq_end" |
+              xargs -I{} -P"$cores" \
+              ${singleChunk} "$chunkSize" {} "$evalSystem" "$chunkOutputDir" "$preEvalFile"
+          }
+
+          if [[ -n "$countInstructions" ]]; then
+            export seq_end cores chunkSize evalSystem chunkOutputDir preEvalFile
+            export -f runAllChunks
+            perf stat \
+              --event instructions:u --field-separator , --output "$chunkOutputDir"/perf-output-file \
+              bash -c runAllChunks
+            cat "$chunkOutputDir"/perf-output-file | tail -n 1 | cut -d, -f1 > "$chunkOutputDir"/instructions
+            rm "$chunkOutputDir"/perf-output-file
+          else
+            runAllChunks
+          fi
 
           if (( chunkSize * chunkCount != attrCount )); then
             # A final incomplete chunk would mess up the stats, don't include it
@@ -237,6 +257,9 @@ let
 
         # We only use the stats from the allowed attrs eval, because the disallowed attrs are generally not even a full chunk
         cp -r "$chunkOutputDirs"/allowed/stats $out/${evalSystem}/stats-by-chunk
+        if [[ -f "$chunkOutputDirs"/allowed/instructions ]]; then
+          cp "$chunkOutputDirs"/allowed/instructions $out/${evalSystem}/instructions
+        fi
 
         cat "$chunkOutputDirs"/*/result/* | jq -s 'add | map_values(.outputs)' > $out/${evalSystem}/paths.json
         cat "$chunkOutputDirs"/*/result/* | jq -s 'add | map_values(.meta)' > $out/${evalSystem}/meta.json
@@ -276,14 +299,20 @@ let
           }) | from_entries
         ' > $out/maintainers.json
 
-        mkdir -p $out/before/stats
+        mkdir -p $out/before/stats $out/before/instructions
         for d in ${diffDir}/before/*; do
           cp -r "$d"/stats-by-chunk $out/before/stats/$(basename "$d")
+          if [[ -f "$d"/instructions ]]; then
+            cp "$d"/instructions $out/before/instructions/$(basename "$d")
+          fi
         done
 
-        mkdir -p $out/after/stats
+        mkdir -p $out/after/stats $out/after/instructions
         for d in ${diffDir}/after/*; do
           cp -r "$d"/stats-by-chunk $out/after/stats/$(basename "$d")
+          if [[ -f "$d"/instructions ]]; then
+            cp "$d"/instructions $out/after/instructions/$(basename "$d")
+          fi
         done
       '';
 
@@ -293,13 +322,16 @@ let
     {
       # Whether to evaluate on a specific set of systems, by default all are evaluated
       evalSystems ? if quickTest then [ "x86_64-linux" ] else supportedSystems,
+      # Output the number of assembly instructions executed during evaluation on
+      # each system
+      countInstructions ? false,
     }:
     symlinkJoin {
       name = "nixpkgs-eval-baseline";
       paths = map (
         evalSystem:
         singleSystem {
-          inherit evalSystem;
+          inherit evalSystem countInstructions;
         }
       ) evalSystems;
     };
@@ -318,6 +350,9 @@ let
       # The branch the local comparison is made against; matches the `master`
       # used in the touched-files expression above.
       baseBranch ? "master",
+      # Output the number of assembly instructions executed during evaluation on
+      # each system
+      countInstructions ? false,
     }:
     let
       diffs = symlinkJoin {
@@ -328,7 +363,7 @@ let
             inherit evalSystem;
             beforeDir = baseline;
             afterDir = singleSystem {
-              inherit evalSystem;
+              inherit evalSystem countInstructions;
             };
           }
         ) evalSystems;


### PR DESCRIPTION
This lays the foundations for a better real-time performance metric.

Right now, our CI produces the Eval Summary page, which gets its performance values from NIX_SHOW_STATS=1.  The vast majority of these values are deterministic (yet they still show a p value, which is slightly frustrating). However, the `cpu.time` attribute varies greatly between runs, and it's often better to ignore it. As discussed with @emilazy, it would be useful to provide a better metric here.

## What this PR does

We now provide an opt-in `countInstructions` flag, which can be used like this:
```
nix-build ci/eval -A singleSystem --arg countInstructions true
```

When it's enabled, the evaluation of all the chunks will be profiled with `perf` as such:
```nix
perf stat \
  --event instructions:u --field-separator , --output "$chunkOutputDir"/perf-output-file \
  bash -c runAllChunks
```

The number of instructions is then saved to $out/evalSystem/instructions. Other CI functions like `eval.combine` are now also aware of this file.

## How useful is this metric?

Funnily enough, even userspace instructions are nondeterministic. However, in my testing, it only seems to vary by about 0.1%. This is _much_ better than the current state of `cpu.time`.

I tested the new logic on my nixpkgs fork with a [PR of mine](https://github.com/NixOS/nixpkgs/pull/519568) that still hasn't made it to master. Calculating percentages manually:
```
x86_64-linux: 2586879747955 -> 2537418487448. percent change: -1.91%
aarch64-linux: 2303158118683 -> 2305054657508. percent change: +0.08%
aarch64-darwin: 2004247677067 -> 2005544586885. percent change: +0.06%
```

The slight diff in the other systems is from run-to-run variance, as minimal-bootstrap is only used on x86. I believe -1.9% to be a fairly accurate metric for that PR. I'm sure there are cases where instructions don't tell the whole story, but I think it's a fairly good one.

## What this PR does _not_ do (yet)

 `eval.compare` (the function that produces the Eval Summary page) isn't aware of the instructions metric yet. This requires some design work, as my ideal implementation would:
- Stop printing `cpu.time` and nondeterministic GC attributes
- Stop including p / t values, as the remaining metrics should all be deterministic
- Print the instructions data with a calculated percentage (potentially per-system, as a single system can have a large regression, and averaging may mask this)

These are all things that could be easily bikeshed, and it requires some time on my end to dive into the Python script. I want to land this in a future PR, so this PR can focus on purely the technical end.

Because the comparison logic hasn't been updated, `countInstructions` is still set to false in GHA. Enabling it would mean nothing if we're not printing it for the user.

In the faraway future, I'd love to automatically print a message if the number of instructions meaningfully regresses. But that's just a pipe dream at this time.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
