### PR TITLE
treewide: follow some GitHub redirects for `fetchFromGitHub`

### DIFF
--- a/pkgs/by-name/go/go-callvis/package.nix
+++ b/pkgs/by-name/go/go-callvis/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "0.7.1";
 
   src = fetchFromGitHub {
-    owner = "ofabry";
+    owner = "ondrajz";
     repo = "go-callvis";
     rev = "v${finalAttrs.version}";
     hash = "sha256-gCQjxJH03QAg6MZx5NJUJR6tKP02ThIa5BGN6A/0ejM=";
@@ -29,7 +29,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Visualize call graph of a Go program using Graphviz";
     mainProgram = "go-callvis";
-    homepage = "https://github.com/ofabry/go-callvis";
+    homepage = "https://github.com/ondrajz/go-callvis";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ meain ];
   };

--- a/pkgs/by-name/go/gogcli/package.nix
+++ b/pkgs/by-name/go/gogcli/package.nix
@@ -10,7 +10,7 @@ buildGoModule (finalAttrs: {
   version = "0.29.0";
 
   src = fetchFromGitHub {
-    owner = "steipete";
+    owner = "openclaw";
     repo = "gogcli";
     tag = "v${finalAttrs.version}";
     hash = "sha256-JunPpEzbNp00uEiJ7AzouXyzFwyNLehLU7mwL3eh4bM=";
@@ -36,7 +36,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "CLI tool for interacting with Google APIs (Gmail, Calendar, Drive, and more)";
-    homepage = "https://github.com/steipete/gogcli";
+    homepage = "https://github.com/openclaw/gogcli";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ macalinao ];
     mainProgram = "gog";

--- a/pkgs/by-name/go/gomi/package.nix
+++ b/pkgs/by-name/go/gomi/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "1.6.2";
 
   src = fetchFromGitHub {
-    owner = "b4b4r07";
+    owner = "babarot";
     repo = "gomi";
     tag = "v${finalAttrs.version}";
     hash = "sha256-Ino7jUd9JvX6afvS6ouPHxU42GYfF696m+OS5CSvx5g=";
@@ -40,7 +40,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Replacement for UNIX rm command";
-    homepage = "https://github.com/b4b4r07/gomi";
+    homepage = "https://github.com/babarot/gomi";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       mimame

--- a/pkgs/by-name/go/gomuks/package.nix
+++ b/pkgs/by-name/go/gomuks/package.nix
@@ -16,7 +16,7 @@ buildGoModule rec {
   version = "0.3.1";
 
   src = fetchFromGitHub {
-    owner = "tulir";
+    owner = "gomuks";
     repo = "gomuks";
     rev = "v${version}";
     sha256 = "sha256-bDJXo8d9K5UO599HDaABpfwc9/dJJy+9d24KMVZHyvI=";

--- a/pkgs/by-name/go/goose-cli/package.nix
+++ b/pkgs/by-name/go/goose-cli/package.nix
@@ -51,7 +51,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "1.28.0";
 
   src = fetchFromGitHub {
-    owner = "block";
+    owner = "aaif-goose";
     repo = "goose";
     tag = "v${finalAttrs.version}";
     hash = "sha256-/1TtsnNiLoTkvyeFR282qSpo+Jt3pvFxduJ7lyzsTXI=";
@@ -181,7 +181,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Open-source, extensible AI agent that goes beyond code suggestions - install, execute, edit, and test with any LLM";
-    homepage = "https://github.com/block/goose";
+    homepage = "https://github.com/aaif-goose/goose";
     mainProgram = "goose";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/go/gore/package.nix
+++ b/pkgs/by-name/go/gore/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "0.6.2";
 
   src = fetchFromGitHub {
-    owner = "motemen";
+    owner = "x-motemen";
     repo = "gore";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-niMYoYkDaZsv6ntUIfB0B4VheiG6rMouZGUSjHnm51w=";
@@ -22,7 +22,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Yet another Go REPL that works nicely";
     mainProgram = "gore";
-    homepage = "https://github.com/motemen/gore";
+    homepage = "https://github.com/x-motemen/gore";
     license = lib.licenses.mit;
     maintainers = [ ];
   };

--- a/pkgs/by-name/go/goreplay/package.nix
+++ b/pkgs/by-name/go/goreplay/package.nix
@@ -11,16 +11,16 @@ buildGoModule (finalAttrs: {
   version = "1.3.3";
 
   src = fetchFromGitHub {
-    owner = "buger";
+    owner = "probelabs";
     repo = "goreplay";
     rev = finalAttrs.version;
     sha256 = "sha256-FiY9e5FgpPu+K8eoO8TsU3xSaSoPPDxYEu0oi/S8Q1w=";
   };
 
   patches = [
-    # Fix build on arm64-linux, see https://github.com/buger/goreplay/pull/1140
+    # Fix build on arm64-linux, see https://github.com/probelabs/goreplay/pull/1140
     (fetchpatch {
-      url = "https://github.com/buger/goreplay/commit/a01afa1e322ef06f36995abc3fda3297bdaf0140.patch";
+      url = "https://github.com/probelabs/goreplay/commit/a01afa1e322ef06f36995abc3fda3297bdaf0140.patch";
       sha256 = "sha256-w3aVe/Fucwd2OuK5Fu2jJTbmMci8ilWaIjYjsWuLRlo=";
     })
   ];
@@ -37,7 +37,7 @@ buildGoModule (finalAttrs: {
   doCheck = false;
 
   meta = {
-    homepage = "https://github.com/buger/goreplay";
+    homepage = "https://github.com/probelabs/goreplay";
     license = lib.licenses.lgpl3Only;
     description = "Open-source tool for capturing and replaying live HTTP traffic";
     maintainers = [ ];

--- a/pkgs/by-name/go/goshs/package.nix
+++ b/pkgs/by-name/go/goshs/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
   version = "2.1.3";
 
   src = fetchFromGitHub {
-    owner = "patrickhener";
+    owner = "goshs-labs";
     repo = "goshs";
     tag = "v${finalAttrs.version}";
     hash = "sha256-bAYnwOg7CHZOKHl8pCC2IDdCkUGsw0A3e47gSuGwuig=";
@@ -43,7 +43,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Simple, yet feature-rich web server written in Go";
     homepage = "https://goshs.de";
-    changelog = "https://github.com/patrickhener/goshs/releases/tag/${finalAttrs.src.rev}";
+    changelog = "https://github.com/goshs-labs/goshs/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       fab

--- a/pkgs/by-name/gq/gqlgenc/package.nix
+++ b/pkgs/by-name/gq/gqlgenc/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
   version = "0.32.1";
 
   src = fetchFromGitHub {
-    owner = "yamashou";
+    owner = "gqlgo";
     repo = "gqlgenc";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-AGbE+R3502Igl4/HaN8yvFVJBsKQ6iVff8IEvddJLEo=";
@@ -20,7 +20,7 @@ buildGoModule (finalAttrs: {
   patches = [
     (fetchpatch2 {
       name = "fix-version.patch";
-      url = "https://github.com/Yamashou/gqlgenc/commit/aad0599a70780696a9530a7adffebfff53538695.patch?full_index=1";
+      url = "https://github.com/gqlgo/gqlgenc/commit/aad0599a70780696a9530a7adffebfff53538695.patch?full_index=1";
       hash = "sha256-moidhkkO/5It8kH1VlwbV+YLlMOTXKH3RyLKGCA2chw=";
     })
   ];
@@ -45,7 +45,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Go tool for building GraphQL client with gqlgen";
     mainProgram = "gqlgenc";
-    homepage = "https://github.com/Yamashou/gqlgenc";
+    homepage = "https://github.com/gqlgo/gqlgenc";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ wattmto ];
   };

--- a/pkgs/by-name/gr/grizzly/package.nix
+++ b/pkgs/by-name/gr/grizzly/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "0.7.1";
 
   src = fetchFromGitHub {
-    owner = "grafana";
+    owner = "grafana-cold-storage";
     repo = "grizzly";
     rev = "v${finalAttrs.version}";
     hash = "sha256-1caG2QIBfbCgg9TLsW4XB0w+4dqUkQEsdWwRazbWeQA=";

--- a/pkgs/by-name/gv/gvolicon/package.nix
+++ b/pkgs/by-name/gv/gvolicon/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   version = "0-unstable-2014-04-28";
 
   src = fetchFromGitHub {
-    owner = "Unia";
+    owner = "Hjdskes";
     repo = "gvolicon";
     rev = "0d65a396ba11f519d5785c37fec3e9a816217a07";
     sha256 = "sha256-lm5OfryV1/1T1RgsVDdp0Jg5rh8AND8M3ighfrznKes=";
@@ -42,7 +42,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Simple and lightweight volume icon that sits in your system tray";
-    homepage = "https://github.com/Unia/gvolicon";
+    homepage = "https://github.com/Hjdskes/gvolicon";
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl3Plus;
     maintainers = [ lib.maintainers.bennofs ];

--- a/pkgs/by-name/ha/hackertyper/package.nix
+++ b/pkgs/by-name/ha/hackertyper/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
   version = "2.1";
 
   src = fetchFromGitHub {
-    owner = "Hurricane996";
+    owner = "hyasynthesized";
     repo = "Hackertyper";
     rev = "8d08e3200c65817bd8c5bd0baa5032919315853b";
     sha256 = "0shri0srihw9fk027k61qkxr9ikwkn28aaamrhps6lg0vpbqpx2w";
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "C rewrite of hackertyper.net";
-    homepage = "https://github.com/Hurricane996/Hackertyper";
+    homepage = "https://github.com/hyasynthesized/Hackertyper";
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.marius851000 ];
     mainProgram = "hackertyper";

--- a/pkgs/by-name/he/helio-workstation/package.nix
+++ b/pkgs/by-name/he/helio-workstation/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "helio-fm";
-    repo = "helio-workstation";
+    repo = "helio-sequencer";
     tag = finalAttrs.version;
     fetchSubmodules = true;
     hash = "sha256-uEo4dxwc1HksYGU5ssYp3rLugszSir2kKo4XxgqvSno=";

--- a/pkgs/by-name/hp/hpx/package.nix
+++ b/pkgs/by-name/hp/hpx/package.nix
@@ -16,14 +16,14 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.11.0";
 
   src = fetchFromGitHub {
-    owner = "STEllAR-GROUP";
+    owner = "TheHPXProject";
     repo = "hpx";
     rev = "v${finalAttrs.version}";
     hash = "sha256-AhByaw1KnEDuRfKiN+/vQMbkG0BJ6Z3+h+QT8scFzAY=";
   };
 
   patches = [
-    # https://github.com/STEllAR-GROUP/hpx/pull/6731
+    # https://github.com/TheHPXProject/hpx/pull/6731
     # Fix build with asio >= 1.34.0
     ./remove_deprecated_asio_features.patch
   ];
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "C++ standard library for concurrency and parallelism";
-    homepage = "https://github.com/STEllAR-GROUP/hpx";
+    homepage = "https://github.com/TheHPXProject/hpx";
     license = lib.licenses.boost;
     platforms = [ "x86_64-linux" ]; # lib.platforms.linux;
     maintainers = with lib.maintainers; [ bobakker ];

--- a/pkgs/by-name/hs/hstr/package.nix
+++ b/pkgs/by-name/hs/hstr/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.2";
 
   src = fetchFromGitHub {
-    owner = "dvorka";
+    owner = "dvorka-oss";
     repo = "hstr";
     tag = "v${finalAttrs.version}";
     hash = "sha256-c+YUpry96OGJ7nmBw180W2r0z4EBd2Cl3SyOQrNxP+o=";
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
   configureFlags = [ "--prefix=$(out)" ];
 
   meta = {
-    homepage = "https://github.com/dvorka/hstr";
+    homepage = "https://github.com/dvorka-oss/hstr";
     description = "Shell history suggest box - easily view, navigate, search and use your command history";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.matthiasbeyer ];

--- a/pkgs/by-name/hu/hub/package.nix
+++ b/pkgs/by-name/hu/hub/package.nix
@@ -16,7 +16,7 @@ buildGoModule (finalAttrs: {
   version = "unstable-2022-12-01";
 
   src = fetchFromGitHub {
-    owner = "github";
+    owner = "mislav";
     repo = "hub";
     rev = "38bcd4ae469e5f53f01901340b715c7658ab417a";
     hash = "sha256-V2GvwKj0m2UXxE42G23OHXyAsTrVRNw1p5CAaJxGYog=";
@@ -24,15 +24,15 @@ buildGoModule (finalAttrs: {
 
   patches = [
     # Fix `fish` completions
-    # https://github.com/github/hub/pull/3036
+    # https://github.com/mislav/hub/pull/3036
     (fetchpatch {
-      url = "https://github.com/github/hub/commit/439b7699e79471fc789929bcdea2f30bd719963e.patch";
+      url = "https://github.com/mislav/hub/commit/439b7699e79471fc789929bcdea2f30bd719963e.patch";
       hash = "sha256-pR/OkGa2ICR4n1pLNx8E2UTtLeDwFtXxeeTB94KFjC4=";
     })
     # Fix `bash` completions
-    # https://github.com/github/hub/pull/2948
+    # https://github.com/mislav/hub/pull/2948
     (fetchpatch {
-      url = "https://github.com/github/hub/commit/64b291006f208fc7db1d5be96ff7db5535f1d853.patch";
+      url = "https://github.com/mislav/hub/commit/64b291006f208fc7db1d5be96ff7db5535f1d853.patch";
       hash = "sha256-jGFFIvSKEIpTQY0Wz63cqciUk25MzPHv5Z1ox8l7wmo=";
     })
   ];

--- a/pkgs/by-name/hy/hyperssh/package.nix
+++ b/pkgs/by-name/hy/hyperssh/package.nix
@@ -17,16 +17,16 @@ buildNpmPackage {
   dontNpmBuild = true;
 
   src = fetchFromGitHub {
-    owner = "mafintosh";
+    owner = "holepunchto";
     repo = "hyperssh";
     rev = "v5.0.3";
     hash = "sha256-vjPSNcQRsqu0ee0hownEE9y8dFf9dqaL7alGRc9WjcI=";
   };
 
   patches = [
-    # TODO: remove after this is merged: https://github.com/mafintosh/hyperssh/pull/16
+    # TODO: remove after this is merged: https://github.com/holepunchto/hyperssh/pull/16
     (fetchurl {
-      url = "https://github.com/mafintosh/hyperssh/commit/ad1d0e06a133e71c9df9f59dd5f805c49f46ec70.patch";
+      url = "https://github.com/holepunchto/hyperssh/commit/ad1d0e06a133e71c9df9f59dd5f805c49f46ec70.patch";
       hash = "sha256-fUjgHHbZHgqokNg2fVVZCjoDA3LqSJiFzBwgA8Tt1m4=";
     })
   ];
@@ -50,7 +50,7 @@ buildNpmPackage {
 
   meta = {
     description = "Run SSH over hyperswarm";
-    homepage = "https://github.com/mafintosh/hyperssh";
+    homepage = "https://github.com/holepunchto/hyperssh";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ davhau ];
     mainProgram = "hyperssh";

--- a/pkgs/by-name/i3/i3ipc-glib/package.nix
+++ b/pkgs/by-name/i3/i3ipc-glib/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.0.1";
 
   src = fetchFromGitHub {
-    owner = "acrisci";
+    owner = "altdesktop";
     repo = "i3ipc-glib";
     tag = "v${finalAttrs.version}";
     hash = "sha256-F9Tiwc/gB7BFWr/qerS4n/+k/nUvJsH7Bp2zb1fe3wU=";
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "C interface library to i3wm";
-    homepage = "https://github.com/acrisci/i3ipc-glib";
+    homepage = "https://github.com/altdesktop/i3ipc-glib";
     maintainers = with lib.maintainers; [ teto ];
     license = lib.licenses.gpl3;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/ia/iannix/package.nix
+++ b/pkgs/by-name/ia/iannix/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   version = "unstable-2020-12-09";
 
   src = fetchFromGitHub {
-    owner = "iannix";
+    owner = "buzzinglight";
     repo = "IanniX";
     rev = "287b51d9b90b3e16ae206c0c4292599619f7b159";
     sha256 = "AhoP+Ok78Vk8Aee/RP572hJeM8O7v2ZTvFalOZZqRy8=";

--- a/pkgs/by-name/ik/ikill/package.nix
+++ b/pkgs/by-name/ik/ikill/package.nix
@@ -9,7 +9,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "1.6.0";
 
   src = fetchFromGitHub {
-    owner = "pjmp";
+    owner = "pombadev";
     repo = "ikill";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-hOQBBwxkVnTkAZJi84qArwAo54fMC0zS+IeYMV04kUs=";
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Interactively kill running processes";
-    homepage = "https://github.com/pjmp/ikill";
+    homepage = "https://github.com/pombadev/ikill";
     maintainers = with lib.maintainers; [ zendo ];
     license = [ lib.licenses.mit ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/il/illum/package.nix
+++ b/pkgs/by-name/il/illum/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.5";
 
   src = fetchFromGitHub {
-    owner = "jmesmon";
+    owner = "codyps";
     repo = "illum";
     tag = "v${finalAttrs.version}";
     sha256 = "S4lUBeRnZlRUpIxFdN/bh979xvdS7roF6/6Dk0ZUrnM=";
@@ -24,8 +24,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     (fetchpatch {
-      name = "prevent-unplug-segfault"; # See https://github.com/jmesmon/illum/issues/19
-      url = "https://github.com/jmesmon/illum/commit/47b7cd60ee892379e5d854f79db343a54ae5a3cc.patch";
+      name = "prevent-unplug-segfault"; # See https://github.com/codyps/illum/issues/19
+      url = "https://github.com/codyps/illum/commit/47b7cd60ee892379e5d854f79db343a54ae5a3cc.patch";
       sha256 = "sha256-hIBBCIJXAt8wnZuyKye1RiEfOCelP3+4kcGrM43vFOE=";
     })
   ];
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    homepage = "https://github.com/jmesmon/illum";
+    homepage = "https://github.com/codyps/illum";
     description = "Daemon that wires button presses to screen backlight level";
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.dancek ];

--- a/pkgs/by-name/in/inriafonts/package.nix
+++ b/pkgs/by-name/in/inriafonts/package.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation rec {
   version = "1.200";
 
   src = fetchFromGitHub {
-    owner = "BlackFoundry";
+    owner = "BlackFoundryCom";
     repo = "InriaFonts";
     rev = "v${version}";
     hash = "sha256-CMKkwGuUEVYavnFi15FCk7Xloyk97w+LhAZ6mpIv5xg=";

--- a/pkgs/by-name/io/io/package.nix
+++ b/pkgs/by-name/io/io/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation {
   version = "2019.05.22-alpha";
 
   src = fetchFromGitHub {
-    owner = "stevedekorte";
+    owner = "IoLanguage";
     repo = "io";
     tag = "2019.05.22-alpha";
     fetchSubmodules = true;

--- a/pkgs/by-name/ip/ip2location-c/package.nix
+++ b/pkgs/by-name/ip/ip2location-c/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "8.7.0";
 
   src = fetchFromGitHub {
-    owner = "chrislim2888";
+    owner = "ip2location";
     repo = "IP2Location-C-Library";
     rev = finalAttrs.version;
     sha256 = "sha256-kp0tNZPP9u2xxFOmBAdivsVLtyF66o38H6eRrs2/S/Y=";

--- a/pkgs/by-name/ir/ircdog/package.nix
+++ b/pkgs/by-name/ir/ircdog/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "0.5.5";
 
   src = fetchFromGitHub {
-    owner = "goshuirc";
+    owner = "ergochat";
     repo = "ircdog";
     tag = "v${finalAttrs.version}";
     hash = "sha256-maF53Z0FHAhGmnOnMsX0dDnmckPNBY4Bcm4OBM/x4hQ=";

--- a/pkgs/by-name/is/isso/package.nix
+++ b/pkgs/by-name/is/isso/package.nix
@@ -14,7 +14,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   format = "setuptools";
 
   src = fetchFromGitHub {
-    owner = "posativ";
+    owner = "isso-comments";
     repo = "isso";
     tag = finalAttrs.version;
     hash = "sha256-8kXqqiMXxF0wCJ+AzYT8j0rjuhlXO3F6UJbump672b4=";
@@ -31,7 +31,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   ];
 
   postPatch = ''
-    # Remove when https://github.com/posativ/isso/pull/973 is available.
+    # Remove when https://github.com/isso-comments/isso/pull/973 is available.
     substituteInPlace isso/tests/test_comments.py \
       --replace "self.client.delete_cookie('localhost.local', '1')" "self.client.delete_cookie(key='1', domain='localhost')"
   '';

--- a/pkgs/by-name/jc/jcal/package.nix
+++ b/pkgs/by-name/jc/jcal/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.5.1";
 
   src = fetchFromGitHub {
-    owner = "fzerorubigd";
+    owner = "persiancal";
     repo = "jcal";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-vJc5uijZlvohEtiS03LYlqtswVE38S9/ejlHrmZ0wqA=";

--- a/pkgs/by-name/jf/jfmt/package.nix
+++ b/pkgs/by-name/jf/jfmt/package.nix
@@ -9,7 +9,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "1.2.1";
 
   src = fetchFromGitHub {
-    owner = "scruffystuffs";
+    owner = "skilly-lily";
     repo = "jfmt.rs";
     rev = "v${finalAttrs.version}";
     hash = "sha256-X3wk669G07BTPAT5xGbAfIu2Qk90aaJIi1CLmOnSG80=";
@@ -20,8 +20,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "CLI utility to format json files";
     mainProgram = "jfmt";
-    homepage = "https://github.com/scruffystuffs/jfmt.rs";
-    changelog = "https://github.com/scruffystuffs/jfmt.rs/blob/${finalAttrs.version}/CHANGELOG.md";
+    homepage = "https://github.com/skilly-lily/jfmt.rs";
+    changelog = "https://github.com/skilly-lily/jfmt.rs/blob/${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.psibi ];
   };

--- a/pkgs/by-name/jg/jgmenu/package.nix
+++ b/pkgs/by-name/jg/jgmenu/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "4.5.0";
 
   src = fetchFromGitHub {
-    owner = "johanmalm";
+    owner = "jgmenu";
     repo = "jgmenu";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-vuSpiZZYe0l5va9dHM54gaoI9x8qXH1gJORUS5489jQ=";
@@ -66,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 
   meta = {
-    homepage = "https://github.com/johanmalm/jgmenu";
+    homepage = "https://github.com/jgmenu/jgmenu";
     description = "Small X11 menu intended to be used with openbox and tint2";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/jr/jrsonnet/package.nix
+++ b/pkgs/by-name/jr/jrsonnet/package.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.5.0-pre98";
 
   src = fetchFromGitHub {
-    owner = "CertainLach";
+    owner = "deltarocks";
     repo = "jrsonnet";
     tag = "v${finalAttrs.version}";
     hash = "sha256-2dNzxZnvnw8TsKnnIlHGpuixrqe4z0a4faOBPv2N+ws=";
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Purely-functional configuration language that helps you define JSON data";
-    homepage = "https://github.com/CertainLach/jrsonnet";
+    homepage = "https://github.com/deltarocks/jrsonnet";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       lach

--- a/pkgs/by-name/js/jsubfinder/package.nix
+++ b/pkgs/by-name/js/jsubfinder/package.nix
@@ -9,7 +9,7 @@ buildGoModule {
   version = "0-unstable-2022-05-31";
 
   src = fetchFromGitHub {
-    owner = "ThreatUnkown";
+    owner = "ThreatUnknown";
     repo = "jsubfinder";
     rev = "e21de1ebc174bb69485f1c224e8063c77d87e4ad";
     hash = "sha256-QjRYJyk0uFGa6FCCYK9SIJhoyam4ALsQJ26DsmbNk8s=";
@@ -20,7 +20,7 @@ buildGoModule {
   meta = {
     description = "Tool to search for in Javascript hidden subdomains and secrets";
     mainProgram = "jsubfinder";
-    homepage = "https://github.com/ThreatUnkown/jsubfinder";
+    homepage = "https://github.com/ThreatUnknown/jsubfinder";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/by-name/ka/kaniko/package.nix
+++ b/pkgs/by-name/ka/kaniko/package.nix
@@ -14,7 +14,7 @@ buildGoModule (finalAttrs: {
   version = "1.25.15";
 
   src = fetchFromGitHub {
-    owner = "chainguard-dev";
+    owner = "chainguard-forks";
     repo = "kaniko";
     rev = "v${finalAttrs.version}";
     hash = "sha256-0d0QdNmR7FaybJJEq6bb9WshTg6dX3HtO9oESg1e4S4=";
@@ -52,7 +52,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Tool to build container images from a Dockerfile, inside a container or Kubernetes cluster";
-    homepage = "https://github.com/chainguard-dev/kaniko";
+    homepage = "https://github.com/chainguard-forks/kaniko";
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/kb/kbdlight/package.nix
+++ b/pkgs/by-name/kb/kbdlight/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.3";
 
   src = fetchFromGitHub {
-    owner = "hobarrera";
+    owner = "WhyNotHugo";
     repo = "kbdlight";
     rev = "v${finalAttrs.version}";
     sha256 = "1f08aid1xrbl4sb5447gkip9lnvkia1c4ap0v8zih5s9w8v72bny";
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    homepage = "https://github.com/hobarrera/kbdlight";
+    homepage = "https://github.com/WhyNotHugo/kbdlight";
     description = "Very simple application that changes MacBooks' keyboard backlight level";
     mainProgram = "kbdlight";
     license = lib.licenses.isc;

--- a/pkgs/by-name/ke/keybinder/package.nix
+++ b/pkgs/by-name/ke/keybinder/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.3.1";
 
   src = fetchFromGitHub {
-    owner = "engla";
+    owner = "kupferlauncher";
     repo = "keybinder";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-elL6DZtzCwAtoyGZYP0jAma6tHPks2KAtrziWtBENGU=";
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
       * Gobject-Introspection (gir)  generated bindings
       * Lua bindings, ``lua-keybinder``
     '';
-    homepage = "https://github.com/engla/keybinder/";
+    homepage = "https://github.com/kupferlauncher/keybinder/";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.bjornfor ];

--- a/pkgs/by-name/ke/keycard-cli/package.nix
+++ b/pkgs/by-name/ke/keycard-cli/package.nix
@@ -12,7 +12,7 @@ buildGoModule (finalAttrs: {
   version = "0.8.2";
 
   src = fetchFromGitHub {
-    owner = "status-im";
+    owner = "keycard-tech";
     repo = "keycard-cli";
     rev = finalAttrs.version;
     hash = "sha256-H9fipHGxINMAXdxUYhyVZusDXA3HW1iQl8iRX6AF7iE=";

--- a/pkgs/by-name/ke/keychain/package.nix
+++ b/pkgs/by-name/ke/keychain/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.9.8";
 
   src = fetchFromGitHub {
-    owner = "funtoo";
+    owner = "danielrobbins";
     repo = "keychain";
     rev = finalAttrs.version;
     sha256 = "sha256-xk3ooFhBkgv93Po5oC4TZRmMhJJXDv7yekoE102FQd8=";

--- a/pkgs/by-name/kj/kjv/package.nix
+++ b/pkgs/by-name/kj/kjv/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
   version = "unstable-2021-03-11";
 
   src = fetchFromGitHub {
-    owner = "bontibon";
+    owner = "layeh";
     repo = "kjv";
     rev = "108595dcbb9bb12d40e0309f029b6fb3ccd81309";
     hash = "sha256-Z6myd9Xn23pYizG+IZVDrP988pYU06QIcpqXtWTcPiw=";
@@ -42,7 +42,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Bible, King James Version";
-    homepage = "https://github.com/bontibon/kjv";
+    homepage = "https://github.com/layeh/kjv";
     license = lib.licenses.unlicense;
     maintainers = with lib.maintainers; [
       jtobin

--- a/pkgs/by-name/ko/koodousfinder/package.nix
+++ b/pkgs/by-name/ko/koodousfinder/package.nix
@@ -10,9 +10,9 @@ python3.pkgs.buildPythonApplication {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "teixeira0xfffff";
+    owner = "HuntDownProject";
     repo = "KoodousFinder";
-    # Not properly tagged, https://github.com/teixeira0xfffff/KoodousFinder/issues/7
+    # Not properly tagged, https://github.com/HuntDownProject/KoodousFinder/issues/7
     #tag = "v${version}";
     rev = "d9dab5572f44e5cd45c04e6fcda38956897855d1";
     hash = "sha256-skCbt2lDKgSyZdHY3WImbr6CF0icrDPTIXNV1736gKk=";
@@ -34,7 +34,7 @@ python3.pkgs.buildPythonApplication {
 
   meta = {
     description = "Tool to allows users to search for and analyze Android apps";
-    homepage = "https://github.com/teixeira0xfffff/KoodousFinder";
+    homepage = "https://github.com/HuntDownProject/KoodousFinder";
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/by-name/kr/krillinai/package.nix
+++ b/pkgs/by-name/kr/krillinai/package.nix
@@ -20,7 +20,7 @@ buildGoModule (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "krillinai";
-    repo = "KlicStudio";
+    repo = "KrillinAI";
     tag = "v${finalAttrs.version}";
     hash = "sha256-k1p9v3MQklycW2FsDCyEWNwjLFSymxx1qVg5qhC8xgI=";
   };
@@ -51,8 +51,8 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Video translation and dubbing tool";
-    homepage = "https://github.com/krillinai/KlicStudio";
-    changelog = "https://github.com/krillinai/KlicStudio/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/krillinai/KrillinAI";
+    changelog = "https://github.com/krillinai/KrillinAI/releases/tag/v${finalAttrs.version}";
     mainProgram = "krillinai-desktop";
     license = lib.licenses.gpl3Plus;
     maintainers = [ ];

--- a/pkgs/by-name/kr/kristall/package.nix
+++ b/pkgs/by-name/kr/kristall/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   version = "0.4";
 
   src = fetchFromGitHub {
-    owner = "MasterQ32";
+    owner = "ikskuh";
     repo = "kristall";
     rev = "V${version}";
     hash = "sha256-zTO55xTc7hXlqVUVlx921+LalKj/yQwjEgXW2YUdG70=";

--- a/pkgs/by-name/ku/kubeseal/package.nix
+++ b/pkgs/by-name/ku/kubeseal/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "0.36.0";
 
   src = fetchFromGitHub {
-    owner = "bitnami-labs";
+    owner = "bitnami";
     repo = "sealed-secrets";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-r+PjrHewqNIjj1ZYGEvAns4cSsg7mQXoR8/et6SJzhs=";
@@ -28,8 +28,8 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Kubernetes controller and tool for one-way encrypted Secrets";
     mainProgram = "kubeseal";
-    homepage = "https://github.com/bitnami-labs/sealed-secrets";
-    changelog = "https://github.com/bitnami-labs/sealed-secrets/blob/v${finalAttrs.version}/RELEASE-NOTES.md";
+    homepage = "https://github.com/bitnami/sealed-secrets";
+    changelog = "https://github.com/bitnami/sealed-secrets/blob/v${finalAttrs.version}/RELEASE-NOTES.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ groodt ];
   };

--- a/pkgs/by-name/ku/kubie/package.nix
+++ b/pkgs/by-name/ku/kubie/package.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   src = fetchFromGitHub {
     rev = "v${finalAttrs.version}";
-    owner = "sbstp";
+    owner = "kubie-org";
     repo = "kubie";
     sha256 = "sha256-eSzNCH0MiGvLKHrSXFSXQq4lN5tfmr0NcuGaN96Invs=";
   };
@@ -41,7 +41,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Shell independent context and namespace switcher for kubectl";
     mainProgram = "kubie";
-    homepage = "https://github.com/sbstp/kubie";
+    homepage = "https://github.com/kubie-org/kubie";
     license = with lib.licenses; [ zlib ];
     maintainers = with lib.maintainers; [ illiusdope ];
   };

--- a/pkgs/by-name/le/ledmon/package.nix
+++ b/pkgs/by-name/le/ledmon/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.92";
 
   src = fetchFromGitHub {
-    owner = "intel";
+    owner = "md-raid-utilities";
     repo = "ledmon";
     rev = "v${finalAttrs.version}";
     sha256 = "1lz59606vf2sws5xwijxyffm8kxcf8p9qbdpczsq1b5mm3dk6lvp";
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
-    homepage = "https://github.com/intel/ledmon";
+    homepage = "https://github.com/md-raid-utilities/ledmon";
     description = "Enclosure LED Utilities";
     platforms = lib.platforms.linux;
     license = with lib.licenses; [ gpl2Only ];

--- a/pkgs/by-name/le/legendary-gl/package.nix
+++ b/pkgs/by-name/le/legendary-gl/package.nix
@@ -11,7 +11,7 @@ python3Packages.buildPythonApplication {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "derrod";
+    owner = "legendary-gl";
     repo = "legendary";
     rev = "56d439ed2d3d9f34e2b08fa23e627c23a487b8d6";
     hash = "sha256-yCHeeEGw+9gtRMGyIhbStxJhmSM/1Fqly7HSRDkZILQ=";
@@ -35,7 +35,7 @@ python3Packages.buildPythonApplication {
 
   meta = {
     description = "Free and open-source Epic Games Launcher alternative";
-    homepage = "https://github.com/derrod/legendary";
+    homepage = "https://github.com/legendary-gl/legendary";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ equirosa ];
     mainProgram = "legendary";

--- a/pkgs/by-name/le/lemminx/package.nix
+++ b/pkgs/by-name/le/lemminx/package.nix
@@ -29,7 +29,7 @@ maven.buildMavenPackage rec {
   version = "0.31.2";
 
   src = fetchFromGitHub {
-    owner = "eclipse";
+    owner = "eclipse-lemminx";
     repo = "lemminx";
     tag = version;
     hash = "sha256-nV+IXeGEnJ7q2GEH9LKiy8ABePHSIt8GFPj/sZzv71E=";
@@ -126,7 +126,7 @@ maven.buildMavenPackage rec {
   meta = {
     description = "XML Language Server";
     mainProgram = "lemminx";
-    homepage = "https://github.com/eclipse/lemminx";
+    homepage = "https://github.com/eclipse-lemminx/lemminx";
     license = lib.licenses.epl20;
     maintainers = with lib.maintainers; [ tricktron ];
   };

--- a/pkgs/development/python-modules/hassil/default.nix
+++ b/pkgs/development/python-modules/hassil/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "home-assistant";
+    owner = "OHF-Voice";
     repo = "hassil";
     tag = "v${version}";
     hash = "sha256-C3nx8w0y4RsHq9txwdSfgS9BMcY4TyZiBOq4QIq5w+0=";
@@ -44,10 +44,10 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    changelog = "https://github.com/home-assistant/hassil/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/OHF-Voice/hassil/blob/${src.tag}/CHANGELOG.md";
     description = "Intent parsing for Home Assistant";
     mainProgram = "hassil";
-    homepage = "https://github.com/home-assistant/hassil";
+    homepage = "https://github.com/OHF-Voice/hassil";
     license = lib.licenses.asl20;
     teams = [ lib.teams.home-assistant ];
   };

--- a/pkgs/development/python-modules/hocr-tools/default.nix
+++ b/pkgs/development/python-modules/hocr-tools/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
   format = "setuptools";
 
   src = fetchFromGitHub {
-    owner = "tmbdev";
+    owner = "ocropus";
     repo = "hocr-tools";
     rev = "v${version}";
     sha256 = "14f9hkp7pr677085w8iidwd0la9cjzy3pyj3rdg9b03nz9pc0w6p";
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Tools for manipulating and evaluating the hOCR format for representing multi-lingual OCR results by embedding them into HTML";
-    homepage = "https://github.com/tmbdev/hocr-tools";
+    homepage = "https://github.com/ocropus/hocr-tools";
     license = lib.licenses.asl20;
     maintainers = [ ];
   };

--- a/pkgs/development/python-modules/httpie/default.nix
+++ b/pkgs/development/python-modules/httpie/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "httpie";
-    repo = "httpie";
+    repo = "cli";
     tag = version;
     hash = "sha256-uZKkUUrPPnLHPHL8YrZgfsyCsSOR0oZ2eFytiV0PIUY=";
   };
@@ -125,7 +125,7 @@ buildPythonPackage rec {
   meta = {
     description = "Command line HTTP client whose goal is to make CLI human-friendly";
     homepage = "https://httpie.org/";
-    changelog = "https://github.com/httpie/httpie/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/httpie/cli/blob/${version}/CHANGELOG.md";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
       antono

--- a/pkgs/development/python-modules/iocextract/default.nix
+++ b/pkgs/development/python-modules/iocextract/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "InQuest";
-    repo = "python-iocextract";
+    repo = "iocextract";
     tag = "v${version}";
     hash = "sha256-cCp9ug/TuVY1zL+kiDlFGBmfFJyAmVwxLD36WT0oRAE=";
   };
@@ -38,8 +38,8 @@ buildPythonPackage rec {
   meta = {
     description = "Module to extract Indicator of Compromises (IOC)";
     mainProgram = "iocextract";
-    homepage = "https://github.com/InQuest/python-iocextract";
-    changelog = "https://github.com/InQuest/python-iocextract/releases/tag/v${version}";
+    homepage = "https://github.com/InQuest/iocextract";
+    changelog = "https://github.com/InQuest/iocextract/releases/tag/v${version}";
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/servers/klipper/default.nix
+++ b/pkgs/servers/klipper/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   version = "0.13.0-unstable-2026-05-09";
 
   src = fetchFromGitHub {
-    owner = "KevinOConnor";
+    owner = "Klipper3d";
     repo = "klipper";
     rev = "4767a8ed97c57e4bb2ecf60fd72e345f58dfa3fc";
     sha256 = "sha256-ZwPy1Et0ftCX8haogRSOUm1et2pvYZxvdsuM74acu6Q=";
@@ -144,7 +144,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Klipper 3D printer firmware";
     mainProgram = "klippy";
-    homepage = "https://github.com/KevinOConnor/klipper";
+    homepage = "https://github.com/Klipper3d/klipper";
     maintainers = with lib.maintainers; [
       lovesegfault
       zhaofengli


### PR DESCRIPTION
This PR updates some `fetchFromGitHub` calls and corresponding `github.com/<owner>/<repo>` links in the same location to point directly to canonical repositories instead of redirecting URLs.

This doesn't update all `fetchFromGitHub` redirects since that would produce a diff too large for maintainers to review.

**Motivation:**
This avoids silent failures if upstream redirects ever change or disappear, and improves reliability and reproducibility of fetches.

**How:**
Changes were generated using [this script](https://git.kybe.xyz/2kybe3/nixpkgs-github-redirect).

**How to verify:**
You can verify that all modified package sources still build using the following script with a `changed.txt` file containing the changed package list.

<details>
  <summary>Verify script</summary>

```bash
#!/usr/bin/env bash

out="result.txt"
: > "$out"

while read -r pkg; do
    echo "=== $pkg ==="

    output=$(nix build "./nixpkgs#$pkg.src" -L -v --rebuild --no-link --print-out-paths)
    status=$?

    if [ $status -eq 0 ]; then
        echo "$pkg: success | $output" | tee -a "$out"
    else
        echo "$pkg: failed" | tee -a "$out"
    fi
done < ./changed.txt
```
</details>

<details>
  <summary>Changed Packages</summary>

```
go-callvis
gomi
gomuks
gogcli
goose-cli
goreplay
gore
goshs
gqlgenc
grizzly
gvolicon
hackertyper
hassil
helio-workstation
hpx
hocr-tools
hstr
httpie
hub
hyperssh
i3ipc-glib
iannix
ikill
illum
io
inriafonts
iocextract
ip2location-c
ircdog
isso
jcal
jfmt
jgmenu
jrsonnet
jsubfinder
kaniko
kbdlight
keybinder
keychain
keycard-cli
kjv
klipper
koodousfinder
krillinai
kristall
kubeseal
kubie
ledmon
lemminx
legendary-gl
```
</details>

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
