### PR TITLE
ipxe: add upstream patches for gcc 16

### DIFF
--- a/pkgs/by-name/ip/ipxe/package.nix
+++ b/pkgs/by-name/ip/ipxe/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  fetchpatch,
   nix-update-script,
   buildPackages,
   mtools,
@@ -104,6 +105,31 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-O7jUpnP+wa9zBIEqYa7FQ9Zo1Ii1oVH10nlk+c4iHwg=";
   };
+
+  patches = [
+    # GCC 16 gains stronger analysis for unused variables and emits a warning
+    # (made fatal by -Werror), so the usage of this variable is made
+    # unconditional.
+    (fetchpatch {
+      name = "w89c840-unused-variable.patch";
+      url = "https://github.com/ipxe/ipxe/commit/2d28657ef63217b9a1774605267d84f89d751441.patch";
+      hash = "sha256-p1r1iDOJbss458LlmfpuIkk+6VqthDl0mcK/EfcCqS4=";
+    })
+
+    # GCC 16 adds a warning (made fatal by -Werror) for attributes that do not
+    # apply. Since the regparm attribute only applies for i386, it is dropped
+    # for x86_64.
+    (fetchpatch {
+      name = "x86_64-drop-regparm-attribute.patch";
+      url = "https://github.com/ipxe/ipxe/commit/c18d0a23b634ae001ea877020c0236bfca1468e5.patch";
+      hash = "sha256-spEIdyw30zYiYmhnvYQEVUrr/uMnFqJO/yLWnPb+QMc=";
+    })
+    (fetchpatch {
+      name = "librm-regparm-attribute-only-for-i386.patch";
+      url = "https://github.com/ipxe/ipxe/commit/be35d67a029485f461ce83cbeda15056a52cb069.patch";
+      hash = "sha256-ki6gUPC6njGvu27RsD3f1L0m82NOKj9es0/o0jXCpqk=";
+    })
+  ];
 
   enableParallelBuilding = true;
   strictDeps = true;


### PR DESCRIPTION
gcc 16 emits more warnings than previous versions for unused attributes and variables, which are made into build failures by the use of -Werror in ipxe. these warnings were fixed upstream (on may 1, the day after gcc 16's release!) so we fetch the relevant patches until they make it into a release.

(part of submitting some fixes to prepare for making gcc 16 the default later this release cycle: https://github.com/NixOS/nixpkgs/pull/537781)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
