### PR TITLE
python314Packages.paste: clean up dependencies, add patch to replace pkg_resources;  python314Packages.pyld: 1.0.5 -> 2.0.4;  mediagoblin: migrate to pyproject = true, fix dependencies  

### DIFF
--- a/pkgs/by-name/me/mediagoblin/package.nix
+++ b/pkgs/by-name/me/mediagoblin/package.nix
@@ -36,9 +36,9 @@ let
   };
 in
 python.pkgs.buildPythonApplication rec {
-  format = "setuptools";
   pname = "mediagoblin";
   inherit version src;
+  pyproject = true;
 
   postPatch = ''
     # https://git.sr.ht/~mediagoblin/mediagoblin/tree/bf61d38df21748aadb480c53fdd928647285e35f/item/.guix/modules/mediagoblin-package.scm#L60-62
@@ -58,7 +58,7 @@ python.pkgs.buildPythonApplication rec {
   ];
 
   build-system = with python.pkgs; [
-    setuptools
+    setuptools_80
   ];
 
   dependencies = with python.pkgs; [

--- a/pkgs/development/python-modules/paste/default.nix
+++ b/pkgs/development/python-modules/paste/default.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   pytestCheckHook,
   setuptools,
-  six,
 }:
 
 buildPythonPackage rec {
@@ -19,16 +18,16 @@ buildPythonPackage rec {
     hash = "sha256-NY/h6hbpluEu1XAv3o4mqoG+l0LXfM1dw7+G0Rm1E4o=";
   };
 
+  patches = [
+    # https://github.com/pasteorg/paste/pull/108
+    ./remove-pkg-resource.patch
+  ];
+
   postPatch = ''
     patchShebangs tests/cgiapp_data/
   '';
 
   build-system = [ setuptools ];
-
-  dependencies = [
-    setuptools
-    six
-  ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 
@@ -36,11 +35,6 @@ buildPythonPackage rec {
     # needs to be modified after Sat, 1 Jan 2005 12:00:00 GMT
     touch tests/urlparser_data/secured.txt
   '';
-
-  disabledTests = [
-    # pkg_resources deprecation warning
-    "test_form"
-  ];
 
   pythonNamespaces = [ "paste" ];
 

--- a/pkgs/development/python-modules/paste/remove-pkg-resource.patch
+++ b/pkgs/development/python-modules/paste/remove-pkg-resource.patch
@@ -1,0 +1,198 @@
+diff --git a/paste/__init__.py b/paste/__init__.py
+index ec8b065..0962681 100644
+--- a/paste/__init__.py
++++ b/paste/__init__.py
+@@ -1,17 +1,8 @@
+ # (c) 2005 Ian Bicking and contributors; written for Paste (http://pythonpaste.org)
+ # Licensed under the MIT license: http://www.opensource.org/licenses/mit-license.php
+ 
+-import warnings
+-
+-try:
+-    with warnings.catch_warnings():
+-        warnings.simplefilter("ignore", category=DeprecationWarning)
+-        import pkg_resources
+-        pkg_resources.declare_namespace(__name__)
+-except (AttributeError, ImportError):
+-    # don't prevent use of paste if pkg_resources isn't installed
+-    from pkgutil import extend_path
+-    __path__ = extend_path(__path__, __name__)
++from pkgutil import extend_path
++__path__ = extend_path(__path__, __name__)
+ 
+ try:
+     import modulefinder
+diff --git a/paste/urlparser.py b/paste/urlparser.py
+index 2210b22..755ef0e 100644
+--- a/paste/urlparser.py
++++ b/paste/urlparser.py
+@@ -9,12 +9,7 @@
+ import mimetypes
+ import warnings
+ import importlib.util as imputil
+-try:
+-    with warnings.catch_warnings():
+-        warnings.simplefilter("ignore", category=DeprecationWarning)
+-        import pkg_resources
+-except ImportError:
+-    pkg_resources = None
++import importlib.metadata
+ from paste import request
+ from paste import fileapp
+ from paste.util import import_string
+@@ -521,19 +516,40 @@ def make_static(global_conf, document_root, cache_max_age=None):
+     return StaticURLParser(
+         document_root, cache_max_age=cache_max_age)
+ 
++class _DistributionResources:
++    """Minimal shim replacing pkg_resources distribution resource methods."""
++
++    def __init__(self, dist):
++        self._root = dist.locate_file('')
++        self.project_name = dist.metadata['Name']
++
++    def _path(self, resource_name):
++        return self._root / resource_name
++
++    def has_resource(self, resource_name):
++        p = self._path(resource_name)
++        return p.is_file() or p.is_dir()
++
++    def resource_isdir(self, resource_name):
++        return self._path(resource_name).is_dir()
++
++    def get_resource_stream(self, manager, resource_name):
++        return self._path(resource_name).open('rb')
++
++
+ class PkgResourcesParser(StaticURLParser):
+ 
+     def __init__(self, egg_or_spec, resource_name, manager=None, root_resource=None):
+-        if pkg_resources is None:
+-            raise NotImplementedError("This class requires pkg_resources.")
+-        if isinstance(egg_or_spec, (bytes, str)):
+-            self.egg = pkg_resources.get_distribution(egg_or_spec)
++        if isinstance(egg_or_spec, str):
++            dist = importlib.metadata.distribution(egg_or_spec)
++            self.egg = _DistributionResources(dist)
++        elif isinstance(egg_or_spec, bytes):
++            dist = importlib.metadata.distribution(egg_or_spec.decode())
++            self.egg = _DistributionResources(dist)
+         else:
+             self.egg = egg_or_spec
+         self.resource_name = resource_name
+-        if manager is None:
+-            manager = pkg_resources.ResourceManager()
+-        self.manager = manager
++        self.manager = manager  # kept for API compatibility; no longer used
+         if root_resource is None:
+             root_resource = resource_name
+         self.root_resource = os.path.normpath(root_resource)
+@@ -595,12 +611,10 @@ def not_found(self, environ, start_response, debug_message=None):
+ def make_pkg_resources(global_conf, egg, resource_name=''):
+     """
+     A static file parser that loads data from an egg using
+-    ``pkg_resources``.  Takes a configuration value ``egg``, which is
++    ``importlib.resources``.  Takes a configuration value ``egg``, which is
+     an egg spec, and a base ``resource_name`` (default empty string)
+     which is the path in the egg that this starts at.
+     """
+-    if pkg_resources is None:
+-        raise NotImplementedError("This function requires pkg_resources.")
+     return PkgResourcesParser(egg, resource_name)
+ 
+ def make_url_parser(global_conf, directory, base_python_name,
+diff --git a/paste/util/template.py b/paste/util/template.py
+index ee6b25f..f4fe3af 100644
+--- a/paste/util/template.py
++++ b/paste/util/template.py
+@@ -682,12 +682,12 @@ def parse_default(tokens, name, context):
+ """
+ 
+ def fill_command(args=None):
+-    import sys, optparse, pkg_resources, os
++    import sys, optparse, importlib.metadata, os
+     if args is None:
+         args = sys.argv[1:]
+-    dist = pkg_resources.get_distribution('Paste')
++    version = importlib.metadata.version('Paste')
+     parser = optparse.OptionParser(
+-        version=str(dist),
++        version=version,
+         usage=_fill_command_usage)
+     parser.add_option(
+         '-o', '--output',
+diff --git a/setup.py b/setup.py
+index cd1ac04..5bd6d89 100644
+--- a/setup.py
++++ b/setup.py
+@@ -52,10 +52,8 @@
+       packages=find_packages(exclude=['ez_setup', 'examples', 'packages', 'tests*']),
+       package_data=finddata.find_package_data(
+           exclude_directories=finddata.standard_exclude_directories + ('tests',)),
+-      namespace_packages=['paste'],
+       zip_safe=False,
+       install_requires=[
+-        'setuptools',  # pkg_resources
+         ],
+       extras_require={
+         'subprocess': [],
+diff --git a/tests/__init__.py b/tests/__init__.py
+index 2f10103..9f2d860 100644
+--- a/tests/__init__.py
++++ b/tests/__init__.py
+@@ -3,5 +3,3 @@
+ import os
+ 
+ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+-
+-import pkg_resources
+diff --git a/tests/cgiapp_data/form.cgi b/tests/cgiapp_data/form.cgi
+index 21dca13..4005dc3 100755
+--- a/tests/cgiapp_data/form.cgi
++++ b/tests/cgiapp_data/form.cgi
+@@ -4,20 +4,11 @@ print('Content-type: text/plain')
+ print('')
+ 
+ import sys
+-import warnings
+ from os.path import dirname
+ 
+ base_dir = dirname(dirname(dirname(__file__)))
+ sys.path.insert(0, base_dir)
+ 
+-with warnings.catch_warnings():
+-    warnings.simplefilter("ignore", category=DeprecationWarning)
+-    try:
+-        import pkg_resources
+-    except ImportError:
+-        # Ignore
+-        pass
+-
+ from paste.util.field_storage import FieldStorage
+ 
+ class FormFieldStorage(FieldStorage):
+diff --git a/tests/test_urlparser.py b/tests/test_urlparser.py
+index c0cf622..297f1d6 100644
+--- a/tests/test_urlparser.py
++++ b/tests/test_urlparser.py
+@@ -1,9 +1,6 @@
+ import os
+ import warnings
+-
+-with warnings.catch_warnings():
+-    warnings.simplefilter("ignore", category=DeprecationWarning)
+-    from pkg_resources import get_distribution
++import importlib.metadata
+ 
+ from paste.fixture import TestApp
+ from paste.urlparser import PkgResourcesParser, StaticURLParser, URLParser
+@@ -155,7 +152,7 @@ def test_egg_parser():
+     # Find a readable file in the Paste pkg's root directory (or upwards the
+     # directory tree). Ensure it's not accessible via the URLParser
+     unreachable_test_file = None
+-    search_path = pkg_root_path = get_distribution('Paste').location
++    search_path = pkg_root_path = str(importlib.metadata.distribution('Paste').locate_file(''))
+     level = 0
+     # We might not find any readable files in the pkg's root directory (this
+     # is likely when Paste is installed as a .egg in site-packages). We

--- a/pkgs/development/python-modules/pyld/default.nix
+++ b/pkgs/development/python-modules/pyld/default.nix
@@ -1,57 +1,72 @@
 {
   lib,
+  cachetools,
+  frozendict,
+  lxml,
   buildPythonPackage,
   fetchFromGitHub,
   python,
   requests,
+  setuptools,
 }:
 
 let
 
   json-ld = fetchFromGitHub {
-    owner = "json-ld";
-    repo = "json-ld.org";
-    rev = "843a70e4523d7cd2a4d3f5325586e726eb1b123f";
-    sha256 = "05j0nq6vafclyypxjj30iw898ig0m32nvz0rjdlslx6lawkiwb2a";
+    owner = "w3c";
+    repo = "json-ld-api";
+    rev = "8ad03db5477e24b70a4ded898a1b2e18d6ab684b";
+    hash = "sha256-M/Vr9muxSHQTHcgFXhg7kiQtIMGnpbl3QXIAE5KBv8k=";
+  };
+
+  json-ld-framing = fetchFromGitHub {
+    owner = "w3c";
+    repo = "json-ld-framing";
+    rev = "dfda94cfdfb360d5b64ac047bdb8ef86ec7ea0f1";
+    hash = "sha256-awn4cPF//wSe7kQ358bPwJY1HwcE25XhGbo5NrqkNXk=";
   };
 
   normalization = fetchFromGitHub {
     owner = "json-ld";
     repo = "normalization";
-    rev = "aceeaf224b64d6880189d795bd99c3ffadb5d79e";
-    sha256 = "125q5rllfm8vg9mz8hn7bhvhv2vqpd86kx2kxlk84smh33l8kbyl";
+    rev = "fbcfce5730bf2726c131a84d06ffb686a190a969";
+    hash = "sha256-a44vLPbWnbbR4kZa/jklCBvrPQwsllixsg0yZclhKls=";
   };
 in
 
 buildPythonPackage rec {
   pname = "pyld";
-  version = "1.0.5";
-  format = "setuptools";
+  version = "2.0.4";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "digitalbazaar";
     repo = "pyld";
-    rev = version;
-    sha256 = "0z2vkllw8bvzxripwb6l757r7av5qwhzsiy4061gmlhq8z8gq961";
+    tag = "v${version}";
+    hash = "sha256-XKPAGOLuLk2VOnvdICo2sNPdeoQok+oGScWXeuYmi4o=";
   };
 
-  propagatedBuildInputs = [ requests ];
+  build-system = [ setuptools ];
 
-  # Unfortunately PyLD does not pass all testcases in the JSON-LD corpus. We
-  # check for at least a minimum amount of successful tests so we know it's not
-  # getting worse, at least.
+  dependencies = [
+    cachetools
+    frozendict
+    lxml
+    requests
+  ];
+
   checkPhase = ''
-    ok_min=401
+    runHook preCheck
 
-    if ! ${python.interpreter} tests/runtests.py -d ${json-ld}/test-suite 2>&1 | tee test.out; then
-      ok_count=$(grep -F '... ok' test.out | wc -l)
-      if [[ $ok_count -lt $ok_min ]]; then
-        echo "Less than $ok_min tests passed ($ok_count). Failing the build."
-        exit 1
-      fi
-    fi
+    cp -r --no-preserve=all ${json-ld}/tests json-ld-tests
+    # We have no internet access
+    substituteInPlace json-ld-tests/manifest.jsonld \
+      --replace-fail '"remote-doc-manifest.jsonld",' ""
+    patch -p1 <${./disable-tests-where-pyld-is-not-strict-enough.diff}
 
-    ${python.interpreter} tests/runtests.py -d ${normalization}/tests
+    ${python.interpreter} tests/runtests.py ${normalization}/tests ${json-ld-framing}/tests json-ld-tests
+
+    runHook postCheck
   '';
 
   meta = {

--- a/pkgs/development/python-modules/pyld/disable-tests-where-pyld-is-not-strict-enough.diff
+++ b/pkgs/development/python-modules/pyld/disable-tests-where-pyld-is-not-strict-enough.diff
@@ -1,0 +1,109 @@
+diff --git a/tests/compact-manifest.jsonld b/tests/compact-manifest.jsonld
+index b8a4023..615fbf2 100644
+--- a/json-ld-tests/compact-manifest.jsonld
++++ b/json-ld-tests/compact-manifest.jsonld
+@@ -1048,7 +1048,7 @@
+       "input": "compact/c013-in.jsonld",
+       "context": "compact/c013-context.jsonld",
+       "expect": "compact/c013-out.jsonld",
+-      "option": {"specVersion": "json-ld-1.1"}    
++      "option": {"specVersion": "json-ld-1.1"}
+     }, {
+       "@id": "#tc014",
+       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+@@ -1175,15 +1175,6 @@
+       "context": "compact/c027-context.jsonld",
+       "expect": "compact/c027-out.jsonld",
+       "option": {"specVersion": "json-ld-1.1"}
+-    }, {
+-      "@id": "#tc028",
+-      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+-      "name": "Empty-property scoped context does not affect term selection.",
+-      "purpose": "Adding a minimal/empty property-scoped context should not affect the using terms defined in outer context.",
+-      "input": "compact/c028-in.jsonld",
+-      "context": "compact/c028-context.jsonld",
+-      "expect": "compact/c028-out.jsonld",
+-      "option": {"specVersion": "json-ld-1.1"}
+     }, {
+       "@id": "#tdi01",
+       "@type": [ "jld:PositiveEvaluationTest", "jld:CompactTest" ],
+diff --git a/tests/expand-manifest.jsonld b/tests/expand-manifest.jsonld
+index f4a5978..b4be431 100644
+--- a/json-ld-tests/expand-manifest.jsonld
++++ b/json-ld-tests/expand-manifest.jsonld
+@@ -1258,14 +1258,6 @@
+       "input": "expand/c035-in.jsonld",
+       "expect": "expand/c035-out.jsonld",
+       "option": {"specVersion": "json-ld-1.1"}
+-    }, {
+-      "@id": "#tc036",
+-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+-      "name": "Expansion with empty property-scoped context.",
+-      "purpose": "Adding a minimal/empty property-scoped context should not affect expansion of terms defined in the outer scope.",
+-      "input": "expand/c036-in.jsonld",
+-      "expect": "expand/c036-out.jsonld",
+-      "option": {"specVersion": "json-ld-1.1"}
+     }, {
+       "@id": "#tdi01",
+       "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
+@@ -1780,13 +1772,6 @@
+      "purpose": "Verifies that an exception is raised on expansion when a context contains an invalid @prefix value",
+      "input": "expand/er53-in.jsonld",
+      "expectErrorCode": "invalid @prefix value"
+-    }, {
+-     "@id": "#ter54",
+-     "@type": [ "jld:NegativeEvaluationTest", "jld:ExpandTest" ],
+-     "name": "Invalid value object, multiple values for @type.",
+-     "purpose": "The value of @type in a value object MUST be a string or null.",
+-     "input": "expand/er54-in.jsonld",
+-     "expectErrorCode": "invalid typed value"
+     }, {
+      "@id": "#ter55",
+      "@type": [ "jld:NegativeEvaluationTest", "jld:ExpandTest" ],
+diff --git a/tests/toRdf-manifest.jsonld b/tests/toRdf-manifest.jsonld
+index 7ca7d08..3b25cb9 100644
+--- a/json-ld-tests/toRdf-manifest.jsonld
++++ b/json-ld-tests/toRdf-manifest.jsonld
+@@ -676,14 +676,6 @@
+       "input": "toRdf/c035-in.jsonld",
+       "expect": "toRdf/c035-out.nq",
+       "option": {"specVersion": "json-ld-1.1"}
+-    }, {
+-      "@id": "#tc036",
+-      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+-      "name": "Expansion with empty property-scoped context.",
+-      "purpose": "Adding a minimal/empty property-scoped context should not affect expansion of terms defined in the outer scope.",
+-      "input": "toRdf/c036-in.jsonld",
+-      "expect": "toRdf/c036-out.nq",
+-      "option": {"specVersion": "json-ld-1.1"}
+     }, {
+       "@id": "#tdi01",
+       "@type": [ "jld:PositiveEvaluationTest", "jld:ToRDFTest" ],
+@@ -1158,13 +1150,6 @@
+       "purpose": "RDF version of expand-0053",
+       "input": "toRdf/e053-in.jsonld",
+       "expect": "toRdf/e053-out.nq"
+-    }, {
+-      "@id": "#te054",
+-      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+-      "name": "Expand term with @type: @vocab",
+-      "purpose": "RDF version of expand-0054",
+-      "input": "toRdf/e054-in.jsonld",
+-      "expect": "toRdf/e054-out.nq"
+     }, {
+       "@id": "#te055",
+       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
+@@ -2206,13 +2191,6 @@
+       "purpose": "Verifies that an exception is raised on expansion when a context contains an invalid @prefix value",
+       "input": "toRdf/er53-in.jsonld",
+       "expectErrorCode": "invalid @prefix value"
+-    }, {
+-     "@id": "#ter54",
+-     "@type": [ "jld:NegativeEvaluationTest", "jld:ToRDFTest" ],
+-     "name": "Invalid value object, multiple values for @type.",
+-     "purpose": "The value of @type in a value object MUST be a string or null.",
+-     "input": "toRdf/er54-in.jsonld",
+-     "expectErrorCode": "invalid typed value"
+     }, {
+      "@id": "#ter55",
+      "@type": [ "jld:NegativeEvaluationTest", "jld:ToRDFTest" ],


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
