### PR TITLE
mdfried: add pdf support, 0.22.2 -> 0.22.4

### DIFF
--- a/pkgs/by-name/md/mdfried/package.nix
+++ b/pkgs/by-name/md/mdfried/package.nix
@@ -18,16 +18,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "mdfried";
-  version = "0.22.2";
+  version = "0.22.4";
 
   src = fetchFromGitHub {
     owner = "benjajaja";
     repo = "mdfried";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-HRtuqnD6erRC1Xx+3NSbaFgqRHzurj1xbOJNGykGIpU=";
+    hash = "sha256-Zcn1C8mXwljJ3HtYgYBPyU9cVHvoNBUn7qjqx45wMhE=";
   };
 
-  cargoHash = "sha256-jnByeBBL13DavExG2pVN7vNRr+UXGkxRY0a4MkwzRe0=";
+  cargoHash = "sha256-Nt+oBl2HX/H/7j62VjaHrY29gpd2vouevBJO0W3AYAk=";
 
   buildFeatures = [ "pdf" ];
 


### PR DESCRIPTION
## Summary

- Adds PDF rendering support via `mupdf-sys` (feature flag `pdf`)
- Bumps from 0.22.2 → 0.22.4 (latest upstream release)
- Includes necessary build infrastructure for mupdf: `bindgenHook`, `gperf`, `python3`, `unzip`, a `make` wrapper to handle read-only store paths, and `fontconfig.dev`/`glib.dev` for mupdf's runtime deps

The `backport release-26.05` label is requested to also land this in stable, where `mdfried` is currently at 0.15.0. See #538621.

## Test plan

- [ ] `nix build .#mdfried` succeeds on Linux x86_64
- [ ] `nix build .#mdfried` succeeds on Darwin aarch64
- [ ] PDF files render correctly at runtime (`mdfried some.pdf`)
- [ ] Existing markdown rendering is unaffected

Resolves #538621