### PR TITLE
closure-compiler: Add $JAVA_ARGS breakout to tweak the JVM

### DIFF
--- a/pkgs/by-name/cl/closurecompiler/package.nix
+++ b/pkgs/by-name/cl/closurecompiler/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/share/java $out/bin
     cp ${finalAttrs.src} $out/share/java/closure-compiler-v${finalAttrs.version}.jar
     makeWrapper ${jre}/bin/java $out/bin/closure-compiler \
-      --add-flags "-jar $out/share/java/closure-compiler-v${finalAttrs.version}.jar"
+      --add-flags "\$NIX_JAVA_ARGS -jar $out/share/java/closure-compiler-v${finalAttrs.version}.jar"
   '';
 
   meta = {


### PR DESCRIPTION
When I tried to use the closure compiler, it immediately crashed and left diagnostic file where the JVM complained about running out of heap memory.

This patch adds an escape hatch to set positional args for the JVM. This was previously not possible since these have to go before the `-jar` on the command line.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
