### PR TITLE
shen-sbcl: 41.1 -> 41.2

### DIFF
--- a/pkgs/by-name/sh/shen-sbcl/package.nix
+++ b/pkgs/by-name/sh/shen-sbcl/package.nix
@@ -10,15 +10,15 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "shen-sbcl";
-  version = "41.1";
+  version = "41.2";
 
   src = fetchzip {
-    url = "https://www.shenlanguage.org/Download/S${finalAttrs.version}.zip";
-    hash = "sha256-v/hlP23yfpkpFEDCTKYoxeMJbfR2qVF9LFUkqsFwo6g=";
+    url = "https://shenlanguage.org/Download/S${finalAttrs.version}.zip";
+    hash = "sha256-hgO/g0XefSXn5pjiV5LzGmoZ8nsqmZcyZpK6nbcE0es=";
   };
 
-  sourceRoot = "${finalAttrs.src.name}/S41";
   nativeBuildInputs = [ sbcl ];
+  strictDeps = true;
   dontStrip = true; # necessary to prevent runtime errors with sbcl
 
   buildPhase = ''
@@ -45,15 +45,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     # remove interactive prompts during image creation
     # shen/tk requires further configuration and isn't supported by default
     substituteInPlace Lib/install.shen \
-      --replace-fail '(y-or-n? "install standard library?")' '${
-        if installStandardLibrary then "true" else "false"
-      }' \
-      --replace-fail '(y-or-n? "install concurrency? (required for Shen/tk)")' '${
-        if installConcurrency then "true" else "false"
-      }' \
+      --replace-fail '(y-or-n? "install standard library?")' '${lib.boolToString installStandardLibrary}' \
+      --replace-fail '(y-or-n? "install concurrency? (required for Shen/tk)")' '${lib.boolToString installConcurrency}' \
       --replace-fail '(y-or-n? "install Shen/tk + IDE?")' 'false' \
-      --replace-fail '(y-or-n? "install THORN?")' '${if installThorn then "true" else "false"}' \
-      --replace-fail '(y-or-n? "install Logic Lab?")' '${if installLogicLab then "true" else "false"}'
+      --replace-fail '(y-or-n? "install THORN?")' '${lib.boolToString installThorn}' \
+      --replace-fail '(y-or-n? "install Logic Lab?")' '${lib.boolToString installLogicLab}'
   '';
 
   meta = {


### PR DESCRIPTION
Bump shen-sbcl to 41.2.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [X] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
