### PR TITLE
meshlab: fix launch failure with EGL-only glew

### DIFF
--- a/pkgs/by-name/me/meshlab/package.nix
+++ b/pkgs/by-name/me/meshlab/package.nix
@@ -76,7 +76,12 @@ stdenv.mkDerivation (finalAttrs: {
     bzip2
     muparser
     eigen
-    glew
+    # MeshLab renders through Qt's xcb platform, which creates a GLX context,
+    # and calls glewInit() against it. The default EGL-enabled glew is built
+    # EGL-only (no GLX dispatch table), so glewInit can't read GL_VERSION and
+    # the app fails to launch with "GLEW initialization failed: Missing GL
+    # version". See https://github.com/NixOS/nixpkgs/issues/531470
+    (glew.override { enableEGL = false; })
     gmp
     levmar
     qhull


### PR DESCRIPTION
meshlab renders through Qt's xcb platform, which creates a GLX context and calls glewInit() against it. Since the glew 2.2.0 -> 2.3.1 upgrade (#526521) dropped Arch's egl+glx coexistence patch, the default EGL-enabled glew is built EGL-only (no GLX dispatch table), so glewInit can't read GL_VERSION and meshlab fails to launch with "GLEW initialization failed: Missing GL version".

Use a GLX-capable glew (enableEGL = false), matching the workaround already used by openscad and rpcs3.

Resolves #531470

Assisted-by: Claude-Code:GLM-5.2

<img width="1874" height="1033" alt="image" src="https://github.com/user-attachments/assets/19819773-dfb3-4ef7-9c36-8429017b1bf9" />


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
