### PR TITLE
nsd: 4.14.3 -> 4.15.0, clean up package a bit

### DIFF
--- a/pkgs/by-name/ns/nsd/package.nix
+++ b/pkgs/by-name/ns/nsd/package.nix
@@ -32,12 +32,22 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nsd";
-  version = "4.14.3";
+  version = "4.15.0";
 
   src = fetchurl {
     url = "https://www.nlnetlabs.nl/downloads/nsd/nsd-${finalAttrs.version}.tar.gz";
-    hash = "sha256-limtZNnBsBm74iKW1RSNeuZfWIziZaZCR1B0DwUrsSs=";
+    hash = "sha256-hPG+4ukqna20HZXsxkET5NPe+GIk3ndM2SADrdjE9XA=";
   };
+
+  patches = [
+    # https://github.com/NLnetLabs/nsd/pull/495 -- Without this patch, the build
+    # breaks with { openssl = libressl; bind8Stats = true; }. The patch will be
+    # included in 4.15.1, so we can drop it here on the next update.
+    (fetchurl {
+      url = "https://github.com/NLnetLabs/nsd/commit/15cf8736e3bfa0fd8f426b13637c44e638fa0d40.patch";
+      hash = "sha256-JVazJ83U80ASZypjic0epE92PZd3F1yi8UU6EapdW5U=";
+    })
+  ];
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/ns/nsd/package.nix
+++ b/pkgs/by-name/ns/nsd/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  removeReferencesTo,
   fstrm,
   libevent,
   openssl,
@@ -51,6 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     pkg-config
+    removeReferencesTo
   ]
   ++ lib.optionals withDnstap [ protobuf ];
 
@@ -95,6 +97,10 @@ stdenv.mkDerivation (finalAttrs: {
       "--with-nsd_conf_file=${configFile}"
       "--with-configdir=etc/nsd"
     ];
+
+  postFixup = ''
+    find "$out" -type f -exec remove-references-to -t ${openssl.dev} -t ${libevent.dev} '{}' +
+  '';
 
   passthru.tests = {
     inherit (nixosTests) nsd;

--- a/pkgs/by-name/ns/nsd/package.nix
+++ b/pkgs/by-name/ns/nsd/package.nix
@@ -57,12 +57,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  # TODO: prePatch doesn't actually get executed because patchPhase is overridden
-  prePatch = ''
-    substituteInPlace nsd-control-setup.sh.in --replace openssl ${openssl}/bin/openssl
-  '';
-
-  patchPhase = ''
+  # Prevent the install script from copying nsd.conf.sample into /etc/nsd.
+  postPatch = ''
     sed 's@$(INSTALL_DATA) nsd.conf.sample $(DESTDIR)$(nsdconfigfile).sample@@g' -i Makefile.in
   '';
 


### PR DESCRIPTION
## Things done

* Update NSD to 4.15.0, [changelog](https://github.com/NLnetLabs/nsd/blob/4dd29b6aa7a2c858171523f33d3e271c6567df20/doc/ChangeLog).
* This update uncovered a compilation issue when building against LibreSSL with `bind8Stats = true`, which [I submitted a fix for upstream](https://github.com/NLnetLabs/nsd/pull/495) that I also included as a patch here.
* To be able to use patches with this package, we need to stop overriding `patchPhase`, so move the current patch step to `postPatch`. Drop `prePatch` entirely as it was dead code, and I’d rather err on the side of changing fewer things as this package is already complex.
* While testing that the binary works by running `result/bin/nsd -v`, I noticed it prints its configure flags which contain store paths of `openssl-dev` and `libevent-dev`. The `-dev` paths are not needed at runtime, stripping them shaves 3.7 MiB off the closure size.
* (This new version is now serving all DNS queries for my personal domains, so I can confirm that at least my configuration still works.)
---

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy]. Zero AI was used in this change and in the upstream contribution.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test