### PR TITLE
python3Packages.pipcl: meta fixes

### DIFF
--- a/pkgs/development/python-modules/pipcl/default.nix
+++ b/pkgs/development/python-modules/pipcl/default.nix
@@ -26,9 +26,10 @@ buildPythonPackage (finalAttrs: {
   ];
 
   meta = {
-    description = "Python packaging operations for use by a `setup.py";
+    description = "Python packaging operations for use by setup.py";
     homepage = "https://github.com/ArtifexSoftware/pipcl";
-    license = lib.licenses.agpl3Plus;
+    changelog = "https://github.com/ArtifexSoftware/pipcl/blob/${finalAttrs.src.tag}/README.rst#changelog";
+    license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [ sarahec ];
   };
 })


### PR DESCRIPTION
`meta` fixes suggested by @dotlambda in #535036

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
