### PR TITLE
[Backport release-26.05] vcv-rack: Fix missing translations and segfault

### DIFF
--- a/pkgs/by-name/vc/vcv-rack/fix-segfault-on-linux.patch
+++ b/pkgs/by-name/vc/vcv-rack/fix-segfault-on-linux.patch
@@ -1,0 +1,13 @@
+--- a/src/window/Window.cpp
++++ b/src/window/Window.cpp
+@@ -819,6 +819,10 @@
+ 	glfwInitHint(GLFW_COCOA_MENUBAR, GLFW_FALSE);
+ #endif
+ 
++#if defined ARCH_LIN
++	glfwInitHint(GLFW_PLATFORM, GLFW_PLATFORM_X11);
++#endif
++
+ 	glfwSetErrorCallback(errorCallback);
+ 	err = glfwInit();
+ 	if (err != GLFW_TRUE) {

--- a/pkgs/by-name/vc/vcv-rack/package.nix
+++ b/pkgs/by-name/vc/vcv-rack/package.nix
@@ -170,11 +170,9 @@ stdenv.mkDerivation (finalAttrs: {
     ./rack-minimize-vendoring.patch
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
-    (fetchpatch {
-      name = "fix-segfault-on-linux.patch";
-      url = "https://github.com/VCVRack/Rack/pull/1944.patch";
-      hash = "sha256-dlndyCfCznGDzlWNWrQTgh+FtmsrrL2DVuRE0xCxUck=";
-    })
+    # https://github.com/VCVRack/Rack/pull/1944
+    # https://github.com/VCVRack/Rack/commit/9f0eb9a0da8e9d6f1729f823555fdac2135214f0
+    ./fix-segfault-on-linux.patch
   ];
 
   prePatch = ''

--- a/pkgs/by-name/vc/vcv-rack/package.nix
+++ b/pkgs/by-name/vc/vcv-rack/package.nix
@@ -31,6 +31,7 @@
   stdenv,
   wrapGAppsHook3,
   zstd,
+  versionCheckHook,
 }:
 
 let
@@ -208,6 +209,10 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail \
         "LightButton<VCVBezelBig, VCVBezelLightBig<WhiteLight>>" \
         "struct rack::componentlibrary::LightButton<VCVBezelBig, VCVBezelLightBig<WhiteLight>>"
+
+    # Set RACK_VERSION to avoid git describe, which fails in the Nix build sandbox.
+    substituteInPlace Makefile \
+      --replace-fail 'RACK_VERSION ?= $' 'RACK_VERSION ?= ${finalAttrs.version}#$'
   ''
   + lib.optionalString stdenv.hostPlatform.isLinux ''
     # Fix reference to zenity
@@ -218,7 +223,6 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail '__yield();' 'asm volatile("yield");'
   ''
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    # * Set VERSION from finalAttrs to avoid build using git to determine version
     # * Darwin needs to build the dist target, which builds the .app container,
     #   yet we want to exclude the documentation from dist target.
     # * Skip stripping the binary to avoid "unsupported load command" error, which
@@ -226,7 +230,6 @@ stdenv.mkDerivation (finalAttrs: {
     # * Replace path to Fundamental module with path to produced build artifact
     #   to avoid downloading a pre-compiled version
     substituteInPlace Makefile \
-      --replace-fail 'VERSION ?= $' 'VERSION ?= ${finalAttrs.version}#$' \
       --replace-fail 'DIST_HTML :=' '#DIST_HTML :=' \
       --replace-fail '$(STRIP)' '#$(STRIP)' \
       --replace-fail 'FUNDAMENTAL_FILENAME := Fundamental' 'FUNDAMENTAL_FILENAME := plugins/Fundamental/dist/Fundamental'
@@ -347,6 +350,9 @@ stdenv.mkDerivation (finalAttrs: {
         $out/bin/${finalAttrs.meta.mainProgram} \
         --add-flags "-s $out/Applications/'VCV Rack ${lib.versions.major finalAttrs.version} Free.app'/Contents/Resources"
     '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "Open-source virtual modular synthesizer";

--- a/pkgs/by-name/vc/vcv-rack/package.nix
+++ b/pkgs/by-name/vc/vcv-rack/package.nix
@@ -306,7 +306,7 @@ stdenv.mkDerivation (finalAttrs: {
     install -D -m755 -t $out/lib libRack.so
 
     mkdir -p $out/share/vcv-rack
-    cp -r res cacert.pem Core.json template.vcv LICENSE-GPLv3.txt $out/share/vcv-rack
+    cp -r res translations cacert.pem Core.json template.vcv LICENSE-GPLv3.txt $out/share/vcv-rack
     cp -r plugins/Fundamental/dist/Fundamental-*.vcvplugin $out/share/vcv-rack/Fundamental.vcvplugin
 
     # Extract pngs from the Apple icon image and create


### PR DESCRIPTION
Backports important vcv-rack fixes from #522317 and #536656. It doesn't work as-is.

Supersedes: #538572
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
