### PR TITLE
rustPlatform.fetchCargoVendor: allow overriding `hash`

### DIFF
--- a/pkgs/build-support/rust/fetch-cargo-vendor.nix
+++ b/pkgs/build-support/rust/fetch-cargo-vendor.nix
@@ -34,7 +34,6 @@ let
     "pname"
     "version"
     "nativeBuildInputs"
-    "hash"
   ];
 
   fetchCargoVendorUtil = writers.writePython3Bin "fetch-cargo-vendor-util" {
@@ -51,17 +50,18 @@ let
   } (builtins.readFile ./fetch-cargo-vendor-util.py);
 in
 
-{
-  name ? if args ? pname && args ? version then "${args.pname}-${args.version}" else "cargo-deps",
-  hash ? (throw "fetchCargoVendor requires a `hash` value to be set for ${name}"),
-  nativeBuildInputs ? [ ],
-  ...
-}@args:
-
 # TODO: add asserts about pname version and name
 
-let
-  vendorStaging = stdenvNoCC.mkDerivation (
+lib.extendMkDerivation {
+  constructDrv = stdenvNoCC.mkDerivation;
+  excludeDrvArgNames = removedArgs;
+  extendDrvArgs =
+    finalAttrs:
+    {
+      name ? if args ? pname && args ? version then "${args.pname}-${args.version}" else "cargo-deps",
+      nativeBuildInputs ? [ ],
+      ...
+    }@args:
     {
       name = "${name}-vendor-staging";
 
@@ -92,22 +92,23 @@ let
       dontInstall = true;
       dontFixup = true;
 
-      outputHash = hash;
-      outputHashAlgo = if hash == "" then "sha256" else null;
+      outputHash = finalAttrs.hash or "";
+      outputHashAlgo = if finalAttrs.outputHash == "" then "sha256" else null;
       outputHashMode = "recursive";
-    }
-    // removeAttrs args removedArgs
-  );
-in
-runCommand "${name}-vendor"
-  {
-    inherit vendorStaging;
-    nativeBuildInputs = [
-      fetchCargoVendorUtil
-      cargo
-      replaceWorkspaceValues
-    ];
-  }
-  ''
-    fetch-cargo-vendor-util create-vendor "$vendorStaging" "$out"
-  ''
+    };
+
+  transformDrv =
+    vendorStaging:
+    runCommand "${lib.removeSuffix "-vendor-staging" vendorStaging.name}-vendor"
+      {
+        inherit vendorStaging;
+        nativeBuildInputs = [
+          fetchCargoVendorUtil
+          cargo
+          replaceWorkspaceValues
+        ];
+      }
+      ''
+        fetch-cargo-vendor-util create-vendor "$vendorStaging" "$out"
+      '';
+}


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
