### PR TITLE
bundlerApp: switch to extendMkDerivation

### DIFF
--- a/pkgs/development/ruby-modules/bundler-app/default.nix
+++ b/pkgs/development/ruby-modules/bundler-app/default.nix
@@ -1,7 +1,7 @@
 {
+  stdenvNoCC,
   lib,
   callPackage,
-  runCommand,
   makeWrapper,
   ruby,
 }@defs:
@@ -11,59 +11,101 @@
 # > nix-shell -p bundler bundix
 # (shell)> bundle lock
 # (shell)> bundix
-# Then use rubyTool in the default.nix:
+# Then use bundlerApp in the default.nix:
 
-# rubyTool { pname = "gemifiedTool"; gemdir = ./.; exes = ["gemified-tool"]; }
-# The 'exes' parameter ensures that a copy of e.g. rake doesn't pollute the system.
-{
-  # use the name of the name in question; its version will be picked up from the gemset
-  pname,
-  # Gemdir is the location of the Gemfile{,.lock} and gemset.nix; usually ./.
-  # This is required unless gemfile, lockfile, and gemset are all provided
-  gemdir ? null,
-  # Exes is the list of executables provided by the gems in the Gemfile
-  exes ? [ ],
-  # Scripts are ruby programs depend on gems in the Gemfile (e.g. scripts/rails)
-  scripts ? [ ],
-  ruby ? defs.ruby,
-  gemfile ? null,
-  lockfile ? null,
-  gemset ? null,
-  preferLocalBuild ? false,
-  allowSubstitutes ? false,
-  installManpages ? true,
-  meta ? { },
-  nativeBuildInputs ? [ ],
-  buildInputs ? [ ],
-  postBuild ? "",
-  gemConfig ? null,
-  passthru ? { },
-}@args:
+# bundlerApp { pname = "gemifiedTool"; gemdir = ./.; exes = ["gemified-tool"]; }
 
-let
-  basicEnv =
-    (callPackage ../bundled-common {
-      inherit ruby;
-    })
-      args;
-
-  cmdArgs =
-    removeAttrs args [
-      "postBuild"
-      "gemConfig"
-      "passthru"
-      "gemset"
-      "gemdir"
-    ]
-    // {
+lib.extendMkDerivation {
+  constructDrv = stdenvNoCC.mkDerivation;
+  excludeDrvArgNames = [
+    # Special arguments
+    "exes"
+    "installManpages"
+    "ruby"
+    "scripts"
+    # Arguments which are only passed to bundled-common
+    "gemConfig"
+    "gemdir"
+    "gemfile"
+    "gemset"
+    "lockfile"
+    "postBuild"
+  ];
+  extendDrvArgs =
+    finalAttrs:
+    {
+      # use the name of the gem in question; its version will be picked up from the gemset
+      pname,
+      # Gemdir is the location of the Gemfile{,.lock} and gemset.nix; usually ./.
+      # This is required unless gemfile, lockfile, and gemset are all provided
+      gemdir ? null,
+      # Exes is the list of executables provided by the gems in the Gemfile. This ensures that a copy of rake,
+      # for example, doesn't pollute the system.
+      exes ? [ ],
+      # Scripts are ruby programs which depend on gems in the Gemfile (e.g. scripts/rails)
+      scripts ? [ ],
+      ruby ? defs.ruby,
+      gemfile ? null,
+      lockfile ? null,
+      gemset ? null,
+      preferLocalBuild ? false,
+      allowSubstitutes ? false,
+      installManpages ? true,
+      meta ? { },
+      nativeBuildInputs ? [ ],
+      buildInputs ? [ ],
+      gemConfig ? null,
+      passthru ? { },
+      ...
+    }@args:
+    let
+      basicEnv = (callPackage ../bundled-common { inherit ruby; }) args;
+    in
+    {
       __structuredAttrs = true;
-
       inherit preferLocalBuild allowSubstitutes; # pass the defaults
-      inherit (basicEnv) version pname;
+      inherit pname;
+      inherit (basicEnv) version;
 
-      nativeBuildInputs = nativeBuildInputs ++ lib.optionals (scripts != [ ]) [ makeWrapper ];
-
+      nativeBuildInputs = nativeBuildInputs ++ [ makeWrapper ];
       strictDeps = true;
+
+      dontUnpack = true;
+      installPhase = ''
+        runHook preInstall
+
+        mkdir -p $out/bin
+        ${lib.concatMapStrings (x: ''
+          makeWrapper '${basicEnv}/bin/${x}' $out/bin/${x}
+        '') exes}
+        ${
+          (lib.concatMapStrings (
+            s:
+            "makeWrapper $out/bin/$(basename ${s}) $srcdir/${s} "
+            + "--set BUNDLE_GEMFILE ${basicEnv.confFiles}/Gemfile "
+            + "--unset BUNDLE_PATH "
+            + "--set BUNDLE_FROZEN 1 "
+            + "--set GEM_HOME ${basicEnv}/${ruby.gemPath} "
+            + "--set GEM_PATH ${basicEnv}/${ruby.gemPath} "
+            + "--chdir \"$srcdir\";\n"
+          ) scripts)
+        }
+
+        ${lib.optionalString installManpages ''
+          for section in {1..9}; do
+            mandir="$out/share/man/man$section"
+
+            # See: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/ruby-modules/gem/default.nix#L184-L200
+            # See: https://github.com/rubygems/rubygems/blob/7a7b234721c375874b7e22b1c5b14925b943f04e/bundler/lib/bundler.rb#L285-L291
+            find -L ${basicEnv}/${ruby.gemPath}/${
+              lib.optionalString (basicEnv.gemType == "git" || basicEnv.gemType == "url") "bundler/"
+            }gems/${basicEnv.name} \( -wholename "*/man/*.$section" -o -wholename "*/man/man$section/*.$section" \) -print -execdir mkdir -p $mandir \; -execdir cp '{}' $mandir \;
+          done
+          compressManPages "''${!outputMan}"
+        ''}
+
+        runHook postInstall
+      '';
 
       meta = {
         mainProgram = pname;
@@ -78,33 +120,4 @@ let
         }
         // passthru;
     };
-in
-runCommand basicEnv.name cmdArgs ''
-  mkdir -p $out/bin
-  ${(lib.concatMapStrings (x: "ln -s '${basicEnv}/bin/${x}' $out/bin/${x};\n") exes)}
-  ${
-    (lib.concatMapStrings (
-      s:
-      "makeWrapper $out/bin/$(basename ${s}) $srcdir/${s} "
-      + "--set BUNDLE_GEMFILE ${basicEnv.confFiles}/Gemfile "
-      + "--unset BUNDLE_PATH "
-      + "--set BUNDLE_FROZEN 1 "
-      + "--set GEM_HOME ${basicEnv}/${ruby.gemPath} "
-      + "--set GEM_PATH ${basicEnv}/${ruby.gemPath} "
-      + "--chdir \"$srcdir\";\n"
-    ) scripts)
-  }
-
-  ${lib.optionalString installManpages ''
-    for section in {1..9}; do
-      mandir="$out/share/man/man$section"
-
-      # See: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/ruby-modules/gem/default.nix#L184-L200
-      # See: https://github.com/rubygems/rubygems/blob/7a7b234721c375874b7e22b1c5b14925b943f04e/bundler/lib/bundler.rb#L285-L291
-      find -L ${basicEnv}/${ruby.gemPath}/${
-        lib.optionalString (basicEnv.gemType == "git" || basicEnv.gemType == "url") "bundler/"
-      }gems/${basicEnv.name} \( -wholename "*/man/*.$section" -o -wholename "*/man/man$section/*.$section" \) -print -execdir mkdir -p $mandir \; -execdir cp '{}' $mandir \;
-    done
-    compressManPages "''${!outputMan}"
-  ''}
-''
+}


### PR DESCRIPTION
This makes usage of the function less "weird":
- usage of `rec` can be replaced with "finalAttrs" lambdas
- many attributes become simpler to use, such as `(import ./gemset.nix).${pname}.version` becoming
  `version`
- installChecks become possible
- `postBuild` hooks can be the more technically-correct `postInstall` instead

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [Package tests] at `passthru.tests`.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
