### PR TITLE
mkl-gnulibs: a variant of mkl linked against GNU OpenMP

### DIFF
--- a/pkgs/by-name/mk/mkl-gnulibs/libmkl_rt.so.in
+++ b/pkgs/by-name/mk/mkl-gnulibs/libmkl_rt.so.in
@@ -1,0 +1,1 @@
+GROUP ( @out@/lib/libmkl_intel_lp64.so @out@/lib/libmkl_gnu_thread.so @out@/lib/libmkl_core.so @out@/lib/libmkl_rt_shim.so )

--- a/pkgs/by-name/mk/mkl-gnulibs/mkl.pc.in
+++ b/pkgs/by-name/mk/mkl-gnulibs/mkl.pc.in
@@ -1,0 +1,10 @@
+prefix=@out@
+includedir=${prefix}/include
+libdir=${prefix}/lib
+
+Name: mkl
+Description: Intel Math Kernel Library
+URL: https://software.intel.com/en-us/intel-mkl
+Version: @version@
+Cflags: -isystem${includedir}
+Libs: -Wl,-rpath,${libdir} -L${libdir} -lmkl_rt -ldl

--- a/pkgs/by-name/mk/mkl-gnulibs/mkl.pc.in
+++ b/pkgs/by-name/mk/mkl-gnulibs/mkl.pc.in
@@ -7,4 +7,4 @@ Description: Intel Math Kernel Library
 URL: https://software.intel.com/en-us/intel-mkl
 Version: @version@
 Cflags: -isystem${includedir}
-Libs: -Wl,-rpath,${libdir} -L${libdir} -lmkl_rt -ldl
+Libs: -Wl,-rpath,${libdir} -L${libdir} -lmkl_rt -lpthread -lm -ldl

--- a/pkgs/by-name/mk/mkl-gnulibs/mkl_rt_shim.c
+++ b/pkgs/by-name/mk/mkl-gnulibs/mkl_rt_shim.c
@@ -1,0 +1,24 @@
+#include <dlfcn.h>
+
+__attribute__((constructor))
+static void preload_mkl()
+{
+    // MKL libs must be loaded with RTLD_GLOBAL (see comments in mkl-service)
+    // Without forcing it here, things fail at runtime when mkl_core tries to
+    // dlopen libmkl_avx512, etc.
+    dlopen("libmkl_core.so",       RTLD_LAZY | RTLD_GLOBAL);
+    dlopen("libmkl_gnu_thread.so", RTLD_LAZY | RTLD_GLOBAL);
+    dlopen("libmkl_intel_lp64.so", RTLD_LAZY | RTLD_GLOBAL);
+}
+
+// mkl-service, possibly others link against these, give it something to call
+
+void MKL_Set_Threading_Layer()
+{
+    // computer says no
+}
+
+void MKL_Set_Interface_Layer()
+{
+    // computer says no
+}

--- a/pkgs/by-name/mk/mkl-gnulibs/package.nix
+++ b/pkgs/by-name/mk/mkl-gnulibs/package.nix
@@ -1,0 +1,45 @@
+{
+  gcc,
+  mkl,
+}:
+
+# Force MKL to link GNU openmp libs, not intel ones. Intel conflicts with
+# pytorch, libgbm, anything else compiled with gcc + openmp. We have not found
+# a way to reliably force this with the intel-provided auto-detecting
+# libmkl_rt.so. - therefore we use a loader script (templated from
+# libmkl_rt.so.in)
+# Also, we must delete the libtbb.so in mkl as it ends up being used in rtech,
+# whilst we want the separate version that we compile against which does
+# have headers.
+mkl.overrideAttrs (o: {
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = o.nativeBuildInputs ++ [ gcc ];
+
+  postFixup = (o.postFixup or "") + ''
+    find $out/lib -name '*tbb*' -delete
+
+    rm $out/lib/libmkl_intel_thread.so
+    rm $out/lib/libmkl_intel_thread.so.2
+
+    gcc -shared ${./mkl_rt_shim.c} -o $out/lib/libmkl_rt_shim.so -L$out/lib -fopenmp
+
+    rm $out/lib/libmkl_rt.so.2
+    export gomp_loc=${gcc.cc.lib}
+    substituteAll ${./libmkl_rt.so.in} $out/lib/libmkl_rt.so.2
+
+    # If we call overrideAttrs on mkl to add the templated pc files later, we lose the extra attributes
+    # we are setting, so we do the pc file generation here.
+    substituteAll ${./mkl.pc.in} $out/lib/pkgconfig/mkl.pc
+    # Need slightly different name for numpy, which special cases "mkl"
+    substituteAll ${./mkl.pc.in} $out/lib/pkgconfig/mkl_rt.pc
+  '';
+})
+// {
+  isILP64 = false;
+  implementation = "mkl";
+  blasProvider = mkl;
+  blasImplementation = "mkl";
+  provider = mkl;
+}

--- a/pkgs/by-name/mk/mkl-gnulibs/package.nix
+++ b/pkgs/by-name/mk/mkl-gnulibs/package.nix
@@ -1,4 +1,5 @@
 {
+  callPackage,
   gcc,
   mkl,
 }:
@@ -44,6 +45,7 @@ mkl.overrideAttrs (
       blasProvider = finalAttrs.finalPackage;
       blasImplementation = "mkl";
       provider = finalAttrs.finalPackage;
+      tests.gnu-openmp = callPackage ./test { mkl-gnulibs = finalAttrs.finalPackage; };
     };
   }
 )

--- a/pkgs/by-name/mk/mkl-gnulibs/package.nix
+++ b/pkgs/by-name/mk/mkl-gnulibs/package.nix
@@ -11,35 +11,39 @@
 # Also, we must delete the libtbb.so in mkl as it ends up being used in rtech,
 # whilst we want the separate version that we compile against which does
 # have headers.
-mkl.overrideAttrs (o: {
-  strictDeps = true;
-  __structuredAttrs = true;
+mkl.overrideAttrs (
+  finalAttrs: o: {
+    strictDeps = true;
+    __structuredAttrs = true;
 
-  nativeBuildInputs = o.nativeBuildInputs ++ [ gcc ];
+    nativeBuildInputs = o.nativeBuildInputs ++ [ gcc ];
 
-  postFixup = (o.postFixup or "") + ''
-    find $out/lib -name '*tbb*' -delete
+    postFixup = (o.postFixup or "") + ''
+      find $out/lib -name '*tbb*' -delete
 
-    rm $out/lib/libmkl_intel_thread.so
-    rm $out/lib/libmkl_intel_thread.so.2
+      rm $out/lib/libmkl_intel_thread.so
+      rm $out/lib/libmkl_intel_thread.so.2
+      rm $out/lib/pkgconfig/*iomp*.pc
 
-    gcc -shared ${./mkl_rt_shim.c} -o $out/lib/libmkl_rt_shim.so -L$out/lib -fopenmp
+      gcc -shared ${./mkl_rt_shim.c} -o $out/lib/libmkl_rt_shim.so -L$out/lib -fopenmp
 
-    rm $out/lib/libmkl_rt.so.2
-    export gomp_loc=${gcc.cc.lib}
-    substituteAll ${./libmkl_rt.so.in} $out/lib/libmkl_rt.so.2
+      rm $out/lib/libmkl_rt.so.2
+      export gomp_loc=${gcc.cc.lib}
+      substituteAll ${./libmkl_rt.so.in} $out/lib/libmkl_rt.so.2
 
-    # If we call overrideAttrs on mkl to add the templated pc files later, we lose the extra attributes
-    # we are setting, so we do the pc file generation here.
-    substituteAll ${./mkl.pc.in} $out/lib/pkgconfig/mkl.pc
-    # Need slightly different name for numpy, which special cases "mkl"
-    substituteAll ${./mkl.pc.in} $out/lib/pkgconfig/mkl_rt.pc
-  '';
-})
-// {
-  isILP64 = false;
-  implementation = "mkl";
-  blasProvider = mkl;
-  blasImplementation = "mkl";
-  provider = mkl;
-}
+      # If we call overrideAttrs on mkl to add the templated pc files later, we lose the extra attributes
+      # we are setting, so we do the pc file generation here.
+      substituteAll ${./mkl.pc.in} $out/lib/pkgconfig/mkl.pc
+      # Need slightly different name for numpy, which special cases "mkl"
+      substituteAll ${./mkl.pc.in} $out/lib/pkgconfig/mkl_rt.pc
+    '';
+
+    passthru = (o.passthru or { }) // {
+      isILP64 = false;
+      implementation = "mkl";
+      blasProvider = finalAttrs.finalPackage;
+      blasImplementation = "mkl";
+      provider = finalAttrs.finalPackage;
+    };
+  }
+)

--- a/pkgs/by-name/mk/mkl-gnulibs/test/default.nix
+++ b/pkgs/by-name/mk/mkl-gnulibs/test/default.nix
@@ -1,0 +1,31 @@
+{
+  stdenv,
+  pkg-config,
+  mkl-gnulibs,
+}:
+
+stdenv.mkDerivation {
+  pname = "mkl-gnulibs-test";
+  version = mkl-gnulibs.version;
+
+  unpackPhase = ''
+    cp ${./test.c} test.c
+  '';
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ mkl-gnulibs ];
+
+  doCheck = true;
+
+  buildPhase = ''
+    gcc test.c -o test $(pkg-config --cflags --libs mkl_rt) -fopenmp
+  '';
+
+  installPhase = ''
+    touch $out
+  '';
+
+  checkPhase = ''
+    ./test
+  '';
+}

--- a/pkgs/by-name/mk/mkl-gnulibs/test/test.c
+++ b/pkgs/by-name/mk/mkl-gnulibs/test/test.c
@@ -1,0 +1,24 @@
+#include <assert.h>
+#include <dlfcn.h>
+#include <mkl_cblas.h>
+#include <omp.h>
+
+int main()
+{
+    /* Verify MKL BLAS computation works via libmkl_rt */
+    float u[] = { 1., 2., 3. };
+    float v[] = { 4., 5., 6. };
+    assert(cblas_sdot(3, u, 1, v, 1) == 32.);
+
+    /* Verify GNU OpenMP is functional alongside MKL (simulates gcc+openmp consumers like pytorch) */
+    int total = 0;
+#pragma omp parallel reduction(+ : total)
+    total += 1;
+    assert(total >= 1);
+
+    /* Verify Intel OpenMP is NOT loaded — its presence alongside libgomp causes the conflict
+       that mkl-gnulibs exists to prevent */
+    assert(dlopen("libiomp5.so", RTLD_NOLOAD) == NULL);
+
+    return 0;
+}


### PR DESCRIPTION
Provide an MKL build with a loader script that forces usage of the GNU OpenMP libs (libgomp). This is provided as a workaround for the cases where using `LD_PRELOAD` to prefer libgomp at runtime is not a viable option.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
