### PR TITLE
frigate: 0.17.1 -> 0.17.2

### DIFF
--- a/pkgs/by-name/fr/frigate/package.nix
+++ b/pkgs/by-name/fr/frigate/package.nix
@@ -15,14 +15,14 @@
 }:
 
 let
-  version = "0.17.1";
+  version = "0.17.2";
 
   src = fetchFromGitHub {
     name = "frigate-${version}-source";
     owner = "blakeblackshear";
     repo = "frigate";
     tag = "v${version}";
-    hash = "sha256-jQQ54By77dOVSIu08YhJn+EUV0D03j1bcMQRk9404RE=";
+    hash = "sha256-8ujG5rVGqIJxM+IiQKvudrA0xqfz+3Uisl/zXwARPpY=";
   };
 
   frigate-web = callPackage ./web.nix {

--- a/pkgs/by-name/fr/frigate/package.nix
+++ b/pkgs/by-name/fr/frigate/package.nix
@@ -239,9 +239,6 @@ python3Packages.buildPythonApplication rec {
     pytestCheckHook
   ];
 
-  # interpreter crash in onnxruntime on aarch64-linux
-  doCheck = !(stdenv.hostPlatform.system == "aarch64-linux");
-
   preCheck = ''
     # Unavailable in the build sandbox
     substituteInPlace frigate/const.py \


### PR DESCRIPTION
https://github.com/blakeblackshear/frigate/releases/tag/v0.17.2

Fixes:
GHSA-hh3j-7g2f-43j2, GHSA-pqfr-m69j-4mq2, GHSA-r57j-5jm9-hpcc, GHSA-4vfc-hxpj-f7x7, GHSA-wwww-5h25-jf98, GHSA-r5fm-h944-8chq


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
