### PR TITLE
nixos/authelia: use lib.types.externalPath

### DIFF
--- a/nixos/modules/services/security/authelia.nix
+++ b/nixos/modules/services/security/authelia.nix
@@ -76,7 +76,7 @@ let
 
               # required
               jwtSecretFile = mkOption {
-                type = types.nullOr types.path;
+                type = types.nullOr types.externalPath;
                 default = null;
                 description = ''
                   Path to your JWT secret used during identity verificaton.
@@ -84,7 +84,7 @@ let
               };
 
               oidcIssuerPrivateKeyFile = mkOption {
-                type = types.nullOr types.path;
+                type = types.nullOr types.externalPath;
                 default = null;
                 description = ''
                   Path to your private key file used to encrypt OIDC JWTs.
@@ -92,7 +92,7 @@ let
               };
 
               oidcHmacSecretFile = mkOption {
-                type = types.nullOr types.path;
+                type = types.nullOr types.externalPath;
                 default = null;
                 description = ''
                   Path to your HMAC secret used to sign OIDC JWTs.
@@ -100,7 +100,7 @@ let
               };
 
               sessionSecretFile = mkOption {
-                type = types.nullOr types.path;
+                type = types.nullOr types.externalPath;
                 default = null;
                 description = ''
                   Path to your session secret. Only used when redis is used as session storage.
@@ -109,7 +109,7 @@ let
 
               # required
               storageEncryptionKeyFile = mkOption {
-                type = types.nullOr types.path;
+                type = types.nullOr types.externalPath;
                 default = null;
                 description = ''
                   Path to your storage encryption key.
@@ -211,7 +211,7 @@ let
                 };
 
                 file_path = mkOption {
-                  type = types.nullOr types.path;
+                  type = types.nullOr types.externalPath;
                   default = null;
                   example = "/var/log/authelia/authelia.log";
                   description = "File path where the logs will be written. If not set logs are written to stdout.";
@@ -464,8 +464,8 @@ in
               message = ''
                 Authelia requires a JWT Secret and a Storage Encryption Key to work.
                 Either set them like so:
-                services.authelia.${name}.secrets.jwtSecretFile = /my/path/to/jwtsecret;
-                services.authelia.${name}.secrets.storageEncryptionKeyFile = /my/path/to/encryptionkey;
+                services.authelia.${name}.secrets.jwtSecretFile = "/my/path/to/jwtsecret";
+                services.authelia.${name}.secrets.storageEncryptionKeyFile = "/my/path/to/encryptionkey";
                 Or set services.authelia.${name}.secrets.manual = true and provide them yourself via
                 environmentVariables or settingsFiles.
                 Do not include raw secrets in nix settings.


### PR DESCRIPTION
Constrain the authelia `secrets.*File` and `settings.log.file_path` options to `lib.types.externalPath`, which only accepts absolute non-store path strings. Passing an unquoted path literal (which silently copies its contents into the Nix store) now fails at evaluation time with a clear type error instead of being accepted.

Closes #538350.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test