### PR TITLE
bichon: init at 1.6.2

### DIFF
--- a/pkgs/by-name/bi/bichon/package.nix
+++ b/pkgs/by-name/bi/bichon/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  fetchPnpmDeps,
+  pnpm,
+  pnpmConfigHook,
+  nodejs,
+  openssl,
+  pkg-config,
+  versionCheckHook,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "bichon";
+  version = "1.6.2";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "rustmailer";
+    repo = "bichon";
+    tag = finalAttrs.version;
+    hash = "sha256-a8BAO93eI2eiFwmvMqUsgL1KZ11X3qg/r/Iw6ckMSTs=";
+  };
+
+  cargoHash = "sha256-GC/2bswme76bAFRCsBHFi3lWnYx5x5H58emCmkiyKfE=";
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    sourceRoot = "${finalAttrs.src.name}/web";
+    fetcherVersion = 4;
+    hash = "sha256-Ax8z1sjt8v6XOenhw7eRuEEo0huPv9fbcfzqc8RxJEc=";
+  };
+  pnpmRoot = "web";
+
+  nativeBuildInputs = [
+    nodejs
+    pnpmConfigHook
+    pnpm
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  env.GIT_HASH = finalAttrs.src.rev;
+
+  preBuild = ''
+    # Build web frontend before rust build
+    pushd web
+    pnpm run build
+    popd
+
+    # Just sets the GIT_HASH variable for builds, we set it above so we don't need git
+    rm crates/server/build.rs
+  '';
+
+  # The tests are flaky and some require the network
+  doCheck = false;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  # `bichon-server` doesn't have a `--version` option but `bichon-cli` does.
+  versionCheckProgram = "${placeholder "out"}/bin/bichon-cli";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/rustmailer/bichon/releases/tag/${finalAttrs.version}";
+    description = "Lightweight, high-performance Rust email archiver with WebUI";
+    homepage = "https://github.com/rustmailer/bichon";
+    license = with lib.licenses; [ agpl3Only ];
+    maintainers = with lib.maintainers; [ pyrox0 ];
+    mainProgram = "bichon-server";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Packages https://github.com/rustmailer/bichon, a webserver for email archival. Should have a module but I haven't made one from my config to copy over so I don't know if I'll add one right now.

No AI used.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
