### PR TITLE
easyspeak: init at 0.8.0

### DIFF
--- a/pkgs/by-name/ea/easyspeak-lang-en/package.nix
+++ b/pkgs/by-name/ea/easyspeak-lang-en/package.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+}:
+
+let
+  whisperRev = "3d3d5dee26484f91867d81cb899cfcf72b96be6c";
+  whisperBase = "https://huggingface.co/Systran/faster-whisper-base.en/resolve/${whisperRev}";
+
+  whisperFile =
+    name: hash:
+    fetchurl {
+      url = "${whisperBase}/${name}";
+      inherit hash;
+    };
+
+  whisperFiles = {
+    "config.json" = whisperFile "config.json" "sha256-87w4Ien8dqJ7rlOOEa5bZ33N01K0YAQpznlR05hWmus=";
+    "model.bin" = whisperFile "model.bin" "sha256-KhZpJVOaFgBfFP8yg1n5ua253E+2Mbs7InUmhi6T4u8=";
+    "tokenizer.json" =
+      whisperFile "tokenizer.json" "sha256-kpxSUkCUNtzhs4p10au8teEy0XDY4yTk4E7ZFfotIt8=";
+    "vocabulary.txt" =
+      whisperFile "vocabulary.txt" "sha256-/3dYh0bTolldMqtbaf/XuVziRBrFdTPLZvw+tXWhFc8=";
+  };
+
+  piperBase = "https://huggingface.co/rhasspy/piper-voices/resolve/v1.0.0/en/en_US/amy/medium";
+
+  piperOnnx = fetchurl {
+    url = "${piperBase}/en_US-amy-medium.onnx";
+    hash = "sha256-s6bke1e4x/vmoM4lGBYaUPWanN2KUINcAssCvdYgbBg=";
+  };
+
+  piperJson = fetchurl {
+    url = "${piperBase}/en_US-amy-medium.onnx.json";
+    hash = "sha256-laI+tNQpCdON9zu5rH9F9Zfb/N4tG/lSb96vVGaXfXc=";
+  };
+
+in
+stdenvNoCC.mkDerivation {
+  pname = "easyspeak-lang-en";
+  version = "1.0.0";
+
+  __structuredAttrs = true;
+
+  strictDeps = true;
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/models/whisper/base.en" "$out/models/piper"
+
+    ${lib.concatStringsSep "\n    " (
+      lib.mapAttrsToList (
+        name: file: "ln -s ${file} \"$out/models/whisper/base.en/${name}\""
+      ) whisperFiles
+    )}
+
+    ln -s ${piperOnnx} "$out/models/piper/en_US-amy-medium.onnx"
+    ln -s ${piperJson} "$out/models/piper/en_US-amy-medium.onnx.json"
+
+    runHook postInstall
+  '';
+
+  passthru.models = {
+    whisper = "models/whisper/base.en";
+    piper = "models/piper/en_US-amy-medium.onnx";
+  };
+
+  meta = {
+    description = "English speech models for EasySpeak (Whisper base.en + Piper en_US-amy-medium)";
+    homepage = "https://easyspeak.dev";
+    license = [
+      lib.licenses.mit
+      lib.licenses.cc-by-sa-40
+    ];
+    maintainers = [ lib.maintainers.ahoneybun ];
+    platforms = lib.platforms.linux;
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+  };
+}

--- a/pkgs/by-name/ea/easyspeak/package.nix
+++ b/pkgs/by-name/ea/easyspeak/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  python314Packages,
+  fetchFromGitHub,
+
+  pulseaudio,
+  piper-tts,
+  sound-theme-freedesktop,
+  easyspeak-lang-en,
+
+  makeWrapper,
+}:
+
+python314Packages.buildPythonPackage (finalAttrs: {
+  pname = "easyspeak";
+  version = "0.8.0";
+  __structuredAttrs = true;
+  strictDeps = true;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ctsdownloads";
+    repo = "easyspeak";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-gITbTDSqOt0g+ofvvfO1idQM4Mfz7kEh9T43X2IyRvo=";
+  };
+
+  build-system = with python314Packages; [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = with python314Packages; [
+    evdev
+    faster-whisper
+    jeepney
+    numpy
+    onnxruntime
+    opencv4
+    pyaudio
+    pyopen-wakeword
+  ];
+
+  pythonRemoveDeps = [
+    "evdev-binary"
+  ];
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  postFixup = ''
+    wrapProgram $out/bin/easyspeak \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          pulseaudio
+          piper-tts
+        ]
+      } \
+      --prefix XDG_DATA_DIRS : "${sound-theme-freedesktop}/share" \
+      --set LC_ALL C.UTF-8 \
+      --set EASYSPEAK_SOUNDS_DIR "${sound-theme-freedesktop}/share/sounds/freedesktop/stereo" \
+      --set EASYSPEAK_WHISPER_MODEL "${easyspeak-lang-en}/${easyspeak-lang-en.models.whisper}" \
+      --set EASYSPEAK_PIPER_MODEL "${easyspeak-lang-en}/${easyspeak-lang-en.models.piper}"
+  '';
+
+  meta = {
+    description = "Voice control for Linux desktops. Fully local, no cloud, Wayland-native.";
+    homepage = "https://easyspeak.dev";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.ahoneybun ];
+    platforms = lib.platforms.linux;
+    mainProgram = "easyspeak";
+  };
+})


### PR DESCRIPTION
This adds easyspeak package which is a CLI application, this also adds the lang-en package which installs the English model:

easyspeak-lang-en: init at 1.0.0

Builds with `nix build .#easyspeak` and works as expected:

<img width="1920" height="1200" alt="Screenshot From 2026-07-04 14-42-56" src="https://github.com/user-attachments/assets/0526073a-dd0d-4040-a443-251650deb277" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
