### PR TITLE
jay: 1.13.0 -> 1.14.0

### DIFF
--- a/pkgs/by-name/ja/jay/package.nix
+++ b/pkgs/by-name/ja/jay/package.nix
@@ -2,33 +2,34 @@
   lib,
   stdenv,
   rustPlatform,
-  fetchFromGitHub,
-  libGL,
-  libinput,
-  pkgconf,
-  xkeyboard_config,
-  libgbm,
-  pango,
-  udev,
-  libglvnd,
-  vulkan-loader,
   autoPatchelfHook,
+  fetchFromGitHub,
   installShellFiles,
+  libGL,
+  libgbm,
+  libglvnd,
+  libinput,
   nix-update-script,
+  pango,
+  pkgconf,
+  sqlite,
+  udev,
+  vulkan-loader,
+  xkeyboard_config,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "jay";
-  version = "1.13.0";
+  version = "1.14.0";
 
   src = fetchFromGitHub {
     owner = "mahkoh";
     repo = "jay";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-tC2V1BgUGsUMpZsKXjFSS8Mp28LrNI/QNu761zpgAkc=";
+    sha256 = "sha256-bdvcGO1E9fkmKiXQxc3nvISwjIAegY8g37HmxXolsmU=";
   };
 
-  cargoHash = "sha256-96vCkZR/8dgZH0hJPeKzP7jQZ41W7XTi9yMnxFaIhoY=";
+  cargoHash = "sha256-5yjMPDh7liaa9+KntfdCzUXz4vWzTcAhFmXrnVZ+pjM=";
 
   nativeBuildInputs = [
     autoPatchelfHook
@@ -38,16 +39,17 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   buildInputs = [
     libGL
-    xkeyboard_config
     libgbm
-    pango
-    udev
     libinput
+    pango
+    sqlite
+    udev
+    vulkan-loader
+    xkeyboard_config
   ];
 
   runtimeDependencies = [
     libglvnd
-    vulkan-loader
   ];
 
   checkFlags = [


### PR DESCRIPTION
Changelog: https://github.com/mahkoh/jay/releases/tag/v1.14.0

Tested on my computer, works flawlessly on x86_64-linux.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
