### PR TITLE
age-plugin-se: 0.1.4 -> 0.2.1

### DIFF
--- a/pkgs/by-name/ag/age-plugin-se/package.nix
+++ b/pkgs/by-name/ag/age-plugin-se/package.nix
@@ -12,13 +12,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "age-plugin-se";
-  version = "0.1.4";
+  version = "0.2.1";
 
   src = fetchFromGitHub {
     owner = "remko";
     repo = "age-plugin-se";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-sg73DzlW4aXNbIIePZox4JkF10OfsMtPw0q/0DWwgDk=";
+    hash = "sha256-ga9EYfvscXf8VHSptjgnjaeZT+D/69PAr/s53JOHG20=";
   };
 
   nativeBuildInputs = [
@@ -36,16 +36,26 @@ stdenv.mkDerivation (finalAttrs: {
       swift-crypto = fetchFromGitHub {
         owner = "apple";
         repo = "swift-crypto";
-        # FIXME: Update to a newer version once https://github.com/NixOS/nixpkgs/issues/343210 is fixed
-        # This is the last version to support swift tools 5.8 which is newest version supported by nixpkgs:
-        # https://github.com/apple/swift-crypto/commit/35703579f63c2518fc929a1ce49805ba6134137c
         tag = "3.7.1";
         hash = "sha256-zxmHxTryAezgqU5qjXlFFThJlfUsPxb1KRBan4DSm9A=";
       };
     in
     ''
+      ${lib.optionalString (lib.versionAtLeast swift.version "6") ''
+        echo "age-plugin-se still applies patch-package-swift-legacy; remove or revisit this patch now that nixpkgs Swift is 6+."
+        exit 1
+      ''}
+      make patch-package-swift-legacy
       ln -s ${swift-crypto} swift-crypto
       substituteInPlace Package.swift --replace-fail 'url: "https://github.com/apple/swift-crypto.git"' 'path: "./swift-crypto"), //'
+      ${lib.optionalString stdenv.hostPlatform.isLinux ''
+        # Swift 5.10.1's corelibs Foundation lacks Date.ISO8601Format().
+        # Remove this substitution once the upstream fallback is released:
+        # https://github.com/remko/age-plugin-se/issues/20
+        substituteInPlace Sources/Plugin.swift --replace-fail \
+          'let createdAt = now.ISO8601Format()' \
+          'let createdAt = ISO8601DateFormatter().string(from: now)'
+      ''}
     '';
 
   makeFlags = [


### PR DESCRIPTION
Updates `age-plugin-se` from 0.1.4 to 0.2.1.

Upstream changes: [v0.1.4...v0.2.1](https://github.com/remko/age-plugin-se/compare/v0.1.4...v0.2.1).

Compatibility changes for nixpkgs Swift 5.10.1:
- run upstream's `patch-package-swift-legacy` target;
- keep `swift-crypto` local;
- use `ISO8601DateFormatter` only on Linux pending [upstream PR #21](https://github.com/remko/age-plugin-se/pull/21).

Related: #476072.

AI disclosure: prepared with assistance from OpenAI Codex (GPT-5) and reviewed by me.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
