### PR TITLE
silicate: init at 1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11502,12 +11502,6 @@
     githubId = 12761234;
     name = "Ida Bzowska";
   };
-  idlip = {
-    name = "Dilip";
-    email = "igoldlip@gmail.com";
-    github = "idlip";
-    githubId = 117019901;
-  };
   idontgetoutmuch = {
     email = "dominic@steinitz.org";
     github = "idontgetoutmuch";
@@ -22756,6 +22750,12 @@
     github = "purcell";
     githubId = 5636;
     name = "Steve Purcell";
+  };
+  pure-sagacity = {
+    name = "Maaz Khokhar";
+    email = "khokharmaaz@gmail.com";
+    github = "pure-sagacity";
+    githubId = 74312880;
   };
   purpole = {
     email = "mail@purpole.io";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11502,6 +11502,12 @@
     githubId = 12761234;
     name = "Ida Bzowska";
   };
+  idlip = {
+    name = "Dilip";
+    email = "igoldlip@gmail.com";
+    github = "idlip";
+    githubId = 117019901;
+  };
   idontgetoutmuch = {
     email = "dominic@steinitz.org";
     github = "idontgetoutmuch";

--- a/pkgs/tools/security/silicate/default.nix
+++ b/pkgs/tools/security/silicate/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "silicate";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "pure-sagacity";
+    repo = "silicate";
+    rev = "v${version}";
+    hash = "sha256-mtP+W1DYWrzf29HqjsgWECcdxRf6zGtXVvyeyqLhl9E=";
+  };
+
+  cargoHash = "sha256-vqmhA/z+aUiSjbmVbpHoCP8T6YQCL+z8Vcix2eq3LIQ=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ];
+
+  meta = with lib; {
+    description = "Simple password manager built for speed";
+    homepage = "https://silicate.maariz.org";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ pure-sagacity ];
+    mainProgram = "silicate";
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5376,6 +5376,8 @@ with pkgs;
   sbt-with-scala-native = callPackage ../development/tools/build-managers/sbt/scala-native.nix { };
   simpleBuildTool = sbt;
 
+  silicate = callPackage ../tools/security/silicate { };
+
   shake =
     # TODO: Erroneous references to GHC on aarch64-darwin: https://github.com/NixOS/nixpkgs/issues/318013
     (


### PR DESCRIPTION
<!--
Silicate is an open source simplistic file-based password manager, written in Rust. Its website is available at (https://silicate.maariz.org)[https://silicate.maariz.org] and its github is at (https://github.com/pure-sagacity/silicate)[https://github.com/pure-sagacity/silicate].

^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
