### PR TITLE
mailspring: fix linux desktop file, package using darwin .app

### DIFF
--- a/pkgs/by-name/ma/mailspring/package.nix
+++ b/pkgs/by-name/ma/mailspring/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildNpmPackage,
   callPackage,
   fetchFromGitHub,
@@ -29,6 +30,7 @@ let
   patches = [
     # zip extraction fails on newer nodejs versions without this fix
     ./bump-yauzl.patch
+    ./remove-rpm-deb-and-macos-package-generation.patch
   ];
 
   electron = electron_41;
@@ -95,8 +97,7 @@ buildNpmPackage (finalAttrs: {
     substituteInPlace app/build/build.js \
       --replace-fail "runWriteCommitHashIntoPackage," "" \
       --replace-fail "runUpdateSandboxHelperPermissions," "" \
-      --replace-fail "runCopySymlinkedPackages," "" \
-      --replace-fail "process.argv.includes('--skip-installers')" "true"
+      --replace-fail "runCopySymlinkedPackages," ""
 
     # Use npm env vars to make node-gyp compile against the electron ABI
     export npm_config_target="${electron.version}"
@@ -125,17 +126,38 @@ buildNpmPackage (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/share/mailspring $out/bin
+    mkdir -p $out/bin
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
 
-    ASAR_PATH=$(find app/dist -name "app.asar" -print -quit)
-    cp -R "$(dirname "$ASAR_PATH")" $out/share/mailspring/resources
+      mkdir -p $out/share/mailspring
+      cp -r app/dist/*/resources $out/share/mailspring
+
+      install -Dm444 app/dist/Mailspring.desktop $out/share/applications/Mailspring.desktop
+      install -Dm444 app/dist/mailspring.appdata.xml $out/share/metainfo/mailspring.appdata.xml
+
+      for size in 16 32 64 128 256 512; do
+        install -Dm444 app/build/resources/linux/icons/$size.png \
+          $out/share/icons/hicolor/''${size}x''${size}/apps/mailspring.png
+      done
 
     makeWrapper ${lib.getExe electron} "$out/bin/mailspring" \
       --add-flags "$out/share/mailspring/resources/app.asar" \
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ html-tidy ]}" \
       --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
-      --add-flags ${lib.escapeShellArg commandLineArgs}
+      --add-flags ${lib.escapeShellArg commandLineArgs} \
+      --inherit-argv0
 
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+
+    mkdir -p $out/Applications
+    cp -r app/dist/*/Mailspring.app $out/Applications
+
+    makeWrapper "$out/Applications/Mailspring.app/Contents/MacOS/Mailspring" "$out/bin/mailspring" \
+      --add-flags ${lib.escapeShellArg commandLineArgs}
+  ''
+  + ''
     runHook postInstall
   '';
 

--- a/pkgs/by-name/ma/mailspring/remove-rpm-deb-and-macos-package-generation.patch
+++ b/pkgs/by-name/ma/mailspring/remove-rpm-deb-and-macos-package-generation.patch
@@ -1,0 +1,54 @@
+From 420f1f58734dbc7305f46b4d8089b461b79321b0 Mon Sep 17 00:00:00 2001
+From: wrench-exile-legacy <user@wrench-exile-legacy.site>
+Date: Mon, 6 Jul 2026 22:40:30 +0100
+Subject: [PATCH] remove rpm, deb and macos package generation
+
+---
+ app/build/build.js | 17 -----------------
+ 1 file changed, 17 deletions(-)
+
+diff --git a/app/build/build.js b/app/build/build.js
+index 6d90aa5b2..ffec9cf8b 100644
+--- a/app/build/build.js
++++ b/app/build/build.js
+@@ -373,12 +373,6 @@ async function createMacZip() {
+   }
+   const arch = process.env.OVERRIDE_TO_INTEL ? 'x64' : process.arch;
+   const cwd = path.join(outputDir, `Mailspring-darwin-${arch}`);
+-  await spawn({
+-    cmd: 'zip',
+-    args: ['-9', '-y', '-r', '-9', '-X', zipPath, 'Mailspring.app'],
+-    opts: { cwd },
+-  });
+-  console.log(`>> Created ${zipPath}`);
+ }
+ 
+ function writeFromTemplate(filePath, data) {
+@@ -422,11 +416,6 @@ async function createDebInstaller() {
+   writeFromTemplate(path.join(linuxAssetsDir, 'mailspring.appdata.xml.in'), data);
+ 
+   const icon = path.join(appDir, 'build', 'resources', 'linux', 'icons', '512.png');
+-  await spawn({
+-    cmd: path.join(appDir, 'script', 'mkdeb'),
+-    args: [packageJSON.version, linuxArch, icon, linuxAssetsDir, contentsDir, outputDir],
+-  });
+-  console.log(`Created ${outputDir}/mailspring-${packageJSON.version}-${linuxArch}.deb`);
+ }
+ 
+ async function createRpmInstaller() {
+@@ -452,12 +441,6 @@ async function createRpmInstaller() {
+   writeFromTemplate(path.join(linuxAssetsDir, 'redhat', 'mailspring.spec.in'), templateData);
+   writeFromTemplate(path.join(linuxAssetsDir, 'Mailspring.desktop.in'), templateData);
+   writeFromTemplate(path.join(linuxAssetsDir, 'mailspring.appdata.xml.in'), templateData);
+-
+-  await spawn({
+-    cmd: path.join(appDir, 'script', 'mkrpm'),
+-    args: [outputDir, contentsDir, linuxAssetsDir],
+-  });
+-  console.log(`Created rpm package in ${rpmDir}`);
+ }
+ 
+ async function main() {
+-- 
+2.54.0
+


### PR DESCRIPTION
Fixes #538021

Closes #538956

---

This PR fixes the missing Linux `.desktop` file and icons, and packages Mailspring using a proper macOS `.app` bundle instead of the generic electron wrapper.

Rather than patching the `Mailspring.desktop.in` template in our Nix derivation, we let the upstream `build.js` handle the templating. We achieve this by letting the script run, but patching out the calls to [mkrpm](https://github.com/Foundry376/Mailspring/blob/4e42bfe185528ce0685573f3459233a47f57d588/app/build/build.js#L458-L461) and [mkdeb](https://github.com/Foundry376/Mailspring/blob/4e42bfe185528ce0685573f3459233a47f57d588/app/build/build.js#L426-L429) (as well as removing the [darwin zip compression](https://github.com/Foundry376/Mailspring/blob/4e42bfe185528ce0685573f3459233a47f57d588/app/build/build.js#L376-L380)).

This ensures that if the `.desktop` template changes upstream in the future, the build will not fail.



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
