### PR TITLE
fricas: 1.3.12 -> 1.3.13

### DIFF
--- a/pkgs/by-name/fr/fricas/package.nix
+++ b/pkgs/by-name/fr/fricas/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fricas";
-  version = "1.3.12";
+  version = "1.3.13";
 
   src = fetchFromGitHub {
     owner = "fricas";
     repo = "fricas";
     rev = finalAttrs.version;
-    sha256 = "sha256-GUGJR65K1bPC0D36l4Yyj3GOsWtUrSKLu6JnlfjHzDc=";
+    sha256 = "sha256-vpClJwB91pCgc6DWy0I2XTfSWkt+7nEAkUK9zz4qh4A=";
   };
 
   buildInputs = [

--- a/pkgs/by-name/fr/fricas/package.nix
+++ b/pkgs/by-name/fr/fricas/package.nix
@@ -19,8 +19,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "fricas";
     repo = "fricas";
-    rev = finalAttrs.version;
-    sha256 = "sha256-vpClJwB91pCgc6DWy0I2XTfSWkt+7nEAkUK9zz4qh4A=";
+    tag = finalAttrs.version;
+    hash = "sha256-vpClJwB91pCgc6DWy0I2XTfSWkt+7nEAkUK9zz4qh4A=";
   };
 
   buildInputs = [
@@ -34,23 +34,16 @@ stdenv.mkDerivation (finalAttrs: {
     libxdmcp
   ];
 
-  # Remove when updating to next version
-  configurePhase = ''
-    runHook preConfigure
-
-    ./configure --prefix=$out --with-lisp='sbcl --dynamic-space-size 3072'
-
-    runHook postConfigure
-  '';
-
   dontStrip = true;
 
   meta = {
     homepage = "https://fricas.github.io";
     description = "Advanced computer algebra system";
+    changelog = "https://github.com/fricas/fricas/blob/${finalAttrs.src.tag}/ChangeLog";
     license = lib.licenses.bsd3;
 
     platforms = lib.platforms.linux;
     maintainers = [ ];
+    mainProgram = "fricas";
   };
 })


### PR DESCRIPTION
This PR is based on https://github.com/NixOS/nixpkgs/pull/497043, but also cleans up the `configurePhase` as recommended by the comment in `package.nix`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
