### PR TITLE
rnsapi: init at 0-unstable-2026-07-06

### DIFF
--- a/pkgs/by-name/rn/rnsapi/package.nix
+++ b/pkgs/by-name/rn/rnsapi/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "rnsapi";
+  version = "0-unstable-2026-07-06";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "attermann";
+    repo = "ReticulumAPI";
+    rev = "9dc2a562c7e8695fb08c5204a403052a19af03d2";
+    hash = "sha256-8WsQyJtxkXVaObBHQCQ2VrqJUApSyePL1IVUoTE4XPk=";
+  };
+
+  build-system = [
+    python3Packages.setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    aiohttp
+    cryptography
+    rns
+  ];
+
+  __darwinAllowLocalNetworking = true;
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+    pytest-aiohttp
+    pytest-asyncio
+    pytest-timeout
+  ];
+
+  pythonImportsCheck = [
+    "rnsapi"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "REST + WebSocket API daemon that exposes the full Reticulum Network Stack (RNS) service over HTTP(S) and WS(S)";
+    homepage = "https://github.com/attermann/ReticulumAPI";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ drupol ];
+    mainProgram = "reticulum-api";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
