### PR TITLE
Add esphome-device-builder

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6394,6 +6394,12 @@
     name = "David Wood";
     keys = [ { fingerprint = "5B08 313C 6853 E5BF FA91  A817 0176 0B4F 9F53 F154"; } ];
   };
+  DavidvtWout = {
+    email = "nixpkgs@vtwout.com";
+    github = "DavidvtWout";
+    githubId = 8415443;
+    name = "David van 't Wout";
+  };
   davidweisse = {
     name = "David Weiße";
     github = "davidweisse";

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -34,6 +34,8 @@
 
 - [Unpackerr](https://unpackerr.zip), extracts downloads for Radarr, Sonarr, Lidarr, Readarr, and/or a Watch folder. Available as [services.unpackerr](#opt-services.unpackerr.enable).
 
+- [ESPHome Device Builder](https://esphome.io/), a web-based dashboard for building and managing ESPHome device configurations. Available as [services.esphome-device-builder](#opt-services.esphome-device-builder.enable).
+
 - [Matrix Authentication Service](https://github.com/element-hq/matrix-authentication-service) is an OAuth2.0 and OpenID Connect provider for Matrix homeservers (such as Synapse). It replaces standard password authentication with modern OpenID Connect flows, and can delegate authentication to upstream OIDC providers. Available as [services.matrix-authentication-service](#opt-services.matrix-authentication-service.enable).
 
 ## Backward Incompatibilities {#sec-release-26.11-incompatibilities}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -729,6 +729,7 @@
   ./services/hardware/vdr.nix
   ./services/home-automation/deye-dummycloud.nix
   ./services/home-automation/ebusd.nix
+  ./services/home-automation/esphome-device-builder.nix
   ./services/home-automation/esphome.nix
   ./services/home-automation/evcc.nix
   ./services/home-automation/govee2mqtt.nix

--- a/nixos/modules/services/home-automation/esphome-device-builder.nix
+++ b/nixos/modules/services/home-automation/esphome-device-builder.nix
@@ -1,0 +1,111 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.esphome-device-builder;
+
+  stateDir = "/var/lib/esphome-device-builder";
+in
+{
+  meta.maintainers = with lib.maintainers; [ DavidvtWout ];
+
+  options.services.esphome-device-builder = with lib; {
+    enable = mkEnableOption "esphome device builder dashboard";
+
+    package = mkPackageOption pkgs "esphome-device-builder" { };
+
+    esphome-package = mkPackageOption pkgs "esphome" { };
+
+    address = mkOption {
+      type = types.str;
+      default = "localhost";
+      description = "esphome device builder dashboard address";
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 6052;
+      description = "esphome device builder dashboard port";
+    };
+
+    openFirewall = mkOption {
+      default = false;
+      type = types.bool;
+      description = "Whether to open the firewall for the specified port.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.port ];
+
+    users.users.esphome-device-builder = {
+      isSystemUser = true;
+      home = stateDir;
+      createHome = true;
+      group = "esphome-device-builder";
+    };
+
+    users.groups.esphome-device-builder = { };
+
+    systemd.services.esphome-device-builder = {
+      description = "ESPHome device builder dashboard";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      path = [
+        cfg.package
+        cfg.esphome-package
+      ];
+
+      environment.PYTHONPATH = cfg.package.pythonPath;
+
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/esphome-device-builder --host ${cfg.address} --port ${toString cfg.port}";
+        User = "esphome-device-builder";
+        Group = "esphome-device-builder";
+        WorkingDirectory = stateDir;
+        Restart = "on-failure";
+        ReadWritePaths = [ stateDir ];
+        ExecPaths = [ stateDir ];
+
+        # Hardening
+        CapabilityBoundingSet = "";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        DevicePolicy = "closed";
+        SupplementaryGroups = [ "dialout" ];
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = false; # breaks bwrap
+        ProtectKernelLogs = false; # breaks bwrap
+        ProtectKernelModules = true;
+        ProtectKernelTunables = false; # breaks bwrap
+        ProtectProc = "invisible";
+        ProcSubset = "all"; # Using "pid" breaks bwrap
+        ProtectSystem = "strict";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_NETLINK"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = false; # Required by platformio for chroot
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "@mount" # Required by platformio for chroot
+        ];
+        UMask = "0077";
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -558,6 +558,7 @@ in
     inherit runTest;
   };
   esphome = runTest ./esphome.nix;
+  esphome-device-builder = runTest ./esphome-device-builder.nix;
   etc = pkgs.callPackage ../modules/system/etc/test.nix { inherit evalMinimalConfig; };
   etcd = import ./etcd/default.nix { inherit pkgs runTest; };
   etebase-server = runTest ./etebase-server.nix;

--- a/nixos/tests/esphome-device-builder.nix
+++ b/nixos/tests/esphome-device-builder.nix
@@ -1,0 +1,26 @@
+{ pkgs, lib, ... }:
+
+let
+  testPort = 6052;
+in
+{
+  name = "esphome-device-builder";
+  meta.maintainers = with lib.maintainers; [ DavidvtWout ];
+
+  nodes.machine =
+    { ... }:
+    {
+      services.esphome-device-builder = {
+        enable = true;
+        port = testPort;
+        address = "0.0.0.0";
+        openFirewall = true;
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("esphome-device-builder.service")
+    machine.wait_for_open_port(${toString testPort})
+    machine.succeed("curl --fail http://localhost:${toString testPort}/")
+  '';
+}

--- a/pkgs/by-name/es/esphome-device-builder/package.nix
+++ b/pkgs/by-name/es/esphome-device-builder/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  esphome,
+  fetchFromGitHub,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication (
+  finalAttrs:
+  let
+    dependencies = with python3Packages; [
+      (python3Packages.toPythonModule esphome)
+      esphome-device-builder-frontend
+      aiohttp
+      aiohttp-asyncmdnsresolver
+      colorlog
+      cryptography
+      fnv-hash-fast
+      ifaddr
+      mashumaro
+      orjson
+      pyyaml
+      ruamel-yaml
+      voluptuous
+      zeroconf
+    ];
+  in
+  {
+    pname = "esphome-device-builder";
+    version = "1.0.29";
+    pyproject = true;
+
+    src = fetchFromGitHub {
+      owner = "esphome";
+      repo = "device-builder";
+      tag = finalAttrs.version;
+      hash = "sha256-23Uj2n9SlQ4FTqRky8IRg3OE04MxVcWB1z6DLfbFQ8E=";
+    };
+
+    build-system = with python3Packages; [ setuptools ];
+
+    pythonRelaxDeps = [ "zeroconf" ];
+
+    postPatch = ''
+      substituteInPlace pyproject.toml \
+        --replace-fail "version = \"0.0.0\"" "version = \"${finalAttrs.version}\""
+    '';
+
+    inherit dependencies;
+
+    passthru = {
+      pythonPath = python3Packages.makePythonPath dependencies;
+    };
+
+    __structuredAttrs = true;
+
+    meta = {
+      changelog = "https://github.com/esphome/esphome-device-builder/releases/tag/${finalAttrs.src.tag}";
+      description = "ESPHome Device Builder Dashboard";
+      homepage = "https://esphome.io/";
+      license = lib.licenses.asl20;
+      maintainers = with lib.maintainers; [ DavidvtWout ];
+      mainProgram = "esphome-device-builder";
+    };
+  }
+)

--- a/pkgs/by-name/es/esphome-device-builder/package.nix
+++ b/pkgs/by-name/es/esphome-device-builder/package.nix
@@ -3,6 +3,7 @@
   esphome,
   fetchFromGitHub,
   python3Packages,
+  nixosTests,
 }:
 
 python3Packages.buildPythonApplication (
@@ -50,6 +51,7 @@ python3Packages.buildPythonApplication (
 
     passthru = {
       pythonPath = python3Packages.makePythonPath dependencies;
+      tests = { inherit (nixosTests) esphome-device-builder; };
     };
 
     __structuredAttrs = true;

--- a/pkgs/development/python-modules/esphome-device-builder-frontend/default.nix
+++ b/pkgs/development/python-modules/esphome-device-builder-frontend/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  setuptools,
+  nodejs,
+  npmHooks,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "esphome-device-builder-frontend";
+  version = "0.1.207";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "esphome";
+    repo = "device-builder-frontend";
+    tag = finalAttrs.version;
+    hash = "sha256-63f9i0LC1xyNuB0rbH3/3N5RkOtRWXxjb2NBJcy85ao=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'version = "0.0.0"' 'version = "${finalAttrs.version}"'
+  '';
+
+  npmDeps = fetchNpmDeps {
+    src = finalAttrs.src;
+    hash = "sha256-eMG0zuShFWuteaz8Zb8S8bZo7UAmjnKyhQSbZWfqIXU=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeBuildInputs = [
+    npmHooks.npmConfigHook
+    nodejs
+  ];
+
+  preBuild = ''
+    npm run build
+  '';
+
+  meta = {
+    changelog = "https://github.com/esphome/esphome-device-builder-frontend/releases/tag/${finalAttrs.src.tag}";
+    description = "Frontend for the ESPHome Device Builder";
+    homepage = "https://github.com/esphome/esphome-device-builder-frontend";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ DavidvtWout ];
+  };
+})

--- a/pkgs/development/python-modules/esphome-device-builder-frontend/default.nix
+++ b/pkgs/development/python-modules/esphome-device-builder-frontend/default.nix
@@ -41,6 +41,8 @@ buildPythonPackage (finalAttrs: {
     npm run build
   '';
 
+  __structuredAttrs = true;
+
   meta = {
     changelog = "https://github.com/esphome/esphome-device-builder-frontend/releases/tag/${finalAttrs.src.tag}";
     description = "Frontend for the ESPHome Device Builder";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5519,6 +5519,10 @@ self: super: with self; {
 
   esphome-dashboard-api = callPackage ../development/python-modules/esphome-dashboard-api { };
 
+  esphome-device-builder-frontend =
+    callPackage ../development/python-modules/esphome-device-builder-frontend
+      { };
+
   esphome-glyphsets = callPackage ../development/python-modules/esphome-glyphsets { };
 
   esprima = callPackage ../development/python-modules/esprima { };


### PR DESCRIPTION
This PR adds the ESPHome Device Builder, the newly developed web dashboard for ESPHome that replaces the classic dashboard (services.esphome). It listens on port 6052 by default, the same as the old dashboard.

The following is added:
- pkgs.esphome-device-builder — the dashboard application
- python3Packages.esphome-device-builder-frontend — the frontend, built from source using npm
- services.esphome-device-builder — a NixOS module to run the device builder dashboard as a systemd service

The module exposes an esphomePackage option that controls which ESPHome version is used for firmware compilation, independently of the dashboard version. This allows users to pin the compiler separately from the UI.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
