### PR TITLE
kanboard: patch CVE-2026-56774

### DIFF
--- a/pkgs/by-name/ka/kanboard/package.nix
+++ b/pkgs/by-name/ka/kanboard/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  fetchpatch,
   nixosTests,
   nix-update-script,
   php,
@@ -17,6 +18,16 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-iI9Dyno1s9P9t7IxfDs5gQUl9yFyu2taXvKY0WnF2Q0=";
   };
+
+  # CVE-2026-56774 / NIXPKGS-2026-2001: scope remember-me session removal to
+  # the owning user so a session row can only be deleted by its owner.
+  # Remove this patch once upgraded past 1.2.52.
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/kanboard/kanboard/commit/928c68aa2b7c00092dd71084d329b912e229f3d1.patch";
+      hash = "sha256-K616dTwAsLJAJMqY+DJjebfi6MV5wSICbd1iy6VynlM=";
+    })
+  ];
 
   dontBuild = true;
 


### PR DESCRIPTION
Backport upstream commit 928c68a ("fix(user): scope remember me session removal to its owner"), which constrains RememberMeSessionModel::remove() by user_id in addition to the session id. Without it, an authenticated user can enumerate sequential session ids and delete other users' (including administrators') persistent "Remember Me" sessions.

Patch can be dropped once kanboard is upgraded past 1.2.52.

CVE-2026-56774 / NIXPKGS-2026-2001

Closes #535589

Assisted-by: Claude-Code:GLM-5.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
