### PR TITLE
xdp-tools: strip debug info from test binaries

### DIFF
--- a/pkgs/by-name/xd/xdp-tools/package.nix
+++ b/pkgs/by-name/xd/xdp-tools/package.nix
@@ -92,6 +92,12 @@ stdenv.mkDerivation (finalAttrs: {
     nuke-refs "$lib"/lib/bpf/*.o
   '';
 
+  stripDebugList = [
+    "bin"
+    "lib"
+    "share/xdp-tools"
+  ];
+
   meta = {
     homepage = "https://github.com/xdp-project/xdp-tools";
     description = "Library and utilities for use with XDP";


### PR DESCRIPTION
The test-tool and libxdp test binaries under `share/xdp-tools/` are outside the default `stripDebugList`, so they keep their `DWARF .debug_str`, which embeds the `gcc` include path and drags the full gcc compiler into the runtime closure.
```
9d8
< /nix/store/521dd0054ifhzmjfmpx9mz0hr7wh7sig-glibc-2.42-67-bin                              2.8 MiB        38.7 MiB
28,32d26
< /nix/store/5d1js1h2bb2h6fhnlsak0hn3vcbp1mwz-xdp-tools-1.6.3-lib                          363.2 KiB        70.4 MiB
< /nix/store/zkw0hl5pzwkmrvkrfvr1q5zlk28nv9v2-gmp-6.3.0                                    722.5 KiB        36.7 MiB
< /nix/store/9zgdw228zjfd4jzr901qzxhfcf43kz91-isl-0.20                                       2.5 MiB        39.2 MiB
< /nix/store/wzigz21rnv9nj8g7r8ai8ldm84zqnhda-mpfr-4.2.2                                   803.3 KiB        37.5 MiB
< /nix/store/c0i98bjjwf0lcmrh97123qayrzchxz3d-libmpc-1.4.0                                 301.5 KiB        37.8 MiB
33a28
> /nix/store/521dd0054ifhzmjfmpx9mz0hr7wh7sig-glibc-2.42-67-bin                              2.8 MiB        38.7 MiB
35c30
< /nix/store/sq0nrnfwhkc5ljvklnrk5ps4358g4nbj-gcc-15.2.0                                   264.1 MiB       326.6 MiB
---
> /nix/store/wx731vjxrdgx3sqhbh313hkkcq8878i9-xdp-tools-1.6.3-lib                          363.2 KiB        70.4 MiB
37c32
< /nix/store/gi89c82l0bf7fw3ki2sn2j618p2rzhhg-xdp-tools-1.6.3                                3.0 MiB       358.0 MiB
---
> /nix/store/1rdlmhqsn0cajknl5ny32zxyylszpcdx-xdp-tools-1.6.3                                2.3 MiB        88.9 MiB
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
