### PR TITLE
gfxstream: work around `ld64` hardening issue

### DIFF
--- a/pkgs/by-name/gf/gfxstream/package.nix
+++ b/pkgs/by-name/gf/gfxstream/package.nix
@@ -13,6 +13,8 @@
   vulkan-headers,
   vulkan-loader,
   libx11,
+  # TODO: Clean up on `staging`.
+  llvmPackages,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -41,6 +43,10 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
     pkg-config
     python3
+  ]
+  # TODO: Clean up on `staging`.
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    llvmPackages.lld
   ];
   buildInputs = [
     aemu
@@ -60,6 +66,8 @@ stdenv.mkDerivation (finalAttrs: {
       "-framework QuartzCore"
       "-needed-lvulkan"
     ];
+    # TODO: Clean up on `staging`.
+    NIX_CFLAGS_LINK = "-fuse-ld=lld";
   };
 
   # dlopens libvulkan.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://hydra.nixos.org/build/334131448/nixlog/4

Copied the fix from https://github.com/NixOS/nixpkgs/commit/7a83e820ddc2dd54a2ff6038ffe5a2f7a4005fb8.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
