### PR TITLE
prometheus-imap-mailstat-exporter: 0.0.1 to 0.7.1

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters/imap-mailstat.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/imap-mailstat.nix
@@ -94,8 +94,8 @@ in
     serviceConfig = {
       ExecStart = ''
         ${pkgs.prometheus-imap-mailstat-exporter}/bin/imap-mailstat-exporter \
-          -config ${createConfigFile cfg.accounts} \
-          ${optionalString cfg.oldestUnseenDate "-oldestunseendate"} \
+          --config.file="${createConfigFile cfg.accounts}" \
+          ${optionalString cfg.oldestUnseenDate "--oldestunseen.feature"} \
           ${concatStringsSep " \\\n  " cfg.extraFlags}
       '';
     };

--- a/pkgs/by-name/pr/prometheus-imap-mailstat-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-imap-mailstat-exporter/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule rec {
   pname = "imap-mailstat-exporter";
-  version = "0.0.1";
+  version = "0.7.1";
 
   src = fetchFromGitHub {
     owner = "bt909";
     repo = "imap-mailstat-exporter";
-    tag = "v${version}";
-    hash = "sha256-aR/94C9SI+FPs3zg3bpexmgGYrhxghyHwpXj25x0yuw=";
+    tag = "${version}";
+    hash = "sha256-dinHRHoTVc/0Lu+TzzmfoCyoDZQQhXw8AOlgbH46hm0=";
   };
 
-  vendorHash = "sha256-M5Ho4CiO5DC6mWzenXEo2pu0WLHj5S8AV3oEFwD31Sw=";
+  vendorHash = "sha256-k3FjfIaNm6408I4uqmJpZsGgMiHel+NUtBclbGKTtZ4=";
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
## Things done

Tested in grafana

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
