### PR TITLE
qrcode: apply guideline checklist

### DIFF
--- a/pkgs/by-name/qr/qrcode/package.nix
+++ b/pkgs/by-name/qr/qrcode/package.nix
@@ -3,9 +3,10 @@
   stdenv,
   fetchFromGitHub,
   unstableGitUpdater,
+  testers,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "qrcode";
   version = "0-unstable-2025-04-29";
 
@@ -16,25 +17,38 @@ stdenv.mkDerivation {
     hash = "sha256-WQeZB8G9Nm68mYmLr0ksZdFDcQxF54X0yJxigJZWvMo=";
   };
 
+  strictDeps = true;
+  enableParallelBuilding = true;
+
   makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
+  # Upstream Makefile has no install target.
   installPhase = ''
-    mkdir -p "$out"/{bin,share/doc/qrcode}
-    cp qrcode "$out/bin"
-    cp DOCUMENTATION LICENCE "$out/share/doc/qrcode"
+    runHook preInstall
+    install -Dm755 qrcode -t "$out/bin"
+    install -Dm644 DOCUMENTATION LICENCE -t "$out/share/doc/qrcode"
+    runHook postInstall
   '';
 
-  passthru.updateScript = unstableGitUpdater { };
+  passthru = {
+    updateScript = unstableGitUpdater { };
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      # Upstream exits non-zero even on successful -V.
+      command = "{ qrcode -V || true; }";
+      version = "0.1";
+    };
+  };
 
   meta = {
-    description = "Small QR-code tool";
+    description = "QR-code encoder and decoder";
     homepage = "https://github.com/qsantos/qrcode";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       raskin
       lucasew
     ];
-    platforms = with lib.platforms; unix;
+    platforms = lib.platforms.unix;
     mainProgram = "qrcode";
   };
-}
+})


### PR DESCRIPTION
Align `qrcode` with current packaging guidelines.

- Use `finalAttrs`, `strictDeps`, and `enableParallelBuilding`
- Add `runHook` around the manual `installPhase` (upstream has no install target) and install with mode-preserving `install -Dm…`
- Add `passthru.tests.version` (`qrcode -V` exits non-zero upstream, so the test tolerates that)
- Tighten `meta`: clearer description, `platforms = lib.platforms.unix`

Built and smoke-tested on `x86_64-linux`; `passthru.tests.version` passes. No upstream source change.

Assisted-by: Grok (xAI) via grok-cli

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test