### PR TITLE
python3Packages.beets-ytimport: init at 1.13.0

### DIFF
--- a/pkgs/development/python-modules/beets-ytimport/default.nix
+++ b/pkgs/development/python-modules/beets-ytimport/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  setuptools,
+  ytmusicapi,
+  yt-dlp,
+  beets-minimal,
+  pytestCheckHook,
+  writableTmpDirAsHomeHook,
+  nix-update-script,
+}:
+buildPythonPackage rec {
+  pname = "beets-ytimport";
+  version = "1.13.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mgoltzsche";
+    repo = "beets-ytimport";
+    tag = "v${version}";
+    hash = "sha256-EwSL1rBEPTcMfrlTkQcqRuhR8OtibBZqA0qQz4+qLEw=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    ytmusicapi
+    yt-dlp
+  ];
+
+  nativeBuildInputs = [
+    beets-minimal
+  ];
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+    pytestCheckHook
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/mgoltzsche/beets-ytimport/releases/tag/v${version}";
+    description = "Beets plugin to import music from Youtube and SoundCloud";
+    homepage = "https://github.com/mgoltzsche/beets-ytimport";
+    maintainers = with lib.maintainers; [ pyrox0 ];
+    license = [ lib.licenses.asl20 ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2066,6 +2066,8 @@ self: super: with self; {
     disableAllPlugins = true;
   };
 
+  beets-ytimport = callPackage ../development/python-modules/beets-ytimport { };
+
   beewi-smartclim = callPackage ../development/python-modules/beewi-smartclim { };
 
   before-after = callPackage ../development/python-modules/before-after { };


### PR DESCRIPTION
https://github.com/mgoltzsche/beets-ytimport

No AI used.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.(not binaries, but of the beets plugin)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
