### PR TITLE
treewide: remove redundant `lib.mkOption` calls

### DIFF
--- a/nixos/modules/config/xdg/autostart.nix
+++ b/nixos/modules/config/xdg/autostart.nix
@@ -7,7 +7,7 @@
   options.xdg.autostart = {
     enable =
       lib.mkEnableOption "auto-starting of desktop applications according to the [XDG Autostart specification](https://specifications.freedesktop.org/autostart-spec/latest)."
-      // lib.mkOption {
+      // {
         default = true;
       };
     install =
@@ -16,7 +16,7 @@
 
         These are handled by your desktop environment or [`systemd-xdg-autostart-generator`](https://www.freedesktop.org/software/systemd/man/latest/systemd-xdg-autostart-generator.html).
       ''
-      // lib.mkOption {
+      // {
         default = true;
       };
   };

--- a/nixos/modules/programs/wayland/waybar.nix
+++ b/nixos/modules/programs/wayland/waybar.nix
@@ -11,11 +11,9 @@ in
 {
   options.programs.waybar = {
     enable = lib.mkEnableOption "waybar, a highly customizable Wayland bar for Sway and Wlroots based compositors";
-    package =
-      lib.mkPackageOption pkgs "waybar" { }
-      // lib.mkOption {
-        apply = pkg: pkg.override { systemdSupport = true; };
-      };
+    package = lib.mkPackageOption pkgs "waybar" { } // {
+      apply = waybar: waybar.override { systemdSupport = true; };
+    };
     systemd.target = lib.mkOption {
       type = lib.types.str;
       description = ''

--- a/nixos/modules/services/finance/taler/module.nix
+++ b/nixos/modules/services/finance/taler/module.nix
@@ -13,7 +13,9 @@ in
 {
   # TODO turn this into a generic taler-like service thingy?
   options.services.taler = {
-    enable = lib.mkEnableOption "the GNU Taler system" // lib.mkOption { internal = true; };
+    enable = lib.mkEnableOption "the GNU Taler system" // {
+      internal = true;
+    };
     includes = lib.mkOption {
       type = lib.types.listOf lib.types.path;
       default = [ ];

--- a/nixos/modules/services/misc/paperless.nix
+++ b/nixos/modules/services/misc/paperless.nix
@@ -294,7 +294,9 @@ in
         This sets `OMP_NUM_THREADS` to `1` in order to mitigate the issue. See
         https://github.com/NixOS/nixpkgs/issues/240591 for more information
       ''
-      // lib.mkOption { default = true; };
+      // {
+        default = true;
+      };
 
     environmentFile = lib.mkOption {
       type = lib.types.nullOr lib.types.path;

--- a/nixos/modules/services/web-apps/bookstack.nix
+++ b/nixos/modules/services/web-apps/bookstack.nix
@@ -197,15 +197,13 @@ in
   options.services.bookstack = {
     enable = lib.mkEnableOption "BookStack: A platform to create documentation/wiki content built with PHP & Laravel";
 
-    package =
-      lib.mkPackageOption pkgs "bookstack" { }
-      // lib.mkOption {
-        apply =
-          bookstack:
-          bookstack.override (prev: {
-            dataDir = cfg.dataDir;
-          });
-      };
+    package = lib.mkPackageOption pkgs "bookstack" { } // {
+      apply =
+        bookstack:
+        bookstack.override (prev: {
+          dataDir = cfg.dataDir;
+        });
+    };
 
     user = lib.mkOption {
       default = defaultUser;

--- a/nixos/modules/services/web-apps/firefly-iii.nix
+++ b/nixos/modules/services/web-apps/firefly-iii.nix
@@ -109,15 +109,13 @@ in
       '';
     };
 
-    package =
-      lib.mkPackageOption pkgs "firefly-iii" { }
-      // lib.mkOption {
-        apply =
-          firefly-iii:
-          firefly-iii.override (prev: {
-            dataDir = cfg.dataDir;
-          });
-      };
+    package = lib.mkPackageOption pkgs "firefly-iii" { } // {
+      apply =
+        firefly-iii:
+        firefly-iii.override (prev: {
+          dataDir = cfg.dataDir;
+        });
+    };
 
     enableNginx = lib.mkOption {
       type = lib.types.bool;

--- a/nixos/modules/services/web-apps/speedtest-tracker.nix
+++ b/nixos/modules/services/web-apps/speedtest-tracker.nix
@@ -92,15 +92,13 @@ in
 
     enable = lib.mkEnableOption "Speedtest Tracker: A self-hosted internet performance tracking application";
 
-    package =
-      lib.mkPackageOption pkgs "speedtest-tracker" { }
-      // lib.mkOption {
-        apply =
-          speedtest-tracker:
-          speedtest-tracker.override (prev: {
-            dataDir = cfg.dataDir;
-          });
-      };
+    package = lib.mkPackageOption pkgs "speedtest-tracker" { } // {
+      apply =
+        speedtest-tracker:
+        speedtest-tracker.override (prev: {
+          dataDir = cfg.dataDir;
+        });
+    };
 
     user = lib.mkOption {
       type = lib.types.str;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
