### PR TITLE
stalwart_0_15: configure `openssl` installation

### DIFF
--- a/pkgs/by-name/st/stalwart_0_15/package.nix
+++ b/pkgs/by-name/st/stalwart_0_15/package.nix
@@ -226,6 +226,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       oddlama
       pandapip1
       norpol
+      debtquity
     ];
   };
 })

--- a/pkgs/by-name/st/stalwart_0_15/package.nix
+++ b/pkgs/by-name/st/stalwart_0_15/package.nix
@@ -70,8 +70,17 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ++ lib.optionals withFoundationdb [ "foundationdb" ]
   ++ lib.optionals stalwartEnterprise [ "enterprise" ];
 
+  cargoBuildFlags = [
+    "-p"
+    "stalwart"
+  ];
+  cargoTestFlags = finalAttrs.cargoBuildFlags;
+
   env = {
+    # https://docs.rs/openssl/latest/openssl/#manual
     OPENSSL_NO_VENDOR = true;
+    OPENSSL_DIR = lib.getDev openssl;
+    OPENSSL_LIB_DIR = "${lib.getLib openssl}/lib";
     ZSTD_SYS_USE_PKG_CONFIG = true;
     ROCKSDB_INCLUDE_DIR = "${rocksdb}/include";
     ROCKSDB_LIB_DIR = "${rocksdb}/lib";
@@ -166,6 +175,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     # No queue event received.
     # NOTE: Test unreliable on high load systems
     "smtp::management::queue::manage_queue"
+    "smtp::outbound::mta_sts::mta_sts_verify"
+    "smtp::outbound::dane::dane_verify"
     # thread 'responses::tests::parse_responses' panicked at crates/dav-proto/src/responses/mod.rs:671:17:
     # assertion `left == right` failed: failed for 008.xml
     #   left: ElementEnd


### PR DESCRIPTION
* define openssl installation rather rely on vendored pkg-config to find system openssl
* add self as maintainer

Resolves: #539070


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
