### PR TITLE
nixos/limine: fix location for boot.loader.limine.additionalFiles

### DIFF
--- a/nixos/modules/system/boot/loader/limine/limine-install.py
+++ b/nixos/modules/system/boot/loader/limine/limine-install.py
@@ -621,7 +621,7 @@ def install_bootloader() -> None:
     paths[config_file_path] = True
 
     for dest_path, source_path in config("additionalFiles").items():
-        dest_path = os.path.join(limine_install_dir, dest_path)
+        dest_path = os.path.join(str(config("efiMountPoint")), dest_path)
 
         copy_file(source_path, dest_path)
 

--- a/nixos/tests/limine/additional-files.nix
+++ b/nixos/tests/limine/additional-files.nix
@@ -1,0 +1,51 @@
+{ pkgs, lib, ... }:
+{
+  name = "additionalFiles";
+  meta.maintainers = with lib.maintainers; [
+    flokli
+  ];
+  meta.platforms = [
+    "x86_64-linux"
+  ];
+  nodes.machine =
+    { ... }:
+    {
+      virtualisation.useBootLoader = true;
+      virtualisation.useEFIBoot = true;
+      boot.loader.limine.enable = true;
+      boot.loader.limine.efiSupport = true;
+      boot.loader.timeout = 0;
+
+      specialisation.withAdditionalFiles.configuration = { ... }: {
+        boot.loader.limine.additionalFiles = {
+          "efi/memtest86/memtest86.efi" = "${pkgs.memtest86-efi}/BOOTX64.efi";
+        };
+      };
+      specialisation.withAdditionalFilesOther.configuration = { ... }: {
+        boot.loader.limine.additionalFiles = {
+          "efi/memtest86/memtest86.efi" = "${builtins.toFile "some-file" "some-content"}";
+        };
+      };
+    };
+
+  testScript =
+    { nodes, ... }:
+    let
+      withAdditionalFiles =
+        nodes.machine.specialisation.withAdditionalFiles.configuration.system.build.toplevel;
+      withAdditionalFilesOther =
+        nodes.machine.specialisation.withAdditionalFilesOther.configuration.system.build.toplevel;
+    in
+    ''
+      machine.start()
+      machine.wait_for_unit("multi-user.target")
+
+      # switch to a generation with additional files and ensure they're present
+      machine.succeed("${withAdditionalFiles}/bin/switch-to-configuration switch")
+      machine.succeed("stat /boot/efi/memtest86/memtest86.efi")
+
+      # switch to the next generation with something else in there and ensure it got updated
+      machine.succeed("${withAdditionalFilesOther}/bin/switch-to-configuration switch")
+      assert machine.succeed("cat /boot/efi/memtest86/memtest86.efi").strip() == "some-content"
+    '';
+}

--- a/nixos/tests/limine/default.nix
+++ b/nixos/tests/limine/default.nix
@@ -3,6 +3,7 @@
   ...
 }:
 {
+  additionalFiles = runTest ./additional-files.nix;
   bios = runTest ./bios.nix;
   checksum = runTest ./checksum.nix;
   secureBoot = runTest ./secure-boot.nix;


### PR DESCRIPTION
The documentation describes this as a set of files copied to /boot, with the attribute name denoting the destination file name in /boot.

This uses essentially the same description as refind, systemd-boot and grub. However limine put it into limine_install_dir (/boot/limine by default) by accident, which broke downstream users.

For example, nixos-apple-silicon uses boot.loader.limine.additionalFiles (and similar directives for other bootloaders) to update its m1n1 bootloader (which chainloads into u-boot, which chainloads into the bootloader selected in NixOS), and due to this bug, put new versions of it in the wrong location, effectively never updating m1n1.

Fix this, by updating the location. The next commit adds a regression VM test for it.

Fixes #537466.
Related: https://github.com/nix-community/nixos-apple-silicon/issues/493

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
