### PR TITLE
python314Packages.fastmcp: increase very close pytest timeout

### DIFF
--- a/pkgs/development/python-modules/fastmcp/default.nix
+++ b/pkgs/development/python-modules/fastmcp/default.nix
@@ -40,6 +40,11 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-1W5NbWIULxFXGSozZEeITcPt1EbY6IsJLQdyevcn9BI=";
   };
 
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "timeout = 5" "timeout = 50"
+  '';
+
   build-system = [
     hatchling
     uv-dynamic-versioning


### PR DESCRIPTION
```
FAILED tests/server/providers/openapi/test_openapi_performance.py::TestOpenAPIPerformance::test_medium_schema_performance - AssertionError: Medium schema parsing took 2.317s, expected <1s
FAILED tests/server/auth/test_oauth_proxy_storage.py::TestOAuthProxyStorage::test_client_persists_across_proxy_instances - Failed: Timeout (>5.0s) from pytest-timeout.
FAILED tests/tools/test_standalone_decorator.py::test_component_import_works_in_fresh_interpreter[from fastmcp.tools import tool] - Failed: Timeout (>5.0s) from pytest-timeout.
FAILED tests/server/auth/providers/test_workos.py::TestWorkOSProvider::test_authkit_domain_https_prefix_handling - Failed: Timeout (>5.0s) from pytest-timeout.
FAILED tests/server/auth/test_oauth_proxy_storage.py::TestOAuthProxyStorage::test_in_memory_storage_option - Failed: Timeout (>5.0s) from pytest-timeout.
FAILED tests/server/auth/test_oauth_proxy_redirect_validation.py::TestOAuthProxyCIMDClient::test_proxy_get_client_returns_cimd_client - Failed: Timeout (>5.0s) from pytest-timeout.
FAILED tests/tools/test_standalone_decorator.py::test_component_import_works_in_fresh_interpreter[from fastmcp.server.auth.authorization import AuthCheck] - Failed: Timeout (>5.0s) from pytest-timeout.
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
