### PR TITLE
nixos/captive-browser: attrs -> toml

### DIFF
--- a/nixos/modules/programs/captive-browser.nix
+++ b/nixos/modules/programs/captive-browser.nix
@@ -11,6 +11,7 @@ let
   inherit (lib)
     concatStringsSep
     escapeShellArgs
+    optionalAttrs
     optionalString
     literalExpression
     mkEnableOption
@@ -45,6 +46,21 @@ let
       "http://cache.nixos.org/"
     ];
 
+  cfgDrv =
+    let
+      attrs = {
+        inherit (cfg) browser dhcp-dns socks5-addr;
+      }
+      // optionalAttrs cfg.bindInterface {
+        bind-device = cfg.interface;
+      };
+      file = (pkgs.formats.toml { }).generate "captive-browser.toml" attrs;
+
+    in
+    pkgs.runCommandLocal "captive-browser" { } ''
+      install -Dm444 ${file} $out/${file.name}
+    '';
+
   desktopItem = pkgs.makeDesktopItem {
     name = "captive-browser";
     desktopName = "Captive Portal Browser";
@@ -55,14 +71,7 @@ let
 
   captive-browser-configured = pkgs.writeShellScriptBin "captive-browser" ''
     export PREV_CONFIG_HOME="$XDG_CONFIG_HOME"
-    export XDG_CONFIG_HOME=${pkgs.writeTextDir "captive-browser.toml" ''
-      browser = """${cfg.browser}"""
-      dhcp-dns = """${cfg.dhcp-dns}"""
-      socks5-addr = """${cfg.socks5-addr}"""
-      ${optionalString cfg.bindInterface ''
-        bind-device = """${cfg.interface}"""
-      ''}
-    ''}
+    export XDG_CONFIG_HOME=${cfgDrv}
     exec ${cfg.package}/bin/captive-browser
   '';
 in


### PR DESCRIPTION
Instead of inlining things, use a proper toml writer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
