### PR TITLE
nixos/nspawn-container: hash name, remove assertion 

### DIFF
--- a/nixos/modules/virtualisation/nspawn-container/default.nix
+++ b/nixos/modules/virtualisation/nspawn-container/default.nix
@@ -81,34 +81,6 @@ in
           which is prohibited within the Nix build sandbox where the test is run.
         '';
       }
-      {
-        # Check every interface defined in allInterfaces.
-        # Containers try to create a bridge "${config.system.name}-${interfaceName}"
-        assertion = lib.all (
-          iface:
-          let
-            hostName = "${config.system.name}-${iface.name}";
-          in
-          lib.stringLength hostName <= 15
-        ) (lib.attrValues cfg.allInterfaces);
-
-        message =
-          let
-            offendingInterfaces = lib.filter (
-              iface: lib.stringLength "${config.system.name}-${iface.name}" > 15
-            ) (lib.attrValues cfg.allInterfaces);
-            offenderList = map (
-              i:
-              "${config.system.name}-${i.name} (${toString (lib.stringLength "${config.system.name}-${i.name}")} chars)"
-            ) offendingInterfaces;
-          in
-          ''
-            The following generated host interface names exceed the Linux 15-character limit:
-              ${lib.concatStringsSep "\n            " offenderList}
-
-            Please shorten 'config.system.name' or the interface names in 'virtualisation.interfaces'.
-          '';
-      }
     ];
 
     virtualisation.systemd-nspawn.options = [

--- a/nixos/modules/virtualisation/nspawn-container/run-nspawn/src/run_nspawn/__init__.py
+++ b/nixos/modules/virtualisation/nspawn-container/run-nspawn/src/run_nspawn/__init__.py
@@ -1,6 +1,7 @@
 import contextlib
 import dataclasses
 import fcntl
+import hashlib
 import logging
 import os
 import signal
@@ -124,6 +125,13 @@ def mk_veth(
     vlan: int,
 ) -> typing.Generator[None, None, None]:
     host_intf_name = f"{container_name}-{container_intf_name}"
+    # If the names for systemd-nspawn containers are too long,
+    # the generated bridge interface names will surpass the
+    # kernel limit IFNAMSIZ (15 characters + '\0').
+    if len(host_intf_name) > 15:
+        hashed = hashlib.sha256(host_intf_name.encode()).hexdigest()[:6]
+        host_intf_name = f"{host_intf_name[:8]}-{hashed}"
+
     with ensure_vlan_bridge(vlan) as bridge_name:
         logger.info("creating interface %s", host_intf_name)
         run_ip(

--- a/nixos/tests/grafana/basic.nix
+++ b/nixos/tests/grafana/basic.nix
@@ -84,7 +84,7 @@ import ../make-test-python.nix (
       };
     };
 
-    nodes = builtins.mapAttrs (
+    containers = builtins.mapAttrs (
       _: val:
       mkMerge [
         val
@@ -97,7 +97,7 @@ import ../make-test-python.nix (
 
     meta.maintainers = [ ];
 
-    inherit nodes;
+    inherit containers;
 
     testScript = ''
       start_all()

--- a/nixos/tests/grafana/provision/default.nix
+++ b/nixos/tests/grafana/provision/default.nix
@@ -183,7 +183,7 @@ import ../../make-test-python.nix (
         };
     };
 
-    nodes = builtins.mapAttrs (
+    containers = builtins.mapAttrs (
       _: val:
       mkMerge [
         val
@@ -196,7 +196,7 @@ import ../../make-test-python.nix (
 
     meta.maintainers = [ ];
 
-    inherit nodes;
+    inherit containers;
 
     testScript = ''
       start_all()


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

@mweinelt IIRC you mentioned this on matrix.