### PR TITLE
postgresqlPackages.vectorchord: disable avx512vnni support

### DIFF
--- a/nixos/tests/web-apps/immich-vectorchord-reindex.nix
+++ b/nixos/tests/web-apps/immich-vectorchord-reindex.nix
@@ -37,6 +37,10 @@
                     hash = "sha256-+BOuiinbKPZZaDl9aYsIoZPgvLZ4FA6Rb4/W+lAz4so=";
                   };
 
+                  # Remove the patches currently used for vectorchord 1.1.1,
+                  # as vectorchord 1.0.0 does not need them.
+                  patches = [ ];
+
                   cargoDeps = pkgs.rustPlatform.fetchCargoVendor {
                     inherit (finalAttrs) src;
                     hash = "sha256-kwe2x7OTjpdPonZsvnR1C/89D5W/R5JswYF79YcSFEA=";

--- a/pkgs/servers/sql/postgresql/ext/vectorchord/0001-disable-avx512vnni.patch
+++ b/pkgs/servers/sql/postgresql/ext/vectorchord/0001-disable-avx512vnni.patch
@@ -1,0 +1,29 @@
+diff --git a/crates/simd/src/byte.rs b/crates/simd/src/byte.rs
+index 0c7c4be..87737d4 100644
+--- a/crates/simd/src/byte.rs
++++ b/crates/simd/src/byte.rs
+@@ -389,7 +389,7 @@ mod reduce_sum_of_xy {
+         }
+     }
+ 
+-    #[crate::multiversion(@"v4:avx512vnni", @"v4", @"v3", @"v2", @"a2:dotprod", @"a2", "z17", "z16", "z15", "z14", "z13", "p9", "p8", "p7", "r1")]
++    #[crate::multiversion(@"v4", @"v3", @"v2", @"a2:dotprod", @"a2", "z17", "z16", "z15", "z14", "z13", "p9", "p8", "p7", "r1")]
+     pub fn reduce_sum_of_xy(s: &[u8], t: &[u8]) -> u32 {
+         assert_eq!(s.len(), t.len());
+         let n = s.len();
+diff --git a/crates/simd/src/halfbyte.rs b/crates/simd/src/halfbyte.rs
+index e1aa016..f7dc3dc 100644
+--- a/crates/simd/src/halfbyte.rs
++++ b/crates/simd/src/halfbyte.rs
+@@ -411,7 +411,7 @@ mod reduce_sum_of_xy {
+         }
+     }
+ 
+-    #[crate::multiversion(@"v4:avx512vnni", @"v4", @"v3", @"v2", @"a2:dotprod", @"a2", "z17", "z16", "z15", "z14", "z13", "p9", "p8", "p7", "r1")]
++    #[crate::multiversion(@"v4", @"v3", @"v2", @"a2:dotprod", @"a2", "z17", "z16", "z15", "z14", "z13", "p9", "p8", "p7", "r1")]
+     pub fn reduce_sum_of_xy(s: &[u8], t: &[u8]) -> u32 {
+         assert_eq!(s.len(), t.len());
+         let n = s.len();
+-- 
+2.54.0
+

--- a/pkgs/servers/sql/postgresql/ext/vectorchord/package.nix
+++ b/pkgs/servers/sql/postgresql/ext/vectorchord/package.nix
@@ -6,6 +6,8 @@
   nix-update-script,
   postgresql,
   postgresqlTestExtension,
+  rustc,
+  stdenv,
 }:
 buildPgrxExtension (finalAttrs: {
   inherit postgresql;
@@ -22,6 +24,17 @@ buildPgrxExtension (finalAttrs: {
   };
 
   cargoHash = "sha256-IXOCzKJArNOcb/2TcJbLz1XdCquUpyF/cLHYU5vmlko=";
+
+  patches = lib.optional (lib.versionOlder rustc.llvm.version "22.0.0" && stdenv.isx86_64) [
+    # Due to a bug in LLVM 21, build fails on x86_64 with:
+    # `rustc-LLVM ERROR: Cannot select: intrinsic %llvm.x86.avx512.vpdpbusd.512`.
+    # This has been fixed in Rust's build of LLVM and LLVM 22 with https://github.com/rust-lang/llvm-project/commit/94e2c19f86a699d7a19ff0f4130b696699189c8d,
+    # but this is not reflected in nixpkgs' packaging of rustc.
+    # For this reason, we temporarily disable avx512vnni support until this is fixed in nixpkgs.
+    # This might cause a performance penalty, but should not affect correctness.
+    # See https://github.com/NixOS/nixpkgs/pull/537113#issuecomment-4846239887
+    ./0001-disable-avx512vnni.patch
+  ];
 
   # Include upgrade scripts in the final package
   # https://github.com/supervc-stack/VectorChord/blob/0.5.0/crates/make/src/main.rs#L366


### PR DESCRIPTION
Due to a bug in LLVM, build fails on linux x86_64 with: `rustc-LLVM ERROR: Cannot select: intrinsic %llvm.x86.avx512.vpdpbusd.512`. This has been fixed in Rust's build of LLVM [1]
but this is not reflected in nixpkgs' packaging of rustc. For this reason, we temporarily disable avx512vnni support until this is fixed in nixpkgs. This might cause a performance penalty, but should not affect correctness.

See https://github.com/NixOS/nixpkgs/pull/537113#issuecomment-4846239887

[1]: https://github.com/rust-lang/llvm-project/commit/94e2c19f86a699d7a19ff0f4130b696699189c8d

https://hydra.nixos.org/build/333995747


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
