### PR TITLE
python3Packages.prometheus-fastapi-instrumentator: 7.1.0 -> 8.0.2

### DIFF
--- a/pkgs/development/python-modules/prometheus-fastapi-instrumentator/default.nix
+++ b/pkgs/development/python-modules/prometheus-fastapi-instrumentator/default.nix
@@ -23,6 +23,7 @@ buildPythonPackage (finalAttrs: {
   pname = "prometheus-fastapi-instrumentator";
   version = "7.1.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "trallnag";

--- a/pkgs/development/python-modules/prometheus-fastapi-instrumentator/default.nix
+++ b/pkgs/development/python-modules/prometheus-fastapi-instrumentator/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage (finalAttrs: {
   ];
 
   # numerous test failures on Darwin
-  doCheck = stdenv.hostPlatform.isLinux;
+  doCheck = !stdenv.hostPlatform.isDarwin;
 
   pythonImportsCheck = [ "prometheus_fastapi_instrumentator" ];
 

--- a/pkgs/development/python-modules/prometheus-fastapi-instrumentator/default.nix
+++ b/pkgs/development/python-modules/prometheus-fastapi-instrumentator/default.nix
@@ -14,14 +14,15 @@
   # tests
   devtools,
   fastapi,
-  httpx,
+  httpx2,
+  pytest-asyncio,
   pytestCheckHook,
   requests,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "prometheus-fastapi-instrumentator";
-  version = "7.1.0";
+  version = "8.0.2";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -29,7 +30,7 @@ buildPythonPackage (finalAttrs: {
     owner = "trallnag";
     repo = "prometheus-fastapi-instrumentator";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-54h/kwIdzFzxdYglwcEBPkLYno1YH2iWklg35qY2b00=";
+    hash = "sha256-fTJjAM1jUZXfhjLo9xqlu45LaoqZ330ogOA6x7aByqw=";
   };
 
   build-system = [
@@ -44,13 +45,22 @@ buildPythonPackage (finalAttrs: {
   nativeCheckInputs = [
     devtools
     fastapi
-    httpx
+    httpx2
+    pytest-asyncio
     pytestCheckHook
     requests
   ];
 
   # numerous test failures on Darwin
   doCheck = !stdenv.hostPlatform.isDarwin;
+
+  # TODO: Cleanup when https://github.com/NixOS/nixpkgs/pull/538958 reaches
+  # `master`...
+  disabledTests = lib.optionals (lib.versionOlder fastapi.version "0.137") [
+    # Asserts that instrumentation works with fastapi 0.137+,
+    # fails on nixpkgs with fastapi 0.136.
+    "test_mount_inside_included_router_resolves_path"
+  ];
 
   pythonImportsCheck = [ "prometheus_fastapi_instrumentator" ];
 

--- a/pkgs/development/python-modules/prometheus-fastapi-instrumentator/default.nix
+++ b/pkgs/development/python-modules/prometheus-fastapi-instrumentator/default.nix
@@ -3,14 +3,20 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  pytestCheckHook,
+
+  # build-system
+  poetry-core,
+
+  # dependencies
+  prometheus-client,
+  starlette,
+
+  # tests
   devtools,
   fastapi,
   httpx,
-  poetry-core,
-  prometheus-client,
+  pytestCheckHook,
   requests,
-  starlette,
 }:
 
 buildPythonPackage (finalAttrs: {

--- a/pkgs/development/python-modules/prometheus-fastapi-instrumentator/default.nix
+++ b/pkgs/development/python-modules/prometheus-fastapi-instrumentator/default.nix
@@ -13,7 +13,7 @@
   starlette,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "prometheus-fastapi-instrumentator";
   version = "7.1.0";
   pyproject = true;
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "trallnag";
     repo = "prometheus-fastapi-instrumentator";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-54h/kwIdzFzxdYglwcEBPkLYno1YH2iWklg35qY2b00=";
   };
 
@@ -50,7 +50,7 @@ buildPythonPackage rec {
   meta = {
     description = "Instrument FastAPI with Prometheus metrics";
     homepage = "https://github.com/trallnag/prometheus-fastapi-instrumentator";
-    changelog = "https://github.com/trallnag/prometheus-fastapi-instrumentator/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/trallnag/prometheus-fastapi-instrumentator/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = with lib.licenses; [
       isc
       bsd3
@@ -58,4 +58,4 @@ buildPythonPackage rec {
     maintainers = with lib.maintainers; [ bcdarwin ];
     platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
