### PR TITLE
firefox-devtools-mcp: init at 0.9.9

### DIFF
--- a/pkgs/by-name/fi/firefox-devtools-mcp/package.nix
+++ b/pkgs/by-name/fi/firefox-devtools-mcp/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  makeWrapper,
+  geckodriver,
+  nix-update-script,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "firefox-devtools-mcp";
+  version = "0.9.9";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "mozilla";
+    repo = "firefox-devtools-mcp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Bz6LkiUbgu81OnPv6xegmo7EYVgGJdlbB5HZsW4QO/Q=";
+  };
+
+  npmDepsHash = "sha256-JnAivSiThEm+EPm6gY08zQfD/aaF2sLfz6YSfsle9uE=";
+
+  # 0.9.9 ships a stale hardcoded server version (0.7.1) in constants.ts; upstream switched to
+  # build-time injection right after release (Bug 2050918), so this substitution should be dropped
+  # once that fix lands in a tagged release.
+  postPatch = ''
+    substituteInPlace src/config/constants.ts \
+      --replace-fail "'0.7.1'" "'${finalAttrs.version}'"
+  '';
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # The `geckodriver` npm dependency's install script downloads a prebuilt binary from the network,
+  # which is unavailable in the sandbox. The server locates geckodriver on PATH first (see
+  # src/firefox/core.ts), so skip the install scripts and provide geckodriver from nixpkgs via the
+  # wrapper below.
+  npmFlags = [ "--ignore-scripts" ];
+
+  # `npm run build` (tsup) emits dist/index.js, the package's bin entry point.
+  postInstall = ''
+    wrapProgram $out/bin/firefox-devtools-mcp \
+      --prefix PATH : ${lib.makeBinPath [ geckodriver ]}
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Model Context Protocol server for Firefox DevTools automation";
+    longDescription = ''
+      A Model Context Protocol (MCP) server that automates Firefox via WebDriver BiDi.
+      It works with MCP clients such as Claude Code, Claude Desktop, Cursor and Cline,
+      exposing tools to navigate pages, take snapshots, inspect the DOM, capture network requests
+      and console messages, take screenshots and more.
+
+      A local Firefox installation is required at runtime.
+    '';
+    homepage = "https://github.com/mozilla/firefox-devtools-mcp";
+    changelog = "https://github.com/mozilla/firefox-devtools-mcp/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    maintainers = with lib.maintainers; [ philiptaron ];
+    mainProgram = "firefox-devtools-mcp";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
It's a simple MCP server for Firefox from Mozilla.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
