### PR TITLE
Revert "throttled: 0.11 -> 0.12"

### DIFF
--- a/pkgs/by-name/th/throttled/package.nix
+++ b/pkgs/by-name/th/throttled/package.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "throttled";
-  version = "0.12";
+  version = "0.11";
 
   src = fetchFromGitHub {
     owner = "erpalma";
     repo = "throttled";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-q5D9FT5wIlOBUToHDokyDQ1yXrwxS7p+D8dC9dPHdfw=";
+    sha256 = "sha256-+3ktDkr5hvOfHcch4+mjgJqcuw24UgWTkJqTyDQumyk=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Reverts NixOS/nixpkgs#536023

> Pre-release for testing before promoting these changes to a stable release.
> Replace the PyGObject/GLib and dbus-python runtime path with dbus-next and asyncio.
