### PR TITLE
nixos/fish: `programs.fish.generateCompletions` fix spaces in filenames

### DIFF
--- a/nixos/modules/programs/fish.nix
+++ b/nixos/modules/programs/fish.nix
@@ -293,8 +293,8 @@ in
                 ''
                   mkdir -p $out
                   if [ -d $package/share/man ]; then
-                    find -L $package/share/man -type f \
-                      | xargs ${pkgs.python3.pythonOnBuildForHost.interpreter} \
+                    find -L $package/share/man -type f -print0 \
+                      | xargs -0 ${pkgs.python3.pythonOnBuildForHost.interpreter} \
                           ${generator}/create_manpage_completions.py --directory $out \
                           >/dev/null
                   fi


### PR DESCRIPTION
`linux-manual` has this fun filename in it:

```console
$ find -L $(nix-build -A linux-manual) -name 'station table - introduction.9.gz'
/nix/store/q45mzaksp2ll04c363mxpyi252j6anrq-linux-manual-7.1.3/share/man/man9/station table - introduction.9.gz
```

Our `find ... | xargs ...` didn't handle this nicely, and would vomit in the following way:

`repro.nix`:

```nix
$ cat repro.nix
let
  pkgs = import ./. { };
  nixosConfig = pkgs.nixos (
    { config, pkgs, ... }: {
      system.stateVersion = config.system.nixos.release;

      programs.fish.enable = true;
      programs.fish.generateCompletions = true;

      environment.systemPackages = [ pkgs.linux-manual ];
    }
  );
in
nixosConfig.config.environment.etc."fish/generated_completions".source
```

The crash:

```console
$ nix-build repro.nix
these 2 derivations will be built:
  /nix/store/qs213n0r723w59jdvfz5w87azd3wh405-linux-manual-7.1.3_fish-completions.drv
  /nix/store/1pwps30drz71icj5v4rdiaarmh37xcn8-system_fish-completions.drv
building '/nix/store/qs213n0r723w59jdvfz5w87azd3wh405-linux-manual-7.1.3_fish-completions.drv'...
usage: create_manpage_completions.py [-h] [-c CLEANUP_IN] [-d DIRECTORY] [-k]
                                     [-m] [-p] [-s] [-v {0,1,2}] [-z]
                                     [file_paths ...]
create_manpage_completions.py: error: unrecognized arguments: -introduction.9.gz /nix/store/q45mzaksp2ll04c363mxpyi252j6anrq-linux-manual-7.1.3/share/man/man9/DRBD State macros.9.gz /nix/store/q45mzaksp2ll04c363mxpyi252j6anrq-linux-manual-7.1.3/share/man/man9/DRM Client usage stats.9.gz /nix/store/q45mzaksp2ll04c363mxpyi252j6anrq-linux-manual-7.1.3/share/man/man9/DRM RAS Node Management.9.gz /nix/store/q45mzaksp2ll04c363mxpyi252j6anrq-linux-manual-7.1.3/share/man/man9/DRM_ACCEL_FOPS.9.gz
```

This fix is simple, use the `find -print0 ... | xargs -0 ...` pattern.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
