### PR TITLE
c-ares: 1.34.6 -> 1.34.7

### DIFF
--- a/pkgs/by-name/c-/c-ares/package.nix
+++ b/pkgs/by-name/c-/c-ares/package.nix
@@ -18,7 +18,7 @@
 
 stdenv.mkDerivation rec {
   pname = "c-ares";
-  version = "1.34.6";
+  version = "1.34.7";
 
   strictDeps = true;
   __structuredAttrs = true;
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     # Note: tag name varies in some versions, e.g. v1.30.0, c-ares-1_17_0.
     url = "https://github.com/c-ares/c-ares/releases/download/v${version}/c-ares-${version}.tar.gz";
-    hash = "sha256-kS3XzDs+innFL9f7nA9Ozwqqc+Re/aiAJmotbia4TvU=";
+    hash = "sha256-VW94HdGIrZMtyCY/7grTqrpnW0zY5U2GkIaBtDzj4yc=";
   };
 
   outputs = [


### PR DESCRIPTION
Release notes: https://github.com/c-ares/c-ares/releases/tag/v1.34.7

Handles:

 - GHSA-pjmc-gx33-gc76
 - GHSA-jv8r-gqr9-68wj
 - GHSA-6wfj-rwm7-3542 (CVE-2026-33630)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

> [!NOTE]
> The package tests on `x86_64-linux` are being built on my end as I open this PR.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
