### PR TITLE
OVMF-{amdsev,inteltdx}: init

### DIFF
--- a/pkgs/by-name/ov/OVMF-amdsev/61-edk2-ovmf-x64-amdsev.json
+++ b/pkgs/by-name/ov/OVMF-amdsev/61-edk2-ovmf-x64-amdsev.json
@@ -1,0 +1,26 @@
+{
+    "description": "OVMF with AMD SEV-* support, direct kernel boot",
+    "interface-types": [
+        "uefi"
+    ],
+    "mapping": {
+        "device": "memory",
+        "filename": "@firmware@"
+    },
+    "targets": [
+        {
+            "architecture": "x86_64",
+            "machines": [
+                "pc-q35-*"
+            ]
+        }
+    ],
+    "features": [
+        "amd-sev",
+        "amd-sev-es",
+        "amd-sev-snp"
+    ],
+    "tags": [
+
+    ]
+}

--- a/pkgs/by-name/ov/OVMF-amdsev/package.nix
+++ b/pkgs/by-name/ov/OVMF-amdsev/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  edk2,
+  util-linux,
+  nasm,
+  acpica-tools,
+  debug ? false,
+}:
+
+edk2.mkDerivation "OvmfPkg/AmdSev/AmdSevX64.dsc" (finalAttrs: {
+  pname = "OVMF-amdsev";
+  version = lib.getVersion edk2;
+
+  outputs = [
+    "out"
+    "fd"
+  ];
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    util-linux
+    nasm
+    acpica-tools
+  ];
+  strictDeps = true;
+
+  hardeningDisable = [
+    "format"
+    "pic"
+    "fortify"
+  ];
+
+  buildFlags = lib.optionals debug [ "-D DEBUG_ON_SERIAL_PORT=TRUE" ];
+  buildConfig = if debug then "DEBUG" else "RELEASE";
+
+  # The AmdSev platform embeds a grub image, built by the PREBUILD hook
+  # (OvmfPkg/AmdSev/Grub/grub.sh). Provide an empty grub.efi instead
+  # (the hook keeps an existing, newer grub.efi), like Fedora does.
+  # The resulting firmware supports direct kernel boot only.
+  postPatch = ''
+    touch OvmfPkg/AmdSev/Grub/grub.efi
+  '';
+
+  # AmdSevX64 only produces a unified firmware image. There is no
+  # CODE/VARS split: SEV-SNP attests the initial guest memory, so the
+  # image is mapped read-only via -bios instead of pflash.
+  postInstall = ''
+    mkdir -vp $fd/FV $fd/share/qemu/firmware
+    mv -v $out/FV/OVMF.fd $fd/FV/OVMF.amdsev.fd
+    substitute ${./61-edk2-ovmf-x64-amdsev.json} \
+      $fd/share/qemu/firmware/61-edk2-ovmf-x64-amdsev.json \
+      --subst-var-by firmware "$fd/FV/OVMF.amdsev.fd"
+  '';
+
+  dontPatchELF = true;
+
+  passthru = {
+    firmware = "${finalAttrs.finalPackage.fd}/FV/OVMF.amdsev.fd";
+    mergedFirmware = "${finalAttrs.finalPackage.fd}/FV/OVMF.amdsev.fd";
+  };
+
+  meta = {
+    description = "UEFI firmware with AMD SEV, SEV-ES and SEV-SNP support, direct kernel boot only";
+    homepage = "https://github.com/tianocore/tianocore.github.io/wiki/OVMF";
+    license = lib.licenses.bsd2;
+    platforms = builtins.filter (lib.hasPrefix "x86_64-") edk2.meta.platforms;
+    maintainers = [ lib.maintainers.katexochen ];
+  };
+})

--- a/pkgs/by-name/ov/OVMF-inteltdx/61-edk2-ovmf-x64-inteltdx.json
+++ b/pkgs/by-name/ov/OVMF-inteltdx/61-edk2-ovmf-x64-inteltdx.json
@@ -1,0 +1,24 @@
+{
+    "description": "OVMF with Intel TDX support",
+    "interface-types": [
+        "uefi"
+    ],
+    "mapping": {
+        "device": "memory",
+        "filename": "@firmware@"
+    },
+    "targets": [
+        {
+            "architecture": "x86_64",
+            "machines": [
+                "pc-q35-*"
+            ]
+        }
+    ],
+    "features": [
+        "intel-tdx"
+    ],
+    "tags": [
+
+    ]
+}

--- a/pkgs/by-name/ov/OVMF-inteltdx/package.nix
+++ b/pkgs/by-name/ov/OVMF-inteltdx/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  edk2,
+  util-linux,
+  nasm,
+  acpica-tools,
+  debug ? false,
+}:
+
+edk2.mkDerivation "OvmfPkg/IntelTdx/IntelTdxX64.dsc" (finalAttrs: {
+  pname = "OVMF-inteltdx";
+  version = lib.getVersion edk2;
+
+  __structuredAttrs = true;
+
+  outputs = [
+    "out"
+    "fd"
+  ];
+
+  nativeBuildInputs = [
+    util-linux
+    nasm
+    acpica-tools
+  ];
+  strictDeps = true;
+
+  hardeningDisable = [
+    "format"
+    "pic"
+    "fortify"
+  ];
+
+  buildFlags = lib.optionals debug [ "-D DEBUG_ON_SERIAL_PORT=TRUE" ];
+  buildConfig = if debug then "DEBUG" else "RELEASE";
+
+  # Only ship the unified firmware image: TDX attests the initial guest
+  # memory, so the image is mapped read-only via -bios instead of pflash
+  # and the CODE/VARS split is not useful.
+  postInstall = ''
+    mkdir -vp $fd/FV $fd/share/qemu/firmware
+    mv -v $out/FV/OVMF.fd $fd/FV/OVMF.inteltdx.fd
+    substitute ${./61-edk2-ovmf-x64-inteltdx.json} \
+      $fd/share/qemu/firmware/61-edk2-ovmf-x64-inteltdx.json \
+      --subst-var-by firmware "$fd/FV/OVMF.inteltdx.fd"
+  '';
+
+  dontPatchELF = true;
+
+  passthru = {
+    firmware = "${finalAttrs.finalPackage.fd}/FV/OVMF.inteltdx.fd";
+    mergedFirmware = "${finalAttrs.finalPackage.fd}/FV/OVMF.inteltdx.fd";
+  };
+
+  meta = {
+    description = "UEFI firmware with Intel TDX support";
+    homepage = "https://github.com/tianocore/tianocore.github.io/wiki/OVMF";
+    license = lib.licenses.bsd2;
+    platforms = builtins.filter (lib.hasPrefix "x86_64-") edk2.meta.platforms;
+    maintainers = [ lib.maintainers.katexochen ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
