### PR TITLE
python3Packages.snuggs: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/snuggs/default.nix
+++ b/pkgs/development/python-modules/snuggs/default.nix
@@ -5,6 +5,7 @@
   fetchpatch,
   click,
   numpy,
+  setuptools,
   pyparsing,
   pytestCheckHook,
   hypothesis,
@@ -13,7 +14,7 @@
 buildPythonPackage rec {
   pname = "snuggs";
   version = "1.4.7";
-  format = "setuptools";
+  pyproject = true;
 
   # Pypi doesn't ship the tests, so we fetch directly from GitHub
   src = fetchFromGitHub {
@@ -22,6 +23,8 @@ buildPythonPackage rec {
     rev = version;
     sha256 = "1p3lh9s2ylsnrzbs931y2vn7mp2y2xskgqmh767c9l1a33shfgwf";
   };
+
+  build-system = [ setuptools ];
 
   patches = [
     # Use non-strict xfail for failing tests
@@ -32,7 +35,7 @@ buildPythonPackage rec {
     })
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     click
     numpy
     pyparsing

--- a/pkgs/development/python-modules/snuggs/default.nix
+++ b/pkgs/development/python-modules/snuggs/default.nix
@@ -11,7 +11,7 @@
   hypothesis,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "snuggs";
   version = "1.4.7";
   pyproject = true;
@@ -20,8 +20,8 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "mapbox";
     repo = "snuggs";
-    rev = version;
-    sha256 = "1p3lh9s2ylsnrzbs931y2vn7mp2y2xskgqmh767c9l1a33shfgwf";
+    tag = finalAttrs.version;
+    hash = "sha256-jj8H9Rgq0MSOObDiN3UXXtx67BY+jKTXz1ZTL3SCdNw=";
   };
 
   build-system = [ setuptools ];
@@ -52,4 +52,4 @@ buildPythonPackage rec {
     homepage = "https://github.com/mapbox/snuggs";
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/snuggs/default.nix
+++ b/pkgs/development/python-modules/snuggs/default.nix
@@ -2,8 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
-  click,
   numpy,
   setuptools,
   pyparsing,
@@ -26,17 +24,7 @@ buildPythonPackage (finalAttrs: {
 
   build-system = [ setuptools ];
 
-  patches = [
-    # Use non-strict xfail for failing tests
-    # https://github.com/mapbox/snuggs/pull/28
-    (fetchpatch {
-      url = "https://github.com/sebastic/snuggs/commit/3b8e04a35ed33a7dd89f0194542b22c7bde867f4.patch";
-      hash = "sha256-SfW4l4BH94rPdskRVHEsZM0twmlV9IPftRU/BBZsjBU=";
-    })
-  ];
-
   dependencies = [
-    click
     numpy
     pyparsing
   ];


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/515974

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
