### PR TITLE
sneakerweb: init at 1.0.1-unstable-2026-07-05

### DIFF
--- a/pkgs/by-name/sn/sneakerweb/package.nix
+++ b/pkgs/by-name/sn/sneakerweb/package.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromCodeberg,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "sneakerweb";
+  version = "1.0.1-unstable-2026-07-05";
+
+  src = fetchFromCodeberg {
+    owner = "worm-blossom";
+    repo = "sneakerweb";
+    rev = "888cf132207a2bf0622a5633a2d347e9e910538c";
+    hash = "sha256-BXF+Iw2eSJPsiVkLrL0RaIqdJtp6yFwU8p9QO6tDDS8=";
+  };
+
+  cargoHash = "sha256-6miju3dsKTHlyt+YMJEIP+Ygpm/wQGW4EVCe7iwOi08=";
+
+  meta = {
+    description = "";
+    homepage = "https://sneakerweb.org/";
+    downloadPage = "https://codeberg.org/worm-blossom/sneakerweb";
+  };
+})


### PR DESCRIPTION
Homepage: https://sneakerweb.org/
downloadPage: https://codeberg.org/worm-blossom/sneakerweb


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
