### PR TITLE
fedpkg: init at 1.47 (also python3Packages.{koji,bodhi-client,rpkg})

### DIFF
--- a/pkgs/by-name/fe/fedpkg/package.nix
+++ b/pkgs/by-name/fe/fedpkg/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  python3Packages,
+  fetchgit,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "fedpkg";
+  version = "1.47";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchgit {
+    url = "https://forge.fedoraproject.org/packaging/fedpkg";
+    tag = finalAttrs.version;
+    hash = "sha256-8vWiBm7Bp3pOv1tqhM9TKi0VubSaUMpUe5LUT1FZVRk=";
+  };
+
+  # fedpkg defaults to reading its config from /etc/rpkg, point it at the
+  # copy installed into the store so the CLI works without extra setup.
+  postPatch = ''
+    substituteInPlace fedpkg/__main__.py \
+      --replace-fail "'/etc/rpkg/%s.conf'" "'$out/etc/rpkg/%s.conf'"
+  '';
+
+  build-system = [
+    python3Packages.hatchling
+  ];
+
+  dependencies = with python3Packages; [
+    argcomplete
+    bodhi-client
+    distro
+    gitpython
+    openidc-client
+    packaging
+    python-bugzilla
+    requests
+    rpkg
+  ];
+
+  pythonImportsCheck = [
+    "fedpkg"
+  ];
+
+  meta = {
+    description = "Fedora plugin to rpkg to manage package sources in a git repository";
+    homepage = "https://forge.fedoraproject.org/packaging/fedpkg";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ katexochen ];
+    mainProgram = "fedpkg";
+  };
+})

--- a/pkgs/development/python-modules/bodhi-client/default.nix
+++ b/pkgs/development/python-modules/bodhi-client/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  poetry-core,
+  authlib,
+  click,
+  koji,
+  munch,
+  requests,
+  requests-kerberos,
+}:
+
+buildPythonPackage rec {
+  pname = "bodhi-client";
+  version = "26.4.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "bodhi_client";
+    inherit version;
+    hash = "sha256-PhC+t3P+9cRbi+ROAWlEvUhjenlKJ+yBorYp4Wz1OxE=";
+  };
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    authlib
+    click
+    koji
+    munch
+    requests
+    requests-kerberos
+  ];
+
+  pythonImportsCheck = [ "bodhi.client" ];
+
+  meta = {
+    description = "Command line client for Bodhi, Fedora's update gating system";
+    homepage = "https://github.com/fedora-infra/bodhi";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ katexochen ];
+    mainProgram = "bodhi";
+  };
+}

--- a/pkgs/development/python-modules/koji/default.nix
+++ b/pkgs/development/python-modules/koji/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  defusedxml,
+  python-dateutil,
+  requests,
+  requests-gssapi,
+  six,
+}:
+
+buildPythonPackage rec {
+  pname = "koji";
+  version = "1.36.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-SBVSueyarVXjk8bF+S6DS8Iojh2gHqZ+5IymNGbEBJ4=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    defusedxml
+    python-dateutil
+    requests
+    requests-gssapi
+    six
+  ];
+
+  pythonImportsCheck = [
+    "koji"
+    "koji_cli"
+  ];
+
+  meta = {
+    description = "System for building and tracking RPMs";
+    homepage = "https://pagure.io/koji/";
+    license = with lib.licenses; [
+      lgpl2Plus
+      gpl2Plus
+    ];
+    maintainers = with lib.maintainers; [ katexochen ];
+    mainProgram = "koji";
+  };
+}

--- a/pkgs/development/python-modules/rpkg/default.nix
+++ b/pkgs/development/python-modules/rpkg/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  hatchling,
+  argcomplete,
+  cccolutils,
+  gitpython,
+  koji,
+  pycurl,
+  pyyaml,
+  requests,
+  rpm,
+  six,
+}:
+
+buildPythonPackage rec {
+  pname = "rpkg";
+  version = "1.69";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-F+EgJJYeIONhz9dn1UsQPzgAmQTo4dqXzPxFFDXNT8s=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    argcomplete
+    cccolutils
+    gitpython
+    koji
+    pycurl
+    pyyaml
+    requests
+    rpm
+    six
+  ];
+
+  # bin/rpkg is shipped as a plain script.
+  postInstall = ''
+    install -Dm755 bin/rpkg $out/bin/rpkg
+  '';
+
+  pythonImportsCheck = [ "pyrpkg" ];
+
+  meta = {
+    description = "Python library and script for managing RPM package sources in a git repository";
+    homepage = "https://pagure.io/rpkg";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ katexochen ];
+    mainProgram = "rpkg";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17875,6 +17875,8 @@ self: super: with self; {
 
   rpi-lgpio = callPackage ../development/python-modules/rpi-lgpio { };
 
+  rpkg = callPackage ../development/python-modules/rpkg { };
+
   rplcd = callPackage ../development/python-modules/rplcd { };
 
   rply = callPackage ../development/python-modules/rply { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8879,6 +8879,8 @@ self: super: with self; {
 
   knx-frontend = callPackage ../development/python-modules/knx-frontend { };
 
+  koji = callPackage ../development/python-modules/koji { };
+
   kokoro = callPackage ../development/python-modules/kokoro { };
 
   kombu = callPackage ../development/python-modules/kombu { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2551,6 +2551,8 @@ self: super: with self; {
 
   boa-api = callPackage ../development/python-modules/boa-api { };
 
+  bodhi-client = callPackage ../development/python-modules/bodhi-client { };
+
   boilerpy3 = callPackage ../development/python-modules/boilerpy3 { };
 
   bokeh = callPackage ../development/python-modules/bokeh { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
