### PR TITLE
rux: init at 0.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14586,6 +14586,12 @@
     github = "kiranshila";
     githubId = 6305359;
   };
+  KirCK = {
+    email = "Arikkenebas09@gmail.com";
+    github = "AristarhKenebas";
+    githubId = 142233116;
+    name = "Aristarh Kenebas";
+  };
   kirelagin = {
     email = "kirelagin@gmail.com";
     matrix = "@kirelagin:matrix.org";

--- a/pkgs/by-name/ru/rux/package.nix
+++ b/pkgs/by-name/ru/rux/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  llvmPackages_21,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+}:
+
+llvmPackages_21.libcxxStdenv.mkDerivation (finalAttrs: {
+  pname = "rux";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "rux-lang";
+    repo = "Rux";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-GqShkT8uXi0C1W0G2+nuU8p1NcigdfEPOF/Yb5KCOhk=";
+  };
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "cmake_minimum_required(VERSION 4.2)" "cmake_minimum_required(VERSION 4.1)"
+  '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  buildInputs = [
+    llvmPackages_21.libcxx
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_CXX_SCAN_FOR_MODULES=OFF"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp ../Bin/Release/rux $out/bin/
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A fast, compiled, strongly typed, multi-paradigm programming language";
+    homepage = "https://rux-lang.dev";
+    license = licenses.mit;
+    maintainers = with maintainers; [
+      KirCK
+      lukas-sgx
+    ];
+    mainProgram = "rux";
+    platforms = platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
Rux is a fast, compiled, strongly typed, multi-paradigm programming language.
Homepage: https://rux-lang.dev

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
