### PR TITLE
rauthy: 0.35.2 -> 0.36.0

### DIFF
--- a/pkgs/by-name/ra/rauthy/package.nix
+++ b/pkgs/by-name/ra/rauthy/package.nix
@@ -8,20 +8,20 @@
   nix-update-script,
   perl,
   wasm-pack,
-  wasm-bindgen-cli_0_2_121,
+  wasm-bindgen-cli_0_2_126,
   binaryen,
   lld,
   rust-jemalloc-sys-unprefixed,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rauthy";
-  version = "0.35.2";
+  version = "0.36.0";
 
   src = fetchFromGitHub {
     owner = "sebadob";
     repo = "rauthy";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-onwNtlz2FP01aYr/T3Y3KK3CJHKsBBOF6vCfWKrdyRE=";
+    hash = "sha256-ctc80gG36O4viHrFcG3RSrr8wnwD3YZD0eyauS9JCPA=";
   };
 
   nativeBuildInputs = [
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     nodejs
     npmHooks.npmConfigHook
     perl
-    wasm-bindgen-cli_0_2_121
+    wasm-bindgen-cli_0_2_126
     wasm-pack
   ];
 
@@ -40,10 +40,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   npmDeps = fetchNpmDeps {
     src = "${finalAttrs.src}/frontend";
-    hash = "sha256-w3x+dUfmJ4H82wX87C3UHEJ5Ls4v6lsn7kKOxvRJY8g=";
+    hash = "sha256-3bLzlGbC1i8TOYNi/SAVqIb8bsK0IhDTGr65rVWU5XY=";
   };
 
-  cargoHash = "sha256-oUc8aMsI3i0WM5/tP/ro93GgkjaDjBdYcgpxiKDvtJ4=";
+  cargoHash = "sha256-lkD2Yd15VuQT+OmMttea0KBWOnhwvRBN6aS1DVR0Heg=";
 
   preBuild = ''
     pushd src/wasm-modules


### PR DESCRIPTION
**Changelog:** https://github.com/sebadob/rauthy/compare/v0.35.2...v0.36.0

Notable upstream changes:
- **Breaking (config):** The config parser now validates for unknown/leftover keys and panics on mismatch. Invalid config entries will now be caught rather than silently ignored.
- **Security fix:** Session state mixing during Webauthn Ceremony Finish was possible when knowing another user ID.
- **New features:** Delegated Group Admins (`rauthy_admin:<group>` roles), RFC 8707 Resource Indicators, secrets-from-file option, custom claims on `client_credentials` tokens, `validate-config` CLI subcommand.
- **Dependency bumps:** hiqlite 0.13→0.14, tikv-jemallocator 0.6→0.7, wasm-bindgen 0.2.121→0.2.126, and several others.
- **wasm-bindgen-cli:** Updated to 0.2.126 to match upstream Cargo.lock.

**Verification:**
- Built successfully on `x86_64-linux`
- `./result/bin/rauthy --help` and `./result/bin/rauthy serve --help` both work
- `nixpkgs-review-gha` run: https://github.com/caniko/nixpkgs-review-gha/actions/runs/28854084702

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^
-->

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
