### PR TITLE
gssproxy: init at 0.9.2

### DIFF
--- a/pkgs/by-name/gs/gssproxy/package.nix
+++ b/pkgs/by-name/gs/gssproxy/package.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  nix-update-script,
+  pkg-config,
+  ding-libs,
+  krb5,
+  libverto,
+  popt,
+  libxml2,
+  libxslt,
+  docbook-xsl-nons,
+  docbook_xml_dtd_44,
+  versionCheckHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gssproxy";
+  version = "0.9.2";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "gssapi";
+    repo = "gssproxy";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-RcT1ge/XxhTaT9hrvcHElAEAbvOtjqep3kdEw5e7WZY=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    docbook-xsl-nons
+    docbook_xml_dtd_44
+    libxml2
+    libxslt
+    pkg-config
+  ];
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  makeFlags = [
+    "SGML_CATALOG_FILES=${docbook-xsl-nons}/xml/xsl/docbook/catalog.xml ${docbook_xml_dtd_44}/xml/dtd/docbook/catalog.xml"
+    "VERTO_CFLAGS=${libverto}/include"
+    "VERTO_LIBS=${libverto}/lib/libverto.so"
+  ];
+
+  postInstall = ''
+    find $out -type d -empty -delete
+  '';
+
+  buildInputs = [
+    ding-libs
+    krb5
+    libverto
+    popt
+  ];
+
+  configureFlags = [
+    "--with-pubconf-path=${placeholder "out"}/etc/gssproxy"
+    "--with-initscript=none"
+    "--without-selinux"
+    # Use REMOTE_FIRST behavior: try gssproxy daemon first, fall back to local credentials
+    "--with-gpp-default-behavior=REMOTE_FIRST"
+    "--with-xml-catalog-path=${docbook-xsl-nons}/xml/xsl/docbook/catalog.xml"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "GSS-API proxy client library for credential isolation";
+    homepage = "https://github.com/gssapi/gssproxy";
+    changelog = "https://github.com/gssapi/gssproxy/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jlesquembre ];
+    mainProgram = "gssproxy";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
