### PR TITLE
cinny-unwrapped: 4.12.2 -> 4.12.3, cinny-desktop: 4.12.2 -> 4.12.5

### DIFF
--- a/pkgs/by-name/ci/cinny-desktop/package.nix
+++ b/pkgs/by-name/ci/cinny-desktop/package.nix
@@ -20,35 +20,30 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cinny-desktop";
-  # We have to be using the same version as cinny-web or this isn't going to work.
-  version = "4.12.2";
+  version = "4.12.5";
 
   src = fetchFromGitHub {
     owner = "cinnyapp";
     repo = "cinny-desktop";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-gaTgNTn0/HHzULHRL03+t73MEUOGdqcEyqaIt8CWA0k=";
+    hash = "sha256-/A/O42jwwK2iDV1IdRjOO8fE/AZ0h7UWAZZLozOqUWs=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/src-tauri";
 
-  cargoHash = "sha256-x7rpnhTz454Ftolu4x50NSGKdg8NfenUwdhPY4a+lbA=";
+  cargoHash = "sha256-EF8gpfeZasazq0NKrjItt4bkgautQjYjEegf1OlWLOw=";
 
   postPatch =
     let
-      cinny' =
-        assert lib.assertMsg (
-          cinny.version == finalAttrs.version
-        ) "cinny.version (${cinny.version}) != cinny-desktop.version (${finalAttrs.version})";
-        cinny.override {
-          conf = {
-            hashRouter.enabled = true;
-          };
+      cinny' = cinny.override {
+        conf = {
+          hashRouter.enabled = true;
         };
+      };
     in
     ''
       ${lib.getExe jq} \
-        'del(.plugins.tauri.updater) | .build.frontendDist = "${cinny'}" | del(.build.beforeBuildCommand) | .bundle.createUpdaterArtifacts = false' tauri.conf.json \
+        '.build.frontendDist = "${cinny'}" | del(.build.beforeBuildCommand) | .bundle.createUpdaterArtifacts = false' tauri.conf.json \
         | ${lib.getExe' moreutils "sponge"} tauri.conf.json
     '';
 
@@ -81,6 +76,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     openssl
     webkitgtk_4_1
   ];
+
+  buildNoDefaultFeatures = true;
+  buildFeatures = [ "custom-protocol" ];
 
   passthru = {
     updateScript = _experimental-update-script-combinators.sequence [

--- a/pkgs/by-name/ci/cinny-unwrapped/package.nix
+++ b/pkgs/by-name/ci/cinny-unwrapped/package.nix
@@ -7,17 +7,17 @@
 buildNpmPackage (finalAttrs: {
   pname = "cinny-unwrapped";
   # Remember to update cinny-desktop when bumping this version.
-  version = "4.12.2";
+  version = "4.12.3";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitHub {
     owner = "cinnyapp";
     repo = "cinny";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-UF5MwV02G0oYIXtvyzHn+DifYM8PFlyb9DZ4w1fuyDE=";
+    hash = "sha256-RjPdq9xNvUbJESV7CqxmgfqAx+MoKZbhUtJNTcH9aUk=";
   };
 
-  npmDepsHash = "sha256-8SyUFv1wgnqfSyBlykmeGI8RAmFt5Q5uS6OFLi+qPPY=";
+  npmDepsHash = "sha256-CU8AVRuMFOGI0/LbN0LGysBk+qc2XQYxQGfrrH72stc=";
 
   # Skip rebuilding native modules since they're not needed for the web app
   npmRebuildFlags = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Opened this PR due to https://github.com/NixOS/nixpkgs/pull/534269 being stale.

- Removed the version assertion between `cinny` and `cinny-desktop` from https://github.com/NixOS/nixpkgs/pull/263790, as upstream doesn't always guarantee their versions in sync.
- Disabled the Tauri updater per https://github.com/NixOS/nixpkgs/pull/534269#issuecomment-4787867679.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
