### PR TITLE
python3Packages.beets-importreplace: init at 0.3

### DIFF
--- a/pkgs/development/python-modules/beets-importreplace/default.nix
+++ b/pkgs/development/python-modules/beets-importreplace/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  setuptools,
+  beets-minimal,
+  pytestCheckHook,
+  writableTmpDirAsHomeHook,
+  nix-update-script,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "beets-importreplace";
+  version = "0.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "edgars-supe";
+    repo = "beets-importreplace";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-lTfHuOBFzBM/uN4GCX6btQy0KRDP/tzG0fp9/qppQtw=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeBuildInputs = [
+    beets-minimal
+  ];
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "beetsplug.importreplace" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Plugin for beets to perform regex replacements during import";
+    homepage = "https://github.com/edgars-supe/beets-importreplace";
+    maintainers = with lib.maintainers; [ pyrox0 ];
+    license = [ lib.licenses.mit ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2062,6 +2062,8 @@ self: super: with self; {
 
   beets-filetote = callPackage ../development/python-modules/beets-filetote { };
 
+  beets-importreplace = callPackage ../development/python-modules/beets-importreplace { };
+
   beets-minimal = beets.override {
     disableAllPlugins = true;
   };


### PR DESCRIPTION
https://github.com/edgars-supe/beets-importreplace

Been using for a while in my personal config with no issues. No AI used.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
