### PR TITLE
graphite-cli: fix darwin build

### DIFF
--- a/pkgs/by-name/gr/graphite-cli/package.nix
+++ b/pkgs/by-name/gr/graphite-cli/package.nix
@@ -76,9 +76,10 @@ let
 
     dontConfigure = true;
     dontBuild = true;
-    # On Linux the binary is wrapped with buildFHSEnv; completions are
-    # generated there. Here we only need to skip fixup to avoid patchelf/strip.
-    dontFixup = stdenv.hostPlatform.isLinux;
+    # Skip fixup on all platforms: strip discards the vercel/pkg virtual
+    # filesystem appended to the binary (see the comment below), leaving a
+    # binary that fails at runtime with "Pkg: Error reading from file."
+    dontFixup = true;
 
     installPhase = ''
       runHook preInstall
@@ -86,7 +87,13 @@ let
       runHook postInstall
     '';
 
-    postInstall = lib.optionalString stdenv.hostPlatform.isDarwin shellCompletions;
+    # gt tries to create ~/.config/graphite/aliases on startup and exits 1
+    # with no output when HOME is not writable, which would leave the
+    # completion files empty.
+    postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+      export HOME=$(mktemp -d)
+      ${shellCompletions}
+    '';
   };
 in
 # The binary is built with vercel/pkg, which appends a virtual filesystem to


### PR DESCRIPTION

<!-- If you filed the issue first, start the body with: Fixes #NNNNNN -->

The 1.8.6 bump (#527044) broke graphite-cli on darwin in two independent ways, unnoticed because the package is unfree and therefore never built by Hydra or ofborg:

1. **Empty shell completions fail the build.** `postInstall` generates completions by running `$out/bin/gt`, but the 1.8.6 vercel/pkg binary tries to create `~/.config/graphite/aliases` on startup and exits 1 with no output when `HOME` is not writable (`HOME=/homeless-shelter` in nix builds). `installShellCompletion` then fails the build on the resulting zero-size files:

   ```
   error: installed shell completion file ... gt.bash does not exist or has zero size
   ```

   Fixed by giving the build a throwaway writable `HOME` (`mktemp -d`). Linux is unaffected: completions there are generated through the buildFHSEnv wrapper, inside which `/` is a writable tmpfs.

2. **fixupPhase strips the binary, corrupting it.** `dontFixup` was only set on Linux, so on darwin fixupPhase ran `strip -S` on the binary. As the comment in the file already explains, the vercel/pkg virtual filesystem is appended to the executable at fixed byte offsets and must not be modified — the stripped binary fails at runtime with `Pkg: Error reading from file.` Fixed by skipping fixup on all platforms; on Linux this is a no-op (the `.drv` is unchanged, verified by instantiating before and after).

Verification:

- aarch64-darwin: `NIXPKGS_ALLOW_UNFREE=1 nix build --impure` succeeds; `./result/bin/gt --version` prints `1.8.6`; bash/zsh/fish completion files are present and non-empty.
- x86_64-linux: derivation unchanged (no rebuild for Linux users); build passes, `gt --version` works, completions non-empty, `passthru.tests.version` passes.
- The failure mechanisms were also reproduced directly against the upstream 1.8.6 npm artifact: `gt completion` exits 1 with no output under an unwritable `HOME`, and a `strip -S`-ed binary fails with `Pkg: Error reading from file.` The darwin `postInstall` was additionally A/B-tested as a nix derivation (linux binary substituted so it can execute): the current version reproduces the exact `does not exist or has zero size` failure, the fixed version builds with non-empty completions.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy]: prepared with the assistance of an AI tool; I reproduced both failures, reviewed the diff, and verified the build on aarch64-darwin myself.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
