### PR TITLE
python{313,314}Packages.pendulum: fix the build on Darwin

### DIFF
--- a/pkgs/development/python-modules/pendulum/default.nix
+++ b/pkgs/development/python-modules/pendulum/default.nix
@@ -7,9 +7,6 @@
   # build-system
   rustPlatform,
 
-  # native dependencies
-  iconv,
-
   # dependencies
   python-dateutil,
   tzdata,
@@ -31,6 +28,13 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-zpBymeYhCy+yu6RPhOuN5xOVk6928hd3+oRsfiBPPuY=";
   };
 
+  patches = [
+    # Fix the build on Darwin.
+    #
+    # <https://github.com/python-pendulum/pendulum/pull/979>
+    ./delete-obsolete-cargo-toml.patch
+  ];
+
   cargoRoot = "rust";
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
@@ -42,8 +46,6 @@ buildPythonPackage (finalAttrs: {
     rustPlatform.maturinBuildHook
     rustPlatform.cargoSetupHook
   ];
-
-  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ iconv ];
 
   dependencies = [
     python-dateutil

--- a/pkgs/development/python-modules/pendulum/delete-obsolete-cargo-toml.patch
+++ b/pkgs/development/python-modules/pendulum/delete-obsolete-cargo-toml.patch
@@ -1,0 +1,39 @@
+From dd0c442ab1f50f19dde95875b39a6a4463e6e835 Mon Sep 17 00:00:00 2001
+From: Emily <hello@emily.moe>
+Date: Sat, 4 Jul 2026 18:18:19 +0100
+Subject: [PATCH] Delete obsolete `.cargo/config.toml`
+
+Maturin adds these flags by itself, but the presence of this file can
+seemingly cause them to not get added at all in some environments,
+likely related to them using their own `.cargo/config.toml` file.
+
+This was possibly caused by
+<https://github.com/PyO3/maturin/commit/74baa6714808eae61ac330c972d22a9122f9b190>,
+as we noticed it when bumping Maturin past that commit in
+Nixpkgs. Removing the file fixes the macOS build in our environment.
+---
+ rust/.cargo/config.toml | 15 ---------------
+ 1 file changed, 15 deletions(-)
+ delete mode 100644 rust/.cargo/config.toml
+
+diff --git a/rust/.cargo/config.toml b/rust/.cargo/config.toml
+deleted file mode 100644
+index f0ba8af4..00000000
+--- a/rust/.cargo/config.toml
++++ /dev/null
+@@ -1,15 +0,0 @@
+-[build]
+-rustflags = []
+-
+-# see https://pyo3.rs/main/building_and_distribution.html#macos
+-[target.x86_64-apple-darwin]
+-rustflags = [
+-  "-C", "link-arg=-undefined",
+-  "-C", "link-arg=dynamic_lookup",
+-]
+-
+-[target.aarch64-apple-darwin]
+-rustflags = [
+-  "-C", "link-arg=-undefined",
+-  "-C", "link-arg=dynamic_lookup",
+-]


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
