### PR TITLE
steel{,-language-server}: stop setting default `STEEL_HOME`

### DIFF
--- a/pkgs/by-name/st/steel-language-server/package.nix
+++ b/pkgs/by-name/st/steel-language-server/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   rustPlatform,
-  makeBinaryWrapper,
   steel,
 }:
 rustPlatform.buildRustPackage {
@@ -14,10 +13,7 @@ rustPlatform.buildRustPackage {
     postPatch
     ;
 
-  nativeBuildInputs = [
-    makeBinaryWrapper
-    rustPlatform.bindgenHook
-  ];
+  nativeBuildInputs = [ rustPlatform.bindgenHook ];
 
   cargoBuildFlags = [
     "--package"
@@ -25,10 +21,6 @@ rustPlatform.buildRustPackage {
   ];
 
   doCheck = false;
-
-  postFixup = ''
-    wrapProgram $out/bin/steel-language-server --set-default STEEL_HOME "${steel}/lib/steel"
-  '';
 
   meta = steel.meta // {
     description = "Steel language server";

--- a/pkgs/by-name/st/steel/package.nix
+++ b/pkgs/by-name/st/steel/package.nix
@@ -5,7 +5,6 @@
   fetchFromGitHub,
   curl,
   pkg-config,
-  makeBinaryWrapper,
   installShellFiles,
   libgit2,
   oniguruma,
@@ -32,7 +31,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeBuildInputs = [
     curl
-    makeBinaryWrapper
     pkg-config
     rustPlatform.bindgenHook
     installShellFiles
@@ -87,13 +85,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --bash <($out/bin/steel completions bash) \
       --fish <($out/bin/steel completions fish) \
       --zsh <($out/bin/steel completions zsh)
-  '';
-
-  postFixup = ''
-    wrapProgram $out/bin/steel --set-default STEEL_HOME "$out/lib/steel"
-    wrapProgram $out/bin/steel-language-server --set-default STEEL_HOME "$out/lib/steel"
-    wrapProgram $out/bin/forge --set-default STEEL_HOME "$out/lib/steel"
-    wrapProgram $out/bin/cargo-steel-lib --set-default STEEL_HOME "$out/lib/steel"
   '';
 
   env = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Imo it's kinda a bad idea to set these as default.

Both the Steel cli and the language server write to the `STEEL_HOME` dir during various operation, but the default is in inside the Nix store, which makes it read-only. Hence users may encounter errors when running tools for the first time, without setting up `STEEL_HOME` properly.

Since all these tools have the same home dir fallback logic, I think it's better to just use those.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
