### PR TITLE
linear: 1.30.2 -> 1.31.1

### DIFF
--- a/pkgs/by-name/li/linear/package.nix
+++ b/pkgs/by-name/li/linear/package.nix
@@ -7,11 +7,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "linear";
-  version = "1.30.2";
+  version = "1.31.1";
 
   src = fetchurl {
     url = "https://releases.linear.app/Linear-${finalAttrs.version}-universal.dmg";
-    hash = "sha256-udtN7sOnbT1B684q/JhPFGq8mYvhc5CbTxuJi6NYFac=";
+    hash = "sha256-haZz9RdbcQiFbCqdy/S25aCsFoSKn3dFAkYL8NgoTYw=";
   };
 
   strictDeps = true;
@@ -41,7 +41,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "App to manage software development and track bugs";
     homepage = "https://linear.app/";
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ iniw ];
+    maintainers = with lib.maintainers; [
+      iniw
+      pradyuman
+    ];
     platforms = lib.platforms.darwin;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };

--- a/pkgs/by-name/li/linear/update.sh
+++ b/pkgs/by-name/li/linear/update.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p coreutils curl gnugrep common-updater-scripts
+#!nix-shell -i bash -p coreutils curl gnugrep jq common-updater-scripts
 #shellcheck shell=bash
 
-set -eu -o pipefail
+set -euo pipefail
 
-source_url="https://releases.linear.app/mac"
-
-version="$(curl -L -I "$source_url" | grep -ioE 'filename="Linear-[0-9]+(\.[0-9]+)*-universal\.dmg"' | grep -oE '[0-9]+(\.[0-9]+)*')"
+releases_url="https://releases.linear.app"
+version_pattern='filename="Linear-\K[0-9]+(\.[0-9]+)*(?=-universal\.dmg")'
+version="$(curl -fsSLI "$releases_url/mac" | grep -ioP "$version_pattern")"
 
 if [[ -z $version ]]; then
   echo "Could not find the latest Linear version in release headers" >&2
   exit 1
 fi
 
-hash=$(nix --extra-experimental-features nix-command hash convert --to sri --hash-algo sha256 "$(nix-prefetch-url --type sha256 "https://releases.linear.app/Linear-${version}-universal.dmg")")
+hash="$(nix store prefetch-file --json "$releases_url/Linear-${version}-universal.dmg" | jq -r .hash)"
 
 update-source-version linear "$version" "$hash" --ignore-same-version


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
