### PR TITLE
xmpp-dns: init at 0.6.3

### DIFF
--- a/pkgs/by-name/xm/xmpp-dns/package.nix
+++ b/pkgs/by-name/xm/xmpp-dns/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitLab,
+  installShellFiles,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "xmpp-dns";
+  version = "0.6.3";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "mdosch";
+    repo = "xmpp-dns";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-GLTAV8LtOtgYwb261m3gq+AwFQspFUjVl4Si/A5ZmzI=";
+  };
+  vendorHash = "sha256-KFDnFD6g88zIRt08aL/0Obik70oELCDb7piKZaSXGY4=";
+
+  nativeBuildInputs = [ installShellFiles ];
+  postInstall = "installManPage man/xmpp-dns.1";
+
+  meta = {
+    description = "CLI tool to check XMPP SRV records";
+    homepage = "https://salsa.debian.org/mdosch/xmpp-dns";
+    changelog = "https://salsa.debian.org/mdosch/xmpp-dns/-/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ haansn08 ];
+    platforms = lib.platforms.all;
+    mainProgram = "xmpp-dns";
+  };
+})


### PR DESCRIPTION
xmpp-dns is a CLI tool to check XMPP SRV records:
https://salsa.debian.org/mdosch/xmpp-dns

It has already been packaged in Debian, Kali Linux, openSUSE, among others:
https://repology.org/project/xmpp-dns/versions

Example output:
```
$(nix-build --no-out-link -A xmpp-dns)/bin/xmpp-dns conversations.im
xmpps-client xmpps.conversations.im. 443
Priority: 1 Weight: 0

xmpp-client xmpp.conversations.im. 5222
Priority: 5 Weight: 0

xmpp-client xmpps.conversations.im. 80
Priority: 10 Weight: 0

xmpps-server xmpps.conversations.im. 5269
Priority: 1 Weight: 0

xmpp-server xmpp.conversations.im. 5269
Priority: 5 Weight: 0

Host-meta:
Websocket: wss://xmpp.conversations.im:443/websocket
BOSH: https://xmpp.conversations.im/bosh
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
