### PR TITLE
gnome-contacts: add glycin-loaders to buildInputs

### DIFF
--- a/pkgs/by-name/gn/gnome-contacts/package.nix
+++ b/pkgs/by-name/gn/gnome-contacts/package.nix
@@ -25,6 +25,7 @@
   libadwaita,
   libglycin,
   libglycin-gtk4,
+  glycin-loaders,
   gsettings-desktop-schemas,
   gst_all_1,
   pipewire,
@@ -62,6 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
     glib
     libportal-gtk4
     evolution-data-server-gtk4
+    glycin-loaders
     gsettings-desktop-schemas
     folks
     libadwaita


### PR DESCRIPTION
Otherwise gnome-concats will fail to display the profile pictures of contacts. This was broken in nixpkgs with 176852055aa4041528d6acbb7020f284be31b3e7 since upstream changed to glycin instead of gdkpixbuf with [`0a3104f`](https://gitlab.gnome.org/GNOME/gnome-contacts/-/commit/0a3104f38267aa3330437924faf415e707b3c8d0).

Closes #539061

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
