### PR TITLE
open-policy-agent: add gid-commit as maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9919,6 +9919,12 @@
     githubId = 67570424;
     name = "gibbert";
   };
+  gid-commit = {
+    name = "Gid van der Ven";
+    email = "ggv@veo.co";
+    github = "gid-commit";
+    githubId = 152498859;
+  };
   gigahawk = {
     email = "Jasper Chan";
     name = "jasperchan515@gmail.com";

--- a/pkgs/by-name/op/open-policy-agent/package.nix
+++ b/pkgs/by-name/op/open-policy-agent/package.nix
@@ -131,6 +131,7 @@ buildGoModule (finalAttrs: {
     maintainers = with lib.maintainers; [
       lewo
       jk
+      gid-commit
     ];
   };
 })


### PR DESCRIPTION
## Description of changes

Adds myself (`gid-commit`) to the maintainer list and as a maintainer of `open-policy-agent`.

I intend to help keep `open-policy-agent` up to date (e.g. the pending update in #525348) and to handle its automated version bumps going forward.

## Things done

- Added entry to `maintainers/maintainer-list.nix` (validated with `nix-build lib/tests/maintainers.nix`).
- Added `gid-commit` to `meta.maintainers` of `open-policy-agent`.

- Built on platform(s)
  - [x] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).