### PR TITLE
nixos/ipu6: Update regression bug warning

### DIFF
--- a/nixos/modules/hardware/facter/camera/ipu6.nix
+++ b/nixos/modules/hardware/facter/camera/ipu6.nix
@@ -101,15 +101,4 @@ in
       else
         throw "Unexpected CPU generation for ipu6 detected.";
   };
-
-  config.warnings =
-    let
-      isKernel6_16OrLater = lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.16";
-      inherit (detected.camera) ipu6;
-    in
-    lib.optional (isKernel6_16OrLater && ipu6.enable) ''
-      A regression bug can occur when combining ipu6 with kernel version 6.16 or later.
-      This will most likely prevent your system from properly suspending or shutting down.
-      For more information see: https://github.com/intel/ipu6-drivers/issues/381
-    '';
 }

--- a/nixos/modules/hardware/video/webcam/ipu6.nix
+++ b/nixos/modules/hardware/video/webcam/ipu6.nix
@@ -126,5 +126,16 @@ in
       '';
     };
 
+    warnings =
+      let
+        inherit (config.boot.kernelPackages) kernel;
+        isKernel6_16OrLater = lib.versionAtLeast kernel.version "6.16";
+        isKernel6_18OrLater = lib.versionAtLeast kernel.version "6.18";
+      in
+      lib.optional (isKernel6_16OrLater && !isKernel6_18OrLater) ''
+        A regression bug can occur when combining ipu6 with kernel version 6.16 or 6.17.
+        This will most likely prevent your system from properly suspending or shutting down.
+        For more information see: https://github.com/intel/ipu6-drivers/issues/381
+      '';
   };
 }


### PR DESCRIPTION
Only show the warning for kernel versions 6.16 and 6.17, as the regression bug no longer occurs in later versions. Verified on local hardware against kernel versions LTS 6.18 and latest (7.1.3).

Additionally, narrow the warning's precondition: it now triggers only when the problematic driver implementation is actually active, rather than whenever matching hardware is detected by NixOS Facter.

(Prior committers to changed  modules: @Mic92, @StarGate01, @mweinelt)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
