### PR TITLE
documenso: 1.12.6 -> 2.14.0

### DIFF
--- a/pkgs/by-name/do/documenso/package-lock.json.patch
+++ b/pkgs/by-name/do/documenso/package-lock.json.patch
@@ -1,167 +1,258 @@
 diff --git a/package-lock.json b/package-lock.json
-index 1a647e8..d44033c 100644
+index cb4e523..51f3b56 100644
 --- a/package-lock.json
 +++ b/package-lock.json
-@@ -16,7 +16,6 @@
-         "@documenso/prisma": "^0.0.0",
-         "@lingui/conf": "^5.2.0",
-         "@lingui/core": "^5.2.0",
--        "inngest-cli": "^0.29.1",
-         "luxon": "^3.5.0",
-         "mupdf": "^1.0.0",
-         "react": "^18",
-@@ -41,7 +40,7 @@
-         "prisma-extension-kysely": "^3.0.0",
-         "prisma-kysely": "^1.8.0",
-         "rimraf": "^5.0.1",
--        "turbo": "^1.9.3",
-+        "turbo": "^2.5.8",
-         "vite": "^6.3.5"
-       },
-       "engines": {
-@@ -13223,15 +13222,6 @@
-         "node": ">=0.4.0"
+@@ -46,7 +46,6 @@
+         "dotenv-cli": "^11.0.0",
+         "husky": "^9.1.7",
+         "inngest": "^3.54.0",
+-        "inngest-cli": "^1.17.9",
+         "lint-staged": "^16.2.7",
+         "nanoid": "^5.1.6",
+         "nodemailer": "^8.0.5",
+@@ -61,7 +60,7 @@
+         "rimraf": "^6.1.2",
+         "superjson": "^2.2.5",
+         "syncpack": "^14.0.0-alpha.27",
+-        "turbo": "^1.13.4",
++        "turbo": "^2.10.1",
+         "vite": "^7.2.4",
+         "vite-plugin-static-copy": "^3.1.4",
+         "zod-openapi": "^4.2.4",
+@@ -4519,19 +4518,6 @@
+         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+       }
+     },
+-    "node_modules/@isaacs/fs-minipass": {
+-      "version": "4.0.1",
+-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+-      "dev": true,
+-      "license": "ISC",
+-      "dependencies": {
+-        "minipass": "^7.0.4"
+-      },
+-      "engines": {
+-        "node": ">=18.0.0"
+-      }
+-    },
+     "node_modules/@jest/schemas": {
+       "version": "29.6.3",
+       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+@@ -13599,6 +13585,90 @@
+         }
+       }
+     },
++    "node_modules/@turbo/darwin-64": {
++      "version": "2.10.1",
++      "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.10.1.tgz",
++      "integrity": "sha512-EjfrTXVmT0r4Spv+nu1KRcvjqavCq35F5GRCvoxQi83uoX3wxQ2QTgDkSxO8O4HVXyi28dW0of/y2RFBOD4emA==",
++      "cpu": [
++        "x64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "darwin"
++      ]
++    },
++    "node_modules/@turbo/darwin-arm64": {
++      "version": "2.10.1",
++      "resolved": "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.10.1.tgz",
++      "integrity": "sha512-nVNvaJ7aHxF5zBw8Nc9Er2Iw8A/SPAw25sqlu/63/qGfDMGdarRYrxjdM0O0XK8X8bGg3Yr93Ro7I5tJksrfgA==",
++      "cpu": [
++        "arm64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "darwin"
++      ]
++    },
++    "node_modules/@turbo/linux-64": {
++      "version": "2.10.1",
++      "resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.10.1.tgz",
++      "integrity": "sha512-jaYr5GQGfW2jMkoux7/Yh+pUhKgqBM0pyAZnNTUybnVPy4qB2jP0C4B32Nmg00BYaAU3FaWr/bQ3CKKIYjdI2Q==",
++      "cpu": [
++        "x64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ]
++    },
++    "node_modules/@turbo/linux-arm64": {
++      "version": "2.10.1",
++      "resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.10.1.tgz",
++      "integrity": "sha512-2Wg5TBGYQjaPMJhQzYf0EEM9N5mSE3AKmWBWKz6fsjZ8dlLL4uV7X3PnwtNO1+kRYjwg34ilJwweaT8MvxZOcA==",
++      "cpu": [
++        "arm64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ]
++    },
++    "node_modules/@turbo/windows-64": {
++      "version": "2.10.1",
++      "resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.10.1.tgz",
++      "integrity": "sha512-fRCK6wZiWQgE5fb+WpaBgDsHNo/fKcCoMEOms9E5Il/Bp/ec9uhsVNn0V/2gmN2hSCyFm7oKf0BZY6Lb6CDMOQ==",
++      "cpu": [
++        "x64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "win32"
++      ]
++    },
++    "node_modules/@turbo/windows-arm64": {
++      "version": "2.10.1",
++      "resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.10.1.tgz",
++      "integrity": "sha512-6REIwRpmmnJdHYL+fIv2BGBC9PYd+8Ta+J53nmcHjqi46v/z+hS1sirYU5fg7Cg1r9/99dpRtSXHKTgvcLYSpg==",
++      "cpu": [
++        "arm64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "win32"
++      ]
++    },
+     "node_modules/@tybys/wasm-util": {
+       "version": "0.10.1",
+       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+@@ -14520,16 +14590,6 @@
+         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
        }
      },
 -    "node_modules/adm-zip": {
 -      "version": "0.5.16",
 -      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
 -      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+-      "dev": true,
 -      "license": "MIT",
 -      "engines": {
 -        "node": ">=12.0"
 -      }
 -    },
      "node_modules/agent-base": {
-       "version": "7.1.3",
-       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-@@ -14705,6 +14695,7 @@
-       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-       "license": "ISC",
-+      "optional": true,
-       "engines": {
-         "node": ">=10"
+       "version": "7.1.4",
+       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+@@ -15567,16 +15627,6 @@
+         "fsevents": "~2.3.1"
        }
-@@ -19315,6 +19306,7 @@
-       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-       "license": "ISC",
-+      "optional": true,
-       "dependencies": {
-         "minipass": "^3.0.0"
-       },
-@@ -19327,6 +19319,7 @@
-       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-       "license": "ISC",
-+      "optional": true,
-       "dependencies": {
-         "yallist": "^4.0.0"
-       },
-@@ -19338,7 +19331,8 @@
-       "version": "4.0.0",
-       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
--      "license": "ISC"
-+      "license": "ISC",
-+      "optional": true
      },
-     "node_modules/fs.realpath": {
-       "version": "1.0.0",
-@@ -21227,23 +21221,6 @@
+-    "node_modules/chownr": {
+-      "version": "3.0.0",
+-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+-      "dev": true,
+-      "license": "BlueOak-1.0.0",
+-      "engines": {
+-        "node": ">=18"
+-      }
+-    },
+     "node_modules/ci-info": {
+       "version": "3.9.0",
+       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+@@ -20684,24 +20734,6 @@
          }
        }
      },
 -    "node_modules/inngest-cli": {
--      "version": "0.29.9",
--      "resolved": "https://registry.npmjs.org/inngest-cli/-/inngest-cli-0.29.9.tgz",
--      "integrity": "sha512-H02T7DGG53WV38RswpWmz7JsZXajx+uXDi1Zgq/ON5a+fNQi4hVRkxfoiZLngNeROVVXlokMTBwOShdsrnr7WA==",
+-      "version": "1.17.9",
+-      "resolved": "https://registry.npmjs.org/inngest-cli/-/inngest-cli-1.17.9.tgz",
+-      "integrity": "sha512-4s2pwwiDiNS2AAWvX/pWXSnqyGE5b9Uf0qj2MlWmSVCzTNNwoxNWu6GEDfISWnyV2CMAq41CwuzcYzzLmqcNuA==",
+-      "dev": true,
 -      "hasInstallScript": true,
 -      "license": "SEE LICENSE IN LICENSE.md",
 -      "dependencies": {
 -        "adm-zip": "^0.5.10",
 -        "debug": "^4.3.4",
--        "node-fetch": "2.6.7",
--        "tar": "6.2.1"
+-        "node-fetch": "^2.6.7",
+-        "tar": "^7.5.3"
 -      },
 -      "bin": {
 -        "inngest": "bin/inngest",
 -        "inngest-cli": "bin/inngest"
 -      }
 -    },
-     "node_modules/inngest/node_modules/@opentelemetry/api": {
-       "version": "1.9.0",
-       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-@@ -25470,6 +25447,7 @@
-       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-       "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-       "license": "MIT",
-+      "optional": true,
-       "dependencies": {
-         "minipass": "^3.0.0",
-         "yallist": "^4.0.0"
-@@ -25483,6 +25461,7 @@
-       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-       "license": "ISC",
-+      "optional": true,
-       "dependencies": {
-         "yallist": "^4.0.0"
-       },
-@@ -25494,13 +25473,15 @@
-       "version": "4.0.0",
-       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
--      "license": "ISC"
-+      "license": "ISC",
-+      "optional": true
-     },
-     "node_modules/mkdirp": {
-       "version": "1.0.4",
-       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-       "license": "MIT",
-+      "optional": true,
-       "bin": {
-         "mkdirp": "bin/cmd.js"
-       },
-@@ -32780,6 +32761,7 @@
-       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-       "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-       "license": "ISC",
-+      "optional": true,
-       "dependencies": {
-         "chownr": "^2.0.0",
-         "fs-minipass": "^2.0.0",
-@@ -32838,6 +32820,7 @@
-       "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-       "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-       "license": "ISC",
-+      "optional": true,
-       "engines": {
-         "node": ">=8"
+     "node_modules/inngest/node_modules/ansi-regex": {
+       "version": "4.1.1",
+       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+@@ -23587,19 +23619,6 @@
+         "node": ">=16 || 14 >=14.17"
        }
-@@ -32846,7 +32829,8 @@
-       "version": "4.0.0",
-       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
--      "license": "ISC"
-+      "license": "ISC",
-+      "optional": true
      },
-     "node_modules/temp-dir": {
-       "version": "2.0.0",
-@@ -34050,102 +34034,102 @@
+-    "node_modules/minizlib": {
+-      "version": "3.1.0",
+-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+-      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+-      "dev": true,
+-      "license": "MIT",
+-      "dependencies": {
+-        "minipass": "^7.1.2"
+-      },
+-      "engines": {
+-        "node": ">= 18"
+-      }
+-    },
+     "node_modules/mlly": {
+       "version": "1.8.0",
+       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+@@ -28767,33 +28786,6 @@
+         "url": "https://opencollective.com/webpack"
        }
+     },
+-    "node_modules/tar": {
+-      "version": "7.5.13",
+-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+-      "dev": true,
+-      "license": "BlueOak-1.0.0",
+-      "dependencies": {
+-        "@isaacs/fs-minipass": "^4.0.0",
+-        "chownr": "^3.0.0",
+-        "minipass": "^7.1.2",
+-        "minizlib": "^3.1.0",
+-        "yallist": "^5.0.0"
+-      },
+-      "engines": {
+-        "node": ">=18"
+-      }
+-    },
+-    "node_modules/tar/node_modules/yallist": {
+-      "version": "5.0.0",
+-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+-      "dev": true,
+-      "license": "BlueOak-1.0.0",
+-      "engines": {
+-        "node": ">=18"
+-      }
+-    },
+     "node_modules/teeny-request": {
+       "version": "10.1.2",
+       "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.2.tgz",
+@@ -29178,107 +29170,23 @@
+       "license": "0BSD"
      },
      "node_modules/turbo": {
 -      "version": "1.13.4",
 -      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.13.4.tgz",
 -      "integrity": "sha512-1q7+9UJABuBAHrcC4Sxp5lOqYS5mvxRrwa33wpIyM18hlOCpRD/fTJNxZ0vhbMcJmz15o9kkVm743mPn7p6jpQ==",
-+      "version": "2.5.8",
-+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.5.8.tgz",
-+      "integrity": "sha512-5c9Fdsr9qfpT3hA0EyYSFRZj1dVVsb6KIWubA9JBYZ/9ZEAijgUEae0BBR/Xl/wekt4w65/lYLTFaP3JmwSO8w==",
++      "version": "2.10.1",
++      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.10.1.tgz",
++      "integrity": "sha512-z9WGX2bAfElLOri8JY6pcwr+GfS18B5iGefLcvv3nwM9MoE/fPQQhpgZKTRlBciqGSDuLnfNyfP+eji8mEapQA==",
        "dev": true,
 -      "license": "MPL-2.0",
 +      "license": "MIT",
@@ -175,615 +266,107 @@ index 1a647e8..d44033c 100644
 -        "turbo-linux-arm64": "1.13.4",
 -        "turbo-windows-64": "1.13.4",
 -        "turbo-windows-arm64": "1.13.4"
-+        "turbo-darwin-64": "2.5.8",
-+        "turbo-darwin-arm64": "2.5.8",
-+        "turbo-linux-64": "2.5.8",
-+        "turbo-linux-arm64": "2.5.8",
-+        "turbo-windows-64": "2.5.8",
-+        "turbo-windows-arm64": "2.5.8"
++        "@turbo/darwin-64": "2.10.1",
++        "@turbo/darwin-arm64": "2.10.1",
++        "@turbo/linux-64": "2.10.1",
++        "@turbo/linux-arm64": "2.10.1",
++        "@turbo/windows-64": "2.10.1",
++        "@turbo/windows-arm64": "2.10.1"
        }
      },
-     "node_modules/turbo-darwin-64": {
+-    "node_modules/turbo-darwin-64": {
 -      "version": "1.13.4",
 -      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.13.4.tgz",
 -      "integrity": "sha512-A0eKd73R7CGnRinTiS7txkMElg+R5rKFp9HV7baDiEL4xTG1FIg/56Vm7A5RVgg8UNgG2qNnrfatJtb+dRmNdw==",
-+      "version": "2.5.8",
-+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.5.8.tgz",
-+      "integrity": "sha512-Dh5bCACiHO8rUXZLpKw+m3FiHtAp2CkanSyJre+SInEvEr5kIxjGvCK/8MFX8SFRjQuhjtvpIvYYZJB4AGCxNQ==",
-       "cpu": [
-         "x64"
-       ],
-       "dev": true,
+-      "cpu": [
+-        "x64"
+-      ],
+-      "dev": true,
 -      "license": "MPL-2.0",
-+      "license": "MIT",
-       "optional": true,
-       "os": [
-         "darwin"
-       ]
-     },
-     "node_modules/turbo-darwin-arm64": {
+-      "optional": true,
+-      "os": [
+-        "darwin"
+-      ]
+-    },
+-    "node_modules/turbo-darwin-arm64": {
 -      "version": "1.13.4",
 -      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.13.4.tgz",
 -      "integrity": "sha512-eG769Q0NF6/Vyjsr3mKCnkG/eW6dKMBZk6dxWOdrHfrg6QgfkBUk0WUUujzdtVPiUIvsh4l46vQrNVd9EOtbyA==",
-+      "version": "2.5.8",
-+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.5.8.tgz",
-+      "integrity": "sha512-f1H/tQC9px7+hmXn6Kx/w8Jd/FneIUnvLlcI/7RGHunxfOkKJKvsoiNzySkoHQ8uq1pJnhJ0xNGTlYM48ZaJOQ==",
-       "cpu": [
-         "arm64"
-       ],
-       "dev": true,
+-      "cpu": [
+-        "arm64"
+-      ],
+-      "dev": true,
 -      "license": "MPL-2.0",
-+      "license": "MIT",
-       "optional": true,
-       "os": [
-         "darwin"
-       ]
-     },
-     "node_modules/turbo-linux-64": {
+-      "optional": true,
+-      "os": [
+-        "darwin"
+-      ]
+-    },
+-    "node_modules/turbo-linux-64": {
 -      "version": "1.13.4",
 -      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.13.4.tgz",
 -      "integrity": "sha512-Bq0JphDeNw3XEi+Xb/e4xoKhs1DHN7OoLVUbTIQz+gazYjigVZvtwCvgrZI7eW9Xo1eOXM2zw2u1DGLLUfmGkQ==",
-+      "version": "2.5.8",
-+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.5.8.tgz",
-+      "integrity": "sha512-hMyvc7w7yadBlZBGl/bnR6O+dJTx3XkTeyTTH4zEjERO6ChEs0SrN8jTFj1lueNXKIHh1SnALmy6VctKMGnWfw==",
-       "cpu": [
-         "x64"
-       ],
-       "dev": true,
+-      "cpu": [
+-        "x64"
+-      ],
+-      "dev": true,
 -      "license": "MPL-2.0",
-+      "license": "MIT",
-       "optional": true,
-       "os": [
-         "linux"
-       ]
-     },
-     "node_modules/turbo-linux-arm64": {
+-      "optional": true,
+-      "os": [
+-        "linux"
+-      ]
+-    },
+-    "node_modules/turbo-linux-arm64": {
 -      "version": "1.13.4",
 -      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.13.4.tgz",
 -      "integrity": "sha512-BJcXw1DDiHO/okYbaNdcWN6szjXyHWx9d460v6fCHY65G8CyqGU3y2uUTPK89o8lq/b2C8NK0yZD+Vp0f9VoIg==",
-+      "version": "2.5.8",
-+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.5.8.tgz",
-+      "integrity": "sha512-LQELGa7bAqV2f+3rTMRPnj5G/OHAe2U+0N9BwsZvfMvHSUbsQ3bBMWdSQaYNicok7wOZcHjz2TkESn1hYK6xIQ==",
-       "cpu": [
-         "arm64"
-       ],
-       "dev": true,
+-      "cpu": [
+-        "arm64"
+-      ],
+-      "dev": true,
 -      "license": "MPL-2.0",
-+      "license": "MIT",
-       "optional": true,
-       "os": [
-         "linux"
-       ]
-     },
-     "node_modules/turbo-windows-64": {
+-      "optional": true,
+-      "os": [
+-        "linux"
+-      ]
+-    },
+-    "node_modules/turbo-windows-64": {
 -      "version": "1.13.4",
 -      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.13.4.tgz",
 -      "integrity": "sha512-OFFhXHOFLN7A78vD/dlVuuSSVEB3s9ZBj18Tm1hk3aW1HTWTuAw0ReN6ZNlVObZUHvGy8d57OAGGxf2bT3etQw==",
-+      "version": "2.5.8",
-+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.5.8.tgz",
-+      "integrity": "sha512-3YdcaW34TrN1AWwqgYL9gUqmZsMT4T7g8Y5Azz+uwwEJW+4sgcJkIi9pYFyU4ZBSjBvkfuPZkGgfStir5BBDJQ==",
-       "cpu": [
-         "x64"
-       ],
-       "dev": true,
+-      "cpu": [
+-        "x64"
+-      ],
+-      "dev": true,
 -      "license": "MPL-2.0",
-+      "license": "MIT",
-       "optional": true,
-       "os": [
-         "win32"
-       ]
-     },
-     "node_modules/turbo-windows-arm64": {
+-      "optional": true,
+-      "os": [
+-        "win32"
+-      ]
+-    },
+-    "node_modules/turbo-windows-arm64": {
 -      "version": "1.13.4",
 -      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.13.4.tgz",
 -      "integrity": "sha512-u5A+VOKHswJJmJ8o8rcilBfU5U3Y1TTAfP9wX8bFh8teYF1ghP0EhtMRLjhtp6RPa+XCxHHVA2CiC3gbh5eg5g==",
-+      "version": "2.5.8",
-+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.5.8.tgz",
-+      "integrity": "sha512-eFC5XzLmgXJfnAK3UMTmVECCwuBcORrWdewoiXBnUm934DY6QN8YowC/srhNnROMpaKaqNeRpoB5FxCww3eteQ==",
-       "cpu": [
-         "arm64"
-       ],
-       "dev": true,
+-      "cpu": [
+-        "arm64"
+-      ],
+-      "dev": true,
 -      "license": "MPL-2.0",
-+      "license": "MIT",
-       "optional": true,
-       "os": [
-         "win32"
-@@ -36114,7 +36098,9 @@
-       },
-       "engines": {
-         "node": ">=18"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
-+      "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g=="
+-      "optional": true,
+-      "os": [
+-        "win32"
+-      ]
+-    },
+     "node_modules/type-is": {
+       "version": "1.6.18",
+       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+@@ -30550,6 +30458,8 @@
      },
-     "packages/app-tests/node_modules/start-server-and-test": {
-       "version": "2.0.12",
-@@ -36136,25 +36122,33 @@
-       },
-       "engines": {
-         "node": ">=16"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-2.0.12.tgz",
-+      "integrity": "sha512-U6QiS5qsz+DN5RfJJrkAXdooxMDnLZ+n5nR8kaX//ZH19SilF6b58Z3zM9zTfrNIkJepzauHo4RceSgvgUSX9w=="
-     },
-     "packages/app-tests/node_modules/start-server-and-test/node_modules/bluebird": {
-       "version": "3.7.2",
--      "license": "MIT"
-+      "license": "MIT",
-+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-     },
-     "packages/app-tests/node_modules/start-server-and-test/node_modules/check-more-types": {
-       "version": "2.24.0",
-       "license": "MIT",
-       "engines": {
-         "node": ">= 0.8.0"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
-+      "integrity": "sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA=="
-     },
-     "packages/app-tests/node_modules/start-server-and-test/node_modules/lazy-ass": {
-       "version": "1.6.0",
-       "license": "MIT",
-       "engines": {
-         "node": "> 0.8"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
-+      "integrity": "sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw=="
-     },
-     "packages/app-tests/node_modules/start-server-and-test/node_modules/ps-tree": {
-       "version": "1.2.0",
-@@ -36167,7 +36161,9 @@
-       },
-       "engines": {
-         "node": ">= 0.10"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
-+      "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA=="
-     },
-     "packages/app-tests/node_modules/start-server-and-test/node_modules/ps-tree/node_modules/event-stream": {
-       "version": "3.3.4",
-@@ -36180,18 +36176,26 @@
-         "split": "0.3",
-         "stream-combiner": "~0.0.4",
-         "through": "~2.3.1"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-+      "integrity": "sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g=="
-     },
-     "packages/app-tests/node_modules/start-server-and-test/node_modules/ps-tree/node_modules/event-stream/node_modules/duplexer": {
-       "version": "0.1.2",
--      "license": "MIT"
-+      "license": "MIT",
-+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
-     },
-     "packages/app-tests/node_modules/start-server-and-test/node_modules/ps-tree/node_modules/event-stream/node_modules/from": {
-       "version": "0.1.7",
--      "license": "MIT"
-+      "license": "MIT",
-+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-+      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g=="
-     },
-     "packages/app-tests/node_modules/start-server-and-test/node_modules/ps-tree/node_modules/event-stream/node_modules/map-stream": {
--      "version": "0.1.0"
-+      "version": "0.1.0",
-+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-+      "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g=="
-     },
-     "packages/app-tests/node_modules/start-server-and-test/node_modules/ps-tree/node_modules/event-stream/node_modules/pause-stream": {
-       "version": "0.0.11",
-@@ -36201,7 +36205,9 @@
-       ],
-       "dependencies": {
-         "through": "~2.3"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A=="
-     },
-     "packages/app-tests/node_modules/start-server-and-test/node_modules/ps-tree/node_modules/event-stream/node_modules/split": {
-       "version": "0.3.3",
-@@ -36211,14 +36217,18 @@
-       },
-       "engines": {
-         "node": "*"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-+      "integrity": "sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA=="
-     },
-     "packages/app-tests/node_modules/start-server-and-test/node_modules/ps-tree/node_modules/event-stream/node_modules/stream-combiner": {
-       "version": "0.0.4",
-       "license": "MIT",
-       "dependencies": {
-         "duplexer": "~0.1.1"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-+      "integrity": "sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw=="
-     },
-     "packages/app-tests/node_modules/start-server-and-test/node_modules/wait-on": {
-       "version": "8.0.3",
-@@ -36235,7 +36245,9 @@
-       },
-       "engines": {
-         "node": ">=12.0.0"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-8.0.3.tgz",
-+      "integrity": "sha512-nQFqAFzZDeRxsu7S3C7LbuxslHhk+gnJZHyethuGKAn2IVleIbTB9I3vJSQiSR+DifUqmdzfPMoMPJfLqMF2vw=="
-     },
-     "packages/app-tests/node_modules/start-server-and-test/node_modules/wait-on/node_modules/joi": {
-       "version": "17.13.3",
-@@ -36246,40 +36258,54 @@
-         "@sideway/address": "^4.1.5",
-         "@sideway/formula": "^3.0.1",
-         "@sideway/pinpoint": "^2.0.0"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-+      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA=="
-     },
-     "packages/app-tests/node_modules/start-server-and-test/node_modules/wait-on/node_modules/joi/node_modules/@hapi/hoek": {
-       "version": "9.3.0",
--      "license": "BSD-3-Clause"
-+      "license": "BSD-3-Clause",
-+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
-     },
-     "packages/app-tests/node_modules/start-server-and-test/node_modules/wait-on/node_modules/joi/node_modules/@hapi/topo": {
-       "version": "5.1.0",
-       "license": "BSD-3-Clause",
-       "dependencies": {
-         "@hapi/hoek": "^9.0.0"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg=="
-     },
-     "packages/app-tests/node_modules/start-server-and-test/node_modules/wait-on/node_modules/joi/node_modules/@sideway/address": {
-       "version": "4.1.5",
-       "license": "BSD-3-Clause",
-       "dependencies": {
-         "@hapi/hoek": "^9.0.0"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
-+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q=="
-     },
-     "packages/app-tests/node_modules/start-server-and-test/node_modules/wait-on/node_modules/joi/node_modules/@sideway/formula": {
-       "version": "3.0.1",
--      "license": "BSD-3-Clause"
-+      "license": "BSD-3-Clause",
-+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
-     },
-     "packages/app-tests/node_modules/start-server-and-test/node_modules/wait-on/node_modules/joi/node_modules/@sideway/pinpoint": {
-       "version": "2.0.0",
--      "license": "BSD-3-Clause"
-+      "license": "BSD-3-Clause",
-+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
-     },
-     "packages/app-tests/node_modules/start-server-and-test/node_modules/wait-on/node_modules/rxjs": {
-       "version": "7.8.2",
+     "packages/app-tests/node_modules/@playwright/test": {
+       "version": "1.56.1",
++      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
++      "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
+       "dev": true,
        "license": "Apache-2.0",
        "dependencies": {
-         "tslib": "^2.1.0"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="
-     },
-     "packages/assets": {
-       "name": "@documenso/assets",
-@@ -36718,7 +36744,9 @@
-     },
-     "packages/signing/node_modules/ts-pattern": {
-       "version": "5.7.1",
--      "license": "MIT"
-+      "license": "MIT",
-+      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.7.1.tgz",
-+      "integrity": "sha512-EGs8PguQqAAUIcQfK4E9xdXxB6s2GK4sJfT/vcc9V1ELIvC4LH/zXu2t/5fajtv6oiRCxdv7BgtVK3vWgROxag=="
-     },
-     "packages/signing/node_modules/vitest": {
-       "version": "3.1.4",
-@@ -36787,7 +36815,9 @@
-         "jsdom": {
-           "optional": true
-         }
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.4.tgz",
-+      "integrity": "sha512-Ta56rT7uWxCSJXlBtKgIlApJnT6e6IGmTYxYcmxjJ4ujuZDI59GUQgVDObXXJujOmPDBYXHK1qmaGtneu6TNIQ=="
-     },
-     "packages/signing/node_modules/vitest/node_modules/@vitest/expect": {
-       "version": "3.1.4",
-@@ -36801,7 +36831,9 @@
-       },
-       "funding": {
-         "url": "https://opencollective.com/vitest"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.4.tgz",
-+      "integrity": "sha512-xkD/ljeliyaClDYqHPNCiJ0plY5YIcM0OlRiZizLhlPmpXWpxnGMyTZXOHFhFeG7w9P5PBeL4IdtJ/HeQwTbQA=="
-     },
-     "packages/signing/node_modules/vitest/node_modules/@vitest/mocker": {
-       "version": "3.1.4",
-@@ -36826,7 +36858,9 @@
-         "vite": {
-           "optional": true
-         }
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.4.tgz",
-+      "integrity": "sha512-8IJ3CvwtSw/EFXqWFL8aCMu+YyYXG2WUSrQbViOZkWTKTVicVwZ/YiEZDSqD00kX+v/+W+OnxhNWoeVKorHygA=="
-     },
-     "packages/signing/node_modules/vitest/node_modules/@vitest/mocker/node_modules/estree-walker": {
-       "version": "3.0.3",
-@@ -36834,7 +36868,9 @@
-       "license": "MIT",
-       "dependencies": {
-         "@types/estree": "^1.0.0"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="
-     },
-     "packages/signing/node_modules/vitest/node_modules/@vitest/pretty-format": {
-       "version": "3.1.4",
-@@ -36845,7 +36881,9 @@
-       },
-       "funding": {
-         "url": "https://opencollective.com/vitest"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.4.tgz",
-+      "integrity": "sha512-cqv9H9GvAEoTaoq+cYqUTCGscUjKqlJZC7PRwY5FMySVj5J+xOm1KQcCiYHJOEzOKRUhLH4R2pTwvFlWCEScsg=="
-     },
-     "packages/signing/node_modules/vitest/node_modules/@vitest/runner": {
-       "version": "3.1.4",
-@@ -36857,7 +36895,9 @@
-       },
-       "funding": {
-         "url": "https://opencollective.com/vitest"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.4.tgz",
-+      "integrity": "sha512-djTeF1/vt985I/wpKVFBMWUlk/I7mb5hmD5oP8K9ACRmVXgKTae3TUOtXAEBfslNKPzUQvnKhNd34nnRSYgLNQ=="
-     },
-     "packages/signing/node_modules/vitest/node_modules/@vitest/snapshot": {
-       "version": "3.1.4",
-@@ -36870,7 +36910,9 @@
-       },
-       "funding": {
-         "url": "https://opencollective.com/vitest"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.4.tgz",
-+      "integrity": "sha512-JPHf68DvuO7vilmvwdPr9TS0SuuIzHvxeaCkxYcCD4jTk67XwL45ZhEHFKIuCm8CYstgI6LZ4XbwD6ANrwMpFg=="
-     },
-     "packages/signing/node_modules/vitest/node_modules/@vitest/spy": {
-       "version": "3.1.4",
-@@ -36881,7 +36923,9 @@
-       },
-       "funding": {
-         "url": "https://opencollective.com/vitest"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.4.tgz",
-+      "integrity": "sha512-Xg1bXhu+vtPXIodYN369M86K8shGLouNjoVI78g8iAq2rFoHFdajNvJJ5A/9bPMFcfQqdaCpOgWKEoMQg/s0Yg=="
-     },
-     "packages/signing/node_modules/vitest/node_modules/@vitest/spy/node_modules/tinyspy": {
-       "version": "3.0.2",
-@@ -36889,7 +36933,9 @@
-       "license": "MIT",
-       "engines": {
-         "node": ">=14.0.0"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
-+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q=="
-     },
-     "packages/signing/node_modules/vitest/node_modules/@vitest/utils": {
-       "version": "3.1.4",
-@@ -36902,12 +36948,16 @@
-       },
-       "funding": {
-         "url": "https://opencollective.com/vitest"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.4.tgz",
-+      "integrity": "sha512-yriMuO1cfFhmiGc8ataN51+9ooHRuURdfAZfwFd3usWynjzpLslZdYnRegTv32qdgtJTsj15FoeZe2g15fY1gg=="
-     },
-     "packages/signing/node_modules/vitest/node_modules/@vitest/utils/node_modules/loupe": {
-       "version": "3.1.3",
-       "dev": true,
--      "license": "MIT"
-+      "license": "MIT",
-+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
-+      "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug=="
-     },
-     "packages/signing/node_modules/vitest/node_modules/chai": {
-       "version": "5.2.0",
-@@ -36922,7 +36972,9 @@
-       },
-       "engines": {
-         "node": ">=12"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
-+      "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw=="
-     },
-     "packages/signing/node_modules/vitest/node_modules/chai/node_modules/assertion-error": {
-       "version": "2.0.1",
-@@ -36930,7 +36982,9 @@
-       "license": "MIT",
-       "engines": {
-         "node": ">=12"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="
-     },
-     "packages/signing/node_modules/vitest/node_modules/chai/node_modules/check-error": {
-       "version": "2.1.1",
-@@ -36938,7 +36992,9 @@
-       "license": "MIT",
-       "engines": {
-         "node": ">= 16"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
-+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw=="
-     },
-     "packages/signing/node_modules/vitest/node_modules/chai/node_modules/deep-eql": {
-       "version": "5.0.2",
-@@ -36946,12 +37002,16 @@
-       "license": "MIT",
-       "engines": {
-         "node": ">=6"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="
-     },
-     "packages/signing/node_modules/vitest/node_modules/chai/node_modules/loupe": {
-       "version": "3.1.3",
-       "dev": true,
--      "license": "MIT"
-+      "license": "MIT",
-+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
-+      "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug=="
-     },
-     "packages/signing/node_modules/vitest/node_modules/chai/node_modules/pathval": {
-       "version": "2.0.0",
-@@ -36959,7 +37019,9 @@
-       "license": "MIT",
-       "engines": {
-         "node": ">= 14.16"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
-+      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA=="
-     },
-     "packages/signing/node_modules/vitest/node_modules/expect-type": {
-       "version": "1.2.1",
-@@ -36967,27 +37029,37 @@
-       "license": "Apache-2.0",
-       "engines": {
-         "node": ">=12.0.0"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.1.tgz",
-+      "integrity": "sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw=="
-     },
-     "packages/signing/node_modules/vitest/node_modules/pathe": {
-       "version": "2.0.3",
-       "dev": true,
--      "license": "MIT"
-+      "license": "MIT",
-+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="
-     },
-     "packages/signing/node_modules/vitest/node_modules/std-env": {
-       "version": "3.9.0",
-       "dev": true,
--      "license": "MIT"
-+      "license": "MIT",
-+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
-+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw=="
-     },
-     "packages/signing/node_modules/vitest/node_modules/tinybench": {
-       "version": "2.9.0",
-       "dev": true,
--      "license": "MIT"
-+      "license": "MIT",
-+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
-+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="
-     },
-     "packages/signing/node_modules/vitest/node_modules/tinyexec": {
-       "version": "0.3.2",
-       "dev": true,
--      "license": "MIT"
-+      "license": "MIT",
-+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="
-     },
-     "packages/signing/node_modules/vitest/node_modules/tinypool": {
-       "version": "1.0.2",
-@@ -36995,7 +37067,9 @@
-       "license": "MIT",
-       "engines": {
-         "node": "^18.0.0 || >=20.0.0"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
-+      "integrity": "sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA=="
-     },
-     "packages/signing/node_modules/vitest/node_modules/tinyrainbow": {
-       "version": "2.0.0",
-@@ -37003,7 +37077,9 @@
-       "license": "MIT",
-       "engines": {
-         "node": ">=14.0.0"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="
-     },
-     "packages/signing/node_modules/vitest/node_modules/vite-node": {
-       "version": "3.1.4",
-@@ -37024,7 +37100,9 @@
-       },
-       "funding": {
-         "url": "https://opencollective.com/vitest"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.4.tgz",
-+      "integrity": "sha512-6enNwYnpyDo4hEgytbmc6mYWHXDHYEn0D1/rw4Q+tnHUGtKTJsn8T1YkX6Q18wI5LCrS8CTYlBaiCqxOy2kvUA=="
-     },
-     "packages/signing/node_modules/vitest/node_modules/why-is-node-running": {
-       "version": "2.3.0",
-@@ -37039,17 +37117,23 @@
-       },
-       "engines": {
-         "node": ">=8"
--      }
-+      },
-+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
-+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="
-     },
-     "packages/signing/node_modules/vitest/node_modules/why-is-node-running/node_modules/siginfo": {
-       "version": "2.0.0",
-       "dev": true,
--      "license": "ISC"
-+      "license": "ISC",
-+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
-+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="
-     },
-     "packages/signing/node_modules/vitest/node_modules/why-is-node-running/node_modules/stackback": {
-       "version": "0.0.2",
-       "dev": true,
--      "license": "MIT"
-+      "license": "MIT",
-+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
-+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="
-     },
-     "packages/tailwind-config": {
-       "name": "@documenso/tailwind-config",
-@@ -37171,4 +37255,4 @@
-       "license": "MIT"
-     }
-   }
--}
-+}
-\ No newline at end of file

--- a/pkgs/by-name/do/documenso/package.json.patch
+++ b/pkgs/by-name/do/documenso/package.json.patch
@@ -1,40 +1,21 @@
 diff --git a/package.json b/package.json
-index 1ff8701..e337979 100644
+index d0ffcb2..9b47856 100644
 --- a/package.json
 +++ b/package.json
-@@ -44,22 +44,22 @@
-     "@commitlint/cli": "^17.7.1",
-     "@commitlint/config-conventional": "^17.7.0",
-     "@lingui/cli": "^5.2.0",
-+    "@prisma/client": "^6.8.2",
-     "dotenv": "^16.5.0",
-     "dotenv-cli": "^8.0.0",
-     "eslint": "^8.40.0",
-     "eslint-config-custom": "*",
-     "husky": "^9.0.11",
-     "lint-staged": "^15.2.2",
-+    "nodemailer": "^6.10.1",
-     "playwright": "1.52.0",
-     "prettier": "^3.3.3",
--    "rimraf": "^5.0.1",
--    "turbo": "^1.9.3",
--    "vite": "^6.3.5",
--    "@prisma/client": "^6.8.2",
-     "prisma": "^6.8.2",
-     "prisma-extension-kysely": "^3.0.0",
-     "prisma-kysely": "^1.8.0",
--    "nodemailer": "^6.10.1"
-+    "rimraf": "^5.0.1",
-+    "turbo": "^2.5.8",
-+    "vite": "^6.3.5"
-   },
-   "name": "@documenso/root",
-   "workspaces": [
-@@ -71,7 +71,6 @@
-     "@documenso/prisma": "^0.0.0",
-     "@lingui/conf": "^5.2.0",
-     "@lingui/core": "^5.2.0",
--    "inngest-cli": "^0.29.1",
-     "luxon": "^3.5.0",
-     "mupdf": "^1.0.0",
-     "react": "^18",
+@@ -63,7 +63,6 @@
+     "dotenv-cli": "^11.0.0",
+     "husky": "^9.1.7",
+     "inngest": "^3.54.0",
+-    "inngest-cli": "^1.17.9",
+     "lint-staged": "^16.2.7",
+     "nanoid": "^5.1.6",
+     "nodemailer": "^8.0.5",
+@@ -78,7 +77,7 @@
+     "rimraf": "^6.1.2",
+     "superjson": "^2.2.5",
+     "syncpack": "^14.0.0-alpha.27",
+-    "turbo": "^1.13.4",
++    "turbo": "^2.10.1",
+     "vite": "^7.2.4",
+     "vite-plugin-static-copy": "^3.1.4",
+     "zod-openapi": "^4.2.4",

--- a/pkgs/by-name/do/documenso/package.nix
+++ b/pkgs/by-name/do/documenso/package.nix
@@ -1,30 +1,53 @@
 {
   lib,
+  stdenv,
   nodejs,
   node-gyp,
   node-pre-gyp,
   pixman,
   fetchFromGitHub,
+  fetchurl,
   buildNpmPackage,
   prisma_6,
   prisma-engines_6,
   vips,
   pkg-config,
+  gzip,
+  autoPatchelfHook,
   cairo,
   pango,
   bash,
   openssl,
 }:
 
+let
+  skiaCanvasVersion = "3.0.8";
+  skiaCanvasTriplet =
+    {
+      x86_64-linux = "linux-x64-glibc";
+      aarch64-linux = "linux-arm64-glibc";
+    }
+    .${stdenv.hostPlatform.system}
+      or (throw "unsupported skia-canvas platform ${stdenv.hostPlatform.system}");
+  skiaCanvasPrebuild = fetchurl {
+    url = "https://github.com/samizdatco/skia-canvas/releases/download/v${skiaCanvasVersion}/${skiaCanvasTriplet}.gz";
+    hash =
+      {
+        x86_64-linux = "sha256-9FklKQWZ1LfLUhHBI/re4nvImddVZpbi4zPQ76xpN7I=";
+        aarch64-linux = "sha256-BmXQemDAXZEqL9FFmus3cU6wRFwveEhAdjhUbD0uGnA=";
+      }
+      .${stdenv.hostPlatform.system};
+  };
+in
 buildNpmPackage (finalAttrs: {
   pname = "documenso";
-  version = "1.12.6";
+  version = "2.14.0";
 
   src = fetchFromGitHub {
     owner = "documenso";
     repo = "documenso";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-1TKjsOKJkv3COFgsE4tPAymI0MdeT+T8HiNgnoWHlAY=";
+    hash = "sha256-ZVcbOKBqjDnCo2pZKjaAuO3MK7r/S6k4kEHwBteHVGg=";
   };
 
   patches = [
@@ -33,9 +56,12 @@ buildNpmPackage (finalAttrs: {
     ./turbo.json.patch
   ];
 
-  npmDepsHash = "sha256-ZddRSBDasa3mMAS2dqXgXRMOc1nvspdXsuTZ7c+einw=";
+  npmDepsHash = "sha256-/Jt1ct/GSumu/pgTrmnVHdMhhg8J2Epvu7wnnCakqGs=";
+  npmDepsFetcherVersion = 2;
 
   nativeBuildInputs = [
+    autoPatchelfHook
+    gzip
     pkg-config
     vips
     node-gyp
@@ -47,8 +73,11 @@ buildNpmPackage (finalAttrs: {
     pixman
     cairo
     pango
+    stdenv.cc.cc.lib
     vips
   ];
+
+  npmRebuildFlags = [ "--ignore-scripts" ];
 
   env = {
     PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
@@ -59,6 +88,13 @@ buildNpmPackage (finalAttrs: {
     TURBO_FORCE = "true";
     TURBO_REMOTE_CACHE_ENABLED = "false";
   };
+
+  preBuild = ''
+    mkdir -p node_modules/skia-canvas/lib
+    gzip -dc ${skiaCanvasPrebuild} > node_modules/skia-canvas/lib/skia.node
+
+    npm exec patch-package
+  '';
 
   buildPhase = ''
     runHook preBuild
@@ -81,7 +117,7 @@ buildNpmPackage (finalAttrs: {
     export PKG_CONFIG_PATH=${lib.getLib openssl.dev}/lib/pkgconfig;
     export PRISMA_QUERY_ENGINE_LIBRARY=${lib.getLib prisma-engines_6}/lib/libquery_engine.node
     export PRISMA_QUERY_ENGINE_BINARY=${lib.getExe' prisma-engines_6 "query-engine"}
-    export PRISMA_SCHEMA_ENGINE_BINARY=${prisma-engines_6}
+    export PRISMA_SCHEMA_ENGINE_BINARY=${lib.getExe' prisma-engines_6 "schema-engine"}
     cd $out/apps/remix
     ${lib.getExe prisma_6} migrate deploy --schema ../../packages/prisma/schema.prisma
     ${lib.getExe nodejs} build/server/main.js
@@ -89,6 +125,14 @@ buildNpmPackage (finalAttrs: {
           chmod +x $out/bin/documenso
 
           runHook postInstall
+  '';
+
+  postInstall = ''
+    # These optional prebuilds are for musl libc and can make autoPatchelf link
+    # glibc addons against incompatible vendored libraries.
+    rm -rf $out/node_modules/*musl* $out/node_modules/@*/*musl*
+    rm -rf $out/node_modules/@datadog/pprof/prebuilds/linuxmusl-*
+    rm -rf $out/node_modules/aws-crt/dist/bin/linux-*-musl
   '';
 
   # cleanup dangling symlinks for workspaces
@@ -118,7 +162,10 @@ buildNpmPackage (finalAttrs: {
     homepage = "https://github.com/documenso/documenso";
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [ happysalada ];
-    platforms = lib.platforms.unix;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
     mainProgram = "documenso";
   };
 })

--- a/pkgs/by-name/do/documenso/turbo.json.patch
+++ b/pkgs/by-name/do/documenso/turbo.json.patch
@@ -1,104 +1,20 @@
 diff --git a/turbo.json b/turbo.json
-index d767b46..b2d1ad3 100644
+index c5c0db0..8c79030 100644
 --- a/turbo.json
 +++ b/turbo.json
-@@ -1,41 +1,8 @@
+@@ -1,6 +1,6 @@
  {
    "$schema": "https://turbo.build/schema.json",
 -  "pipeline": {
--    "build": {
--      "dependsOn": ["prebuild", "^build"],
--      "outputs": [".next/**", "!.next/cache/**"]
--    },
--    "prebuild": {
--      "cache": false,
--      "dependsOn": ["^prebuild"]
--    },
--    "lint": {
--      "cache": false
--    },
--    "lint:fix": {
--      "cache": false
--    },
--    "clean": {
--      "cache": false
--    },
--    "dev": {
--      "cache": false,
--      "persistent": true
--    },
--    "start": {
--      "dependsOn": ["^build"],
--      "cache": false,
--      "persistent": true
--    },
--    "dev:test": {
--      "cache": false
--    },
--    "test:e2e": {
--      "dependsOn": ["^build"],
--      "cache": false
--    }
--  },
--  "globalDependencies": ["**/.env.*local"],
-+  "globalDependencies": [
-+    "**/.env.*local"
-+  ],
-   "globalEnv": [
-     "APP_VERSION",
-     "NEXT_PRIVATE_ENCRYPTION_KEY",
-@@ -119,5 +86,53 @@
-     "E2E_TEST_AUTHENTICATE_USERNAME",
-     "E2E_TEST_AUTHENTICATE_USER_EMAIL",
-     "E2E_TEST_AUTHENTICATE_USER_PASSWORD"
++  "tasks": {
+     "build": {
+       "dependsOn": ["prebuild", "^build"],
+       "outputs": [".next/**", "!.next/cache/**"]
+@@ -152,5 +152,6 @@
+     "NEXT_PRIVATE_WEBHOOK_SSRF_BYPASS_HOSTS",
+     "NEXT_PUBLIC_TURNSTILE_SITE_KEY",
+     "NEXT_PRIVATE_TURNSTILE_SECRET_KEY"
 -  ]
 +  ],
-+  "tasks": {
-+    "build": {
-+      "dependsOn": [
-+        "prebuild",
-+        "^build"
-+      ],
-+      "outputs": [
-+        ".next/**",
-+        "!.next/cache/**"
-+      ]
-+    },
-+    "prebuild": {
-+      "cache": false,
-+      "dependsOn": [
-+        "^prebuild"
-+      ]
-+    },
-+    "lint": {
-+      "cache": false
-+    },
-+    "lint:fix": {
-+      "cache": false
-+    },
-+    "clean": {
-+      "cache": false
-+    },
-+    "dev": {
-+      "cache": false,
-+      "persistent": true
-+    },
-+    "start": {
-+      "dependsOn": [
-+        "^build"
-+      ],
-+      "cache": false,
-+      "persistent": true
-+    },
-+    "dev:test": {
-+      "cache": false
-+    },
-+    "test:e2e": {
-+      "dependsOn": [
-+        "^build"
-+      ],
-+      "cache": false
-+    }
-+  },
 +  "envMode": "loose"
  }

--- a/pkgs/by-name/do/documenso/update-from-upstream.sh
+++ b/pkgs/by-name/do/documenso/update-from-upstream.sh
@@ -1,55 +1,116 @@
 #!/usr/bin/env bash
-CMDS=();DESC=();NARGS=$#;ARG1=$1;make_command(){ CMDS+=($1);DESC+=("$2");};usage(){ printf "\nUsage: %s [command]\n\nCommands:\n" $0;line="              ";for((i=0;i<=$(( ${#CMDS[*]} -1));i++));do printf "  %s %s ${DESC[$i]}\n" ${CMDS[$i]} "${line:${#CMDS[$i]}}";done;echo;};runme(){ if test $NARGS -eq 1;then eval "$ARG1"||usage;else usage;fi;}
+set -euo pipefail
 
-version="1.12.6";
+version="2.14.0"
 
-make_command "about" "About this update script."
-about(){
-  echo "Documenso upstream needs some fixing before it can be build in a pure sandbox"
-  echo "environment. This script does the following:"
+usage() {
+  printf "Usage: %s {about|update} [version]\n" "$0"
+}
+
+about() {
+  echo "Documenso upstream needs some fixing before it can be built in a pure sandbox"
+  echo "environment. This script regenerates the JSON patches for a version bump:"
   echo "  - download documenso version ${version} from github in a temp dir"
-  echo "  - uninstall inngest-cli which runs a binary download script at build time."
-  echo "  - upgrade turborepo as the older upstream version 'phones home' at build time."
-  echo "  - update the turbo.json to make it work with preset environment vars"
-  echo "  - fix the lockfile by generating missing hash signatures"
+  echo "  - remove inngest-cli which runs a binary download script at build time"
+  echo "  - upgrade turborepo because the older upstream version phones home at build time"
+  echo "  - update turbo.json for the newer turborepo config"
+  echo "  - fix package-lock.json metadata needed by npmDepsFetcherVersion = 2"
   echo "  - create patches from changed json files"
 }
 
-make_command "update" "Get upstream and prepatch."
-update(){
+patch_sources() {
+  node <<'NODE'
+const fs = require('fs');
+
+const packageJsonPath = 'package.json';
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+delete packageJson.devDependencies['inngest-cli'];
+packageJson.devDependencies.turbo = '^2.10.1';
+fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+
+const turboJsonPath = 'turbo.json';
+let turboJson = fs.readFileSync(turboJsonPath, 'utf8');
+turboJson = turboJson.replace('  "pipeline": {', '  "tasks": {');
+if (!turboJson.includes('  "envMode": "loose"')) {
+  turboJson = turboJson.replace('\n  ]\n}\n', '\n  ],\n  "envMode": "loose"\n}\n');
+}
+fs.writeFileSync(turboJsonPath, turboJson);
+NODE
+}
+
+fix_playwright_lockfile_metadata() {
+  local package_key="packages/app-tests/node_modules/@playwright/test"
+  local playwright_version resolved integrity
+
+  playwright_version=$(jq -r --arg key "$package_key" '.packages[$key].version // empty' package-lock.json)
+  if [[ -z "$playwright_version" ]]; then
+    return
+  fi
+
+  resolved=$(npm view "@playwright/test@${playwright_version}" dist.tarball)
+  integrity=$(npm view "@playwright/test@${playwright_version}" dist.integrity)
+
+  node - "$package_key" "$resolved" "$integrity" <<'NODE'
+const fs = require('fs');
+
+const [packageKey, resolved, integrity] = process.argv.slice(2);
+const path = 'package-lock.json';
+const lockfile = JSON.parse(fs.readFileSync(path, 'utf8'));
+const packageEntry = lockfile.packages[packageKey];
+const updated = {};
+for (const [key, value] of Object.entries(packageEntry)) {
+  updated[key] = value;
+  if (key === 'version') {
+    updated.resolved = resolved;
+    updated.integrity = integrity;
+  }
+}
+lockfile.packages[packageKey] = updated;
+fs.writeFileSync(path, `${JSON.stringify(lockfile, null, 2)}\n`);
+NODE
+}
+
+update() {
+  local update_version=${1:-$version}
+  local current_nixpkgs_dir temptarfile tempdir
 
   echo "updating documenso for nixpkgs packaging"
   current_nixpkgs_dir=${PWD}
-  temptarfile=/tmp/documenso-v${version}.tar.gz
-  tempdir=/tmp/documenso-v${version}
+  temptarfile="/tmp/documenso-v${update_version}.tar.gz"
+  tempdir="/tmp/documenso-v${update_version}"
 
-  if [ ! -f "$temptarfile" ]; then
-    echo "Tarball does not exist; downloading from github.";
-    wget https://github.com/documenso/documenso/archive/refs/tags/v${version}.tar.gz -O $temptarfile
+  if [[ ! -f "$temptarfile" ]]; then
+    echo "Tarball does not exist; downloading from github."
+    wget "https://github.com/documenso/documenso/archive/refs/tags/v${update_version}.tar.gz" -O "$temptarfile"
   fi
 
-  rm -Rf $tempdir
-  mkdir $tempdir
-  tar -xzvf /tmp/documenso-v${version}.tar.gz -C $tempdir --strip-components=1
-  cd $tempdir
+  rm -Rf "$tempdir"
+  mkdir "$tempdir"
+  tar -xzf "$temptarfile" -C "$tempdir" --strip-components=1
+  cd "$tempdir"
   git init
   git add package-lock.json package.json turbo.json
   git commit -m "commit4diff" package-lock.json package.json turbo.json
 
-  echo "rm inngest-cli from root"
-  npm uninstall inngest-cli
+  patch_sources
+  npm install --package-lock-only --ignore-scripts --no-audit --no-fund
+  fix_playwright_lockfile_metadata
 
-  npx @turbo/codemod migrate . --force
-
-  jq '.envMode="loose"' turbo.json > turbo-patched.json
-  cp turbo-patched.json turbo.json
-
-  echo "fix package-lock.json hashes"
-  nix run nixpkgs#npm-lockfile-fix -- package-lock.json
-
-  git diff package-lock.json > $current_nixpkgs_dir/package-lock.json.patch
-  git diff package.json > $current_nixpkgs_dir/package.json.patch
-  git diff turbo.json > $current_nixpkgs_dir/turbo.json.patch
+  git diff --src-prefix=a/ --dst-prefix=b/ -- package-lock.json > "$current_nixpkgs_dir/package-lock.json.patch"
+  git diff --src-prefix=a/ --dst-prefix=b/ -- package.json > "$current_nixpkgs_dir/package.json.patch"
+  git diff --src-prefix=a/ --dst-prefix=b/ -- turbo.json > "$current_nixpkgs_dir/turbo.json.patch"
 }
 
-runme
+case "${1:-}" in
+  about)
+    about
+    ;;
+  update)
+    shift
+    update "${1:-}"
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
Update Documenso from 1.12.6 to 2.14.0 because the packaged release is far behind the current maintained upstream release. This keeps the build sandbox-friendly by removing the Inngest CLI dev dependency that downloads binaries during install, fetching the skia-canvas native prebuild as fixed-output Nix inputs, using a Turbo version that does not fail TLS setup before remote cache is disabled, and dropping incompatible musl sharp optional prebuilds from the installed closure. The update script is refreshed only enough to regenerate the JSON patch files for this bump. Upstream release: https://github.com/documenso/documenso/releases/tag/v2.14.0. This PR was prepared with AI assistance; see the commit trailer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Verified with `nix build .#legacyPackages.x86_64-linux.documenso --print-build-logs`, `nix-build /Users/seungwon/.claude/outputs/documenso-smoke.nix --no-out-link`, and `shellcheck pkgs/by-name/do/documenso/update-from-upstream.sh`. The smoke derivation imports `sharp`, `@node-rs/bcrypt`, `@node-rs/argon2`, `aws-crt`, `.prisma/client`, and `skia-canvas`.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
