### PR TITLE
pacman: 7.1.0 -> 7.1.0-unstable-2026-01-25

### DIFF
--- a/pkgs/by-name/pa/pacman/package.nix
+++ b/pkgs/by-name/pa/pacman/package.nix
@@ -44,14 +44,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pacman";
-  version = "7.1.0";
+  version = "7.1.0-unstable-2026-01-25";
 
   src = fetchFromGitLab {
     domain = "gitlab.archlinux.org";
     owner = "pacman";
     repo = "pacman";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-bGg2ZrIsEYJYZCLsIh4FZROhpyLSBO0Lar1mSoz66wI=";
+    rev = "cb7452f63414291b52061166ab2ebf1083897917";
+    hash = "sha256-ocynGQ1oIeaQgLlCTCrxq/ihxziDMqrIPKAJThvV7SE=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
Bumping pacman to the latest commit of release/7.1.x branch for unreleased fixes to issues, e.g. https://gitlab.archlinux.org/pacman/pacman/-/work_items/289

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
