### PR TITLE
spice: apply upstream patches for gcc 16

### DIFF
--- a/pkgs/by-name/sp/spice/package.nix
+++ b/pkgs/by-name/sp/spice/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   meson,
   ninja,
   pkg-config,
@@ -38,6 +39,22 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./remove-rt-on-darwin.patch
+
+    # C++ does not allow designated initializers to refer to members of
+    # anonymous unions. This fails with GCC 16, and was fixed upstream across
+    # two merge requests but not yet released.
+    # https://gitlab.freedesktop.org/spice/spice/-/merge_requests/246
+    (fetchpatch {
+      name = "spice-test-display-base-initializer-anonymous-union.patch";
+      url = "https://gitlab.freedesktop.org/spice/spice/-/commit/59bc22a40611121b2ea7888bf3c1a501c4fc0b91.patch";
+      hash = "sha256-VQ+DrzmIws3EyZU5c0OqMZwMltUvCW34h5oXuHB8YWs=";
+    })
+    # https://gitlab.freedesktop.org/spice/spice/-/merge_requests/244
+    (fetchpatch {
+      name = "spice-test-gst-initializer-anonymous-union.patch";
+      url = "https://gitlab.freedesktop.org/spice/spice/-/commit/a904cd86430aa555a50730e9389e210637a546c1.patch";
+      hash = "sha256-6GGqi+Y4I/oftE8zXuRnX021+r7SrQPUdAdBsCv9MIw=";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
c++ does not allow designated initializers to refer to members of anonymous unions, and gcc 16 rejects this. this appears in two places in spice, so we pull the upstream patches that fix this but have not yet made it into a release.

(part of submitting some fixes to prepare for making gcc 16 the default later this release cycle: https://github.com/NixOS/nixpkgs/pull/537781)

## Things done

- Built on platform:
  - [x] x86_64-linux (both on this commit and with `default-gcc-version = 16;` in all-packages.nix)
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
