### PR TITLE
nixos/security.wrappers: Fix loop condition to include last_cap

### DIFF
--- a/nixos/modules/security/wrappers/wrapper.c
+++ b/nixos/modules/security/wrappers/wrapper.c
@@ -116,7 +116,7 @@ static int make_caps_ambient(const char *self_path) {
         return 1;
     }
     uint64_t set = user_data[0].permitted | (uint64_t)user_data[1].permitted << 32;
-    for (unsigned cap = 0; cap < last_cap; cap++) {
+    for (unsigned cap = 0; cap <= last_cap; cap++) {
         if (!(set & (1ULL << cap))) {
             continue;
         }


### PR DESCRIPTION
Fix an off-by-one error in `security.wrappers` when raising capabilities into the ambient set.

`/proc/sys/kernel/cap_last_cap` contains the highest valid capability number, inclusive, but the wrapper iterated only while `cap < last_cap`. This caused the highest supported capability to be skipped. On current kernels this is `CAP_CHECKPOINT_RESTORE` (capability 40).

Change the loop condition to `cap <= last_cap` so all supported capabilities are considered for `PR_CAP_AMBIENT_RAISE`.

Resolves #538650

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test