### PR TITLE
python3Packages.ai-edge-litert: mark as broke

### DIFF
--- a/pkgs/development/python-modules/ai-edge-litert/default.nix
+++ b/pkgs/development/python-modules/ai-edge-litert/default.nix
@@ -84,7 +84,6 @@ buildPythonPackage {
   passthru.updateScript = ./update.py;
 
   meta = {
-    broken = stdenv.hostPlatform.isDarwin; # elftools.common.exceptions.ELFError: Magic number does not match
     changelog = "https://github.com/google-ai-edge/LiteRT/releases/tag/v${release.version}";
     description = "LiteRT is for mobile and embedded devices";
     downloadPage = "https://github.com/google-ai-edge/LiteRT";
@@ -93,5 +92,9 @@ buildPythonPackage {
     platforms = lib.attrNames platforms;
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
     maintainers = with lib.maintainers; [ hexa ];
+    badPlatforms = [
+      # elftools.common.exceptions.ELFError: Magic number does not match
+      lib.systems.inspect.patterns.isDarwin
+    ];
   };
 }

--- a/pkgs/development/python-modules/ai-edge-litert/default.nix
+++ b/pkgs/development/python-modules/ai-edge-litert/default.nix
@@ -96,5 +96,8 @@ buildPythonPackage {
       # elftools.common.exceptions.ELFError: Magic number does not match
       lib.systems.inspect.patterns.isDarwin
     ];
+    # Incompatible with the openvino currently shipped in nixpkgs:
+    #   auto-patchelf could not satisfy dependency libopenvino.so.2620
+    broken = true;
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **python3Packages.ai-edge-litert: use badPlatforms instead of broken to disable on darwin**
- **python3Packages.ai-edge-litert: mark as broken**

---

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
