### PR TITLE
treewide: largely remove danth from maintainers

### DIFF
--- a/nixos/modules/programs/firefox.nix
+++ b/nixos/modules/programs/firefox.nix
@@ -327,7 +327,6 @@ in
   };
 
   meta.maintainers = with lib.maintainers; [
-    danth
     linsui
   ];
 }

--- a/nixos/modules/services/web-apps/ocis.nix
+++ b/nixos/modules/services/web-apps/ocis.nix
@@ -202,7 +202,6 @@ in
 
   meta.maintainers = with lib.maintainers; [
     bhankas
-    danth
     ramblurr
   ];
 }

--- a/pkgs/by-name/as/ascii-image-converter/package.nix
+++ b/pkgs/by-name/as/ascii-image-converter/package.nix
@@ -21,7 +21,7 @@ buildGoModule (finalAttrs: {
     description = "Convert images into ASCII art on the console";
     homepage = "https://github.com/TheZoraiz/ascii-image-converter#readme";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ danth ];
+    maintainers = [ ];
     mainProgram = "ascii-image-converter";
   };
 })

--- a/pkgs/by-name/he/helix-unwrapped/package.nix
+++ b/pkgs/by-name/he/helix-unwrapped/package.nix
@@ -83,7 +83,6 @@ rustPlatform.buildRustPackage (
       mainProgram = "hx";
       maintainers = with lib.maintainers; [
         aciceri
-        danth
         yusdacra
       ];
     };

--- a/pkgs/by-name/oc/ocis_5-bin/package.nix
+++ b/pkgs/by-name/oc/ocis_5-bin/package.nix
@@ -67,7 +67,6 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       ramblurr
       bhankas
-      danth
       ramblurr
     ];
 

--- a/pkgs/by-name/st/starship/package.nix
+++ b/pkgs/by-name/st/starship/package.nix
@@ -65,7 +65,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://github.com/starship/starship/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.isc;
     maintainers = with lib.maintainers; [
-      danth
       Frostman
       da157
       sigmasquadron


### PR DESCRIPTION
I have not used most of these in a while, so have no interest in maintaining them any more.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
