### PR TITLE
scx.{csheds, rustscheds}: move EXPECTED_SCHEDULERS into env

### DIFF
--- a/pkgs/os-specific/linux/scx/scx_cscheds.nix
+++ b/pkgs/os-specific/linux/scx/scx_cscheds.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   fetchFromGitHub,
   llvmPackages,
   libbpf,
@@ -49,7 +50,7 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
   ];
 
   __structuredAttrs = true;
-  EXPECTED_SCHEDULERS = finalAttrs.passthru.schedulers;
+  env.EXPECTED_SCHEDULERS = lib.concatStringsSep " " finalAttrs.passthru.schedulers;
 
   doInstallCheck = true;
   installCheckPhase = ''

--- a/pkgs/os-specific/linux/scx/scx_rustscheds.nix
+++ b/pkgs/os-specific/linux/scx/scx_rustscheds.nix
@@ -48,6 +48,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       "-C link-args=-lz"
       "-C link-args=-lzstd"
     ];
+    EXPECTED_SCHEDULERS = lib.concatStringsSep " " finalAttrs.passthru.schedulers;
   };
 
   hardeningDisable = [
@@ -64,7 +65,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   __structuredAttrs = true;
-  EXPECTED_SCHEDULERS = finalAttrs.passthru.schedulers;
 
   doInstallCheck = true;
   installCheckPhase = ''


### PR DESCRIPTION
Now this is not strictly necessary because `__structuredAttrs` is already enabled and `EXPECTED_SCHEDULERS` is only used directly in the `installCheckPhase`, but this would help with semi-automated detection of actual problems with env variables (because this definitely looks like one), and (personally) I like when variables that are not directly used by stdenv live in `env`.

Tested with `nix-build -A scx.full -A scx.rustscheds -A scx.cscheds`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
