### PR TITLE
lego: 4.35.2 -> 5.4.1

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -38,6 +38,9 @@
 - `gotosocial` has been updated to 0.22.0. This release contains a very long database migration, which should not be cancelled or interrupted under any circumstances.
  -  Postgres users: Following the migration, if you encounter slowdown on Postgres specifically (ie., timing out while loading timelines) you may need to run some manual database maintenance steps. Please check https://docs.gotosocial.org/en/stable/admin/database_maintenance/#postgres.
 
+- `lego` has been updated to 5.x, which has a changed CLI and state layout.
+  See [upstream's v4 to v5 CLI migration guide](https://go-acme.github.io/lego/migration/cli/) for details.
+
 - `xsecurelock` no longer supports authentication via htaccess files (`~/.xsecurelock.pw`) or via the `pamtester` program by default. Only the recommended PAM module is supported unless rebuilt with `withHtaccess` or `withPamtester`.
 
 - `python3Packages.django-health-check` has been updated to major version 4. See its [migration guide](https://codingjoe.dev/django-health-check/migrate-to-v4/) and [changelog](https://github.com/codingjoe/django-health-check/releases/tag/4.0.0) for breaking changes.

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -56,6 +56,12 @@
 
 - `boot.vesa` has been removed. It was deprecated in 2020 because Xorg now works better with kernel modesetting. If you still need the legacy VESA 800x600 fallback, set `boot.kernelParams = [ "vga=0x317" "nomodeset" ];` directly.
 
+- `security.acme` now uses `lego` 5.x.
+  Existing ACME account state is migrated automatically.
+  If you pass raw `lego` flags through `security.acme.*.extraLegoFlags`, `security.acme.*.extraLegoRunFlags`, or `security.acme.*.extraLegoRenewFlags`, update them for the `lego` 5.x CLI.
+  In particular, `lego renew` has been replaced by the renewal mode of `lego run`.
+  The certificate identifiers formed by `domain` and `extraDomainNames` must be unique and canonical to avoid repeated renewals. Use IDNA A-labels for internationalized domain names and RFC 5952 notation for IPv6 addresses.
+
 - `authentik` has been updated to 2026.5.3, which changes the default listen address from `0.0.0.0` to `[::]`.
   IPv4-only deployments might need to adjust their listen settings.
   Deployments running the server and worker in the same network namespace must also set at least the worker

--- a/nixos/modules/security/acme/default.nix
+++ b/nixos/modules/security/acme/default.nix
@@ -242,8 +242,6 @@ let
         + lib.optionalString (data.csr != null) " - ${data.csr}"
         + lib.optionalString (data.profile != null) " - ${data.profile}";
       certDir = mkHash hashData;
-      # TODO remove domainHash usage entirely. Waiting on go-acme/lego#1532
-      domainHash = mkHash "${lib.concatStringsSep " " extraDomains} ${data.domain}";
       accountHash = (mkAccountHash acmeServer data);
       accountDir = accountDirRoot + accountHash;
 
@@ -254,7 +252,10 @@ let
               "--dns"
               data.dnsProvider
             ]
-            ++ lib.optionals (!data.dnsPropagationCheck) [ "--dns.propagation-disable-ans" ]
+            ++ lib.optionals (!data.dnsPropagationCheck) [
+              "--dns.propagation.disable-ans"
+              "--dns.propagation.disable-rns"
+            ]
             ++ lib.optionals (data.dnsResolver != null) [
               "--dns.resolvers"
               data.dnsResolver
@@ -269,7 +270,7 @@ let
         else if data.listenHTTP != null then
           [
             "--http"
-            "--http.port"
+            "--http.address"
             data.listenHTTP
           ]
         else
@@ -309,21 +310,27 @@ let
       ]) extraDomains
       ++ data.extraLegoFlags;
 
-      # Although --must-staple is common to both modes, it is not declared as a
-      # mode-agnostic argument in lego and thus must come after the mode.
+      # `lego run` renews when its state still contains a certificate resource. The full
+      # path is also a recovery path, so force renewal without an ARI `replaces`
+      # identifier that may refer to a stale certificate.
       runOpts = lib.escapeShellArgs (
-        commonOpts
-        ++ [ "run" ]
+        [ "run" ]
+        ++ commonOpts
+        ++ [
+          "--no-random-sleep"
+          "--renew-force"
+          "--ari-disable"
+        ]
+        ++ lib.optionals (data.csr == null) [ "--force-cert-domains" ]
         ++ lib.optionals data.ocspMustStaple [ "--must-staple" ]
         ++ lib.optionals (data.profile != null) [ "--profile=${data.profile}" ]
         ++ data.extraLegoRunFlags
       );
       renewOpts = lib.escapeShellArgs (
-        commonOpts
-        ++ [
-          "renew"
-          "--no-random-sleep"
-        ]
+        [ "run" ]
+        ++ commonOpts
+        ++ [ "--no-random-sleep" ]
+        ++ lib.optionals (data.csr == null) [ "--force-cert-domains" ]
         ++ lib.optionals data.ocspMustStaple [ "--must-staple" ]
         ++ lib.optionals (data.profile != null) [ "--profile=${data.profile}" ]
         ++ data.extraLegoRenewFlags
@@ -575,13 +582,18 @@ let
             }
           }
 
-          echo '${domainHash}' > domainhash.txt
+          # Multiple certificates can share an account. Serialize the check and
+          # migration because lego v5 moves the shared key out of keys/.
+          exec {MIGRATION_LOCK_FD}> "${lockdir}migration-${accountHash}.lock"
+          ${pkgs.flock}/bin/flock "$MIGRATION_LOCK_FD"
+          if [ -n "$(find accounts -path '*/keys/*.key' -print -quit)" ]; then
+            printf 'Y\n' | lego migrate --account-only --path .
+          fi
+          exec {MIGRATION_LOCK_FD}>&-
 
-          # Check if a new order is needed
-          # We can only renew if the list of domains has not changed.
+          # Check if the existing certificate can be renewed.
           # We also need an account key. Avoids #190493
-          if cmp -s domainhash.txt certificates/domainhash.txt && [ -e '${certificateKey}' ] && \
-            [ -e 'certificates/${keyName}.crt' ] && \
+          if [ -e '${certificateKey}' ] && [ -e 'certificates/${keyName}.crt' ] && \
             [ -n "$(find accounts -name '${
               if (data.email != null) then data.email else placeholderEmail
             }.key')" ];
@@ -590,7 +602,7 @@ let
             # Try to renew, and silently fail if the cert is not expired.
             # Avoids #85794 and resolves #129838
             if ! lego ${renewOpts} ${
-              if data.validMinDays != null then "--days ${toString data.validMinDays}" else "--dynamic"
+              if data.validMinDays != null then "--renew-days ${toString data.validMinDays}" else ""
             }; then
               if is_expiration_skippable out/full.pem; then
                 echo 1>&2 "nixos-acme: Ignoring failed renewal because expiration isn't due yet"
@@ -609,8 +621,6 @@ let
             # High number to avoid Systemd reserved codes.
             exit 10
           fi
-
-          mv domainhash.txt certificates/
 
           touch out/acme-success
 
@@ -871,7 +881,7 @@ let
           type = lib.types.listOf lib.types.str;
           inherit (defaultAndText "extraLegoFlags" [ ]) default defaultText;
           description = ''
-            Additional global flags to pass to all lego commands.
+            Additional flags to pass to both `lego run` invocations.
           '';
         };
 
@@ -879,7 +889,7 @@ let
           type = lib.types.listOf lib.types.str;
           inherit (defaultAndText "extraLegoRenewFlags" [ ]) default defaultText;
           description = ''
-            Additional flags to pass to lego renew.
+            Additional flags to pass to the non-forced renewal `lego run` invocation.
           '';
         };
 
@@ -887,7 +897,7 @@ let
           type = lib.types.listOf lib.types.str;
           inherit (defaultAndText "extraLegoRunFlags" [ ]) default defaultText;
           description = ''
-            Additional flags to pass to lego run.
+            Additional flags to pass to the forced obtain/reissue `lego run` invocation.
           '';
         };
       };

--- a/nixos/tests/acme/dns01.nix
+++ b/nixos/tests/acme/dns01.nix
@@ -93,26 +93,47 @@ in
       };
   };
 
-  testScript = ''
-    ${(import ./utils.nix).pythonUtils}
+  testScript =
+    { nodes, ... }:
+    let
+      orderRenewScript = nodes.client.systemd.services."acme-order-renew-${domain}".script;
+    in
+    ''
+      ${(import ./utils.nix).pythonUtils}
 
-    cert = "${domain}"
+      import shlex
 
-    dnsserver.start()
-    acme.start()
+      cert = "${domain}"
 
-    wait_for_running(dnsserver)
-    dnsserver.wait_for_open_port(53)
-    wait_for_running(acme)
-    acme.wait_for_open_port(443)
+      with subtest("Disable DNS propagation checks"):
+          order_renew_script = ${builtins.toJSON orderRenewScript}
+          lego_run_commands = [
+              line
+              for line in order_renew_script.splitlines()
+              if "lego run " in line
+          ]
+          assert len(lego_run_commands) == 2, lego_run_commands
+          for command in lego_run_commands:
+              args = shlex.split(command)
+              assert "--dns.propagation.disable-ans" in args, args
+              assert "--dns.propagation.disable-rns" in args, args
+              assert "--dns.propagation.wait" not in args, args
 
-    with subtest("Boot and acquire a new cert"):
-        client.start()
-        wait_for_running(client)
+      dnsserver.start()
+      acme.start()
 
-        check_issuer(client, cert, "pebble")
-        check_domain(client, cert, cert, fail=True)
-        check_domain(client, cert, f"toodeep.nesting.{cert}", fail=True)
-        check_domain(client, cert, f"whatever.{cert}")
-  '';
+      wait_for_running(dnsserver)
+      dnsserver.wait_for_open_port(53)
+      wait_for_running(acme)
+      acme.wait_for_open_port(443)
+
+      with subtest("Boot and acquire a new cert"):
+          client.start()
+          wait_for_running(client)
+
+          check_issuer(client, cert, "pebble")
+          check_domain(client, cert, cert, fail=True)
+          check_domain(client, cert, f"toodeep.nesting.{cert}", fail=True)
+          check_domain(client, cert, f"whatever.{cert}")
+    '';
 }

--- a/nixos/tests/acme/http01-builtin.nix
+++ b/nixos/tests/acme/http01-builtin.nix
@@ -6,6 +6,31 @@
 let
   domain = "example.test";
   ip = "192.168.1.2";
+  migrationCertNames = [
+    "migration-2.${domain}"
+    "migration-3.${domain}"
+  ];
+  migrationCerts = lib.genAttrs migrationCertNames (_: {
+    listenHTTP = ":80";
+  });
+  migrationTestLego = pkgs.writeShellScriptBin "lego" ''
+    if [[ ''${1-} == migrate ]]; then
+      printf '1\n' >> /run/acme/test-migration-attempts
+      if ! mkdir /run/acme/test-migration-active; then
+        touch /run/acme/test-migration-collision
+        exit 99
+      fi
+      trap 'rm -rf /run/acme/test-migration-active' EXIT
+      sleep 2
+    fi
+
+    ${lib.getExe pkgs.lego} "$@"
+  '';
+  migrationServicePaths =
+    lib.genAttrs (map (name: "acme-order-renew-${name}") migrationCertNames)
+      (_: {
+        path = lib.mkBefore [ migrationTestLego ];
+      });
 in
 {
   name = "http01-builtin";
@@ -37,6 +62,12 @@ in
           extraDomainNames = [ ip ];
           listenHTTP = ":80";
         };
+
+        # Delay account migration and fail a second concurrent invocation so
+        # the shared-account migration race is deterministic.
+        systemd.services."acme-order-renew-${config.networking.fqdn}".path = lib.mkBefore [
+          migrationTestLego
+        ];
 
         systemd.targets."renew-triggered" = {
           wantedBy = [ "acme-order-renew-${config.networking.fqdn}.service" ];
@@ -81,6 +112,18 @@ in
 
           preservation.configuration = { };
 
+          migration_serial.configuration = {
+            security.acme.maxConcurrentRenewals = 1;
+            security.acme.certs = migrationCerts;
+            systemd.services = migrationServicePaths;
+          };
+
+          migration_parallel.configuration = {
+            security.acme.maxConcurrentRenewals = 10;
+            security.acme.certs = migrationCerts;
+            systemd.services = migrationServicePaths;
+          };
+
           add_cert_and_domain.configuration = {
             security.acme.certs = {
               "${config.networking.fqdn}" = {
@@ -94,6 +137,10 @@ in
             };
             # To make sure it's the account creation leader that is doing the work.
             security.acme.maxConcurrentRenewals = 10;
+          };
+
+          remove_domain.configuration = {
+            security.acme.certs."${config.networking.fqdn}".extraDomainNames = lib.mkForce [ ip ];
           };
 
           concurrency.configuration = {
@@ -170,9 +217,12 @@ in
 
       domain = "${domain}"
       ip = "${ip}"
+      jq = "${lib.getExe pkgs.jq}"
       cert = "${certName}"
       cert2 = "builtin-2." + domain
       cert3 = "builtin-3." + domain
+      migration_certs = [cert] + ${builtins.toJSON migrationCertNames}
+      migration_units = [f"acme-order-renew-{name}.service" for name in migration_certs]
       legacy_account_dir = "/var/lib/acme/.lego/accounts/1ccf607d9aa280e9af00"
 
       acme.start()
@@ -186,6 +236,93 @@ in
           check_issuer(builtin, cert, "pebble")
           check_domain(builtin, cert, cert)
           check_ip(builtin, cert, ip)
+
+      with subtest("Handles v4 account and certificate state"):
+          switch_to(builtin, "migration_serial")
+          for migration_cert in migration_certs:
+              check_issuer(builtin, migration_cert, "pebble")
+              check_domain(builtin, migration_cert, migration_cert)
+
+          switch_to(builtin, "migration_parallel")
+          builtin.succeed(f"systemctl start {' '.join(migration_units)}")
+
+          builtin.succeed(
+              f"""
+              set -euo pipefail
+
+              account_file=$(find /var/lib/acme/.lego/accounts -type f -name account.json -print -quit)
+              test -n "$account_file"
+              account_dir=$(dirname "$account_file")
+
+              account_id=$(basename "$account_dir")
+              key_path="$account_dir/$account_id.key"
+              test -f "$key_path"
+
+              mkdir "$account_dir/keys"
+              mv "$key_path" "$account_dir/keys/$account_id.key"
+              {jq} '{{
+                email: .email,
+                registration: {{
+                  body: (.registration | del(.accountURL)),
+                  uri: .registration.accountURL
+                }}
+              }}' "$account_dir/account.json" > "$account_dir/account.json.tmp"
+              mv "$account_dir/account.json.tmp" "$account_dir/account.json"
+
+              {jq} -e '
+                .registration.body.status == "valid"
+                and (.registration.uri | startswith("https://acme.test/"))
+              ' "$account_dir/account.json" > /dev/stderr
+
+              cert_resource=$(find "/var/lib/acme/.lego/{cert}" -type f -name '{cert}.json' -print -quit)
+              test -n "$cert_resource"
+              {jq} '{{
+                domain: .id,
+                certUrl: .certUrl,
+                certStableUrl: .certStableUrl
+              }}' "$cert_resource" > "$cert_resource.tmp"
+              mv "$cert_resource.tmp" "$cert_resource"
+
+              chown -R acme:acme /var/lib/acme/.lego/accounts "/var/lib/acme/.lego/{cert}"
+              chmod -R u=rwX,g=,o= /var/lib/acme/.lego/accounts
+              chmod -R u=rwX,g=rX,o= "/var/lib/acme/.lego/{cert}"
+              rm -rf /run/acme/test-migration-*
+              """
+          )
+
+          builtin.succeed(f"systemctl start {' '.join(migration_units)}")
+          builtin.succeed('test "$(wc -l < /run/acme/test-migration-attempts)" -eq 1')
+          builtin.succeed("test ! -e /run/acme/test-migration-active")
+          builtin.succeed("test ! -e /run/acme/test-migration-collision")
+          builtin.succeed(
+              f"""
+              set -euo pipefail
+
+              account_file=$(find /var/lib/acme/.lego/accounts -type f -name account.json -print -quit)
+              test -n "$account_file"
+              account_dir=$(dirname "$account_file")
+
+              account_id=$(basename "$account_dir")
+              test -f "$account_dir/$account_id.key"
+              test ! -e "$account_dir/keys"
+
+              {jq} -e '
+                .origin == "migration"
+                and .keyType == "EC256"
+                and .server == "https://acme.test/dir"
+                and .registration.status == "valid"
+                and (.registration.accountURL | startswith("https://acme.test/"))
+              ' "$account_dir/account.json" > /dev/stderr
+              """
+          )
+          builtin.succeed(f"systemctl start acme-order-renew-{cert}.service")
+
+          check_issuer(builtin, cert, "pebble")
+          check_domain(builtin, cert, cert)
+          check_ip(builtin, cert, ip)
+          for migration_cert in migration_certs[1:]:
+              check_issuer(builtin, migration_cert, "pebble")
+              check_domain(builtin, migration_cert, migration_cert)
 
       with subtest("Validate permissions"):
           check_permissions(builtin, cert, "acme")
@@ -297,6 +434,16 @@ in
           builtin.succeed("test $(ls -1 /var/lib/acme/.lego/accounts | tee /dev/stderr | wc -l) -eq 2")
           check_permissions(builtin, cert, "acme")
           check_permissions(builtin, cert2, "acme")
+
+      with subtest("Remove an existing cert domain"):
+          builtin.succeed("systemctl stop renew-triggered.target")
+          switch_to(builtin, "remove_domain")
+          builtin.wait_for_unit("renew-triggered.target")
+
+          check_issuer(builtin, cert, "pebble")
+          check_domain(builtin, cert, f"builtin-alt.{domain}", fail=True)
+          check_ip(builtin, cert, ip)
+          check_permissions(builtin, cert, "acme")
 
       with subtest("Check account hashing compatibility with pre-24.05 settings"):
           builtin.succeed("systemctl stop renew-triggered.target")

--- a/pkgs/by-name/le/lego/package.nix
+++ b/pkgs/by-name/le/lego/package.nix
@@ -7,20 +7,20 @@
 
 buildGoModule (finalAttrs: {
   pname = "lego";
-  version = "4.35.2";
+  version = "5.4.1";
 
   src = fetchFromGitHub {
     owner = "go-acme";
     repo = "lego";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-NBCvVlMDEEhlfWWG7X5T1Udg+42+ibS1Ph6F+/yrXF0=";
+    hash = "sha256-LEPx725uvHUH5E5H8dwvOG0JA7DByZs0/DHHGC/nMJI=";
   };
 
-  vendorHash = "sha256-Q85McGGSILE8BPwreCtih6my1nih9ameLKHFe1dgNWQ=";
+  vendorHash = "sha256-6lvowCEYf++CIJz+AZ6ZIQC0WZxqIj7ygAoOpN01rns=";
 
   doCheck = false;
 
-  subPackages = [ "cmd/lego" ];
+  subPackages = [ "." ];
 
   ldflags = [
     "-s"


### PR DESCRIPTION
Update `lego` to 5.4.1 and migrate the NixOS ACME integration to lego 5. This updates the generated `lego run` invocations, migrates existing account state, and documents the raw `extraLego*Flags` CLI compatibility change in the release notes.

See the [upstream changelog](https://github.com/go-acme/lego/blob/v5.4.1/CHANGELOG.md) for release details.

The existing ACME VM test matrix passes, with added coverage for handling v4 account and certificate state.

Closes #529238. Follow-up to #529467.

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


