### PR TITLE
praat: 6.4.65 -> 6.6.30

### DIFF
--- a/pkgs/by-name/pr/praat/package.nix
+++ b/pkgs/by-name/pr/praat/package.nix
@@ -8,18 +8,17 @@
   stdenv,
   wrapGAppsHook3,
   libjack2,
-  iconConvTools,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "praat";
-  version = "6.4.65";
+  version = "6.6.30";
 
   src = fetchFromGitHub {
     owner = "praat";
     repo = "praat.github.io";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-v4cAFLSJllrNgTm6ewR40HYvdi8a1bZcEBz/BTdFsxA=";
+    hash = "sha256-D6XnrN+pvUpgUcgyU8pEtuOx2cIMoSm8Px0+f5xi1aM=";
   };
 
   strictDeps = true;
@@ -27,7 +26,6 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     pkg-config
     wrapGAppsHook3
-    iconConvTools
   ];
 
   buildInputs = [
@@ -41,26 +39,14 @@ stdenv.mkDerivation (finalAttrs: {
     "AR=${stdenv.cc.targetPrefix}ar"
   ];
 
-  configurePhase = ''
-    runHook preConfigure
-
-    cp makefiles/makefile.defs.linux.pulse-gcc makefile.defs
-
-    runHook postConfigure
-  '';
-
-  installPhase = ''
-    runHook preInstall
-
-    install -Dt $out/bin praat
-    install -Dm444 main/praat.desktop -t $out/share/applications
-    icoFileToHiColorTheme main/praat.ico praat $out
-    install -Dm444 main/praat-480.svg $out/share/icons/hicolor/scalable/apps/praat.svg
-
-    runHook postInstall
-  '';
+  buildFlags = [ "PRAAT_AUDIO=pulse" ];
+  installFlags = [ "PREFIX=${placeholder "out"}" ];
 
   enableParallelBuilding = true;
+
+  postInstall = ''
+    mv $out/share/applications/org.praat.Praat.desktop $out/share/applications/praat.desktop
+  '';
 
   meta = {
     description = "Doing phonetics by computer";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Build system got changed around again. Also put StartupWMClass into the desktop file since the filename has changed to org.praat.Praat.deskop but the wmclass is still simply praat

EDIT: if we just mv/rename the file instead, it will be easier to catch if upstream changes the wmclass at some point, doing that momentarily

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
