### PR TITLE
maintainers: drop ghuntley

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10011,12 +10011,6 @@
     name = "Will Owens";
     keys = [ { fingerprint = "8E98 BB01 BFF8 AEA4 E303  FC4C 8074 09C9 2CE2 3033"; } ];
   };
-  ghuntley = {
-    email = "ghuntley@ghuntley.com";
-    github = "ghuntley";
-    githubId = 127353;
-    name = "Geoffrey Huntley";
-  };
   gibbert = {
     email = "gbjgms@gmail.com";
     github = "zgibberish";

--- a/pkgs/by-name/co/coder/package.nix
+++ b/pkgs/by-name/co/coder/package.nix
@@ -104,7 +104,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       bpmct
       developmentcats
-      ghuntley
       kylecarbs
       phorcys420
     ];

--- a/pkgs/by-name/ma/mastodon/package.nix
+++ b/pkgs/by-name/ma/mastodon/package.nix
@@ -190,7 +190,6 @@ stdenv.mkDerivation rec {
       happy-river
       erictapen
       izorkin
-      ghuntley
     ];
   };
 }

--- a/pkgs/by-name/op/openvscode-server/package.nix
+++ b/pkgs/by-name/op/openvscode-server/package.nix
@@ -239,7 +239,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       dguenther
-      ghuntley
       emilytrau
     ];
     platforms = [

--- a/pkgs/by-name/pu/pulumi-bin/package.nix
+++ b/pkgs/by-name/pu/pulumi-bin/package.nix
@@ -49,7 +49,6 @@ stdenv.mkDerivation {
     license = with lib.licenses; [ asl20 ];
     platforms = builtins.attrNames data.pulumiPkgs;
     maintainers = with lib.maintainers; [
-      ghuntley
       jlesquembre
       cpcloud
       wrbbz


### PR DESCRIPTION
I am one of the maintainers to the `coder` package, as part of our recent efforts to keep the package up-to-date we are cleaning up maintainers.

As mentioned in https://github.com/NixOS/nixpkgs/pull/535719, I am handling @ghuntley's removal separately in this PR.

**As per the guidelines in https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md, this maintainer is inactive enough to be removed from the maintainer list (last commit seems to be in 2023)**, so I went ahead and dropped this maintainer fully.

Last commits on maintained packages:
- coder: ["coder: resolve hash mismatch in fixed-output derivation" (23091da)](https://github.com/NixOS/nixpkgs/commit/23091da20c6491ccce78acbc71bfa98d8c64af28) on Mar 12, 2023
- mastodon: ["mastodon: add ghuntley as maintainer " (6e0c9dc)](https://github.com/NixOS/nixpkgs/commit/6e0c9dcd87280deae219d2c5abfa1f5fd550f23a) on Nov 16, 2022
- openvscode-server: none in commit history
- pulumi: ["pulumi: 2.6.1 -> 2.10.2" (a922b0b)](https://github.com/NixOS/nixpkgs/commit/a922b0bf6fad2c7025de22a16ba12c911dd0be00) on Sep 24, 2020

NOTE: Please let me know if I should only drop them from the package I maintain rather than fully!

cc @ghuntley for visibility

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
