### PR TITLE
webull-desktop: correct issue #537123

### DIFF
--- a/pkgs/by-name/we/webull-desktop/package.nix
+++ b/pkgs/by-name/we/webull-desktop/package.nix
@@ -60,7 +60,9 @@ stdenv.mkDerivation (finalAttrs: {
       };
 
       # Keep the "CURL_GNUTLS_3" symbol which is sought by libwbhttpsclient.so
-      patches = (previousAttrs.patches or [ ]) ++ [
+      # "fix-wakeup-consumption.patch" that is applied to newer versions of curl
+      #                                is not needed and will not apply to curl-8.10.0
+      patches = [
         (builtins.toFile "curl-gnutls-keep-symbols-compatible.patch" ''
           --- a/lib/libcurl.vers.in
           +++ b/lib/libcurl.vers.in


### PR DESCRIPTION
curl-8.10.0 (dependency built in this derivation) in its original derivation had no patches.  Current patches to curl do not cleanly apply to 8.10.0 and are not applicable to 8.10.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Modify `[patches]` so that ONLY the `curl-gnutls-keep-symbols-compatible.patch` is applied.
Fixes new failure to build since `nixpkgs` commit 3fcd08a
 
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
