### PR TITLE
python3Packages.ale-py: add missing nvcc to fix CUDA build

### DIFF
--- a/pkgs/development/python-modules/ale-py/default.nix
+++ b/pkgs/development/python-modules/ale-py/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  config,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -16,6 +17,9 @@
   SDL2,
   opencv,
   zlib,
+
+  # nativeBuildInputs
+  cudaPackages,
 
   # dependencies
   numpy,
@@ -47,6 +51,11 @@ buildPythonPackage (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     jax
+  ];
+
+  nativeBuildInputs = lib.optionals config.cudaSupport [
+    # Required by opencv's cmake
+    cudaPackages.cuda_nvcc
   ];
 
   # disable lto on darwin, cmake cannot find llvm-ar

--- a/pkgs/development/python-modules/ale-py/default.nix
+++ b/pkgs/development/python-modules/ale-py/default.nix
@@ -43,6 +43,14 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-hFbreHk0i4h+JOyvDYcNX3TmwgvxNC5U0l5Xrqqz1zQ=";
   };
 
+  # disable lto on darwin, cmake cannot find llvm-ar
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace src/ale/CMakeLists.txt \
+      --replace-fail \
+        'set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)' \
+        'set(CMAKE_INTERPROCEDURAL_OPTIMIZATION FALSE)'
+  '';
+
   build-system = [
     cmake
     ninja
@@ -57,14 +65,6 @@ buildPythonPackage (finalAttrs: {
     # Required by opencv's cmake
     cudaPackages.cuda_nvcc
   ];
-
-  # disable lto on darwin, cmake cannot find llvm-ar
-  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    substituteInPlace src/ale/CMakeLists.txt \
-      --replace-fail \
-        'set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)' \
-        'set(CMAKE_INTERPROCEDURAL_OPTIMIZATION FALSE)'
-  '';
 
   dontUseCmakeConfigure = true;
 
@@ -111,7 +111,6 @@ buildPythonPackage (finalAttrs: {
   ];
 
   disabledTestPaths = [
-    #
     "tests/python/test_atari_vector_xla.py"
   ];
 


### PR DESCRIPTION

## Things done

Currrently fails on `master` with:
```
CMake Error at /nix/store/k1b82rs72af124wmq6nb00nhw5i7ikp7-cmake-4.1.2/share/cmake-4.1/Modules/FindCUDAToolkit.cmake:890 (message):
  Could not find nvcc, please set CUDAToolkit_ROOT.
Call Stack (most recent call first):
  /nix/store/aj4wq613wdcz9kznan22q04ac1y976ji-opencv-4.13.0/lib/cmake/opencv4/OpenCVConfig.cmake:86 (find_package)
  /nix/store/aj4wq613wdcz9kznan22q04ac1y976ji-opencv-4.13.0/lib/cmake/opencv4/OpenCVConfig.cmake:108 (find_host_package)
  src/ale/CMakeLists.txt:67 (find_package)


-- Configuring incomplete, errors occurred!

*** CMake configuration failed
```

cc @NixOS/cuda-maintainers 

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
