### PR TITLE
waynav: init at 1.0.1, maintainers: add ali-abrar

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1416,6 +1416,11 @@
       }
     ];
   };
+  ali-abrar = {
+    name = "Ali Abrar";
+    github = "ali-abrar";
+    githubId = 7432518;
+  };
   alinnow = {
     name = "Alin";
     email = "alin@alin.ovh";

--- a/pkgs/by-name/wa/waynav/package.nix
+++ b/pkgs/by-name/wa/waynav/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  wayland,
+  wayland-protocols,
+  wayland-scanner,
+  libxkbcommon,
+  cairo,
+  gitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "waynav";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "kovetskiy";
+    repo = "waynav";
+    rev = finalAttrs.version;
+    hash = "sha256-0bRVGJ1Go7lKg9iATNOsF2l1APsN4bVrkw5HAIGyw9g=";
+  };
+
+  strictDeps = true;
+  depsBuildBuild = [ pkg-config ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    wayland
+    wayland-protocols
+    libxkbcommon
+    cairo
+  ];
+
+  doCheck = true;
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = {
+    description = "Keyboard-driven grid mouse navigator for Wayland, a keynav rewrite";
+    homepage = "https://github.com/kovetskiy/waynav";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ali-abrar ];
+    inherit (wayland.meta) platforms;
+    mainProgram = "waynav";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adding the waynav package.

waynav is a keyboard-driven grid mouse navigator for Wayland, a
from-scratch rewrite of keynav for wlroots-compatible compositors.
Tested on niri.

Homepage: https://github.com/kovetskiy/waynav

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
