### PR TITLE
emacsPackages.modus-themes-exporter: init at 0-unstable-2026-04-24

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/modus-themes-exporter/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/modus-themes-exporter/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  melpaBuild,
+  fetchFromGitHub,
+  modus-themes,
+  nix-update-script,
+}:
+melpaBuild {
+  pname = "modus-themes-exporter";
+  version = "0-unstable-2026-04-24";
+
+  src = fetchFromGitHub {
+    owner = "protesilaos";
+    repo = "modus-themes-exporter";
+    rev = "a19c4b0f22d353afcd441fbbc6c0565858a86c9b";
+    hash = "sha256-/PCCArQUV1uhhbOC3fqSuUkgDqc4+QlLubTtjx8/vGc=";
+  };
+
+  packageRequires = [ modus-themes ];
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch=main" ]; };
+
+  meta = {
+    description = "Export a Modus themes to another application";
+    homepage = "https://github.com/protesilaos/modus-themes-exporter";
+    maintainers = [ lib.maintainers.HeitorAugustoLN ];
+    license = lib.licenses.gpl3Plus;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds [modus-themes-exporter](https://github.com/protesilaos/modus-themes-exporter) package for Emacs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
