### PR TITLE
mailspring: manually install icons and .desktop

### DIFF
--- a/pkgs/by-name/ma/mailspring/package.nix
+++ b/pkgs/by-name/ma/mailspring/package.nix
@@ -118,6 +118,23 @@ buildNpmPackage (finalAttrs: {
       --replace-fail "await this.getElectronZipPath(downloadOpts)" "'$(pwd)/electron.zip'"
 
     pushd app
+
+    substituteInPlace \
+      build/resources/linux/Mailspring.desktop.in \
+      --replace-fail "<%= description %>" "The best email app for people and teams at work" \
+      --replace-fail "<%= productName %>" Mailspring
+
+    substituteInPlace \
+      build/resources/linux/mailspring.appdata.xml.in \
+      --replace-fail "<%= name %>" mailspring \
+      --replace-fail "<%= description %>" "The best email app for people and teams at work" \
+      --replace-fail "<%= productName %>" Mailspring
+
+    grep '<%' app/build/resources/linux/*.in && {
+      echo "Missing templates to be substituted for Mailspring!"
+      exit 1
+    }
+
     npm rebuild
     popd
   '';
@@ -135,6 +152,13 @@ buildNpmPackage (finalAttrs: {
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ html-tidy ]}" \
       --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
       --add-flags ${lib.escapeShellArg commandLineArgs}
+
+    install -Dm444 app/build/resources/linux/Mailspring.desktop.in $out/share/applications/Mailspring.desktop
+    install -Dm444 app/build/resources/linux/mailspring.appdata.xml.in $out/share/metainfo/mailspring.appdata.xml
+    install -Dm444 app/build/resources/linux/icons/512.png $out/share/pixmaps/mailspring.png
+    for size in 16 32 64 128 256; do
+      install -Dm444 app/build/resources/linux/icons/$size.png $out/share/icons/hicolor/''${size}x''${size}/apps/mailspring.png
+    done
 
     runHook postInstall
   '';


### PR DESCRIPTION
These files are usually installed by upstream's build.js: https://github.com/Foundry376/Mailspring/blob/4e42bfe185528ce0685573f3459233a47f57d588/app/build/build.js

Fixes #538021

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
