### PR TITLE
networkmanager-vpnc: fix gui configuration

### DIFF
--- a/pkgs/by-name/ne/networkmanager-vpnc/export_nm_vpn_editor_factory_vpnc.patch
+++ b/pkgs/by-name/ne/networkmanager-vpnc/export_nm_vpn_editor_factory_vpnc.patch
@@ -1,0 +1,46 @@
+commit 4c9e26cdc9f58f0e35aa345ae3bb643bea139608
+Author: Christian Krause <chkr@plauener.de>
+Date:   Tue May 6 00:33:39 2025 +0200
+
+    Export nm_vpn_editor_factory_vpnc properly
+    
+    - commit e2fc231149165cb37a25362b85cbcd58b15a2a11 removed
+      libnm-glib version
+    - after that commit, nm_vpn_editor_factory_vpnc was not correctly
+      exported anymore which caused the settings editor be missing
+      when adding or editing a vnpc connection in gnome-control-center
+    - this commit re-adds the removed G_MODULE_EXPORT declaration
+
+diff --git a/properties/nm-vpnc-editor.c b/properties/nm-vpnc-editor.c
+index a06807d..0c8081d 100644
+--- a/properties/nm-vpnc-editor.c
++++ b/properties/nm-vpnc-editor.c
+@@ -27,7 +27,6 @@
+ #include "nm-default.h"
+ 
+ #include "nm-vpnc-editor.h"
+-#include "nm-vpnc-editor-plugin.h"
+ 
+ #include <nma-cert-chooser.h>
+ #include <netinet/in.h>
+@@ -1130,3 +1129,20 @@ vpnc_editor_interface_init (NMVpnEditorInterface *iface)
+ 	iface->get_widget = get_widget;
+ 	iface->update_connection = update_connection;
+ }
++
++/*****************************************************************************/
++
++#ifndef NM_VPN_OLD
++
++#include "nm-vpnc-editor-plugin.h"
++
++G_MODULE_EXPORT NMVpnEditor *
++nm_vpn_editor_factory_vpnc (NMVpnEditorPlugin *editor_plugin,
++                            NMConnection *connection,
++                            GError **error)
++{
++       g_return_val_if_fail (!error || !*error, NULL);
++
++       return nm_vpnc_editor_new (connection, error);
++}
++#endif

--- a/pkgs/by-name/ne/networkmanager-vpnc/package.nix
+++ b/pkgs/by-name/ne/networkmanager-vpnc/package.nix
@@ -1,6 +1,7 @@
 {
   stdenv,
   lib,
+  fetchpatch,
   fetchurl,
   replaceVars,
   vpnc,
@@ -31,6 +32,8 @@ stdenv.mkDerivation rec {
     (replaceVars ./fix-paths.patch {
       inherit vpnc kmod;
     })
+    # https://gitlab.gnome.org/GNOME/NetworkManager-vpnc/-/merge_requests/19
+    ./export_nm_vpn_editor_factory_vpnc.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
allow configuring vpnc connections with nm-connection-editor

https://gitlab.gnome.org/GNOME/NetworkManager-vpnc/-/merge_requests/19

Tested that the configuration now shows up properly in nm-connection-editor with this change. ~Draft because I haven't tested yet whether this actually leads to a working connection.~ also tested this actually leads to a working connection.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
