### PR TITLE
[Backport release-26.05] tmux: 3.7 -> 3.7b, tmuxp: 1.71.0 -> 1.73.0, python3Packages.libtmux: 0.59.0 -> 0.60.0

### DIFF
--- a/pkgs/by-name/tm/tmux/package.nix
+++ b/pkgs/by-name/tm/tmux/package.nix
@@ -18,7 +18,10 @@
   libutempter,
   withSixel ? true,
   versionCheckHook,
-  nix-update-script,
+  common-updater-scripts,
+  writeShellScript,
+  curl,
+  jq,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -99,7 +102,10 @@ stdenv.mkDerivation (finalAttrs: {
           ln -sv ${ncurses}/share/terminfo/t/{tmux,tmux-256color,tmux-direct} $out/share/terminfo/t
         ''
     );
-    updateScript = nix-update-script { };
+    updateScript = writeShellScript "update-tmux" ''
+      latest=$(${lib.getExe curl} --silent ''${GITHUB_TOKEN:+--header "Authorization: Bearer $GITHUB_TOKEN"} https://api.github.com/repos/tmux/tmux/releases/latest | ${lib.getExe jq} -r .tag_name)
+      ${lib.getExe' common-updater-scripts "update-source-version"} tmux "$latest"
+    '';
   };
 
   meta = {

--- a/pkgs/by-name/tm/tmux/package.nix
+++ b/pkgs/by-name/tm/tmux/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   autoreconfHook,
   bison,
   libevent,
@@ -26,7 +25,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tmux";
-  version = "3.6a";
+  version = "3.7";
 
   outputs = [
     "out"
@@ -37,19 +36,8 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "tmux";
     repo = "tmux";
     tag = finalAttrs.version;
-    hash = "sha256-VwOyR9YYhA/uyVRJbspNrKkJWJGYFFktwPnnwnIJ97s=";
+    hash = "sha256-dgqI1jZjnluN/F/AjngzcaMy3TgudmkvDT336YlhGZM=";
   };
-
-  patches = [
-    # Fix NULL pointer dereference in control_write() when a control-mode
-    # client is notified before control_state has been allocated.
-    # https://github.com/tmux/tmux/issues/4980
-    (fetchpatch {
-      name = "tmux-control-notify-uninitialized.patch";
-      url = "https://github.com/tmux/tmux/commit/e5a2a25fafb8ee107c230d8acad694f6b635f8bb.patch";
-      hash = "sha256-UPbhMNnH1WJwTH/LVwjVonTqvNhyuniUrYm7iLVkCfg=";
-    })
-  ];
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/tm/tmux/package.nix
+++ b/pkgs/by-name/tm/tmux/package.nix
@@ -25,7 +25,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tmux";
-  version = "3.7";
+  version = "3.7b";
 
   outputs = [
     "out"
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "tmux";
     repo = "tmux";
     tag = finalAttrs.version;
-    hash = "sha256-dgqI1jZjnluN/F/AjngzcaMy3TgudmkvDT336YlhGZM=";
+    hash = "sha256-CTq06XP997M0ODxQihTq34dI9H6jSRLUXLYuTWOwDpc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/tm/tmuxp/package.nix
+++ b/pkgs/by-name/tm/tmuxp/package.nix
@@ -7,12 +7,12 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "tmuxp";
-  version = "1.70.0";
+  version = "1.71.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
-    hash = "sha256-XanIOOlZjN5K4hTyd/n0mFotB7GAreQhp6UimdQp+Vw=";
+    hash = "sha256-+Nsr4gNem/gB6ZMre53rfuM8Kwkiu86aGJmrxiFRorY=";
   };
 
   build-system = with python3Packages; [

--- a/pkgs/by-name/tm/tmuxp/package.nix
+++ b/pkgs/by-name/tm/tmuxp/package.nix
@@ -7,12 +7,12 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "tmuxp";
-  version = "1.67.0";
+  version = "1.70.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
-    hash = "sha256-mQcg2fpab0dYeQrswgHS0prwrZrYxHtYrCCssOipTxI=";
+    hash = "sha256-XanIOOlZjN5K4hTyd/n0mFotB7GAreQhp6UimdQp+Vw=";
   };
 
   build-system = with python3Packages; [

--- a/pkgs/by-name/tm/tmuxp/package.nix
+++ b/pkgs/by-name/tm/tmuxp/package.nix
@@ -7,12 +7,12 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "tmuxp";
-  version = "1.71.0";
+  version = "1.73.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
-    hash = "sha256-+Nsr4gNem/gB6ZMre53rfuM8Kwkiu86aGJmrxiFRorY=";
+    hash = "sha256-UExY0hC7HDWeISQ/mMZLMcMnqDko4i188MyoDbNePZc=";
   };
 
   build-system = with python3Packages; [

--- a/pkgs/development/python-modules/libtmux/0001-fix-test_control_mode_stdout_preserves_non_ascii_out.patch
+++ b/pkgs/development/python-modules/libtmux/0001-fix-test_control_mode_stdout_preserves_non_ascii_out.patch
@@ -1,0 +1,37 @@
+From 8e12cc39f60012b6abb3a097f97950fe2c061386 Mon Sep 17 00:00:00 2001
+From: Michael Daniels <mdaniels5757@gmail.com>
+Date: Sun, 24 May 2026 10:09:00 -0400
+Subject: [PATCH] fix test_control_mode_stdout_preserves_non_ascii_output in
+ nix sandbox
+
+The select() call times out when in the nix sandbox for unknown reasons,
+even though the fd is ready.
+---
+ tests/test_control_mode.py | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/tests/test_control_mode.py b/tests/test_control_mode.py
+index f72f6846..1a564e78 100644
+--- a/tests/test_control_mode.py
++++ b/tests/test_control_mode.py
+@@ -4,7 +4,6 @@ from __future__ import annotations
+ 
+ import locale
+ import os
+-import select
+ import sys
+ import typing as t
+ 
+@@ -87,9 +86,6 @@ def test_control_mode_stdout_preserves_non_ascii_output(
+             )
+ 
+             for _ in range(20):
+-                ready, _, _ = select.select([ctl.stdout], [], [], 1)
+-                assert ready, "timed out waiting for control-mode output"
+-
+                 line = ctl.stdout.readline()
+                 if FORMAT_SEPARATOR in line:
+                     break
+-- 
+2.51.2
+

--- a/pkgs/development/python-modules/libtmux/default.nix
+++ b/pkgs/development/python-modules/libtmux/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "libtmux";
-  version = "0.58.1";
+  version = "0.59.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tmux-python";
     repo = "libtmux";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-+ipLzjdP5zqtJ5e+QqgUHiPVpp3BgJ3/qxbNNgh2mv8=";
+    hash = "sha256-RsK3nVGpgNX05tCc5kK5GFLUS5vVoe8NRKgg7Y/DzwM=";
   };
 
   patches = [ ./0001-fix-test_control_mode_stdout_preserves_non_ascii_out.patch ];

--- a/pkgs/development/python-modules/libtmux/default.nix
+++ b/pkgs/development/python-modules/libtmux/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "libtmux";
-  version = "0.58.0";
+  version = "0.58.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tmux-python";
     repo = "libtmux";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-w5WutYesmIIBhWtcT5Qahyx7NffRBM+MPE7KOGF3fkU=";
+    hash = "sha256-+ipLzjdP5zqtJ5e+QqgUHiPVpp3BgJ3/qxbNNgh2mv8=";
   };
 
   patches = [ ./0001-fix-test_control_mode_stdout_preserves_non_ascii_out.patch ];

--- a/pkgs/development/python-modules/libtmux/default.nix
+++ b/pkgs/development/python-modules/libtmux/default.nix
@@ -7,21 +7,24 @@
   ncurses,
   procps,
   pytest-rerunfailures,
+  pytest-xdist,
   pytestCheckHook,
   tmux,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "libtmux";
-  version = "0.55.1";
+  version = "0.58.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tmux-python";
     repo = "libtmux";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-A8mi0Q9ScbHmFRSvcF+wbn+lAO8B3/rU/+HvTXvxWPE=";
+    hash = "sha256-w5WutYesmIIBhWtcT5Qahyx7NffRBM+MPE7KOGF3fkU=";
   };
+
+  patches = [ ./0001-fix-test_control_mode_stdout_preserves_non_ascii_out.patch ];
 
   postPatch = ''
     substituteInPlace pyproject.toml \
@@ -31,34 +34,33 @@ buildPythonPackage (finalAttrs: {
   build-system = [ hatchling ];
 
   nativeCheckInputs = [
-    procps
-    tmux
     ncurses
-    pytest-rerunfailures
+    procps
     pytestCheckHook
+    pytest-rerunfailures
+    pytest-xdist
+    tmux
   ];
 
   enabledTestPaths = [ "tests" ];
 
-  disabledTests = [
+  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [ "tests/test/test_retry.py" ];
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
     # Fail with: 'no server running on /tmp/tmux-1000/libtmux_test8sorutj1'.
     "test_new_session_width_height"
-    # Assertion error
+    # AssertionError: assert '' == '$'
+    "test_capture_pane"
+    # AssertionError: assert '' == '$'
     "test_capture_pane_start"
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    # tests/test_pane.py:113: AssertionError
-    "test_capture_pane_start"
-    # assert (1740973920.500444 - 1740973919.015309) <= 1.1
-    "test_retry_three_times"
-    "test_function_times_out_no_raise"
-    # assert False
-    "test_retry_three_times_no_raise_assert"
+    # AssertionError: assert '' == '$'
+    "test_capture_pane_end"
+    # IndexError: list index out of range
+    "test_new_window_with_environment"
   ];
 
-  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [ "tests/test/test_retry.py" ];
-
   pythonImportsCheck = [ "libtmux" ];
+
+  __darwinAllowLocalNetworking = true;
 
   meta = {
     description = "Typed scripting library / ORM / API wrapper for tmux";

--- a/pkgs/development/python-modules/libtmux/default.nix
+++ b/pkgs/development/python-modules/libtmux/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "libtmux";
-  version = "0.60.0";
+  version = "0.61.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tmux-python";
     repo = "libtmux";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-1h+qkQDYRwP2peMOvKC1kk4DFcG4cwuBApsF8MmkWbo=";
+    hash = "sha256-ZhVwe6JQTDQDozHHOpwkzWsfSxiP43W4asRngokC7gU=";
   };
 
   patches = [ ./0001-fix-test_control_mode_stdout_preserves_non_ascii_out.patch ];

--- a/pkgs/development/python-modules/libtmux/default.nix
+++ b/pkgs/development/python-modules/libtmux/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "libtmux";
-  version = "0.59.0";
+  version = "0.60.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tmux-python";
     repo = "libtmux";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-RsK3nVGpgNX05tCc5kK5GFLUS5vVoe8NRKgg7Y/DzwM=";
+    hash = "sha256-1h+qkQDYRwP2peMOvKC1kk4DFcG4cwuBApsF8MmkWbo=";
   };
 
   patches = [ ./0001-fix-test_control_mode_stdout_preserves_non_ascii_out.patch ];
@@ -45,7 +45,12 @@ buildPythonPackage (finalAttrs: {
   enabledTestPaths = [ "tests" ];
 
   disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [ "tests/test/test_retry.py" ];
-  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+  disabledTests = [
+    # test is broken for tmux 3.7a and later
+    # https://github.com/tmux-python/libtmux/issues/697
+    "test_new_window_name_invalid_on_3_7"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # Fail with: 'no server running on /tmp/tmux-1000/libtmux_test8sorutj1'.
     "test_new_session_width_height"
     # AssertionError: assert '' == '$'


### PR DESCRIPTION
Diff: tmux/tmux@3.7...3.7b

Changelog: https://github.com/tmux/tmux/raw/3.7a/CHANGES
Changelog: https://github.com/tmux/tmux/raw/3.7b/CHANGES
(cherry picked from commit 40b0a76)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
