### PR TITLE
apacheHttpdPackages.mod_auth_openidc: init at 2.4.19.4

### DIFF
--- a/pkgs/servers/http/apache-modules/mod_auth_openidc/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_auth_openidc/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  autoreconfHook,
+  pkg-config,
+  apacheHttpd,
+  aprutil,
+  cjose,
+  curl,
+  jansson,
+  pcre,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation rec {
+
+  pname = "mod_auth_openidc";
+  version = "2.4.19.4";
+
+  src = fetchFromGitHub {
+    owner = "OpenIDC";
+    repo = "mod_auth_openidc";
+    rev = "v${version}";
+    sha256 = "sha256-I/j8AYBd9pPH47/Rsry6DWSvJGFeFxYn7BpkK9dtnEE=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+  buildInputs = [
+    apacheHttpd
+    aprutil
+    cjose
+    curl
+    jansson
+    pcre
+  ];
+
+  configureFlags = [
+    "--with-apxs2=${apacheHttpd.dev}/bin/apxs"
+  ];
+
+  installPhase = ''
+    mkdir -p $out/modules
+    cp src/.libs/mod_auth_openidc.so $out/modules
+  '';
+
+  meta = {
+    homepage = "https://github.com/OpenIDC/mod_auth_openidc";
+    description = "OpenID authentication and authorization module for Apache";
+    license = lib.licenses.asl20;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7273,6 +7273,7 @@ with pkgs;
     {
       inherit apacheHttpd;
       mod_auth_mellon = callPackage ../servers/http/apache-modules/mod_auth_mellon { };
+      mod_auth_openidc = callPackage ../servers/http/apache-modules/mod_auth_openidc { };
       mod_ca = callPackage ../servers/http/apache-modules/mod_ca { };
       mod_crl = callPackage ../servers/http/apache-modules/mod_crl { };
       mod_cspnonce = callPackage ../servers/http/apache-modules/mod_cspnonce { };


### PR DESCRIPTION
Adding httpd module mod_auth_openidc.

Has been tested on my personal server, and everything seems to be in order.

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
