### PR TITLE
python3Packages.tmodbus: init at 0.4.1; python3Packages.modbus-connnection: init at 3.3.0

### DIFF
--- a/pkgs/development/python-modules/modbus-connection/default.nix
+++ b/pkgs/development/python-modules/modbus-connection/default.nix
@@ -1,0 +1,63 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  lib,
+  pymodbus,
+  pyprojectVersionPatchHook,
+  pytest-asyncio,
+  pytestCheckHook,
+  tmodbus,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "modbus-connection";
+  version = "3.3.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "home-assistant-libs";
+    repo = "modbus-connection";
+    tag = finalAttrs.version;
+    hash = "sha256-IEdOLd+BjX2b6bQS7hw33CyuDFVJ5dO0BaHLLhGp3LE=";
+  };
+
+  nativeBuildInputs = [
+    pyprojectVersionPatchHook
+  ];
+
+  build-system = [
+    hatchling
+  ];
+
+  optional-dependencies = {
+    pymodbus = [
+      pymodbus
+    ]
+    ++ pymodbus.optional-dependencies.serial;
+    tmodbus = [
+      tmodbus
+    ]
+    ++ tmodbus.optional-dependencies.async-serial
+    ++ tmodbus.optional-dependencies.smart;
+  };
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ]
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
+
+  pythonImportsCheck = [
+    "modbus_connection"
+  ];
+
+  meta = {
+    description = "Small, backend-neutral Modbus connection abstraction";
+    homepage = "https://github.com/home-assistant-libs/modbus-connection";
+    changelog = "https://github.com/home-assistant-libs/modbus-connection/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ hexa ];
+  };
+})

--- a/pkgs/development/python-modules/tmodbus/default.nix
+++ b/pkgs/development/python-modules/tmodbus/default.nix
@@ -1,0 +1,117 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  hatch-vcs,
+  lib,
+  pytest-asyncio,
+  pytestCheckHook,
+  rustPlatform,
+  serialx,
+  socat,
+  tenacity,
+}:
+
+let
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "wlcrs";
+    repo = "tmodbus";
+    tag = "v${version}";
+    hash = "sha256-pVP2QaCYkeeKhlEha7qIyNhbN1DfVyRxTSZBloEMXxc=";
+  };
+
+  rmodbus-server = rustPlatform.buildRustPackage (finalAttrs: {
+    pname = "rmodbus-server";
+    version = "0.1.0";
+
+    inherit src;
+
+    sourceRoot = "${src.name}/integration_tests/rmodbus";
+
+    cargoHash = "sha256-t7lJ7zC5+z1E/EDWTPR6cbGhcy/RmtXQXon+FiXRZlI=";
+
+    meta = {
+      description = "Rust Modbus server";
+      license = lib.licenses.bsd3;
+      mainProgram = "server";
+    };
+  });
+
+  tokio-modbus-server = rustPlatform.buildRustPackage (finalAttrs: {
+    pname = "tokio-modbus-server";
+    version = "0.1.0";
+
+    inherit src;
+
+    sourceRoot = "${src.name}/integration_tests/tokio";
+
+    cargoHash = "sha256-grYnQxf0CH7hkFq1zTMxw6brtHfCheh/O2EtPPPpVqA=";
+
+    meta = {
+      description = "Rust Tokio Modbus server";
+      license = lib.licenses.bsd3;
+      mainProgram = "tokio-server";
+    };
+  });
+in
+
+buildPythonPackage (finalAttrs: {
+  pname = "tmodbus";
+  inherit version src;
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  postPatch = ''
+    substituteInPlace \
+      integration_tests/tokio/test_tokio_client.py \
+      integration_tests/rmodbus/test_rmodbus_client.py \
+      --replace-fail "/usr/bin/socat" "${lib.getExe socat}"
+
+    mkdir -p integration_tests/{rmodbus,tokio}/target/release
+    ln -s ${lib.getExe' rmodbus-server "ascii-server"} integration_tests/rmodbus/target/release/
+    ln -s ${lib.getExe rmodbus-server} integration_tests/rmodbus/target/release/
+    ln -s ${lib.getExe tokio-modbus-server} integration_tests/tokio/target/release/
+  '';
+
+  build-system = [
+    hatch-vcs
+    hatchling
+  ];
+
+  optional-dependencies = {
+    async-serial = [
+      serialx
+    ];
+    smart = [
+      tenacity
+    ];
+  };
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ]
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
+
+  pythonImportsCheck = [
+    "tmodbus"
+  ];
+
+  passthru = {
+    inherit rmodbus-server tokio-modbus-server;
+  };
+
+  meta = {
+    description = "Modern Python Modbus library";
+    homepage = "https://github.com/wlcrs/tmodbus";
+    changelog = "https://github.com/wlcrs/tmodbus/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ hexa ];
+    badPlatforms = [
+      "aarch64-darwin" # tests fail, no indication they should work
+    ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20321,6 +20321,8 @@ self: super: with self; {
 
   tmdbsimple = callPackage ../development/python-modules/tmdbsimple { };
 
+  tmodbus = callPackage ../development/python-modules/tmodbus { };
+
   tnefparse = callPackage ../development/python-modules/tnefparse { };
 
   todoist = callPackage ../development/python-modules/todoist { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10689,6 +10689,8 @@ self: super: with self; {
 
   modal = callPackage ../development/python-modules/modal { };
 
+  modbus-connection = callPackage ../development/python-modules/modbus-connection { };
+
   modbus-tk = callPackage ../development/python-modules/modbus-tk { };
 
   moddb = callPackage ../development/python-modules/moddb { };


### PR DESCRIPTION
Upcoming modbus connnection abstraction for Home Assistant 2026.8.0. Requires pymodbus>=3.13, ~~which is in staging-next right now~~.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] ~~aarch64-darwin~~
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
