### PR TITLE
gimp: apply patch for CVE-2026-58379

### DIFF
--- a/pkgs/applications/graphics/gimp/default.nix
+++ b/pkgs/applications/graphics/gimp/default.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchurl,
+  fetchpatch,
   replaceVars,
   meson,
   ninja,
@@ -116,6 +117,12 @@ stdenv.mkDerivation (finalAttrs: {
     # so we need to pick up the one from the package.
     (replaceVars ./tests-dbus-conf.patch {
       session_conf = "${dbus.out}/share/dbus-1/session.conf";
+    })
+
+    (fetchpatch {
+      name = "fix-cve-2026-58379";
+      url = "https://gitlab.gnome.org/GNOME/gimp/-/commit/b630f167ba7b73b17e7dd6df1fee1623f8324575.patch";
+      hash = "sha256-0QMLfn9h0FtvzqA+Ui+lg5KMBhss1gbHae90SfPGF4c=";
     })
   ];
 


### PR DESCRIPTION
It looks like [CVE-2026-58381](https://nvd.nist.gov/vuln/detail/CVE-2026-58381) (#538216) is already fixed in version `3.2.4`. Stable should either update to `3.2+` or apply patches for the CVEs since `3.2` already fixed several ones. I'm not sure if we should patch `gimp2` too. Is it even supported?

Closes #538329

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
