### PR TITLE
prusa-slicer: fix build with catch2 3.15.0

### DIFF
--- a/pkgs/by-name/pr/prusa-slicer/catch2_3_15.patch
+++ b/pkgs/by-name/pr/prusa-slicer/catch2_3_15.patch
@@ -1,0 +1,32 @@
+From 8abf7e1b707adf145d7434dbf53ad14c9c7cccd3 Mon Sep 17 00:00:00 2001
+From: Andreas Schneider <asn@cryptomilk.org>
+Date: Fri, 12 Jun 2026 18:20:39 +0200
+Subject: [PATCH] Fix build with Catch2 v3: include
+ catch_interfaces_capture.hpp
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Catch::getResultCapture() requires an explicit include of
+<catch2/interfaces/catch_interfaces_capture.hpp> in Catch2 v3,
+which was not previously included.
+
+tests/sla_print/sla_test_utils.cpp:87:32: error: ‘getResultCapture’ is not a member of ‘Catch’
+    m.WriteOBJFile((Catch::getResultCapture().getCurrentTestName() + "_" +
+                           ^~~~~~~~~~~~~~~~
+---
+ tests/sla_print/sla_test_utils.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/tests/sla_print/sla_test_utils.cpp b/tests/sla_print/sla_test_utils.cpp
+index 01eb222969c..c9355ca8e91 100644
+--- a/tests/sla_print/sla_test_utils.cpp
++++ b/tests/sla_print/sla_test_utils.cpp
+@@ -5,6 +5,7 @@
+ #include "libslic3r/SLA/BranchingTreeSLA.hpp"
+ 
+ #include <iomanip>
++#include <catch2/interfaces/catch_interfaces_capture.hpp>
+ 
+ void test_support_model_collision(
+     const std::string            &obj_filename,

--- a/pkgs/by-name/pr/prusa-slicer/package.nix
+++ b/pkgs/by-name/pr/prusa-slicer/package.nix
@@ -80,6 +80,9 @@ clangStdenv.mkDerivation (finalAttrs: {
     ./allow_wayland.patch
     # Pick https://github.com/prusa3d/PrusaSlicer/pull/14207 to remove unused and insecure ilmbase dependency
     ./no-ilmbase.patch
+    # catch2 3.15 support
+    # https://github.com/prusa3d/PrusaSlicer/pull/15462
+    ./catch2_3_15.patch
   ];
 
   # (not applicable to super-slicer fork)


### PR DESCRIPTION
See https://github.com/prusa3d/PrusaSlicer/pull/15462

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
