### PR TITLE
tweetxvault: init at 0.2.4

### DIFF
--- a/pkgs/by-name/tw/tweetxvault/package.nix
+++ b/pkgs/by-name/tw/tweetxvault/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "tweetxvault";
+  version = "0.2.4";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "lhl";
+    repo = "tweetxvault";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-SSsvQaJH9systhlO4UvbNNSNT1le1ryPjvZBbKy7MoM=";
+  };
+
+  build-system = [ python3Packages.hatchling ];
+
+  pythonRelaxDeps = [
+    "platformdirs"
+    "rich"
+    "pyarrow"
+    "huggingface-hub"
+  ];
+
+  dependencies = with python3Packages; [
+    browser-cookie3
+    httpx
+    lancedb
+    loguru
+    numpy
+    platformdirs
+    pyarrow
+    pydantic
+    rich
+    tqdm
+    typer
+  ];
+
+  optional-dependencies = {
+    embed = with python3Packages; [
+      huggingface-hub
+      onnxruntime
+      tokenizers
+    ];
+  };
+
+  nativeCheckInputs =
+    with python3Packages;
+    [
+      versionCheckHook
+      pytestCheckHook
+      pytest-asyncio
+    ]
+    ++ finalAttrs.passthru.optional-dependencies.embed;
+
+  pythonImportsCheck = [ "tweetxvault" ];
+
+  meta = {
+    description = "Archive X (Twitter) bookmarks, likes, authored tweets, and official X exports locally";
+    homepage = "https://github.com/lhl/tweetxvault";
+    changelog = "https://github.com/lhl/tweetxvault/blob/main/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    mainProgram = "tweetxvault";
+    maintainers = with lib.maintainers; [ io12 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/lhl/tweetxvault/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
