### PR TITLE
d2: add `withImageSupport` guard to allow closure size reduction

### DIFF
--- a/pkgs/by-name/d2/d2/package.nix
+++ b/pkgs/by-name/d2/d2/package.nix
@@ -11,7 +11,12 @@
   libgbm,
   makeWrapper,
   playwright-driver,
+  withImageSupport ? lib.meta.availableOn stdenv.hostPlatform libdrm,
 }:
+
+assert lib.assertMsg (
+  withImageSupport -> lib.meta.availableOn stdenv.hostPlatform libdrm
+) "d2: withImageSupport is not supported on ${stdenv.hostPlatform.system} (requires libdrm)";
 
 buildGoModule (finalAttrs: {
   pname = "d2";
@@ -39,7 +44,8 @@ buildGoModule (finalAttrs: {
     makeWrapper
   ];
 
-  buildInputs = lib.optionals (lib.meta.availableOn stdenv.hostPlatform libdrm) [
+  # playwright-drivers.browsers pulls down ~2GB+ for Webkit, Chrome, Firefox etc
+  buildInputs = lib.optionals withImageSupport [
     libgbm
     playwright-driver.browsers
   ];
@@ -50,7 +56,7 @@ buildGoModule (finalAttrs: {
     installManPage ci/release/template/man/d2.1
   ''
   # Wrap the d2 executable to set LD_LIBRARY_PATH for Playwright
-  + lib.optionalString (finalAttrs.buildInputs != [ ]) ''
+  + lib.optionalString withImageSupport ''
     wrapProgram $out/bin/d2 \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath finalAttrs.buildInputs}
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

D2 currently pulls down ~2GB worth of packages and libraries that are required for image output support after https://github.com/NixOS/nixpkgs/pull/488723. However this is not required for D2 to support a fairly common use-case of live viewing and hot reloading changes and causes an unnecessarily larger closure size. This PR adds a `withImageSupport` attribute that is defaulted to true (depending on if libdrb is available) to ensure full functionality of D2 when users add pkgs.d2 to their configurations but also allows unneeded and bloating features to not be included. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
