### PR TITLE
coccoc-browser: init at 153.0.150

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -403,6 +403,12 @@
     githubId = 7755101;
     name = "Aaron Andersen";
   };
+  aanhlongg = {
+    email = "nguyen.vietlong@protonmail.com";
+    github = "aanhlongg";
+    githubId = 169835631;
+    name = "Vietlong Nguyen";
+  };
   aaqaishtyaq = {
     email = "aaqaishtyaq@gmail.com";
     github = "aaqaishtyaq";

--- a/pkgs/by-name/co/coccoc-browser/package.nix
+++ b/pkgs/by-name/co/coccoc-browser/package.nix
@@ -1,0 +1,122 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  dpkg,
+  makeWrapper,
+  cairo,
+  pango,
+  systemd,
+  at-spi2-core,
+  qt6,
+  glib,
+  libxext,
+  libxcomposite,
+  libxdamage,
+  libxfixes,
+  libxrandr,
+  libx11,
+  libxcb,
+  nspr,
+  nss,
+  alsa-lib,
+  pipewire,
+  vulkan-loader,
+  libGL,
+  wayland,
+  waylandSupport ? true,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "coccoc-browser";
+  version = "153.0.150";
+
+  src = fetchurl {
+    url = "https://browser-linux.coccoc.com/deb/pool/main/coccoc-browser-stable_147.0.7727.150-1_amd64.deb";
+    hash = "sha256-MwQRQiEHdMyTY5E3LxhA7a+/T/eAEGBoCf8NhiFxkYE=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    cairo
+    pango
+    systemd
+    at-spi2-core
+    stdenv.cc.cc.lib
+    qt6.qtbase
+    glib
+    libxext
+    libxcomposite
+    libxdamage
+    libxfixes
+    libxrandr
+    libx11
+    libxcb
+    nspr
+    nss
+    alsa-lib
+  ];
+
+  dontWrapQtApps = true;
+
+  unpackPhase = ''
+    dpkg-deb --fsys-tarfile $src | tar -x --no-same-permissions
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/opt $out/share
+
+    cp -R opt/coccoc $out/opt/
+    cp -R usr/share/* $out/share/
+
+    # delete qt5 shim to prevent dependency collision
+    rm -f $out/opt/coccoc/browser/libqt5_shim.so
+
+    substituteInPlace $out/share/applications/coccoc-browser.desktop \
+      --replace-fail "/usr/bin/coccoc-browser-stable" "coccoc-browser"
+
+    for size in 16 24 32 48 64 128 256; do
+      if [ -f "$out/opt/coccoc/browser/product_logo_$size.png" ]; then
+        mkdir -p $out/share/icons/hicolor/''${size}x''${size}/apps
+        ln -s "$out/opt/coccoc/browser/product_logo_$size.png" $out/share/icons/hicolor/''${size}x''${size}/apps/coccoc.png
+      fi
+    done
+
+    ln -s $out/opt/coccoc/browser/coccoc-browser $out/bin/coccoc-browser
+
+    wrapProgram $out/bin/coccoc-browser \
+      ${lib.optionalString waylandSupport ''--add-flags "--ozone-platform-hint=auto" --add-flags "--enable-features=WaylandWindowDecorations"''} \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath (
+          [
+            pipewire
+            vulkan-loader
+            libGL
+          ]
+          ++ lib.optionals waylandSupport [ wayland ]
+        )
+      }
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Cốc Cốc! The optimized web browser for vietnamese people";
+    homepage = "https://coccoc.com/";
+    maintainers = with lib.maintainers; [ aanhlongg ];
+    license = lib.licenses.unfree;
+    platforms = lib.platforms.linux;
+    mainProgram = "coccoc-browser";
+  };
+})


### PR DESCRIPTION
Init for [Cốc Cốc Browser](https://coccoc.com/), a popular browser optimized for vietnamese people, offering an built-in ad blocker, video downloading, sidebar integration, direct torrent support, vietnamese language support, Tor-based incognito mode, and more.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
