### PR TITLE
scip: 0.7.1 -> 0.9.0

### DIFF
--- a/pkgs/by-name/sc/scip/package.nix
+++ b/pkgs/by-name/sc/scip/package.nix
@@ -1,25 +1,25 @@
 {
   lib,
   stdenv,
-  buildGo125Module,
+  buildGoModule,
   fetchFromGitHub,
   libredirect,
   iana-etc,
   versionCheckHook,
 }:
 
-buildGo125Module (finalAttrs: {
+buildGoModule (finalAttrs: {
   pname = "scip";
-  version = "0.7.1";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
-    owner = "sourcegraph";
+    owner = "scip-code";
     repo = "scip";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-lpzGrTvWUXUFfmyn5z4rsqJEcAOA8D1qfN1assRAdn4=";
+    hash = "sha256-3iUDxZAde1aVpZNFKvuITHg/b+3+sXHQvmjq/f6AIzM=";
   };
 
-  vendorHash = "sha256-ARfsSW/d2bb4Lp6hedSmMerr3LrkuTfUCi569hI6eYY=";
+  vendorHash = "sha256-p4/YFp+FY83c0HO+8DBI8qQu4EV0DbXa2rEdfkgfsI4=";
 
   subPackages = [ "cmd/scip" ];
 
@@ -45,9 +45,9 @@ buildGo125Module (finalAttrs: {
   meta = {
     description = "SCIP Code Intelligence Protocol CLI";
     mainProgram = "scip";
-    homepage = "https://github.com/sourcegraph/scip";
-    changelog = "https://github.com/sourcegraph/scip/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    homepage = "https://github.com/scip-code/scip";
+    changelog = "https://github.com/scip-code/scip/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ nicolas-guichard ];
   };
 })


### PR DESCRIPTION
Diff: https://github.com/scip-code/scip/compare/v0.7.1...v0.9.0
Changelog: https://github.com/scip-code/scip/releases/tag/v0.9.0

This also:
- adds myself as maintainer for this package
- changes the repo URL to the scip-code GitHub organization
- switches to using buildGoModule instead of buildGo125Module
  As far as I know the SCIP command-line tool doesn't depend on Go internals and https://github.com/NixOS/nixpkgs/pull/448358 didn't provide a reason for switching to the versioned version.

Supersedes https://github.com/NixOS/nixpkgs/pull/527075

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
