### PR TITLE
openfortivpn-webview-qt: 1.2.3 -> 1.3.0

### DIFF
--- a/pkgs/by-name/op/openfortivpn-webview-qt/package.nix
+++ b/pkgs/by-name/op/openfortivpn-webview-qt/package.nix
@@ -2,23 +2,24 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  cmake,
   qt6Packages,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "openfortivpn-webview-qt";
-  version = "1.2.3";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "gm-vm";
     repo = "openfortivpn-webview";
-    rev = "v${finalAttrs.version}-electron";
-    hash = "sha256-jGDCFdqRfnYwUgVs3KO1pDr52JgkYVRHi2KvABaZFl4=";
+    rev = "v${finalAttrs.version}-qt";
+    hash = "sha256-TohrOgLzvxmUsRVV36XHgE9ul38CjU/qKF+LZOZQieE=";
   };
   sourceRoot = "${finalAttrs.src.name}/openfortivpn-webview-qt";
 
   nativeBuildInputs = [
+    cmake
     qt6Packages.wrapQtAppsHook
-    qt6Packages.qmake
   ];
   buildInputs = [ qt6Packages.qtwebengine ];
   installPhase = ''


### PR DESCRIPTION
Updates `openfortivpn-webview-qt` to the upstream `v1.3.0-qt` release, which adds FIDO2/WebAuthn support. The package now uses upstream's CMake project for the Qt build.

Release: https://github.com/gm-vm/openfortivpn-webview/releases/tag/v1.3.0-qt
Closes #539205

Assisted-by: pi coding agent / Mika (OpenAI GPT-5.5)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
