### PR TITLE
init koregalore at 0.6.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6240,6 +6240,11 @@
     github = "darkyzhou";
     githubId = 7220778;
   };
+  darnir = {
+    name = "darnir";
+    github = "darnir";
+    githubId = 1660085;
+  };
   daru-san = {
     name = "Daru";
     email = "zadarumaka@proton.me";

--- a/pkgs/by-name/ko/korgalore/package.nix
+++ b/pkgs/by-name/ko/korgalore/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  python3Packages,
+  fetchgit,
+  git,
+  makeWrapper,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "korgalore";
+  version = "0.6.1";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchgit {
+    url = "https://git.kernel.org/pub/scm/utils/korgalore/korgalore.git";
+    tag = "v${version}";
+    hash = "sha256-fd1y7nBqdtr6cJBV6NirlcaVkxxE7r1TC98F/6rodsE=";
+  };
+
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = with python3Packages; [
+    google-auth
+    google-auth-oauthlib
+    google-auth-httplib2
+    google-api-python-client
+    click
+    click-log
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # We're not dependencing on PyGObject here since it is only required for the
+  # GTK GUI. This current package, does not build the GUI, only the command line
+  # application.
+
+  # korgalore shells out to `git` to read public-inbox repositories, so put it
+  # on the runtime PATH.
+  makeWrapperArgs = [
+    "--prefix"
+    "PATH"
+    ":"
+    (lib.makeBinPath [ git ])
+  ];
+
+  nativeCheckInputs = with python3Packages; [ pytestCheckHook ] ++ [ git ];
+
+  # A couple of tests write into $HOME; the sandbox default (/homeless-shelter)
+  # is not writable.
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  pythonImportsCheck = [ "korgalore" ];
+
+  meta = {
+    description = "Tool to feed public-inbox messages into your Gmail inbox";
+    homepage = "https://korgalore.docs.kernel.org/";
+    changelog = "https://git.kernel.org/pub/scm/utils/korgalore/korgalore.git/tree/CHANGELOG";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ darnir ];
+    mainProgram = "kgl";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Korgalore is a tool for feeding public-inbox git repositories directly into mail targets (Gmail, JMAP, IMAP, or local maildir) as an alternative to subscribing.

Homepage: https://korgalore.docs.kernel.org/en/latest/

- Is the package ready for general use?: Yes. It is still marked as beta, but is actively usable. Upstream does not consider it vapourware
- Does the project have a clear license statement?: GPLv2+
- How realistic is it that it will be used by other people?: It's meant to be used by Linux kernel maintainers and other interested parties in following kernel development
- Is the software actively maintained upstream?: Yes
- Are you willing to maintain the package?: Yes

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
