### PR TITLE
python3Packages.ai-edge-litert: unbreak

### DIFF
--- a/pkgs/development/python-modules/ai-edge-litert/default.nix
+++ b/pkgs/development/python-modules/ai-edge-litert/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchurl,
   lib,
+  patchelf,
   python,
   pythonAtLeast,
   stdenv,
@@ -71,6 +72,13 @@ buildPythonPackage {
     # TODO: npu-sdk
   };
 
+  preFixup = ''
+    while IFS= read -r -d "" so; do
+      ${patchelf}/bin/patchelf --replace-needed libopenvino.so.2620 libopenvino.so "$so"
+      ${patchelf}/bin/patchelf --replace-needed libopenvino_tensorflow_lite_frontend.so.2620 libopenvino_tensorflow_lite_frontend.so "$so"
+    done < <(find "$out" -type f \( -name '*.so' -o -name '*.so.*' \) -print0)
+  '';
+
   pythonRemoveDeps = lib.optionals (pythonAtLeast "3.12") [
     # https://github.com/google-ai-edge/LiteRT/pull/5298
     "backports.strenum"
@@ -96,8 +104,5 @@ buildPythonPackage {
       # elftools.common.exceptions.ELFError: Magic number does not match
       lib.systems.inspect.patterns.isDarwin
     ];
-    # Incompatible with the openvino currently shipped in nixpkgs:
-    #   auto-patchelf could not satisfy dependency libopenvino.so.2620
-    broken = true;
   };
 }


### PR DESCRIPTION
The library we have in nixpkgs seems compatible enough, and there's no way I'm being sniped into dealing with bazel, so this hack will have to do.

Fixes #535894

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Package import check at build time.
  - [x] Frigate works with this (both builds and actually runs, though I don't use genai stuff which is what I suspect this package is used for)
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc @mweinelt 