### PR TITLE
nixos/cosmic: use oo7 for Secret portal

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -75,6 +75,8 @@
 
 - `komodo` has been updated to the v2 release line (2.x). See the [upstream v1 → v2 upgrade guide](https://github.com/moghtech/komodo/releases/tag/v2.0.0).
 
+- COSMIC now uses `oo7` as its default Secret Service provider, matching COSMIC's upstream portal configuration. Existing GNOME keyring data is not migrated automatically. Users may need to re-enter credentials after switching; set [](#opt-services.gnome.gnome-keyring.enable) to `true` temporarily if access to the old GNOME keyring is still required.
+
 - The `shell_interact()` function on interactive runs of NixOS VM tests has been deprecated. Use the SSH backdoor instead.
 
 - `security.run0.enableSudoAlias` now uses the `run0-sudo-shim` instead of a shell-script to improve compatibility.

--- a/nixos/modules/services/desktop-managers/cosmic.nix
+++ b/nixos/modules/services/desktop-managers/cosmic.nix
@@ -117,6 +117,7 @@ in
       portal = {
         enable = true;
         extraPortals = with pkgs; [
+          oo7-portal
           xdg-desktop-portal-cosmic
           xdg-desktop-portal-gtk
         ];
@@ -124,7 +125,10 @@ in
       };
     };
 
-    systemd.packages = [ pkgs.cosmic-session ];
+    systemd.packages = with pkgs; [
+      cosmic-session
+      oo7-server
+    ];
 
     fonts.packages = with pkgs; [
       fira
@@ -164,7 +168,9 @@ in
     networking.networkmanager.enable = lib.mkDefault true;
     services.acpid.enable = lib.mkDefault true;
     services.avahi.enable = lib.mkDefault true;
-    services.gnome.gnome-keyring.enable = lib.mkDefault true;
+    # COSMIC's upstream portal config prefers oo7-portal for
+    # org.freedesktop.impl.portal.Secret, with gnome-keyring only as fallback.
+    services.gnome.gnome-keyring.enable = lib.mkDefault false;
     services.gvfs.enable = lib.mkDefault true;
     services.orca.enable = lib.mkDefault (notExcluded pkgs.orca);
     services.power-profiles-daemon.enable = lib.mkDefault (


### PR DESCRIPTION
Switch COSMIC to the Secret Service backend preferred by upstream COSMIC portal routing: `oo7-portal` first, with `oo7-server` available for user D-Bus activation. This keeps `xdg-desktop-portal-gtk` because upstream COSMIC still declares `default=cosmic;gtk;`.

GNOME keyring now defaults off for COSMIC, but users can temporarily opt back in with `services.gnome.gnome-keyring.enable = true` if they need access to old keyrings. Existing GNOME keyring data is preserved in place and is not automatically migrated.

`nixpkgs-review-gha` is running: https://github.com/caniko/nixpkgs-review-gha/actions/runs/28826584841

Generated with assistance from OpenAI Codex (GPT-5); reviewed before submission.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test