### PR TITLE
python314Packages.mpv: fix build

### DIFF
--- a/pkgs/development/python-modules/mpv/default.nix
+++ b/pkgs/development/python-modules/mpv/default.nix
@@ -7,6 +7,7 @@
   setuptools,
   pytestCheckHook,
   pyvirtualdisplay,
+  writableTmpDirAsHomeHook,
   xvfb,
 }:
 
@@ -35,6 +36,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     pyvirtualdisplay
+    writableTmpDirAsHomeHook
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     xvfb

--- a/pkgs/development/python-modules/mpv/default.nix
+++ b/pkgs/development/python-modules/mpv/default.nix
@@ -42,6 +42,15 @@ buildPythonPackage rec {
     xvfb
   ];
 
+  disabledTestPaths = [
+    # timing sensitive
+    "tests/test_mpv.py::CommandTests::test_sub_add"
+
+    # flaky
+    "tests/test_mpv.py::ObservePropertyTest::test_property_observer_decorator"
+    "tests/test_mpv.py::RegressionTests::test_wait_for_property_concurrency"
+  ];
+
   pythonImportsCheck = [ "mpv" ];
 
   meta = {


### PR DESCRIPTION
```
python3.13-mpv> 3.534 [v] vo/x11: Assuming -nan FPS for display sync. python3.13-mpv> ----------------------------- Captured stderr call ----------------------------- python3.13-mpv> Fontconfig error: Cannot load default config file: No such file: (null) python3.13-mpv> Fontconfig error: Cannot load default config file: No such file: (null) python3.13-mpv>
python3.13-mpv> Fontconfig error: No writable cache directories
python3.13-mpv>         /var/cache/fontconfig
python3.13-mpv>         /homeless-shelter/.cache/fontconfig
python3.13-mpv>
python3.13-mpv> Fontconfig error: No writable cache directories
python3.13-mpv>         /var/cache/fontconfig
python3.13-mpv>         /homeless-shelter/.cache/fontconfig
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
