### PR TITLE
doc2dash: init at 3.1.0

### DIFF
--- a/pkgs/by-name/do/doc2dash/package.nix
+++ b/pkgs/by-name/do/doc2dash/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  nix-update-script,
+}:
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "doc2dash";
+  version = "3.1.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "hynek";
+    repo = "doc2dash";
+    tag = finalAttrs.version;
+    hash = "sha256-u6K+BDc9tUxq4kCekTaqQLtNN/OLVc3rh14sVSfPtoQ=";
+  };
+
+  build-system = with python3Packages; [
+    hatchling
+    hatch-vcs
+    hatch-fancy-pypi-readme
+  ];
+
+  dependencies = with python3Packages; [
+    attrs
+    beautifulsoup4
+    click
+    rich
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+    pytest-cov-stub
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/hynek/doc2dash/releases/tag/${finalAttrs.src.tag}";
+    description = "Create docsets for Dash.app-compatible API browsers";
+    homepage = "https://doc2dash.hynek.me";
+    license = with lib.licenses; [ mit ];
+    maintainers = [ lib.maintainers.pyrox0 ];
+    mainProgram = "doc2dash";
+  };
+})


### PR DESCRIPTION
Adds https://doc2dash.hynek.me/, a generator for Dash.app-compatible docsets.

No AI used.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
