### PR TITLE
ci: update pinned

### DIFF
--- a/ci/default.nix
+++ b/ci/default.nix
@@ -70,7 +70,7 @@ rec {
   };
   parse = pkgs.lib.recurseIntoAttrs {
     nix_latest = pkgs.callPackage ./parse.nix { nix = pkgs.nixVersions.latest; };
-    nix_2_28 = pkgs.callPackage ./parse.nix { nix = pkgs.nixVersions.nix_2_28; };
+    stable = pkgs.callPackage ./parse.nix { nix = pkgs.nixVersions.stable; };
     lix = pkgs.callPackage ./parse.nix { nix = pkgs.lix; };
     lix_latest = pkgs.callPackage ./parse.nix { nix = pkgs.lixPackageSets.latest.lix; };
   };

--- a/ci/pinned.json
+++ b/ci/pinned.json
@@ -9,9 +9,9 @@
       },
       "branch": "nixpkgs-unstable",
       "submodules": false,
-      "revision": "8c91a71d13451abc40eb9dae8910f972f979852f",
-      "url": "https://github.com/NixOS/nixpkgs/archive/8c91a71d13451abc40eb9dae8910f972f979852f.tar.gz",
-      "hash": "sha256-fnzKKPvS+oieI/pTzotA5tkoM47EB1NpaBcgk4R97hE="
+      "revision": "6edbf1a6a03e75886a6609c088801a0856449e88",
+      "url": "https://github.com/NixOS/nixpkgs/archive/6edbf1a6a03e75886a6609c088801a0856449e88.tar.gz",
+      "hash": "sha256-0lkauQbtrljJqwtzTCILPAiHAJyMvn6XDo264moDv30="
     }
   },
   "version": 8

--- a/ci/update-pinned.sh
+++ b/ci/update-pinned.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p npins -I nixpkgs=../
+#!nix-shell -i bash -E 'with import ../. {}; mkShell { packages = [ npins ]; }'
 
 set -euo pipefail
 


### PR DESCRIPTION
- **ci/update-pinned.sh: import Nixpkgs relative to script**

Follow up to #529691, which switched from using whatever `nixpkgs` is on the impure system `NIX_PATH` to a local import, this commit improves that by making the import work regardless of CWD when executing `update-pinned.sh`. Previously, running `./ci/update-pinned.sh` from outside the `ci` directory would fail.

- **ci: nix_2_28 → stable**

Extract the ci changes that were dropped from https://github.com/NixOS/nixpkgs/pull/536372, which are needed for the bump.

- **ci: update pinned**

Update pinned Nixpkgs to latest `nixpkgs-unstable` (6edbf1a6a03e75886a6609c088801a0856449e88), which includes https://github.com/NixOS/nixpkgs/pull/538443 and https://github.com/NixOS/nixpkgs/pull/533944.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- [x] Tested basic functionality of `ci/update-pinned.sh`
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
