### PR TITLE
qxmpp: 1.15.1 -> 1.16.1

### DIFF
--- a/pkgs/by-name/qx/qxmpp/package.nix
+++ b/pkgs/by-name/qx/qxmpp/package.nix
@@ -5,22 +5,24 @@
   cmake,
   pkg-config,
   kdePackages,
+  ctestCheckHook,
   withGstreamer ? true,
   gst_all_1,
   withOmemo ? true,
   libomemo-c,
+  withEncryption ? true,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "qxmpp";
-  version = "1.15.1";
+  version = "1.16.1";
 
   src = fetchFromGitLab {
     domain = "invent.kde.org";
     owner = "libraries";
     repo = "qxmpp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-PkdzEQKI0NiLvDyI+SEoKainF7UiAU3UVJQjgwYKHuo=";
+    hash = "sha256-JuGSLi0oqlUTbJnjlqd9qo0Dk2yCY1hfryQy0CuEjLo=";
   };
 
   nativeBuildInputs = [
@@ -46,21 +48,30 @@ stdenv.mkDerivation (finalAttrs: {
       libomemo-c
     ];
   cmakeFlags = [
-    "-DBUILD_EXAMPLES=false"
-    "-DBUILD_TESTS=false"
-  ]
-  ++ lib.optionals withGstreamer [
-    "-DWITH_GSTREAMER=ON"
-  ]
-  ++ lib.optionals withOmemo [
-    "-DBUILD_OMEMO=ON"
+    (lib.cmakeBool "BUILD_DOCUMENTATION" false)
+    (lib.cmakeBool "BUILD_EXAMPLES" false)
+    (lib.cmakeBool "BUILD_TESTING" finalAttrs.doCheck)
+    (lib.cmakeBool "BUILD_OMEMO" withOmemo)
+    (lib.cmakeBool "WITH_ENCRYPTION" withEncryption)
+    (lib.cmakeBool "WITH_GSTREAMER" withGstreamer)
+  ];
+
+  doCheck = true;
+  nativeCheckInputs = [ ctestCheckHook ];
+  disabledTests = [
+    "tst_QXmppIceConnection"
+    "tst_QXmppTransferManager"
   ];
 
   meta = {
     description = "Cross-platform C++ XMPP client and server library";
+    changelog = "https://invent.kde.org/libraries/qxmpp/-/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     homepage = "https://invent.kde.org/libraries/qxmpp";
     license = lib.licenses.lgpl21Plus;
-    maintainers = with lib.maintainers; [ astro ];
+    maintainers = with lib.maintainers; [
+      astro
+      haansn08
+    ];
     platforms = with lib.platforms; linux;
   };
 })


### PR DESCRIPTION
Upstream changelog: https://invent.kde.org/libraries/qxmpp/-/blob/v1.16.1/CHANGELOG.md

This PR also enables unit tests.

Kaidan still builds and works.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests] (for Kaidan).
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
