### PR TITLE
google-drive-ocamlfuse: 0.7.32 → 0.9.0

### DIFF
--- a/pkgs/applications/networking/google-drive-ocamlfuse/default.nix
+++ b/pkgs/applications/networking/google-drive-ocamlfuse/default.nix
@@ -4,41 +4,45 @@
   buildDunePackage,
   fetchFromGitHub,
   extlib,
-  ocamlfuse,
+  fuse3,
   gapi-ocaml,
   ocaml_sqlite3,
+  otoml,
   tiny_httpd,
   ounit2,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "google-drive-ocamlfuse";
-  version = "0.7.32";
+  version = "0.9.0";
+
+  minimalOCamlVersion = "4.13";
 
   src = fetchFromGitHub {
     owner = "astrada";
     repo = "google-drive-ocamlfuse";
-    rev = "v${version}";
-    hash = "sha256-AWr1tcium70rXFKMTv6xcWxndOJua3UXG8Q04TN1Siw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-nTZdE9F6ufQ/O/Ck6fzoK65uZ0ylMR6HkwKsBNRDjMs=";
   };
 
-  doCheck = lib.versionAtLeast ocaml.version "5";
+  doCheck = lib.versionAtLeast ocaml.version "4.14";
   checkInputs = [ ounit2 ];
 
   buildInputs = [
     extlib
-    ocamlfuse
+    fuse3
     gapi-ocaml
     ocaml_sqlite3
+    otoml
     tiny_httpd
   ];
 
   meta = {
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/astrada/google-drive-ocamlfuse/";
     description = "FUSE-based file system backed by Google Drive, written in OCaml";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ obadz ];
     mainProgram = "google-drive-ocamlfuse";
   };
-}
+})

--- a/pkgs/development/ocaml-modules/fuse3/default.nix
+++ b/pkgs/development/ocaml-modules/fuse3/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildDunePackage,
+  camlidl,
+  dune-configurator,
+  pkg-config,
+  fuse3,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "fuse3";
+  version = "3.10.0";
+
+  src = fetchFromGitHub {
+    owner = "astrada";
+    repo = "ocamlfuse";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-xy3Jf4GTQP3vM6vRxBAeOIASWRuoNdlbt91eCco2zMg=";
+  };
+
+  nativeBuildInputs = [
+    camlidl
+    pkg-config
+  ];
+
+  buildInputs = [ dune-configurator ];
+
+  propagatedBuildInputs = [
+    camlidl
+    fuse3
+  ];
+
+  meta = {
+    description = "OCaml bindings for libfuse 3";
+    homepage = "https://github.com/astrada/ocamlfuse/";
+    platforms = lib.platforms.linux;
+    license = lib.licenses.gpl2Plus;
+  };
+})

--- a/pkgs/development/ocaml-modules/gapi-ocaml/default.nix
+++ b/pkgs/development/ocaml-modules/gapi-ocaml/default.nix
@@ -12,7 +12,7 @@
 
 buildDunePackage (finalAttrs: {
   pname = "gapi-ocaml";
-  version = if lib.versionAtLeast cryptokit.version "1.21" then "0.4.8" else "0.4.7";
+  version = if lib.versionAtLeast cryptokit.version "1.21" then "0.4.9" else "0.4.7";
 
   src = fetchFromGitHub {
     owner = "astrada";
@@ -21,7 +21,7 @@ buildDunePackage (finalAttrs: {
     hash =
       {
         "0.4.7" = "sha256-uQJfrgF0oafURlamHslt9hX9MP4vFeVqDhuX7T/kjiY=";
-        "0.4.8" = "sha256-RvHcse3ech8BwnR0Kd1oE5ycAdSBpeQ0IGAp9egFbBY=";
+        "0.4.9" = "sha256-UWoWWpCAKCNEwEFO4UBXrTO49QyxLXrulDHX6dGr0z4=";
       }
       ."${finalAttrs.version}";
   };
@@ -42,6 +42,7 @@ buildDunePackage (finalAttrs: {
     description = "OCaml client for google services";
     homepage = "https://github.com/astrada/gapi-ocaml";
     license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ bennofs ];
   };
 })

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -710,6 +710,10 @@ let
 
         functory = callPackage ../development/ocaml-modules/functory { };
 
+        fuse3 = callPackage ../development/ocaml-modules/fuse3 {
+          inherit (pkgs) fuse3;
+        };
+
         ### G ###
 
         gapi-ocaml = callPackage ../development/ocaml-modules/gapi-ocaml { };


### PR DESCRIPTION
Depends on libfuse 3 (and no longer libfuse 2).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
