### PR TITLE
wrangler: reduce output size

### DIFF
--- a/pkgs/by-name/wr/wrangler/package.nix
+++ b/pkgs/by-name/wr/wrangler/package.nix
@@ -93,26 +93,15 @@ stdenv.mkDerivation (finalAttrs: {
       done
     '';
 
-  # I'm sure this is suboptimal but it seems to work. Points:
-  # - when build is run in the original repo, no specific executable seems to be generated; you run the resulting build with pnpm run start
-  # - this means we need to add a dedicated script - perhaps it is possible to create this from the workers-sdk dir, but I don't know how to do this
-  # - the build process builds a version of miniflare which is used by wrangler; for this reason, the miniflare package is copied also
-  # - pnpm stores all content in the top-level node_modules directory, but it is linked to from a node_modules directory inside wrangler
-  # - as they are linked via symlinks, the relative location of them on the filesystem should be maintained
-  # - Update: Now we're copying everything over due to broken symlink errors
   installPhase = ''
     runHook preInstall
     mkdir -p $out/{bin,lib}
-    mv packages/~vitest-pool-workers packages/vitest-pool-workers
-    cp -r {fixtures,packages,node_modules} $out/lib
-    cp -r tools $out/lib/tools
-    rm -rf node_modules/typescript node_modules/eslint node_modules/prettier node_modules/bin node_modules/.bin node_modules/**/bin node_modules/**/.bin
-    rm -rf $out/lib/**/bin $out/lib/**/.bin
-    NODE_PATH_ARRAY=( "$out/lib/node_modules" "$out/lib/packages/wrangler/node_modules" )
+    pnpm config set --location=project injectWorkspacePackages true
+    pnpm --filter=wrangler --prod deploy $out/lib
     makeWrapper ${lib.getExe nodejs} $out/bin/wrangler \
       --inherit-argv0 \
-      --prefix-each NODE_PATH : "$${NODE_PATH_ARRAY[@]}" \
-      --add-flags $out/lib/packages/wrangler/bin/wrangler.js \
+      --set "NODE_PATH" $out/lib/node_modules \
+      --add-flags $out/lib/bin/wrangler.js \
       --set-default SSL_CERT_FILE "${cacert}/etc/ssl/certs/ca-bundle.crt" # https://github.com/cloudflare/workers-sdk/issues/3264
     runHook postInstall
   '';

--- a/pkgs/by-name/wr/wrangler/package.nix
+++ b/pkgs/by-name/wr/wrangler/package.nix
@@ -127,6 +127,7 @@ stdenv.mkDerivation (finalAttrs: {
       dezren39
       ryand56
       ezrizhu
+      yuannan
     ];
     mainProgram = "wrangler";
     # Tunneling and other parts of wrangler, which require workerd won't run on


### PR DESCRIPTION
### Minimisation of Wrangler Output Size

The output size of `wrangler` is excessive as the entire `node_modules` directory is copied into the output, alongside fixtures etc.

Instead use `pnpm deploy` to limit the dependencies (direct and transitive) installed into `node_modules` to only those required for `wrangler` at production time deployment.

#### Comparison
Comparsion with nixpkgs version: 26.11.20260705.d407951:

- Before, du -hs /nix/store/20y9rbh92ix4zx0dxqirask23dv3r2xd-wrangler-4.93.0
  2.2G

- After, du -hs /nix/store/hspwm4nlr0y6zksylql1s3i3ngvsc272-wrangler-4.93.0
  357M

#### Testing 
Due to the large amount of features that `wrangler` contains, I am unable to rigorously test all features of the CLI. 

- Running the `wrangler` binary works, with flags `-v` and `-h`.
- `wrangler docs` works.
- `wrangler complete bash` works.
- `wrangler login` works.
- `wrangler whoami` works.
- `wrangler pages deploy` works, with a real deployment.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
