### PR TITLE
lib.customisation.callPackageWith: warn on functors

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -31,6 +31,7 @@ let
     deepSeq
     extends
     id
+    warn
     ;
   inherit (lib.strings) levenshtein levenshteinAtMost;
 
@@ -303,11 +304,27 @@ rec {
           loc' = if loc != null then loc.file + ":" + toString loc.line else "<unknown location>";
         in
         "lib.customisation.callPackageWith: Function called without required argument \"${arg}\" at ${loc'}${prettySuggestions (getSuggestions arg)}";
+      inherit (builtins) functionArgs;
+      functionArgsWithWarn =
+        f:
+        if f ? __functor then
+          let
+            pos = builtins.unsafeGetAttrPos "__functor" f;
+          in
+          warn ''
+            `lib.customisation.callPackageWith` was called with a functor in ${
+              if pos != null then "unknown position" else "${pos.file}:${toString pos.line}"
+            }.
+            This is deprecated as of Nixpkgs 26.11, and will be unsupported in a
+            future release.
+          '' (f.__functionArgs or (functionArgs (f.__functor f)))
+        else
+          functionArgs f;
     in
     autoArgs: fn: args:
     let
       f = if isFunction fn then fn else import fn;
-      fargs = functionArgs f;
+      fargs = functionArgsWithWarn f;
 
       # All arguments that will be passed to the function
       # This includes automatic ones and ones passed explicitly

--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -91,13 +91,11 @@ let
           };
 
           # NOTE: The `common-*.nix` helpers contain a top-level function which
-          # takes the Lix source to build and version information. We use the
-          # outer `callPackage` for that.
-          #
+          # takes the Lix source to build and version information.
           # That *returns* another function which takes the actual build
           # dependencies, and that uses the new scope's `self.callPackage` so
           # that `nix-eval-jobs` can be built against the correct `lix` version.
-          lix = self.callPackage (callPackage ./common-lix.nix lix-args) {
+          lix = self.callPackage (import ./common-lix.nix (lix-args // { inherit lib; })) {
             stdenv = lixStdenv;
           };
 
@@ -129,9 +127,11 @@ let
             nix = self.lix;
           };
 
-          nix-eval-jobs = self.callPackage (callPackage ./common-nix-eval-jobs.nix nix-eval-jobs-args) {
-            stdenv = lixStdenv;
-          };
+          nix-eval-jobs =
+            self.callPackage (import ./common-nix-eval-jobs.nix (nix-eval-jobs-args // { inherit lib; }))
+              {
+                stdenv = lixStdenv;
+              };
 
           nix-fast-build = nix-fast-build.override {
             inherit (self) nix-eval-jobs;


### PR DESCRIPTION
Trying this out in CI to see if there's any internal usages. If we're able to call `builtins.functionArgs` directly, it'll be a minor performance improvement. Whether we _want_ to do this depends on how much functors are used, whether we'd like to support them, and how minor the improvement really is.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
