### PR TITLE
vorta: 0.11.0 -> 0.11.5

### DIFF
--- a/pkgs/by-name/vo/vorta/package.nix
+++ b/pkgs/by-name/vo/vorta/package.nix
@@ -11,14 +11,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "vorta";
-  version = "0.11.0";
+  version = "0.11.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "borgbase";
     repo = "vorta";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-/60KVJGKNz3aouv5jzubFlz+AxPEbRDSv4ZO9MEi3V0=";
+    hash = "sha256-6WY1UAB5Vr+5Az6UYq2DwXwjabcQr7A3QAEQ2/aIzfg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/vo/vorta/package.nix
+++ b/pkgs/by-name/vo/vorta/package.nix
@@ -6,6 +6,7 @@
   qt6Packages,
   borgbackup,
   versionCheckHook,
+  nix-update-script,
   makeFontsConf,
 }:
 
@@ -93,6 +94,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
     # Darwin-only test
     "tests/network_manager/test_darwin.py"
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     changelog = "https://github.com/borgbase/vorta/releases/tag/v${finalAttrs.version}";

--- a/pkgs/by-name/vo/vorta/package.nix
+++ b/pkgs/by-name/vo/vorta/package.nix
@@ -99,7 +99,10 @@ python3Packages.buildPythonApplication (finalAttrs: {
     description = "Desktop Backup Client for Borg";
     homepage = "https://vorta.borgbase.com/";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ ma27 ];
+    maintainers = with lib.maintainers; [
+      ma27
+      stephsi
+    ];
     platforms = lib.platforms.linux;
     mainProgram = "vorta";
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I recently noticed that the package was several patch versions behind as its `package.nix` file was missing the nix auto update script. Thus I updated to the latest version, added the nix auto update script and also added myself as a maintainer. 
During local testing (on nixos only) I tried out core functionalities like performing backups (local and via ssh), pruning backups and navigating the UI.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
