### PR TITLE
python3Packages.sagemaker-mlflow: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/development/python-modules/sagemaker-mlflow/default.nix
+++ b/pkgs/development/python-modules/sagemaker-mlflow/default.nix
@@ -11,13 +11,16 @@
   mlflow-skinny,
 
   # tests
+  matplotlib,
+  pandas,
   pytestCheckHook,
   scikit-learn,
+  skops,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "sagemaker-mlflow";
-  version = "0.4.0";
+  version = "0.5.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -25,8 +28,16 @@ buildPythonPackage (finalAttrs: {
     owner = "aws";
     repo = "sagemaker-mlflow";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-QE40ZBW7N3GPC+eJqj5uzS3L+A6Wu2/LgHOiUsEXKMw=";
+    hash = "sha256-nSI1BGJ2hhzuHxnGjElDuPpuc2rRn2mX5+s4ZSuZna0=";
   };
+
+  # AssertionError: sagemaker_mlflow version is dev - 0.5.0.dev1
+  postPatch = ''
+    substituteInPlace VERSION \
+      --replace-fail \
+        "0.5.0.dev1" \
+        "${finalAttrs.version}"
+  '';
 
   build-system = [
     setuptools
@@ -40,9 +51,18 @@ buildPythonPackage (finalAttrs: {
   pythonImportsCheck = [ "sagemaker_mlflow" ];
 
   nativeCheckInputs = [
+    matplotlib
+    pandas
     pytestCheckHook
     scikit-learn
+    skops
   ];
+
+  # mlflow.exceptions.MlflowException: The filesystem tracking backend (e.g., './mlruns') is in maintenance mode and will not receive further updates.
+  # Please migrate to a database backend (e.g., 'sqlite:///mlflow.db') to access the latest MLflow features.
+  preCheck = ''
+    export MLFLOW_ALLOW_FILE_STORE=true
+  '';
 
   disabledTests = [
     # AssertionError: assert 's3' in '/build/source/not implemented/0/d3c16d2bad4245bf9fc68f86d2e7599d/artifacts'
@@ -56,18 +76,6 @@ buildPythonPackage (finalAttrs: {
     "test_log_artifact"
     "test_presigned_url"
     "test_presigned_url_with_fields"
-
-    # Exercises a `sqlite://` model-registry store, only available with the
-    # sqlalchemy backend of the full `mlflow` package (not `mlflow-skinny`).
-    "test_store_instantiation_none"
-  ];
-
-  disabledTestPaths = [
-    # `from mlflow.models import infer_signature` fails to import at collection
-    # time: `infer_signature` is only available in the full `mlflow` package,
-    # not in `mlflow-skinny`. Also see:
-    # https://github.com/aws/sagemaker-mlflow/issues/16
-    "test/integration/tests/test_model_registry.py"
   ];
 
   meta = {


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/aws/sagemaker-mlflow/compare/v0.4.0...v0.5.0
Changelog: https://github.com/aws/sagemaker-mlflow/releases/tag/v0.5.0

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test