### PR TITLE
sbomnix: use the latest Nix version in `$PATH` again

### DIFF
--- a/pkgs/by-name/sb/sbomnix/package.nix
+++ b/pkgs/by-name/sb/sbomnix/package.nix
@@ -4,7 +4,6 @@
   git,
   grype,
   nix,
-  nixVersions,
   nix-visualize,
   python3,
   vulnix,
@@ -31,9 +30,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     "--prefix PATH : ${
       lib.makeBinPath [
         git
-        # nix
-        # TODO: remove once sbomnix support new JSON format: https://github.com/tiiuae/sbomnix/issues/267
-        nixVersions.nix_2_31
+        nix
         python3.pkgs.graphviz
         nix-visualize
         vulnix


### PR DESCRIPTION
Undoes the [previous workaround](https://github.com/NixOS/nixpkgs/pull/512547) for the new JSON derivation format, which pinned the runtime Nix version to 2.31.

As [sbomnix no longer supports the legacy derivation format starting with 1.8.0](https://github.com/tiiuae/sbomnix/releases/tag/v1.8.0) and the [new JSON format is only available starting with Nix 2.33](https://nix.dev/manual/nix/2.34/release-notes/rl-2.33.html#derivation-json-format-changes), now the workaround causes sbomnix to fail.

The relevant error message and the [full log of the affected CI/CD run](https://github.com/hfxbse/nixos-config/actions/runs/28719704508/job/85170956816):
```
INFO     Evaluating flakeref '/home/runner/work/nixos-config/nixos-config#nixosConfigurations.snowball.config.system.build.toplevel'
INFO     Realising flakeref '/home/runner/work/nixos-config/nixos-config#nixosConfigurations.snowball.config.system.build.toplevel'
INFO     Generating SBOM for target '/nix/store/s26wnp7zbcqvsvmyxskf9j993mgffzjy-nixos-system-snowball-26.11.20260702.6517942'
CRITICAL Unexpected JSON from `nix derivation show`: unsupported legacy `inputDrvs` in derivation `/nix/store/pw80sv0ldsx1f3rfyl8z84jx9hbyvsbi-nixos-system-snowball-26.11.20260702.6517942.drv`. The pinned Nix output schema may have changed; refusing to continue.
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
