### PR TITLE
xfstests: fix updateScript for git.kernel.org

### DIFF
--- a/pkgs/by-name/xf/xfstests/package.nix
+++ b/pkgs/by-name/xf/xfstests/package.nix
@@ -29,8 +29,10 @@
   util-linux,
   which,
   writeScript,
+  writeShellScript,
   xfsprogs,
-  nix-update-script,
+  gitMinimal,
+  nix-update,
   runtimeShell,
 }:
 
@@ -157,7 +159,24 @@ stdenv.mkDerivation (finalAttrs: {
     }:$PATH
     exec ./check "$@"
   '';
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = writeShellScript "update-xfstests" ''
+    set -euo pipefail
+    export PATH=${
+      lib.makeBinPath [
+        coreutils
+        gitMinimal
+        gawk
+        nix-update
+      ]
+    }:$PATH
+    VERSION="$(git ls-remote --tags --refs https://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git \
+      | awk '{ print $2 }' \
+      | grep '^refs/tags/v' \
+      | sed 's|^refs/tags/v||' \
+      | sort -V \
+      | tail -n1)"
+    exec nix-update --version "$VERSION" xfstests "$@"
+  '';
 
   meta = {
     description = "Torture test suite for filesystems";


### PR DESCRIPTION
Replace `nix-update-script` with a custom `updateScript` that uses `git ls-remote --tags --refs` to detect the latest version from `git.kernel.org`, since `nix-update` cannot auto-detect versions from this host (it only supports GitHub/GitLab/PyPI/npm etc.).

The r-ryantm bot has been failing on this package because of this limitation:
- https://r.ryantm.com/log/xfstests/2026-06-23.log
- https://r.ryantm.com/log/xfstests/2026-07-02.log

The custom script follows the same pattern used by the [mailcap](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/ma/mailcap/package.nix) package for its pagure.io hosting.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md