### PR TITLE
subcat: 1.4.0-unstable-2025-05-13 -> 1.6.0-unstable-2026-06-28

### DIFF
--- a/pkgs/by-name/su/subcat/package.nix
+++ b/pkgs/by-name/su/subcat/package.nix
@@ -6,21 +6,26 @@
 
 python3.pkgs.buildPythonApplication {
   pname = "subcat";
-  version = "1.4.0-unstable-2025-05-13";
+  version = "1.6.0-unstable-2026-06-28";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "duty1g";
     repo = "subcat";
-    rev = "1b3d015b064f244bfbc05114e4d30ab17861fb46";
-    hash = "sha256-Jft+3ZM9+luvRwO/pL3iTYkz+322TQ/HTD38MttJjQU=";
+    # https://github.com/duty1g/subcat/issues/10
+    rev = "19535a896f60573a234d5b266d08cc6e78d8a525";
+    hash = "sha256-E6gK5CHuFyu3GPyofHErlu92RAgl6jBPfWbTTX3aNtA=";
   };
 
   build-system = with python3.pkgs; [ setuptools ];
 
   dependencies = with python3.pkgs; [
+    aiohttp
+    dnspython
+    playwright
     pyyaml
     requests
+    rich
     urllib3
   ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
