### PR TITLE
nixos/tests/machinectl: Create /usr directory

### DIFF
--- a/nixos/tests/systemd-machinectl.nix
+++ b/nixos/tests/systemd-machinectl.nix
@@ -106,6 +106,8 @@ let
       }
     ];
 
+    extraCommands = "mkdir -p usr";
+
     contents = [
       {
         source = containerSystem + "/etc/os-release";
@@ -171,6 +173,7 @@ in
 
       systemd.tmpfiles.rules = [
         "d /var/lib/machines/shared-decl 0755 root root - -"
+        "d /var/lib/machines/shared-decl/usr 0755 root root - -"
       ];
       systemd.nspawn.shared-decl = {
         execConfig = {
@@ -228,7 +231,7 @@ in
     machine.wait_until_succeeds("systemctl -M shared-decl is-active default.target");
     machine.succeed("machinectl stop shared-decl");
 
-    machine.succeed("mkdir -p ${containerRoot}");
+    machine.succeed("mkdir -p ${containerRoot}/usr");
 
     # start container with shared nix store by using same arguments as for systemd-nspawn@.service
     machine.succeed("systemd-run systemd-nspawn --machine=${containerName} --network-veth -U --bind-ro=/nix/store ${containerSystem}/init")


### PR DESCRIPTION
Since #488508 was merged, systemd nspawn now expects /usr to exist in the rootfs before it will start a container.

Create the /usr directory in the relevant containers throughout this test.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
