### PR TITLE
whale: init at 0.1.62

### DIFF
--- a/pkgs/by-name/wh/whale/package.nix
+++ b/pkgs/by-name/wh/whale/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  gitMinimal,
+  nix-update-script,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "whale";
+  version = "0.1.62";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "usewhale";
+    repo = "Whale";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-EvuNdgpW5M+i33tGLurQDq0z+Ht/z5agIsaWWapXqpY=";
+  };
+
+  vendorHash = "sha256-YBY5b2SLcWeiCQDZELJdsi+mJ+YEuo+yTbotUlLgqEA=";
+
+  nativeCheckInputs = [
+    gitMinimal
+    writableTmpDirAsHomeHook
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  ldflags = [
+    "-s"
+    "-X=github.com/usewhale/whale/internal/build.Version=${finalAttrs.version}"
+  ];
+
+  excludedPackages = [ "cmd/dev" ];
+
+  checkFlags = [
+    # Fails in the sandbox
+    "-skip=TestRulePolicyMCPPathOutsideWorkspaceRequiresExternalDirectoryApproval"
+  ];
+
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Terminal-first AI coding agent for DeepSeek";
+    homepage = "https://github.com/usewhale/Whale";
+    changelog = "https://github.com/usewhale/Whale/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "whale";
+  };
+})


### PR DESCRIPTION
Terminal-first AI coding agent for DeepSeek

https://github.com/usewhale/Whale


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
