### PR TITLE
wt: Add missing dependencies libICE and libSM; lms: 3.74.0 -> 3.78.0

### DIFF
--- a/pkgs/by-name/lm/lms/package.nix
+++ b/pkgs/by-name/lm/lms/package.nix
@@ -13,8 +13,6 @@
   graphicsmagick,
   ffmpeg,
   zlib,
-  libsm,
-  libice,
   stb,
   openssl,
   xxhash,
@@ -23,20 +21,22 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lms";
-  version = "3.74.0";
+  version = "3.78.0";
 
   src = fetchFromGitHub {
     owner = "epoupon";
     repo = "lms";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-D1Sg6XzZ8t/dFKrVh7k+KGLg2r6LeLGJk4FweVb4L1A=";
+    hash = "sha256-uOijIipay4ncE8hP6vJG9vOGiD/Ad6WJHEQ7P1HKi/Y=";
   };
 
   strictDeps = true;
+
   nativeBuildInputs = [
     cmake
     pkg-config
   ];
+
   buildInputs = [
     gtest
     boost
@@ -44,11 +44,8 @@ stdenv.mkDerivation (finalAttrs: {
     taglib
     libconfig
     libarchive
-    graphicsmagick
     ffmpeg
     zlib
-    libsm
-    libice
     stb
     openssl
     xxhash

--- a/pkgs/development/libraries/wt/default.nix
+++ b/pkgs/development/libraries/wt/default.nix
@@ -18,6 +18,8 @@
   openssl,
   harfbuzz,
   icu,
+  libice,
+  libsm,
 }:
 
 let
@@ -53,6 +55,8 @@ let
         openssl
         harfbuzz
         icu
+        libice
+        libsm
       ];
 
       dontWrapQtApps = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

The last update on `wt` broke `lms`.
When I looked into it I found out something strange. There are two links to libSM and libICE in wt and one pair is not set correctly. I don't know what's causing this issue.
I added both depedencies to wt and now there's only one pair and they are set correctly:
```
❯ bash -c "diff <(sed 's/\(.*\) (.*/\1/' before | sort) <(sed 's/\(.*\) (.*/\1/' after | sort)"
41d40
<       libICE.so.6 => not found
63d61
<       libSM.so.6 => not found
``` 
ldd on wt: [before.txt](https://github.com/user-attachments/files/29766030/before.txt) [after.txt](https://github.com/user-attachments/files/29766043/after.txt)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
