### PR TITLE
apacheKafka: 4.2.1 and 4.3.1 bumps and cleanup

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -57,6 +57,8 @@
 
 - `security.polkit.enablePkexecWrapper` has been introduced, making the `pkexec` setuid wrapper opt-in.
 
+- Apache Kafka has dropped support for ZooKeeper mode. The `apacheKafka_3_9` and `apacheKafka_4_0` packages have been removed, as every remaining packaged version is KRaft-only. The `services.apache-kafka.zookeeper` option (previously an alias for `services.apache-kafka.settings."zookeeper.connect"`) has been removed; migrate your cluster to [KRaft](#module-services-apache-kafka-kraft) mode instead.
+
 - When Avahi's mDNS resolver is enabled (`services.avahi.nssmdns4` or `services.avahi.nssmdns6`), only the minimal mDNS resolver is enabled by default to avoid adding a 5 second delay to every failed reverse hostname lookup (e.g., delaying ping by 5 seconds). The "full" mDNS resolver now remains disabled unless `services.avahi.nssmdnsFull` is also enabled. Users who have customized [`/etc/mdns.allow`](https://github.com/avahi/nss-mdns/tree/master#etcmdnsallow) to allow mDNS domains not ending `.local` must enable `services.avahi.nssmdnsFull` to continue to resolve such domains.
 
 - `systemd.user.extraConfig` has been removed in favor of the structured [](#opt-systemd.user.settings.Manager) option. Use `systemd.user.settings.Manager` to set any `systemd-user.conf(5)` option directly. For example, replace `systemd.user.extraConfig = "DefaultTimeoutStartSec=60";` with `systemd.user.settings.Manager.DefaultTimeoutStartSec = 60;`.

--- a/nixos/modules/services/misc/apache-kafka.nix
+++ b/nixos/modules/services/misc/apache-kafka.nix
@@ -63,7 +63,7 @@ in
 
         options = {
           "broker.id" = lib.mkOption {
-            description = "Broker ID. -1 or null to auto-allocate in zookeeper mode.";
+            description = "Broker ID.";
             default = null;
             type = with lib.types; nullOr int;
           };
@@ -172,9 +172,13 @@ in
       [ "services" "apache-kafka" "logDirs" ]
       [ "services" "apache-kafka" "settings" "log.dirs" ]
     )
-    (lib.mkRenamedOptionModule
-      [ "services" "apache-kafka" "zookeeper" ]
-      [ "services" "apache-kafka" "settings" "zookeeper.connect" ]
+    (lib.mkRemovedOptionModule
+      [
+        "services"
+        "apache-kafka"
+        "zookeeper"
+      ]
+      "ZooKeeper mode is no longer supported by any packaged Apache Kafka version; please migrate to KRaft mode instead"
     )
 
     (lib.mkRemovedOptionModule [

--- a/nixos/modules/services/misc/kafka.md
+++ b/nixos/modules/services/misc/kafka.md
@@ -12,10 +12,9 @@ manual](https://kafka.apache.org/documentation/#configuration) broker settings.
 
 ## KRaft {#module-services-apache-kafka-kraft}
 
-Unlike in Zookeeper mode, Kafka in
-[KRaft](https://kafka.apache.org/documentation/#kraft) mode requires each log
-dir to be "formatted" (which means a cluster-specific a metadata file must
-exist in each log dir)
+Kafka in [KRaft](https://kafka.apache.org/documentation/#kraft) mode requires
+each log dir to be "formatted" (which means a cluster-specific a metadata file
+must exist in each log dir)
 
 The upstream intention is for users to execute the [storage
 tool](https://kafka.apache.org/documentation/#kraft_storage) to achieve this,
@@ -59,5 +58,4 @@ Notable changes to be aware of include:
   - [Upstream docs](https://kafka.apache.org/documentation.html#brokerconfigs_broker.id)
 
 - Removal of `services.apache-kafka.zookeeper`
-  - Translate using: `services.apache-kafka.settings."zookeeper.connect"`
-  - [Upstream docs](https://kafka.apache.org/documentation.html#brokerconfigs_zookeeper.connect)
+  - ZooKeeper mode is no longer supported; migrate to [KRaft](#module-services-apache-kafka-kraft) mode instead.

--- a/nixos/tests/kafka/base.nix
+++ b/nixos/tests/kafka/base.nix
@@ -115,7 +115,6 @@ let
 in
 with pkgs;
 {
-  kafka_4_0 = makeKafkaTest "kafka_4_0" { kafkaPackage = apacheKafka_4_0; };
   kafka_4_1 = makeKafkaTest "kafka_4_1" { kafkaPackage = apacheKafka_4_1; };
   kafka_4_2 = makeKafkaTest "kafka_4_2" { kafkaPackage = apacheKafka_4_2; };
   kafka_4_3 = makeKafkaTest "kafka_4_3" { kafkaPackage = apacheKafka_4_3; };

--- a/nixos/tests/kafka/base.nix
+++ b/nixos/tests/kafka/base.nix
@@ -5,10 +5,7 @@ with pkgs.lib;
 let
   makeKafkaTest =
     name:
-    {
-      kafkaPackage,
-      mode ? "kraft",
-    }:
+    { kafkaPackage }:
     (import ../make-test-python.nix {
       inherit name;
 
@@ -16,48 +13,36 @@ let
         kafka =
           { ... }:
           {
-            services.apache-kafka = mkMerge [
-              {
-                enable = true;
-                package = kafkaPackage;
-                settings = {
-                  "offsets.topic.replication.factor" = 1;
-                  "log.dirs" = [
-                    "/var/lib/kafka/logdir1"
-                    "/var/lib/kafka/logdir2"
-                  ];
-                };
-              }
-              (mkIf (mode == "zookeeper") {
-                settings = {
-                  "zookeeper.session.timeout.ms" = 600000;
-                  "zookeeper.connect" = [ "zookeeper1:2181" ];
-                };
-              })
-              (mkIf (mode == "kraft") {
-                clusterId = "ak2fIHr4S8WWarOF_ODD0g";
-                formatLogDirs = true;
-                settings = {
-                  "node.id" = 1;
-                  "process.roles" = [
-                    "broker"
-                    "controller"
-                  ];
-                  "listeners" = [
-                    "PLAINTEXT://:9092"
-                    "CONTROLLER://:9093"
-                  ];
-                  "listener.security.protocol.map" = [
-                    "PLAINTEXT:PLAINTEXT"
-                    "CONTROLLER:PLAINTEXT"
-                  ];
-                  "controller.quorum.voters" = [
-                    "1@kafka:9093"
-                  ];
-                  "controller.listener.names" = [ "CONTROLLER" ];
-                };
-              })
-            ];
+            services.apache-kafka = {
+              enable = true;
+              package = kafkaPackage;
+              clusterId = "ak2fIHr4S8WWarOF_ODD0g";
+              formatLogDirs = true;
+              settings = {
+                "offsets.topic.replication.factor" = 1;
+                "log.dirs" = [
+                  "/var/lib/kafka/logdir1"
+                  "/var/lib/kafka/logdir2"
+                ];
+                "node.id" = 1;
+                "process.roles" = [
+                  "broker"
+                  "controller"
+                ];
+                "listeners" = [
+                  "PLAINTEXT://:9092"
+                  "CONTROLLER://:9093"
+                ];
+                "listener.security.protocol.map" = [
+                  "PLAINTEXT:PLAINTEXT"
+                  "CONTROLLER:PLAINTEXT"
+                ];
+                "controller.quorum.voters" = [
+                  "1@kafka:9093"
+                ];
+                "controller.listener.names" = [ "CONTROLLER" ];
+              };
+            };
 
             networking.firewall.allowedTCPPorts = [
               9092
@@ -67,28 +52,10 @@ let
             # i686 tests: qemu-system-i386 can simulate max 2047MB RAM (not 2048)
             virtualisation.memorySize = 2047;
           };
-      }
-      // optionalAttrs (mode == "zookeeper") {
-        zookeeper1 =
-          { ... }:
-          {
-            services.zookeeper = {
-              enable = true;
-            };
-
-            networking.firewall.allowedTCPPorts = [ 2181 ];
-            virtualisation.diskSize = 1024;
-          };
       };
 
       testScript = ''
         start_all()
-
-        ${optionalString (mode == "zookeeper") ''
-          zookeeper1.wait_for_unit("default.target")
-          zookeeper1.wait_for_unit("zookeeper.service")
-          zookeeper1.wait_for_open_port(2181)
-        ''}
 
         kafka.wait_for_unit("default.target")
         kafka.wait_for_unit("apache-kafka.service")

--- a/nixos/tests/kafka/base.nix
+++ b/nixos/tests/kafka/base.nix
@@ -115,10 +115,6 @@ let
 in
 with pkgs;
 {
-  kafka_3_9 = makeKafkaTest "kafka_3_9" {
-    kafkaPackage = apacheKafka_3_9;
-    mode = "zookeeper";
-  };
   kafka_4_0 = makeKafkaTest "kafka_4_0" { kafkaPackage = apacheKafka_4_0; };
   kafka_4_1 = makeKafkaTest "kafka_4_1" { kafkaPackage = apacheKafka_4_1; };
   kafka_4_2 = makeKafkaTest "kafka_4_2" { kafkaPackage = apacheKafka_4_2; };

--- a/nixos/tests/kafka/base.nix
+++ b/nixos/tests/kafka/base.nix
@@ -122,5 +122,6 @@ with pkgs;
   kafka_4_0 = makeKafkaTest "kafka_4_0" { kafkaPackage = apacheKafka_4_0; };
   kafka_4_1 = makeKafkaTest "kafka_4_1" { kafkaPackage = apacheKafka_4_1; };
   kafka_4_2 = makeKafkaTest "kafka_4_2" { kafkaPackage = apacheKafka_4_2; };
+  kafka_4_3 = makeKafkaTest "kafka_4_3" { kafkaPackage = apacheKafka_4_3; };
   kafka = makeKafkaTest "kafka" { kafkaPackage = apacheKafka; };
 }

--- a/pkgs/servers/apache-kafka/3_9.nix
+++ b/pkgs/servers/apache-kafka/3_9.nix
@@ -1,5 +1,0 @@
-import ./generic.nix {
-  kafkaVersion = "3.9.2";
-  scalaVersion = "2.13";
-  hash = "sha256-1dlRwiSE+aCQiwVWO8gKBC3pd53x4GqJ930nzrX2gyM=";
-}

--- a/pkgs/servers/apache-kafka/4_0.nix
+++ b/pkgs/servers/apache-kafka/4_0.nix
@@ -1,5 +1,0 @@
-import ./generic.nix {
-  kafkaVersion = "4.0.1";
-  scalaVersion = "2.13";
-  hash = "sha256-M8xc04WE6w9yYWxMLwX7SINKVvoKnNn+AKxzIMNM9SQ=";
-}

--- a/pkgs/servers/apache-kafka/4_2.nix
+++ b/pkgs/servers/apache-kafka/4_2.nix
@@ -1,5 +1,5 @@
 import ./generic.nix {
-  kafkaVersion = "4.2.0";
+  kafkaVersion = "4.2.1";
   scalaVersion = "2.13";
-  hash = "sha256-ZklCfC0GKQih+guUHY0idPUlNiAvqhsT41RbOVoihfs=";
+  hash = "sha256-z/g5pZlKj9mwJrVU0JhSgHpu+f1NgkbvFRcyYx2knfo=";
 }

--- a/pkgs/servers/apache-kafka/4_3.nix
+++ b/pkgs/servers/apache-kafka/4_3.nix
@@ -1,0 +1,5 @@
+import ./generic.nix {
+  kafkaVersion = "4.3.1";
+  scalaVersion = "2.13";
+  hash = "sha256-8Rgyiy0FNJc1DVvv2CwI23/9cQMn/1KUPdXKqhsl2yE=";
+}

--- a/pkgs/servers/apache-kafka/default.nix
+++ b/pkgs/servers/apache-kafka/default.nix
@@ -3,5 +3,4 @@
   apacheKafka_4_3 = callPackage ./4_3.nix { };
   apacheKafka_4_2 = callPackage ./4_2.nix { };
   apacheKafka_4_1 = callPackage ./4_1.nix { };
-  apacheKafka_4_0 = callPackage ./4_0.nix { };
 }

--- a/pkgs/servers/apache-kafka/default.nix
+++ b/pkgs/servers/apache-kafka/default.nix
@@ -4,5 +4,4 @@
   apacheKafka_4_2 = callPackage ./4_2.nix { };
   apacheKafka_4_1 = callPackage ./4_1.nix { };
   apacheKafka_4_0 = callPackage ./4_0.nix { };
-  apacheKafka_3_9 = callPackage ./3_9.nix { };
 }

--- a/pkgs/servers/apache-kafka/default.nix
+++ b/pkgs/servers/apache-kafka/default.nix
@@ -1,5 +1,6 @@
 { callPackage }:
 {
+  apacheKafka_4_3 = callPackage ./4_3.nix { };
   apacheKafka_4_2 = callPackage ./4_2.nix { };
   apacheKafka_4_1 = callPackage ./4_1.nix { };
   apacheKafka_4_0 = callPackage ./4_0.nix { };

--- a/pkgs/servers/apache-kafka/generic.nix
+++ b/pkgs/servers/apache-kafka/generic.nix
@@ -32,6 +32,9 @@ stdenv.mkDerivation rec {
     inherit hash;
   };
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [
     jre

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -308,9 +308,10 @@ mapAliases {
   antlr4_8 = throw "antlr4_8 has been removed. Consider using a more recent version of antlr4"; # Added 2025-10-20
   ao = throw "'ao' has been renamed to/replaced by 'libfive'"; # Converted to throw 2025-10-27
   apacheAnt = throw "'apacheAnt' has been renamed to/replaced by 'ant'"; # Converted to throw 2025-10-27
-  apacheKafka_3_7 = throw "apacheKafka_2_8 through _3_9 have been removed from nixpkgs as outdated"; # Added 2025-09-27
-  apacheKafka_3_8 = throw "apacheKafka_2_8 through _3_9 have been removed from nixpkgs as outdated"; # Added 2025-09-27
-  apacheKafka_3_9 = throw "apacheKafka_2_8 through _3_9 have been removed from nixpkgs as outdated"; # Added 2026-07-07
+  apacheKafka_3_7 = throw "apacheKafka_2_8 through _4_0 have been removed from nixpkgs as outdated"; # Added 2025-09-27
+  apacheKafka_3_8 = throw "apacheKafka_2_8 through _4_0 have been removed from nixpkgs as outdated"; # Added 2025-09-27
+  apacheKafka_3_9 = throw "apacheKafka_2_8 through _4_0 have been removed from nixpkgs as outdated"; # Added 2026-07-07
+  apacheKafka_4_0 = throw "apacheKafka_2_8 through _4_0 have been removed from nixpkgs as outdated"; # Added 2026-07-07
   apmplanner2 = throw "'apmplanner2' has been removed as it depends on insecure&unmaintained qtwebkit"; # Added 2026-04-26
   apple-sdk_11 = throw "apple-sdk_11 was removed as Nixpkgs no longer supports macOS 11; see the 25.11 release notes"; # Added 2025-05-10
   apple-sdk_12 = throw "apple-sdk_12 was removed as Nixpkgs no longer supports macOS 12; see the 25.11 release notes"; # Added 2025-05-10

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -308,8 +308,9 @@ mapAliases {
   antlr4_8 = throw "antlr4_8 has been removed. Consider using a more recent version of antlr4"; # Added 2025-10-20
   ao = throw "'ao' has been renamed to/replaced by 'libfive'"; # Converted to throw 2025-10-27
   apacheAnt = throw "'apacheAnt' has been renamed to/replaced by 'ant'"; # Converted to throw 2025-10-27
-  apacheKafka_3_7 = throw "apacheKafka_2_8 through _3_8 have been removed from nixpkgs as outdated"; # Added 2025-09-27
-  apacheKafka_3_8 = throw "apacheKafka_2_8 through _3_8 have been removed from nixpkgs as outdated"; # Added 2025-09-27
+  apacheKafka_3_7 = throw "apacheKafka_2_8 through _3_9 have been removed from nixpkgs as outdated"; # Added 2025-09-27
+  apacheKafka_3_8 = throw "apacheKafka_2_8 through _3_9 have been removed from nixpkgs as outdated"; # Added 2025-09-27
+  apacheKafka_3_9 = throw "apacheKafka_2_8 through _3_9 have been removed from nixpkgs as outdated"; # Added 2026-07-07
   apmplanner2 = throw "'apmplanner2' has been removed as it depends on insecure&unmaintained qtwebkit"; # Added 2026-04-26
   apple-sdk_11 = throw "apple-sdk_11 was removed as Nixpkgs no longer supports macOS 11; see the 25.11 release notes"; # Added 2025-05-10
   apple-sdk_12 = throw "apple-sdk_12 was removed as Nixpkgs no longer supports macOS 12; see the 25.11 release notes"; # Added 2025-05-10

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4827,9 +4827,10 @@ with pkgs;
     apacheKafka_4_0
     apacheKafka_4_1
     apacheKafka_4_2
+    apacheKafka_4_3
     ;
 
-  apacheKafka = apacheKafka_4_2;
+  apacheKafka = apacheKafka_4_3;
 
   libastyle = astyle.override { asLibrary = true; };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4823,7 +4823,6 @@ with pkgs;
   antlr = antlr4;
 
   inherit (callPackages ../servers/apache-kafka { })
-    apacheKafka_4_0
     apacheKafka_4_1
     apacheKafka_4_2
     apacheKafka_4_3

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4823,7 +4823,6 @@ with pkgs;
   antlr = antlr4;
 
   inherit (callPackages ../servers/apache-kafka { })
-    apacheKafka_3_9
     apacheKafka_4_0
     apacheKafka_4_1
     apacheKafka_4_2


### PR DESCRIPTION
Kafka release bumps and cleanup for no longer supported versions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [X] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [X] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
