### PR TITLE
turbo-unwrapped: 2.9.18 -> 2.10.12

### DIFF
--- a/pkgs/by-name/tu/turbo-unwrapped/package.nix
+++ b/pkgs/by-name/tu/turbo-unwrapped/package.nix
@@ -6,7 +6,6 @@
   fetchFromGitHub,
   installShellFiles,
   llvmPackages,
-  nix-update-script,
   protobuf,
   rustPlatform,
   xcbuild,
@@ -83,11 +82,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   passthru = {
-    updateScript = nix-update-script {
-      extraArgs = [
-        "--use-github-releases"
-      ];
-    };
+    inherit ghostty-src ghostty-deps;
+    updateScript = ./update.sh;
   };
 
   meta = {

--- a/pkgs/by-name/tu/turbo-unwrapped/package.nix
+++ b/pkgs/by-name/tu/turbo-unwrapped/package.nix
@@ -2,47 +2,70 @@
   lib,
   stdenv,
   capnproto,
+  cctools,
   fetchFromGitHub,
-  fontconfig,
   installShellFiles,
   llvmPackages,
   nix-update-script,
-  openssl,
-  pkg-config,
   protobuf,
-  rust-jemalloc-sys,
   rustPlatform,
-  zlib,
+  xcbuild,
+  zig_0_15,
 }:
-
-rustPlatform.buildRustPackage (finalAttrs: {
+let
   pname = "turbo-unwrapped";
-  version = "2.9.18";
+  version = "2.10.12";
+
+  ghostty-src = fetchFromGitHub {
+    owner = "ghostty-org";
+    repo = "ghostty";
+    rev = "a887df42c56f6de86c0fe6da9c4eeca37931e083";
+    hash = "sha256-1Zz65SCk3rkJ9+Q0MmyNOTNiDSLBRIHRd3IvFM4iNXw=";
+  };
+  ghostty-deps = zig_0_15.fetchDeps {
+    inherit pname version;
+    src = ghostty-src;
+    fetchAll = true;
+    hash = "sha256-PnM+hZIlLyQwK8vJgd/Bhjt1lNIz06T8FahwliRmMrY=";
+  };
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  inherit pname version;
 
   src = fetchFromGitHub {
     owner = "vercel";
     repo = "turborepo";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ugPkWeUJqt1KnGYC85hihHXl3JPlfbTvk4RaLIvVq2Y=";
+    hash = "sha256-KDrqW6cu57aZCB7Nypm7mjQrJze40IEzrUeCZ1Crvbg=";
   };
 
-  cargoHash = "sha256-LBGaZgW4q//VJfXIqzByQogz0o/fyQcTAAFwlHPuRUc=";
+  cargoHash = "sha256-oDRckEe9gVlC3B9jRpMsvs4qjcRolIKvYQdf3mIw2hI=";
 
   nativeBuildInputs = [
     capnproto
     installShellFiles
-    pkg-config
     protobuf
+    zig_0_15.hook
   ]
   # https://github.com/vercel/turbo/blob/ea740706e0592b3906ab34c7cfa1768daafc2a84/CONTRIBUTING.md#linux-dependencies
-  ++ lib.optional stdenv.hostPlatform.isLinux llvmPackages.bintools;
-
-  buildInputs = [
-    fontconfig
-    openssl
-    rust-jemalloc-sys
-    zlib
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ llvmPackages.bintools ]
+  # Tools required for building `libghostty-vt-sys` on darwin.
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    cctools
+    xcbuild
   ];
+
+  dontUseZigBuild = true;
+  dontUseZigCheck = true;
+  dontUseZigInstall = true;
+
+  env = {
+    # Use vendored ghostty source and dependencies.
+    GHOSTTY_SOURCE_DIR = ghostty-src;
+    GHOSTTY_ZIG_SYSTEM_DIR = ghostty-deps;
+    # nightly features are used
+    RUSTC_BOOTSTRAP = 1;
+  };
 
   cargoBuildFlags = [
     "--package"
@@ -58,11 +81,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --fish <($out/bin/turbo completion fish) \
       --zsh <($out/bin/turbo completion zsh)
   '';
-
-  env = {
-    # nightly features are used
-    RUSTC_BOOTSTRAP = 1;
-  };
 
   passthru = {
     updateScript = nix-update-script {

--- a/pkgs/by-name/tu/turbo-unwrapped/update.sh
+++ b/pkgs/by-name/tu/turbo-unwrapped/update.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix-update gnugrep gnused
+
+set -euo pipefail
+
+nix-update turbo-unwrapped
+
+src="$(nix-build --no-out-link -A turbo-unwrapped.src)"
+rev=$(grep "const GHOSTTY_COMMIT" "$src/crates/libghostty-vt-sys/build.rs" | cut -d '"' -f2)
+sed -i -E "s|\brev = \".*\";|rev = \"$rev\";|" "pkgs/by-name/tu/turbo-unwrapped/package.nix"
+
+nix-update turbo-unwrapped --no-src --custom-dep ghostty-src --custom-dep ghostty-deps


### PR DESCRIPTION
blog: https://turborepo.dev/blog/2-10
changelog: https://github.com/vercel/turborepo/releases/tag/v2.10.12
diff: https://github.com/vercel/turborepo/compare/v2.9.18...v2.10.12

<details>
<summary>changelogs</summary>

https://github.com/vercel/turborepo/releases/tag/v2.10.0
https://github.com/vercel/turborepo/releases/tag/v2.10.1
https://github.com/vercel/turborepo/releases/tag/v2.10.2
https://github.com/vercel/turborepo/releases/tag/v2.10.3
https://github.com/vercel/turborepo/releases/tag/v2.10.4
https://github.com/vercel/turborepo/releases/tag/v2.10.5
https://github.com/vercel/turborepo/releases/tag/v2.10.6
https://github.com/vercel/turborepo/releases/tag/v2.10.7
https://github.com/vercel/turborepo/releases/tag/v2.10.8
https://github.com/vercel/turborepo/releases/tag/v2.10.9
https://github.com/vercel/turborepo/releases/tag/v2.10.10
https://github.com/vercel/turborepo/releases/tag/v2.10.11
https://github.com/vercel/turborepo/releases/tag/v2.10.12
</details>

Turbo now has ghostty as a dependency so it requires a bit of Zig hackery to build properly. Also updated the updateScript so future updates can be handled by `r-ryantm` again. All of the old `buildInputs` don't seem necessary anymore, so I removed them.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
