### PR TITLE
mdfried: 0.15.0 -> 0.22.4 [backport to 26.05]

### DIFF
--- a/pkgs/by-name/md/mdfried/package.nix
+++ b/pkgs/by-name/md/mdfried/package.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "mdfried";
-  version = "0.22.0";
+  version = "0.22.2";
 
   src = fetchFromGitHub {
     owner = "benjajaja";
     repo = "mdfried";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-zJSh5g1FkR/nqk2qj22Xo8qIOjwyF346PM4KOUOCBBo=";
+    hash = "sha256-HRtuqnD6erRC1Xx+3NSbaFgqRHzurj1xbOJNGykGIpU=";
   };
 
-  cargoHash = "sha256-2wwaEKknnxX6QuE+6udHL2GTOuPpS1oqRI+b3aP0e1I=";
+  cargoHash = "sha256-jnByeBBL13DavExG2pVN7vNRr+UXGkxRY0a4MkwzRe0=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/md/mdfried/package.nix
+++ b/pkgs/by-name/md/mdfried/package.nix
@@ -2,22 +2,37 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  pkg-config,
+  chafa,
+  glib,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "mdfried";
-  version = "0.15.0";
+  version = "0.22.0";
 
   src = fetchFromGitHub {
     owner = "benjajaja";
     repo = "mdfried";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-V++xkJBnTlqzcsw6BDkrqScIV+phzxyDqQXcV34L4ps=";
+    hash = "sha256-zJSh5g1FkR/nqk2qj22Xo8qIOjwyF346PM4KOUOCBBo=";
   };
 
-  cargoHash = "sha256-qnsJkwAmBcakYcoqGdYRqfN6e46PG5IH6SAXLvy3mM8=";
+  cargoHash = "sha256-2wwaEKknnxX6QuE+6udHL2GTOuPpS1oqRI+b3aP0e1I=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    chafa
+    glib
+  ];
 
   doCheck = true;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Markdown viewer TUI for the terminal, with big text and image rendering";

--- a/pkgs/by-name/md/mdfried/package.nix
+++ b/pkgs/by-name/md/mdfried/package.nix
@@ -1,10 +1,18 @@
 {
   lib,
+  stdenv,
   rustPlatform,
   fetchFromGitHub,
   pkg-config,
   chafa,
+  fontconfig,
   glib,
+  gnumake,
+  gperf,
+  libiconv,
+  python3,
+  unzip,
+  writeShellScriptBin,
   nix-update-script,
 }:
 
@@ -21,14 +29,38 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-jnByeBBL13DavExG2pVN7vNRr+UXGkxRY0a4MkwzRe0=";
 
+  buildFeatures = [ "pdf" ];
+
+  # Prevent updateAutotoolsGnuConfigScripts from modifying mupdf's vendored
+  # autotools files — doing so invalidates cargo's fingerprint for mupdf-sys
+  # and causes a rebuild that fails on read-only cargoArtifacts files.
+  updateAutotoolsGnuConfigScriptsPhase = "true";
+
   nativeBuildInputs = [
     pkg-config
+    rustPlatform.bindgenHook # for mupdf-sys bindgen
+    gperf # for mupdf vendored Makefile
+    python3 # for mupdf vendored Makefile
+    unzip # for mupdf vendored docx_template build
+    # mupdf-sys cp_r copies files from the read-only Nix store, preserving
+    # mode 444. make then fails to regenerate headers. Wrap make to chmod first.
+    (writeShellScriptBin "make" ''
+      chmod -R u+w . 2>/dev/null || true
+      exec ${lib.getExe gnumake} "$@"
+    '')
   ];
 
   buildInputs = [
     chafa
-    glib
+    fontconfig.dev # for font-kit (mupdf dep)
+    glib.dev # for glib-2.0.pc (mupdf needs glib.dev, chafa could do with just glib)
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    libiconv
   ];
+
+  CFLAGS_aarch64_apple_darwin = lib.optionalString stdenv.hostPlatform.isDarwin "-UTARGET_OS_MAC";
+  CXXFLAGS_aarch64_apple_darwin = lib.optionalString stdenv.hostPlatform.isDarwin "-UTARGET_OS_MAC";
 
   doCheck = true;
 

--- a/pkgs/by-name/md/mdfried/package.nix
+++ b/pkgs/by-name/md/mdfried/package.nix
@@ -59,8 +59,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     libiconv
   ];
 
-  CFLAGS_aarch64_apple_darwin = lib.optionalString stdenv.hostPlatform.isDarwin "-UTARGET_OS_MAC";
-  CXXFLAGS_aarch64_apple_darwin = lib.optionalString stdenv.hostPlatform.isDarwin "-UTARGET_OS_MAC";
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    CFLAGS_aarch64_apple_darwin = "-UTARGET_OS_MAC";
+    CXXFLAGS_aarch64_apple_darwin = "-UTARGET_OS_MAC";
+  };
 
   doCheck = true;
 

--- a/pkgs/by-name/md/mdfried/package.nix
+++ b/pkgs/by-name/md/mdfried/package.nix
@@ -18,16 +18,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "mdfried";
-  version = "0.22.2";
+  version = "0.22.4";
 
   src = fetchFromGitHub {
     owner = "benjajaja";
     repo = "mdfried";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-HRtuqnD6erRC1Xx+3NSbaFgqRHzurj1xbOJNGykGIpU=";
+    hash = "sha256-Zcn1C8mXwljJ3HtYgYBPyU9cVHvoNBUn7qjqx45wMhE=";
   };
 
-  cargoHash = "sha256-jnByeBBL13DavExG2pVN7vNRr+UXGkxRY0a4MkwzRe0=";
+  cargoHash = "sha256-Nt+oBl2HX/H/7j62VjaHrY29gpd2vouevBJO0W3AYAk=";
 
   buildFeatures = [ "pdf" ];
 


### PR DESCRIPTION
Backport of master commits to release-26.05, cherry-picked with `-x`:

- `25fa18a45834` — mdfried: 0.15.0 -> 0.22.0
- `1c95683621db` — mdfried: 0.22.0 -> 0.22.2
- `9b73ac2bfce5` — mdfried: add pdf support
- `32f67766fba3` — mdfried: 0.22.2 -> 0.22.4
- `4af074100f49` — mdfried: move env variables into env for structuredAttrs

No breaking changes; adds new features (syntax highlighting, image rendering improvements, PDF rendering via mupdf).

Resolves #538621