### PR TITLE
{awscli2, python3Packages.botocore}: use standard-format CA bundle

### DIFF
--- a/pkgs/by-name/aw/awscli2/package.nix
+++ b/pkgs/by-name/aw/awscli2/package.nix
@@ -75,6 +75,7 @@ py.pkgs.buildPythonApplication rec {
       --replace-fail 'prompt-toolkit>=3.0.24,<3.0.52' 'prompt-toolkit>=3.0.24' \
       --replace-fail 'ruamel_yaml>=0.15.0,<=0.19.1' 'ruamel_yaml>=0.15.0' \
       --replace-fail 'ruamel_yaml_clib>=0.2.0,<=0.2.15' 'ruamel_yaml_clib>=0.2.0' \
+      --replace-fail 'urllib3>=1.25.4,<=2.6.3' 'urllib3>=1.25.4' \
       --replace-fail 'wcwidth<0.3.0' 'wcwidth>=0.3.0'
 
     substituteInPlace requirements-base.txt \

--- a/pkgs/by-name/aw/awscli2/package.nix
+++ b/pkgs/by-name/aw/awscli2/package.nix
@@ -86,7 +86,7 @@ py.pkgs.buildPythonApplication rec {
     # through PYTHONPATH
     sed -i '/pip>=/d' requirements/bootstrap.txt
 
-    ln -sf ${cacert}/etc/ssl/certs/ca-bundle.crt awscli/botocore/cacert.pem
+    ln -sf ${cacert}/etc/ssl/certs/ca-no-trust-rules-bundle.crt awscli/botocore/cacert.pem
   '';
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/botocore/default.nix
+++ b/pkgs/development/python-modules/botocore/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
-    ln -sf ${cacert}/etc/ssl/certs/ca-bundle.crt botocore/cacert.pem
+    ln -sf ${cacert}/etc/ssl/certs/ca-no-trust-rules-bundle.crt botocore/cacert.pem
   '';
 
   build-system = [


### PR DESCRIPTION
`awscli2` fails to build on `staging-next` with test failures like

```
FAILED tests/unit/customizations/s3/test_factory.py::test_factory_always_acquires_crt_transfer_lock_for_crt_manager[crt-True] - RuntimeError: 1033 (AWS_IO_TLS_CTX_ERROR): Failed to create tls context
= 22 failed, 4532 passed, 4 skipped, 3 deselected, 2 warnings in 98.20s (0:01:38) =
```

due to `ca-bundle.crt`'s format introduced with https://github.com/NixOS/nixpkgs/pull/490115

`ca-bundle.crt`
```
-----BEGIN TRUSTED CERTIFICATE-----
MIIC+TCCAoCgAwIBAgINAKaLeSkAAAAAUNCR+TAKBggqhkjOPQQDAzCBvzELMAkG
...
-----END TRUSTED CERTIFICATE-----
   → Trusted Uses: E-mail Protection   (extra CertAux DER appended after the cert)
```

compared with `ca-no-trust-rules-bundle.crt` which is consistent with upstream's vendored bundle
```
-----BEGIN CERTIFICATE-----
MIIC+TCCAoCgAwIBAgINAKaLeSkAAAAAUNCR+TAKBggqhkjOPQQDAzCBvzELMAkG
...
-----END CERTIFICATE-----
```

this PR replaces `ca-bundle.crt` with  `ca-no-trust-rules-bundle.crt`  and relaxes the `urllib3` pin.

should resolve the failure in https://github.com/NixOS/nixpkgs/pull/535855

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
