### PR TITLE
nixos-render-docs: extend admonition support

### DIFF
--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/commonmark.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/commonmark.py
@@ -22,6 +22,7 @@ class CommonMarkRenderer(Renderer):
     __output__ = "commonmark"
 
     _admonition_style: AdmonitionStyle
+    _div_fence_sizes: list[int]
     _parstack: list[Par]
     _link_stack: list[str]
     _list_stack: list[List]
@@ -29,6 +30,7 @@ class CommonMarkRenderer(Renderer):
     def __init__(self, manpage_urls: Mapping[str, str], admonition_style: AdmonitionStyle = AdmonitionStyle.PLAIN):
         super().__init__(manpage_urls)
         self._admonition_style = admonition_style
+        self._div_fence_sizes = [ ]
         self._parstack = [ Par("") ]
         self._link_stack = []
         self._list_stack = []
@@ -46,6 +48,24 @@ class CommonMarkRenderer(Renderer):
         self._parstack[-1].continuing = True
         return result
 
+    def _fenced_div_open(self, classes: Sequence[str] = ()) -> str:
+        fence_size = (
+            self._div_fence_sizes[-1] + 1
+            if self._div_fence_sizes
+            else 3
+        )
+        fence = ":" * fence_size
+        class_refs = [f".{c}" for c in classes]
+        annotation = (" {" + " ".join(class_refs) + "}") if classes else ""
+        pbreak = self._maybe_parbreak()
+        self._div_fence_sizes.append(fence_size)
+        return f"{pbreak}{fence}{annotation}"
+    def _fenced_div_close(self) -> str:
+        fence_size = self._div_fence_sizes.pop()
+        fence = ":" * fence_size
+        pbreak = self._maybe_parbreak()
+        return f"{pbreak}{fence}"
+
     def _admonition_open(self, kind: str) -> str:
         match self._admonition_style:
             case AdmonitionStyle.PLAIN:
@@ -57,6 +77,8 @@ class CommonMarkRenderer(Renderer):
                 lbreak = self._break()
                 self._enter_block("> ")
                 return f"{pbreak}> [!{kind}]{lbreak}> "
+            case AdmonitionStyle.PANDOC:
+                return self._fenced_div_open(classes=[kind.lower()])
 
     def _admonition_close(self) -> str:
         match self._admonition_style:
@@ -64,6 +86,8 @@ class CommonMarkRenderer(Renderer):
                 self._leave_block()
             case AdmonitionStyle.GFM:
                 self._leave_block()
+            case AdmonitionStyle.PANDOC:
+                return self._fenced_div_close()
         return ""
 
     def _indent_raw(self, s: str) -> str:

--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/commonmark.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/commonmark.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import cast, Optional
 
 from .md import md_escape, md_make_code, Renderer
+from .types import AdmonitionStyle
 
 from markdown_it.token import Token
 
@@ -20,12 +21,14 @@ class Par:
 class CommonMarkRenderer(Renderer):
     __output__ = "commonmark"
 
+    _admonition_style: AdmonitionStyle
     _parstack: list[Par]
     _link_stack: list[str]
     _list_stack: list[List]
 
-    def __init__(self, manpage_urls: Mapping[str, str]):
+    def __init__(self, manpage_urls: Mapping[str, str], admonition_style: AdmonitionStyle = AdmonitionStyle.PLAIN):
         super().__init__(manpage_urls)
+        self._admonition_style = admonition_style
         self._parstack = [ Par("") ]
         self._link_stack = []
         self._list_stack = []
@@ -44,11 +47,23 @@ class CommonMarkRenderer(Renderer):
         return result
 
     def _admonition_open(self, kind: str) -> str:
-        pbreak = self._maybe_parbreak()
-        self._enter_block("")
-        return f"{pbreak}**{kind}:** "
+        match self._admonition_style:
+            case AdmonitionStyle.PLAIN:
+                pbreak = self._maybe_parbreak()
+                self._enter_block("")
+                return f"{pbreak}**{kind}:** "
+            case AdmonitionStyle.GFM:
+                pbreak = self._maybe_parbreak()
+                lbreak = self._break()
+                self._enter_block("> ")
+                return f"{pbreak}> [!{kind}]{lbreak}> "
+
     def _admonition_close(self) -> str:
-        self._leave_block()
+        match self._admonition_style:
+            case AdmonitionStyle.PLAIN:
+                self._leave_block()
+            case AdmonitionStyle.GFM:
+                self._leave_block()
         return ""
 
     def _indent_raw(self, s: str) -> str:

--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/md.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/md.py
@@ -579,6 +579,58 @@ def _block_titles(block: str) -> Callable[[markdown_it.MarkdownIt], None]:
 
     return do_add
 
+
+def _gfm_alerts(md: markdown_it.MarkdownIt) -> None:
+
+    _ALERT_PATTERN = re.compile(r"^\[\!(TIP|NOTE|IMPORTANT|WARNING|CAUTION)\][ \t]*(?:\n|$)", re.IGNORECASE)
+
+    @dataclasses.dataclass
+    class Entry:
+        open: Token
+        content: Token | None = None
+
+    """
+    Find blockquote tokens and convert GFM-alert-style blockquotes to admonition tokens.
+    """
+    def gfm_alert(state: markdown_it.rules_core.StateCore) -> None:
+        stack: list[Entry] = []
+        size = len(state.tokens)
+
+        for i, token in enumerate(state.tokens):
+            match token.type:
+                case "blockquote_open":
+                    entry = Entry(token)
+                    # Get the first inline token of the blockquote's first paragraph
+                    if i + 2 < size:
+                        para = state.tokens[i + 1]
+                        inline = state.tokens[i + 2]
+                        if para and para.type == "paragraph_open" and inline and inline.type == "inline":
+                            entry.content = inline
+                    stack.append(entry)
+
+                case "blockquote_close":
+                    entry = stack.pop()
+
+                    if entry.content is None:
+                        continue
+
+                    m = _ALERT_PATTERN.match(entry.content.content)
+                    if m is None:
+                        continue
+
+                    # Remove the alert marker from the rendered text.
+                    entry.content.content = entry.content.content[m.end() :]
+
+                    # Rewrite the enclosing blockquote as an admonition.
+                    entry.open.type = "admonition_open"
+                    entry.open.tag = "div"
+                    entry.open.meta["kind"] = m.group(1).lower()
+                    token.type = "admonition_close"
+                    token.tag = "div"
+
+    md.core.ruler.after("block", "github-alerts", gfm_alert)
+
+
 TR = TypeVar('TR', bound='Renderer')
 
 class Converter(ABC, Generic[TR]):
@@ -626,6 +678,7 @@ class Converter(ABC, Generic[TR]):
         self._md.use(_block_attr)
         self._md.use(_block_titles("example"))
         self._md.use(_block_titles("figure"))
+        self._md.use(_gfm_alerts)
         self._md.enable(["smartquotes", "replacements"])
 
     def _parse(self, src: str) -> list[Token]:

--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/options.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/options.py
@@ -21,7 +21,7 @@ from .html import HTMLRenderer
 from .manpage import ManpageRenderer, man_escape
 from .manual_structure import make_xml_id, XrefTarget
 from .md import Converter, md_escape, md_make_code
-from .types import OptionLoc, Option, RenderedOption, AnchorStyle
+from .types import OptionLoc, Option, RenderedOption, AnchorStyle, AdmonitionStyle
 
 def option_is(option: Option, key: str, typ: str) -> Optional[dict[str, str]]:
     if key not in option:
@@ -317,18 +317,20 @@ class OptionsCommonMarkRenderer(OptionDocsRestrictions, CommonMarkRenderer):
 
 class CommonMarkConverter(BaseConverter[OptionsCommonMarkRenderer]):
     __option_block_separator__ = ""
+    _admonition_style: AdmonitionStyle
     _anchor_style: AnchorStyle
     _anchor_prefix: str
 
 
-    def __init__(self, manpage_urls: Mapping[str, str], revision: str, anchor_style: AnchorStyle = AnchorStyle.NONE, anchor_prefix: str = ""):
+    def __init__(self, manpage_urls: Mapping[str, str], revision: str, anchor_style: AnchorStyle = AnchorStyle.NONE, anchor_prefix: str = "", admonition_style: AdmonitionStyle = AdmonitionStyle.PLAIN):
         super().__init__(revision)
-        self._renderer = OptionsCommonMarkRenderer(manpage_urls)
+        self._renderer = OptionsCommonMarkRenderer(manpage_urls, admonition_style)
+        self._admonition_style = admonition_style
         self._anchor_style = anchor_style
         self._anchor_prefix = anchor_prefix
 
     def _parallel_render_prepare(self) -> Any:
-        return (self._renderer._manpage_urls, self._revision, self._anchor_style, self._anchor_prefix)
+        return (self._renderer._manpage_urls, self._revision, self._anchor_style, self._anchor_prefix, self._admonition_style)
     @classmethod
     def _parallel_render_init_worker(cls, a: Any) -> CommonMarkConverter:
         return cls(*a)
@@ -514,6 +516,15 @@ def parse_anchor_style(value: str|AnchorStyle) -> AnchorStyle:
     except ValueError:
         raise argparse.ArgumentTypeError(f"Invalid value {value}\nExpected one of {', '.join(style.value for style in AnchorStyle)}")
 
+def parse_admonition_style(value: str|AdmonitionStyle) -> AdmonitionStyle:
+    if isinstance(value, AdmonitionStyle):
+        # Used by `argparse.add_argument`'s `default`
+        return value
+    try:
+        return AdmonitionStyle(value.lower())
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"Invalid value {value}\nExpected one of {', '.join(style.value for style in AdmonitionStyle)}")
+
 def _build_cli_commonmark(p: argparse.ArgumentParser) -> None:
     p.add_argument('--manpage-urls', required=True)
     p.add_argument('--revision', required=True)
@@ -528,6 +539,13 @@ def _build_cli_commonmark(p: argparse.ArgumentParser) -> None:
         required=False,
         default="",
         help="(default: no prefix) String to prepend to anchor ids. Not used when anchor style is none."
+    )
+    p.add_argument(
+        '--admonition-style',
+        required=False,
+        default=AdmonitionStyle.PLAIN.value,
+        choices = [style.value for style in AdmonitionStyle],
+        help = "(default: %(default)s) Admonition style to use for notes, warnings, etc. \nOnly plain is standard CommonMark."
     )
     p.add_argument("infile")
     p.add_argument("outfile")
@@ -566,7 +584,9 @@ def _run_cli_commonmark(args: argparse.Namespace) -> None:
         md = CommonMarkConverter(json.load(manpage_urls),
             revision = args.revision,
             anchor_style = parse_anchor_style(args.anchor_style),
-            anchor_prefix = args.anchor_prefix)
+            anchor_prefix = args.anchor_prefix,
+            admonition_style = parse_admonition_style(args.admonition_style),
+         )
 
         with open(args.infile, 'r') as f:
             md.add_options(json.load(f))

--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/options.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/options.py
@@ -328,7 +328,7 @@ class CommonMarkConverter(BaseConverter[OptionsCommonMarkRenderer]):
         self._anchor_prefix = anchor_prefix
 
     def _parallel_render_prepare(self) -> Any:
-        return (self._renderer._manpage_urls, self._revision)
+        return (self._renderer._manpage_urls, self._revision, self._anchor_style, self._anchor_prefix)
     @classmethod
     def _parallel_render_init_worker(cls, a: Any) -> CommonMarkConverter:
         return cls(*a)

--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/types.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/types.py
@@ -20,4 +20,5 @@ class AnchorStyle(Enum):
 
 class AdmonitionStyle(Enum):
     PLAIN = "plain"
+    PANDOC = "pandoc"
     GFM = "gfm"

--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/types.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/types.py
@@ -17,3 +17,7 @@ RenderFn = Callable[[Token, Sequence[Token], int], str]
 class AnchorStyle(Enum):
     NONE = "none"
     LEGACY = "legacy"
+
+class AdmonitionStyle(Enum):
+    PLAIN = "plain"
+    GFM = "gfm"

--- a/pkgs/by-name/ni/nixos-render-docs/src/tests/sample_md.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/tests/sample_md.py
@@ -1,4 +1,10 @@
 sample1 = """\
+> [!NOTE]
+> This is a *GFM* note.
+>
+> > [!caution]
+> > This is a **nested** GFM alert.
+
 :::: {.warning}
 foo
 ::: {.note}

--- a/pkgs/by-name/ni/nixos-render-docs/src/tests/sample_options_admonition.json
+++ b/pkgs/by-name/ni/nixos-render-docs/src/tests/sample_options_admonition.json
@@ -1,0 +1,17 @@
+{
+  "services.frobnicator.types.<name>.enable": {
+    "declarations": [
+      "nixos/modules/services/frobnicator.nix"
+    ],
+    "description": "Whether to enable the frobnication of this (`<name>`) type.\n::: {.important}\n\nAdmonition.\n\n:::",
+    "loc": [
+      "services",
+      "frobnicator",
+      "types",
+      "<name>",
+      "enable"
+    ],
+    "readOnly": false,
+    "type": "boolean"
+  }
+}

--- a/pkgs/by-name/ni/nixos-render-docs/src/tests/sample_options_admonition_gfm.md
+++ b/pkgs/by-name/ni/nixos-render-docs/src/tests/sample_options_admonition_gfm.md
@@ -1,0 +1,16 @@
+## services\.frobnicator\.types\.\<name>\.enable
+
+Whether to enable the frobnication of this (` <name> `) type\.
+
+> [!Important]
+> Admonition\.
+
+
+
+*Type:*
+boolean
+
+*Declared by:*
+ - [\<nixpkgs/nixos/modules/services/frobnicator\.nix>](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/frobnicator.nix)
+
+

--- a/pkgs/by-name/ni/nixos-render-docs/src/tests/sample_options_admonition_pandoc.md
+++ b/pkgs/by-name/ni/nixos-render-docs/src/tests/sample_options_admonition_pandoc.md
@@ -1,0 +1,19 @@
+## services\.frobnicator\.types\.\<name>\.enable
+
+Whether to enable the frobnication of this (` <name> `) type\.
+
+::: {.important}
+
+Admonition\.
+
+:::
+
+
+
+*Type:*
+boolean
+
+*Declared by:*
+ - [\<nixpkgs/nixos/modules/services/frobnicator\.nix>](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/frobnicator.nix)
+
+

--- a/pkgs/by-name/ni/nixos-render-docs/src/tests/sample_options_admonition_plain.md
+++ b/pkgs/by-name/ni/nixos-render-docs/src/tests/sample_options_admonition_plain.md
@@ -1,0 +1,15 @@
+## services\.frobnicator\.types\.\<name>\.enable
+
+Whether to enable the frobnication of this (` <name> `) type\.
+
+**Important:** Admonition\.
+
+
+
+*Type:*
+boolean
+
+*Declared by:*
+ - [\<nixpkgs/nixos/modules/services/frobnicator\.nix>](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/frobnicator.nix)
+
+

--- a/pkgs/by-name/ni/nixos-render-docs/src/tests/test_asciidoc.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/tests/test_asciidoc.py
@@ -45,6 +45,18 @@ f
 def test_full() -> None:
     c = Converter({ 'man(1)': 'http://example.org' })
     assert c._render(sample1) == """\
+[NOTE]
+====
+This is a __GFM__ note{zwsp}.
+
+[CAUTION]
+=====
+This is a **nested** GFM alert{zwsp}.
+=====
+
+====
+
+
 [WARNING]
 ====
 foo

--- a/pkgs/by-name/ni/nixos-render-docs/src/tests/test_commonmark.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/tests/test_commonmark.py
@@ -1,3 +1,5 @@
+import pytest
+
 import nixos_render_docs as nrd
 
 from sample_md import sample1
@@ -6,9 +8,14 @@ from typing import Mapping
 
 
 class Converter(nrd.md.Converter[nrd.commonmark.CommonMarkRenderer]):
-    def __init__(self, manpage_urls: Mapping[str, str]):
+    def __init__(
+        self,
+        manpage_urls: Mapping[str, str],
+        admonition_style: nrd.types.AdmonitionStyle = nrd.types.AdmonitionStyle.PLAIN,
+    ):
         super().__init__()
-        self._renderer = nrd.commonmark.CommonMarkRenderer(manpage_urls)
+        self._renderer = nrd.commonmark.CommonMarkRenderer(manpage_urls, admonition_style)
+
 
 # NOTE: in these tests we represent trailing spaces by ` ` and replace them with real space later,
 # since a number of editors will strip trailing whitespace on save and that would break the tests.
@@ -23,6 +30,84 @@ def test_indented_fence() -> None:
 >    ```\
 """.replace(' ', ' ')
     assert c._render(s) == s
+
+
+@pytest.mark.parametrize(
+    ("style", "expected"),
+    [
+        (
+            nrd.types.AdmonitionStyle.PLAIN,
+            """\
+**Warning:** foo
+
+**Note:** nested
+
+**Important:** nested GFM
+
+:::
+
+**Caution:** GFM caution
+
+**Important:** nested fenced
+
+**Note:** nested GFM\
+""",
+        ),
+        (
+            nrd.types.AdmonitionStyle.GFM,
+            f"""\
+> [!Warning]
+> foo
+>{" "}
+> > [!Note]
+> > nested
+
+> [!Important]
+> nested GFM
+
+:::
+
+> [!Caution]
+> GFM caution
+>{" "}
+> > [!Important]
+> > nested fenced
+>{" "}
+> > [!Note]
+> > nested GFM\
+""",
+        ),
+    ],
+)
+def test_admonition_styles(
+    style: nrd.types.AdmonitionStyle,
+    expected: str,
+) -> None:
+    c = Converter({}, admonition_style=style)
+    assert c._render("""\
+:::: {.warning}
+foo
+::: {.note}
+nested
+:::
+::::
+
+> [!important]
+> nested GFM
+
+:::
+
+> [!caution]
+> GFM caution
+>
+> ::: {.important}
+> nested fenced
+> :::
+>
+> > [!note]
+> > nested GFM
+""") == expected
+
 
 def test_full() -> None:
     c = Converter({ 'man(1)': 'http://example.org' })

--- a/pkgs/by-name/ni/nixos-render-docs/src/tests/test_commonmark.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/tests/test_commonmark.py
@@ -77,6 +77,47 @@ def test_indented_fence() -> None:
 > > nested GFM\
 """,
         ),
+        (
+            nrd.types.AdmonitionStyle.PANDOC,
+            """\
+::: {.warning}
+
+foo
+
+:::: {.note}
+
+nested
+
+::::
+
+:::
+
+::: {.important}
+
+nested GFM
+
+:::
+
+:::
+
+::: {.caution}
+
+GFM caution
+
+:::: {.important}
+
+nested fenced
+
+::::
+
+:::: {.note}
+
+nested GFM
+
+::::
+
+:::""",
+        ),
     ],
 )
 def test_admonition_styles(

--- a/pkgs/by-name/ni/nixos-render-docs/src/tests/test_commonmark.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/tests/test_commonmark.py
@@ -27,6 +27,10 @@ def test_indented_fence() -> None:
 def test_full() -> None:
     c = Converter({ 'man(1)': 'http://example.org' })
     assert c._render(sample1) == """\
+**Note:** This is a *GFM* note\\.
+
+**Caution:** This is a **nested** GFM alert\\.
+
 **Warning:** foo
 
 **Note:** nested

--- a/pkgs/by-name/ni/nixos-render-docs/src/tests/test_html.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/tests/test_html.py
@@ -149,6 +149,14 @@ def test_footnotes() -> None:
 def test_full() -> None:
     c = Converter({ 'man(1)': 'http://example.org' }, {})
     assert c._render(sample1) == unpretty("""
+        <div class="note">
+          <h3 class="title">Note</h3>
+          <p>This is a <span class="emphasis"><em>GFM</em></span> note.</p>
+          <div class="caution">
+            <h3 class="title">Caution</h3>
+            <p>This is a <span class="strong"><strong>nested</strong></span> GFM alert.</p>
+          </div>
+        </div>
         <div class="warning">
          <h3 class="title">Warning</h3>
          <p>foo</p>

--- a/pkgs/by-name/ni/nixos-render-docs/src/tests/test_manpage.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/tests/test_manpage.py
@@ -41,6 +41,18 @@ def test_full() -> None:
     assert c._render(sample1) == """\
 .sp
 .RS 4
+\\fBNote\\fP
+.br
+This is a \\fIGFM\\fR note\\&.
+.sp
+.RS 4
+\\fBCaution\\fP
+.br
+This is a \\fBnested\\fR GFM alert\\&.
+.RE
+.RE
+.sp
+.RS 4
 \\fBWarning\\fP
 .br
 foo

--- a/pkgs/by-name/ni/nixos-render-docs/src/tests/test_options.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/tests/test_options.py
@@ -47,6 +47,8 @@ def test_options_commonmark_legacy_anchors() -> None:
          "tests/sample_options_admonition_plain.md"),
         (nixos_render_docs.types.AdmonitionStyle.GFM,
          "tests/sample_options_admonition_gfm.md"),
+        (nixos_render_docs.types.AdmonitionStyle.PANDOC,
+         "tests/sample_options_admonition_pandoc.md"),
     ],
 )
 def test_options_commonmark_admonition_style(style, expected_file):

--- a/pkgs/by-name/ni/nixos-render-docs/src/tests/test_options.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/tests/test_options.py
@@ -39,3 +39,29 @@ def test_options_commonmark_legacy_anchors() -> None:
     c.add_options(opts)
     s = c.finalize()
     assert s == expected
+
+@pytest.mark.parametrize(
+    ("style", "expected_file"),
+    [
+        (nixos_render_docs.types.AdmonitionStyle.PLAIN,
+         "tests/sample_options_admonition_plain.md"),
+        (nixos_render_docs.types.AdmonitionStyle.GFM,
+         "tests/sample_options_admonition_gfm.md"),
+    ],
+)
+def test_options_commonmark_admonition_style(style, expected_file):
+    c = nixos_render_docs.options.CommonMarkConverter(
+        {},
+        "local",
+        admonition_style=style,
+    )
+
+    with Path("tests/sample_options_admonition.json").open() as f:
+        opts = json.load(f)
+
+    with Path(expected_file).open() as f:
+        expected = f.read()
+
+    c.add_options(opts)
+
+    assert c.finalize() == expected

--- a/pkgs/by-name/ni/nixos-render-docs/src/tests/test_plugins.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/tests/test_plugins.py
@@ -429,6 +429,90 @@ def test_admonitions() -> None:
               children=None, content='', markup=':::', info='', meta={}, block=True, hidden=False)
     ]
 
+@pytest.mark.parametrize(
+    ("alert", "kind"),
+    [
+        ("NOTE", "note"),
+        ("TIP", "tip"),
+        ("IMPORTANT", "important"),
+        ("WARNING", "warning"),
+        ("CAUTION", "caution"),
+    ],
+)
+def test_gfm_alert_kinds(alert: str, kind: str) -> None:
+    c = Converter({})
+    assert c._parse(f"> [!{alert}]\n> body") == [
+        Token(type='admonition_open', tag='div', markup='>', meta={'kind': kind}, nesting=1, map=[0, 2], block=True),
+        Token(type='paragraph_open', tag='p', nesting=1, map=[0, 2], level=1, block=True),
+        Token(type='inline', tag='', nesting=0, map=[0, 2], level=2, block=True, content='body', children=[
+            Token(type='text', tag='', nesting=0, content='body'),
+        ]),
+        Token(type='paragraph_close', tag='p', nesting=-1, level=1, block=True),
+        Token(type='admonition_close', tag='div', nesting=-1, markup='>', block=True)
+    ]
+
+def test_gfm_alert_basic_structure_preserved() -> None:
+    c = Converter({})
+    tokens = c._parse("> [!NOTE]\n> body text")
+    assert any(t.type == "inline" for t in tokens)
+
+@pytest.mark.parametrize(
+    "md",
+    [
+        "> # [!NOTE]",
+        "> - [!NOTE]",
+        "> - [!WARNING] body",
+        "> ### [!TIP]",
+        "> ```\n> [!NOTE]\n> ```",
+        "> This is not [!NOTE] an alert",
+        "> [!NOTE] with trailing text is ignored",
+    ],
+)
+def test_gfm_alert_rejected(md: str) -> None:
+    c = Converter({})
+    tokens = c._parse(md)
+    assert all(t.type != "admonition_open" for t in tokens)
+    assert tokens[0].type == "blockquote_open"
+    assert tokens[-1].type == "blockquote_close"
+
+def test_gfm_alert_multi_paragraph() -> None:
+    c = Converter({})
+    assert c._parse(
+        "> [!NOTE]\n"
+        "> line 1\n"
+        ">\n"
+        "> line 2"
+    ) == [
+        Token(type='admonition_open', tag='div', markup='>', meta={'kind': 'note'}, nesting=1, map=[0, 4], block=True),
+        Token(type='paragraph_open', tag='p', nesting=1, map=[0, 2], level=1, block=True),
+        Token(type='inline', tag='', nesting=0, map=[0, 2], level=2, block=True, content='line 1', children=[
+            Token(type='text', tag='', nesting=0, content='line 1'),
+        ]),
+        Token(type='paragraph_close', tag='p', nesting=-1, level=1, block=True),
+        Token(type='paragraph_open', tag='p', nesting=1, map=[3, 4], level=1, block=True),
+        Token(type='inline', tag='', nesting=0, map=[3, 4], level=2, block=True, content='line 2', children=[
+            Token(type='text', tag='', nesting=0, content='line 2')
+        ]),
+        Token(type='paragraph_close', tag='p', nesting=-1, level=1, block=True),
+        Token(type='admonition_close', tag='div', markup='>', block=True, nesting=-1),
+    ]
+
+def test_gfm_alert_whitespace_tolerant() -> None:
+    c = Converter({})
+    tokens = c._parse("> [!NOTE]   \n> body")
+    assert tokens[0].type == "admonition_open"
+    assert tokens[0].meta["kind"] == "note"
+
+def test_gfm_alert_empty_body_allowed() -> None:
+    c = Converter({})
+    assert c._parse("> [!NOTE]\n>") == [
+        Token(type='admonition_open', tag='div', markup='>', meta={'kind': 'note'}, nesting=1, map=[0, 2], block=True),
+        Token(type='paragraph_open', tag='p', nesting=1, map=[0, 1], level=1, block=True),
+        Token(type='inline', tag='', nesting=0, map=[0, 1], level=2, block=True, children=[]),
+        Token(type='paragraph_close', tag='p', nesting=-1, level=1, block=True),
+        Token(type='admonition_close', tag='div', markup='>', nesting=-1, block=True),
+    ]
+
 def test_example() -> None:
     c = Converter({})
     assert c._parse("::: {.example}\n# foo") == [


### PR DESCRIPTION
### Summary

Improve support in nixos-render-docs (nrd) for different markdown "admonition" (aka "admonishment" or "alert") formats.

nrd already parses pandoc-style fenced-div admonitions into a common internal admonition token representation. The first commit extends the parser to also recognise [GitHub-Flavoured Markdown (GFM) alerts](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts), so both styles produce the same internal tokens.

The next two commits introduce a `--admonition-style` CLI flag to the `commonmark` renderer, following the precedent of the existing `--anchor-style` option.
This option has three modes:
- `plain`: (existing behaviour; new default) render admonition as plain markdown,
  prefixed with (e.g.) `**Note:**` or `**Warning:**`.
- `gfm`: render admonitions as GFM-alerts,
  e.g. `> [!Note]`
- `pandoc`: render admonitions as pandoc-style annotated fenced-div, as used currently in NixOS docs.
  e.g. `::: {.warning}`

### Motivation

Several downstream projects, including [flake-parts], [Home Manager], and [Nixvim], consume nrd's CommonMark output with static site generators such as mdBook. These generators often support markdown extensions beyond CommonMark; for example, mdBook supports GFM alerts.

[flake-parts]: https://github.com/hercules-ci/flake-parts-website
[Home Manager]: https://github.com/nix-community/home-manager/blob/b885baad531fa3d3beae2ba9a0712d22974d8016/docs/mdbook/render-options.py#L86-L88
[Nixvim]: https://github.com/nix-community/nixvim

Nixvim has maintained nrd GFM-support patches for ~2 years, which other projects can benefit from by upstreaming to Nixpkgs.

This also gives NixOS and Nixpkgs the option of adopting GFM alert syntax in the future if desired. Whether that policy should change is intentionally out-of-scope for this PR.

### Prior discussion

- https://github.com/NixOS/nixpkgs/pull/370352#discussion_r1901254774
- Nixvim's extension to nixos-render-docs
  - https://github.com/nix-community/nixvim/issues/2217

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

### Tests

- Added or updated several unit and integration tests
  - A LLM was used to identify coverage gaps and draft some of the tests.
  - Very little LLM code made it into the final diff, due to manual iteration.
  
- Manually tested the CLI end-to-end with:
  ````shell
  $ echo '{
      "_module.args": {
        "declarations": [
          {
            "name": "<nixpkgs/lib/modules.nix>",
            "url": "https://github.com/NixOS/nixpkgs/blob/master/lib/modules.nix"
          }
        ],
        "default": {
          "_type": "literalExpression",
          "text": "{ }"
        },
        "description": "blah blah\\n> [!note]\\n> note\\n",
        "loc": [
          "_module",
          "args"
        ],
        "readOnly": false,
        "type": "lazy attribute set of raw value"
      }
    }' > options.json

  $ nix-build -A nixos-render-docs
  /nix/store/ml0cyhs7qgdndi2in53jzq7hi65gbjd5-nixos-render-docs-0.0

  $ result/bin/nixos-render-docs options commonmark \
    --admonition-style pandoc \
    --revision master --manpage-urls doc/manpage-urls.json \
    options.json options.md
  ````
  Produced:
  ````md
  ## _module\.args

  blah blah

  ::: {.note}

  note

  :::



  *Type:*
  lazy attribute set of raw value



  *Default:*

  ```nix
  { }
  ```

  *Declared by:*
   - [\<nixpkgs/lib/modules\.nix>](https://github.com/NixOS/nixpkgs/blob/master/lib/modules.nix)


  ````


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
  - I used an LLM to help review the patch series and iterate on fixes and improvements, primarily around the markdown-it token decorator.
  - Some test cases were drafted by an LLM, and then improved manually.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
