### PR TITLE
openomf: 0.8.5 -> 0.8.6, modernize

### DIFF
--- a/pkgs/by-name/op/openomf/package.nix
+++ b/pkgs/by-name/op/openomf/package.nix
@@ -17,7 +17,8 @@
   SDL2_mixer,
   unzip,
   zlib,
-  withRemix ? true,
+  nix-update-script,
+  versionCheckHook,
 }:
 
 let
@@ -37,6 +38,9 @@ in
 stdenv.mkDerivation (finalAttrs: {
   pname = "openomf";
   version = "0.8.6";
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "omf2097";
@@ -89,17 +93,32 @@ stdenv.mkDerivation (finalAttrs: {
 
     unzip -p ${icons} omf-logo/omf-256x256.png > $out/share/icons/hicolor/256x256/apps/org.openomf.OpenOMF.png
     install -Dm644 $src/resources/flatpak/org.openomf.OpenOMF.desktop $out/share/applications/org.openomf.OpenOMF.desktop
-  ''
-  + lib.optionalString withRemix ''
-    ln -s ${remix} $out/share/games/openomf/ARENA2.ogg
-  ''
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    mkdir -p $out/resources
-    ln -s $out/share/games/openomf/* $out/resources
   '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "One Must Fall 2097 Remake";
+    longDescription = ''
+      OpenOMF is an open-source remake of the 1994 DOS fighting game One Must
+      Fall 2097 by Diversions Entertainment. It reimplements the original
+      engine from scratch, uses the original (now freeware) game assets, and
+      adds modern conveniences such as online netplay.
+
+      Includes remixed music mod. To add other mods: drop its .zip file
+      into the user mods directory as-is; it does not need to be extracted.
+
+      The user mods directory is <state>/mods, where <state> is resolved at
+      launch in the following order.
+
+        1. $OPENOMF_STATE_PATH, if set
+        2. $XDG_STATE_HOME, if set
+           (e.g. ~/.local/state, giving ~/.local/state/mods)
+        3. SDL's preference path, ~/.local/share/OpenOMF/mods
+    '';
     homepage = "https://www.openomf.org";
     changelog = "https://github.com/omf2097/openomf/releases/tag/${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;

--- a/pkgs/by-name/op/openomf/package.nix
+++ b/pkgs/by-name/op/openomf/package.nix
@@ -6,7 +6,6 @@
   cmake,
   argtable,
   enet,
-  git,
   libconfuse,
   libnatpmp,
   libepoxy,
@@ -30,25 +29,39 @@ let
     url = "https://www.omf2097.com/pub/files/omf/openomf-icons.zip";
     hash = "sha256-8LWmrkY3ZiXcuVe0Zj90RQFUTwM27dJ4ev9TiBGoVk0=";
   };
-  remix = fetchurl {
-    url = "https://github.com/omf2097/openomf/releases/download/0.8.0/ARENA2.ogg";
-    hash = "sha256-jOIzDaIwQDlwCaPrRZdG5Y0g7bWKwc38mPKP030PGb4=";
+  musicRemixes = fetchurl {
+    url = "https://github.com/omf2097/openomf-music-mod/releases/download/1.0/openomf-mods-1.0.zip";
+    hash = "sha256-uiaM6n+dDcTeBNNnypEWXPNG8Xac1JQXCTfVkORfvi0=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "openomf";
-  version = "0.8.5";
+  version = "0.8.6";
 
   src = fetchFromGitHub {
     owner = "omf2097";
     repo = "openomf";
     tag = finalAttrs.version;
-    hash = "sha256-5X8drQKMwYZ5M/i7hxyI25AysQGedQ5BLEYcNXWHgNk=";
+    hash = "sha256-KzT2leU52nxUIsuiVM5soWmi+x1LStdxY5JLoCkSSb8=";
   };
+
+  postPatch = ''
+    # TODO: Take this upstream
+    substituteInPlace cmake-scripts/version.cmake \
+      --replace-fail "set(VERSION_MAJOR 0)" "set(VERSION_MAJOR ${lib.versions.major finalAttrs.version})" \
+      --replace-fail "set(VERSION_MINOR 0)" "set(VERSION_MINOR ${lib.versions.minor finalAttrs.version})" \
+      --replace-fail "set(VERSION_PATCH 0)" "set(VERSION_PATCH ${lib.versions.patch finalAttrs.version})" \
+      --replace-fail "set(VERSION_LABEL)" "set(VERSION_LABEL)
+      return()"
+
+    substituteInPlace src/resources/resource_paths.c \
+      --replace-fail \
+        "/usr/local/share/games:/usr/share/games:/usr/local/share:/usr/share" \
+        "$out/share/games"
+  '';
 
   nativeBuildInputs = [
     cmake
-    git
     unzip
   ];
 
@@ -69,7 +82,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   postInstall = ''
     mkdir -p $out/share/icons/hicolor/256x256/apps
-    unzip -j ${assets} -d $out/share/games/openomf
+
+    unzip -j ${assets} -d $out/share/games/openomf/resources
+
+    unzip ${musicRemixes} -d $out/share/games/openomf/mods
+
     unzip -p ${icons} omf-logo/omf-256x256.png > $out/share/icons/hicolor/256x256/apps/org.openomf.OpenOMF.png
     install -Dm644 $src/resources/flatpak/org.openomf.OpenOMF.desktop $out/share/applications/org.openomf.OpenOMF.desktop
   ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Release: https://github.com/omf2097/openomf/releases/tag/0.8.6
Diff: https://github.com/omf2097/openomf/compare/0.8.5...0.8.6

- Bump to latest version
- Nix fixes for version check and resource loading (open to removing the version check change)
- Remove the Darwin symlinks since it's no longer necessary
- Modernize the package
- ~Some concern with `musicRemixes`. The hash will probably change over time.~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
