### PR TITLE
ttl: 0.19.1 -> 0.21.0

### DIFF
--- a/pkgs/by-name/tt/ttl/package.nix
+++ b/pkgs/by-name/tt/ttl/package.nix
@@ -51,7 +51,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mainProgram = "ttl";
     homepage = "https://github.com/lance0/ttl";
     changelog = "https://github.com/lance0/ttl/releases/tag/v${finalAttrs.version}";
-    maintainers = with lib.maintainers; [ vincentbernat ];
+    maintainers = with lib.maintainers; [
+      vincentbernat
+      herbetom
+    ];
     license = with lib.licenses; [
       asl20
       mit

--- a/pkgs/by-name/tt/ttl/package.nix
+++ b/pkgs/by-name/tt/ttl/package.nix
@@ -27,6 +27,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   doInstallCheck = true;
 
+  # opt ouf of default features to deselect the update-check feature
+  buildNoDefaultFeatures = true;
+
   postInstall = ''
     installShellCompletion --cmd ttl \
       --bash <($out/bin/ttl --completions bash) \

--- a/pkgs/by-name/tt/ttl/package.nix
+++ b/pkgs/by-name/tt/ttl/package.nix
@@ -9,21 +9,22 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ttl";
-  version = "0.19.1";
+  version = "0.21.0";
 
   src = fetchFromGitHub {
     owner = "lance0";
     repo = "ttl";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-xY0z5GH6aLL38wOH6B2V9pAv9HnrJfpmQDjDKGSL4qo=";
+    hash = "sha256-bna3zD1RI2eSYX+IyDxi8IB/gys8PDDRThDdcUfcHR0=";
   };
 
-  cargoHash = "sha256-zYO3sY/MdDPfypDeseabTtwMeeUZQ8OiVfch+5fRetI=";
+  cargoHash = "sha256-VLNDcP7LjClYEqew0xDQdevMM0LKJJnUXxh6tBtx6lw=";
 
   nativeBuildInputs = [
     installShellFiles
     versionCheckHook
   ];
+
   doInstallCheck = true;
 
   postInstall = ''


### PR DESCRIPTION
closes #531206

This PR does the following:

- This updates the ttl package to the latest version.
- It adds me as maintainer.
- It disables all default features (This currently means the binary won't check and show a message if it isn't the latest release.)

Release Notes:
- https://github.com/lance0/ttl/releases/tag/v0.20.0
- https://github.com/lance0/ttl/releases/tag/v0.20.1
- https://github.com/lance0/ttl/releases/tag/v0.20.2
- https://github.com/lance0/ttl/releases/tag/v0.21.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
