### PR TITLE
proton-pass-cli: fix updateScript path

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13866,6 +13866,12 @@
     githubId = 12160;
     name = "Kirill Radzikhovskyy";
   };
+  kirksw = {
+    email = "kirk@cntd.io";
+    github = "kirksw";
+    githubId = 24637669;
+    name = "Kirk Sweeney";
+  };
   kiskae = {
     github = "Kiskae";
     githubId = 546681;

--- a/pkgs/by-name/pr/proton-pass-cli/package.nix
+++ b/pkgs/by-name/pr/proton-pass-cli/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   makeWrapper,
+  writeShellScript,
   jq,
   curl,
   testers,
@@ -61,7 +62,11 @@ stdenv.mkDerivation (finalAttrs: {
       package = finalAttrs.finalPackage;
       command = "pass-cli --version";
     };
-    updateScript = ./update.sh;
+    updateScript = writeShellScript "update-version" ''
+      set -euo pipefail
+      ${lib.getExe curl} -fsSL -o pkgs/by-name/pr/proton-pass-cli/versions.json \
+        https://proton.me/download/pass-cli/versions.json
+    '';
   };
 
   meta = {

--- a/pkgs/by-name/pr/proton-pass-cli/package.nix
+++ b/pkgs/by-name/pr/proton-pass-cli/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeWrapper,
+  jq,
+  curl,
+  testers,
+}:
+
+let
+  versions = lib.importJSON ./versions.json;
+  arch =
+    if stdenv.hostPlatform.isx86_64 then
+      "x86_64"
+    else if stdenv.hostPlatform.isAarch64 then
+      "aarch64"
+    else
+      throw "Unsupported architecture";
+
+  os =
+    if stdenv.hostPlatform.isLinux then
+      "linux"
+    else if stdenv.hostPlatform.isDarwin then
+      "macos"
+    else
+      throw "Unsupported OS";
+  inherit (versions.passCliVersions.urls.${os}.${arch}) url hash;
+  inherit (versions.passCliVersions) version;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "proton-pass-cli";
+  inherit version;
+
+  # run ./update
+  src = fetchurl {
+    inherit url;
+    sha256 = hash;
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontUnpack = true;
+  dontBuild = true;
+  dontConfigure = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp $src $out/bin/pass-cli
+    chmod +x $out/bin/pass-cli
+
+    # add dependencies
+    wrapProgram $out/bin/pass-cli \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          jq
+          curl
+        ]
+      }
+  '';
+
+  passthru = {
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      command = "pass-cli --version";
+    };
+    updateScript = ./update.sh;
+  };
+
+  meta = {
+    description = "Command-line interface for Proton Pass";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.kirksw ];
+    mainProgram = "pass-cli";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/pr/proton-pass-cli/package.nix
+++ b/pkgs/by-name/pr/proton-pass-cli/package.nix
@@ -43,11 +43,9 @@ stdenv.mkDerivation (finalAttrs: {
   dontConfigure = true;
 
   installPhase = ''
-    mkdir -p $out/bin
-    cp $src $out/bin/pass-cli
-    chmod +x $out/bin/pass-cli
+    runHook preInstall
 
-    # add dependencies
+    install -Dm755 $src $out/bin/pass-cli
     wrapProgram $out/bin/pass-cli \
       --prefix PATH : ${
         lib.makeBinPath [
@@ -55,6 +53,8 @@ stdenv.mkDerivation (finalAttrs: {
           curl
         ]
       }
+
+    runHook postInstall
   '';
 
   passthru = {

--- a/pkgs/by-name/pr/proton-pass-cli/package.nix
+++ b/pkgs/by-name/pr/proton-pass-cli/package.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
     };
     updateScript = writeShellScript "update-version" ''
       set -euo pipefail
-      ${lib.getExe curl} -fsSL -o pkgs/by-name/pr/proton-pass-cli/versions.json \
+      ${lib.getExe curl} -fsSL -o ${./versions.json} \
         https://proton.me/download/pass-cli/versions.json
     '';
   };

--- a/pkgs/by-name/pr/proton-pass-cli/update.sh
+++ b/pkgs/by-name/pr/proton-pass-cli/update.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl
-# shellcheck shell=bash
-
-set -e
-
-curl https://proton.me/download/pass-cli/versions.json >versions.json

--- a/pkgs/by-name/pr/proton-pass-cli/update.sh
+++ b/pkgs/by-name/pr/proton-pass-cli/update.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl
+# shellcheck shell=bash
+
+set -e
+
+curl https://proton.me/download/pass-cli/versions.json >versions.json

--- a/pkgs/by-name/pr/proton-pass-cli/versions.json
+++ b/pkgs/by-name/pr/proton-pass-cli/versions.json
@@ -1,0 +1,34 @@
+{
+  "formatVersion": 1,
+  "passCliVersions": {
+    "version": "1.3.2",
+    "urls": {
+      "macos": {
+        "aarch64": {
+          "url": "https://proton.me/download/pass-cli/1.3.2/pass-cli-macos-aarch64",
+          "hash": "07e866c5a80fe4bb3e25cf0364df18f5fbddad3abe1e4308094ccc56c77c694e"
+        },
+        "x86_64": {
+          "url": "https://proton.me/download/pass-cli/1.3.2/pass-cli-macos-x86_64",
+          "hash": "5669132f21cd67ca7cc20bf31ce62242c6c34e3ccab23c860d285c4199401fb0"
+        }
+      },
+      "linux": {
+        "aarch64": {
+          "url": "https://proton.me/download/pass-cli/1.3.2/pass-cli-linux-aarch64",
+          "hash": "c399b06d8420a80534ed3e3ebd469891c569f17b4c14dca71935778c9423005c"
+        },
+        "x86_64": {
+          "url": "https://proton.me/download/pass-cli/1.3.2/pass-cli-linux-x86_64",
+          "hash": "5fb14ad6dd3e4ae046812b01ba16140a4711f0bb4240c8dba65a390752d2ba1d"
+        }
+      },
+      "windows": {
+        "x86_64": {
+          "url": "https://proton.me/download/pass-cli/1.3.2/pass-cli-windows-x86_64.zip",
+          "hash": "0b4d84f601d3c0ce20b1e4e5a4703c45a090cbb704b58d6c4d3309248109e977"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- make `proton-pass-cli` updateScript write to the checked-in `versions.json` via an absolute store path

## Testing
- nix build .#proton-pass-cli --no-link