### PR TITLE
lix: gate libcpuid/libseccomp to what was linked

### DIFF
--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -42,6 +42,16 @@ let
     excludes = [ "package.nix" ];
     hash = "sha256-uu/SIG8fgVVWhsGxmszTPHwe4SQtLgbxdShOMKbeg2w=";
   };
+  lixCpuidPatch = fetchpatch2 {
+    name = "lix-2.94-cpuid.patch";
+    url = "https://gerrit.lix.systems/changes/lix~6113/revisions/1/patch?download&raw";
+    hash = "sha256-YyKBNptp8wbOYoHlNqoxZSoFJrKFhm2H7LVvAX9Fnow=";
+  };
+  lixCpuidSeccompPatch = fetchpatch2 {
+    name = "lix-2.95-cpuid-seccomp.patch";
+    url = "https://gerrit.lix.systems/changes/lix~6114/revisions/1/patch?download&raw";
+    hash = "sha256-2J7INu0Ov9bZ/NxelYdlykWcOY1/8PzJXiVXMD1C9JQ=";
+  };
   makeLixScope =
     {
       attrName,
@@ -203,6 +213,7 @@ lib.makeExtensible (
 
         patches = [
           lixMdbookPatch
+          lixCpuidPatch
         ];
       };
     };
@@ -226,6 +237,10 @@ lib.makeExtensible (
           inherit src;
           hash = "sha256-a5XtutX+NS4wOqxeqbscWZMs99teKick5+cQfbCRGxQ=";
         };
+
+        patches = [
+          lixCpuidSeccompPatch
+        ];
       };
     };
 
@@ -248,6 +263,10 @@ lib.makeExtensible (
           inherit src;
           hash = "sha256-a5XtutX+NS4wOqxeqbscWZMs99teKick5+cQfbCRGxQ=";
         };
+
+        patches = [
+          lixCpuidSeccompPatch
+        ];
       };
     };
 


### PR DESCRIPTION
This PR fixes #539200.

1. Nixpkgs only provides libcpuid to Lix on x86.
   - https://github.com/NixOS/nixpkgs/blob/9acc6884ece717d2d20a485da38fb2fc39d575a0/pkgs/tools/package-management/lix/common-lix.nix#L294
2. Nixpkgs only provides libseccomp on Linux.
   - https://github.com/NixOS/nixpkgs/blob/9acc6884ece717d2d20a485da38fb2fc39d575a0/pkgs/by-name/li/libseccomp/package.nix#L65
3. However, Lix lists libcpuid and libseccomp as requirements unconditionally.
   - https://git.lix.systems/lix-project/lix/src/tag/2.94.2/lix/libutil/lix-util.pc.in#L10
   - https://git.lix.systems/lix-project/lix/src/tag/2.94.2/lix/libstore/lix-store.pc.in#L9
   - https://git.lix.systems/lix-project/lix/src/tag/2.95.2/lix/lix.pc.in#L10
4. `nix-serve-ng` pulls in those requirements from Lix.
   - https://github.com/aristanetworks/nix-serve-ng/blob/f63998a6c81fab86e840dbab483d387dee5ffc0a/nix-serve-ng.cabal#L63-L67
   - https://github.com/NixOS/nixpkgs/blob/9acc6884ece717d2d20a485da38fb2fc39d575a0/pkgs/development/haskell-modules/configuration-nix.nix#L534
5. As a result, `nix-serve-ng` fails to build on `aarch64-linux` and `aarch64-darwin`.
6. This PR fixes the issue by patching Lix to only list those libraries as requirements conditionally, just like it already does for other libraries via e.g. `@AWS_SDK_IF_FOUND@` and `@BOEHM_IF_FOUND@`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test