### PR TITLE
pnpm_8: drop

### DIFF
--- a/doc/languages-frameworks/javascript.section.md
+++ b/doc/languages-frameworks/javascript.section.md
@@ -305,7 +305,7 @@ This package puts the corepack wrappers for pnpm and yarn in your PATH, and they
 
 ### pnpm {#javascript-pnpm}
 
-pnpm is available as the top-level package `pnpm`. Additionally, there are variants pinned to certain major versions, like `pnpm_8`, `pnpm_9`, `pnpm_10`, `pnpm_10_29_2` and `pnpm_11`, which support different sets of lock file versions.
+pnpm is available as the top-level package `pnpm`. Additionally, there are variants pinned to certain major versions, like `pnpm_9`, `pnpm_10`, `pnpm_10_29_2` and `pnpm_11`, which support different sets of lock file versions.
 
 When packaging an application that includes a `pnpm-lock.yaml`, you need to fetch the pnpm store for that project using a fixed-output-derivation. The function `fetchPnpmDeps` can create this pnpm store derivation. In conjunction, the setup hook `pnpmConfigHook` will prepare the build environment to install the pre-fetched dependencies store. Here is an example for a package that contains `package.json` and a `pnpm-lock.yaml` files using the fetcher and setup hook above:
 

--- a/pkgs/by-name/re/remark42/package.nix
+++ b/pkgs/by-name/re/remark42/package.nix
@@ -3,14 +3,15 @@
   stdenv,
   fetchFromGitHub,
   buildGoModule,
-  nodejs_22,
-  pnpm_8,
+  nodejs-slim_22,
+  pnpm_9,
   fetchPnpmDeps,
   pnpmConfigHook,
   testers,
 }:
 
 let
+  pnpm = pnpm_9.override { nodejs-slim = nodejs-slim_22; };
   version = "1.15.0";
 
   src = fetchFromGitHub {
@@ -26,34 +27,49 @@ let
 
     strictDeps = true;
 
-    pnpmRoot = "frontend";
+    sourceRoot = "${src.name}/frontend";
 
     nativeBuildInputs = [
-      nodejs_22
-      pnpm_8
+      nodejs-slim_22
+      pnpm
       pnpmConfigHook
     ];
 
     pnpmDeps = fetchPnpmDeps {
-      inherit (finalAttrs) pname version src;
-      sourceRoot = "${finalAttrs.src.name}/frontend";
-      pnpm = pnpm_8;
-      fetcherVersion = 3;
-      hash = "sha256-E2tUZXhcufuztXS+Z//uZk9omvaPrevNbGqVd41Lwhw=";
+      inherit (finalAttrs)
+        pname
+        version
+        src
+        sourceRoot
+        postPatch
+        ;
+      inherit pnpm;
+      fetcherVersion = 4;
+      hash = "sha256-wFrMoSeD87H1yfMD0jBcw60DKDeh4yjka5aWyHuQssA=";
     };
+
+    postPatch = ''
+      substituteInPlace "package.json" "apps/remark42/package.json" \
+        --replace-fail "pnpm@8.15.9" "pnpm@${pnpm.version}"
+
+      substituteInPlace "apps/remark42/package.json" \
+        --replace-fail '"pnpm": "8.*"' '"pnpm": "9.*"'
+    '';
 
     buildPhase = ''
       runHook preBuild
-      pushd "$pnpmRoot"
+
       pnpm --filter ./apps/remark42 --fail-if-no-match run build
-      popd
+
       runHook postBuild
     '';
 
     installPhase = ''
       runHook preInstall
+
       mkdir -p $out/web
-      cp -r "$pnpmRoot/apps/remark42/public/." $out/web/
+      cp -r "apps/remark42/public/." $out/web/
+
       runHook postInstall
     '';
   });

--- a/pkgs/development/tools/pnpm/default.nix
+++ b/pkgs/development/tools/pnpm/default.nix
@@ -6,22 +6,6 @@ let
   inherit (lib) mapAttrs' nameValuePair;
 
   variants = {
-    "8" = {
-      version = "8.15.9";
-      hash = "sha256-2qJ6C1QbxjUyP/lsLe2ZVGf/n+bWn/ZwIVWKqa2dzDY=";
-      knownVulnerabilities = [
-        "CVE-2026-48995"
-        "CVE-2026-50014"
-        "CVE-2026-50015"
-        "CVE-2026-50016"
-        "CVE-2026-50017"
-        "CVE-2026-50573"
-        "CVE-2026-55699"
-        "CVE-2026-59194"
-        "CVE-2026-59195"
-        "CVE-2026-59196"
-      ];
-    };
     "9" = {
       version = "9.15.9";
       hash = "sha256-z4anrXZEBjldQoam0J1zBxFyCsxtk+nc6ax6xNxKKKc=";

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1843,6 +1843,7 @@ mapAliases {
   pltScheme = throw "'pltScheme' has been renamed to/replaced by 'racket'"; # Converted to throw 2025-10-27
   plv8 = throw "'plv8' has been removed. Use 'postgresqlPackages.plv8' instead."; # Added 2025-07-19
   pn = throw "'pn' has been removed as upstream was archived in 2020"; # Added 2025-10-17
+  pnpm_8 = throw "'pnpm_8' has been removed as it hasn't been updated since 2024. Please use 'pnpm'"; # Added 2026-07-07
   poac = throw "'poac' has been renamed to/replaced by 'cabinpkg'"; # Converted to throw 2025-10-27
   pocket-updater-utility = throw "'pocket-updater-utility' has been renamed to/replaced by 'pupdate'"; # Converted to throw 2025-10-27
   podofo010 = throw "'podofo010' has been renamed to 'podofo0'"; # Converted to throw 2025-10-27

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2801,7 +2801,6 @@ with pkgs;
   tdarr-node = tdarrPackages.node;
 
   inherit (callPackage ../development/tools/pnpm { })
-    pnpm_8
     pnpm_9
     pnpm_10_29_2
     pnpm_10_34_0


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
