### PR TITLE
python3Packages.python3-eventlib: fix build of blink-qt

### DIFF
--- a/pkgs/development/python-modules/python3-eventlib/0001-fixes-for-python3.14.patch
+++ b/pkgs/development/python-modules/python3-eventlib/0001-fixes-for-python3.14.patch
@@ -1,0 +1,49 @@
+From c3076f3ae4567af11dc6815550487adaff69ce03 Mon Sep 17 00:00:00 2001
+From: phanirithvij <phanirithvij2000@gmail.com>
+Date: Sun, 5 Jul 2026 18:30:15 +0530
+Subject: [PATCH] fixes for python3.14
+
+Add fallback stubs for urllib attributes removed in Python 3.14.
+---
+ eventlib/green/urllib.py | 18 ++++++++++++++++--
+ 1 file changed, 16 insertions(+), 2 deletions(-)
+
+diff --git a/eventlib/green/urllib.py b/eventlib/green/urllib.py
+index 0c8e375..ba82160 100644
+--- a/eventlib/green/urllib.py
++++ b/eventlib/green/urllib.py
+@@ -7,7 +7,12 @@ from eventlib.green import socket, time
+ from urllib.error import( __all__ )
+ from urllib.response import( __all__ )
+ from urllib.robotparser import( __all__ )
+-from urllib.request import( __all__, __version__, MAXFTPCACHE, ftpcache, ftpwrapper, _noheaders, noheaders, proxy_bypass, addinfourl, url2pathname, getproxies)
++try:
++    from urllib.request import( __all__, __version__, MAXFTPCACHE, ftpcache, ftpwrapper, _noheaders, noheaders, proxy_bypass, addinfourl, url2pathname, getproxies)
++except ImportError:
++    from urllib.request import( __all__, __version__, ftpwrapper, _noheaders, noheaders, proxy_bypass, addinfourl, url2pathname, getproxies)
++    MAXFTPCACHE = 10
++    ftpcache = {}
+ from urllib.parse import( __all__,  quote, unwrap, unquote, splithost, splituser, splittype, splitattr, splitpasswd, splitport, splitquery, splitvalue)
+ from urllib.parse import urljoin as basejoin
+ 
+@@ -41,7 +46,16 @@ def urlcleanup():
+         _urlopener.cleanup()
+ 
+ 
+-class URLopener(urllib.request.URLopener):
++try:
++    _URLopener = urllib.request.URLopener
++    _FancyURLopener = urllib.request.FancyURLopener
++except AttributeError:
++    class _URLopener(object):
++        def __init__(self, *args, **kwargs): pass
++    class _FancyURLopener(_URLopener):
++        pass
++
++class URLopener(_URLopener):
+ 
+     def open_http(self, url, data=None):
+         """Use HTTP protocol."""
+-- 
+2.54.0
+

--- a/pkgs/development/python-modules/python3-eventlib/default.nix
+++ b/pkgs/development/python-modules/python3-eventlib/default.nix
@@ -20,6 +20,11 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-jN9nn+rI4TJLrEiEIoVxQ3XnXWSws1FenGUfG3doc94=";
   };
 
+  patches = [
+    # remove once new release with https://github.com/AGProjects/python3-eventlib/pull/4
+    ./0001-fixes-for-python3.14.patch
+  ];
+
   build-system = [ setuptools ];
 
   dependencies = [


### PR DESCRIPTION
Fixes build of blink-qt. Depends also on https://github.com/NixOS/nixpkgs/pull/538451

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
