### PR TITLE
Revert "ci: update pinned"

### DIFF
--- a/ci/default.nix
+++ b/ci/default.nix
@@ -70,7 +70,7 @@ rec {
   };
   parse = pkgs.lib.recurseIntoAttrs {
     nix_latest = pkgs.callPackage ./parse.nix { nix = pkgs.nixVersions.latest; };
-    stable = pkgs.callPackage ./parse.nix { nix = pkgs.nixVersions.stable; };
+    nix_2_28 = pkgs.callPackage ./parse.nix { nix = pkgs.nixVersions.nix_2_28; };
     lix = pkgs.callPackage ./parse.nix { nix = pkgs.lix; };
     lix_latest = pkgs.callPackage ./parse.nix { nix = pkgs.lixPackageSets.latest.lix; };
   };

--- a/ci/pinned.json
+++ b/ci/pinned.json
@@ -9,9 +9,9 @@
       },
       "branch": "nixpkgs-unstable",
       "submodules": false,
-      "revision": "6edbf1a6a03e75886a6609c088801a0856449e88",
-      "url": "https://github.com/NixOS/nixpkgs/archive/6edbf1a6a03e75886a6609c088801a0856449e88.tar.gz",
-      "hash": "sha256-0lkauQbtrljJqwtzTCILPAiHAJyMvn6XDo264moDv30="
+      "revision": "8c91a71d13451abc40eb9dae8910f972f979852f",
+      "url": "https://github.com/NixOS/nixpkgs/archive/8c91a71d13451abc40eb9dae8910f972f979852f.tar.gz",
+      "hash": "sha256-fnzKKPvS+oieI/pTzotA5tkoM47EB1NpaBcgk4R97hE="
     }
   },
   "version": 8

--- a/ci/update-pinned.sh
+++ b/ci/update-pinned.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -E 'with import ../. {}; mkShell { packages = [ npins ]; }'
+#!nix-shell -i bash -p npins -I nixpkgs=../
 
 set -euo pipefail
 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#538674 because it cannot be backported.

See:
- https://github.com/NixOS/nixpkgs/pull/538699
- https://github.com/NixOS/nixpkgs/pull/536372

Draft until discussion is resolved; maybe there's a clean way we _can_ backport?