### PR TITLE
marge-bot: specify correct dependencies

### DIFF
--- a/pkgs/by-name/ma/marge-bot/package.nix
+++ b/pkgs/by-name/ma/marge-bot/package.nix
@@ -1,13 +1,13 @@
 {
   lib,
-  python3,
   fetchFromGitLab,
+  python3Packages,
   git,
   openssh,
   nix-update-script,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "marge-bot";
   version = "1.1.0";
   pyproject = true;
@@ -19,18 +19,17 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     hash = "sha256-nTVfsprCTa2S/F8GDdDw5SwQw+OrGkHrX/QwU1FZDsw=";
   };
 
-  nativeBuildInputs = [
-    python3.pkgs.setuptools
+  build-system = with python3Packages; [
+    hatchling
+    uv-build
   ];
 
-  propagatedBuildInputs =
-    (with python3.pkgs; [
+  dependencies =
+    (with python3Packages; [
       configargparse
-      maya
       pyyaml
       requests
       python-gitlab
-      hatchling
     ])
     ++ [
       git
@@ -38,10 +37,11 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     ];
 
   nativeCheckInputs =
-    (with python3.pkgs; [
+    (with python3Packages; [
       pytest-cov-stub
       pytestCheckHook
-      pendulum
+      python-dateutil
+      time-machine
     ])
     ++ [
       git


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

marge-bot migrated to uv back in 0.15.1: https://gitlab.com/marge-org/marge-bot/-/compare/0.15.0...0.15.1

maya and pendulum were removed back in 0.14.2: https://gitlab.com/marge-org/marge-bot/-/compare/0.14.1...0.14.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
