### PR TITLE
kdePackages.plasma-login-manager: fix KCM

### DIFF
--- a/pkgs/kde/plasma/plasma-login-manager/config-path.patch
+++ b/pkgs/kde/plasma/plasma-login-manager/config-path.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 1a1d9a3..fb2c9af 100644
+index be80162e..d6bd3cde 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -82,8 +82,8 @@ set(RUNTIME_DIR                 "${RUNTIME_DIR_DEFAULT}"
+@@ -84,8 +84,8 @@ set(RUNTIME_DIR                 "${RUNTIME_DIR_DEFAULT}"
  set(SESSION_COMMAND             "${DATA_INSTALL_DIR}/scripts/Xsession"              CACHE PATH      "Script to execute when starting the X11 desktop session")
  set(WAYLAND_SESSION_COMMAND     "${DATA_INSTALL_DIR}/scripts/wayland-session"       CACHE PATH      "Script to execute when starting the Wayland desktop session")
  
@@ -13,3 +13,17 @@ index 1a1d9a3..fb2c9af 100644
  set(SYSTEM_CONFIG_DIR           "${CMAKE_INSTALL_PREFIX}/lib/plasmalogin/plasmalogin.conf.d"      CACHE PATH      "Path of the system plasmalogin config directory")
  set(LOG_FILE                    "${CMAKE_INSTALL_FULL_LOCALSTATEDIR}/log/plasmalogin.log"  CACHE PATH      "Path of the plasmalogin log file")
  set(DBUS_CONFIG_FILENAME        "org.freedesktop.DisplayManager.conf"               CACHE STRING    "Name of the plasmalogin config file")
+diff --git a/src/frontend/settings/CMakeLists.txt b/src/frontend/settings/CMakeLists.txt
+index d77b6fdd..916ee28d 100644
+--- a/src/frontend/settings/CMakeLists.txt
++++ b/src/frontend/settings/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ set(PLASMALOGIN_SYSTEM_CONFIG_FILE  "${CMAKE_INSTALL_PREFIX}/lib/plasmalogin/defaults.conf"      CACHE PATH  "Path of the system plasma-login config file")
+ set(PLASMALOGIN_SYSTEM_CONFIG_DIR   "${CMAKE_INSTALL_PREFIX}/lib/plasmalogin/plasmalogin.conf.d" CACHE PATH  "Path of the system plasma-login config directory")
+-set(PLASMALOGIN_CONFIG_FILE         "${CMAKE_INSTALL_FULL_SYSCONFDIR}/plasmalogin.conf"          CACHE PATH  "Path of the plasma-login config file")
+-set(PLASMALOGIN_CONFIG_DIR          "${CMAKE_INSTALL_FULL_SYSCONFDIR}/plasmalogin.conf.d"        CACHE PATH  "Path of the plasma-login config directory")
++set(PLASMALOGIN_CONFIG_FILE         "/etc/plasmalogin.conf"          CACHE PATH  "Path of the plasma-login config file")
++set(PLASMALOGIN_CONFIG_DIR          "/etc/plasmalogin.conf.d"        CACHE PATH  "Path of the plasma-login config directory")
+ 
+ configure_file(config.h.in config.h IMMEDIATE @ONLY)
+ 


### PR DESCRIPTION
Somehow it grew a second define and I missed it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
