### PR TITLE
feishin: add override for web version

### DIFF
--- a/pkgs/by-name/fe/feishin/package.nix
+++ b/pkgs/by-name/fe/feishin/package.nix
@@ -14,6 +14,7 @@
   copyDesktopItems,
   makeDesktopItem,
   nix-update-script,
+  webVersion ? false,
 }:
 let
   pname = "feishin";
@@ -34,6 +35,7 @@ buildNpmPackage {
   inherit src;
 
   npmConfigHook = pnpmConfigHook;
+  npmBuildScript = if webVersion then "build:web" else "build";
 
   npmDeps = null;
   pnpmDeps = fetchPnpmDeps {
@@ -52,8 +54,8 @@ buildNpmPackage {
   nativeBuildInputs = [
     pnpm_10
   ]
-  ++ lib.optionals (stdenv.hostPlatform.isLinux) [ copyDesktopItems ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && !webVersion) [ copyDesktopItems ]
+  ++ lib.optionals (stdenv.hostPlatform.isDarwin && !webVersion) [
     darwin.autoSignDarwinBinariesHook
     actool
   ];
@@ -73,7 +75,7 @@ buildNpmPackage {
     ln -s ${dart-sass}/bin/dart-sass "$dir"/sass
   '';
 
-  postBuild = ''
+  postBuild = lib.optionalString (!webVersion) ''
     cp -r ${electron.dist} electron-dist
     chmod -R u+w electron-dist
 
@@ -88,14 +90,18 @@ buildNpmPackage {
   installPhase = ''
     runHook preInstall
   ''
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+  + lib.optionalString webVersion ''
+    mkdir -p $out
+    cp -r out/web/* $out
+  ''
+  + lib.optionalString (stdenv.hostPlatform.isDarwin && !webVersion) ''
     mkdir -p $out/{Applications,bin}
     cp -r dist/**/Feishin.app $out/Applications/
     makeWrapper $out/Applications/Feishin.app/Contents/MacOS/Feishin $out/bin/feishin \
       --prefix PATH : "${lib.makeBinPath [ mpv-unwrapped ]}" \
       --set DISABLE_AUTO_UPDATES 1
   ''
-  + lib.optionalString stdenv.hostPlatform.isLinux ''
+  + lib.optionalString (stdenv.hostPlatform.isLinux && !webVersion) ''
     mkdir -p $out/share/feishin
 
     pushd dist/*-unpacked/
@@ -126,7 +132,7 @@ buildNpmPackage {
     runHook postInstall
   '';
 
-  desktopItems = [
+  desktopItems = lib.optionals (!webVersion) [
     (makeDesktopItem {
       name = "feishin";
       desktopName = "Feishin";
@@ -152,11 +158,11 @@ buildNpmPackage {
     sourceProvenance = with lib.sourceTypes; [ fromSource ];
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.unix;
-    mainProgram = "feishin";
     maintainers = with lib.maintainers; [
       BatteredBunny
       onny
       jlbribeiro
     ];
-  };
+  }
+  // lib.optionalAttrs (!webVersion) { mainProgram = "feishin"; };
 }

--- a/pkgs/by-name/fe/feishin/package.nix
+++ b/pkgs/by-name/fe/feishin/package.nix
@@ -34,6 +34,8 @@ buildNpmPackage {
 
   inherit src;
 
+  __structuredAttrs = true;
+
   npmConfigHook = pnpmConfigHook;
   npmBuildScript = if webVersion then "build:web" else "build";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11208,4 +11208,6 @@ with pkgs;
     enableWayland = false;
     enableX11 = true;
   };
+
+  feishin-web = feishin.override { webVersion = true; };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds an override for the `feishin` package to build only the web version, by setting `pkgs.feishin.override { webVersion = true; }`. This allows using it behind a reverse proxy to self-host Feishin as a web frontend, instead of building the full Electron package. This is inspired by how Feishin's docker container is built: <https://github.com/jeffvli/feishin/blob/development/Dockerfile> (although this one bundles Nginx). I plan to follow up with a NixOS module for Feishin Web.

I've already deployed a simplified web-only version to my server. The package def is here: <https://github.com/rharish101/nix-configs/blob/main/pkgs/feishin/default.nix>

What this does is simply package all the web files (index.html, assets/ dir) into the package root, similar to the BentoPDF package. So you can simply make your reverse proxy point to the package root, like this section from my Caddy config: <https://github.com/rharish101/nix-configs/blob/0d547c3d0bc6b855bba441ccef887ebc298753ab/modules/containers/caddy-wg-client.nix#L199-L201>
```caddy
root * ${pkgs.feishin}
try_files {path} /index.html
file_server
```

Maintainer tags: @BatteredBunny @onny @jlbribeiro

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
