### PR TITLE
postfix-tlspol: 1.10.0 -> 1.11.0

### DIFF
--- a/nixos/modules/services/mail/postfix-tlspol.nix
+++ b/nixos/modules/services/mail/postfix-tlspol.nix
@@ -164,6 +164,20 @@ in
       };
       users.groups.postfix-tlspol = { };
 
+      systemd.sockets.postfix-tlspol = {
+        wantedBy = [ "sockets.target" ];
+        socketConfig = {
+          Accept = false;
+          ListenStream = [
+            (lib.removePrefix "unix:" cfg.settings.server.address)
+          ];
+          SocketUser = "postfix-tlspol";
+          SocketGroup = "postfix-tlspol";
+          SocketMode = cfg.settings.server.socket-permissions;
+          DirectoryMode = "0755";
+        };
+      };
+
       systemd.services.postfix-tlspol = {
         after = [
           "nss-lookup.target"
@@ -173,7 +187,6 @@ in
           "nss-lookup.target"
           "network-online.target"
         ];
-        wantedBy = [ "multi-user.target" ];
 
         description = "Postfix DANE/MTA-STS TLS policy socketmap service";
         documentation = [ "https://github.com/Zuplu/postfix-tlspol" ];
@@ -217,9 +230,6 @@ in
           RestrictAddressFamilies = [
             "AF_INET"
             "AF_INET6"
-          ]
-          ++ lib.optionals (lib.hasPrefix "unix:" cfg.settings.server.address) [
-            "AF_UNIX"
           ];
           RestrictNamespaces = true;
           RestrictRealtime = true;
@@ -237,7 +247,7 @@ in
           RuntimeDirectory = "postfix-tlspol";
           RuntimeDirectoryMode = "1750";
           WorkingDirectory = "/var/cache/postfix-tlspol";
-          UMask = "0117";
+          UMask = "0077";
         };
       };
     })

--- a/nixos/tests/postfix-tlspol.nix
+++ b/nixos/tests/postfix-tlspol.nix
@@ -9,7 +9,10 @@
 
   containers.machine = {
     services.postfix.enable = true;
-    services.postfix-tlspol.enable = true;
+    services.postfix-tlspol = {
+      enable = true;
+      settings.server.metrics-address = "127.0.0.1:8642";
+    };
 
     services.dnsmasq = {
       enable = true;
@@ -26,13 +29,19 @@
     with subtest("Interact with the service"):
       machine.succeed("postfix-tlspol -purge")
 
-      response = json.loads((machine.succeed("postfix-tlspol -query localhost")))
+      response = machine.log(machine.succeed("postfix-tlspol -query localhost"))
+      response = json.loads(machine.succeed("postfix-tlspol -query localhost"))
       machine.log(json.dumps(response, indent=2))
 
       assert response["dane"]["policy"] == "", f"Unexpected DANE policy for localhost: {response["dane"]["policy"]}"
       assert response["mta-sts"]["policy"] == "TEMP", f"Unexpected MTA-STS policy for localhost: {response["mta-sts"]["policy"]}"
 
-    machine.log(machine.execute("systemd-analyze security postfix-tlspol.service | grep -v ✓")[1])
+    with subtest("Metrics listener"):
+      machine.log(machine.succeed("curl --silent --fail http://localhost:8642/metrics | grep --quiet postfix_tlspol_queries_total"))
+
+
+    with subtest("Hardening"):
+      machine.log(machine.execute("systemd-analyze security postfix-tlspol.service | grep -v ✓")[1])
   '';
 
 }

--- a/pkgs/by-name/po/postfix-tlspol/package.nix
+++ b/pkgs/by-name/po/postfix-tlspol/package.nix
@@ -7,13 +7,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "postfix-tlspol";
-  version = "1.10.0";
+  version = "1.11.0";
 
   src = fetchFromGitHub {
     owner = "Zuplu";
     repo = "postfix-tlspol";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-JwggXJM8FDMG4oGRcVjVw1J/toTzc/kxrjdENFT9oGs=";
+    hash = "sha256-mdnCa0xrexkKWHdtCeSXxwMnx9xNKAdkZlHIhqxD/P4=";
   };
 
   vendorHash = null;


### PR DESCRIPTION
https://github.com/Zuplu/postfix-tlspol/releases/tag/v1.11.0

Migrates the socketmap listener to socket activation.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
