### PR TITLE
maintainers: fix wrong githubId and github for aaravrav

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -411,8 +411,8 @@
   };
   aaravrav = {
     name = "aaravrav";
-    github = "Aarav";
-    githubId = 3279912;
+    github = "aaravrav";
+    githubId = 37036762;
   };
   aarnphm = {
     email = "contact@aarnphm.xyz";


### PR DESCRIPTION
When adding myself as maintainer in e2214c23a0f0, I accidentally had submitted the wrong githubId. This PR corrects that.