### PR TITLE
dnsdist: reduce closure size

### DIFF
--- a/pkgs/by-name/dn/dnsdist/package.nix
+++ b/pkgs/by-name/dn/dnsdist/package.nix
@@ -22,6 +22,7 @@
   systemd,
   xdp-tools,
   zlib,
+  removeReferencesTo,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -33,6 +34,13 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-WGgPeAUXt4fmT+5M1NzFf0Ob5gcIT4nuRpl4nX1iaHU=";
   };
 
+  # Avoid embedding /nix/store paths
+  postConfigure = ''
+    sed -i -E \
+      '/PKG_CONFIG_PATH=/ s#/nix/store/[0-9a-z]{32}-#/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-#g' \
+      config.h
+  '';
+
   nativeBuildInputs = [
     cargo
     pkg-config
@@ -40,6 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     python3
     python3.pkgs.pyyaml
     rustPlatform.cargoSetupHook
+    removeReferencesTo
   ];
 
   buildInputs = [
@@ -88,6 +97,10 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = true;
 
   enableParallelBuilding = true;
+
+  postFixup = ''
+    remove-references-to -t ${boost.dev} $out/bin/dnsdist
+  '';
 
   passthru.tests = nixosTests.dnsdist;
 


### PR DESCRIPTION
Before
```
/nix/store/4j907z7ck0k4j4kc77ma8jykdcmi90fj-dnsdist-2.0.7                               18.4 MiB       878.8 MiB
➜ dnsdist --version
dnsdist 2.0.7 (Lua 5.2.4)
Enabled features: AF_XDP dns-over-tls(openssl) dns-over-https(nghttp2) dnscrypt ebpf fstrm ipcipher libedit libsodium protobuf re2 recvmmsg/sendmmsg snmp systemd yaml
Configured with: " '--disable-static' '--prefix=/nix/store/4j907z7ck0k4j4kc77ma8jykdcmi90fj-dnsdist-2.0.7' '--with-libsodium' '--with-re2' '--enable-dnscrypt' '--enable-dnstap' '--enable-dns-over-tls' '--enable-dns-over-https' '--enable-yaml' '--with-ebpf' '--with-xsk' '--with-libcap' '--with-protobuf=yes' '--with-net-snmp' '--disable-dependency-tracking' '--enable-unit-tests' '--enable-systemd' '--with-boost=/nix/store/rg5ccs6ysavd7zxhasp36ij14arzaxzc-boost-1.89.0-dev' 'CC=gcc' 'CXX=g++' 'PKG_CONFIG=pkg-config' 'PKG_CONFIG_PATH=/nix/store/86h5zqwyw8gw7yn4lc1k6jqmfay74869-protobuf-34.1/lib/pkgconfig:/nix/store/wf1i19pf92vxrgiyxmjcaz1sfq587vqj-abseil-cpp-20260107.1-dev/lib/pkgconfig:/nix/store/l9k0anq0z7zz81zcwy035jfwap9ga6rl-python3-3.13.13/lib/pkgconfig:/nix/store/rg5ccs6ysavd7zxhasp36ij14arzaxzc-boost-1.89.0-dev/lib/pkgconfig:/nix/store/vb44rjy072c3gdcbidpqna2bbq4mc1nw-fstrm-0.6.1-dev/lib/pkgconfig:/nix/store/b2f0cn980wsjfh2l1hczga2mlai0djnp-libbpf-1.7.0/lib/pkgconfig:/nix/store/jnd7zknc1lli92b2hr768spa1127h5vy-libcap-2.77-dev/lib/pkgconfig:/nix/store/4g8336bf2smjllsxh4jkj1pap9g90pr3-libedit-20251016-3.1-dev/lib/pkgconfig:/nix/store/4p2xg4f1b5pzabl3hpdnr2sisv74g3nk-ncurses-6.6-dev/lib/pkgconfig:/nix/store/cil2vgf2zq49v7w9zbipm1a99kflg0yq-libsodium-1.0.22-unstable-2026-04-09-dev/lib/pkgconfig:/nix/store/wkpwmi3wr10v4zcbcfrj72k3f6vifvyh-lua-5.2.4/lib/pkgconfig:/nix/store/7mnqhbq8sy5a0lpsi6rx6w26wkzlawlm-net-snmp-5.9.5.2-dev/lib/pkgconfig:/nix/store/4xp8hvv4wwxylhpik0i10l9bz6a74jaz-nghttp2-1.69.0-dev/lib/pkgconfig:/nix/store/i0jqva96qfgc76g8w7jbyiv6h3si07b9-openssl-3.6.2-dev/lib/pkgconfig:/nix/store/ri4xg81dhbf0hiw60rjbsq50aj4d7xqd-re2-2025-11-05-dev/lib/pkgconfig:/nix/store/4frdj7794qnfzk7vjawqyq3d5jx6iyav-icu4c-76.1-dev/lib/pkgconfig:/nix/store/kyi2963z20g7wc4axpsv50zdz2ypg5fx-systemd-260.2-dev/lib/pkgconfig:/nix/store/kyi2963z20g7wc4axpsv50zdz2ypg5fx-systemd-260.2-dev/share/pkgconfig:/nix/store/gi89c82l0bf7fw3ki2sn2j618p2rzhhg-xdp-tools-1.6.3/lib/pkgconfig:/nix/store/a9psmsc93llkravrd50rrv8k3dwdw60x-zlib-1.3.2-dev/share/pkgconfig'"
```

After
```
/nix/store/dja45f666p0lk26pg3jimkkq8h1dgrfd-dnsdist-2.0.7                               18.4 MiB       252.5 MiB
➜ dnsdist --version
dnsdist 2.0.7 (Lua 5.2.4)
Enabled features: AF_XDP dns-over-tls(openssl) dns-over-https(nghttp2) dnscrypt ebpf fstrm ipcipher libedit libsodium protobuf re2 recvmmsg/sendmmsg snmp systemd yaml
Configured with: " '--disable-static' '--prefix=/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-dnsdist-2.0.7' '--with-libsodium' '--with-re2' '--enable-dnscrypt' '--enable-dnstap' '--enable-dns-over-tls' '--enable-dns-over-https' '--enable-yaml' '--with-ebpf' '--with-xsk' '--with-libcap' '--with-protobuf=yes' '--with-net-snmp' '--disable-dependency-tracking' '--enable-unit-tests' '--enable-systemd' '--with-boost=/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-boost-1.89.0-dev' 'CC=gcc' 'CXX=g++' 'PKG_CONFIG=pkg-config' 'PKG_CONFIG_PATH=/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-protobuf-34.1/lib/pkgconfig:/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-abseil-cpp-20260107.1-dev/lib/pkgconfig:/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-python3-3.13.13/lib/pkgconfig:/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-boost-1.89.0-dev/lib/pkgconfig:/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-fstrm-0.6.1-dev/lib/pkgconfig:/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-libbpf-1.7.0/lib/pkgconfig:/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-libcap-2.77-dev/lib/pkgconfig:/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-libedit-20251016-3.1-dev/lib/pkgconfig:/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-ncurses-6.6-dev/lib/pkgconfig:/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-libsodium-1.0.22-unstable-2026-04-09-dev/lib/pkgconfig:/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-lua-5.2.4/lib/pkgconfig:/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-net-snmp-5.9.5.2-dev/lib/pkgconfig:/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-nghttp2-1.69.0-dev/lib/pkgconfig:/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-openssl-3.6.2-dev/lib/pkgconfig:/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-re2-2025-11-05-dev/lib/pkgconfig:/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-icu4c-76.1-dev/lib/pkgconfig:/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-systemd-260.2-dev/lib/pkgconfig:/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-systemd-260.2-dev/share/pkgconfig:/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-xdp-tools-1.6.3/lib/pkgconfig:/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-zlib-1.3.2-dev/share/pkgconfig'"
```




<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
