### PR TITLE
nixos/nfsd: allow exports to be an attrset

### DIFF
--- a/nixos/modules/services/network-filesystems/nfsd.nix
+++ b/nixos/modules/services/network-filesystems/nfsd.nix
@@ -6,6 +6,14 @@
 }:
 let
 
+  attrsToExports = lib.concatMapAttrsStringSep "\n" (
+    exportPoint: clientsAndOptions:
+    exportPoint
+    + lib.concatMapAttrsStringSep "" (
+      client: options: " ${client}(${lib.concatStringsSep "," options})"
+    ) clientsAndOptions
+  );
+
   cfg = config.services.nfs.server;
 
   exports = pkgs.writeText "exports" cfg.exports;
@@ -48,12 +56,26 @@ in
         };
 
         exports = lib.mkOption {
-          type = lib.types.lines;
+          type = with lib.types; coercedTo (attrsOf (attrsOf (listOf str))) attrsToExports lines;
           default = "";
           description = ''
             Contents of the /etc/exports file.  See
             {manpage}`exports(5)` for the format.
           '';
+          example = {
+            "/usr" = {
+              "*.local.domain" = [ "ro" ];
+              "@trusted" = [ "rw" ];
+            };
+            "/home/joe" = {
+              "pc001" = [
+                "rw"
+                "all_squash"
+                "anonuid=150"
+                "anongid=100"
+              ];
+            };
+          };
         };
 
         hostName = lib.mkOption {

--- a/nixos/tests/nfs/kerberos.nix
+++ b/nixos/tests/nfs/kerberos.nix
@@ -83,9 +83,16 @@ import ../make-test-python.nix (
 
           services.nfs.server.enable = true;
           services.nfs.server.createMountPoints = true;
-          services.nfs.server.exports = ''
-            /data *(rw,no_root_squash,fsid=0,sec=krb5p)
-          '';
+          services.nfs.server.exports = {
+            "/data" = {
+              "*" = [
+                "rw"
+                "no_root_squash"
+                "fsid=0"
+                "sec=krb5p"
+              ];
+            };
+          };
         };
     };
 

--- a/nixos/tests/nfs/simple.nix
+++ b/nixos/tests/nfs/simple.nix
@@ -37,9 +37,16 @@ import ../make-test-python.nix (
         { ... }:
         {
           services.nfs.server.enable = true;
-          services.nfs.server.exports = ''
-            /data 192.168.1.0/255.255.255.0(rw,no_root_squash,no_subtree_check,fsid=0)
-          '';
+          services.nfs.server.exports = {
+            "/data" = {
+              "192.168.1.0/255.255.255.0" = [
+                "rw"
+                "no_root_squash"
+                "no_subtree_check"
+                "fsid=0"
+              ];
+            };
+          };
           services.nfs.server.createMountPoints = true;
           networking.firewall.enable = false; # FIXME: figure out what ports need to be allowed
         };


### PR DESCRIPTION
This is in the spirit of RFC 42.

The attrset format currently doesn't allow specifying default options using `-`. Should I include that functionality?

cc @24apricots
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
