### PR TITLE
flyline: init at 1.5.0

### DIFF
--- a/pkgs/by-name/fl/flyline/package.nix
+++ b/pkgs/by-name/fl/flyline/package.nix
@@ -1,0 +1,38 @@
+{
+  fetchFromGitHub,
+  rustPlatform,
+  nix-update-script,
+  lib,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "flyline";
+  version = "1.5.0";
+  src = fetchFromGitHub {
+    owner = "HalFrgrd";
+    repo = "flyline";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2apK1e/Hqb8bUj9Ng7cB+pz27Hv14MXMy2JYYI7nxKE=";
+  };
+
+  cargoHash = "sha256-Ci1PVqGZ4ttrkUAtePHKKsqI/SVoedlH4Mua7MzFDvo=";
+
+  checkFlags = [
+    # docker_integration_tests fails
+    "--skip=test_bash_3_2_57"
+    "--skip=test_bash_4_4_18"
+    "--skip=test_bash_4_4_rc1"
+    "--skip=test_bash_5_0"
+    "--skip=test_bash_5_3"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Bash plugin to replace readline for a modern line editing experience";
+    homepage = "https://github.com/HalFrgrd/flyline";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ lwb-2021 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add [flyline](https://github.com/HalFrgrd/flyline)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
