### PR TITLE
dropbear: 2026.91 -> 2026.92; dropbear: new maintainer

### DIFF
--- a/pkgs/by-name/dr/dropbear/package.nix
+++ b/pkgs/by-name/dr/dropbear/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   zlib,
   libxcrypt,
   enableSCP ? false,
@@ -15,17 +15,23 @@ let
     SFTPSERVER_PATH = sftpPath;
     DROPBEAR_PATH_SSH_PROGRAM = "${placeholder "out"}/bin/dbclient";
   };
-
 in
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "dropbear";
-  version = "2026.91";
+  version = "2026.92";
 
-  src = fetchurl {
-    url = "https://matt.ucc.asn.au/dropbear/releases/dropbear-${finalAttrs.version}.tar.bz2";
-    sha256 = "sha256-3vqSRHWr9rwedKvAAXPka/3IBL1Hyq+hT1pO8Mx22jQ=";
+  src = fetchFromGitHub {
+    owner = "mkj";
+    repo = "dropbear";
+    tag = "DROPBEAR_${finalAttrs.version}";
+    hash = "sha256-xXjKWj6tMW/Qlq4DttxKAqOwsER2QEeb1Qw3Gllu2QQ=";
   };
+
+  patches = [
+    # Allow sessions to inherit the PATH from the parent dropbear.
+    # Otherwise they only get the usual /bin:/usr/bin kind of PATH
+    ./pass-path.patch
+  ];
 
   env.CFLAGS = lib.pipe (lib.attrNames dflags) [
     (map (name: "-D${name}=\\\"${dflags.${name}}\\\""))
@@ -55,27 +61,36 @@ stdenv.mkDerivation (finalAttrs: {
     )
   '';
 
-  postInstall = lib.optionalString enableSCP ''
-    ln -rs $out/bin/scp $out/bin/dbscp
-  '';
-
-  patches = [
-    # Allow sessions to inherit the PATH from the parent dropbear.
-    # Otherwise they only get the usual /bin:/usr/bin kind of PATH
-    ./pass-path.patch
-  ];
-
   buildInputs = [
     zlib
     libxcrypt
   ];
 
+  postInstall = lib.optionalString enableSCP ''
+    ln -rs $out/bin/scp $out/bin/dbscp
+  '';
+
   meta = {
-    description = "Small footprint implementation of the SSH 2 protocol";
+    description = "Small memory footprint ssh server/client suitable for memory-constrained environments";
+    longDescription = ''
+      Dropbear is particularly useful for "embedded"-type Linux (or other Unix) systems, such as wireless routers.
+
+      ## Features
+
+      * Implements X11 forwarding, and authentication-agent forwarding for OpenSSH clients
+      * Can run from inetd or standalone
+      * Compatible with OpenSSH ~/.ssh/authorized_keys public key authentication
+      * Multi-hop mode uses SSH TCP forwarding to tunnel through multiple SSH hosts in a single command:
+
+      ```shell
+      dbclient user1@hop1,user2@hop2,destination
+      ```
+    '';
     homepage = "https://matt.ucc.asn.au/dropbear/dropbear.html";
-    changelog = "https://github.com/mkj/dropbear/raw/DROPBEAR_${finalAttrs.version}/CHANGES";
+    changelog = "https://github.com/mkj/dropbear/releases/tag/DROPBEAR_${finalAttrs.version}";
+    downloadPage = "https://matt.ucc.asn.au/dropbear/releases";
     license = lib.licenses.mit;
-    maintainers = [ ];
     platforms = lib.platforms.linux;
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/dr/dropbear/package.nix
+++ b/pkgs/by-name/dr/dropbear/package.nix
@@ -91,6 +91,8 @@ stdenv.mkDerivation (finalAttrs: {
     downloadPage = "https://matt.ucc.asn.au/dropbear/releases";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [
+      debtquity
+    ];
   };
 })


### PR DESCRIPTION
* diff: https://github.com/mkj/dropbear/compare/DROPBEAR_2026.91...DROPBEAR_2026.92
* changelog: https://github.com/mkj/dropbear/releases/tag/DROPBEAR_2026.92
* change src to github
* update meta attributes
* add self as maintainer

Supercedes: #539120


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
