### PR TITLE
tigervnc: unbreak on darwin

### DIFF
--- a/pkgs/by-name/fl/fltk_1_3/package.nix
+++ b/pkgs/by-name/fl/fltk_1_3/package.nix
@@ -59,6 +59,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     patchShebangs documentation/make_*
+  ''
+  # https://github.com/fltk/fltk/commit/dd819a118cfaa889bec6563b6a8e1e969b91f7ee
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace CMake/setup.cmake \
+      --replace-fail 'set (FLTK_CONFIG_PATH FLTK.framework/Resources/CMake)' 'set (FLTK_CONFIG_PATH ''${FLTK_DATADIR}/fltk)'
   '';
 
   nativeBuildInputs = [
@@ -156,9 +161,6 @@ stdenv.mkDerivation (finalAttrs: {
       mv bin/{test,examples}/* $bin/bin/
     ''
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
-      mkdir -p $out/Library/Frameworks
-      mv $out{,/Library/Frameworks}/FLTK.framework
-
       moveAppBundles() {
         echo "Moving and symlinking $1"
         appname="$(basename "$1")"

--- a/pkgs/by-name/ti/tigervnc/package.nix
+++ b/pkgs/by-name/ti/tigervnc/package.nix
@@ -70,9 +70,13 @@ stdenv.mkDerivation (finalAttrs: {
          --replace-fail '"/usr/bin/ssh' '"${openssh}/bin/ssh'
       source_top="$(pwd)"
     ''
+    # On Mac, do not build a .dmg, instead move the built .app to the source dir.
+    # Also drop the script's trailing `exit`: it fires an EXIT trap that
+    # `rm -rf`s the temp dir, which would delete the .app before the move we
+    # append below can run (the move would otherwise be unreachable dead code
+    # after `exit`).
     + ''
-      # On Mac, do not build a .dmg, instead copy the .app to the source dir
-      gawk -i inplace 'BEGIN { del=0 } /hdiutil/ { del=2 } del<=0 { print } /$VERSION.dmg/ { del -= 1 }' release/makemacapp.in
+      gawk -i inplace 'BEGIN { del=0 } /hdiutil/ { del=2 } /^exit$/ { next } del<=0 { print } /$VERSION.dmg/ { del -= 1 }' release/makemacapp.in
       echo "mv \"\$APPROOT\" \"\$SRCDIR/\"" >> release/makemacapp.in
     '';
 
@@ -143,10 +147,10 @@ stdenv.mkDerivation (finalAttrs: {
     ''
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
       mkdir -p $out/Applications
-      mv 'TigerVNC Viewer ${finalAttrs.version}.app' $out/Applications/
+      mv 'TigerVNC.app' $out/Applications/
       rm $out/bin/vncviewer
       echo "#!/usr/bin/env bash
-      open $out/Applications/TigerVNC\ Viewer\ ${finalAttrs.version}.app --args \$@" >> $out/bin/vncviewer
+      open $out/Applications/TigerVNC.app --args \$@" >> $out/bin/vncviewer
       chmod +x $out/bin/vncviewer
     '';
 
@@ -219,7 +223,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Fork of tightVNC, made in cooperation with VirtualGL";
     maintainers = [ ];
     platforms = lib.platforms.unix;
-    broken = stdenv.hostPlatform.isDarwin;
     # Prevent a store collision.
     priority = 4;
     mainProgram = "vncviewer";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<img width="450" height="174" alt="image" src="https://github.com/user-attachments/assets/d2d41ff8-e634-4d71-9643-41d4457356ef" />

Assisted-by: Claude-Code:GLM-5.2

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
