### PR TITLE
home-assistant: various fixes

### DIFF
--- a/pkgs/development/python-modules/aioimaplib/default.nix
+++ b/pkgs/development/python-modules/aioimaplib/default.nix
@@ -29,6 +29,10 @@ buildPythonPackage rec {
     ./event-loop.patch
   ];
 
+  postPatch = ''
+    sed -i "/crypto.X509Extension/,+1d" tests/ssl_cert.py
+  '';
+
   build-system = [ poetry-core ];
 
   nativeCheckInputs = [
@@ -43,6 +47,7 @@ buildPythonPackage rec {
   disabledTests = [
     # TimeoutError
     "test_idle_start__exits_queue_get_without_timeout_error"
+    "test_client_can_connect_to_server_over_ssl"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # Comparison to magic strings

--- a/pkgs/development/python-modules/airos/default.nix
+++ b/pkgs/development/python-modules/airos/default.nix
@@ -3,7 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   pythonOlder,
-  setuptools,
+  setuptools_80,
   aiohttp,
   mashumaro,
   aiofiles,
@@ -26,7 +26,7 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-/A9bP7wc+N0Jz/jJLvKHqVPjF3ddHjVKWlSN8tqGHIw=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [ setuptools_80 ];
 
   dependencies = [
     aiohttp

--- a/pkgs/development/python-modules/asyncssh/default.nix
+++ b/pkgs/development/python-modules/asyncssh/default.nix
@@ -82,6 +82,8 @@ buildPythonPackage rec {
     "test_forward_remote"
     # Seems weirdly filesystem specific
     "test_put_name_too_long"
+    # SFTP copy ends up with an empty file on ZFS
+    "test_copy_max_requests"
   ];
 
   pythonImportsCheck = [ "asyncssh" ];

--- a/pkgs/development/python-modules/azure-identity/default.nix
+++ b/pkgs/development/python-modules/azure-identity/default.nix
@@ -12,13 +12,13 @@
 
 buildPythonPackage rec {
   pname = "azure-identity";
-  version = "1.25.1";
+  version = "1.25.3";
   pyproject = true;
 
   src = fetchPypi {
     pname = "azure_identity";
     inherit version;
-    hash = "sha256-h8qDKIg95gNkQ+HDe0Do3I+3SJgkD2EHHgnS42k2FFY=";
+    hash = "sha256-qyPA1jAV9QtjDvbGzzlecmL0Oc4G5dB6ZOh0xyT42eY=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/bleak-esphome/bluetooth-adapters-2.4.0-compat.patch
+++ b/pkgs/development/python-modules/bleak-esphome/bluetooth-adapters-2.4.0-compat.patch
@@ -1,0 +1,21 @@
+diff --git a/tests/conftest.py b/tests/conftest.py
+index 55defbe..551d19e 100644
+--- a/tests/conftest.py
++++ b/tests/conftest.py
+@@ -9,7 +9,7 @@ from aioesphomeapi import (
+     ReconnectLogic,
+ )
+ from bleak_retry_connector import BleakSlotManager
+-from bluetooth_adapters import BluetoothAdapters
++from bluetooth_adapters import get_adapters
+ from habluetooth import (
+     BluetoothManager,
+     set_manager,
+@@ -20,7 +20,7 @@ from zeroconf import Zeroconf
+ @pytest.fixture(scope="session", autouse=True)
+ def manager():
+     slot_manager = BleakSlotManager()
+-    bluetooth_adapters = BluetoothAdapters()
++    bluetooth_adapters = get_adapters()
+     set_manager(BluetoothManager(bluetooth_adapters, slot_manager))
+ 

--- a/pkgs/development/python-modules/bleak-esphome/default.nix
+++ b/pkgs/development/python-modules/bleak-esphome/default.nix
@@ -29,6 +29,10 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-S4tYL/fq7wMjq81WRftZ1A+RVxs7kGpaM/TfVBNBgaI=";
   };
 
+  patches = [
+    ./bluetooth-adapters-2.4.0-compat.patch
+  ];
+
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace-fail "setuptools>=75.8.2" setuptools

--- a/pkgs/development/python-modules/buienradar/default.nix
+++ b/pkgs/development/python-modules/buienradar/default.nix
@@ -25,6 +25,11 @@ buildPythonPackage rec {
     hash = "sha256-DTdxzBe9fBOH5fHME++oq62xMtBKnjY7BCevwjl8VZ8=";
   };
 
+  patches = [
+    # https://github.com/mjj4791/python-buienradar/pull/26
+    ./setuptools-82-compat.patch
+  ];
+
   build-system = [ setuptools ];
 
   dependencies = [

--- a/pkgs/development/python-modules/buienradar/setuptools-82-compat.patch
+++ b/pkgs/development/python-modules/buienradar/setuptools-82-compat.patch
@@ -1,0 +1,30 @@
+Author: Martin Weinelt <hexa@darmstadt.ccc.de>
+Date:   Sun Jul 5 16:24:28 2026 +0200
+
+    Make compatible with setuptools 82
+    
+    This migrates the version retrieval to the stdlib importlib library.
+
+diff --git a/buienradar/__main__.py b/buienradar/__main__.py
+index b0838c1..b556374 100755
+--- a/buienradar/__main__.py
++++ b/buienradar/__main__.py
+@@ -19,8 +19,8 @@ Usage:
+ """
+ import logging
+ import sys
++from importlib.metadata import version
+ 
+-import pkg_resources
+ from docopt import docopt
+ 
+ from .buienradar import get_data, parse_data
+@@ -30,7 +30,7 @@ from .constants import CONTENT, MESSAGE, RAINCONTENT, SUCCESS
+ def main(argv=sys.argv[1:]):
+     """Parse argument and start main program."""
+     args = docopt(__doc__, argv=argv,
+-                  version=pkg_resources.require('buienradar')[0].version)
++                  version=version('buienradar'))
+ 
+     level = logging.ERROR
+     if args['-v']:

--- a/pkgs/development/python-modules/mill-local/default.nix
+++ b/pkgs/development/python-modules/mill-local/default.nix
@@ -4,7 +4,7 @@
   async-timeout,
   buildPythonPackage,
   fetchFromGitHub,
-  setuptools,
+  setuptools_80,
 }:
 
 buildPythonPackage rec {
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     hash = "sha256-t6nZ6KXX5GFIcdNIXyFxYtSjOuuUJmCekaBITNgcIkU=";
   };
 
-  buildInputs = [ setuptools ];
+  buildInputs = [ setuptools_80 ];
 
   dependencies = [
     aiohttp

--- a/pkgs/development/python-modules/pymodbus/default.nix
+++ b/pkgs/development/python-modules/pymodbus/default.nix
@@ -2,10 +2,7 @@
   lib,
   aiohttp,
   buildPythonPackage,
-  click,
   fetchFromGitHub,
-  prompt-toolkit,
-  pygments,
   pymodbus-repl,
   pyserial,
   pytest-asyncio,
@@ -16,7 +13,6 @@
   setuptools,
   sqlalchemy,
   twisted,
-  typer,
 }:
 
 buildPythonPackage (finalAttrs: {

--- a/pkgs/development/python-modules/pystiebeleltron/default.nix
+++ b/pkgs/development/python-modules/pystiebeleltron/default.nix
@@ -31,6 +31,11 @@ buildPythonPackage rec {
     pytest-mock
   ];
 
+  disabledTestPaths = [
+    # mock server is not compatible with pymodbus 3.13
+    "test/test_pystiebeleltron.py"
+  ];
+
   pythonImportsCheck = [ "pystiebeleltron" ];
 
   meta = {

--- a/pkgs/development/python-modules/roombapy/default.nix
+++ b/pkgs/development/python-modules/roombapy/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  amqtt,
   buildPythonPackage,
   click,
   fetchFromGitHub,
@@ -43,7 +42,6 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    amqtt
     pytest-asyncio
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/yalexs/default.nix
+++ b/pkgs/development/python-modules/yalexs/default.nix
@@ -60,6 +60,11 @@ buildPythonPackage rec {
     requests-mock
   ];
 
+  disabledTests = [
+    # aiohttp api breakage, remove when bumping to 9.2.8 or newer
+    "test__raise_response_exceptions"
+  ];
+
   pythonImportsCheck = [ "yalexs" ];
 
   meta = {

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -182,36 +182,34 @@ let
     ];
   };
 in
-lib.listToAttrs (
-  map (
-    component:
-    lib.nameValuePair component (
-      home-assistant.overridePythonAttrs (old: {
-        pname = "homeassistant-test-${component}";
-        pyproject = false;
+lib.genAttrs home-assistant.supportedComponentsWithTests (
+  component:
+  home-assistant.overridePythonAttrs (old: {
+    pname = "homeassistant-test-${component}";
+    pyproject = false;
 
-        dontBuild = true;
-        dontInstall = true;
+    dontBuild = true;
+    dontInstall = true;
 
-        nativeCheckInputs =
-          old.requirementsTest
-          ++ home-assistant.getPackages component home-assistant.python3Packages
-          ++ extraCheckInputs.${component} or [ ];
+    nativeCheckInputs =
+      old.requirementsTest
+      ++ home-assistant.getPackages component home-assistant.python3Packages
+      ++ extraCheckInputs.${component} or [ ];
 
-        disabledTests = extraDisabledTests.${component} or [ ];
-        disabledTestPaths = extraDisabledTestPaths.${component} or [ ];
+    disabledTests = extraDisabledTests.${component} or [ ];
+    disabledTestPaths = extraDisabledTestPaths.${component} or [ ];
 
-        # components are more often racy than the core
-        dontUsePytestXdist = true;
+    # components are more often racy than the core
+    dontUsePytestXdist = true;
 
-        enabledTestPaths = [ "tests/components/${component}" ];
+    enabledTestPaths = [ "tests/components/${component}" ];
 
-        meta = old.meta // {
-          broken = lib.elem component [ ];
-          # upstream only tests on Linux, so do we.
-          platforms = lib.platforms.linux;
-        };
-      })
-    )
-  ) home-assistant.supportedComponentsWithTests
+    pytestFlags = [ "-vvv" ];
+
+    meta = old.meta // {
+      broken = lib.elem component [ ];
+      # upstream only tests on Linux, so do we.
+      platforms = lib.platforms.linux;
+    };
+  })
 )

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   home-assistant,
+  writableTmpDirAsHomeHook,
 }:
 
 let
@@ -15,10 +16,12 @@ let
       "frontend"
       "stream"
     ];
+    analytics = getComponentDeps "homeassistant_hardware";
     anthropic = getComponentDeps "ai_task" ++ getComponentDeps "openai_conversation";
     assist_pipeline = getComponentDeps "frontend";
     automation = getComponentDeps "frontend" ++ getComponentDeps "mobile_app";
     axis = getComponentDeps "deconz";
+    backup = getComponentDeps "homeassistant_hardware";
     bluetooth = getComponentDeps "switchbot";
     braviatv = getComponentDeps "ssdp";
     bthome = getComponentDeps "frontend";
@@ -28,6 +31,7 @@ let
     emulated_hue = [
       defusedxml
     ];
+    esphome = getComponentDeps "homeassistant_hardware";
     gardena_bluetooth = getComponentDeps "husqvarna_automower_ble";
     go2rtc = [
       tqdm
@@ -44,7 +48,11 @@ let
     homeassistant_sky_connect = getComponentDeps "zha";
     homeassistant_yellow = getComponentDeps "zha";
     homekit = getComponentDeps "frontend";
-    http = getComponentDeps "cloud" ++ getComponentDeps "frontend";
+    http = concatMap getComponentDeps [
+      "cloud"
+      "frontend"
+      "homeassistant_hardware"
+    ];
     intelliclima = getComponentDeps "intellifire";
     logbook = getComponentDeps "alexa";
     lovelace = getComponentDeps "frontend" ++ [
@@ -54,9 +62,11 @@ let
     mastodon = concatMap getComponentDeps [
       "stream"
     ];
+    matter = getComponentDeps "homeassistant_hardware";
     miele = getComponentDeps "cloud";
     mobile_app = getComponentDeps "frontend";
     mopeka = getComponentDeps "switchbot";
+    mqtt = getComponentDeps "homeassistant_hardware";
     nest = [
       av
     ];
@@ -65,8 +75,14 @@ let
       pymetno
       radios
       rpi-bad-power
-    ];
+    ]
+    ++ getComponentDeps "homeassistant_hardware"
+    ++ getComponentDeps "usb";
     open_router = getComponentDeps "ai_task";
+    osoenergy = [
+      # loguru wants to write into HOME
+      writableTmpDirAsHomeHook
+    ];
     raspberry_pi = [
       rpi-bad-power
     ];
@@ -91,10 +107,14 @@ let
     yolink = getComponentDeps "cloud";
     zeroconf = getComponentDeps "shelly";
     zha = getComponentDeps "deconz" ++ getComponentDeps "frontend";
-    zwave_js = getComponentDeps "frontend";
+    zwave_js = getComponentDeps "frontend" ++ getComponentDeps "homeassistant_hardware";
   };
 
   extraDisabledTestPaths = {
+    bluetooth = [
+      # [2026.7.1] Fails to replace HCI device after advertisement became stale
+      "tests/components/bluetooth/test_manager.py::test_switching_adapters_based_on_stale_with_discovered_interval"
+    ];
     influxdb = [
       # These tests fail because they check for the number of warnings in the
       # logs and there is an extra warning in the logs:
@@ -122,6 +142,10 @@ let
   };
 
   extraDisabledTests = {
+    bsblan = [
+      # [2026.7.1] outdated snapshot
+      "test_diagnostics"
+    ];
     conversation = lib.optionals stdenv.hostPlatform.isAarch64 [
       # intent fixture mismatch on aarch64
       "test_error_no_device_on_floor"
@@ -138,6 +162,10 @@ let
       # [2026.6.0] Failed: Description not found for placeholder `reason` in component.opendisplay.exceptions.device_not_found.message
       # https://github.com/home-assistant/core/pull/172909
       "test_upload_image_device_not_in_range"
+    ];
+    smlight = [
+      # [2026.7.1] outdated snapshot
+      "test_entry_diagnostics"
     ];
     teslemetry = [
       # [2026.6.4] http://github.com/home-assistant/core/commit/a33a92982af19e682a0d0fa7bec0cb16929c00d1


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
