### PR TITLE
prometheus: 3.12.0 → 3.13.0

### DIFF
--- a/pkgs/by-name/pr/prometheus/package.nix
+++ b/pkgs/by-name/pr/prometheus/package.nix
@@ -3,7 +3,10 @@
   lib,
   go,
   buildGoModule,
-  buildNpmPackage,
+  nodejs,
+  pnpmConfigHook,
+  pnpm_11,
+  fetchPnpmDeps,
   fetchFromGitHub,
   nixosTests,
   enableAWS ? true,
@@ -47,18 +50,29 @@ let
     hash = source.hash;
   };
 
-  assets = buildNpmPackage {
+  assets = stdenv.mkDerivation (finalAssetsAttrs: {
     pname = "${pname}-assets";
     inherit version;
 
     src = "${src}/web/ui";
 
-    npmDepsHash = source.npmDepsHash;
-
     patches = [
       # Disable old React app as it depends on deprecated create-react-apps
       # script
       ./disable-react-app.diff
+    ];
+
+    pnpmDeps = fetchPnpmDeps {
+      inherit (finalAssetsAttrs) pname version src;
+      pnpm = pnpm_11;
+      fetcherVersion = 4;
+      hash = source.pnpmDepsHash;
+    };
+
+    nativeBuildInputs = [
+      nodejs
+      pnpmConfigHook
+      pnpm_11
     ];
 
     env.CI = true;
@@ -69,20 +83,29 @@ let
     checkPhase = ''
       runHook preCheck
 
-      npm test
+      pnpm test
 
       runHook postCheck
     '';
 
-    postInstall = ''
+    buildPhase = ''
+      runHook preBuild
+
+      pnpm build
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
       mkdir -p $out/static
-      cp -r $out/lib/node_modules/prometheus-io/static/* $out/static
+      cp -r static/* $out/static
       find $out/static -type f -exec gzip -f9 {} \;
 
-      # Remove node_modules
-      rm -rf $out/lib
+      runHook postInstall
     '';
-  };
+  });
 in
 buildGoModule (finalAttrs: {
   inherit
@@ -209,6 +232,7 @@ buildGoModule (finalAttrs: {
   doInstallCheck = true;
 
   passthru = {
+    inherit assets;
     tests = { inherit (nixosTests) prometheus; };
     updateScript = ./update.sh;
   };

--- a/pkgs/by-name/pr/prometheus/source.nix
+++ b/pkgs/by-name/pr/prometheus/source.nix
@@ -1,6 +1,6 @@
 {
-  version = "3.12.0";
-  hash = "sha256-xeENUVmG9tbIF+7i2u9zuvo7RXI9iNWFVDNUfNpF6/4=";
-  npmDepsHash = "sha256-cHMI5DqSRpIanrgk/H3aFUHLrGXH1v796PH1qDrCnbE=";
-  vendorHash = "sha256-caSI9uzbH93j06sJus9jSqo6qHKbP8D9DuDkiAlnfF4=";
+  version = "3.13.0";
+  hash = "sha256-v6jk4MqoxcfK+yj+T31Ovqj1tyh3mc4aEr8BD0vjBOc=";
+  pnpmDepsHash = "sha256-Z1TYYZhELi+rIiuleN8xR/WiMn9TF4KotFMTOsR2e6Y=";
+  vendorHash = "sha256-yvzQHfe7yd6Sjh1Vd2VxTp3jK8OWoKTmJ2uMyXX3+xs=";
 }

--- a/pkgs/by-name/pr/prometheus/update.sh
+++ b/pkgs/by-name/pr/prometheus/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p nix coreutils curl jq nix-prefetch-git prefetch-npm-deps
+#!nix-shell -i bash -p nix coreutils curl jq nix-prefetch-git
 
 set -euo pipefail
 
@@ -22,10 +22,12 @@ if [[ "$UPDATE_NIX_OLD_VERSION" == "$TARGET_VERSION" ]]; then
     exit 0
 fi
 
-extractVendorHash() {
-    original="${1?original hash missing}"
-    result="$(nix-build -A prometheus.goModules 2>&1 | tail -n3 | grep 'got:' | cut -d: -f2- | xargs echo || true)"
-    [ -z "$result" ] && { echo "$original"; } || { echo "$result"; }
+FAKE_HASH="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+extractHash() {
+    attr="${1?attr missing}"
+    result="$(nix-build -A "$attr" 2>&1 | tail -n3 | grep 'got:' | cut -d: -f2- | xargs echo || true)"
+    [ -z "$result" ] && { echo "$FAKE_HASH"; } || { echo "$result"; }
 }
 
 TMP=$(mktemp -d)
@@ -37,28 +39,24 @@ SOURCE_NIX="$NIXPKGS_PROMETHEUS_PATH/source.nix"
 PREFETCH_JSON=$TMP/prefetch.json
 nix-prefetch-git --rev "$TARGET_TAG" --url "https://github.com/$OWNER/$REPO" > "$PREFETCH_JSON"
 PREFETCH_HASH="$(jq '.hash' -r < "$PREFETCH_JSON")"
-PREFETCH_PATH="$(jq '.path' -r < "$PREFETCH_JSON")"
-NPM_DEPS_HASH="$(prefetch-npm-deps "$PREFETCH_PATH/web/ui/package-lock.json")"
-
-FAKE_HASH="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
 
 cat > "$SOURCE_NIX" <<-EOF
 {
   version = "$TARGET_VERSION";
   hash = "$PREFETCH_HASH";
-  npmDepsHash = "$NPM_DEPS_HASH";
+  pnpmDepsHash = "$FAKE_HASH";
   vendorHash = "$FAKE_HASH";
 }
 EOF
 
-GO_HASH="$(nix-instantiate --eval -A prometheus.vendorHash | tr -d '"')"
-VENDOR_HASH=$(extractVendorHash "$GO_HASH")
+VENDOR_HASH=$(extractHash prometheus.goModules)
+PNPM_DEPS_HASH=$(extractHash prometheus.assets.pnpmDeps)
 
 cat > "$SOURCE_NIX" <<-EOF
 {
   version = "$TARGET_VERSION";
   hash = "$PREFETCH_HASH";
-  npmDepsHash = "$NPM_DEPS_HASH";
+  pnpmDepsHash = "$PNPM_DEPS_HASH";
   vendorHash = "$VENDOR_HASH";
 }
 EOF


### PR DESCRIPTION
* https://github.com/prometheus/prometheus/releases/tag/v3.13.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
