### PR TITLE
skewrun: init at 1.1.1

### DIFF
--- a/pkgs/by-name/sk/skewrun/package.nix
+++ b/pkgs/by-name/sk/skewrun/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  fetchFromGitHub,
+  libfaketime,
+  makeBinaryWrapper,
+  nix-update-script,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "skewrun";
+  version = "1.1.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "JVBotelho";
+    repo = "skewrun";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-C4LF2am3gnQb+k9cdfB2xcszZ5imRBwz0ldP0gjfXRs=";
+  };
+
+  cargoHash = "sha256-hGJvirVLtP1ondLxJuyfiV7Y0+pGt8Pu3lzLAhRYtoo=";
+
+  buildInputs = [
+    libfaketime
+    makeBinaryWrapper
+  ];
+
+  postFixup = ''
+    wrapProgram $out/bin/skewrun --prefix PATH : "${
+      lib.makeBinPath [
+        libfaketime
+      ]
+    }"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Active Directory time discovery toolkit";
+    homepage = "https://github.com/JVBotelho/skewrun";
+    changelog = "https://github.com/JVBotelho/skewrun/releases/tag/v${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "skewrun";
+  };
+})


### PR DESCRIPTION
Active Directory time discovery toolkit

https://github.com/JVBotelho/skewrun

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
