### PR TITLE
hunspellDictionaries.ru-ru-mozilla: init at 0-unstable-2026-05-30

### DIFF
--- a/pkgs/by-name/hu/hunspell/dictionaries.nix
+++ b/pkgs/by-name/hu/hunspell/dictionaries.nix
@@ -866,6 +866,28 @@ rec {
     ];
   };
 
+  ru_RU-mozilla = ru-ru-mozilla;
+  ru-ru-mozilla = mkDict {
+    pname = "hunspell-dict-ru-ru-mozilla";
+    version = "0-unstable-2026-05-30";
+
+    src = fetchFromGitHub {
+      owner = "Goudron";
+      repo = "ru-spelling-dictionary";
+      rev = "43cc600462d8681bc6e92d1afb29874e2902ea9b";
+      hash = "sha256-EN/f5lbpBiyItEFcHTJbuwuJF3rghkB1f5T9G0a2tdk=";
+    };
+
+    dictFileName = "ru_RU";
+    readmeFile = "README.md";
+
+    meta = {
+      description = "Hunspell dictionary for Russian, updated version as used in Mozilla products";
+      homepage = "https://github.com/Goudron/ru-spelling-dictionary";
+      license = [ lib.licenses.mpl20 ];
+    };
+  };
+
   # CZECH
 
   cs_CZ = cs-cz;


### PR DESCRIPTION
This one is significantly better than the old LibreOffice version.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
