### PR TITLE
zotero: sign on macOS

### DIFF
--- a/pkgs/by-name/zo/zotero/package.nix
+++ b/pkgs/by-name/zo/zotero/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   buildNpmPackage,
+  darwin,
   nodejs_22,
   perl,
   python3,
@@ -184,6 +185,7 @@ buildNpmPackage (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     makeBinaryWrapper
+    darwin.autoSignDarwinBinariesHook
   ]
   ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
     wrapGAppsHook3

--- a/pkgs/by-name/zo/zotero/package.nix
+++ b/pkgs/by-name/zo/zotero/package.nix
@@ -182,10 +182,10 @@ buildNpmPackage (finalAttrs: {
     rsync
     copyDesktopItems
   ]
-  ++ lib.optionals stdenv.targetPlatform.isDarwin [
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     makeBinaryWrapper
   ]
-  ++ lib.optionals (!stdenv.targetPlatform.isDarwin) [
+  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
     wrapGAppsHook3
   ];
 
@@ -247,12 +247,12 @@ buildNpmPackage (finalAttrs: {
       # The correct firefox version can be found in zotero/app/config.sh at `GECKO_VERSION_LINUX`.
       mkdir -p app/xulrunner/
     ''
-    + lib.optionalString stdenv.targetPlatform.isDarwin ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
       cp -r "${firefox-esr-140-unwrapped}/Applications/Firefox ESR.app" app/xulrunner/Firefox.app
     ''
-    + lib.optionalString (!stdenv.targetPlatform.isDarwin) ''
-      cp -r "${firefox-esr-140-unwrapped}/lib/firefox" "app/xulrunner/firefox-${stdenv.targetPlatform.parsed.kernel.name}-${
-        lib.replaceString "aarch64" "arm64" stdenv.targetPlatform.parsed.cpu.name
+    + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
+      cp -r "${firefox-esr-140-unwrapped}/lib/firefox" "app/xulrunner/firefox-${stdenv.hostPlatform.parsed.kernel.name}-${
+        lib.replaceString "aarch64" "arm64" stdenv.hostPlatform.parsed.cpu.name
       }"
     ''
     + ''
@@ -261,9 +261,7 @@ buildNpmPackage (finalAttrs: {
       build_dir=$(mktemp -d)
       ./app/scripts/prepare_build -s ./build -o "$build_dir" -c release
       ./app/build.sh -d "$build_dir" -c release -s \
-        ${
-          if stdenv.targetPlatform.isDarwin then "-p m" else "-p l -a ${zoteroArch stdenv.targetPlatform}"
-        }
+        ${if stdenv.hostPlatform.isDarwin then "-p m" else "-p l -a ${zoteroArch stdenv.hostPlatform}"}
 
       runHook postBuild
     '';
@@ -307,12 +305,12 @@ buildNpmPackage (finalAttrs: {
   installPhase = ''
     runHook preInstall
   ''
-  + lib.optionalString stdenv.targetPlatform.isDarwin ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
     # Copy package contents
     mkdir -p $out/Applications
     cp -r app/staging/Zotero.app $out/Applications/
   ''
-  + lib.optionalString (!stdenv.targetPlatform.isDarwin) ''
+  + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     # Copy package contents
     mkdir -p $out/lib/
     cp -r app/staging/*/. $out/lib/
@@ -331,7 +329,7 @@ buildNpmPackage (finalAttrs: {
     runHook postInstall
   '';
 
-  preFixup = lib.optionalString (!stdenv.targetPlatform.isDarwin) ''
+  preFixup = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     gappsWrapperArgs+=(--suffix LD_LIBRARY_PATH : ${
       lib.makeLibraryPath [
         libGL
@@ -341,7 +339,7 @@ buildNpmPackage (finalAttrs: {
     })
   '';
 
-  postFixup = lib.optionalString stdenv.targetPlatform.isDarwin ''
+  postFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
     mkdir -p $out/bin
     makeWrapper $out/Applications/Zotero.app/Contents/MacOS/zotero $out/bin/zotero
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- Added signing on macOS using the `darwin.autoSignDarwinBinariesHook` hook. If we (a) don't sign at all, or (b) sign only the executable inside the `.app` bundle, `zotero` fails to start on `aarch64-darwin`.
- Changed `targetPlatform` to `hostPlatform` in the derivation for zotero in line with my understanding of nixpkgs best practices, but I can either remove or cherry-pick that change to a separate PR if needed.
 
Note that `nix-build -A zotero.passthru.tests` fails on `aarch64-darwin`, but this is not new (i.e., it failed in the exact same way before the PR). Running the resultant Zotero binary (after signing) does seem to work correctly, so I am not trying to address this at the moment.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
