### PR TITLE
python3Packages.skrl: 1.4.3 -> 2.1.0

### DIFF
--- a/pkgs/development/python-modules/skrl/default.nix
+++ b/pkgs/development/python-modules/skrl/default.nix
@@ -19,16 +19,21 @@
   flax,
   hypothesis,
   jax,
+  mujoco,
   optax,
   pettingzoo,
   pygame,
   pymunk,
+  pytest-xdist,
   pytestCheckHook,
+  warp-lang,
+  warp-nn,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "skrl";
-  version = "1.4.3";
+  version = "2.1.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -36,25 +41,8 @@ buildPythonPackage (finalAttrs: {
     owner = "Toni-SM";
     repo = "skrl";
     tag = finalAttrs.version;
-    hash = "sha256-5lkoYAmMIWqK3+E3WxXMWS9zal2DhZkfl30EkrHKpdI=";
+    hash = "sha256-pntQ/7kefi7LLLG1DTKY9Zjlzb0UXiduQCzlX5PkZds=";
   };
-
-  # Fix Jax 0.10.0 compatibility
-  # TypeError: clip() got an unexpected keyword argument 'a_min'
-  postPatch = ''
-    substituteInPlace skrl/models/jax/gaussian.py \
-      --replace-fail \
-        "jnp.clip(log_std, a_min=log_std_min, a_max=log_std_max)" \
-        "jnp.clip(log_std, min=log_std_min, max=log_std_max)" \
-      --replace-fail \
-        "jnp.clip(actions, a_min=clip_actions_min, a_max=clip_actions_max)" \
-        "jnp.clip(actions, min=clip_actions_min, max=clip_actions_max)"
-
-    substituteInPlace skrl/models/jax/deterministic.py \
-      --replace-fail \
-        "jnp.clip(actions, a_min=self._d_clip_actions_min, a_max=self._d_clip_actions_max)" \
-        "jnp.clip(actions, min=self._d_clip_actions_min, max=self._d_clip_actions_max)"
-  '';
 
   build-system = [ setuptools ];
 
@@ -74,20 +62,37 @@ buildPythonPackage (finalAttrs: {
     flax
     hypothesis
     jax
+    mujoco
     optax
     pettingzoo
     pygame
     pymunk
+    pytest-xdist
     pytestCheckHook
+    warp-lang
+    warp-nn
+    writableTmpDirAsHomeHook
   ];
 
   disabledTests = [
+    # Flaky when using pytest-xdist
+    "test_agent"
+
     # TypeError: The array passed to from_dlpack must have __dlpack__ and __dlpack_device__ methods
     "test_env"
     "test_multi_agent_env"
 
     # OverflowError
     "test_key"
+
+    # Require GPU access
+    "test_device[cuda]"
+    "test_parse_device[cuda]"
+  ];
+
+  disabledTestPaths = [
+    # TypeError: Can't instantiate abstract class Memory without an implementation for abstract method 'sample'
+    "tests/memories/torch/test_base.py"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/warp-nn/default.nix
+++ b/pkgs/development/python-modules/warp-nn/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  warp-lang,
+
+  # tests
+  hypothesis,
+  pytestCheckHook,
+  torch,
+  writableTmpDirAsHomeHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "warp-nn";
+  version = "0.3.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "NVIDIA";
+    repo = "warp-nn";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-dziGJhuuLHy8gEB39tvpLTHjPOwz6YVhsCB6KbIb7vI=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    warp-lang
+  ];
+
+  pythonImportsCheck = [ "warp_nn" ];
+
+  nativeCheckInputs = [
+    hypothesis
+    pytestCheckHook
+    torch
+    writableTmpDirAsHomeHook
+  ];
+
+  meta = {
+    description = "CUDA Graphable Neural Networks for NVIDIA Warp";
+    homepage = "https://github.com/NVIDIA/warp-nn";
+    changelog = "https://github.com/NVIDIA/warp-nn/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.tost;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21981,6 +21981,8 @@ self: super: with self; {
     llvmPackages = pkgs.llvmPackages_21;
   };
 
+  warp-nn = callPackage ../development/python-modules/warp-nn { };
+
   warrant = callPackage ../development/python-modules/warrant { };
 
   warrant-lite = callPackage ../development/python-modules/warrant-lite { };


### PR DESCRIPTION
## Things done

- **python3Packages.warp-nn: init at 0.3.0**
- **python3Packages.skrl: 1.4.3 -> 2.1.0**
  - Diff: https://github.com/Toni-SM/skrl/compare/1.4.3...2.1.0
  - Changelog: https://github.com/Toni-SM/skrl/releases/tag/2.1.0

cc @bcdarwin
cc @NixOS/cuda-maintainers 

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test