### PR TITLE
zorite: init at 0.6.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21339,6 +21339,11 @@
     githubId = 17091659;
     name = "Pablo Andres Dealbera";
   };
+  packetThrower = {
+    github = "packetThrower";
+    githubId = 6597817;
+    name = "Will Lehnertz";
+  };
   pacman99 = {
     email = "pachum99@gmail.com";
     matrix = "@pachumicchu:myrdd.info";

--- a/pkgs/by-name/zo/zorite/package.nix
+++ b/pkgs/by-name/zo/zorite/package.nix
@@ -1,0 +1,92 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  perl,
+  wayland,
+  libxkbcommon,
+  vulkan-loader,
+  fontconfig,
+  freetype,
+  libx11,
+  libxcb,
+  libxcb-util,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "zorite";
+  version = "0.6.1";
+
+  src = fetchFromGitHub {
+    owner = "packetThrower";
+    repo = "zorite";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-cWSXqjsU6rNwgeujHx6tMIEYbi9Uv37X0Wi+PXb9yaI=";
+  };
+
+  # Covers the crates.io and git dependencies (gpui and friends) in one hash.
+  cargoHash = "sha256-TiwLCz/EpYSX8Xh9nhqz212AHAL4MZeNY9eOf6fj+mM=";
+
+  nativeBuildInputs = [
+    pkg-config
+    # rusqlite's bundled-sqlcipher-vendored-openssl builds OpenSSL from
+    # source, and OpenSSL's build system is perl.
+    perl
+  ];
+
+  buildInputs = [
+    wayland
+    libxkbcommon
+    fontconfig
+    freetype
+    libx11
+    libxcb
+    libxcb-util
+  ];
+
+  postFixup = ''
+    # gpui dlopens Vulkan and the Wayland/X11 client libraries at runtime
+    # rather than linking them.
+    patchelf --add-rpath ${
+      lib.makeLibraryPath [
+        wayland
+        libxkbcommon
+        vulkan-loader
+      ]
+    } $out/bin/zorite
+  '';
+
+  postInstall = ''
+    install -Dm644 resources/icons/icon.png \
+      $out/share/icons/hicolor/512x512/apps/zorite.png
+    mkdir -p $out/share/applications
+    cat > $out/share/applications/zorite.desktop <<INI
+    [Desktop Entry]
+    Name=Zorite
+    Comment=Local-first Markdown daily journal
+    Exec=zorite
+    Icon=zorite
+    Type=Application
+    Categories=Office;
+    INI
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Local-first, Markdown daily-journal desktop app with wiki-links, whiteboards, and PDF annotation";
+    homepage = "https://github.com/packetThrower/zorite";
+    changelog = "https://github.com/packetThrower/zorite/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ packetThrower ];
+    mainProgram = "zorite";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+})


### PR DESCRIPTION
New package: **Zorite**, a local-first Markdown daily-journal desktop app (Rust + [GPUI](https://www.gpui.rs/)) — wiki-links and backlinks, freeform whiteboards, PDF viewing/annotation with fillable AcroForm fields, and typeset LaTeX math. GPL-3.0-or-later. Homepage: https://github.com/packetThrower/zorite

I'm the upstream author. Releases are tagged `vX.Y.Z`, and `passthru.updateScript = nix-update-script` is wired so r-ryantm can handle future bumps.

Packaging notes:
- A single `cargoHash` (fetchCargoVendor) covers the git dependencies (gpui pinned to a zed-industries/zed rev, plus a few sibling git crates).
- `perl` in `nativeBuildInputs`: rusqlite's `bundled-sqlcipher-vendored-openssl` builds OpenSSL from source, whose build system is perl.
- gpui dlopens Vulkan and the Wayland/X11 client libraries at runtime rather than linking them, hence the `patchelf --add-rpath` in `postFixup` (same pattern as `zed-editor`).

**Automation disclosure** (per the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy)): this derivation and PR text were drafted with an LLM-based tool (Claude) operated by me, and I reviewed them before submission. Verification of the output: this exact `package.nix` was built successfully in upstream CI on x86_64-linux ([run](https://github.com/packetThrower/zorite/actions/runs/28896029538)) and aarch64-linux ([run](https://github.com/packetThrower/zorite/actions/runs/28902045724)).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`. *(the binary links cleanly against store paths; the app itself is exercised heavily upstream on the same tag)*
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
