### PR TITLE
tree-sitter: support scoped grammar aliases

### DIFF
--- a/pkgs/by-name/tr/tree-sitter/grammars/README.md
+++ b/pkgs/by-name/tr/tree-sitter/grammars/README.md
@@ -149,6 +149,9 @@ grammars.withPlugins (p: [
 
 The scoped `withPlugins` helper receives derivations from the same overridden scope, so added or replaced grammars are visible.
 
+Deprecated or renamed grammar aliases live in [aliases.nix](aliases.nix) and are exposed only when `config.allowAliases = true`.
+An alias resolves to the same derivation as its canonical name, so `derivations`, `allGrammars`, and `withPlugins` all see it once enabled.
+
 The set also carries package-set helpers (`callPackage`, `newScope`, `overrideScope`, …) alongside the grammars, so do not iterate it directly.
 Use one of its grammar-only views instead; each reflects any `overrideScope`:
 

--- a/pkgs/by-name/tr/tree-sitter/grammars/aliases.nix
+++ b/pkgs/by-name/tr/tree-sitter/grammars/aliases.nix
@@ -1,0 +1,16 @@
+{ lib }:
+_final: prev:
+let
+  checkInGrammars =
+    name: alias:
+    if builtins.hasAttr name prev then
+      throw "Alias ${name} is still in tree-sitter-grammars"
+    else
+      alias;
+
+  mapAliases = lib.mapAttrs checkInGrammars;
+in
+mapAliases {
+  # keep-sorted start block=yes
+  # keep-sorted end
+}

--- a/pkgs/by-name/tr/tree-sitter/package.nix
+++ b/pkgs/by-name/tr/tree-sitter/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  config,
   newScope,
   fetchFromGitHub,
   fetchFromGitLab,
@@ -76,6 +77,8 @@ let
   builtGrammars = lib.mapAttrs (_: lib.makeOverridable buildGrammar) grammars;
 
   hasTreeSitterPrefix = lib.hasPrefix "tree-sitter-";
+  grammarAliases = import ./grammars/aliases.nix { inherit lib; };
+
   grammarDerivationsFrom = lib.filterAttrs (
     name: value: hasTreeSitterPrefix name && lib.isDerivation value
   );
@@ -117,6 +120,7 @@ let
   grammarsScope = lib.makeScope newScope (
     self:
     builtGrammars
+    // lib.optionalAttrs config.allowAliases (grammarAliases self builtGrammars)
     // {
       derivations = grammarDerivationsFrom self;
       allGrammars = lib.filter (p: !(p.meta.broken or false)) (


### PR DESCRIPTION
Add allowAliases-gated alias plumbing to the tree-sitter grammar scope so renamed grammars can preserve compatibility. 

Related https://github.com/NixOS/nixpkgs/pull/530059#discussion_r3454573684

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
