### PR TITLE
dependency-track: 4.14.1 -> 4.14.2; include patch for node 22 support

### DIFF
--- a/pkgs/by-name/de/dependency-track/package.nix
+++ b/pkgs/by-name/de/dependency-track/package.nix
@@ -2,7 +2,7 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
-  nodejs_20,
+  fetchpatch2,
   jre_headless,
   protobuf_30,
   xmlstarlet,
@@ -13,20 +13,17 @@
   nixosTests,
 }:
 let
-  version = "4.14.1";
+  version = "4.14.2";
 
   frontend = buildNpmPackage {
     pname = "dependency-track-frontend";
     inherit version;
 
-    # TODO: pinned due to build error on node 22
-    nodejs = nodejs_20;
-
     src = fetchFromGitHub {
       owner = "DependencyTrack";
       repo = "frontend";
-      rev = version;
-      hash = "sha256-xjIRkffmXYMAfZ8wJehnPRfTThJjTgNL8ONl9N9ZJ+M=";
+      tag = version;
+      hash = "sha256-/MH1YjEJdRjYjenkzOcp7oytudsJcinPbc9OAGFnI/Q=";
     };
 
     installPhase = ''
@@ -34,7 +31,14 @@ let
       cp -R ./dist $out/
     '';
 
-    npmDepsHash = "sha256-CW9LOur8N3obrOeHgYFH2OO/vg8XihUspuXS5Zrix8I=";
+    patches = [
+      (fetchpatch2 {
+        url = "https://github.com/DependencyTrack/frontend/pull/1575.patch?full_index=1";
+        hash = "sha256-Wo+6yXa/8jB/pph0DTNsFz6lK3sedvro+7yvLSKes9c=";
+      })
+    ];
+
+    npmDepsHash = "sha256-md+PGEC1/Kl2MQhhYldSErcsDSefbPvwVDsw0Yklq1E=";
     forceGitDeps = true;
     makeCacheWritable = true;
 
@@ -50,8 +54,8 @@ maven.buildMavenPackage rec {
   src = fetchFromGitHub {
     owner = "DependencyTrack";
     repo = "dependency-track";
-    rev = version;
-    hash = "sha256-pIZM8FQ0IFqRbTQT5VIlCmS+fCCXULJJ6bdEv6xfjbc=";
+    tag = version;
+    hash = "sha256-9EPjIm2VOmt1FEiPoJtwNHoKZcewO0kJgBSc9fnUXeI=";
   };
 
   postPatch = ''
@@ -84,7 +88,7 @@ maven.buildMavenPackage rec {
   '';
 
   mvnJdk = jre_headless;
-  mvnHash = "sha256-eZuwBt+emThf4mxVaphFgBWNqP64Cs9WIKW+GPvHll4=";
+  mvnHash = "sha256-pshUDIPPGGGzxg5WJXC3mjnqGXn8HVowFCb2l5f6zjA=";
   manualMvnArtifacts = [
     "com.coderplus.maven.plugins:copy-rename-maven-plugin:1.0.1"
     # added to saticfy protobuf compiler plugin dependency resolving
@@ -92,7 +96,7 @@ maven.buildMavenPackage rec {
     "com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:2.19.1"
     "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.21.0"
     "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.3"
-    "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.0"
+    "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.2"
     "io.micrometer:micrometer-core:1.16.0"
     "io.micrometer:micrometer-observation:1.16.0"
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
