### PR TITLE
esptool: 5.3.0 -> 5.3.1

### DIFF
--- a/pkgs/by-name/es/esptool/package.nix
+++ b/pkgs/by-name/es/esptool/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  addBinToPathHook,
   fetchFromGitHub,
   python3Packages,
   softhsm,
@@ -8,14 +9,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "esptool";
-  version = "5.3.0";
+  version = "5.3.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "espressif";
     repo = "esptool";
     tag = "v${version}";
-    hash = "sha256-NRfXLf8u35/9RD1QxEuV06K3h030qXj5GM+QjvLC6FM=";
+    hash = "sha256-oHQ6rkMnzvjtP/dg+tyc7Dw+D/WuWDqRwqePKBBnjCw=";
   };
 
   postPatch = ''
@@ -77,16 +78,13 @@ python3Packages.buildPythonApplication rec {
   nativeCheckInputs =
     with python3Packages;
     [
+      addBinToPathHook
       pyelftools
       pytestCheckHook
       requests
       softhsm
     ]
     ++ lib.concatAttrValues optional-dependencies;
-
-  preCheck = ''
-    export PATH="$out/bin:$PATH"
-  '';
 
   pytestFlags = [
     "-m"
@@ -102,12 +100,10 @@ python3Packages.buildPythonApplication rec {
     "test_esp_rfc2217_server_py"
   ];
 
-  postCheck = ''
+  preCheck = ''
     export SOFTHSM2_CONF=$(mktemp)
     echo "directories.tokendir = $(mktemp -d)" > "$SOFTHSM2_CONF"
     ./ci/setup_softhsm2.sh
-
-    pytest test/test_espsecure_hsm.py
   '';
 
   meta = {

--- a/pkgs/by-name/es/esptool/package.nix
+++ b/pkgs/by-name/es/esptool/package.nix
@@ -7,7 +7,7 @@
   installShellFiles,
 }:
 
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "esptool";
   version = "5.3.1";
   pyproject = true;
@@ -15,7 +15,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "espressif";
     repo = "esptool";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-oHQ6rkMnzvjtP/dg+tyc7Dw+D/WuWDqRwqePKBBnjCw=";
   };
 
@@ -84,7 +84,7 @@ python3Packages.buildPythonApplication rec {
       requests
       softhsm
     ]
-    ++ lib.concatAttrValues optional-dependencies;
+    ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
 
   pytestFlags = [
     "-m"
@@ -107,7 +107,7 @@ python3Packages.buildPythonApplication rec {
   '';
 
   meta = {
-    changelog = "https://github.com/espressif/esptool/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/espressif/esptool/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     description = "ESP8266 and ESP32 serial bootloader utility";
     homepage = "https://github.com/espressif/esptool";
     license = lib.licenses.gpl2Plus;
@@ -117,4 +117,4 @@ python3Packages.buildPythonApplication rec {
     platforms = with lib.platforms; linux ++ darwin;
     mainProgram = "esptool";
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/espressif/esptool/compare/v5.3.0...v5.3.1

Changelog: https://github.com/espressif/esptool/blob/v5.3.1/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
