### PR TITLE
nvimpager: use neovim-unwrapped

### DIFF
--- a/pkgs/by-name/nv/nvimpager/package.nix
+++ b/pkgs/by-name/nv/nvimpager/package.nix
@@ -4,7 +4,7 @@
   stdenv,
   bash,
   ncurses,
-  neovim,
+  neovim-unwrapped,
   procps,
   scdoc,
   lua51Packages,
@@ -36,14 +36,14 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   preBuild = ''
     patchShebangs nvimpager
-    substituteInPlace nvimpager --replace-fail ':-nvim' ':-${lib.getExe neovim}'
+    substituteInPlace nvimpager --replace-fail ':-nvim' ':-${lib.getExe neovim-unwrapped}'
   '';
 
   doCheck = true;
   nativeCheckInputs = [
     lua51Packages.busted
     ncurses # for tput
-    neovim
+    neovim-unwrapped
     procps # for nvim_get_proc() which uses ps(1)
     util-linux
   ];


### PR DESCRIPTION
I don't think there's a reason for `nvimpager` to use the wrapped `neovim` package?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
