### PR TITLE
OVMF: ship qemu firmware descriptors

### DIFF
--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -97,6 +97,82 @@ let
 
   buildPrefix = "Build/*/*";
 
+  isQemuPlatform = builtins.elem projectDscPath [
+    "OvmfPkg/OvmfPkgX64.dsc"
+    "ArmVirtPkg/ArmVirtQemu.dsc"
+    "OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc"
+    "OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc"
+  ];
+
+  # QEMU firmware interop descriptors to install, keyed by file name.
+  # Add an attribute to ship an additional descriptor.
+  qemuDescriptors =
+    let
+      description = "${fwPrefix} UEFI firmware for ${cpuName}${lib.optionalString secureBoot " with Secure Boot"}";
+
+      flashMapping = varsFile: {
+        device = "flash";
+        mode = "split";
+        executable = {
+          filename = "${placeholder "fd"}/FV/${fwPrefix}_CODE.fd";
+          format = "raw";
+        };
+        nvram-template = {
+          filename = "${placeholder "fd"}/FV/${varsFile}";
+          format = "raw";
+        };
+      };
+
+      common = {
+        interface-types = [ "uefi" ];
+        targets = [
+          {
+            architecture = cpuName;
+            machines =
+              {
+                x86_64 =
+                  if systemManagementModeRequired then
+                    [ "pc-q35-*" ]
+                  else
+                    [
+                      "pc-i440fx-*"
+                      "pc-q35-*"
+                    ];
+                aarch64 = [ "virt-*" ];
+                riscv64 = [ "virt*" ];
+                loongarch64 = [ "virt*" ];
+              }
+              .${cpuName} or [ ];
+          }
+        ];
+        features =
+          lib.optionals stdenv.hostPlatform.isx86 [
+            "acpi-s3"
+            "amd-sev"
+          ]
+          ++ lib.optionals (stdenv.hostPlatform.isx86 && !systemManagementModeRequired) [ "amd-sev-es" ]
+          ++ lib.optionals secureBoot [ "secure-boot" ]
+          ++ lib.optionals systemManagementModeRequired [ "requires-smm" ]
+          ++ lib.optionals (stdenv.hostPlatform.isx86 && !debug) [ "verbose-dynamic" ];
+        tags = [ ];
+      };
+    in
+    lib.optionalAttrs isQemuPlatform (
+      {
+        "50-edk2-${cpuName}${lib.optionalString secureBoot "-sb"}.json" = common // {
+          inherit description;
+          mapping = flashMapping "${fwPrefix}_VARS.fd";
+        };
+      }
+      // lib.optionalAttrs msVarsTemplate {
+        "40-edk2-${cpuName}${lib.optionalString secureBoot "-sb"}-enrolled.json" = common // {
+          description = "${description}, Microsoft keys enrolled";
+          mapping = flashMapping "${fwPrefix}_VARS.ms.fd";
+          features = common.features ++ [ "enrolled-keys" ];
+        };
+      }
+    );
+
 in
 
 assert msVarsTemplate -> fdSize4MB;
@@ -242,7 +318,17 @@ edk2.mkDerivation projectDscPath (finalAttrs: {
     mkdir -vp $fd/AAVMF
     ln -s $fd/FV/AAVMF_CODE.fd $fd/AAVMF/QEMU_EFI-pflash.raw
     ln -s $fd/FV/AAVMF_VARS.fd $fd/AAVMF/vars-template-pflash.raw
-  '';
+  ''
+  + lib.optionalString (qemuDescriptors != { }) ''
+    mkdir -vp $fd/share/qemu/firmware
+  ''
+  + lib.concatStrings (
+    lib.mapAttrsToList (name: descriptor: ''
+      python3 -m json.tool > $fd/share/qemu/firmware/${name} <<'EOF'
+      ${builtins.toJSON descriptor}
+      EOF
+    '') qemuDescriptors
+  );
 
   dontPatchELF = true;
 


### PR DESCRIPTION
These can be used by libvirt or systemd-vmspawn to discover available firmware.

Related to https://github.com/NixOS/nixpkgs/pull/538983.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
