### PR TITLE
android-tools: 35.0.2 -> 36.0.1

### DIFF
--- a/pkgs/tools/misc/android-tools/default.nix
+++ b/pkgs/tools/misc/android-tools/default.nix
@@ -14,10 +14,9 @@
   brotli,
   lz4,
   zstd,
+  libusb1,
   pcre2,
-  fetchpatch2,
   fmt,
-  udev,
 }:
 
 let
@@ -26,21 +25,12 @@ in
 
 stdenv.mkDerivation rec {
   pname = "android-tools";
-  version = "35.0.2";
+  version = "36.0.1";
 
   src = fetchurl {
     url = "https://github.com/nmeum/android-tools/releases/download/${version}/android-tools-${version}.tar.xz";
-    hash = "sha256-0sMiIoAxXzbYv6XALXYytH42W/4ud+maNWT7ZXbwQJc=";
+    hash = "sha256-OOioS3OUgBQd4INr9tWBszOax9U9D3zowESjNoyML48=";
   };
-
-  patches = [
-    (fetchpatch2 {
-      url = "https://raw.githubusercontent.com/nmeum/android-tools/0c4d79943e23785589ce1881cbb5a9bc76d64d9b/patches/extras/0003-extras-libjsonpb-Fix-incompatibility-with-protobuf-v.patch";
-      stripLen = 1;
-      extraPrefix = "vendor/extras/";
-      hash = "sha256-PO6ZKP54ri2ujVa/uFXgMy/zMQjjIo4e/EPW2Cu6a1Q=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake
@@ -56,22 +46,15 @@ stdenv.mkDerivation rec {
     brotli
     lz4
     zstd
+    libusb1
     pcre2
     fmt
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [ udev ];
+  ];
   propagatedBuildInputs = [ pythonEnv ];
 
   preConfigure = ''
     export GOCACHE=$TMPDIR/go-cache
   '';
-
-  cmakeFlags = [
-    (lib.cmakeBool "CMAKE_FIND_PACKAGE_PREFER_CONFIG" true)
-    (lib.cmakeBool "protobuf_MODULE_COMPATIBLE" true)
-    (lib.cmakeBool "ANDROID_TOOLS_LIBUSB_ENABLE_UDEV" stdenv.hostPlatform.isLinux)
-    (lib.cmakeBool "ANDROID_TOOLS_USE_BUNDLED_LIBUSB" true)
-  ];
 
   meta = {
     description = "Android SDK platform tools";


### PR DESCRIPTION
* Revert some changes from 576fde128ae73b212c038e10b590148761d0ba82 commit. This update now uses system provided libusb instead of bundled one.

* Also, revert changes from 37a1895466014e1ed2589e7ad1add0a7e589e8e8 commit. udev is not required directly which is used with libusb.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
