### PR TITLE
kopuz: 0.8.2 -> 0.9.0

### DIFF
--- a/pkgs/by-name/ko/kopuz/package.nix
+++ b/pkgs/by-name/ko/kopuz/package.nix
@@ -10,6 +10,7 @@
   dioxus-cli,
   yt-dlp,
   fetchFromGitHub,
+  fetchurl,
   libopus,
   # Linux only
   wrapGAppsHook3,
@@ -24,20 +25,37 @@
   libayatana-appindicator,
 }:
 
+let
+  rustyV8Version = "130.0.7";
+  rustyV8Target = stdenv.hostPlatform.rust.rustcTarget;
+  rustyV8Hashes = {
+    "aarch64-apple-darwin" = "sha256-9tvQD08OdW6GoNnx/3vgS27D9Aj9YdQdNJ9SgNvwAOo=";
+    "aarch64-unknown-linux-gnu" = "sha256-vu/ns1q+53FZ98tVCWZmsHYwwRBH1fOnTdBlhjcpkVo=";
+    "x86_64-unknown-linux-gnu" = "sha256-pkdsuU6bAkcIHEZUJOt5PXdzK424CEgTLXjLtQ80t10=";
+  };
+  librustyV8 = fetchurl {
+    url = "https://github.com/denoland/rusty_v8/releases/download/v${rustyV8Version}/librusty_v8_release_${rustyV8Target}.a.gz";
+    hash =
+      rustyV8Hashes.${rustyV8Target}
+        or (throw "no prebuilt librusty_v8 hash for target ${rustyV8Target}");
+  };
+in
 rustPlatform.buildRustPackage (finalAttrs: {
   __structuredAttrs = true;
 
   pname = "kopuz";
-  version = "0.8.2";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "Kopuz-org";
     repo = "kopuz";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-d6wSefvx2KT1EyhLq2pn9MSDtW+AvDj7WVz27MJeTmg=";
+    hash = "sha256-e3cPRxaUIbxXRQqGXRf9rVLP97eVGnz/D24O8WGDJcA=";
   };
 
-  cargoHash = "sha256-fr65eE8wFWtW/PT5ZACGMcNCo/QNo9xf39LVBQMGLVk=";
+  cargoHash = "sha256-69FjH+cXaqsviDUlAGnkPrvxKVq0w3LXDwgEraoaEGA=";
+
+  env.RUSTY_V8_ARCHIVE = librustyV8;
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
Updated version of kopuz to v0.9.0 from v0.8.2

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
