### PR TITLE
treewide: fix electron-forge console output via the CI env var

### DIFF
--- a/pkgs/by-name/ch/cheating-daddy/package.nix
+++ b/pkgs/by-name/ch/cheating-daddy/package.nix
@@ -40,6 +40,8 @@ buildNpmPackage (finalAttrs: {
     ONNXRUNTIME_NODE_INSTALL = "skip";
     ONNXRUNTIME_NODE_INSTALL_CUDA = "skip";
     ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+    # electron-forge's console output is squeezed into one narrow column if unset
+    CI = "1";
   };
 
   makeCacheWritable = true;

--- a/pkgs/by-name/el/electron-fiddle/dont-fetch-contributors.patch
+++ b/pkgs/by-name/el/electron-fiddle/dont-fetch-contributors.patch
@@ -1,0 +1,23 @@
+diff --git a/tools/contributors.ts b/tools/contributors.ts
+index ad085d3..1a30ab4 100644
+--- a/tools/contributors.ts
++++ b/tools/contributors.ts
+@@ -126,6 +126,7 @@ async function fetchDetailsContributors(
+ }
+ 
+ async function fetchContributors() {
++  return []
+   const response = await fetch(CONTRIBUTORS_URL, { headers: HEADERS });
+ 
+   if (!response.ok) {
+@@ -173,10 +174,6 @@ async function fetchAndWriteContributorsFile() {
+ 
+         try {
+           data = await fetchContributors();
+-
+-          if (!data || data.length === 0) {
+-            throw new Error('Contributors array is empty');
+-          }
+         } catch (error) {
+           if (process.env.CI) {
+             throw error;

--- a/pkgs/by-name/el/electron-fiddle/package.nix
+++ b/pkgs/by-name/el/electron-fiddle/package.nix
@@ -27,6 +27,7 @@ let
 
   patches = [
     ./dont-use-initial-releases-json.patch
+    ./dont-fetch-contributors.patch
 
     # zip extraction fails on newer nodejs versions without this fix
     ./bump-yauzl.patch
@@ -66,6 +67,9 @@ let
         --replace-fail 'await this.getElectronZipPath(downloadOpts)' '"electron.zip"'
     '';
 
+    # electron-forge's console output is squeezed into one narrow column if unset
+    env.CI = "1";
+
     yarnBuildScript = "package";
 
     installPhase = ''
@@ -100,6 +104,8 @@ in
 buildFHSEnv {
   inherit pname version;
   runScript = "${lib.getExe electron} ${unwrapped}/lib/electron-fiddle/resources/app.asar";
+
+  passthru = { inherit unwrapped; };
 
   extraInstallCommands = ''
     mkdir -p "$out/share/icons/hicolor/scalable/apps"

--- a/pkgs/by-name/ka/kando/package.nix
+++ b/pkgs/by-name/ka/kando/package.nix
@@ -69,6 +69,8 @@ buildNpmPackage.override { inherit nodejs; } rec {
     ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
     # use our own node headers since we skip downloading them
     NIX_CFLAGS_COMPILE = "-I${nodejs}/include/node";
+    # electron-forge's console output is squeezed into one narrow column if unset
+    CI = "1";
   };
 
   postConfigure = ''

--- a/pkgs/by-name/lo/logseq/package.nix
+++ b/pkgs/by-name/lo/logseq/package.nix
@@ -244,6 +244,9 @@ stdenv.mkDerivation (finalAttrs: {
     cp -r static/node_modules resources/node_modules
   '';
 
+  # electron-forge's console output is squeezed into one narrow column if unset
+  env.CI = "1";
+
   yarnBuildScript = "release-electron";
 
   installPhase = ''

--- a/pkgs/by-name/rs/rstudio/package.nix
+++ b/pkgs/by-name/rs/rstudio/package.nix
@@ -191,6 +191,9 @@ stdenv.mkDerivation (finalAttrs: {
   env = {
     ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
+    # electron-forge's console output is squeezed into one narrow column if unset
+    CI = "1";
+
     # on Darwin, cmake uses find_library to locate R instead of using the PATH
     NIX_LDFLAGS = "-L${R}/lib/R/lib";
 

--- a/pkgs/by-name/st/stoat-desktop/package.nix
+++ b/pkgs/by-name/st/stoat-desktop/package.nix
@@ -72,6 +72,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
+  # electron-forge's console output is squeezed into one narrow column if unset
+  env.CI = "1";
+
   buildPhase = ''
     runHook preBuild
 

--- a/pkgs/by-name/yt/ytmdesktop/package.nix
+++ b/pkgs/by-name/yt/ytmdesktop/package.nix
@@ -97,6 +97,9 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace node_modules/@electron/packager/dist/packager.js \
       --replace-fail 'await this.getElectronZipPath(downloadOpts)' '"electron.zip"'
 
+    # electron-forge's console output is squeezed into one narrow column if unset
+    export CI="1";
+
     yarn run package
 
     runHook postBuild


### PR DESCRIPTION
`electron-forge` does some unfriendly text formatting if the `DEBUG` or `CI` variables are not set.
See: https://github.com/electron/forge/blob/fc5fb4d4269cbce909fc59f570b8aa1e1add4090/packages/api/core/src/api/make.ts#L128

For `electron-fiddle` I had to add an extra patch, because that package used the `CI` variable for deciding if failing to fetch the contributor list halts the build or continues.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
