### PR TITLE
sdrangel: 7.22.9 -> 7.27.1, satisfy more optional dependencies

### DIFF
--- a/pkgs/by-name/gg/ggmorse/package.nix
+++ b/pkgs/by-name/gg/ggmorse/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+stdenv.mkDerivation {
+  pname = "ggmorse";
+  version = "0.1.0-unstable-2024-05-31";
+
+  src = fetchFromGitHub {
+    owner = "ggerganov";
+    repo = "ggmorse";
+    rev = "8fb433d6cd6a71940f51b5724663ec0c75bf0b62";
+    hash = "sha256-6GhyPhzNNAx1DSomfIfejbnLTckKa7/+VUZhSaGvGtI=";
+  };
+
+  postPatch = ''
+    substituteInPlace ./CMakeLists.txt \
+      --replace-fail "cmake_minimum_required (VERSION 3.0)" \
+                     "cmake_minimum_required (VERSION 3.5)"
+  '';
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "GGMORSE_BUILD_EXAMPLES" false)
+  ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
+    description = "Morse code decoding library";
+    homepage = "https://github.com/ggerganov/ggmorse";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.nekowinston ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/by-name/in/inmarsatc/package.nix
+++ b/pkgs/by-name/in/inmarsatc/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+stdenv.mkDerivation {
+  pname = "inmarsatc";
+  version = "0-unstable-2023-07-10";
+
+  src = fetchFromGitHub {
+    owner = "cropinghigh";
+    repo = "inmarsatc";
+    rev = "cda1242e79981d71cd8608e971c8dbc691942b10";
+    hash = "sha256-UCmdHR9bSr1x4G0OP7n+o6pdS1thTl9hzH7YMykSiGw=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [ cmake ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
+    description = "C++ library with functions to receive Inmarsat-C signals";
+    homepage = "https://github.com/cropinghigh/inmarsatc";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.nekowinston ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/sd/sdrangel/package.nix
+++ b/pkgs/by-name/sd/sdrangel/package.nix
@@ -14,13 +14,17 @@
   fetchFromGitHub,
   fftwFloat,
   flac,
+  ggmorse,
   glew,
   hackrf,
   hidapi,
   ffmpeg,
+  inmarsatc,
   libiio,
+  libogg,
   libopus,
   libpulseaudio,
+  libunwind,
   libusb1,
   limesuite,
   libbladeRF,
@@ -30,6 +34,7 @@
   pkg-config,
   qt6,
   qt6Packages,
+  rnnoise,
   rtl-sdr,
   serialdv,
   sdrplay,
@@ -71,13 +76,16 @@ stdenv.mkDerivation (finalAttrs: {
     ffmpeg
     fftwFloat
     flac
+    ggmorse
     glew
     hackrf
     hidapi
     libbladeRF
     libiio
+    libogg
     libopus
     libpulseaudio
+    libunwind
     libusb1
     limesuite
     mbelib
@@ -93,6 +101,7 @@ stdenv.mkDerivation (finalAttrs: {
     qt6Packages.qttools
     qt6Packages.qtwebsockets
     qt6Packages.qtwebengine
+    rnnoise
     rtl-sdr
     serialdv
     sgp4
@@ -100,7 +109,10 @@ stdenv.mkDerivation (finalAttrs: {
     uhd
     zlib
   ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [ qt6Packages.qtwayland ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    inmarsatc
+    qt6Packages.qtwayland
+  ]
   ++ lib.optionals withSDRplay [ sdrplay ];
 
   cmakeFlags = [

--- a/pkgs/by-name/sd/sdrangel/package.nix
+++ b/pkgs/by-name/sd/sdrangel/package.nix
@@ -43,6 +43,7 @@
   uhd,
   zlib,
   withSDRplay ? false,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -55,6 +56,9 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-rdPXqA0ySnqh/rlMlfcDLyAd6egbggWHrRQRnXeQPFM=";
   };
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   nativeBuildInputs = [
     cmake
@@ -116,13 +120,15 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals withSDRplay [ sdrplay ];
 
   cmakeFlags = [
-    "-DAPT_DIR=${aptdec}"
-    "-DDAB_DIR=${dab_lib}"
-    "-DSGP4_DIR=${sgp4}"
-    "-DSOAPYSDR_DIR=${soapysdr-with-plugins}"
+    (lib.cmakeFeature "APT_DIR" aptdec.outPath)
+    (lib.cmakeFeature "DAB_DIR" dab_lib.outPath)
+    (lib.cmakeFeature "SGP4_DIR" sgp4.outPath)
+    (lib.cmakeFeature "SOAPYSDR_DIR" soapysdr-with-plugins.outPath)
+    (lib.cmakeBool "ENABLE_QT6" true)
     "-Wno-dev"
-    "-DENABLE_QT6=ON"
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Software defined radio (SDR) software";

--- a/pkgs/by-name/sd/sdrangel/package.nix
+++ b/pkgs/by-name/sd/sdrangel/package.nix
@@ -89,7 +89,6 @@ stdenv.mkDerivation (finalAttrs: {
     libogg
     libopus
     libpulseaudio
-    libunwind
     libusb1
     limesuite
     mbelib
@@ -104,7 +103,6 @@ stdenv.mkDerivation (finalAttrs: {
     qt6Packages.qtspeech
     qt6Packages.qttools
     qt6Packages.qtwebsockets
-    qt6Packages.qtwebengine
     rnnoise
     rtl-sdr
     serialdv
@@ -115,7 +113,9 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     inmarsatc
+    libunwind
     qt6Packages.qtwayland
+    qt6Packages.qtwebengine
   ]
   ++ lib.optionals withSDRplay [ sdrplay ];
 

--- a/pkgs/by-name/sd/sdrangel/package.nix
+++ b/pkgs/by-name/sd/sdrangel/package.nix
@@ -12,7 +12,6 @@
   dsdcc,
   faad2,
   fetchFromGitHub,
-  fetchpatch,
   fftwFloat,
   flac,
   glew,
@@ -43,22 +42,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sdrangel";
-  version = "7.22.9";
+  version = "7.27.1";
 
   src = fetchFromGitHub {
     owner = "f4exb";
     repo = "sdrangel";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-VYSM9ldzx/8tWKQb++qGROSXdeEXIDhGqnnHUmkW4+k=";
+    hash = "sha256-rdPXqA0ySnqh/rlMlfcDLyAd6egbggWHrRQRnXeQPFM=";
   };
-
-  patches = [
-    # Fix build with Qt 6.10, remove when the commit reaches a release
-    (fetchpatch {
-      url = "https://github.com/f4exb/sdrangel/commit/fd6a8d51f8c39fd31b4e864f528bf1921ebd4260.patch";
-      hash = "sha256-S8LQbCTEgyEt1wByDsDMqqyQjK5HALtvUIODgQ1skSA=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
Has a bunch of new features, including Meshtastic & Meshcore, Inmarsat C plugins; plus lots of other fixes and enhancements.

- adds `ggmorse` & `inmarsatc` to satisfy those deps
- without `libogg` I see: `Package 'ogg', required by 'flac', not found`

Release notes: https://github.com/f4exb/sdrangel/releases/tag/v7.27.1
Diff: https://github.com/f4exb/sdrangel/compare/v7.22.9...v7.27.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
