### PR TITLE
python3Packages.dpcontracts: fix tests

### DIFF
--- a/pkgs/development/python-modules/dpcontracts/default.nix
+++ b/pkgs/development/python-modules/dpcontracts/default.nix
@@ -20,13 +20,10 @@ buildPythonPackage {
     hash = "sha256-FygJPXo7lZ9tlfqY6KmPJ3PLIilMGLBr3013uj9hCEs=";
   };
 
-  # Replacements in README.rst are necessary to check it with doctest
-  postPatch = ''
-    substituteInPlace README.rst \
-      --replace-fail " PreconditionError" " dpcontracts.PreconditionError" \
-      --replace-fail " PostconditionError" " dpcontracts.PostconditionError" \
-      --replace-fail ">>> class Counter:" $'>>> from dpcontracts import preserve\n    >>> class Counter:'
-  '';
+  patches = [
+    # Replacements in README.rst are necessary to check it with doctest
+    ./fix-doctests.patch
+  ];
 
   build-system = [
     setuptools

--- a/pkgs/development/python-modules/dpcontracts/fix-doctests.patch
+++ b/pkgs/development/python-modules/dpcontracts/fix-doctests.patch
@@ -1,0 +1,66 @@
+diff --git a/README.rst b/README.rst
+index 94855fe..c761229 100644
+--- a/README.rst
++++ b/README.rst
+@@ -299,7 +299,7 @@ automatically generated based on the code of that function:
+     ...     return math.sqrt(x)
+     >>> square_root(-1)
+     Traceback (most recent call last):
+-    PreconditionError: @require(lambda args: args.x > 0) failed
++    dpcontracts.PreconditionError: @require(lambda args: args.x > 0) failed
+ 
+ This is true for postconditions as well:
+ 
+@@ -308,7 +308,7 @@ This is true for postconditions as well:
+     ...     return x - y
+     >>> sub(10, 100)
+     Traceback (most recent call last):
+-    PostconditionError: @ensure(lambda args, result: result > 0) failed
++    dpcontracts.PostconditionError: @ensure(lambda args, result: result > 0) failed
+ 
+ And of course for invariants:
+ 
+@@ -321,7 +321,7 @@ And of course for invariants:
+     >>> counter = Counter(10)
+     >>> counter.increment(-100)
+     Traceback (most recent call last):
+-    PostconditionError: @invariant(lambda self: self.counter >= 0) failed
++    dpcontracts.PostconditionError: @invariant(lambda self: self.counter >= 0) failed
+ 
+ Tests can span more than one line as well:
+ 
+@@ -333,7 +333,7 @@ Tests can span more than one line as well:
+     ...     return x - y
+     >>> sub2(10, 100)
+     Traceback (most recent call last):
+-    PostconditionError: @ensure(lambda args, result: all([
++    dpcontracts.PostconditionError: @ensure(lambda args, result: all([
+         result > 0])) failed
+ 
+ Preserving Old Values
+@@ -342,6 +342,7 @@ Sometimes it's important to be able to compare the results of a function with th
+ previous state of the program. Earlier states can be preserved using the
+ `preserve` decorator:
+ 
++    >>> from dpcontracts import preserve
+     >>> class Counter:
+     ...     def __init__(self, initial_value):
+     ...         self.value = initial_value
+@@ -359,7 +360,7 @@ previous state of the program. Earlier states can be preserved using the
+     >>> counter.increment(10)
+     >>> counter.increment(9)
+     Traceback (most recent call last):
+-    PostconditionError: counter is incremented by value
++    dpcontracts.PostconditionError: counter is incremented by value
+ 
+ Note that Python's pass-by-reference semantics still apply, so if you need to
+ preserve an old value, you might have to copy it.
+@@ -445,7 +446,7 @@ Contracts can be placed on coroutines (that is, async functions):
+     ... async def func(a, b="Foo", *c):
+     ...     await asyncio.sleep(1)
+ 
+-    >>> asyncio.get_event_loop().run_until_complete(
++    >>> asyncio.run(
+     ...     func( 1, "foo", True, True, False))
+ 
+ Predicates functions themselves cannot be coroutines, as this could


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
