### PR TITLE
treewide: follow some GitHub redirects for `fetchFromGitHub`

### DIFF
--- a/pkgs/by-name/ba/barracuda/package.nix
+++ b/pkgs/by-name/ba/barracuda/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "Zaneham";
-    repo = "BarraCUDA";
+    repo = "Booth";
     tag = "v${finalAttrs.version}";
     hash = "sha256-WQGnW7fpTIJuUkf9OYWPPWbE4VMhfff32bKGR9e01oQ=";
   };
@@ -36,8 +36,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Multi architecture, multi language compiler with the intended goal of allowing for cross platform development on GPU's and CPU's";
-    homepage = "https://github.com/Zaneham/BarraCUDA";
-    changelog = "https://github.com/Zaneham/BarraCUDA/releases/tag/${finalAttrs.src.tag}";
+    homepage = "https://github.com/Zaneham/Booth";
+    changelog = "https://github.com/Zaneham/Booth/releases/tag/${finalAttrs.src.tag}";
     maintainers = with lib.maintainers; [ dstremur ];
     license = lib.licenses.asl20;
     platforms = [ "x86_64-linux" ];

--- a/pkgs/by-name/bi/bit-logo/package.nix
+++ b/pkgs/by-name/bi/bit-logo/package.nix
@@ -10,7 +10,7 @@ buildGoModule (finalAttrs: {
   version = "0.3.0";
 
   src = fetchFromGitHub {
-    owner = "superstarryeyes";
+    owner = "paulilaaso";
     repo = "bit";
     tag = "v${finalAttrs.version}";
     hash = "sha256-iLwWKn8csoRkr5H8R2kpZVZCxsL0LDWHNvNoxyM6y98=";
@@ -31,7 +31,7 @@ buildGoModule (finalAttrs: {
       CLI/TUI logo designer + ANSI font library with gradient colors,
       shadows, and multi-format export.
     '';
-    homepage = "https://github.com/superstarryeyes/bit";
+    homepage = "https://github.com/paulilaaso/bit";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ yiyu ];
     mainProgram = "bit-logo";

--- a/pkgs/by-name/bm/bmon/package.nix
+++ b/pkgs/by-name/bm/bmon/package.nix
@@ -15,14 +15,14 @@ stdenv.mkDerivation (finalAttrs: {
   version = "4.0";
 
   src = fetchFromGitHub {
-    owner = "tgraf";
+    owner = "Jafaral";
     repo = "bmon";
     rev = "v${finalAttrs.version}";
     sha256 = "1ilba872c09mnlvylslv4hqv6c9cz36l76q74rr99jvis1dg69gf";
   };
 
   # The source code defines `__unused__`, which is a reserved name
-  # https://github.com/tgraf/bmon/issues/89
+  # https://github.com/Jafaral/bmon/issues/89
   patches = [
     (fetchpatch {
       url = "https://github.com/macports/macports-ports/raw/6d1dd5e9c8fae608bd22f3ede21e576f29c6358c/net/bmon/files/patch-fix__unused.diff";
@@ -49,10 +49,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Network bandwidth monitor";
-    homepage = "https://github.com/tgraf/bmon";
+    homepage = "https://github.com/Jafaral/bmon";
     # Licensed under BSD and MIT
-    #  - https://github.com/tgraf/bmon/blob/master/LICENSE.BSD
-    #  - https://github.com/tgraf/bmon/blob/master/LICENSE.MIT
+    #  - https://github.com/Jafaral/bmon/blob/master/LICENSE.BSD
+    #  - https://github.com/Jafaral/bmon/blob/master/LICENSE.MIT
     license = lib.licenses.bsd2;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/bu/bunnyfetch/package.nix
+++ b/pkgs/by-name/bu/bunnyfetch/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "0.2.0";
 
   src = fetchFromGitHub {
-    owner = "Rosettea";
+    owner = "sammy-ette";
     repo = "bunnyfetch";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-6MnjCXc9/8twdf8PHKsVJY1yWYwUf5R01vtQFJbyy7M=";
@@ -22,7 +22,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Tiny system info fetch utility";
-    homepage = "https://github.com/Rosettea/bunnyfetch";
+    homepage = "https://github.com/sammy-ette/bunnyfetch";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ devins2518 ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/cp/cpc/package.nix
+++ b/pkgs/by-name/cp/cpc/package.nix
@@ -9,7 +9,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "4.0.0";
 
   src = fetchFromGitHub {
-    owner = "probablykasper";
+    owner = "kasper9n";
     repo = "cpc";
     tag = "v${finalAttrs.version}";
     hash = "sha256-Gd2bFOyPERcwTGurJJDMNrRjFq7smtkgFMGUXxZVwaI=";
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     mainProgram = "cpc";
     description = "Text calculator with support for units and conversion";
-    homepage = "https://github.com/probablykasper/cpc";
+    homepage = "https://github.com/kasper9n/cpc";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       s0me1newithhand7s

--- a/pkgs/by-name/cr/crosspatch/package.nix
+++ b/pkgs/by-name/cr/crosspatch/package.nix
@@ -13,7 +13,7 @@ let
   version = "1.1.5";
 
   src = fetchFromGitHub {
-    owner = "NickPlayzGITHUB";
+    owner = "nockcs";
     repo = "CrossPatch";
     hash = "sha256-Ux+tLP5Hv8ecnuITMqLiuX0YtF2ENZ7ezi2gNKfuNcM=";
     tag = version;
@@ -64,7 +64,7 @@ stdenv.mkDerivation {
   meta = {
     mainProgram = "crosspatch";
     description = "A mod Manager for Sonic Racing: CrossWorlds";
-    homepage = "https://github.com/NickPlayzGITHUB/CrossPatch";
+    homepage = "https://github.com/nockcs/CrossPatch";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ luna-the-tuna ];

--- a/pkgs/by-name/fe/fertilizer/package.nix
+++ b/pkgs/by-name/fe/fertilizer/package.nix
@@ -10,7 +10,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "moleculekayak";
+    owner = "molecular-labs";
     repo = "fertilizer";
     tag = "v${finalAttrs.version}";
     hash = "sha256-dPTR3GfofXBV1gwQ8Xdl8Dyz23CU9qBLAahwpxj8z+Q=";
@@ -34,8 +34,8 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   meta = {
     description = "Cross-seeding tool for music";
-    homepage = "https://github.com/moleculekayak/fertilizer";
-    changelog = "https://github.com/moleculekayak/fertilizer/releases";
+    homepage = "https://github.com/molecular-labs/fertilizer";
+    changelog = "https://github.com/molecular-labs/fertilizer/releases";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ ambroisie ];
     mainProgram = "fertilizer";

--- a/pkgs/by-name/fi/finamp/package.nix
+++ b/pkgs/by-name/fi/finamp/package.nix
@@ -21,7 +21,7 @@ flutter341.buildFlutterApplication {
   inherit version;
   pname = "finamp";
   src = fetchFromGitHub {
-    owner = "UnicornsOnLSD";
+    owner = "finamp-app";
     repo = "finamp";
     rev = version;
     hash = "sha256-o7q7Yr47maTrt4CG3PiV9Fdhy77ToboVdd8olZFfFts=";
@@ -98,10 +98,10 @@ flutter341.buildFlutterApplication {
   };
 
   meta = {
-    # Finamp depends on `ìsar`, which for Linux is only compiled for x86_64. https://github.com/UnicornsOnLSD/finamp/issues/766
+    # Finamp depends on `ìsar`, which for Linux is only compiled for x86_64. https://github.com/finamp-app/finamp/issues/766
     broken = stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isx86_64;
     description = "Open source Jellyfin music player";
-    homepage = "https://github.com/UnicornsOnLSD/finamp";
+    homepage = "https://github.com/finamp-app/finamp";
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [ dseelp ];
     mainProgram = "finamp";

--- a/pkgs/by-name/fv/fvm/package.nix
+++ b/pkgs/by-name/fv/fvm/package.nix
@@ -12,7 +12,7 @@ let
   version = "4.1.2";
 
   src = fetchFromGitHub {
-    owner = "leoafarias";
+    owner = "conceptadev";
     repo = "fvm";
     tag = version;
     hash = "sha256-Kyxyt2UsrQ6Bc6EuYJjpEFdYwcus2/bcVrWsd/gs3Ok=";
@@ -47,7 +47,7 @@ buildDartApplication {
 
   meta = {
     description = "Simple CLI to manage Flutter SDK versions";
-    homepage = "https://github.com/leoafarias/fvm";
+    homepage = "https://github.com/conceptadev/fvm";
     license = lib.licenses.mit;
     mainProgram = "fvm";
     maintainers = [ ];

--- a/pkgs/by-name/go/go-graft/package.nix
+++ b/pkgs/by-name/go/go-graft/package.nix
@@ -10,7 +10,7 @@ buildGoModule (finalAttrs: {
   version = "0.2.19";
 
   src = fetchFromGitHub {
-    owner = "mzz2017";
+    owner = "daeuniverse";
     repo = "gg";
     rev = "v${finalAttrs.version}";
     hash = "sha256-DXW0NtFYvcCX4CgMs5/5HPaO9f9eFtw401wmJdCbHPU=";
@@ -37,8 +37,8 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Command-line tool for one-click proxy in your research and development without installing v2ray or anything else";
-    changelog = "https://github.com/mzz2017/gg/releases/tag/${finalAttrs.src.rev}";
-    homepage = "https://github.com/mzz2017/gg";
+    changelog = "https://github.com/daeuniverse/gg/releases/tag/${finalAttrs.src.rev}";
+    homepage = "https://github.com/daeuniverse/gg";
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [
       xyenon

--- a/pkgs/by-name/go/gostatic/package.nix
+++ b/pkgs/by-name/go/gostatic/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "2.35";
 
   src = fetchFromGitHub {
-    owner = "piranha";
+    owner = "sansolovyov";
     repo = "gostatic";
     rev = finalAttrs.version;
     hash = "sha256-pxk9tauB7u0oe6g4maHh+dREZXKwMz44v3KB43yYW6c=";
@@ -19,7 +19,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Fast static site generator";
-    homepage = "https://github.com/piranha/gostatic";
+    homepage = "https://github.com/sansolovyov/gostatic";
     license = lib.licenses.isc;
     maintainers = [ ];
     mainProgram = "gostatic";

--- a/pkgs/by-name/gr/graphify/package.nix
+++ b/pkgs/by-name/gr/graphify/package.nix
@@ -12,7 +12,7 @@ python3Packages.buildPythonApplication rec {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "safishamsi";
+    owner = "Graphify-Labs";
     repo = "graphify";
     tag = "v${version}";
     hash = "sha256-QEzB1tFBqGhpmI7oudMRC1Ia0CDcm+GYt6AgxMA5zDo=";
@@ -84,8 +84,8 @@ python3Packages.buildPythonApplication rec {
 
   meta = {
     description = "AI coding assistant skill. Turn any folder of code, docs, papers, images, or videos into a queryable knowledge graph.";
-    homepage = "https://github.com/safishamsi/graphify";
-    changelog = "https://github.com/safishamsi/graphify/blob/${src.rev}/CHANGELOG.md";
+    homepage = "https://github.com/Graphify-Labs/graphify";
+    changelog = "https://github.com/Graphify-Labs/graphify/blob/${src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ stunkymonkey ];
     mainProgram = "graphify";

--- a/pkgs/by-name/he/herdr/package.nix
+++ b/pkgs/by-name/he/herdr/package.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
-    owner = "ogulcancelik";
+    owner = "herdrdev";
     repo = "herdr";
     tag = "v${finalAttrs.version}";
     hash = "sha256-3BA8eredGku+vsL2Af7sUf43QiArR5XTHNrI+X11vFM=";
@@ -78,7 +78,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Agent multiplexer that lives in your terminal";
     homepage = "https://herdr.dev";
-    changelog = "https://github.com/ogulcancelik/herdr/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/herdrdev/herdr/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [
       kevinpita

--- a/pkgs/by-name/kt/ktfmt/package.nix
+++ b/pkgs/by-name/kt/ktfmt/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.63";
 
   src = fetchFromGitHub {
-    owner = "facebook";
+    owner = "Kotlin";
     repo = "ktfmt";
     tag = "v${finalAttrs.version}";
     hash = "sha256-wAnlUEPFyilAbEXN6DGXHXeYfZgx2tlp4vDENP4O2Hw=";
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Program that reformats Kotlin source code to comply with the common community standard for Kotlin code conventions";
-    homepage = "https://github.com/facebook/ktfmt";
+    homepage = "https://github.com/Kotlin/ktfmt";
     license = lib.licenses.asl20;
     mainProgram = "ktfmt";
     maintainers = with lib.maintainers; [ ghostbuster91 ];

--- a/pkgs/by-name/lu/lue/package.nix
+++ b/pkgs/by-name/lu/lue/package.nix
@@ -12,7 +12,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "superstarryeyes";
+    owner = "paulilaaso";
     repo = "lue";
     tag = "v${finalAttrs.version}";
     hash = "sha256-T7uh9PSCTkT+jYxQYC4ebPkabDz3pc6JjCGtgNatIAM=";
@@ -49,7 +49,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   meta = {
     description = "Terminal eBook Reader with Text-to-Speech";
-    homepage = "https://github.com/superstarryeyes/lue";
+    homepage = "https://github.com/paulilaaso/lue";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ yiyu ];
     mainProgram = "lue";

--- a/pkgs/by-name/ng/ngt/package.nix
+++ b/pkgs/by-name/ng/ngt/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.6.0";
 
   src = fetchFromGitHub {
-    owner = "yahoojapan";
+    owner = "NGT-labs";
     repo = "NGT";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-dAJ8Xz7Cgmajac43G/3JWj1gwlG2z1RaN7R49IsbMnc=";
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    homepage = "https://github.com/yahoojapan/NGT";
+    homepage = "https://github.com/NGT-labs/NGT";
     description = "Nearest Neighbor Search with Neighborhood Graph and Tree for High-dimensional Data";
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
     license = lib.licenses.asl20;

--- a/pkgs/by-name/nh/nhentai/package.nix
+++ b/pkgs/by-name/nh/nhentai/package.nix
@@ -31,7 +31,7 @@ python.pkgs.buildPythonApplication rec {
 
   src = fetchFromGitHub {
     owner = "RicterZ";
-    repo = "nhentai";
+    repo = "doujinshi-dl";
     rev = version;
     hash = "sha256-KwcaCeeGeR6qSfraSYyf4VEims9YWB6j3HmpT8XSePo=";
   };
@@ -62,7 +62,7 @@ python.pkgs.buildPythonApplication rec {
   ];
 
   meta = {
-    homepage = "https://github.com/RicterZ/nhentai";
+    homepage = "https://github.com/RicterZ/doujinshi-dl";
     description = "CLI tool for downloading doujinshi from adult site(s)";
     license = lib.licenses.mit;
     maintainers = [ ];

--- a/pkgs/by-name/ni/nix-bundle/package.nix
+++ b/pkgs/by-name/ni/nix-bundle/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.4.1";
 
   src = fetchFromGitHub {
-    owner = "matthewbauer";
+    owner = "nix-community";
     repo = "nix-bundle";
     rev = "v${finalAttrs.version}";
     sha256 = "0js8spwjvw6kjxz1i072scd035fhiyazixvn84ibdnw8dx087gjv";
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    homepage = "https://github.com/matthewbauer/nix-bundle";
+    homepage = "https://github.com/nix-community/nix-bundle";
     description = "Create bundles from Nixpkgs attributes";
     longDescription = ''
       nix-bundle is a way to package Nix attributes into single-file

--- a/pkgs/by-name/ni/nixos-facter/package.nix
+++ b/pkgs/by-name/ni/nixos-facter/package.nix
@@ -16,7 +16,7 @@ let
   # We are waiting on some changes to be merged upstream: https://github.com/openSUSE/hwinfo/pulls
   hwinfoOverride = hwinfo.overrideAttrs {
     src = fetchFromGitHub {
-      owner = "numtide";
+      owner = "nix-community";
       repo = "hwinfo";
       rev = "bfeab0b4e38b200c7a62a44d4d01601a86fe1091";
       hash = "sha256-GL3fNCSaU45fNihEksgtPtbuLkc+tVGXtPH05wbrHwI=";
@@ -28,7 +28,7 @@ buildGoModule (finalAttrs: {
   version = "0.4.4";
 
   src = fetchFromGitHub {
-    owner = "numtide";
+    owner = "nix-community";
     repo = "nixos-facter";
     tag = "v${finalAttrs.version}";
     hash = "sha256-w4tFIouJQLf/JeY7wvvSLbxQv73Bbs11a8EAu6iXwKU=";
@@ -71,7 +71,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Declarative hardware configuration for NixOS";
-    homepage = "https://github.com/numtide/nixos-facter";
+    homepage = "https://github.com/nix-community/nixos-facter";
     license = lib.licenses.gpl3Plus;
     maintainers = [ lib.maintainers.brianmcgee ];
     mainProgram = "nixos-facter";

--- a/pkgs/by-name/no/noctalia-shell/package.nix
+++ b/pkgs/by-name/no/noctalia-shell/package.nix
@@ -72,7 +72,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "noctalia-dev";
-    repo = "noctalia-shell";
+    repo = "noctalia";
     tag = "v${finalAttrs.version}";
     hash = "sha256-QszLpoDPD7JEv8B/w1U2u1ksBw/CYBDmwUTLhJrekF0=";
   };
@@ -113,9 +113,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    changelog = "https://github.com/noctalia-dev/noctalia-shell/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/noctalia-dev/noctalia/releases/tag/v${finalAttrs.version}";
     description = "Sleek and minimal desktop shell thoughtfully crafted for Wayland, built with Quickshell";
-    homepage = "https://github.com/noctalia-dev/noctalia-shell";
+    homepage = "https://github.com/noctalia-dev/noctalia";
     license = lib.licenses.mit;
     mainProgram = "noctalia-shell";
     maintainers = with lib.maintainers; [ spacedentist ];

--- a/pkgs/by-name/no/nono/package.nix
+++ b/pkgs/by-name/no/nono/package.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   __darwinAllowLocalNetworking = true; # required for tests
 
   src = fetchFromGitHub {
-    owner = "always-further";
+    owner = "nolabs-ai";
     repo = "nono";
     tag = "v${finalAttrs.version}";
     hash = "sha256-RxVYatzKjv6LJ+M4Js+sTvg0hMnovXxtr6WxwFYF16Y=";
@@ -142,14 +142,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
   passthru.updateScript = nix-update-script { };
   meta = {
     description = "Secure, kernel-enforced sandbox for AI agents, MCP and LLM workloads";
-    homepage = "https://github.com/always-further/nono";
-    changelog = "https://github.com/always-further/nono/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    homepage = "https://github.com/nolabs-ai/nono";
+    changelog = "https://github.com/nolabs-ai/nono/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       jk
     ];
     mainProgram = "nono";
-    # https://github.com/always-further/nono#platform-support
+    # https://github.com/nolabs-ai/nono#platform-support
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })

--- a/pkgs/by-name/no/nordzy-icon-theme/package.nix
+++ b/pkgs/by-name/no/nordzy-icon-theme/package.nix
@@ -12,7 +12,7 @@ stdenvNoCC.mkDerivation rec {
   version = "1.8.7";
 
   src = fetchFromGitHub {
-    owner = "alvatip";
+    owner = "MolassesLover";
     repo = "Nordzy-icon";
     rev = version;
     sha256 = "sha256-r/WYGcHRAFX7TennestobjcJhwu3GE8aQXxnaeokQM0=";
@@ -49,7 +49,7 @@ stdenvNoCC.mkDerivation rec {
 
   meta = {
     description = "Icon theme using the Nord color palette, based on WhiteSur and Numix icon themes";
-    homepage = "https://github.com/alvatip/Nordzy-icon";
+    homepage = "https://github.com/MolassesLover/Nordzy-icon";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ alexnortung ];

--- a/pkgs/by-name/no/norgolith/package.nix
+++ b/pkgs/by-name/no/norgolith/package.nix
@@ -13,9 +13,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.4.0";
 
   src = fetchFromGitHub {
-    owner = "NTBBloodbath";
-    repo = "norgolith";
-    tag = "v${finalAttrs.version}";
+    owner = "norgolith";
+    repo = "core";
+    tag = "norgolith-v${finalAttrs.version}";
     hash = "sha256-K3Gg/8LKmxrHLzVUx4IF3nTxwl2PU7CrV5oZ8BwHo1U=";
   };
 
@@ -43,7 +43,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "The monolithic Norg static site generator built with Rust";
     homepage = "https://norgolith.amartin.beer";
-    changelog = "https://github.com/NTBBloodbath/norgolith/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/norgolith/core/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [ Ladas552 ];
     mainProgram = "lith";

--- a/pkgs/by-name/no/nototools/package.nix
+++ b/pkgs/by-name/no/nototools/package.nix
@@ -11,7 +11,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "googlefonts";
+    owner = "notofonts";
     repo = "nototools";
     tag = "v${finalAttrs.version}";
     sha256 = "sha256-0se0YcnhDwwMbt2C4hep0T/JEidHfFRUnm2Sy7qr2uk=";
@@ -75,7 +75,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   meta = {
     description = "Noto fonts support tools and scripts plus web site generation";
-    homepage = "https://github.com/googlefonts/nototools";
+    homepage = "https://github.com/notofonts/nototools";
     license = lib.licenses.asl20;
     maintainers = [ ];
   };

--- a/pkgs/by-name/oa/oapi-codegen/package.nix
+++ b/pkgs/by-name/oa/oapi-codegen/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "2.8.0";
 
   src = fetchFromGitHub {
-    owner = "deepmap";
+    owner = "oapi-codegen";
     repo = "oapi-codegen";
     tag = "v${finalAttrs.version}";
     hash = "sha256-CrHseuO3gNFTJgP9b8Tec7qJ/jvmKgm3ZwiMBrAcIq8=";

--- a/pkgs/by-name/oa/oauth2c/package.nix
+++ b/pkgs/by-name/oa/oauth2c/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "1.20.0";
 
   src = fetchFromGitHub {
-    owner = "cloudentity";
+    owner = "SecureAuthCorp";
     repo = "oauth2c";
     rev = "v${finalAttrs.version}";
     hash = "sha256-l/fXorXE4+6n7qQM2c2pJssNq3DKaxOjapdfNlXuAWg=";
@@ -20,7 +20,7 @@ buildGoModule (finalAttrs: {
   doCheck = false; # tests want to talk to oauth2c.us.authz.cloudentity.io
 
   meta = {
-    homepage = "https://github.com/cloudentity/oauth2c";
+    homepage = "https://github.com/SecureAuthCorp/oauth2c";
     description = "User-friendly OAuth2 CLI";
     mainProgram = "oauth2c";
     longDescription = ''

--- a/pkgs/by-name/oc/ocsigen-i18n/package.nix
+++ b/pkgs/by-name/oc/ocsigen-i18n/package.nix
@@ -11,14 +11,14 @@ ocamlPackages.buildDunePackage rec {
   buildInputs = with ocamlPackages; [ ppxlib ];
 
   src = fetchFromGitHub {
-    owner = "besport";
+    owner = "ocsigen";
     repo = "ocsigen-i18n";
     rev = version;
     hash = "sha256-NIl1YUTws8Ff4nrqdhU7oS/TN0lxVQgrtyEZtpS1ojM=";
   };
 
   meta = {
-    homepage = "https://github.com/besport/ocsigen-i18n";
+    homepage = "https://github.com/ocsigen/ocsigen-i18n";
     description = "I18n made easy for web sites written with eliom";
     license = lib.licenses.lgpl21;
     maintainers = [ lib.maintainers.gal_bolle ];

--- a/pkgs/by-name/on/onetbb/package.nix
+++ b/pkgs/by-name/on/onetbb/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   src = fetchFromGitHub {
-    owner = "oneapi-src";
+    owner = "uxlfoundation";
     repo = "oneTBB";
     tag = "v${finalAttrs.version}";
     hash = "sha256-HIHF6KHlEI4rgQ9Epe0+DmNe1y95K9iYa4V/wFnJfEU=";

--- a/pkgs/by-name/op/opencorsairlink/package.nix
+++ b/pkgs/by-name/op/opencorsairlink/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
   src = fetchFromGitHub {
-    owner = "audiohacked";
+    owner = "hyperkineticnerd";
     repo = "OpenCorsairLink";
     rev = "46dbf206e19a40d6de6bd73142ed93bdb26c5c1a";
     sha256 = "1nizicl0mc9pslc6065mnrs0fnn8sh7ca8iiw7w9ix57zrhabpld";
@@ -31,14 +31,14 @@ stdenv.mkDerivation {
     # Pull upstream fix for -fno-common toolchain
     (fetchpatch {
       name = "fno-common.patch";
-      url = "https://github.com/audiohacked/OpenCorsairLink/commit/d600c7ff032a3911d30b039844a31f0b3acfe26a.patch";
+      url = "https://github.com/hyperkineticnerd/OpenCorsairLink/commit/d600c7ff032a3911d30b039844a31f0b3acfe26a.patch";
       sha256 = "030rwka5bvf79x6ir18vqb09izhz1crp94x5gqjxwv3b20vvv4kx";
     })
   ];
 
   meta = {
     description = "Linux and Mac OS support for the CorsairLink Devices";
-    homepage = "https://github.com/audiohacked/OpenCorsairLink";
+    homepage = "https://github.com/hyperkineticnerd/OpenCorsairLink";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.all;
     maintainers = [ ];

--- a/pkgs/by-name/op/openlibm/package.nix
+++ b/pkgs/by-name/op/openlibm/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.8.7";
 
   src = fetchFromGitHub {
-    owner = "JuliaLang";
+    owner = "JuliaMath";
     repo = "openlibm";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-fSEszCJ1PXkSydTLk8KAyu7zffUrKf+7a1ZDf3Wl/lE=";

--- a/pkgs/by-name/op/openlierox/package.nix
+++ b/pkgs/by-name/op/openlierox/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.58_rc5";
 
   src = fetchFromGitHub {
-    owner = "albertz";
+    owner = "openlierox";
     repo = "openlierox";
     rev = finalAttrs.version;
     hash = "sha256-4ofjroEHlfrQitc7M+YTNWut0LGgntgQoOeBWU8nscY=";

--- a/pkgs/by-name/op/openspecfun/package.nix
+++ b/pkgs/by-name/op/openspecfun/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "openspecfun";
   version = "0.5.7";
   src = fetchFromGitHub {
-    owner = "JuliaLang";
+    owner = "JuliaMath";
     repo = "openspecfun";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-fx9z6bbU2V4x6Pr7/vmlSxkWxZ6qTYuPxnfqKLv08CA=";
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Collection of special mathematical functions";
-    homepage = "https://github.com/JuliaLang/openspecfun";
+    homepage = "https://github.com/JuliaMath/openspecfun";
     license = lib.licenses.mit;
     maintainers = [ ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/op/openttd-ttf/package.nix
+++ b/pkgs/by-name/op/openttd-ttf/package.nix
@@ -10,7 +10,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   version = "0.8";
 
   src = fetchFromGitHub {
-    owner = "zephyris";
+    owner = "OpenTTD";
     repo = "openttd-ttf";
     tag = finalAttrs.version;
     hash = "sha256-ZV74ZQ4Z4jw2tjG3kXj4Vo1J+W3BF0SJIFIae9DWLAc=";
@@ -47,8 +47,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    homepage = "https://github.com/zephyris/openttd-ttf";
-    changelog = "https://github.com/zephyris/openttd-ttf/releases/tag/${finalAttrs.version}";
+    homepage = "https://github.com/OpenTTD/OpenTTD-TTF";
+    changelog = "https://github.com/OpenTTD/OpenTTD-TTF/releases/tag/${finalAttrs.version}";
     description = "TrueType typefaces for text in a pixel art style, designed for use in OpenTTD";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.all;

--- a/pkgs/by-name/op/openutau/package.nix
+++ b/pkgs/by-name/op/openutau/package.nix
@@ -18,7 +18,7 @@ buildDotnetModule rec {
   version = "0.1.565";
 
   src = fetchFromGitHub {
-    owner = "stakira";
+    owner = "openutau";
     repo = "OpenUtau";
     tag = version;
     hash = "sha256-tjW1xmt409AlEmw/N1RG46oigP4mWAoTecQGV/hwMo4=";

--- a/pkgs/by-name/op/optional-lite/package.nix
+++ b/pkgs/by-name/op/optional-lite/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.6.0";
 
   src = fetchFromGitHub {
-    owner = "martinmoene";
+    owner = "nonstd-lite";
     repo = "optional-lite";
     tag = "v${finalAttrs.version}";
     hash = "sha256-qmKuxYc0cpoOtRRb4okJZ8pYPvzQid1iqBctnhGlz6M=";
@@ -31,8 +31,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "C++17-like optional, a nullable object for C++98, C++11 and later in a single-file header-only library";
-    homepage = "https://github.com/martinmoene/optional-lite";
-    changelog = "https://github.com/martinmoene/optional-lite/blob/v${finalAttrs.version}/CHANGES.txt";
+    homepage = "https://github.com/nonstd-lite/optional-lite";
+    changelog = "https://github.com/nonstd-lite/optional-lite/blob/v${finalAttrs.version}/CHANGES.txt";
     license = lib.licenses.boost;
     maintainers = with lib.maintainers; [ titaniumtown ];
   };

--- a/pkgs/by-name/or/orchard/package.nix
+++ b/pkgs/by-name/or/orchard/package.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
   version = "0.54.0";
 
   src = fetchFromGitHub {
-    owner = "cirruslabs";
+    owner = "openai";
     repo = "orchard";
     rev = version;
     hash = "sha256-Kf8RGYxgnXX9iEbZ9B0aRKUDQ5PgfyBfVk/C62zSrMU=";
@@ -53,7 +53,7 @@ buildGoModule rec {
   meta = {
     mainProgram = "orchard";
     description = "Orchestrator for running Tart Virtual Machines on a cluster of Apple Silicon devices";
-    homepage = "https://github.com/cirruslabs/orchard";
+    homepage = "https://github.com/openai/orchard";
     license = lib.licenses.fairsource09;
     maintainers = with lib.maintainers; [ techknowlogick ];
   };

--- a/pkgs/by-name/os/osqp-eigen/package.nix
+++ b/pkgs/by-name/os/osqp-eigen/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.11.2";
 
   src = fetchFromGitHub {
-    owner = "robotology";
+    owner = "gbionics";
     repo = "osqp-eigen";
     rev = "v${finalAttrs.version}";
     hash = "sha256-/9M7DufsgjlG4UbBfi64FQsMms06OsljZP2C9uCQe7w=";
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Simple Eigen-C++ wrapper for OSQP library";
-    homepage = "https://github.com/robotology/osqp-eigen";
+    homepage = "https://github.com/gbionics/osqp-eigen";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ nim65s ];
   };

--- a/pkgs/by-name/os/osqp/package.nix
+++ b/pkgs/by-name/os/osqp/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.0.0";
 
   src = fetchFromGitHub {
-    owner = "oxfordcontrol";
+    owner = "osqp";
     repo = "osqp";
     tag = "v${finalAttrs.version}";
     hash = "sha256-BOAytzJzHcggncQzeDrXwJOq8B3doWERJ6CKIVg1yJY=";

--- a/pkgs/by-name/ov/oven-media-engine/package.nix
+++ b/pkgs/by-name/ov/oven-media-engine/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   version = "0.20.5";
 
   src = fetchFromGitHub {
-    owner = "AirenSoft";
+    owner = "OvenMediaLabs";
     repo = "OvenMediaEngine";
     rev = "v${version}";
     sha256 = "sha256-GIjQ8lTZ0jEcZkhvx7lQ8sbHJ9KbJT77FsNt2Ca997Y=";

--- a/pkgs/by-name/ox/oxipng/package.nix
+++ b/pkgs/by-name/ox/oxipng/package.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   # do not use fetchCrate (only repository includes tests)
   src = fetchFromGitHub {
-    owner = "shssoichiro";
+    owner = "oxipng";
     repo = "oxipng";
     tag = "v${finalAttrs.version}";
     hash = "sha256-G06GAlxEVOqt2xHq+JOLSYbsa++aArbu+sb0ypQn9u4=";
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   meta = {
-    homepage = "https://github.com/shssoichiro/oxipng";
+    homepage = "https://github.com/oxipng/oxipng";
     description = "Multithreaded lossless PNG compression optimizer";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ dywedir ];

--- a/pkgs/by-name/pa/padbuster/package.nix
+++ b/pkgs/by-name/pa/padbuster/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
   version = "0.3.3";
 
   src = fetchFromGitHub {
-    owner = "AonCyberLabs";
+    owner = "strozfriedberg";
     repo = "padbuster";
     rev = "50e4a3e2bf5dfff5699440b3ebc61ed1b5c49bbe";
     sha256 = "VIvZ28MVnTSQru6l8flLVVqIIpxxXD8lCqzH81sPe/U=";

--- a/pkgs/by-name/pa/paho-mqtt-c/package.nix
+++ b/pkgs/by-name/pa/paho-mqtt-c/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.3.16";
 
   src = fetchFromGitHub {
-    owner = "eclipse";
+    owner = "eclipse-paho";
     repo = "paho.mqtt.c";
     tag = "v${finalAttrs.version}";
     hash = "sha256-ETSx3dvGP9Kjf7v8zglnUvMK6nOcgUnryJ5QUVvEgT4=";

--- a/pkgs/by-name/pa/paho-mqtt-cpp/package.nix
+++ b/pkgs/by-name/pa/paho-mqtt-cpp/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.6.0";
 
   src = fetchFromGitHub {
-    owner = "eclipse";
+    owner = "eclipse-paho";
     repo = "paho.mqtt.cpp";
     tag = "v${finalAttrs.version}";
     hash = "sha256-WpuI0BPGPCuV1riviUGy2CLshW0RSVIxcjgFmmH2SqA=";

--- a/pkgs/by-name/pa/patroni/package.nix
+++ b/pkgs/by-name/pa/patroni/package.nix
@@ -27,7 +27,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "zalando";
+    owner = "patroni";
     repo = "patroni";
     tag = "v${finalAttrs.version}";
     hash = "sha256-KCixqBMXJTl+Ins8B+VQ3qRxNSgEGlZz3XRYp4qDUHs=";

--- a/pkgs/by-name/pd/pdf2svg/package.nix
+++ b/pkgs/by-name/pd/pdf2svg/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.2.4";
 
   src = fetchFromGitHub {
-    owner = "db9052";
+    owner = "dawbarton";
     repo = "pdf2svg";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-zME0U+PyENnoLyjo9W2i2MRM00wNmHkYcR2LMEtTbBY=";

--- a/pkgs/development/libraries/nss/generic.nix
+++ b/pkgs/development/libraries/nss/generic.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   inherit version;
 
   src = fetchFromGitHub {
-    owner = "nss-dev";
+    owner = "mozilla";
     repo = "nss";
     rev = "NSS_${lib.replaceStrings [ "." ] [ "_" ] version}_RTM";
     inherit hash;
@@ -260,7 +260,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS";
     description = "Set of libraries for development of security-enabled client and server applications";
-    changelog = "https://github.com/nss-dev/nss/blob/master/doc/rst/releases/nss_${underscoreVersion}.rst";
+    changelog = "https://github.com/mozilla/nss/blob/master/doc/rst/releases/nss_${underscoreVersion}.rst";
     maintainers = with lib.maintainers; [
       hexa
       ajs124

--- a/pkgs/development/python-modules/bittensor-cli/default.nix
+++ b/pkgs/development/python-modules/bittensor-cli/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage (finalAttrs: {
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
-    owner = "latent-to";
+    owner = "RaoFoundation";
     repo = "btcli";
     tag = "v${finalAttrs.version}";
     hash = "sha256-rwPYuDfRi3L1BvNN+MoqJlJjyp/vyK7/p6iyB7RJ9Wk=";
@@ -77,8 +77,8 @@ buildPythonPackage (finalAttrs: {
 
   meta = {
     description = "Bittensor command line tool";
-    homepage = "https://github.com/latent-to/btcli";
-    changelog = "https://github.com/latent-to/btcli/releases/tag/${finalAttrs.src.tag}";
+    homepage = "https://github.com/RaoFoundation/btcli";
+    changelog = "https://github.com/RaoFoundation/btcli/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ kilyanni ];
     mainProgram = "btcli";

--- a/pkgs/development/python-modules/iocextract/default.nix
+++ b/pkgs/development/python-modules/iocextract/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   format = "setuptools";
 
   src = fetchFromGitHub {
-    owner = "InQuest";
+    owner = "pedramamini";
     repo = "iocextract";
     tag = "v${version}";
     hash = "sha256-cCp9ug/TuVY1zL+kiDlFGBmfFJyAmVwxLD36WT0oRAE=";
@@ -38,8 +38,8 @@ buildPythonPackage rec {
   meta = {
     description = "Module to extract Indicator of Compromises (IOC)";
     mainProgram = "iocextract";
-    homepage = "https://github.com/InQuest/iocextract";
-    changelog = "https://github.com/InQuest/iocextract/releases/tag/v${version}";
+    homepage = "https://github.com/pedramamini/iocextract";
+    changelog = "https://github.com/pedramamini/iocextract/releases/tag/v${version}";
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/name-that-hash/default.nix
+++ b/pkgs/development/python-modules/name-that-hash/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "HashPals";
+    owner = "bee-san";
     repo = "name-that-hash";
     rev = version;
     hash = "sha256-zOb4BS3zG1x8GLXAooqqvMOw0fNbw35JuRWOdGP26/8=";
@@ -36,7 +36,7 @@ buildPythonPackage rec {
   meta = {
     longDescription = "Don't know what type of hash it is? Name That Hash will name that hash type! Identify MD5, SHA256 and 300+ other hashes.";
     description = "Module and CLI for the identification of hashes";
-    homepage = "https://github.com/HashPals/Name-That-Hash";
+    homepage = "https://github.com/bee-san/Name-That-Hash";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ eyjhb ];
   };

--- a/pkgs/development/python-modules/open-interpreter/default.nix
+++ b/pkgs/development/python-modules/open-interpreter/default.nix
@@ -46,8 +46,8 @@ buildPythonPackage rec {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "KillianLucas";
-    repo = "open-interpreter";
+    owner = "openinterpreter";
+    repo = "openinterpreter";
     tag = "v${version}";
     hash = "sha256-fogCcWAhcrCrrcV0q4oKttkf/GeJaJSZnbgiFxvySs8=";
   };
@@ -114,9 +114,9 @@ buildPythonPackage rec {
   meta = {
     broken = true;
     description = "OpenAI's Code Interpreter in your terminal, running locally";
-    homepage = "https://github.com/KillianLucas/open-interpreter";
+    homepage = "https://github.com/openinterpreter/openinterpreter";
     license = lib.licenses.mit;
-    changelog = "https://github.com/KillianLucas/open-interpreter/releases/tag/v${version}";
+    changelog = "https://github.com/openinterpreter/openinterpreter/releases/tag/v${version}";
     maintainers = with lib.maintainers; [ happysalada ];
     mainProgram = "interpreter";
   };


### PR DESCRIPTION
This PR updates some `fetchFromGitHub` calls and corresponding `github.com/<owner>/<repo>` links in the same location to point directly to canonical repositories instead of redirecting URLs.

This doesn't update all `fetchFromGitHub` redirects since that would produce a diff too large for maintainers to review.

**Motivation:**
This avoids silent failures if upstream redirects ever change or disappear, and improves reliability and reproducibility of fetches.

**How:**
Changes were generated using [this script](https://git.kybe.xyz/2kybe3/nixpkgs-github-redirect).

**How to verify:**
You can verify that all modified package sources still build using the following script with a `changed.txt` file containing the changed package list.

<details>
  <summary>Verify script</summary>

```bash
#!/usr/bin/env bash

out="result.txt"
: > "$out"

while read -r pkg; do
    echo "=== $pkg ==="

    output=$(nix build "./nixpkgs#$pkg.src" -L -v --rebuild --no-link --print-out-paths)
    status=$?

    if [ $status -eq 0 ]; then
        echo "$pkg: success | $output" | tee -a "$out"
    else
        echo "$pkg: failed" | tee -a "$out"
    fi
done < ./changed.txt
```
</details>

<details>
  <summary>Changed Packages</summary>

```
ngt
nhentai
nix-bundle
nixos-facter
noctalia-shell
nordzy-icon-theme
nono
norgolith
nototools
nss
nth
oapi-codegen
oauth2c
ocsigen-i18n
onetbb
open-interpreter
opencorsairlink
openlibm
openlierox
openspecfun
openttd-ttf
openutau
optional-lite
orchard
osqp
osqp-eigen
oven-media-engine
oxipng
padbuster
paho-mqtt-c
paho-mqtt-cpp
pdf2svg
patroni
pgmodeler
pekwm
phpantom-lsp
pietrasanta-traceroute
pinniped
pinboard
pip-audit
playerctl
plecost
plover
pms
plover_4
podman
pritunl-client
prometheus-nginx-exporter
pulseeffects-legacy
pyinfra
```
</details>

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
