### PR TITLE
caldav: fix building on darwin

### DIFF
--- a/pkgs/development/python-modules/caldav/darwin-fix-test.patch
+++ b/pkgs/development/python-modules/caldav/darwin-fix-test.patch
@@ -1,0 +1,13 @@
+diff -Naur caldav-3.2.1.orig/tests/test_caldav.py caldav-3.2.1/tests/test_caldav.py
+--- caldav-3.2.1.orig/tests/test_caldav.py	2026-05-28 14:32:52.000000000 +0200
++++ caldav-3.2.1/tests/test_caldav.py	2026-07-04 22:15:51.643400969 +0200
+@@ -574,7 +574,8 @@
+     and no config file is present."""
+     from unittest.mock import patch
+ 
+-    with patch.dict(os.environ, {}, clear=True):
++    fs.create_dir("/not-exist")
++    with patch.dict(os.environ, {"HOME": "/not-exist"}, clear=True):
+         result = get_davclient()
+     assert result is None
+ 

--- a/pkgs/development/python-modules/caldav/default.nix
+++ b/pkgs/development/python-modules/caldav/default.nix
@@ -38,6 +38,10 @@ buildPythonPackage rec {
     hash = "sha256-SCqc0MVxKaHpES+NkDcaItHlkk0kCFj6kFqH8k08vdA=";
   };
 
+  patches = [
+    ./darwin-fix-test.patch
+  ];
+
   build-system = [
     hatchling
     hatch-vcs


### PR DESCRIPTION
This change resolves a build failure on Darwin related to how pyfakefs processes absolute paths. This issue was discussed in issue #497560 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
