### PR TITLE
swiftPackages.swift{,NoSwiftDriver}: work around `ld64` hardening issue

### DIFF
--- a/pkgs/development/compilers/swift/swiftpm/default.nix
+++ b/pkgs/development/compilers/swift/swiftpm/default.nix
@@ -135,6 +135,11 @@ let
           # so we don't have to account for that scenario.
           "-DCMAKE_BUILD_WITH_INSTALL_NAME_DIR=ON"
         ];
+
+        # TODO: Clean up on `staging`.
+        env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+          NIX_LDFLAGS = "-headerpad_max_install_names";
+        };
       }
     );
 

--- a/pkgs/development/compilers/swift/wrapper/default.nix
+++ b/pkgs/development/compilers/swift/wrapper/default.nix
@@ -5,6 +5,10 @@
   useSwiftDriver ? true,
   swift-driver,
   clang,
+
+  # TODO: Clean up on `staging`.
+  llvmPackages,
+  writeShellScriptBin,
 }:
 
 stdenv.mkDerivation (
@@ -90,6 +94,15 @@ stdenv.mkDerivation (
           cp "$input" "$out/nix-support/$(basename "$input")"
         done
       fi
+    ''
+    # TODO: Clean up on `staging`.
+    + lib.optionalString stdenv.targetPlatform.isDarwin ''
+      printf "NIX_SWIFTFLAGS_COMPILE+=' -use-ld=lld -tools-directory %s'\n" \
+        ${writeShellScriptBin "ld" ''
+          exec ${lib.getExe' llvmPackages.lld "ld64.lld"} "$@"
+        ''}/bin \
+        >> $out/nix-support/setup-hook
+      printf '%s\n' ${lib.getBin llvmPackages.lld} >> $out/nix-support/propagated-build-inputs
     '';
 
     passthru = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
