### PR TITLE
orion-browser: init at 1.1.1

### DIFF
--- a/pkgs/by-name/or/orion-browser/package.nix
+++ b/pkgs/by-name/or/orion-browser/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  makeWrapper,
+  unzip,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "orion-browser";
+  version = "149";
+
+  src = fetchurl {
+    url = "https://cdn.kagi.com/updates/26_0/${finalAttrs.version}.zip";
+    hash = "sha256-C0mtGNE9Or0alFe2Gu4LkRcHMvk1RLXZ/mUo/XtWB2g=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  unpackCmd = "unzip -q $curSrc -x '__MACOSX/*'";
+
+  nativeBuildInputs = [
+    makeWrapper
+    unzip
+  ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications" "$out/bin"
+    cp -R Orion.app "$out/Applications"
+    makeWrapper "$out/Applications/Orion.app/Contents/MacOS/Orion" "$out/bin/orion"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "WebKit-based web browser by Kagi";
+    homepage = "https://orionbrowser.com/";
+    changelog = "https://orionbrowser.com/updates/orion-release-notes";
+    license = lib.licenses.unfree;
+    mainProgram = "orion";
+    maintainers = with lib.maintainers; [ pradyuman ];
+    platforms = [ "aarch64-darwin" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/or/orion-browser/update.sh
+++ b/pkgs/by-name/or/orion-browser/update.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env nix
+#!nix shell -f ``<nixpkgs>`` curl jq libplist _7zz common-updater-scripts -c bash
+
+set -euo pipefail
+
+macos_version="26_0"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+dmg="$tmpdir/Orion.dmg"
+curl -fsSL -o "$dmg" "https://cdn.kagi.com/downloads/$macos_version/Orion.dmg"
+version="$(
+  7zz e -so "$dmg" "Orion/Orion.app/Contents/Info.plist" \
+    | plistutil -i - -f json -o - \
+    | jq -r '.CFBundleVersion'
+)"
+
+if [[ -z "$version" ]]; then
+  echo "[update] Failed to read Orion version from Info.plist" >&2
+  exit 1
+fi
+
+zip="$tmpdir/Orion.zip"
+curl -fsSL -o "$zip" "https://cdn.kagi.com/updates/$macos_version/$version.zip"
+hash="$(nix hash file --type sha256 --sri "$zip")"
+
+update-source-version orion-browser "$version" "$hash"


### PR DESCRIPTION
Adding the [Orion](https://orionbrowser.com/) browser for `aarch64-darwin`.

The Linux release is distributed as a Flatpak, so this package only covers the macOS build for now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
