### PR TITLE
leetcode-cli: bump, modernize, adopt

### DIFF
--- a/pkgs/by-name/le/leetcode-cli/package.nix
+++ b/pkgs/by-name/le/leetcode-cli/package.nix
@@ -14,16 +14,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "leetcode-cli";
-  version = "0.5.0";
+  version = "0.5.4";
 
   src = fetchFromGitHub {
     owner = "clearloop";
     repo = "leetcode-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-h3mCZzif+Uzv3bsEb9I24txrx1BHkc5I86gWcwDHsOc=";
+    hash = "sha256-Qg4Sd3tcyOZsPl++/Y6qU2tTCzJ4nL062kJn6gSMygI=";
   };
 
-  cargoHash = "sha256-8bHpNckEsJ4VWlmEaDTeMW+Txi9SQh30lK5CKKperC8=";
+  cargoHash = "sha256-bbwyuFY3i/pcWBJjaKIZf2zHEkp4raZp7i5cWZtS9w8=";
 
   nativeBuildInputs = [
     installShellFiles

--- a/pkgs/by-name/le/leetcode-cli/package.nix
+++ b/pkgs/by-name/le/leetcode-cli/package.nix
@@ -52,7 +52,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     description = "Leetcode CLI utility";
     homepage = "https://github.com/clearloop/leetcode-cli";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ congee ];
+    maintainers = with lib.maintainers; [
+      congee
+      ethancedwards8
+    ];
     mainProgram = "leetcode";
   };
 })

--- a/pkgs/by-name/le/leetcode-cli/package.nix
+++ b/pkgs/by-name/le/leetcode-cli/package.nix
@@ -1,6 +1,6 @@
 {
   dbus,
-  fetchCrate,
+  fetchFromGitHub,
   installShellFiles,
   lib,
   nix-update-script,
@@ -16,9 +16,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "leetcode-cli";
   version = "0.5.0";
 
-  src = fetchCrate {
-    inherit (finalAttrs) pname version;
-    hash = "sha256-EafEz5MhY9f56N1LCPaW+ktYrV01r9vHCbublDnfAKg=";
+  src = fetchFromGitHub {
+    owner = "clearloop";
+    repo = "leetcode-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-h3mCZzif+Uzv3bsEb9I24txrx1BHkc5I86gWcwDHsOc=";
   };
 
   cargoHash = "sha256-8bHpNckEsJ4VWlmEaDTeMW+Txi9SQh30lK5CKKperC8=";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Replaces: https://github.com/NixOS/nixpkgs/pull/537896

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
