### PR TITLE
crossmacro: 1.2.1 -> 1.3.1

### DIFF
--- a/pkgs/by-name/cr/crossmacro/package.nix
+++ b/pkgs/by-name/cr/crossmacro/package.nix
@@ -4,6 +4,8 @@
   dotnetCorePackages,
   fetchFromGitHub,
   installShellFiles,
+  clang,
+  autoPatchelfHook,
   nix-update-script,
   fontconfig,
   freetype,
@@ -23,32 +25,42 @@
   icu,
   openssl,
   zlib,
+  pipewire,
 }:
 
 buildDotnetModule rec {
   pname = "crossmacro";
-  version = "1.2.1";
+  version = "1.3.1";
 
   src = fetchFromGitHub {
     owner = "alper-han";
     repo = "CrossMacro";
     tag = "v${version}";
-    hash = "sha256-lMXp7ItwpZ14ATRKuR7Q8/FhfMNQ+YCgHL13oj6iBNs=";
+    hash = "sha256-2L25A2OO2Ju6n1QlblNBtKva1PfbidFz/QESjLBVuSU=";
   };
 
   projectFile = "src/CrossMacro.UI.Linux/CrossMacro.UI.Linux.csproj";
   nugetDeps = ./deps.json;
 
   dotnet-sdk = dotnetCorePackages.sdk_10_0;
-  dotnet-runtime = dotnetCorePackages.runtime_10_0;
+  dotnet-runtime = null;
 
   executables = [ "CrossMacro.UI" ];
   buildType = "Release";
+  selfContainedBuild = true;
 
   dotnetFlags = [
-    "-p:SelfContained=false"
+    "-p:PublishAot=true"
+    "-p:PublishReadyToRun=false"
+    "-p:OptimizationPreference=Speed"
+    "-p:StripSymbols=true"
+    "-p:IlcTrimMetadata=true"
+    "-p:DebugType=None"
+    "-p:DebugSymbols=false"
     "-p:Version=${version}"
   ];
+
+  buildInputs = runtimeDeps;
 
   runtimeDeps = [
     zlib
@@ -69,14 +81,21 @@ buildDotnetModule rec {
     libglvnd
     wayland
     libxkbcommon
+    pipewire
   ];
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [
+    installShellFiles
+    clang
+    autoPatchelfHook
+  ];
 
   postInstall = ''
     installManPage docs/man/crossmacro.1
 
     install -Dm644 scripts/assets/CrossMacro.desktop $out/share/applications/crossmacro.desktop
+    substituteInPlace $out/share/applications/crossmacro.desktop \
+      --replace-fail "Exec=crossmacro" "Exec=$out/lib/crossmacro/CrossMacro.UI"
 
     for size in 16 32 48 64 128 256 512; do
       install -Dm644 src/CrossMacro.UI/Assets/icons/''${size}x''${size}/apps/crossmacro.png \
@@ -85,9 +104,28 @@ buildDotnetModule rec {
 
     install -Dm644 scripts/assets/io.github.alper-han.CrossMacro.metainfo.xml \
       $out/share/metainfo/io.github.alper-han.CrossMacro.metainfo.xml
+  '';
 
-    mkdir -p $out/bin
-    ln -sf $out/bin/CrossMacro.UI $out/bin/crossmacro
+  postFixup = ''
+    # Align wrapper and ELF paths so KWin's strict /proc/<pid>/exe check grants Wayland permissions.
+    # Move the real ELF binary to .CrossMacro.UI-wrapped
+    mv $out/lib/crossmacro/CrossMacro.UI \
+       $out/lib/crossmacro/.CrossMacro.UI-wrapped
+
+    # Move the buildDotnetModule wrapper from bin/ into lib/ so
+    # its path matches what KWin resolves after unwrapping.
+    mv $out/bin/CrossMacro.UI $out/lib/crossmacro/CrossMacro.UI
+
+    # Update the wrapper's exec target to the renamed binary
+    substituteInPlace $out/lib/crossmacro/CrossMacro.UI \
+      --replace-fail \
+        "\"$out/lib/crossmacro/CrossMacro.UI\"" \
+        "\"$out/lib/crossmacro/.CrossMacro.UI-wrapped\""
+
+    # Point bin/ entries at the lib/ wrapper
+    rm -f $out/bin/crossmacro
+    ln -s $out/lib/crossmacro/CrossMacro.UI $out/bin/CrossMacro.UI
+    ln -s $out/bin/CrossMacro.UI $out/bin/crossmacro
   '';
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
Supersedes #537993

Updates crossmacro to 1.3.1 and applies upstream build changes missed by the automated update:
- Migrates the UI package to Native AOT.
- Aligns `/proc/<pid>/exe` wrapper resolution for KWin Wayland permissions.
- Adds `pipewire` for Wayland screen reading.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
