### PR TITLE
virtme-ng: init at 1.41

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20039,6 +20039,12 @@
     github = "nigelgbanks";
     githubId = 487373;
   };
+  nikableh = {
+    email = "nika@nikableh.moe";
+    github = "nikableh";
+    githubId = 61655860;
+    name = "Nika Krasnova";
+  };
   nikhilmaddirala = {
     name = "Nikhil Maddirala";
     github = "nikhilmaddirala";

--- a/pkgs/by-name/vi/virtme-ng/package.nix
+++ b/pkgs/by-name/vi/virtme-ng/package.nix
@@ -1,0 +1,138 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  fetchpatch,
+  rustPlatform,
+  cargo,
+  rustc,
+  installShellFiles,
+  makeWrapper,
+  qemu,
+  virtiofsd,
+  busybox,
+  socat,
+  openssh,
+  kmod,
+  file,
+  glibc,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "virtme-ng";
+  version = "1.41";
+  pyproject = true;
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "arighi";
+    repo = "virtme-ng";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/R+2ND/N+exF9eDSxAN8LR3cDuxBvpGSkiXcckyq8TY=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    cargoRoot = "virtme_ng_init";
+    hash = "sha256-KpVGrhOCsgLD7vH3NGEtgaH/tcVOisVyXDKjJ+4hxgM=";
+  };
+
+  cargoRoot = "virtme_ng_init";
+
+  # NixOS-support fixes, merged upstream in arighi/virtme-ng#480 but not yet in a
+  # release; drop once a release includes them. The README hunk is excluded (it
+  # doesn't apply to v1.41 and the README isn't installed anyway).
+  patches = [
+    (fetchpatch {
+      name = "nixos-support-pr480.patch";
+      url = "https://github.com/arighi/virtme-ng/commit/bd434224876a071f9c0a4619c82c158ff9a07150.patch";
+      excludes = [ "README.md" ];
+      hash = "sha256-YPnm+IC185pxrkpuZPLcoTTQq47EoTxLNgYmXsitTfA=";
+    })
+  ];
+
+  postPatch = ''
+    # data_files installs the bash completions and man page under absolute /usr
+    # paths; drop it and install them into the store layout in postInstall.
+    substituteInPlace setup.py \
+      --replace-fail "data_files=data_files," ""
+  '';
+
+  env.BUILD_VIRTME_NG_INIT = 1;
+
+  build-system = [
+    cargo
+    rustc
+    rustPlatform.cargoSetupHook
+  ]
+  ++ (with python3Packages; [
+    setuptools
+    argparse-manpage
+  ]);
+
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+  ];
+
+  # setup.py builds virtme-ng-init with `-C target-feature=+crt-static`
+  buildInputs = [ glibc.static ];
+
+  dependencies = with python3Packages; [
+    argcomplete
+    requests
+    # Required by the bundled vng-mcp (Model Context Protocol) server.
+    mcp
+    anyio
+  ];
+
+  # Provide the host tools virtme-ng shells out to (qemu, virtiofsd, busybox,
+  # etc.) as a PATH *suffix*: `vng --build` compiles the kernel on the host and
+  # must use the user's GNU coreutils/diff/find, not shadow them with busybox.
+  makeWrapperArgs = [
+    "--suffix"
+    "PATH"
+    ":"
+    (lib.makeBinPath [
+      qemu
+      virtiofsd
+      busybox
+      socat
+      openssh
+      kmod
+      file
+      glibc.bin # getent
+    ])
+  ];
+
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "virtme_ng"
+    "virtme_ng.mcp"
+  ];
+
+  postInstall = ''
+    installShellCompletion --cmd vng --bash vng-prompt
+    installShellCompletion --cmd virtme-ng --bash virtme-ng-prompt
+  '';
+
+  meta = {
+    description = "Quickly build and run kernels inside a virtualized snapshot of your live system";
+    homepage = "https://github.com/arighi/virtme-ng";
+    changelog = "https://github.com/arighi/virtme-ng/releases/tag/v${finalAttrs.version}";
+    # virtme-ng is GPL-2.0-only; the virtme-ng-init guest helper is GPL-3.0-only
+    # and statically links Rust crates under MIT and MIT OR Apache-2.0.
+    license = with lib.licenses; [
+      gpl2Only
+      gpl3Only
+      mit
+      asl20
+    ];
+    mainProgram = "vng";
+    maintainers = [ lib.maintainers.nikableh ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
[virtme-ng](https://github.com/arighi/virtme-ng) is a tool that allows to easily and quickly recompile and test a Linux kernel, starting from the source code.

## Things done

Tested manually on mainline kernel. `vng --build && vng` ran successfully.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
