### PR TITLE
go-avahi-cname: init at 2.6.1

### DIFF
--- a/pkgs/by-name/go/go-avahi-cname/package.nix
+++ b/pkgs/by-name/go/go-avahi-cname/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "go-avahi-cname";
+  version = "2.6.1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "grishy";
+    repo = "go-avahi-cname";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MeEytTRZF5zpfWYNzvqiMdjvf6IJpS1t5V7+D08GjAY=";
+  };
+
+  vendorHash = "sha256-vbIHB9u9Ftwdw7rHnj6rkk/ABmESNvOgp0hixeWVnkI=";
+
+  ldflags = [
+    "-w"
+    "-s"
+    "-X=main.version=${finalAttrs.version}"
+    "-X=main.commit=${finalAttrs.src.rev}"
+    "-X=main.date=1970-01-01T00:00:00Z"
+  ];
+
+  # bind: operation not permitted
+  __darwinAllowLocalNetworking = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Lightweight mDNS publisher of subdomains for your machine";
+    homepage = "https://github.com/grishy/go-avahi-cname";
+    changelog = "https://github.com/grishy/go-avahi-cname/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sarahec ];
+    mainProgram = "go-avahi-cname";
+  };
+})


### PR DESCRIPTION
Lightweight mDNS (avahi) publisher of subdomains for your machine. Useful when you need a CNAME for a service such as `ncps.homelab.local` running within `homelab.local`.

I've been using this for months to expose a [ncps](https://docs.ncps.dev/) service on my main server and it's been flawless.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
