### PR TITLE
sneakerweb: init at 1.0.1

### DIFF
--- a/pkgs/by-name/sn/sneakerweb/package.nix
+++ b/pkgs/by-name/sn/sneakerweb/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromCodeberg,
+  stdenv,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "sneakerweb";
+  version = "1.0.1";
+
+  src = fetchFromCodeberg {
+    owner = "worm-blossom";
+    repo = "sneakerweb";
+    rev = "5b26074b7db7bd5c5200b2ad5263cd79b29134e6";
+    hash = "sha256-QufVMRFu/49M39lJYd3ImlvF+cCWYepx7E/mK3957NY=";
+  };
+
+  cargoHash = "sha256-6miju3dsKTHlyt+YMJEIP+Ygpm/wQGW4EVCe7iwOi08=";
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "A parallel web transported by physical media";
+    homepage = "https://sneakerweb.org/";
+    license = lib.licenses.OR [
+      lib.licenses.asl20
+      lib.licenses.mit
+    ];
+    maintainers = [ lib.maintainers.munksgaard ];
+    mainProgram = "sneakerweb";
+  };
+})


### PR DESCRIPTION
From the [website](https://sneakerweb.org):

> The sneakerweb is a peer-to-peer protocol for web publishing without permission: there are no DNS servers, domain registrars, or web hosts.
>
> Instead, websites are stored directly on user devices, and transferred between them through the ultimate fallback infrastructure: physical storage media.
>
> Your collected sites can be viewed offline, in the same web browser you normally use, and then shared with others via .snk files. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
