### PR TITLE
anchor: fix cargo metadata discovery on darwin Nix sandboxes

### DIFF
--- a/pkgs/by-name/an/anchor/package.nix
+++ b/pkgs/by-name/an/anchor/package.nix
@@ -1,8 +1,8 @@
 {
   lib,
-  stdenv,
   rustPlatform,
   fetchFromGitHub,
+  fetchpatch,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -19,6 +19,17 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-oEgWfklxjP8+TxrhDKJgcTsanpqJpEiHXJyir8neYj8=";
 
+  # Upstream patch to fix cargo metadata discovery on macOS Nix sandboxes.
+  # Replaces fragile subprocess-cwd approach with in-process manifest path
+  # resolution. Remove on next version bump (included in v1.1.3+).
+  # See: https://github.com/otter-sec/anchor/pull/4757
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/otter-sec/anchor/commit/25bf2112b67d84e5bc406d7eac2919c90d8e54ed.patch";
+      hash = "sha256-q5OGNoUGPuCNHgaZNo9fmUxqQnFH2MhRW4ZefX+Of0Y=";
+    })
+  ];
+
   # Only build the anchor-cli package
   cargoBuildFlags = [
     "-p"
@@ -30,16 +41,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "-p"
     "anchor-cli"
   ];
-
-  # These tests use tempdir + cargo metadata subprocess which fails on Darwin
-  # sandboxes due to getcwd() differences (XNU vs Linux). Tracked upstream at
-  # https://github.com/otter-sec/anchor/issues/4751
-  checkFlags = map (t: "--skip=${t}") (
-    lib.optionals stdenv.hostPlatform.isDarwin [
-      "program::tests::discover_solana_programs_finds_sibling_programs_from_nested_member"
-      "program::tests::discover_solana_programs_lists_all_members_from_nested_member"
-    ]
-  );
 
   meta = {
     description = "Solana Sealevel Framework";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
