### PR TITLE
space-station-14-launcher: add nix-update-script; 0.39.0 -> 0.39.1

### DIFF
--- a/pkgs/by-name/sp/space-station-14-launcher/package.nix
+++ b/pkgs/by-name/sp/space-station-14-launcher/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   config,
+  nix-update-script,
   buildDotnetModule,
   dotnetCorePackages,
   fetchFromGitHub,
@@ -132,6 +133,8 @@ buildDotnetModule rec {
 
     icoFileToHiColorTheme SS14.Launcher/Assets/icon.ico ${pname} $out
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Launcher for Space Station 14, a multiplayer game about paranoia and disaster";

--- a/pkgs/by-name/sp/space-station-14-launcher/package.nix
+++ b/pkgs/by-name/sp/space-station-14-launcher/package.nix
@@ -40,7 +40,7 @@
 }:
 let
   pname = "space-station-14-launcher";
-  version = "0.39.0";
+  version = "0.39.1";
 in
 buildDotnetModule rec {
   inherit pname;
@@ -53,7 +53,7 @@ buildDotnetModule rec {
     owner = "space-wizards";
     repo = "SS14.Launcher";
     tag = "v${version}";
-    hash = "sha256-i5jcaB1wa+Toj6orpEQ9sK3EX1CLWadnhTEQDOU7QU4=";
+    hash = "sha256-u3tsPWAFMckWSHhiPqL50i9BMxR+VrLnpUSWGRRu9AA=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
`nix-update-script` is needed for releases which change `nugetDeps` to get automatically updated.

Changelog (practically just one change): https://github.com/space-wizards/SS14.Launcher/compare/v0.39.0...v0.39.1
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
