### PR TITLE
wine: add option for smartcard support

### DIFF
--- a/pkgs/applications/emulators/wine/base.nix
+++ b/pkgs/applications/emulators/wine/base.nix
@@ -64,6 +64,7 @@
   x11Support ? false,
   ffmpegSupport ? false,
   embedInstallers ? false,
+  smartcardSupport ? false,
 }:
 
 let
@@ -251,6 +252,9 @@ stdenv.mkDerivation (
         ++ lib.optionals ffmpegSupport [
           pkgs.ffmpeg-headless
         ]
+        ++ lib.optionals smartcardSupport [
+          pkgs.pcsclite
+        ]
       );
 
     inherit patches;
@@ -275,7 +279,8 @@ stdenv.mkDerivation (
       ++ lib.optionals vulkanSupport [ "--with-vulkan" ]
       ++ lib.optionals ((stdenv.hostPlatform.isDarwin && !xineramaSupport) || !x11Support) [
         "--without-x"
-      ];
+      ]
+      ++ lib.optionals smartcardSupport [ "--with-pcsclite" ];
 
     # Wine locates a lot of libraries dynamically through dlopen().  Add
     # them to the RPATH so that the user doesn't have to set them in

--- a/pkgs/applications/emulators/wine/default.nix
+++ b/pkgs/applications/emulators/wine/default.nix
@@ -51,6 +51,7 @@ args@{
   ffmpegSupport ? false,
   embedInstallers ? false, # The Mono and Gecko MSI installers
   moltenvk, # Allow users to override MoltenVK easily
+  smartcardSupport ? false,
 }:
 
 let

--- a/pkgs/top-level/wine-packages.nix
+++ b/pkgs/top-level/wine-packages.nix
@@ -57,6 +57,7 @@ lib.makeExtensible (
       gphoto2Support = true;
       krb5Support = true;
       embedInstallers = true;
+      smartcardSupport = true;
     };
 
     stable = self.base.override { wineRelease = "stable"; };


### PR DESCRIPTION
This is required for certain games that use `WinSCard.dll`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
