### PR TITLE
1password-cli: 2.32.0 -> 2.36.0-beta.03

### DIFF
--- a/pkgs/by-name/_1/_1password-cli/package.nix
+++ b/pkgs/by-name/_1/_1password-cli/package.nix
@@ -24,13 +24,13 @@ let
     if extension == "zip" then fetchzip args else fetchurl args;
 
   pname = "1password-cli";
-  version = "2.32.0";
+  version = "2.36.0-beta.03";
   sources = rec {
-    aarch64-linux = fetch "linux_arm64" "sha256-7t8Ar6vF8lU3fPy5Gw9jtUkcx9gYKg6AFDB8/3QBvbk=" "zip";
-    i686-linux = fetch "linux_386" "sha256-+KSi87muDH/A8LNH7iDPQC/CnZhTpvFNSw1cuewqaXI=" "zip";
-    x86_64-linux = fetch "linux_amd64" "sha256-4I7lSey6I4mQ7dDtuOASnZzAItFYkIDZ8UMsqb0q5tE=" "zip";
+    aarch64-linux = fetch "linux_arm64" "sha256-3Oa1bbzwDI9JJySy9cjGcGbpdVybK0Ws7OOt8Q2RDnw=" "zip";
+    i686-linux = fetch "linux_386" "sha256-VLsczxeThEHGc0dX/aK/QTh4uj5mxOpvBoGHUlHwUxE=" "zip";
+    x86_64-linux = fetch "linux_amd64" "sha256-HqPLLkU75gFUu1kVSmijXTiEpDQ8s5kmpLwhZLsIetI=" "zip";
     aarch64-darwin =
-      fetch "apple_universal" "sha256-PVSI/iYsjphNqs0DGQlzRhmvnwj4RHcNODE2nbQ8CO0="
+      fetch "apple_universal" "sha256-XyUgZ2MMrG2FvqBTKVg1DGgWbHJoNnjIR57brqhhBDE="
         "pkg";
     x86_64-darwin = aarch64-darwin;
   };


### PR DESCRIPTION
## Summary
- update `1password-cli` to `2.36.0-beta.03`
- refresh linux and darwin source hashes

## Testing
- NIXPKGS_ALLOW_UNFREE=1 nix build .#_1password-cli --no-link --impure