### PR TITLE
ci/treefmt: add `gitMinimal` for `treefmt`

### DIFF
--- a/ci/treefmt.nix
+++ b/ci/treefmt.nix
@@ -4,6 +4,11 @@
   ...
 }:
 {
+  runtimeInputs = [
+    # tree-root uses `git rev-parse --show-toplevel`
+    pkgs.gitMinimal
+  ];
+
   settings = {
     # numtide/treefmt-nix defaults
     excludes = [


### PR DESCRIPTION
In https://github.com/NixOS/nixpkgs/pull/530947 we dropped `tree-root-file` in favour of allowing `treefmt` to detect the `tree-root` via `git rev-parse --show-toplevel`.

Since then, I noticed that r-ryantm started [failing](https://nixpkgs-update-logs.nix-community.org/nixfmt/2026-07-06.log) to run `pkgs.nixfmt.updateScript` because `git` is not on the PATH.

This can be reproduced by attempting to run `treefmt` in a `--pure` shell, or on a system that doesn't have `git` installed.

This PR adds `runtimeInputs = [ gitMinimal ]` to our treefmt config, meaning a `git` executable is always available.

Without this change:
```sh
$ nix-shell --run 'treefmt ci/treefmt.nix' --pure
INFO config: no tree root specified
INFO config: attempting to resolve tree root using git: git rev-parse --show-toplevel
INFO config: failed to resolve tree root with git: failed to start tree-root-cmd: exec: "git": executable file not found in $PATH
INFO config: attempting to resolve tree root using jujutsu: jj workspace root
INFO config: failed to resolve tree root with jujutsu: failed to start tree-root-cmd: exec: "jj": executable file not found in $PATH
INFO config: setting tree root to the directory containing the config file: /nix/store/hnihgx2192nm3p391ybdy25vjkav6kar-treefmt.toml
INFO config: tree root: /nix/store
Error: failed to create walker: path ci/treefmt.nix not inside the tree root /nix/store (relative path: ../../home/matt/nixpkgs/fmt/ci/treefmt.nix)
```

With this change:
```sh
$ nix-shell --run 'treefmt ci/treefmt.nix' --pure
INFO config: no tree root specified
INFO config: attempting to resolve tree root using git: git rev-parse --show-toplevel
INFO config: tree root: /home/matt/nixpkgs/fmt
INFO formatter | nixf-diagnose: 1 file(s) processed in 3.901986ms
INFO formatter | keep-sorted: 1 file(s) processed in 2.401761ms
INFO formatter | nixfmt: 1 file(s) processed in 10.13108ms
INFO formatter | editorconfig-checker[1]: 1 file(s) processed in 3.576479ms
traversed 1 files
emitted 1 files for processing
formatted 1 files (0 changed) in 37ms
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
