### PR TITLE
unifly: init at 0.9.2

### DIFF
--- a/pkgs/by-name/un/unifly/package.nix
+++ b/pkgs/by-name/un/unifly/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  llvmPackages,
+  installShellFiles,
+  dbus,
+  versionCheckHook,
+  stdenv,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "unifly";
+  version = "0.9.2";
+
+  src = fetchFromGitHub {
+    owner = "hyperb1iss";
+    repo = "unifly";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Hw/zm9OjBcAI0H2vvwnAj4tjF0E+d6RHpWIexhPBuy8=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    llvmPackages.bintools
+    installShellFiles
+  ];
+
+  buildInputs = [ dbus ];
+
+  cargoHash = "sha256-4nLfMzlN5KQK3JvmoHbktI/tyc3aaI78Oa5RtQN4xLo=";
+
+  doCheck = false;
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd unifly \
+      --bash <($out/bin/unifly completions bash) \
+      --fish <($out/bin/unifly completions fish) \
+      --zsh <($out/bin/unifly completions zsh)
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Elegant UniFi network management CLI & TUI - for humans and agents";
+    homepage = "https://hyperb1iss.github.io/unifly";
+    changelog = "https://github.com/hyperb1iss/unifly/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.apsl20;
+    maintainers = with lib.maintainers; [ britter ];
+    mainProgram = "unifly";
+  };
+})


### PR DESCRIPTION
Adds a derivation for [unifly](https://github.com/hyperb1iss/unifly) - an elegant UniFi network management CLI & TUI. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
