### PR TITLE
nixos/misskey: fixes for attrTag submodule docs

### DIFF
--- a/nixos/modules/services/web-apps/misskey.nix
+++ b/nixos/modules/services/web-apps/misskey.nix
@@ -231,7 +231,7 @@ in
         webserver = lib.mkOption {
           type = lib.types.attrTag {
             nginx = lib.mkOption {
-              type = lib.types.submodule (import ../web-servers/nginx/vhost-options.nix);
+              type = lib.types.submodule ../web-servers/nginx/vhost-options.nix;
               default = { };
               description = ''
                 Extra configuration for the nginx virtual host of Misskey.
@@ -240,7 +240,7 @@ in
             };
             caddy = lib.mkOption {
               type = lib.types.submodule (
-                import ../web-servers/caddy/vhost-options.nix { cfg = config.services.caddy; }
+                lib.modules.importApply ../web-servers/caddy/vhost-options.nix { cfg = config.services.caddy; }
               );
               default = { };
               description = ''


### PR DESCRIPTION
Fix the declaration location of attributes of submodules of attrTag

Now that #531031 has landed, the NixOS docs can be fixed for this as well.


## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
