### PR TITLE
r2ghidra: init at 6.1.8

### DIFF
--- a/pkgs/development/tools/analysis/radare2/default.nix
+++ b/pkgs/development/tools/analysis/radare2/default.nix
@@ -25,6 +25,7 @@
   vte,
   xxhash,
   zlib,
+  callPackage,
   useX11 ? false,
   rubyBindings ? false,
   luaBindings ? false,
@@ -138,7 +139,22 @@ stdenv.mkDerivation (finalAttrs: {
   versionCheckProgramArg = "-v";
   doInstallCheck = true;
 
-  passthru.updateScript = ./update.sh;
+  passthru = rec {
+    updateScript = ./update.sh;
+
+    plugins = {
+      r2ghidra = callPackage ./r2ghidra.nix {
+        radare2 = finalAttrs.finalPackage;
+      };
+    };
+
+    withPlugins =
+      filter:
+      callPackage ./wrapper.nix {
+        radare2 = finalAttrs.finalPackage;
+        plugins = filter plugins;
+      };
+  };
 
   meta = {
     description = "UNIX-like reverse engineering framework and command-line toolset";

--- a/pkgs/development/tools/analysis/radare2/r2ghidra.nix
+++ b/pkgs/development/tools/analysis/radare2/r2ghidra.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  python3,
+  radare2,
+  zlib,
+}:
+let
+  ghidra-native-src = fetchFromGitHub {
+    owner = "radareorg";
+    repo = "ghidra-native";
+    tag = "0.6.4";
+    hash = "sha256-DFvHM/erGE9wFjcB3Dlyhv4oebzXwe2yGG+GzLaY7hU=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "r2ghidra";
+  version = "6.1.8";
+
+  src = fetchFromGitHub {
+    owner = "radareorg";
+    repo = "r2ghidra";
+    tag = finalAttrs.version;
+    hash = "sha256-f5iohbAUYG524KJqSvL3PQCFnLQc055Ta02G3CRSO9I=";
+  };
+
+  postUnpack = ''
+    rm -rf $sourceRoot/subprojects/ghidra-native
+    cp -r ${ghidra-native-src} $sourceRoot/subprojects/ghidra-native
+    chmod -R u+w $sourceRoot/subprojects/ghidra-native
+    cp $sourceRoot/subprojects/packagefiles/ghidra-native/meson.build \
+      $sourceRoot/subprojects/ghidra-native/meson.build
+    for p in $sourceRoot/subprojects/packagefiles/ghidra-native/patches/*.patch; do
+      patch -d $sourceRoot/subprojects/ghidra-native -p1 < "$p"
+    done
+    # Shadows libc++'s <version> header when meson adds the subproject root to
+    # the include search path.
+    rm -f $sourceRoot/subprojects/ghidra-native/version
+  '';
+
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace-fail \
+        "res = run_command(['radare2','-HR2_LIBR_PLUGINS'], capture:true, check:false)
+    if res.returncode() == 0
+      r2_plugdir = res.stdout().strip()
+    else
+      prefix = get_option('prefix')
+      r2_plugdir = prefix + '/lib/radare2/plugins'
+    endif" \
+        "r2_plugdir = get_option('prefix') + '/lib/radare2/plugins'"
+  '';
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    python3
+  ];
+
+  buildInputs = [
+    radare2
+    zlib
+  ];
+
+  mesonFlags = [
+    (lib.mesonBool "rxml" true)
+  ];
+
+  meta = {
+    description = "Deep integration of Ghidra decompiler in radare2";
+    homepage = "https://github.com/radareorg/r2ghidra";
+    changelog = "https://github.com/radareorg/r2ghidra/releases/tag/${finalAttrs.version}";
+    license = with lib.licenses; [
+      lgpl3Only
+      asl20 # ghidra-native (decompiler core)
+    ];
+    maintainers = with lib.maintainers; [ theoparis ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/development/tools/analysis/radare2/wrapper.nix
+++ b/pkgs/development/tools/analysis/radare2/wrapper.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  makeWrapper,
+  symlinkJoin,
+  radare2,
+  plugins,
+}:
+symlinkJoin {
+  name = "radare2-with-plugins-${radare2.version}";
+
+  paths = [ radare2 ] ++ plugins;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  passthru = {
+    unwrapped = radare2;
+  };
+
+  postBuild = ''
+    mkdir -p $out/share/radare2-plugins-home/radare2
+    ln -s $out/lib/radare2/plugins $out/share/radare2-plugins-home/radare2/plugins
+
+    wrapperArgs=(--set XDG_DATA_HOME "$out/share/radare2-plugins-home")
+    # r2ghidra looks up its sleigh specs relative to $SLEIGHHOME instead of
+    # scanning dir.plugins/XDG_DATA_HOME like other plugins.
+    if [ -d "$out/lib/radare2/plugins/r2ghidra_sleigh" ]; then
+      wrapperArgs+=(--set SLEIGHHOME "$out/lib/radare2/plugins/r2ghidra_sleigh")
+    fi
+
+    rm $out/bin/*
+    for binary in $(ls ${radare2}/bin); do
+      makeWrapper ${radare2}/bin/$binary $out/bin/$binary "''${wrapperArgs[@]}"
+    done
+  '';
+
+  meta = radare2.meta // {
+    # prefer wrapped over unwrapped
+    priority = (radare2.meta.priority or lib.meta.defaultPriority) - 1;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5346,6 +5346,8 @@ with pkgs;
     // (config.radare or { })
   );
 
+  radarePlugins = recurseIntoAttrs radare2.plugins;
+
   rizinPlugins = recurseIntoAttrs rizin.plugins;
 
   cutterPlugins = recurseIntoAttrs cutter.plugins;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds r2ghidra and updates the radare2 package to support adding plugins similar to rizin. The main motiviation for this PR is because rizin.withPlugins is actually broken on Darwin, and so I've decided to use upstream radare2 since it uses meson and does not have this problem (dyld path errors).

FYI, these two commits were assisted by Claude and may need some minor clean up work, but it does build and run fine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
