### PR TITLE
Revert "[Backport release-25.11] oauth2-proxy: 7.15.2 -> 7.15.3"

### DIFF
--- a/pkgs/by-name/oa/oauth2-proxy/package.nix
+++ b/pkgs/by-name/oa/oauth2-proxy/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule rec {
   pname = "oauth2-proxy";
-  version = "7.15.3";
+  version = "7.15.2";
 
   src = fetchFromGitHub {
     repo = "oauth2-proxy";
     owner = "oauth2-proxy";
-    sha256 = "sha256-HpWmIOqyE3L0JYAQh+bd30Gr2dDpTGH8DwFJo5XwflY=";
+    sha256 = "sha256-qhWU6i57WS8TWJ5ggzwmeoIv0osQjA9wdwqnvxMddrc=";
     rev = "v${version}";
   };
 
-  vendorHash = "sha256-o4JWhqLbfHmlIY1XhaupIhYLfXJNguFueH+SpAe9xaw=";
+  vendorHash = "sha256-Iu1dm0f3eYJpr9eR8RL7wAV8UGwpOway0aP8r5wci0M=";
 
   # Taken from https://github.com/oauth2-proxy/oauth2-proxy/blob/master/Makefile
   ldflags = [ "-X github.com/oauth2-proxy/oauth2-proxy/v7/pkg/version.VERSION=v${version}" ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#530520

```
go: go.mod requires go >= 1.26.0 (running go 1.25.10; GOTOOLCHAIN=local)
```