### PR TITLE
mediaextract: init at 1.2.1

### DIFF
--- a/pkgs/by-name/me/mediaextract/package.nix
+++ b/pkgs/by-name/me/mediaextract/package.nix
@@ -1,0 +1,58 @@
+{
+  fetchFromGitHub,
+  help2man,
+  lib,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mediaextract";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "panzi";
+    repo = "mediaextract";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-BTCArtei6bDdEHuVqdQBfTJUZxOw63zdPFXFvWGxcl8=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  makeFlags = [
+    "CC=cc"
+    "CXX=C++"
+    "PREFIX=$(out)"
+    "TARGET=nix" # ignore special casing in Makefile since cc-wrapper handles it
+  ];
+
+  # Drop shell-out for TARGET in Makefile
+  patchPhase = ''
+    runHook prePatch
+
+    sed -i '2d' Makefile
+
+    runHook postPatch
+  '';
+
+  configurePhase = ''
+    runHook preConfigure
+
+    make TARGET=nix builddir
+
+    runHook postConfigure
+  '';
+
+  nativeBuildInputs = [
+    help2man
+  ];
+
+  meta = {
+    description = "Extracts media files (AVI, Ogg, Wave, PNG, ...) that are embedded within other files";
+    homepage = "http://panzi.github.io/mediaextract/";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.samasaur ];
+    platforms = lib.platforms.all;
+    mainProgram = "mediaextract";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds [mediaextract](https://github.com/panzi/mediaextract)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
