### PR TITLE
taws: init at 1.2.1

### DIFF
--- a/pkgs/by-name/ta/taws/package.nix
+++ b/pkgs/by-name/ta/taws/package.nix
@@ -1,0 +1,54 @@
+{
+  buildPackages,
+  fetchFromGitHub,
+  installShellFiles,
+  lib,
+  rustPlatform,
+  stdenv,
+  versionCheckHook,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "taws";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "huseyinbabal";
+    repo = "taws";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-76dC5ZLhQkItqGdWkq+U8mzimjDAAkzzpopx8ZPHCx4=";
+  };
+
+  cargoHash = "sha256-62Pk1RRx0eErGWNCYEyw0jFoNp97a+1kn5brgd81P5k=";
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  postInstall =
+    let
+      taws =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/taws"
+        else
+          lib.getExe buildPackages.taws;
+    in
+    ''
+      installShellCompletion --cmd taws \
+        --bash <(${taws} completion bash) \
+        --fish <(${taws} completion fish) \
+        --zsh <(${taws} completion zsh)
+    '';
+
+  meta = {
+    description = "Terminal-based AWS resource viewer and manager";
+    homepage = "https://github.com/huseyinbabal/taws";
+    changelog = "https://github.com/huseyinbabal/taws/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "taws";
+    maintainers = [ lib.maintainers.EpicEric ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
taws is a terminal UI for AWS, allowing you to view and manage resources: <https://github.com/huseyinbabal/taws>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
