### PR TITLE
nim-unwrapped-2_2: 2.2.4 -> 2.2.10

### DIFF
--- a/pkgs/by-name/ni/nim-unwrapped-2_2/excpt-cstring-fix.patch
+++ b/pkgs/by-name/ni/nim-unwrapped-2_2/excpt-cstring-fix.patch
@@ -1,0 +1,17 @@
+diff --git a/lib/system/excpt.nim b/lib/system/excpt.nim
+index 85ea17a..2b51f5a 100644
+--- a/lib/system/excpt.nim
++++ b/lib/system/excpt.nim
+@@ -212,10 +212,10 @@ when defined(nativeStacktrace) and nativeStackTraceSupported:
+       if enabled:
+         if dlresult != 0:
+           var oldLen = s.len
+-          add(s, tempDlInfo.dli_fname)
++          add(s, cstrToStrBuiltin(tempDlInfo.dli_fname))
+           if tempDlInfo.dli_sname != nil:
+             for k in 1..max(1, 25-(s.len-oldLen)): add(s, ' ')
+-            add(s, tempDlInfo.dli_sname)
++            add(s, cstrToStrBuiltin(tempDlInfo.dli_sname))
+         else:
+           add(s, '?')
+           add(s, "\n")

--- a/pkgs/by-name/ni/nim-unwrapped-2_2/extra-mangling-2.patch
+++ b/pkgs/by-name/ni/nim-unwrapped-2_2/extra-mangling-2.patch
@@ -2,7 +2,7 @@ diff --git a/compiler/modulegraphs.nim b/compiler/modulegraphs.nim
 index 77762d23a..59dd8903a 100644
 --- a/compiler/modulegraphs.nim
 +++ b/compiler/modulegraphs.nim
-@@ -503,7 +503,11 @@ proc uniqueModuleName*(conf: ConfigRef; m: PSym): string =
+@@ -506,7 +506,11 @@ proc uniqueModuleName*(conf: ConfigRef; m: PSym): string =
    for i in 0..<trunc:
      let c = rel[i]
      case c
@@ -19,9 +19,9 @@ diff --git a/compiler/modulepaths.nim b/compiler/modulepaths.nim
 index c9e6060e5..2b349f27c 100644
 --- a/compiler/modulepaths.nim
 +++ b/compiler/modulepaths.nim
-@@ -79,6 +79,17 @@ proc checkModuleName*(conf: ConfigRef; n: PNode; doLocalError=true): FileIndex =
-   else:
-     result = fileInfoIdx(conf, fullPath)
+@@ -83,6 +83,17 @@ type
+   SelectedBase = enum
+     FromProject, FromSearchPath, FromNimblePath
  
 +proc rot13(result: var string) =
 +  # don't mangle .nim
@@ -37,16 +37,16 @@ index c9e6060e5..2b349f27c 100644
  proc mangleModuleName*(conf: ConfigRef; path: AbsoluteFile): string =
    ## Mangle a relative module path to avoid path and symbol collisions.
    ##
-@@ -87,9 +98,11 @@ proc mangleModuleName*(conf: ConfigRef; path: AbsoluteFile): string =
-   ##
-   ## Example:
-   ## `foo-#head/../bar` becomes `@foo-@hhead@s..@sbar`
--  "@m" & relativeTo(path, conf.projectPath).string.multiReplace(
-+  result = "@m" & relativeTo(path, conf.projectPath).string.multiReplace(
+@@ -109,9 +120,11 @@ proc mangleModuleName*(conf: ConfigRef; path: AbsoluteFile): string =
+     of FromSearchPath: "@p"
+     of FromNimblePath: "@n"
+ 
+-  prefix & best.multiReplace(
++  result = prefix & best.multiReplace(
      {$os.DirSep: "@s", $os.AltSep: "@s", "#": "@h", "@": "@@", ":": "@c"})
 +  rot13(result)
  
  proc demangleModuleName*(path: string): string =
    ## Demangle a relative module path.
-   result = path.multiReplace({"@@": "@", "@h": "#", "@s": "/", "@m": "", "@c": ":"})
+   result = path.multiReplace({"@@": "@", "@h": "#", "@s": "/", "@m": "", "@p": "", "@n": "", "@c": ":"})
 +  rot13(result)

--- a/pkgs/by-name/ni/nim-unwrapped-2_2/package.nix
+++ b/pkgs/by-name/ni/nim-unwrapped-2_2/package.nix
@@ -13,12 +13,12 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "nim-unwrapped";
-  version = "2.2.4";
+  version = "2.2.10";
   strictDeps = true;
 
   src = fetchurl {
     url = "https://nim-lang.org/download/nim-${finalAttrs.version}.tar.xz";
-    hash = "sha256-+CtBl1D8zlYfP4l6BIaxgBhoRddvtdmfJIzhZhCBicc=";
+    hash = "sha256-eVe37QBCBrzxC8xPO0dEFTh45i8kMVUqmo6dP0Do1dU=";
   };
 
   buildInputs = [
@@ -38,6 +38,9 @@ stdenv.mkDerivation (finalAttrs: {
 
     ./extra-mangling-2.patch
     # Mangle store paths of modules to prevent runtime dependence.
+
+    ./excpt-cstring-fix.patch
+    # Fix type mismatch: cstring should be converted to string with $
 
     ./openssl.patch
     # dlopen is widely used by Python, Ruby, Perl, ... what you're really telling me here is that your OS is fundamentally broken. That might be news for you, but it isn't for me.


### PR DESCRIPTION
Updates nim-unwrapped (and therefore nim) to the latest stable.

I fix one of the patches and added a new one to make the compilation work.

 
## Things done 
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
