### PR TITLE
stalwart_0_16: use ThinLTO and 16 codegen units on aarch64

### DIFF
--- a/pkgs/by-name/st/stalwart_0_16/package.nix
+++ b/pkgs/by-name/st/stalwart_0_16/package.nix
@@ -77,7 +77,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
       (stdenv.hostPlatform.isLinux && (stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isArmv7))
       {
         JEMALLOC_SYS_WITH_LG_PAGE = 16;
-      };
+      }
+  // lib.optionalAttrs stdenv.hostPlatform.isAarch64 {
+    CARGO_PROFILE_RELEASE_LTO = "thin";
+    CARGO_PROFILE_RELEASE_CODEGEN_UNITS = "16";
+  };
 
   depsBuildBuild = [
     pkg-config


### PR DESCRIPTION
Hydra aarch64 builders time out compiling the stalwart server with the upstream cargo release profile (fat LTO + codegen-units = 1). Switch to ThinLTO and 16 codegen units on aarch64 to retain most of the release optimization while making the final link step tractable for the builder.

If ThinLTO still misses Hydra's 2h30 timeout, the follow-up is either `CARGO_PROFILE_RELEASE_LTO = "false"` or a `meta.timeout` bump.