### PR TITLE
modules/image/repart: add option for passing env

### DIFF
--- a/nixos/modules/image/repart-image.nix
+++ b/nixos/modules/image/repart-image.nix
@@ -39,7 +39,7 @@
   definitionsDirectory,
   imageSize ? "auto",
   sectorSize,
-  mkfsEnv ? { },
+  env ? { },
   createEmpty ? true,
 }:
 
@@ -159,9 +159,7 @@ stdenvNoCC.mkDerivation (
     ]
     ++ fileSystemTools;
 
-    env = mkfsEnv;
-
-    inherit finalPartitions definitionsDirectory;
+    inherit env finalPartitions definitionsDirectory;
 
     partitionsJSON = builtins.toJSON finalAttrs.finalPartitions;
 

--- a/nixos/modules/image/repart.nix
+++ b/nixos/modules/image/repart.nix
@@ -311,6 +311,13 @@ in
       '';
     };
 
+    env = lib.mkOption {
+      type = lib.types.attrs;
+      default = { };
+      description = ''
+        env attribute to pass to the repart-image.nix builder
+      '';
+    };
   };
 
   config = {
@@ -380,6 +387,7 @@ in
             mkfsEnv = mkfsOptionsToEnv cfg.mkfsOptions;
             val = pkgs.callPackage ./repart-image.nix {
               systemd = cfg.package;
+              env = lib.recursiveUpdate cfg.env mkfsEnv;
               inherit (config.image) baseName;
               inherit (cfg)
                 name
@@ -391,7 +399,7 @@ in
                 sectorSize
                 finalPartitions
                 ;
-              inherit fileSystems definitionsDirectory mkfsEnv;
+              inherit fileSystems definitionsDirectory;
             };
           in
           lib.asserts.checkAssertWarn cfg.assertions cfg.warnings val;


### PR DESCRIPTION
This allows users to set a new option, `image.repart.env`. This option lets users override the `env` attribute of the derivation that is built by the repart module, meaning you can pre/post process the image using only the module system and do not have to create a new derivation, or use overrideAttrs.

An example of usage is below:

```nix
{ pkgs, config, ... }:
{
  image.repart.env = {
    preInstall = ''
      dd if=${pkgs.ubootRock5ModelB}/u-boot-rockchip.bin of=${config.image.repart.imageFileBasename}.raw seek=64 conv=notrunc
    '';
  };
}
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
