### PR TITLE
lmstudio: hdiutil -> back to _7zz

### DIFF
--- a/pkgs/by-name/lm/lmstudio/darwin.nix
+++ b/pkgs/by-name/lm/lmstudio/darwin.nix
@@ -1,7 +1,6 @@
 {
   stdenv,
   fetchurl,
-  undmg,
   darwin,
   meta,
   pname,
@@ -9,6 +8,7 @@
   url,
   hash,
   passthru,
+  _7zz,
 }:
 stdenv.mkDerivation {
   inherit meta pname version;
@@ -18,8 +18,8 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [
-    undmg
     darwin.sigtool
+    _7zz
   ];
 
   sourceRoot = ".";
@@ -50,22 +50,10 @@ stdenv.mkDerivation {
   dontFixup = true;
 
   # undmg doesn't support APFS and 7zz does break the xattr. Took that approach from https://github.com/NixOS/nixpkgs/blob/a3c6ed7ad2649c1a55ffd94f7747e3176053b833/pkgs/by-name/in/insomnia/package.nix#L52
-  unpackCmd = ''
-    echo "Creating temp directory"
-    mnt=$(TMPDIR=/tmp mktemp -d -t nix-XXXXXXXXXX)
-    function finish {
-      echo "Ejecting temp directory"
-      /usr/bin/hdiutil detach $mnt -force
-      rm -rf $mnt
-    }
-    # Detach volume when receiving SIG "0"
-    trap finish EXIT
-    # Mount DMG file
-    echo "Mounting DMG file into \"$mnt\""
-    /usr/bin/hdiutil attach -nobrowse -mountpoint $mnt $curSrc
-    # Copy content to local dir for later use
-    echo 'Copying extracted content into "sourceRoot"'
-    cp -a $mnt/LM\ Studio.app $PWD/
+  # NOTE (djmaxus): even with hdiutil, a check `xattr -lr LM\ Studio.app` returns nothing,
+  # meaning that xattrs are lost anyway? So, I brought back simple 7zip unpacking
+  unpackPhase = ''
+    7zz x -snld $src
   '';
 
   inherit passthru;


### PR DESCRIPTION
closes #537765

* hdiutil is outside the sandbox
* it was chosen in an attempt to preserve xattr's
* when put to the test, it didn't: 

```
nix-shell -A lmstudio 
cd $(mktemp -d) 
unpackPhase # before this commit
xattr -lr LM\ Studio.app

```

So, I just brought back _7zz
with flags to omit warnings.
Same result of `xattr -lr`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
