### PR TITLE
treewide: follow some GitHub redirects for `fetchFromGitHub`

### DIFF
--- a/pkgs/by-name/li/libcdio-paranoia/package.nix
+++ b/pkgs/by-name/li/libcdio-paranoia/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.0.2";
 
   src = fetchFromGitHub {
-    owner = "rocky";
+    owner = "libcdio";
     repo = "libcdio-paranoia";
     rev = "release-10.2+${finalAttrs.version}";
     hash = "sha256-n05PSVgh6z7BFPq4CjJa5DqCO7Huj8Bsg0x3HQPsbeI=";
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
       This is a port of xiph.org's cdda paranoia to use libcdio for CDROM
       access. By doing this, cdparanoia runs on platforms other than GNU/Linux.
     '';
-    homepage = "https://github.com/rocky/libcdio-paranoia";
+    homepage = "https://github.com/libcdio/libcdio-paranoia";
     license = lib.licenses.gpl3;
     maintainers = [ ];
     mainProgram = "cd-paranoia";

--- a/pkgs/by-name/li/libconfuse/package.nix
+++ b/pkgs/by-name/li/libconfuse/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "1npfk5jv59kk4n8pkyx89fn9s6p8x3gbffs42jaw24frgxfgp8ca";
     rev = "v${finalAttrs.version}";
     repo = "libconfuse";
-    owner = "martinh";
+    owner = "libconfuse";
   };
 
   patches = [

--- a/pkgs/by-name/li/libetpan/package.nix
+++ b/pkgs/by-name/li/libetpan/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.10.1";
 
   src = fetchFromGitHub {
-    owner = "dinhviethoa";
+    owner = "dinhvh";
     repo = "libetpan";
     tag = finalAttrs.version;
     hash = "sha256-OBLGek7WYjiAiMMhycbx4eUy8d4XLF/B9p7GGO6LFHA=";

--- a/pkgs/by-name/li/libfreeaptx/package.nix
+++ b/pkgs/by-name/li/libfreeaptx/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.2.2";
 
   src = fetchFromGitHub {
-    owner = "iamthehorker";
+    owner = "regularhunter";
     repo = "libfreeaptx";
     rev = finalAttrs.version;
     sha256 = "sha256-ntbF0jz/ilOk45xMQxx00WJtJq4Wb7VyKE0eKvghYnY=";
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Free Implementation of Audio Processing Technology codec (aptX)";
     license = lib.licenses.lgpl21Plus;
-    homepage = "https://github.com/iamthehorker/libfreeaptx";
+    homepage = "https://github.com/regularhunter/libfreeaptx";
     platforms = lib.platforms.unix;
     maintainers = [ ];
   };

--- a/pkgs/by-name/li/libgumath/package.nix
+++ b/pkgs/by-name/li/libgumath/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
 
   src = fetchFromGitHub {
     owner = "xnd-project";
-    repo = "gumath";
+    repo = "libgumath";
     rev = "360ed454105ac5615a7cb7d216ad25bc4181b876";
     sha256 = "1wprkxpmjrk369fpw8rbq51r7jvqkcndqs209y7p560cnagmsxc6";
   };

--- a/pkgs/by-name/li/libnabo/package.nix
+++ b/pkgs/by-name/li/libnabo/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "libnabo";
 
   src = fetchFromGitHub {
-    owner = "ethz-asl";
+    owner = "norlab-ulaval";
     repo = "libnabo";
     rev = finalAttrs.version;
     sha256 = "sha256-/XXRwiLLaEvp+Q+c6lBiuWBb9by6o0pDf8wFtBNp7o8=";

--- a/pkgs/by-name/li/libndtypes/package.nix
+++ b/pkgs/by-name/li/libndtypes/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
 
   src = fetchFromGitHub {
     owner = "xnd-project";
-    repo = "ndtypes";
+    repo = "libndtypes";
     rev = "3ce6607c96d8fe67b72cc0c97bf595620cdd274e";
     sha256 = "18303q0jfar1lmi4krp94plczb455zcgw772f9lb8xa5p0bkhx01";
   };

--- a/pkgs/by-name/li/libnet/package.nix
+++ b/pkgs/by-name/li/libnet/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.3";
 
   src = fetchFromGitHub {
-    owner = "sam-github";
+    owner = "libnet";
     repo = "libnet";
     rev = "v${finalAttrs.version}";
     hash = "sha256-P3LaDMMNPyEnA8nO1Bm7H0mW/hVBr0cFdg+p2JmWcGI=";
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    homepage = "https://github.com/sam-github/libnet";
+    homepage = "https://github.com/libnet/libnet";
     description = "Portable framework for low-level network packet construction";
     mainProgram = "libnet-config";
     license = lib.licenses.bsd3;

--- a/pkgs/by-name/li/libpsm2/package.nix
+++ b/pkgs/by-name/li/libpsm2/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   src = fetchFromGitHub {
-    owner = "intel";
+    owner = "cornelisnetworks";
     repo = "opa-psm2";
     rev = "PSM2_${finalAttrs.version}";
     sha256 = "sha256-MzocxY+X2a5rJvTo+gFU0U10YzzazR1IxzgEporJyhI=";
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    homepage = "https://github.com/intel/opa-psm2";
+    homepage = "https://github.com/cornelisnetworks/opa-psm2";
     description = "PSM2 library supports a number of fabric media and stacks";
     license = with lib.licenses; [
       gpl2Only

--- a/pkgs/by-name/li/librealsense/package.nix
+++ b/pkgs/by-name/li/librealsense/package.nix
@@ -46,7 +46,7 @@ stdenv'.mkDerivation rec {
   ];
 
   src = fetchFromGitHub {
-    owner = "IntelRealSense";
+    owner = "realsenseai";
     repo = "librealsense";
     rev = "v${version}";
     sha256 = "sha256-d/FkvnUa7CqW25ZG8PY9+cd7uRL4zC1Md/JT8B/qAKU=";
@@ -184,7 +184,7 @@ stdenv'.mkDerivation rec {
 
   meta = {
     description = "Cross-platform library for Intel® RealSense™ depth cameras (D400 series and the SR300)";
-    homepage = "https://github.com/IntelRealSense/librealsense";
+    homepage = "https://github.com/realsenseai/librealsense";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       brian-dawn

--- a/pkgs/by-name/li/libremidi/package.nix
+++ b/pkgs/by-name/li/libremidi/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "4.5.0";
 
   src = fetchFromGitHub {
-    owner = "jcelerier";
+    owner = "celtera";
     repo = "libremidi";
     rev = "v${finalAttrs.version}";
     hash = "sha256-JwXOIBq+pmPIR4y/Zv5whEyCfpLHmbllzdH2WLZmWLw=";
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    homepage = "https://github.com/jcelerier/libremidi";
+    homepage = "https://github.com/celtera/libremidi";
     description = "Modern C++ MIDI real-time & file I/O library";
     license = lib.licenses.bsd2;
     maintainers = [ ];

--- a/pkgs/by-name/li/librepods/package.nix
+++ b/pkgs/by-name/li/librepods/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   src = fetchFromGitHub {
-    owner = "kavishdevar";
+    owner = "librepods-org";
     repo = "librepods";
     tag = "v${finalAttrs.version}";
     hash = "sha256-6l1WjwjDbv5e3tDaWo9+XSEjr9ge/hKysIkeUqyiO4U=";
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
-    homepage = "https://github.com/kavishdevar/librepods";
+    homepage = "https://github.com/librepods-org/librepods";
     description = "AirPods liberated from Apple's ecosystem";
     license = lib.licenses.gpl3;
     mainProgram = "librepods";

--- a/pkgs/by-name/li/libspatialaudio/package.nix
+++ b/pkgs/by-name/li/libspatialaudio/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   version = "0.3.0";
 
   src = fetchFromGitHub {
-    owner = "videolabs";
+    owner = "videolan";
     repo = "libspatialaudio";
     rev = version;
     hash = "sha256-sPnQPD41AceXM4uGqWXMYhuQv0TUkA6TZP8ChxUFIoI=";
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   # Fix the build with CMake 4.
   #
-  # See: <https://github.com/videolabs/libspatialaudio/commit/cec3eeac0984cfd8c1d09fef0dd511c6ccf2a175>
+  # See: <https://github.com/videolan/libspatialaudio/commit/cec3eeac0984cfd8c1d09fef0dd511c6ccf2a175>
   postPatch = ''
     substituteInPlace CMakeLists.txt \
       --replace-fail \
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Ambisonic encoding / decoding and binauralization library in C++";
-    homepage = "https://github.com/videolabs/libspatialaudio";
+    homepage = "https://github.com/videolan/libspatialaudio";
     license = lib.licenses.lgpl21Plus;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ krav ];

--- a/pkgs/by-name/li/libsurvive/package.nix
+++ b/pkgs/by-name/li/libsurvive/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.01";
 
   src = fetchFromGitHub {
-    owner = "cntools";
+    owner = "collabora";
     repo = "libsurvive";
     tag = "v${finalAttrs.version}";
     # Fixes 'Unknown CMake command "cnkalman_generate_code"'
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     eigen
   ];
 
-  # https://github.com/cntools/libsurvive/issues/272
+  # https://github.com/collabora/libsurvive/issues/272
   postPatch = ''
     substituteInPlace survive.pc.in \
       libs/cnkalman/cnkalman.pc.in libs/cnkalman/libs/cnmatrix/cnmatrix.pc.in \
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Open Source Lighthouse Tracking System";
-    homepage = "https://github.com/cntools/libsurvive";
+    homepage = "https://github.com/collabora/libsurvive";
     license = lib.licenses.mit;
     maintainers = [ ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/li/lightdm-tiny-greeter/package.nix
+++ b/pkgs/by-name/li/lightdm-tiny-greeter/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   version = "1.2";
 
   src = fetchFromGitHub {
-    owner = "off-world";
+    owner = "tobiohlala";
     repo = "lightdm-tiny-greeter";
     rev = version;
     sha256 = "08azpj7b5qgac9bgi1xvd6qy6x2nb7iapa0v40ggr3d1fabyhrg6";
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Tiny multi user lightdm greeter";
     mainProgram = "lightdm-tiny-greeter";
-    homepage = "https://github.com/off-world/lightdm-tiny-greeter";
+    homepage = "https://github.com/tobiohlala/lightdm-tiny-greeter";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/li/lightdm/package.nix
+++ b/pkgs/by-name/li/lightdm/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   src = fetchFromGitHub {
-    owner = "canonical";
+    owner = "ubuntu";
     repo = "lightdm";
     tag = finalAttrs.version;
     sha256 = "sha256-ttNlhWD0Ran4d3QvZ+PxbFbSUGMkfrRm+hJdQxIDJvM=";
@@ -129,7 +129,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    homepage = "https://github.com/canonical/lightdm";
+    homepage = "https://github.com/ubuntu/lightdm";
     description = "Cross-desktop display manager";
     platforms = lib.platforms.linux;
     license = with lib.licenses; [

--- a/pkgs/by-name/li/lightgbm/package.nix
+++ b/pkgs/by-name/li/lightgbm/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "4.6.0";
 
   src = fetchFromGitHub {
-    owner = "microsoft";
+    owner = "lightgbm-org";
     repo = "lightgbm";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;

--- a/pkgs/by-name/li/lint-staged/package.nix
+++ b/pkgs/by-name/li/lint-staged/package.nix
@@ -11,7 +11,7 @@ buildNpmPackage rec {
   version = "17.0.8";
 
   src = fetchFromGitHub {
-    owner = "okonet";
+    owner = "lint-staged";
     repo = "lint-staged";
     rev = "v${version}";
     hash = "sha256-xjbEVAZhcMns5daTE68PCX2mib0Lz4HZKwxR1a8/ucU=";

--- a/pkgs/by-name/li/linux-exploit-suggester/package.nix
+++ b/pkgs/by-name/li/linux-exploit-suggester/package.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation {
   version = "unstable-2022-04-01";
 
   src = fetchFromGitHub {
-    owner = "mzet-";
+    owner = "The-Z-Labs";
     repo = "linux-exploit-suggester";
     rev = "54a5c01497d6655be88f6262ccad5bc5a5e4f4ec";
     sha256 = "v0Q8O+aaXEqwWAwGP/u5Nkm4DzM6nM11GI4XbK2PeWM=";
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation {
   meta = {
     description = "Tool designed to assist in detecting security deficiencies for given Linux kernel/Linux-based machine";
     mainProgram = "linux-exploit-suggester";
-    homepage = "https://github.com/mzet-/linux-exploit-suggester";
+    homepage = "https://github.com/The-Z-Labs/linux-exploit-suggester";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ emilytrau ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/li/lix-diff/package.nix
+++ b/pkgs/by-name/li/lix-diff/package.nix
@@ -9,7 +9,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "1.5.1";
 
   src = fetchFromGitHub {
-    owner = "tgirlcloud";
+    owner = "isabelroses";
     repo = "lix-diff";
     tag = "v${finalAttrs.version}";
     hash = "sha256-mURA7fZ9RAhVtOx+gnEeJI48tyvi+zbKE+xUs5UMPY4=";

--- a/pkgs/by-name/lo/local-ai/package.nix
+++ b/pkgs/by-name/lo/local-ai/package.nix
@@ -337,7 +337,7 @@ let
   pname = "local-ai";
   version = "2.28.0";
   src = fetchFromGitHub {
-    owner = "go-skynet";
+    owner = "mudler";
     repo = "LocalAI";
     tag = "v${version}";
     hash = "sha256-Hpz0dGkgasSY/FGO7mDzqsLjXut0LdQ9PUXGaURUOlY=";

--- a/pkgs/by-name/lo/lora/package.nix
+++ b/pkgs/by-name/lo/lora/package.nix
@@ -17,7 +17,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "cyrealtype";
-    repo = "lora";
+    repo = "Lora-Cyrillic";
     tag = "v${finalAttrs.version}";
     hash = "sha256-v9wE9caI9HTCfO01Yf+s6KajF7WpnL12nu+IuOV7T+w=";
   };
@@ -38,7 +38,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Lora Font: well-balanced contemporary serif with roots in calligraphy";
-    homepage = "https://github.com/cyrealtype/lora";
+    homepage = "https://github.com/cyrealtype/Lora-Cyrillic";
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ ofalvai ];

--- a/pkgs/by-name/lr/lr/package.nix
+++ b/pkgs/by-name/lr/lr/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.0.1";
 
   src = fetchFromGitHub {
-    owner = "chneukirchen";
+    owner = "leahneukirchen";
     repo = "lr";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-zpHThIB1FS45RriE214SM9ZQJ1HyuBkBi/+PTeJjEFc=";
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
   makeFlags = [ "PREFIX=$(out)" ];
 
   meta = {
-    homepage = "https://github.com/chneukirchen/lr";
+    homepage = "https://github.com/leahneukirchen/lr";
     description = "List files recursively";
     license = lib.licenses.mit;
     platforms = lib.platforms.all;

--- a/pkgs/by-name/ls/lsh/package.nix
+++ b/pkgs/by-name/ls/lsh/package.nix
@@ -8,16 +8,16 @@ buildGoModule (finalAttrs: {
   version = "1.6.3";
   src = fetchFromGitHub {
     owner = "latitudesh";
-    repo = "lsh";
+    repo = "cli";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-A0uZLcwFIuimSgwItDSfDCcDLZqI+q6C5iPyJgyUelQ=";
   };
   vendorHash = "sha256-MlpNAEbdl8AHu0uKhW/p0NTBROdGHKN+ODrcRCs9t4s=";
   subPackages = [ "." ];
   meta = {
-    changelog = "https://github.com/latitudesh/lsh/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/latitudesh/cli/releases/tag/v${finalAttrs.version}";
     description = "Command-Line Interface for Latitude.sh";
-    homepage = "https://github.com/latitudesh/lsh";
+    homepage = "https://github.com/latitudesh/cli";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.dzmitry-lahoda ];
   };

--- a/pkgs/by-name/lu/lune/package.nix
+++ b/pkgs/by-name/lu/lune/package.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage rec {
   version = "0.10.4";
 
   src = fetchFromGitHub {
-    owner = "filiptibell";
+    owner = "lune-org";
     repo = "lune";
     tag = "v${version}";
     hash = "sha256-AbviyCy2nn6WHC575JKl/t3bM/4Myb+Wx5/buTvB4MY=";

--- a/pkgs/by-name/lv/lv2bm/package.nix
+++ b/pkgs/by-name/lv/lv2bm/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.1";
 
   src = fetchFromGitHub {
-    owner = "moddevices";
+    owner = "mod-audio";
     repo = "lv2bm";
     rev = "v${finalAttrs.version}";
     sha256 = "0vlppxfb9zbmffazs1kiyb79py66s8x9hihj36m2vz86zsq7ybl0";

--- a/pkgs/by-name/m3/m33-linux/package.nix
+++ b/pkgs/by-name/m3/m33-linux/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
 
   src = fetchFromGitHub {
     owner = "donovan6000";
-    repo = "M3D-Linux";
+    repo = "M33-Linux";
     rev = "5c1b90c13d260771dac970b49fdc9f840fee5f4a";
     sha256 = "1bvbclkyfcv23vxb4s1zssvygklks1nhp4iwi4v90c1fvyz0356f";
   };
@@ -39,7 +39,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    homepage = "https://github.com/donovan6000/M3D-Linux";
+    homepage = "https://github.com/donovan6000/M33-Linux";
     description = "Linux program that can communicate with the Micro 3D printer";
     mainProgram = "m33-linux";
     license = lib.licenses.gpl2Only;

--- a/pkgs/by-name/ma/mantra/package.nix
+++ b/pkgs/by-name/ma/mantra/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "3.1";
 
   src = fetchFromGitHub {
-    owner = "MrEmpy";
+    owner = "brosck";
     repo = "Mantra";
     tag = "v${finalAttrs.version}";
     hash = "sha256-DnErXuMbCRK3WxhdyPj0dOUtGnCcmynPk/hYmOsOKVU=";
@@ -24,8 +24,8 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Tool used to hunt down API key leaks in JS files and pages";
-    homepage = "https://github.com/MrEmpy/Mantra";
-    changelog = "https://github.com/MrEmpy/Mantra/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/brosck/mantra";
+    changelog = "https://github.com/brosck/mantra/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "mantra";

--- a/pkgs/by-name/ma/mariadb-galera/package.nix
+++ b/pkgs/by-name/ma/mariadb-galera/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "26.4.27";
 
   src = fetchFromGitHub {
-    owner = "codership";
+    owner = "mariadb-corporation";
     repo = "galera";
     tag = "release_${finalAttrs.version}";
     hash = "sha256-Z1UtNM7HPcbFMr35JVJZCxPl43ZQxy+eBkiQFoVmFhY=";

--- a/pkgs/by-name/ma/mastodon-archive/package.nix
+++ b/pkgs/by-name/ma/mastodon-archive/package.nix
@@ -11,7 +11,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "kensanata";
-    repo = "mastodon-backup";
+    repo = "mastodon-archive";
     rev = "v${finalAttrs.version}";
     hash = "sha256-yz17ddcA0U9fq1aDlPmD3OkNL6Epzdp9C7L+31yNLBc=";
   };

--- a/pkgs/by-name/ma/maxfetch/package.nix
+++ b/pkgs/by-name/ma/maxfetch/package.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation {
   version = "unstable-2023-07-31";
 
   src = fetchFromGitHub {
-    owner = "jobcmax";
+    owner = "natewhar";
     repo = "maxfetch";
     rev = "17baa4047073e20572403b70703c69696af6b68d";
     hash = "sha256-LzOhrFFjGs9GIDjk1lUFKhlnzJuEUrKjBcv1eT3kaY8=";
@@ -37,7 +37,7 @@ stdenvNoCC.mkDerivation {
 
   meta = {
     description = "Nice fetching program written in sh";
-    homepage = "https://github.com/jobcmax/maxfetch";
+    homepage = "https://github.com/natewhar/maxfetch";
     license = lib.licenses.gpl2Plus;
     mainProgram = "maxfetch";
     maintainers = with lib.maintainers; [ jtbx ];

--- a/pkgs/by-name/mb/mbpfan/package.nix
+++ b/pkgs/by-name/mb/mbpfan/package.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "mbpfan";
   version = "2.4.0";
   src = fetchFromGitHub {
-    owner = "dgraziotin";
+    owner = "linux-on-mac";
     repo = "mbpfan";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-F9IWUcILOuLn5K4zRSU5jn+1Wk1xy0CONSI6JTXU2pA=";
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Daemon that uses input from coretemp module and sets the fan speed using the applesmc module";
     mainProgram = "mbpfan";
-    homepage = "https://github.com/dgraziotin/mbpfan";
+    homepage = "https://github.com/linux-on-mac/mbpfan";
     license = lib.licenses.gpl3;
     platforms = lib.platforms.linux;
     maintainers = [ ];

--- a/pkgs/by-name/mc/mcporter/package.nix
+++ b/pkgs/by-name/mc/mcporter/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.12.3";
 
   src = fetchFromGitHub {
-    owner = "steipete";
+    owner = "openclaw";
     repo = "mcporter";
     tag = "v${finalAttrs.version}";
     hash = "sha256-dfbNyvIbdhZOLuwRDNLqUJHVeMEemioanktD6nL0Pmk=";
@@ -58,8 +58,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "TypeScript runtime and CLI for connecting to configured Model Context Protocol servers";
-    homepage = "https://github.com/steipete/mcporter";
-    changelog = "https://github.com/steipete/mcporter/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/openclaw/mcporter";
+    changelog = "https://github.com/openclaw/mcporter/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ mkg20001 ];
     mainProgram = "mcporter";

--- a/pkgs/by-name/mi/minesector/package.nix
+++ b/pkgs/by-name/mi/minesector/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.1.5";
 
   src = fetchFromGitHub {
-    owner = "grassdne";
+    owner = "ruuzia";
     repo = "minesector";
     tag = finalAttrs.version;
     hash = "sha256-VMTXZ4CIk9RpE4R9shHPl0R/T7mJUKY2b8Zi0DPW0/Q=";
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     mainProgram = "minesector";
     description = "Snazzy Minesweeper-based game built with SDL2";
-    homepage = "https://github.com/grassdne/minesector";
+    homepage = "https://github.com/ruuzia/minesector";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
     maintainers = [ ];

--- a/pkgs/by-name/mi/mirrorbits/package.nix
+++ b/pkgs/by-name/mi/mirrorbits/package.nix
@@ -13,7 +13,7 @@ buildGoModule (finalAttrs: {
   version = "0.6.1";
 
   src = fetchFromGitHub {
-    owner = "etix";
+    owner = "videolabs";
     repo = "mirrorbits";
     tag = "v${finalAttrs.version}";
     hash = "sha256-PqPE/PgIyQylbYoABC/saxLF83XjgRAS0QimragJ8P8=";
@@ -46,7 +46,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Geographical download redirector for distributing files efficiently across a set of mirrors";
-    homepage = "https://github.com/etix/mirrorbits";
+    homepage = "https://github.com/videolabs/mirrorbits";
     longDescription = ''
       Mirrorbits is a geographical download redirector written in Go for
       distributing files efficiently across a set of mirrors. It offers

--- a/pkgs/by-name/mo/mod-arpeggiator-lv2/package.nix
+++ b/pkgs/by-name/mo/mod-arpeggiator-lv2/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   version = "0-unstable-2021-11-09";
 
   src = fetchFromGitHub {
-    owner = "moddevices";
+    owner = "mod-audio";
     repo = "mod-arpeggiator-lv2";
     rev = "82f3d9f159ce216454656a8782362c3d5ed48bed";
     sha256 = "sha256-1KiWMTVTTf1/iR4AzJ1Oe0mOrWN5edsZN0tQMidgnRA=";
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "LV2 arpeggiator";
-    homepage = "https://github.com/moddevices/mod-arpeggiator-lv2";
+    homepage = "https://github.com/mod-audio/mod-arpeggiator-lv2";
     license = lib.licenses.gpl2Plus;
     maintainers = [ lib.maintainers.magnetophon ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/mo/mod-distortion/package.nix
+++ b/pkgs/by-name/mo/mod-distortion/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
   version = "0-unstable-2016-08-19";
 
   src = fetchFromGitHub {
-    owner = "portalmod";
+    owner = "mod-audio";
     repo = "mod-distortion";
     rev = "e672d5feb9d631798e3d56eb96e8958c3d2c6821";
     sha256 = "005wdkbhn9dgjqv019cwnziqg86yryc5vh7j5qayrzh9v446dw34";
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
   installFlags = [ "INSTALL_PATH=$(out)/lib/lv2" ];
 
   meta = {
-    homepage = "https://github.com/portalmod/mod-distortion";
+    homepage = "https://github.com/mod-audio/mod-distortion";
     description = "Analog distortion emulation lv2 plugins";
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.magnetophon ];

--- a/pkgs/by-name/mo/mono_repo/package.nix
+++ b/pkgs/by-name/mo/mono_repo/package.nix
@@ -15,7 +15,7 @@ buildDartApplication (finalAttrs: {
   # Fetch the whole monorepo
   src = fetchFromGitHub {
     owner = "google";
-    repo = "mono_repo";
+    repo = "mono_repo.dart";
     tag = "mono_repo-v${finalAttrs.version}";
     hash = "sha256-2/YJ2S3I9K5Xzje787HdJ/KxfbiBEGKU8feuHnOizn8=";
   };

--- a/pkgs/by-name/mp/mprocs/package.nix
+++ b/pkgs/by-name/mp/mprocs/package.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "pvolok";
-    repo = "mprocs";
+    repo = "dekit";
     tag = "v${finalAttrs.version}";
     hash = "sha256-fh294Re4gEveWgX29m0SXdI8hwuiXuniTq7pVZ464ws=";
   };
@@ -31,8 +31,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "TUI tool to run multiple commands in parallel and show the output of each command separately";
-    homepage = "https://github.com/pvolok/mprocs";
-    changelog = "https://github.com/pvolok/mprocs/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/pvolok/dekit";
+    changelog = "https://github.com/pvolok/dekit/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ GaetanLepage ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/mu/museum/package.nix
+++ b/pkgs/by-name/mu/museum/package.nix
@@ -13,7 +13,7 @@ buildGoModule (finalAttrs: {
   version = "1.3.36";
 
   src = fetchFromGitHub {
-    owner = "ente-io";
+    owner = "ente";
     repo = "ente";
     sparseCheckout = [ "server" ];
     tag = "photos-v${finalAttrs.version}";
@@ -55,8 +55,8 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "API server for ente.io";
-    homepage = "https://github.com/ente-io/ente/tree/main/server";
-    changelog = "https://github.com/ente-io/ente/releases/tag/photos-v${finalAttrs.version}";
+    homepage = "https://github.com/ente/ente/tree/main/server";
+    changelog = "https://github.com/ente/ente/releases/tag/photos-v${finalAttrs.version}";
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [
       pinpox

--- a/pkgs/by-name/na/nanomq/package.nix
+++ b/pkgs/by-name/na/nanomq/package.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.24.11";
 
   src = fetchFromGitHub {
-    owner = "emqx";
+    owner = "nanomq";
     repo = "nanomq";
     tag = finalAttrs.version;
     hash = "sha256-I2SLc/KbkBvqbbWuLr8ARmmg4DeE7ZbTqcM1tw8WhwQ=";

--- a/pkgs/by-name/nb/nbping/package.nix
+++ b/pkgs/by-name/nb/nbping/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage {
 
   src = fetchFromGitHub {
     owner = "hanshuaikang";
-    repo = "Nping";
+    repo = "NBping";
     tag = "v${version}";
     hash = "sha256-QaJTV5RNvsYuBUPrWcmbBj1QSKtfDNTvHd5fMfuoU3c=";
   };
@@ -21,8 +21,8 @@ rustPlatform.buildRustPackage {
 
   meta = {
     description = "Ping Tool in Rust with Real-Time Data and Visualizations";
-    homepage = "https://github.com/hanshuaikang/Nping";
-    changelog = "https://github.com/hanshuaikang/Nping/releases/";
+    homepage = "https://github.com/hanshuaikang/NBping";
+    changelog = "https://github.com/hanshuaikang/NBping/releases/";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ luftmensch-luftmensch ];
     mainProgram = "nbping";

--- a/pkgs/by-name/ne/neocmakelsp/package.nix
+++ b/pkgs/by-name/ne/neocmakelsp/package.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.10.3";
 
   src = fetchFromGitHub {
-    owner = "Decodetalkers";
+    owner = "neocmakelsp";
     repo = "neocmakelsp";
     rev = "v${finalAttrs.version}";
     hash = "sha256-HfoVAUg9StAUXmP66LVRzCj4sd4kl6pCzWUS3lZEKtU=";
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "CMake lsp based on tower-lsp and treesitter";
-    homepage = "https://github.com/Decodetalkers/neocmakelsp";
+    homepage = "https://github.com/neocmakelsp/neocmakelsp";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/ne/networkmanager-l2tp/package.nix
+++ b/pkgs/by-name/ne/networkmanager-l2tp/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "nm-l2tp";
-    repo = "network-manager-l2tp";
+    repo = "NetworkManager-l2tp";
     rev = version;
     hash = "sha256-5EIG/5fexhrcOOQE+31+TJKMtINGVL+EI32m9tEhYVo=";
   };
@@ -78,7 +78,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "L2TP plugin for NetworkManager";
     inherit (networkmanager.meta) platforms;
-    homepage = "https://github.com/nm-l2tp/network-manager-l2tp";
+    homepage = "https://github.com/nm-l2tp/NetworkManager-l2tp";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
       obadz

--- a/pkgs/by-name/ne/new-session-manager/package.nix
+++ b/pkgs/by-name/ne/new-session-manager/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.6.1";
 
   src = fetchFromGitHub {
-    owner = "linuxaudio";
+    owner = "jackaudio";
     repo = "new-session-manager";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-5G2GlBuKjC/r1SMm78JKia7bMA97YcvUR5l6zBucemw=";

--- a/pkgs/by-name/ne/nexa/package.nix
+++ b/pkgs/by-name/ne/nexa/package.nix
@@ -56,8 +56,8 @@ buildGo125Module (finalAttrs: {
   version = "0.2.73";
 
   src = fetchFromGitHub {
-    owner = "NexaAI";
-    repo = "nexa-sdk";
+    owner = "qualcomm";
+    repo = "GenieX";
     tag = "v${finalAttrs.version}";
     hash = "sha256-JioUguVO2z37BYxkXBlDEswJIh80bpOONG6EVNlq5OA=";
   };
@@ -199,8 +199,8 @@ buildGo125Module (finalAttrs: {
 
   meta = {
     description = "Nexa AI SDK CLI for model management, inference, and server operations";
-    homepage = "https://github.com/NexaAI/nexa-sdk";
-    changelog = "https://github.com/NexaAI/nexa-sdk/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/qualcomm/GenieX";
+    changelog = "https://github.com/qualcomm/GenieX/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ mkg20001 ];
     mainProgram = "nexa";

--- a/pkgs/by-name/ne/nextinspace/package.nix
+++ b/pkgs/by-name/ne/nextinspace/package.nix
@@ -10,7 +10,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "not-stirred";
+    owner = "gideonshaked";
     repo = "nextinspace";
     tag = "v${finalAttrs.version}";
     hash = "sha256-oEvRxaxx1pIco2+jm/3HUN0a0nqdo2VosCisM0MWTjU=";

--- a/pkgs/development/python-modules/fx2/default.nix
+++ b/pkgs/development/python-modules/fx2/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   format = "setuptools";
 
   src = fetchFromGitHub {
-    owner = "whitequark";
+    owner = "GlasgowEmbedded";
     repo = "libfx2";
     rev = "v${version}";
     hash = "sha256-uMgf1VL3yvkLUfRlBn9NKcerfHfcFg9yEgHGWmwyh8I=";
@@ -47,7 +47,7 @@ buildPythonPackage rec {
   meta = {
     description = "Chip support package for Cypress EZ-USB FX2 series microcontrollers";
     mainProgram = "fx2tool";
-    homepage = "https://github.com/whitequark/libfx2";
+    homepage = "https://github.com/GlasgowEmbedded/libfx2";
     license = lib.licenses.bsd0;
     maintainers = [ ];
   };

--- a/pkgs/development/python-modules/meshcore-cli/default.nix
+++ b/pkgs/development/python-modules/meshcore-cli/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "fdlamotte";
+    owner = "meshcore-dev";
     repo = "meshcore-cli";
     tag = "v${finalAttrs.version}";
     hash = "sha256-wby97e9Xulk2pwNJ9mnvKxWlTsWmH4n3zlTtYi7WS6I=";
@@ -45,7 +45,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     changelog = "https://github.com/meshcore-dev/meshcore-cli/releases/tag/${finalAttrs.src.tag}";
     description = "Command line interface to MeshCore node";
-    homepage = "https://github.com/fdlamotte/meshcore-cli";
+    homepage = "https://github.com/meshcore-dev/meshcore-cli";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.haylin ];
     mainProgram = "meshcore-cli";

--- a/pkgs/development/python-modules/myjwt/default.nix
+++ b/pkgs/development/python-modules/myjwt/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "mBouamama";
+    owner = "tyki6";
     repo = "MyJWT";
     tag = finalAttrs.version;
     hash = "sha256-jqBnxo7Omn5gLMCQ7SNbjo54nyFK7pn94796z2Qc9lg=";
@@ -58,7 +58,7 @@ buildPythonPackage (finalAttrs: {
 
   meta = {
     description = "CLI tool for testing vulnerabilities of JSON Web Tokens (JWT)";
-    homepage = "https://github.com/mBouamama/MyJWT";
+    homepage = "https://github.com/tyki6/MyJWT";
     changelog = "https://github.com/tyki6/MyJWT/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];


### PR DESCRIPTION
This PR updates some `fetchFromGitHub` calls and corresponding `github.com/<owner>/<repo>` links in the same location to point directly to canonical repositories instead of redirecting URLs.

This doesn't update all `fetchFromGitHub` redirects since that would produce a diff too large for maintainers to review.

**Motivation:**
This avoids silent failures if upstream redirects ever change or disappear, and improves reliability and reproducibility of fetches.

**How:**
Changes were generated using [this script](https://git.kybe.xyz/2kybe3/nixpkgs-github-redirect).

**How to verify:**
You can verify that all modified package sources still build using the following script with a `changed.txt` file containing the changed package list.

<details>
  <summary>Verify script</summary>

```bash
#!/usr/bin/env bash

out="result.txt"
: > "$out"

while read -r pkg; do
    echo "=== $pkg ==="

    output=$(nix build "./nixpkgs#$pkg.src" -L -v --rebuild --no-link --print-out-paths)
    status=$?

    if [ $status -eq 0 ]; then
        echo "$pkg: success | $output" | tee -a "$out"
    else
        echo "$pkg: failed" | tee -a "$out"
    fi
done < ./changed.txt
```
</details>

<details>
  <summary>Changed Packages</summary>

```
libcdio-paranoia
libetpan
libconfuse
libfreeaptx
libgumath
libfx2
libnabo
libndtypes
libnet
libpsm2
librealsense
libremidi
librepods
libspatialaudio
libsurvive
lightdm
lightdm-tiny-greeter
lightgbm
lint-staged
linux-exploit-suggester
lix-diff
local-ai
lora
lr
lsh
lune
lv2bm
m33-linux
mantra
mariadb-galera
mastodon-archive
maxfetch
mbpfan
mcporter
meshcore-cli
minesector
mirrorbits
mod-distortion
mod-arpeggiator-lv2
mono_repo
mprocs
museum
myjwt
nanomq
neocmakelsp
nbping
networkmanager-l2tp
new-session-manager
nexa
nextinspace
```
</details>

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
