### PR TITLE
prometheus-kea-exporter: 0.7.0 -> 0.7.1

### DIFF
--- a/nixos/tests/kea.nix
+++ b/nixos/tests/kea.nix
@@ -110,6 +110,13 @@
             };
           };
         };
+
+        services.prometheus.exporters.kea = {
+          enable = true;
+          controlSocketPaths = [
+            config.services.kea.dhcp4.settings.control-socket.socket-name
+          ];
+        };
       };
 
     nameserver =
@@ -217,5 +224,9 @@
 
       with subtest("DDNS"):
           nameserver.wait_until_succeeds("kdig +short client.lan.nixos.test @10.0.0.2 | grep -q 10.0.0.3")
+
+      with subtest("Prometheus Exporter"):
+        router.log(router.execute("curl 127.0.0.1:9547")[1])
+        router.succeed("curl --silent 127.0.0.1:9547 | grep -qE '^kea_dhcp4_addresses_assigned_total.*1.0$'")
     '';
 }

--- a/pkgs/by-name/pr/prometheus-kea-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-kea-exporter/package.nix
@@ -1,19 +1,21 @@
 {
   lib,
   python3Packages,
-  fetchPypi,
+  fetchFromGitHub,
   nixosTests,
+  versionCheckHook,
 }:
 
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "kea-exporter";
-  version = "0.7.0";
+  version = "0.7.1";
   pyproject = true;
 
-  src = fetchPypi {
-    pname = "kea_exporter";
-    inherit version;
-    hash = "sha256-kn2iwYWcyW90tgfWmzLF7rU06fJyLRzqYKNLOgu/Yqk=";
+  src = fetchFromGitHub {
+    owner = "mweinelt";
+    repo = "kea-exporter";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-UwQYR01cBdPEUBhOo5TqwmptAvJpxln1OLU2boAFdn4=";
   };
 
   nativeBuildInputs = with python3Packages; [
@@ -26,21 +28,17 @@ python3Packages.buildPythonApplication rec {
     requests
   ];
 
-  checkPhase = ''
-    $out/bin/kea-exporter --help > /dev/null
-    $out/bin/kea-exporter --version | grep -q ${version}
-  '';
-
+  nativeInstallCheckInputs = [ versionCheckHook ];
   passthru.tests = {
     inherit (nixosTests) kea;
   };
 
   meta = {
-    changelog = "https://github.com/mweinelt/kea-exporter/blob/v${version}/HISTORY";
+    changelog = "https://github.com/mweinelt/kea-exporter/blob/v${finalAttrs.version}/HISTORY";
     description = "Export Kea Metrics in the Prometheus Exposition Format";
     mainProgram = "kea-exporter";
     homepage = "https://github.com/mweinelt/kea-exporter";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ hexa ];
   };
-}
+})


### PR DESCRIPTION
https://github.com/mweinelt/kea-exporter/blob/v0.7.1/HISTORY

cc @polsevev
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. (kea)
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
