### PR TITLE
fluux-messenger: 0.16.2 -> 0.17.0

### DIFF
--- a/pkgs/by-name/fl/fluux-messenger/package.nix
+++ b/pkgs/by-name/fl/fluux-messenger/package.nix
@@ -18,24 +18,24 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "fluux-messenger";
-  version = "0.16.2";
+  version = "0.17.0";
   __structuredAttrs = true;
   strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "processone";
     repo = "fluux-messenger";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-G5VDcFHp+mIYBXh7Vju/8bGB3CPD1dyZKq8zAOKn3UY=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ojPEj7W41+tQXQ9AW/XN8IIX6zhOcKigxNiBv6qu9V4=";
   };
 
   cargoRoot = "apps/fluux/src-tauri";
-  cargoHash = "sha256-/jaEpC0f6B1zTxN7MHv/DESFnRTSAd3qi9rrnXurcPQ=";
+  cargoHash = "sha256-GpF/Qp0yM4uSMwxNT6dYPeO2buvE6SxtER8hfaepDoc=";
 
   npmDeps = fetchNpmDeps {
     name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
     inherit (finalAttrs) src;
-    hash = "sha256-XAzE4I13GN4Gfi6g4VX5ZwM2DhVycKz7cGBQroAFvf8=";
+    hash = "sha256-nNXjsiQY7Lmq+aB5nSlMGrB1zCtAe9FFFHqOsQOG3Dk=";
   };
 
   nativeBuildInputs = [
@@ -69,10 +69,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "XMPP client for communities and organizations";
+    longDescription = "A modern, Web and Desktop cross-platform XMPP client for communities and organizations, built with a reusable Typescript SDK and Tauri for desktop";
+    changelog = "https://github.com/processone/fluux-messenger/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     homepage = "https://github.com/processone/fluux-messenger";
     license = lib.licenses.agpl3Plus;
     mainProgram = "fluux";
     maintainers = [ lib.maintainers.haansn08 ];
     platforms = lib.platforms.all;
+    # see also https://github.com/processone/fluux-messenger/blob/main/fluux-messenger.doap
   };
 })


### PR DESCRIPTION
Upstream release: https://github.com/processone/fluux-messenger/releases/tag/v0.17.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
