### PR TITLE
python3Packages.hypothesis: 6.151.10 -> 6.156.1

### DIFF
--- a/pkgs/development/python-modules/filelock/default.nix
+++ b/pkgs/development/python-modules/filelock/default.nix
@@ -10,16 +10,16 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "filelock";
-  version = "3.29.0";
+  version = "3.29.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tox-dev";
     repo = "filelock";
-    tag = version;
-    hash = "sha256-efBEyjuCcLkHsfpG61eKN6ALk4QW4UMdNmD56rSgFLc=";
+    tag = finalAttrs.version;
+    hash = "sha256-rpkRk3SwpUWNdjyLCk6FMwNvEhHMSOKWnn096thkhWE=";
   };
 
   build-system = [
@@ -44,10 +44,10 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    changelog = "https://github.com/tox-dev/py-filelock/releases/tag/${version}";
+    changelog = "https://github.com/tox-dev/filelock/releases/tag/${finalAttrs.version}";
     description = "Platform independent file lock for Python";
     homepage = "https://github.com/benediktschmitt/py-filelock";
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/hypothesis/default.nix
+++ b/pkgs/development/python-modules/hypothesis/default.nix
@@ -3,27 +3,43 @@
   buildPythonPackage,
   isPyPy,
   fetchFromGitHub,
-  setuptools,
   attrs,
+  gitMinimal,
   pexpect,
   doCheck ? true,
   pytestCheckHook,
   pytest-xdist,
+  rustPlatform,
   sortedcontainers,
-  pythonAtLeast,
+  syrupy,
   tzdata,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "hypothesis";
-  version = "6.151.10";
+  version = "6.156.1";
   pyproject = true;
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "HypothesisWorks";
     repo = "hypothesis";
-    tag = "hypothesis-python-${version}";
-    hash = "sha256-zxX4zF6huOF7sTpVFAiN0iElxsW2C5BE0kiZbpPzXpc=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Z3LffzA+tsJtvXebTayfRZo32b0LcU2RFDS6bAdCDqU=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/hypothesis";
+
+  cargoRoot = "rust";
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      cargoRoot
+      ;
+    hash = "sha256-WEuCK1jpemnNpO+UxsfpdAkFLSM0v2WRjZr3qmSLBJI=";
   };
 
   # I tried to package sphinx-selective-exclude, but it throws
@@ -39,9 +55,13 @@ buildPythonPackage rec {
     sed -i -e '/sphinx_selective_exclude.eager_only/ d' docs/conf.py
   '';
 
-  postUnpack = "sourceRoot=$sourceRoot/hypothesis-python";
+  nativeBuildInputs = [
+    rustPlatform.cargoSetupHook
+  ];
 
-  build-system = [ setuptools ];
+  build-system = [
+    rustPlatform.maturinBuildHook
+  ];
 
   dependencies = [
     attrs
@@ -49,9 +69,11 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
+    gitMinimal
     pexpect
     pytest-xdist
     pytestCheckHook
+    (syrupy.overridePythonAttrs { doCheck = false; })
   ]
   ++ lib.optionals isPyPy [ tzdata ];
 
@@ -65,7 +87,12 @@ buildPythonPackage rec {
   preCheck = ''
     rm tox.ini
     export HYPOTHESIS_PROFILE=ci
+    export TMPDIR=$(mktemp -d)
   '';
+
+  pytestFlags = [
+    "-o cache_dir=$TMPDIR/.pytest_cache"
+  ];
 
   enabledTestPaths = [ "tests/cover" ];
 
@@ -82,46 +109,13 @@ buildPythonPackage rec {
   setupHook = ./setup-hook.sh;
 
   disabledTests = [
-    # racy, fails to find a file sometimes
-    "test_recreate_charmap"
-    "test_uses_cached_charmap"
     # fail when using CI profile
     "test_given_does_not_pollute_state"
     "test_find_does_not_pollute_state"
     "test_does_print_on_reuse_from_database"
     "test_prints_seed_only_on_healthcheck"
-    # calls script with the naked interpreter
-    "test_constants_from_running_file"
-    # fails consistenly
     "test_prints_seed_on_very_slow_shrinking"
-  ]
-  ++ lib.optionals (pythonAtLeast "3.12") [
-    # AssertionError: assert [b'def      \...   f(): pass'] == [b'def\\', b'    f(): pass']
-    # https://github.com/HypothesisWorks/hypothesis/issues/4355
-    "test_clean_source"
-  ]
-  ++ lib.optionals (pythonAtLeast "3.14") [
-    "test_attrs_inference_builds"
-    "test_bound_missing_dot_access_forward_ref"
-    "test_bound_missing_forward_ref"
-    "test_bound_type_checking_only_forward_ref_wrong_type"
-    "test_bound_type_cheking_only_forward_ref"
-    "test_builds_suggests_from_type"
-    "test_bytestring_not_treated_as_generic_sequence"
-    "test_evil_prng_registration_nonsense"
-    "test_issue_4194_regression"
-    "test_passing_referenced_instance_within_function_scope_warns"
-    "test_registering_a_Random_is_idempotent"
-    "test_register_random_within_nested_function_scope"
-    "test_resolve_fwd_refs"
-    "test_resolves_forwardrefs_to_builtin_types"
-    "test_resolving_standard_collection_as_generic"
-    "test_resolving_standard_container_as_generic"
-    "test_resolving_standard_contextmanager_as_generic"
-    "test_resolving_standard_iterable_as_generic"
-    "test_resolving_standard_reversible_as_generic"
-    "test_resolving_standard_sequence_as_generic"
-    "test_specialised_collection_types"
+    "test_regex_output_should_print_as_string"
   ]
   ++ lib.optionals isPyPy [
     # hypothesis.errors.Unsatisfiable: Could not find any examples from datetimes(min_value=datetime.datetime(2003, 1, 1, 0, 0), max_value=datetime.datetime(2005, 12, 31, 23, 59, 59, 999999)) that satisfied lambda x: x.month == 2 and x.day == 29
@@ -135,11 +129,11 @@ buildPythonPackage rec {
     mainProgram = "hypothesis";
     homepage = "https://github.com/HypothesisWorks/hypothesis";
     changelog = "https://hypothesis.readthedocs.io/en/latest/changes.html#v${
-      lib.replaceStrings [ "." ] [ "-" ] version
+      lib.replaceStrings [ "." ] [ "-" ] finalAttrs.version
     }";
     license = lib.licenses.mpl20;
     maintainers = [
       lib.maintainers.fliegendewurst
     ];
   };
-}
+})


### PR DESCRIPTION
https://hypothesis.readthedocs.io/en/latest/changelog.html#v6-156-1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
