### PR TITLE
emacs: fix site-start.el native compilation destination

### DIFF
--- a/pkgs/applications/editors/emacs/make-emacs.nix
+++ b/pkgs/applications/editors/emacs/make-emacs.nix
@@ -466,9 +466,8 @@ stdenv.mkDerivation (finalAttrs: {
       | xargs -n $((1000/NIX_BUILD_CORES + 1)) -P $NIX_BUILD_CORES \
         $out/bin/emacs --batch -l comp --eval "(while argv \
           (comp-trampoline-compile (intern (pop argv))))"
-    mkdir -p $out/share/emacs/native-lisp
     $out/bin/emacs --batch \
-      --eval "(add-to-list 'native-comp-eln-load-path \"$out/share/emacs/native-lisp\")" \
+      --eval "(add-to-list 'native-comp-eln-load-path \"$out/lib/emacs/$siteVersionDir/native-lisp\")" \
       -f batch-native-compile $out/share/emacs/site-lisp/site-start.el
   '';
 


### PR DESCRIPTION
Previously, natively compiled site-start.el was put into a wrong place and Emacs could not find it at runtime.  As a result, starting Emacs with an empty .emacs.d (--init-directory) created
an `*Async-native-compile-log*` buffer showing:

> Compiling /nix/store/jplfqmm84dmrfdlbq1qn4lz259av9lm7-emacs-30.2/share/emacs/site-lisp/site-start.el...

The compiled start-start.el file was at
.emacs.d/eln-cache/30.2-d829fb48/site-start-6352488c-77e47a63.eln.

With this patch, Emacs can find the natively compiled site-start.el at runtime.  So starting Emacs with an empty .emacs.d will not create an `*Async-native-compile-log*` buffer and .emacs.d/ remains empty.

The correct destination is found from INSTALL of Emacs source code:

> '/usr/local/lib/emacs/VERSION/native-lisp' holds the natively compiled
>		pre-loaded Emacs Lisp files.  If the build used the
>		'configure' option '--with-native-compilation=aot', then
> 		this directory holds all natively compiled Lisp files.

Also, the last item of native-comp-eln-load-path aligns with that.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
