### PR TITLE
domoticz: 2024.7 ->2026.2-unstable-2026-07-09 + add lenny as maintainer

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -74,6 +74,7 @@
 - Starting with v14, `flameshot` will primarily utilise xdg-desktop-portal calls for screenshotting. This will directly affect users on X11 window managers due to the lack of a compatible portal with Screenshot feature. See [upstream changelog](https://github.com/flameshot-org/flameshot/releases/tag/v14.0.0) or [NixOS Flameshot](https://wiki.nixos.org/wiki/Flameshot) wiki page for workarounds.
 - `nim1` and respective aliases have been removed due to entering EOL; please migrate to `nim` or `nim-unwrapped` (nim 2).
 - `nim-2_0` & `nim-2_2` and respective aliases have been removed; please migrate to `nim` or `nim-unwrapped` (nim 2.2.10).
+- `domoticz` has been updated from `2024.7` to `2026.x`, breaking third party applications and scripts using the old RType calls. Review the [release notes](https://github.com/domoticz/domoticz/blob/2026.2/History.txt#L398) for more information.
 
 ## Other Notable Changes {#sec-nixpkgs-release-26.11-notable-changes}
 

--- a/pkgs/by-name/do/domoticz/package.nix
+++ b/pkgs/by-name/do/domoticz/package.nix
@@ -94,7 +94,10 @@ stdenv.mkDerivation (finalAttrs: {
       various devices like: lights, switches, various sensors/meters like
       temperature, rain, wind, UV, electra, gas, water and much more
     '';
-    maintainers = with lib.maintainers; [ edcragg ];
+    maintainers = with lib.maintainers; [
+      edcragg
+      lenny
+    ];
     homepage = "https://www.domoticz.com/";
     changelog = "https://github.com/domoticz/domoticz/blob/${finalAttrs.version}/History.txt";
     license = lib.licenses.gpl3Plus;

--- a/pkgs/by-name/do/domoticz/package.nix
+++ b/pkgs/by-name/do/domoticz/package.nix
@@ -20,26 +20,20 @@
   cereal,
   minizip,
   versionCheckHook,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "domoticz";
-  version = "2024.7";
+  version = "2026.2";
 
   src = fetchFromGitHub {
     owner = "domoticz";
     repo = "domoticz";
     tag = finalAttrs.version;
-    hash = "sha256-D8U1kK3m1zT83YvZ42hGSU9PzBfS1VGr2mxUYbM2vNQ=";
+    hash = "sha256-WJDNnzjmQe9Ap5EqmXEgrglIbGcLRRFBJgAHDvzswzo=";
+    fetchSubmodules = true;
   };
-
-  patches = [
-    # Boost 1.87 compatibility, remove once upgraded to 2025.1
-    (fetchpatch {
-      url = "https://github.com/domoticz/domoticz/commit/5d0db89bbd120ed5dc05b4ff8c136f14a42f0cd3.patch";
-      hash = "sha256-FPe83yJKJEgnY3kABy9CTRe1CBh42dPG1ZWCUE5PO8E=";
-    })
-  ];
 
   buildInputs = [
     openssl
@@ -91,6 +85,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   doInstallCheck = true;
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Home automation system";
     longDescription = ''
@@ -105,8 +101,5 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.all;
     broken = stdenv.hostPlatform.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/domoticz.x86_64-darwin
     mainProgram = "domoticz";
-    knownVulnerabilities = [
-      "CVE-2026-1001"
-    ];
   };
 })

--- a/pkgs/by-name/do/domoticz/package.nix
+++ b/pkgs/by-name/do/domoticz/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   makeWrapper,
   cmake,
   python3,
@@ -20,18 +19,17 @@
   cereal,
   minizip,
   versionCheckHook,
-  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "domoticz";
-  version = "2026.2";
+  version = "2026.2-unstable-2026-07-09";
 
   src = fetchFromGitHub {
     owner = "domoticz";
     repo = "domoticz";
-    tag = finalAttrs.version;
-    hash = "sha256-WJDNnzjmQe9Ap5EqmXEgrglIbGcLRRFBJgAHDvzswzo=";
+    rev = "7e12d1e5d7bf3f7d083ef31d5dd611d678f89d48"; # pinned due to removed dependency (see nixpkgs pr #539060)
+    hash = "sha256-+6EIEsgGTaLEPzBa/R5EYAxnYB3+cj54LGDJwutTQGA=";
     fetchSubmodules = true;
   };
 
@@ -81,11 +79,9 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   nativeInstallCheckInputs = [
-    versionCheckHook
+    # versionCheckHook # readd once we can move to a tagged release again
   ];
   doInstallCheck = true;
-
-  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Home automation system";


### PR DESCRIPTION
Changelog: https://github.com/domoticz/domoticz/blob/2026.2/History.txt


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
