### PR TITLE
nixos/eval-config: remove deprecated parameters

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -49,6 +49,8 @@
 
 - Support for the legacy U‐Boot image format has been removed from the initrd generators, as it is deprecated upstream and no longer used by any platform in Nixpkgs.
 
+- The `extraArgs` and `check` arguments to `nixos/lib/eval-config.nix` (and therefore to `lib.nixosSystem`) have been removed after being deprecated with a warning since 2021. Passing them is now an evaluation error. Instead of `extraArgs`, set `config._module.args`; instead of `check = false`, set `config._module.check = false`. The `extraArgs` attribute on the resulting configuration has been removed as well.
+
 - Rustical migrates from `settings.http.host` and `settings.http.port` to `settings.http.bind` to support UNIX domain sockets as well as TCP sockets in one setting.
 
 - A number of options for `services.llama-cpp` have been removed in favor of the structured [](#opt-services.llama-cpp.settings) option, attributes from which are used as arguments to `llama-server` executable, you can see all available options by running `llama-server --help`. Configuring model presets using Nix attribute set via `services.llama-cpp.modelsPreset` is no longer supported, please use `services.llama-cpp.settings.models-preset` with a path to an INI file containing desired options.

--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -21,20 +21,16 @@ evalConfigArgs@{
   #     of inheritParentConfig.
   baseModules ? import ../modules/module-list.nix,
   # !!! See comment about args in lib/modules.nix
-  extraArgs ? { },
-  # !!! See comment about args in lib/modules.nix
   specialArgs ? { },
   modules,
   modulesLocation ? (builtins.unsafeGetAttrPos "modules" evalConfigArgs).file or null,
-  # !!! See comment about check in lib/modules.nix
-  check ? true,
   prefix ? [ ],
   lib ? import ../../lib,
   extraModules ? [ ],
 }:
 
 let
-  inherit (lib) optional;
+  inherit (lib) optional warn;
 
   evalModulesMinimal =
     (import ./default.nix {
@@ -62,15 +58,8 @@ let
   };
 
   withWarnings =
-    x:
-    lib.warnIf (evalConfigArgs ? extraArgs)
-      "The extraArgs argument to eval-config.nix is deprecated. Please set config._module.args instead."
-      lib.warnIf
-      (evalConfigArgs ? check)
-      "The check argument to eval-config.nix is deprecated. Please set config._module.check instead."
-      lib.warnIf
-      (specialArgs ? pkgs)
-      ''
+    if specialArgs ? pkgs then
+      warn ''
         You have set specialArgs.pkgs, which means that options like nixpkgs.config
         and nixpkgs.overlays will be ignored. If you wish to reuse an already created
         pkgs, which you know is configured correctly for this NixOS configuration,
@@ -78,31 +67,16 @@ let
         `(modulesPath + "/misc/nixpkgs/read-only.nix"), and set `{ nixpkgs.pkgs = <your pkgs>; }`.
         This properly disables the ignored options to prevent future surprises.
       ''
-      x;
+    else
+      x: x;
 
-  legacyModules =
-    lib.optional (evalConfigArgs ? extraArgs) {
-      config = {
-        _module.args = extraArgs;
-      };
-    }
-    ++ lib.optional (evalConfigArgs ? check) {
-      config = {
-        _module.check = lib.mkDefault check;
-      };
-    };
-
-  allUserModules =
-    let
-      # Add the invoking file (or specified modulesLocation) as error message location
-      # for modules that don't have their own locations; presumably inline modules.
-      locatedModules =
-        if modulesLocation == null then
-          modules
-        else
-          map (lib.setDefaultModuleLocation modulesLocation) modules;
-    in
-    locatedModules ++ legacyModules;
+  userModules =
+    # Add the invoking file (or specified modulesLocation) as error message location
+    # for modules that don't have their own locations; presumably inline modules.
+    if modulesLocation == null then
+      modules
+    else
+      map (lib.setDefaultModuleLocation modulesLocation) modules;
 
   noUserModules = evalModulesMinimal {
     inherit prefix specialArgs;
@@ -129,13 +103,12 @@ let
     };
   };
 
-  nixosWithUserModules = noUserModules.extendModules { modules = allUserModules; };
+  nixosWithUserModules = noUserModules.extendModules { modules = userModules; };
 
   withExtraAttrs =
     configuration:
     configuration
     // {
-      inherit extraArgs;
       inherit (configuration._module.args) pkgs;
       inherit lib;
       extendModules = args: withExtraAttrs (configuration.extendModules args);


### PR DESCRIPTION
These have been deprecated since 78ada833615d - I think we can finally get rid of them. I would normally throw on something like this, but given that it's been four years, I think removal is fine.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
