### PR TITLE
tree-sitter-grammars: enable __structuredAttrs

### DIFF
--- a/pkgs/by-name/tr/tree-sitter/grammars/build-grammar.nix
+++ b/pkgs/by-name/tr/tree-sitter/grammars/build-grammar.nix
@@ -37,21 +37,28 @@ stdenv.mkDerivation (
       tree-sitter
     ];
 
-    CFLAGS = [
-      "-Isrc"
-      # Match upstream `tree-sitter build --wasm`
-      (if isWasi then "-Os" else "-O2")
-    ]
-    ++ lib.optionals isWasi [
-      "-fvisibility=hidden"
-    ];
-    CXXFLAGS = [
-      "-Isrc"
-      (if isWasi then "-Os" else "-O2")
-    ]
-    ++ lib.optionals isWasi [
-      "-fvisibility=hidden"
-    ];
+    env = args.env or { } // {
+      CFLAGS = toString (
+        [
+          "-Isrc"
+          # Match upstream `tree-sitter build --wasm`
+          (if isWasi then "-Os" else "-O2")
+        ]
+        ++ lib.optionals isWasi [
+          "-fvisibility=hidden"
+        ]
+      );
+      CXXFLAGS = toString (
+        [
+          "-Isrc"
+          (if isWasi then "-Os" else "-O2")
+        ]
+        ++ lib.optionals isWasi [
+          "-fvisibility=hidden"
+        ]
+      );
+      inherit language;
+    };
 
     stripDebugList = [ "parser" ];
 
@@ -170,5 +177,7 @@ stdenv.mkDerivation (
     "generate"
     "excludeBrokenTreeSitterJson"
     "meta"
+    "language"
+    "env"
   ]
 )


### PR DESCRIPTION
* Move existing env variables into env and stringify them, as is required.
* `language` is used as an env variable by `jq`, so move it to env as well
* Do not clobber `env` if it exists, but merge in these attributes.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
