### PR TITLE
python3Packages.trezor-agent: 0.12.0 -> 0.13.0

### DIFF
--- a/pkgs/development/python-modules/trezor-agent/default.nix
+++ b/pkgs/development/python-modules/trezor-agent/default.nix
@@ -1,51 +1,41 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   trezor,
   libagent,
-  ecdsa,
-  ed25519,
-  mnemonic,
-  keepkey,
-  semver,
   setuptools,
-  wheel,
   pinentry,
+  nix-update-script,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "trezor-agent";
-  version = "0.12.0";
+  version = "0.13.0";
   format = "setuptools";
 
-  src = fetchPypi {
-    pname = "trezor_agent";
-    inherit version;
-    hash = "sha256-4IylpUvXZYAXFkyFGNbN9iPTsHff3M/RL2Eq9f7wWFU=";
+  src = fetchFromGitHub {
+    owner = "romanz";
+    repo = "trezor-agent";
+    tag = "trezor/${finalAttrs.version}";
+    hash = "sha256-hoaMsdD0LRLF5F33ECYnBRxzmtydHxT1UOkVna1hLYA=";
   };
+
+  sourceRoot = "${finalAttrs.src.name}/agents/trezor";
 
   propagatedBuildInputs = [
     setuptools
     trezor
     libagent
-    ecdsa
-    ed25519
-    mnemonic
-    keepkey
-    semver
-    wheel
     pinentry
   ];
 
-  # relax dependency constraint
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "trezor[hidapi]>=0.12.0,<0.13" "trezor[hidapi]>=0.12.0,<0.14"
-  '';
-
   doCheck = false;
   pythonImportsCheck = [ "libagent" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version-regex=trezor/(.*)" ];
+  };
 
   meta = {
     description = "Using Trezor as hardware SSH agent";
@@ -57,4 +47,4 @@ buildPythonPackage rec {
       mmahut
     ];
   };
-}
+})

--- a/pkgs/development/python-modules/trezor-agent/default.nix
+++ b/pkgs/development/python-modules/trezor-agent/default.nix
@@ -2,17 +2,17 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
   trezor,
   libagent,
-  setuptools,
-  pinentry,
+  keyrings-alt,
   nix-update-script,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "trezor-agent";
   version = "0.13.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "romanz";
@@ -23,24 +23,25 @@ buildPythonPackage (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/agents/trezor";
 
-  propagatedBuildInputs = [
-    setuptools
-    trezor
+  build-system = [ setuptools ];
+
+  dependencies = [
     libagent
-    pinentry
+    trezor
+    keyrings-alt
   ];
 
   doCheck = false;
-  pythonImportsCheck = [ "libagent" ];
+  pythonImportsCheck = [ "trezor_agent" ];
 
   passthru.updateScript = nix-update-script {
     extraArgs = [ "--version-regex=trezor/(.*)" ];
   };
 
   meta = {
-    description = "Using Trezor as hardware SSH agent";
+    description = "Using Trezor as hardware SSH/GPG/age agent";
     homepage = "https://github.com/romanz/trezor-agent";
-    license = lib.licenses.gpl3;
+    license = lib.licenses.lgpl3Only;
     maintainers = with lib.maintainers; [
       hkjn
       np

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20620,9 +20620,7 @@ self: super: with self; {
 
   trezor = callPackage ../development/python-modules/trezor { };
 
-  trezor-agent = callPackage ../development/python-modules/trezor-agent {
-    pinentry = pkgs.pinentry-curses;
-  };
+  trezor-agent = callPackage ../development/python-modules/trezor-agent { };
 
   trie = callPackage ../development/python-modules/trie { };
 


### PR DESCRIPTION
## Summary

- Update trezor-agent from 0.12.0 to 0.13.0
- Modernize packaging: `pyproject = true`, `build-system`/`dependencies`
- Add `keyrings-alt` for headless keyring backends (prevents `NoKeyringError` in minimal environments)
- Fix `pythonImportsCheck` to `trezor_agent` (was incorrectly `libagent`)
- Fix license to `lgpl3Only` (matches upstream)
- Update description to reflect GPG/age support

Supersedes #499028 — builds on @amozeo's work with packaging improvements and bug fixes.
Depends on #499027 (already merged).

pbsds edit: closes https://github.com/NixOS/nixpkgs/pull/499028

## Test plan

- [ ] `nix-build -A python3Packages.trezor-agent`
- [ ] Verify SSH agent functionality with a Trezor device
- [ ] Verify GPG agent functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)