### PR TITLE
python3Packages.open-clip-torch: cleanup, add missing dependency

### DIFF
--- a/pkgs/development/python-modules/open-clip-torch/default.nix
+++ b/pkgs/development/python-modules/open-clip-torch/default.nix
@@ -18,14 +18,15 @@
   torchvision,
   tqdm,
 
-  # checks
-  pytestCheckHook,
+  # tests
   braceexpand,
   pandas,
+  pytestCheckHook,
+  requests,
   transformers,
   webdataset,
 }:
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "open-clip-torch";
   version = "3.3.0";
   pyproject = true;
@@ -33,7 +34,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "mlfoundations";
     repo = "open_clip";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-rJT0LCIS0uChBUdZ6WTQv0npZ0Ae8veIXMgr6JTgUj4=";
   };
 
@@ -53,20 +54,23 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    pytestCheckHook
     braceexpand
     pandas
+    pytestCheckHook
+    requests
     transformers
     webdataset
   ];
 
   pythonImportsCheck = [ "open_clip" ];
 
-  # -> On Darwin:
-  # AttributeError: Can't pickle local object 'build_params.<locals>.<lambda>'
-  # -> On Linux:
-  # KeyError: Caught KeyError in DataLoader worker process 0
-  disabledTestPaths = [ "tests/test_wds.py" ];
+  disabledTestPaths = [
+    # -> On Darwin:
+    # AttributeError: Can't pickle local object 'build_params.<locals>.<lambda>'
+    # -> On Linux:
+    # KeyError: Caught KeyError in DataLoader worker process 0
+    "tests/test_wds.py"
+  ];
 
   disabledTests = [
     # requires network
@@ -86,9 +90,9 @@ buildPythonPackage rec {
   meta = {
     description = "Open source implementation of CLIP";
     homepage = "https://github.com/mlfoundations/open_clip";
-    changelog = "https://github.com/mlfoundations/open_clip/releases/tag/${src.tag}";
+    changelog = "https://github.com/mlfoundations/open_clip/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ iynaix ];
     mainProgram = "open-clip";
   };
-}
+})


### PR DESCRIPTION
## Things done

Preparation for #536976

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
