### PR TITLE
python3Packages.cuda-core: init at 1.0.1

### DIFF
--- a/pkgs/development/python-modules/cuda-core/default.nix
+++ b/pkgs/development/python-modules/cuda-core/default.nix
@@ -1,0 +1,136 @@
+{
+  lib,
+  config,
+  buildPythonPackage,
+  cudaPackages,
+  fetchFromGitHub,
+  symlinkJoin,
+
+  # build-system
+  cuda-bindings,
+  cuda-pathfinder,
+  cython,
+  setuptools,
+  setuptools-scm,
+
+  # dependencies
+  numpy,
+
+  # tests
+  cffi,
+  cloudpickle,
+  psutil,
+  pytestCheckHook,
+
+  # passthru
+  cuda-core,
+
+  cudaSupport ? config.cudaSupport,
+}:
+buildPythonPackage.override { stdenv = cudaPackages.backendStdenv; } (finalAttrs: {
+  pname = "cuda-core";
+  version = "1.0.1";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "NVIDIA";
+    repo = "cuda-python";
+    tag = "cuda-core-v${finalAttrs.version}";
+    hash = "sha256-SRy/hnOzzb4wUCLOre4k326RNhYI0650XzC8Dc9kf/M=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/cuda_core";
+
+  env = {
+    CUDA_HOME = symlinkJoin {
+      name = "cuda-redist";
+      paths =
+        with cudaPackages;
+        [
+          # Used to detect CUDA MAJOR VERSION
+          (lib.getInclude cuda_cudart)
+        ]
+        ++ lib.optionals finalAttrs.doInstallCheck [
+          # Compilation tests include <cuda/atomic> etc. (found via $CUDA_HOME/include)
+          (lib.getInclude cccl)
+        ];
+    };
+  };
+
+  build-system = [
+    cuda-bindings
+    cuda-pathfinder
+    cython
+    setuptools
+    setuptools-scm
+  ];
+
+  nativeBuildInputs = [
+    cudaPackages.cuda_nvcc
+  ];
+
+  buildInputs = [
+    cudaPackages.cuda_nvrtc # nvrtc.h
+    cudaPackages.cuda_profiler_api # cudaProfiler.h
+  ];
+
+  preBuild = ''
+    export CUDA_PYTHON_PARALLEL_LEVEL=$NIX_BUILD_CORES
+  '';
+
+  dependencies = [
+    cuda-pathfinder
+    numpy
+  ];
+
+  pythonImportsCheck = [ "cuda.core" ];
+
+  preCheck = ''
+    rm -rf cuda/core
+  '';
+
+  nativeCheckInputs = [
+    cffi
+    cloudpickle
+    psutil
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Fail inside the sandbox:
+    #   cuda.bindings.nvml.UnknownError: Unknown Error
+    #   hwloc/linux: failed to find sysfs cpu topology directory, aborting linux discovery.
+    "test_affinity"
+    "test_device_cpu_affinity"
+    "test_device_pci_bus_id"
+    "test_device_pci_info"
+    "test_to_cuda_device"
+    "test_to_system_device"
+  ];
+
+  disabledTestPaths = [
+    # AssertionError (tries to run an external python process that imports `cuda`)
+    # ModuleNotFoundError: No module named 'cuda'
+    "tests/test_rlcompleter_patch.py"
+  ];
+
+  # Tests require a GPU
+  doCheck = false;
+
+  passthru.gpuCheck = cuda-core.overridePythonAttrs {
+    requiredSystemFeatures = [ "cuda" ];
+    doCheck = true;
+  };
+
+  meta = {
+    description = "Pythonic interface to the CUDA runtime";
+    homepage = "https://nvidia.github.io/cuda-python/cuda-core/latest";
+    downloadPage = "https://github.com/NVIDIA/cuda-python/tree/main/cuda_core";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      GaetanLepage
+    ];
+    broken = !cudaSupport;
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3526,6 +3526,8 @@ self: super: with self; {
 
   cuda-bindings = callPackage ../development/python-modules/cuda-bindings { };
 
+  cuda-core = callPackage ../development/python-modules/cuda-core { };
+
   cuda-pathfinder = callPackage ../development/python-modules/cuda-pathfinder { };
 
   cuda-tile = callPackage ../development/python-modules/cuda-tile { };


### PR DESCRIPTION
## Things done

Add [cuda-core](https://nvidia.github.io/cuda-python/cuda-core/latest/getting-started.html#what-is-cuda-core), a pythonic interface to the CUDA runtime.

cc  @NixOS/cuda-maintainers 

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
