### PR TITLE
immich: move derivation attributes out of passthru

### DIFF
--- a/pkgs/by-name/im/immich/package.nix
+++ b/pkgs/by-name/im/immich/package.nix
@@ -197,8 +197,8 @@ stdenv.mkDerivation (finalAttrs: {
     \) -exec rm -r {} +
 
     mkdir -p "$packageOut/build/plugins"
-    ln -s '${finalAttrs.passthru.plugin-core}' "$packageOut/build/plugins/immich-plugin-core"
-    ln -s '${finalAttrs.passthru.web}' "$packageOut/build/www"
+    ln -s '${finalAttrs.plugin-core}' "$packageOut/build/plugins/immich-plugin-core"
+    ln -s '${finalAttrs.web}' "$packageOut/build/www"
     ln -s '${geodata}' "$packageOut/build/geodata"
 
     echo '${builtins.toJSON buildLock}' > "$packageOut/build/build-lock.json"
@@ -222,6 +222,65 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
+  plugin-core = stdenv.mkDerivation {
+    pname = "immich-plugin-core";
+    inherit (finalAttrs) version src pnpmDeps;
+
+    nativeBuildInputs = [
+      binaryen
+      extism-js
+      nodejs
+      pnpmConfigHook
+      pnpm
+    ];
+
+    buildPhase = ''
+      runHook preBuild
+
+      pnpm --filter @immich/plugin-core... build
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      cd packages/plugin-core
+      mkdir $out
+      cp -r dist manifest.json $out
+
+      runHook postInstall
+    '';
+  };
+
+  web = stdenv.mkDerivation {
+    pname = "immich-web";
+    inherit (finalAttrs) version src pnpmDeps;
+
+    nativeBuildInputs = [
+      nodejs
+      pnpmConfigHook
+      pnpm
+    ];
+
+    buildPhase = ''
+      runHook preBuild
+
+      pnpm --filter immich-web... build
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      cd web
+      cp -r build $out
+
+      runHook postInstall
+    '';
+  };
+
   passthru = {
     tests = {
       inherit (nixosTests) immich immich-vectorchord-reindex;
@@ -229,65 +288,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     machine-learning = immich-machine-learning.override {
       immich = finalAttrs.finalPackage;
-    };
-
-    plugin-core = stdenv.mkDerivation {
-      pname = "immich-plugin-core";
-      inherit (finalAttrs) version src pnpmDeps;
-
-      nativeBuildInputs = [
-        binaryen
-        extism-js
-        nodejs
-        pnpmConfigHook
-        pnpm
-      ];
-
-      buildPhase = ''
-        runHook preBuild
-
-        pnpm --filter @immich/plugin-core... build
-
-        runHook postBuild
-      '';
-
-      installPhase = ''
-        runHook preInstall
-
-        cd packages/plugin-core
-        mkdir $out
-        cp -r dist manifest.json $out
-
-        runHook postInstall
-      '';
-    };
-
-    web = stdenv.mkDerivation {
-      pname = "immich-web";
-      inherit (finalAttrs) version src pnpmDeps;
-
-      nativeBuildInputs = [
-        nodejs
-        pnpmConfigHook
-        pnpm
-      ];
-
-      buildPhase = ''
-        runHook preBuild
-
-        pnpm --filter immich-web... build
-
-        runHook postBuild
-      '';
-
-      installPhase = ''
-        runHook preInstall
-
-        cd web
-        cp -r build $out
-
-        runHook postInstall
-      '';
     };
 
     inherit


### PR DESCRIPTION
Referncing attrisbutes in passthru defeats the purpose of passthru. Move
those attributes to the derivation to simplify.

Note that this does change the derivation hash, as previously these
attributes were not part of the derivation itself.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
