### PR TITLE
part-db: 2.4.0 -> 2.13.1

### DIFF
--- a/nixos/modules/services/web-apps/part-db.nix
+++ b/nixos/modules/services/web-apps/part-db.nix
@@ -176,18 +176,34 @@ in
           root = "${pkg}/public";
           locations = {
             "/" = {
-              tryFiles = "$uri $uri/ /index.php?$query_string";
+              tryFiles = "$uri $uri/ /index.php$is_args$args";
               index = "index.php";
               extraConfig = ''
+                add_header Content-Security-Policy "default-src 'self'; script-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; sandbox;" always;
+                add_header X-Content-Type-Options "nosniff" always;
                 sendfile off;
               '';
             };
-            "~ \\.php$" = {
+            "= /index.php" = {
               extraConfig = ''
-                include ${config.services.nginx.package}/conf/fastcgi_params ;
-                fastcgi_param SCRIPT_FILENAME $request_filename;
-                fastcgi_param modHeadersAvailable true; #Avoid sending the security headers twice
+                include ${config.services.nginx.package}/conf/fastcgi_params;
+                fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+                fastcgi_param DOCUMENT_ROOT $realpath_root;
+                fastcgi_param modHeadersAvailable true; # Avoid sending the security headers twice
                 fastcgi_pass unix:${config.services.phpfpm.pools.part-db.socket};
+                internal;
+              '';
+            };
+            "~ \\.php$" = {
+              return = "404";
+            };
+            "~* ^/media/.*\\.(php[3-8]?|phar|phtml|pht|phps)$" = {
+              return = "403";
+            };
+            "~* \\.svg$" = {
+              extraConfig = ''
+                add_header Content-Security-Policy "default-src 'self'; script-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-ancestors 'none'; sandbox;" always;
+                add_header X-Content-Type-Options "nosniff" always;
               '';
             };
           };
@@ -239,6 +255,31 @@ in
           argument = "${pkgs.writeText "part-db-env" (
             lib.concatStringsSep "\n" (lib.mapAttrsToList (key: value: "${key}=\"${value}\"") cfg.settings)
           )}";
+        };
+        "/var/lib/part-db/".d = {
+          mode = "0755";
+          user = "part-db";
+          group = "part-db";
+        };
+        "/var/lib/part-db/public/".d = {
+          mode = "0755";
+          user = "part-db";
+          group = "part-db";
+        };
+        "/var/lib/part-db/public/media/".d = {
+          mode = "0755";
+          user = "part-db";
+          group = "part-db";
+        };
+        "/var/lib/part-db/uploads/".d = {
+          mode = "0750";
+          user = "part-db";
+          group = "part-db";
+        };
+        "/var/lib/part-db/share/".d = {
+          mode = "0750";
+          user = "part-db";
+          group = "part-db";
         };
         "/var/log/part-db/".d = {
           mode = "0750";

--- a/nixos/modules/services/web-apps/part-db.nix
+++ b/nixos/modules/services/web-apps/part-db.nix
@@ -8,6 +8,11 @@ let
   cfg = config.services.part-db;
   pkg = cfg.package;
 
+  envFile = pkgs.writeText "part-db-env" (
+    lib.concatStringsSep "\n" (lib.mapAttrsToList (key: value: "${key}=\"${value}\"") cfg.settings)
+    + "\n"
+  );
+
   inherit (lib)
     mkEnableOption
     mkPackageOption
@@ -59,6 +64,17 @@ in
       default = "localhost";
       description = ''
         The virtualHost at which you wish part-db to be served.
+      '';
+    };
+
+    environmentFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/run/secrets/part-db.env";
+      description = ''
+        Path to a file containing extra Part-DB environment variables in dotenv
+        format. This can be used for secrets such as `APP_SECRET` without
+        putting them in the Nix store.
       '';
     };
 
@@ -213,10 +229,32 @@ in
 
     systemd = {
       services = {
+        part-db-setup = {
+          before = [ "part-db-migrate.service" ];
+          wantedBy = [ "multi-user.target" ];
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+          };
+          restartTriggers = [ envFile ];
+          script = ''
+            install -Dm0600 -o part-db -g part-db ${envFile} /var/lib/part-db/env.local
+          ''
+          + lib.optionalString (cfg.environmentFile != null) ''
+            cat ${lib.escapeShellArg cfg.environmentFile} >> /var/lib/part-db/env.local
+          '';
+        };
+
         part-db-migrate = {
           before = [ "phpfpm-part-db.service" ];
-          after = [ "postgresql.target" ];
-          requires = [ "postgresql.target" ];
+          after = [
+            "postgresql.target"
+            "part-db-setup.service"
+          ];
+          requires = [
+            "postgresql.target"
+            "part-db-setup.service"
+          ];
           wantedBy = [ "multi-user.target" ];
           serviceConfig = {
             Type = "oneshot";
@@ -250,11 +288,6 @@ in
           mode = "0750";
           user = "part-db";
           group = "part-db";
-        };
-        "/var/lib/part-db/env.local"."L+" = {
-          argument = "${pkgs.writeText "part-db-env" (
-            lib.concatStringsSep "\n" (lib.mapAttrsToList (key: value: "${key}=\"${value}\"") cfg.settings)
-          )}";
         };
         "/var/lib/part-db/".d = {
           mode = "0755";

--- a/nixos/tests/web-apps/part-db.nix
+++ b/nixos/tests/web-apps/part-db.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
 {
   name = "part-db";
   meta.maintainers = with lib.maintainers; [ oddlama ];
@@ -15,8 +15,20 @@
     machine.wait_for_unit("part-db-migrate.service")
     machine.wait_for_unit("phpfpm-part-db.service")
     machine.wait_for_unit("nginx.service")
+
+    machine.succeed("test -d /var/lib/part-db/public/media")
+    machine.succeed("test -d /var/lib/part-db/uploads")
+    machine.succeed("test -d /var/lib/part-db/share")
+    machine.succeed("test $(readlink ${pkgs.part-db}/public/media) = /var/lib/part-db/public/media/")
+    machine.succeed("test $(readlink ${pkgs.part-db}/uploads) = /var/lib/part-db/uploads/")
+
     machine.wait_for_open_port(80)
 
     machine.succeed("curl -L --fail http://localhost | grep 'Part-DB'", timeout=10)
+    machine.succeed("echo static > /var/lib/part-db/public/media/static.txt")
+    machine.succeed("curl -I --fail http://localhost/media/static.txt | grep 'Content-Security-Policy'")
+    machine.succeed("curl -I --fail http://localhost/media/static.txt | grep 'X-Content-Type-Options: nosniff'")
+    machine.succeed("echo '<?php echo 1; ?>' > /var/lib/part-db/public/media/shell.phar")
+    machine.succeed("curl -I http://localhost/media/shell.phar | grep 'HTTP/1.1 403 Forbidden'")
   '';
 }

--- a/nixos/tests/web-apps/part-db.nix
+++ b/nixos/tests/web-apps/part-db.nix
@@ -5,7 +5,12 @@
 
   nodes = {
     machine = {
-      services.part-db.enable = true;
+      services.part-db = {
+        enable = true;
+        environmentFile = pkgs.writeText "part-db.env" ''
+          APP_SECRET=0123456789abcdef0123456789abcdef
+        '';
+      };
     };
   };
 
@@ -21,6 +26,8 @@
     machine.succeed("test -d /var/lib/part-db/share")
     machine.succeed("test $(readlink ${pkgs.part-db}/public/media) = /var/lib/part-db/public/media/")
     machine.succeed("test $(readlink ${pkgs.part-db}/uploads) = /var/lib/part-db/uploads/")
+    machine.succeed("grep APP_SECRET=0123456789abcdef0123456789abcdef /var/lib/part-db/env.local")
+    machine.succeed("test $(stat -c %a:%U:%G /var/lib/part-db/env.local) = 600:part-db:part-db")
 
     machine.wait_for_open_port(80)
 

--- a/pkgs/by-name/pa/part-db/package.nix
+++ b/pkgs/by-name/pa/part-db/package.nix
@@ -14,7 +14,7 @@
 }:
 let
   pname = "part-db";
-  version = "2.4.0";
+  version = "2.13.1";
 
   srcWithVendor = php.buildComposerProject2 {
     inherit pname version;
@@ -23,7 +23,7 @@ let
       owner = "Part-DB";
       repo = "Part-DB-server";
       tag = "v${version}";
-      hash = "sha256-z/bvFFzKVMN6lr9RnrBc/hTrZ9a/mjgpkDYslUFHM50=";
+      hash = "sha256-j7Kj03RxbrRoHJ4kFeZo1VmeHT3YucY4Zxog93+5Q38=";
     };
 
     php = php.buildEnv {
@@ -36,7 +36,7 @@ let
       );
     };
 
-    vendorHash = "sha256-gt5HBi+vV5WhaEXNFFIO8xcbX1Z60SICvxXWGNzsn5o=";
+    vendorHash = "sha256-ZYo0gNsR9liMWWjHZGGf/XFNZJBnBrVVLf7WVhN/pY4=";
 
     # Upstream composer.json file is missing the description field
     composerStrictValidation = false;
@@ -65,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   yarnOfflineCache = fetchYarnDeps {
     yarnLock = finalAttrs.src + "/yarn.lock";
-    hash = "sha256-F9kZ8nAIghkg+xUkglvRZXOSadv2lbKTP0gNfLD4LYE=";
+    hash = "sha256-xdRMAOmGQFPuej/8A88edH23jL/3K8igx0BB7Z78sjM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/pa/part-db/package.nix
+++ b/pkgs/by-name/pa/part-db/package.nix
@@ -11,6 +11,8 @@
   envLocalPath ? "/var/lib/part-db/env.local",
   cachePath ? "/var/cache/part-db/",
   logPath ? "/var/log/part-db/",
+  mediaPath ? "/var/lib/part-db/public/media/",
+  uploadsPath ? "/var/lib/part-db/uploads/",
 }:
 let
   pname = "part-db";
@@ -79,10 +81,12 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir $out
     mv * .* $out/
 
-    rm -rf $out/var/{cache,log}
+    rm -rf $out/var/{cache,log} $out/public/media $out/uploads
     ln -s ${envLocalPath} $out/.env.local
     ln -s ${logPath} $out/var/log
     ln -s ${cachePath} $out/var/cache
+    ln -s ${mediaPath} $out/public/media
+    ln -s ${uploadsPath} $out/uploads
   '';
 
   passthru.tests = { inherit (nixosTests) part-db; };


### PR DESCRIPTION
Update Part-DB to 2.13.1 and adjust the NixOS module for writable attachment storage, APP_SECRET handling, and upstream-recommended nginx hardening for served media files.

Changelog: https://github.com/Part-DB/Part-DB-server/releases/tag/v2.13.1

Resolves #537341

Assisted-by: pi coding agent / Mika (OpenAI GPT-5.5)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

