### PR TITLE
lean4: 4.30.0 -> 4.31.0

### DIFF
--- a/pkgs/by-name/le/lean4/mimalloc.patch
+++ b/pkgs/by-name/le/lean4/mimalloc.patch
@@ -1,17 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6aa7bf1547..f8615c7317 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -80,11 +80,7 @@
-   ExternalProject_add(
+@@ -123,13 +123,7 @@ endif()
+ if(USE_MIMALLOC)
+   FetchContent_Declare(
      mimalloc
-     PREFIX mimalloc
 -    GIT_REPOSITORY https://github.com/microsoft/mimalloc
 -    GIT_TAG v2.2.3
--    # just download, we compile it as part of each stage as it is small
--    CONFIGURE_COMMAND ""
--    BUILD_COMMAND ""
+-    # Unnecessarily deep directory structure, but it saves us from a complicated
+-    # stage0 update for now. If we ever update the other dependencies like
+-    # cadical, it might be worth reorganizing the directory structure.
+-    SOURCE_DIR
+-    "${CMAKE_BINARY_DIR}/mimalloc/src/mimalloc"
 +    SOURCE_DIR "MIMALLOC-SRC"
-     INSTALL_COMMAND ""
+     EXCLUDE_FROM_ALL
    )
-   list(APPEND EXTRA_DEPENDS mimalloc)
- endif()
- 
+   FetchContent_MakeAvailable(mimalloc)

--- a/pkgs/by-name/le/lean4/package.nix
+++ b/pkgs/by-name/le/lean4/package.nix
@@ -1,26 +1,39 @@
 {
   lib,
   stdenv,
-  cmake,
-  cctools,
   fetchFromGitHub,
-  git,
-  gmp,
+
+  # nativeBuildInputs
   cadical,
+  cmake,
   leangz,
   makeWrapper,
   pkg-config,
+  # darwin-only:
+  cctools,
+
+  # buildInputs
+  gmp,
   libuv,
-  enableMimalloc ? true,
+
+  # nativeCheckInputs
+  gitMinimal,
   perl,
-  testers,
+
+  # nativeInstallCheckInputs
+  versionCheckHook,
+
+  enableMimalloc ? true,
 }:
 let
   cadical' = cadical.override { version = "2.1.3"; };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "lean4";
-  version = "4.30.0";
+  version = "4.31.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   # Using a vendored version rather than nixpkgs' version to match the exact version required by
   # Lean.  Apparently, even a slight version change can impact greatly the final performance.
@@ -35,46 +48,67 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "leanprover";
     repo = "lean4";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-YTsfIppd6km7wOjAxRH5KMPsW++ztFDCJT2up72J86Q=";
+    hash = "sha256-up4Juc/IyMuggGLMSDgwYEOoMk/K5U8NI0jzeAKqhO0=";
   };
 
-  postPatch =
-    let
-      pattern = "\${LEAN_BINARY_DIR}/../mimalloc/src/mimalloc";
-    in
-    ''
-      substituteInPlace src/CMakeLists.txt \
-        --replace-fail 'set(GIT_SHA1 "")' 'set(GIT_SHA1 "${finalAttrs.src.tag}")'
+  patches = [
+    ./mimalloc.patch
+  ];
 
-      # Remove tests that fails in sandbox.
-      # It expects `sourceRoot` to be a git repository.
-      rm -rf src/lake/examples/git/
+  postPatch = ''
+    substituteInPlace src/CMakeLists.txt \
+      --replace-fail \
+        'set(GIT_SHA1 "")' \
+        'set(GIT_SHA1 "${finalAttrs.src.tag}")'
+  ''
+  # Remove tests that fails in sandbox.
+  # It expects `sourceRoot` to be a git repository.
+  + ''
+    rm -rf src/lake/examples/git/
+  ''
+  + lib.optionalString enableMimalloc (
     ''
-    + (lib.optionalString enableMimalloc ''
       substituteInPlace CMakeLists.txt \
         --replace-fail 'MIMALLOC-SRC' '${finalAttrs.mimalloc-src}'
-      for file in stage0/src/CMakeLists.txt stage0/src/runtime/CMakeLists.txt src/CMakeLists.txt src/runtime/CMakeLists.txt; do
-        substituteInPlace "$file" \
-          --replace-fail '${pattern}' '${finalAttrs.mimalloc-src}'
-      done
-    '');
+    ''
+    + (
+      let
+        # Single-quoted at the use site so the literal `${LEAN_BINARY_DIR}` reaches
+        # substituteInPlace
+        pattern = "\${LEAN_BINARY_DIR}/../mimalloc/src/mimalloc";
+      in
+      ''
+        substituteInPlace \
+          src/CMakeLists.txt \
+          src/runtime/CMakeLists.txt \
+          stage0/src/CMakeLists.txt \
+          stage0/src/runtime/CMakeLists.txt \
+          --replace-fail \
+            '${pattern}' \
+            '${finalAttrs.mimalloc-src}'
+      ''
+    )
+  );
 
   preConfigure = ''
     patchShebangs stage0/src/bin/ src/bin/
   '';
 
   nativeBuildInputs = [
+    cadical'
     cmake
-    pkg-config
-    makeWrapper
     leangz # Provides leantar
+    makeWrapper
+    pkg-config
   ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [ cctools.libtool ];
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    cctools.libtool
+  ];
 
   buildInputs = [
+    cadical'
     gmp
     libuv
-    cadical'
   ];
 
   postInstall = ''
@@ -83,25 +117,21 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   nativeCheckInputs = [
-    git
+    gitMinimal
     perl
   ];
 
-  patches = [ ./mimalloc.patch ];
-
   cmakeFlags = [
-    "-DUSE_GITHASH=OFF"
-    "-DINSTALL_LICENSE=OFF"
-    "-DINSTALL_CADICAL=OFF"
-    "-DUSE_MIMALLOC=${if enableMimalloc then "ON" else "OFF"}"
+    (lib.cmakeBool "USE_GITHASH" false)
+    (lib.cmakeBool "INSTALL_LICENSE" false)
+    (lib.cmakeBool "INSTALL_CADICAL" false)
+    (lib.cmakeBool "USE_MIMALLOC" enableMimalloc)
   ];
 
-  passthru.tests = {
-    version = testers.testVersion {
-      package = finalAttrs.finalPackage;
-      version = "v${finalAttrs.version}";
-    };
-  };
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
 
   meta = {
     description = "Automatic and interactive theorem prover";


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/leanprover/lean4/compare/v4.30.0...v4.31.0
Changelog: https://github.com/leanprover/lean4/blob/v4.31.0/RELEASES.md

cc @Coda-Coda @jthulhu @nadja-y @xhalo32

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test