### PR TITLE
discord: expose stageModules to allow overriding

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/linux.nix
@@ -222,7 +222,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   dontUnpack = true;
 
-  inherit libPath;
+  inherit libPath stageModules;
 
   autoPatchelfIgnoreMissingDeps = [
     "libssl.so.1.1"
@@ -262,7 +262,7 @@ stdenv.mkDerivation (finalAttrs: {
         --prefix LD_LIBRARY_PATH : ${finalAttrs.libPath}:$out/opt/${binaryName}:${addDriverRunpath.driverLink}/lib \
         --suffix VK_ADD_DRIVER_FILES : "${addDriverRunpath.driverLink}/share/vulkan/icd.d" \
         ${lib.strings.optionalString disableUpdates "--run ${lib.getExe disableBreakingUpdates}"} \
-        --run "${stageModules} $out/opt/${binaryName}/modules" \
+        --run "${finalAttrs.stageModules} $out/opt/${binaryName}/modules" \
         --add-flags ${lib.escapeShellArg commandLineArgs}
 
     ln -s $out/opt/${binaryName}/${binaryName} $out/bin/


### PR DESCRIPTION
## Things done
This basically just exposes `stageModules`, and allows overriding it in `.overrideAttrs`.
The reason for this is, that if someone wants to get Krisp working, they need to change the Discord modules, and they _cannot_ be symlinked.

E.g. I currently use this patch like so (which could be better):

```nix
patchedDiscord = pkgs.discord.overrideAttrs (old: {
  stageModules = pkgs.writeShellScript "discord-stage-mine" ''
    # ${old.stageModules} "$@"
    store_modules="$1"
    modules_dir="''${XDG_CONFIG_HOME:-$HOME/.config}/discord/${old.version}/modules"

    mkdir -p "$modules_dir"
    for m in "$store_modules"/*; do
      dest="$modules_dir/$(basename "$m")"

      if [ -L "$dest" ]; then
        rm "$dest"
      fi

      ${lib.getExe' pkgs.rsync "rsync"} -a --checksum --delete "$m/" "$dest"
    done

    chmod -R u+w "$modules_dir"

    echo '${
      builtins.toJSON (lib.mapAttrs (_: mod: { installedVersion = mod; }) old.passthru.moduleVersions)
    }' \
      > "$modules_dir/installed.json"
  '';

  postFixup = (old.postFixup or "") + ''
    ${pkgs.findutils}/bin/find "$out/opt/Discord/modules" \
      -name 'discord_krisp.node' -exec ${discordPatcher} {} \;
  '';
});

```

Previously I just wrapped Discord, but after https://github.com/NixOS/nixpkgs/pull/530640 , this is no longer possible to do.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
