### PR TITLE
opentxl: allow disabling compiler in wrapper

### DIFF
--- a/pkgs/by-name/op/opentxl/package.nix
+++ b/pkgs/by-name/op/opentxl/package.nix
@@ -4,6 +4,7 @@
   makeWrapper,
   opentxl-unwrapped,
   targetPackages,
+  withCompiler ? true,
 }:
 let
   inherit (targetPackages.stdenv.cc) targetPrefix;
@@ -29,19 +30,21 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/bin
 
     # Wrap compiler
-    makeWrapper ${opentxl-unwrapped}/bin/txlc \
-      $out/bin/${targetPrefix}txlc \
-      --set TXLLIB ${opentxl-unwrapped}/lib \
-      --set BUILD_TXLLIB ${opentxl-unwrapped}/lib \
-      --set TARGET_TXLLIB ${targetOpentxl}/lib \
-      --set CC ${targetPackages.stdenv.cc}/bin/${targetPrefix}cc \
-      --set OS ${opentxl-unwrapped.osOption stdenv.targetPlatform}
-    ${
-      # For convenience, if there is a target prefix, create a symlink named txlc
-      lib.optionalString (targetPrefix != "") ''
-        ln -s $out/bin/${targetPrefix}txlc $out/bin/txlc
-      ''
-    }
+    ${lib.optionalString withCompiler ''
+      makeWrapper ${opentxl-unwrapped}/bin/txlc \
+        $out/bin/${targetPrefix}txlc \
+        --set TXLLIB ${opentxl-unwrapped}/lib \
+        --set BUILD_TXLLIB ${opentxl-unwrapped}/lib \
+        --set TARGET_TXLLIB ${targetOpentxl}/lib \
+        --set CC ${targetPackages.stdenv.cc}/bin/${targetPrefix}cc \
+        --set OS ${opentxl-unwrapped.osOption stdenv.targetPlatform}
+      ${
+        # For convenience, if there is a target prefix, create a symlink named txlc
+        lib.optionalString (targetPrefix != "") ''
+          ln -s $out/bin/${targetPrefix}txlc $out/bin/txlc
+        ''
+      }
+    ''}
 
     # Wrap other scripts
     for name in txl2c txlp; do


### PR DESCRIPTION
The compiler isn't used as frequently as the plain `txl` binary, so it's useful to allow a developer to opt out of including it in the wrapper. This also significantly reduces the closure size of the package since it no longer needs to pull in a full C toolchain.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
