### PR TITLE
orca-slicer: add gsettings-desktop-schemas to fix Wayland rendering and file-chooser crash

### DIFF
--- a/pkgs/by-name/or/orca-slicer/package.nix
+++ b/pkgs/by-name/or/orca-slicer/package.nix
@@ -22,6 +22,7 @@
   glib,
   glib-networking,
   gmp,
+  gsettings-desktop-schemas,
   gst_all_1,
   gtest,
   gtk3,
@@ -108,6 +109,7 @@ clangStdenv.mkDerivation (finalAttrs: {
     glib
     glib-networking
     gmp
+    gsettings-desktop-schemas
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
     gst_all_1.gst-plugins-bad


### PR DESCRIPTION
## Description

`wrapGAppsHook3` is already in `nativeBuildInputs`, but it only wraps the binary with the GSettings schemas found among the **`buildInputs`**. `gsettings-desktop-schemas` isn't there, so its schemas (`org.gnome.desktop.*`) never reach the wrapper's `XDG_DATA_DIRS`, and GTK aborts / misbehaves whenever it reads them. In practice this causes, on a stock install:

- **Broken rendering on Wayland** — `org.gnome.desktop.interface` scaling/text-scaling can't be read, so the UI renders as tiny, overlapping, unreadable text.
- **Crash when opening the GTK file chooser** — importing a model aborts the app (see the `Gtk-CRITICAL` logs in #513195).

### Related

- Addresses #513195 (crash / no preview — matching `Gtk-CRITICAL` logs).
- #509657 works around a similar Wayland issue by forcing `GDK_BACKEND=x11` (XWayland); this fixes the root cause instead, keeping native Wayland.
