### PR TITLE
python3Packages.torchtitan: add missing test dependency expecttest

### DIFF
--- a/pkgs/development/python-modules/torchtitan/default.nix
+++ b/pkgs/development/python-modules/torchtitan/default.nix
@@ -20,6 +20,7 @@
   tyro,
 
   # tests
+  expecttest,
   pytestCheckHook,
   tomli-w,
   triton,
@@ -58,6 +59,7 @@ buildPythonPackage (finalAttrs: {
   pythonImportsCheck = [ "torchtitan" ];
 
   nativeCheckInputs = [
+    expecttest
     pytestCheckHook
     tomli-w
     transformers

--- a/pkgs/development/python-modules/torchtitan/default.nix
+++ b/pkgs/development/python-modules/torchtitan/default.nix
@@ -31,6 +31,7 @@ buildPythonPackage (finalAttrs: {
   pname = "torchtitan";
   version = "0.2.2";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "pytorch";


### PR DESCRIPTION
## Things done

Preparation for #536976.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
