### PR TITLE
spice-vdagent: add patch for gcc 16

### DIFF
--- a/pkgs/by-name/sp/spice-vdagent/package.nix
+++ b/pkgs/by-name/sp/spice-vdagent/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   pkg-config,
   alsa-lib,
   spice-protocol,
@@ -23,9 +24,23 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-Y+D5vVWXxGOKz9bxDXojVPWZvZ31sx5EMnDKzwfhakA=";
   };
 
+  patches = [
+    # gcc 16's unused variable analysis is stronger than previous versions, and
+    # detects an issue. since vdagent is built with -Werror, this causes a
+    # build failure. a merge request was accepted upstream, but until this
+    # makes it into a release, we fetch the patch.
+    # https://gitlab.freedesktop.org/spice/linux/vd_agent/-/merge_requests/60
+    (fetchpatch {
+      name = "gcc16-unused-variable-device-info.patch";
+      url = "https://gitlab.freedesktop.org/spice/linux/vd_agent/-/commit/e3c74bd3e75a3804692da7d526016a823f6273e0.patch";
+      hash = "sha256-Bf1fwvsQuAVzkN6SNXk7YZxRuhhVInAFxnlrRlavgy0=";
+    })
+  ];
+
   postPatch = ''
     substituteInPlace data/spice-vdagent.desktop --replace /usr $out
   '';
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
     alsa-lib
@@ -40,6 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
     dbus
     systemd
   ];
+
   meta = {
     description = "Enhanced SPICE integration for linux QEMU guest";
     longDescription = ''


### PR DESCRIPTION
GCC 16 gains stronger analysis of unused variables than previous versions, and spice-vdagent contains an unused loop variable. We've proposed a fix upstream at https://gitlab.freedesktop.org/spice/linux/vd_agent/-/merge_requests/60, ~~but ignoring the error seems simpler than vendoring a trivial unmerged patch in the interim.~~ and now that it's been accepted, we fetchpatch the change.

(part of submitting some fixes to prepare for making gcc 16 the default later this release cycle: https://github.com/NixOS/nixpkgs/pull/537781)

## Things done

- Built on platform:
  - [x] x86_64-linux (both on this commit and with `default-gcc-version = 16;` in all-packages.nix)
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
