### PR TITLE
pegtl: apply upstream workaround for gcc 16 bug

### DIFF
--- a/pkgs/by-name/pe/pegtl/package.nix
+++ b/pkgs/by-name/pe/pegtl/package.nix
@@ -18,6 +18,20 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-nPWSO2wPl/qenUQgvQDQu7Oy1dKa/PnNFSclmkaoM8A=";
   };
 
+  # GCC 16.1.0 has a bug with `__PRETTY_FUNCTION__` that leads to static
+  # assertions in PEGTL failing. Upstream has enabled a workaround for GCC 16
+  # specifically instead, and the bug was fixed for GCC 17+. The upstream patch
+  # does not apply cleanly since the codebase has changed substantially since
+  # v3.2.8, but it's trivial to apply a similar trick on our own.
+  # https://github.com/taocpp/PEGTL/issues/382
+  # https://github.com/taocpp/PEGTL/commit/0176e87da3a02d0ab40ce39f03e0e4108d1bbba5
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91155
+  postPatch = ''
+    substituteInPlace include/tao/pegtl/demangle.hpp --replace-fail \
+      "#elif( __GNUC__ == 9 ) && ( __GNUC_MINOR__ < 3 )" \
+      "#elif ( ( __GNUC__ == 9 ) && ( __GNUC_MINOR__ < 3 ) ) || ( __GNUC__ == 16 )"
+  '';
+
   nativeBuildInputs = [
     cmake
     ninja


### PR DESCRIPTION
gcc 16.1.0 resurfaced a bug from gcc 9.1/9.2 where `__PRETTY_FUNCTION__` could end up truncated, which breaks the build of pegtl. upstream pegtl has re-enabled the workaround from gcc 9.1/9.2 for gcc 16, and while we can't fetch that as a patch since the codebase has changed substantially since v3.2.8, we apply approximately the same trick. see:
- https://github.com/taocpp/PEGTL/issues/382
- https://github.com/taocpp/PEGTL/commit/0176e87da3a02d0ab40ce39f03e0e4108d1bbba5
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91155

pegtl could also probably use an update to 4.0.0, but neither lix nor `kvrocks` (the two in-tree dependents) build with that, so we won't bother right now.

(part of submitting some fixes to prepare for making gcc 16 the default later this release cycle: https://github.com/NixOS/nixpkgs/pull/537781)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
