### PR TITLE
exiv2: fix i686-linux build

### DIFF
--- a/pkgs/by-name/ex/exiv2/package.nix
+++ b/pkgs/by-name/ex/exiv2/package.nix
@@ -46,6 +46,8 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.is32bit "-D_FILE_OFFSET_BITS=64";
+
   nativeBuildInputs = [
     cmake
     doxygen

--- a/pkgs/by-name/ex/exiv2/package.nix
+++ b/pkgs/by-name/ex/exiv2/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   doxygen,
   gettext,
@@ -36,6 +37,14 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-ESRiiBBckGIhnhSOMmcF/m1PYi2sLGv1xxE0b22nl5M=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-i686-lens-rounding.patch";
+      url = "https://github.com/Exiv2/exiv2/commit/7d25da6045556c8b9a81632cffd1bd2e2a9d0977.patch";
+      hash = "sha256-wA14qgkGIM7hvYRfv4+jPcMIbbr2oE9UvdaanVm4Sy0=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
Canon teleconverter focal lengths are rounded before integer conversion. Enabling large-file support prevents high inode numbers from making `stat()` fail with `EOVERFLOW`, which Exiv2 otherwise turns into misleading allocation failures.

Upstream: [Canon lens matching](https://redirect.github.com/Exiv2/exiv2/pull/9475) and [32-bit large-file support](https://redirect.github.com/Exiv2/exiv2/pull/9481).

Closes #534518

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test




