### PR TITLE
chromium,chromedriver: 150.0.7871.46 -> 150.0.7871.100

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,10 +1,10 @@
 {
   "chromium": {
-    "version": "150.0.7871.46",
+    "version": "150.0.7871.100",
     "chromedriver": {
-      "version": "149.0.7827.201",
-      "hash_darwin": "sha256-MHCcid+7wdYm8uIdrUIlXrk8ADHNUUXzPyMPFGP98WY=",
-      "hash_darwin_aarch64": "sha256-Gwmdo9qNyV/BnCj18f0BFpNgDf28e8vjNF98e5/vVjQ="
+      "version": "150.0.7871.101",
+      "hash_darwin": "sha256-LJPfzeJjVcEHenRNqKNOGcEZLL/rHRH55yBefLFTlEs=",
+      "hash_darwin_aarch64": "sha256-+WZw22dgaDsDMOQUJTjTuCGyUZT1t1RBjutyqmumX/A="
     },
     "deps": {
       "depot_tools": {
@@ -21,8 +21,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "5b586c06e0d27582900f17e2d59c5370d8d6e0bb",
-        "hash": "sha256-OAZNyZtR5WFWW42r74RSy9fT7Eb7CNZwzoIHhuoqR28=",
+        "rev": "b5a9b587b83512ef1fab99cb7510c58a06d22089",
+        "hash": "sha256-bylGmZC9NhUjcU6amK3mwuZ1it7uTm2hsC60DaKINr4=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {


### PR DESCRIPTION
https://chromereleases.googleblog.com/2026/07/stable-channel-update-for-desktop.html

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests] (`nixosTests.chromium`).
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
