### PR TITLE
antec-flux-pro-display: init at 1.2

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -30,6 +30,8 @@
 
 - [tap](https://github.com/bluesky-social/indigo/tree/main/cmd/tap), an ATProtocol firehose synchronisation utility. Available as [services.tap](#opt-services.tap.enable).
 
+- [antec-flux-pro-display](https://github.com/Reikooters/antec-flux-pro-display) a service to enable support for the Antec Flux Pro Case temperature display. Available as [hardware.antec-flux-pro-display.enable](#opt-hardware.antec-flux-pro-display.enable)
+
 - [Nezha](https://github.com/nezhahq/nezha), a self-hosted, lightweight server and website monitoring and O&M tool. Available as [services.nezha](#opt-services.nezha.enable).
 
 - [Watt](https://github.com/NotAShelf/watt), a CPU frequency and power management daemon for Linux. Available as [services.watt](#opt-services.watt.enable).

--- a/nixos/modules/hardware/antec-flux-pro-display.nix
+++ b/nixos/modules/hardware/antec-flux-pro-display.nix
@@ -1,0 +1,78 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib.modules) mkIf;
+  inherit (lib.meta) getExe;
+  inherit (lib.types) int str submodule;
+  inherit (lib.options) mkEnableOption mkOption mkPackageOption;
+  toConf = lib.generators.toKeyValue { };
+
+  cfg = config.hardware.antec-flux-pro-display;
+in
+{
+  meta.maintainers = [ lib.maintainers.kruziikrel13 ];
+
+  options.hardware.antec-flux-pro-display = {
+    enable = mkEnableOption "support for Antec Flux Pro GPU and CPU Temperature Sensor.";
+    package = mkPackageOption pkgs "antec-flux-pro-display";
+    settings = mkOption {
+      description = "Settings written to /etc/antec-flux-pro-display/config.conf";
+      type = submodule {
+        options = {
+          cpu_device = mkOption {
+            type = str;
+            description = "CPU temperature device name.";
+            example = "k10temp";
+          };
+          cpu_temp_type = mkOption {
+            type = str;
+            description = "CPU temperature sensor label.";
+            example = "tctl";
+          };
+          gpu_device = mkOption {
+            type = str;
+            description = "GPU temperature device name.";
+            example = "amdgpu";
+          };
+          gpu_temp_type = mkOption {
+            type = str;
+            description = "GPU temperature sensor label.";
+            example = "edge";
+          };
+          update_interval = mkOption {
+            type = int;
+            description = "Update interval in milliseconds.";
+            default = 1000;
+          };
+        };
+      };
+      default = { };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.udev.packages = [ cfg.package ];
+    environment.etc."antec-flux-pro-display/config.conf".text = toConf cfg.settings;
+
+    systemd.services.antec-flux-pro-display = {
+      description = "Antec Flux Pro Display Service";
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = getExe cfg.package;
+        Restart = "always";
+        RestartSec = 5;
+        ProtectSystem = "strict";
+        ProtectHome = "true";
+        PrivateTmp = "true";
+        NoNewPrivileges = "true";
+      };
+      restartTriggers = [ config.environment."antec-flux-pro-display/config.conf".source ];
+      wantedBy = [ "multi-user.target" ];
+      after = [ "systemd-udevd.service" ];
+    };
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -49,6 +49,7 @@
   ./config/xdg/terminal-exec.nix
   ./config/zram.nix
   ./hardware/acpilight.nix
+  ./hardware/antec-flux-pro-display.nix
   ./hardware/all-firmware.nix
   ./hardware/all-hardware.nix
   ./hardware/apple-touchbar.nix

--- a/pkgs/by-name/an/antec-flux-pro-display/package.nix
+++ b/pkgs/by-name/an/antec-flux-pro-display/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  lm_sensors,
+  udevCheckHook,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "antec-flux-pro-display";
+  version = "1.2";
+
+  src = fetchFromGitHub {
+    owner = "Reikooters";
+    repo = "antec-flux-pro-display";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-trRSo1SBR2hGXyaDmIz2Ul2JuASzQkq16sQ78Y9kfg8=";
+  };
+  cargoHash = "sha256-Jl06uXEkkd4z7t8VVf1knr33c8MDiMD9nj1X3XPbEh4=";
+
+  buildInputs = [ lm_sensors ];
+
+  nativeBuildInputs = [ udevCheckHook ];
+
+  postInstall = ''
+    mkdir -p $out/etc/udev/rules.d
+    cp ${finalAttrs.src}/sample/udev/*.rules $out/etc/udev/rules.d
+
+    # Remove plugdev group in favor of uaccess tag
+    sed -i 's/, GROUP="plugdev"//' $out/etc/udev/rules.d/*.rules
+  '';
+
+  meta = {
+    homepage = "https://github.com/Reikooters/antec-flux-pro-display";
+    description = "Antec Flux Pro Hardware Display Service";
+    mainProgram = "antec-flux-pro-display";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.kruziikrel13 ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
