### PR TITLE
codexbar: 0.37.2 -> 0.41.0, add kinnrai to maintainers

### DIFF
--- a/pkgs/by-name/co/codexbar/package.nix
+++ b/pkgs/by-name/co/codexbar/package.nix
@@ -38,7 +38,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Show usage stats for AI coding-provider limits";
     homepage = "https://codex.bar/";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ Br1ght0ne ];
+    maintainers = with lib.maintainers; [
+      Br1ght0ne
+      kinnrai
+    ];
     platforms = lib.platforms.darwin;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };

--- a/pkgs/by-name/co/codexbar/package.nix
+++ b/pkgs/by-name/co/codexbar/package.nix
@@ -8,13 +8,13 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "codexbar";
-  version = "0.37.2";
+  version = "0.41.0";
   __structuredAttrs = true;
   strictDeps = true;
 
   src = fetchurl {
     url = "https://github.com/steipete/CodexBar/releases/download/v${finalAttrs.version}/CodexBar-macos-universal-${finalAttrs.version}.zip";
-    hash = "sha256-3I98PH/eAH1G9up+1AiwXshxGoZRNf3bFxsx5W32unc=";
+    hash = "sha256-M3i05Yu15uTLd/bO5E5bYen3dYo1iTEI/z7+VxeFhY0=";
   };
 
   sourceRoot = ".";


### PR DESCRIPTION
Version bump for `codexbar` and addition of myself to the maintainers to help keep it up to date.

Changelog: https://github.com/steipete/CodexBar/releases/tag/v0.41.0
Diff: https://github.com/steipete/CodexBar/compare/v0.37.2...v0.41.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
