### PR TITLE
compiler-rt: fix MinGW atomic runtime bootstrap

### DIFF
--- a/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
@@ -36,7 +36,8 @@
   # implementation of the routines instead of the implementation
   # using ad-hoc mutexes (which doesn't depend on libc at all).
   # Use of pthreads helps code play better with sanitizers.
-  withAtomicsPthread ? lib.versionAtLeast release_version "19" && stdenv.cc.libc != null,
+  withAtomicsPthread ?
+    lib.versionAtLeast release_version "19" && stdenv.cc.libc != null && !stdenv.hostPlatform.isMinGW,
 
   # In recent releases, the compiler-rt build seems to produce
   # many `libclang_rt*` libraries, but not a single unified
@@ -214,7 +215,7 @@ stdenv.mkDerivation (finalAttrs: {
       # Fixes https://github.com/NixOS/nixpkgs/issues/393603
       (lib.cmakeBool "COMPILER_RT_DISABLE_AARCH64_FMV" true)
   ++ lib.optionals withAtomics [
-    (lib.cmakeBool "COMPILER_RT_EXCLUDE_ATOMIC_BUILTIN" (!withAtomicsLib))
+    (lib.cmakeBool "COMPILER_RT_EXCLUDE_ATOMIC_BUILTIN" withAtomicsLib)
     (lib.cmakeBool "COMPILER_RT_BUILD_STANDALONE_LIBATOMIC" withAtomicsLib)
     (lib.cmakeBool "COMPILER_RT_LIBATOMIC_USE_PTHREAD" withAtomicsPthread)
   ]
@@ -291,11 +292,21 @@ stdenv.mkDerivation (finalAttrs: {
     + lib.optionalString forceLinkCompilerRt ''
       ln -s $out/lib/*/libclang_rt.builtins-*.a $out/lib/libcompiler_rt.a
     ''
-    + lib.optionalString (withAtomics && withAtomicsLib) ''
-      ln -s $out/lib/*/libclang_rt.atomic-*.so $out/lib/libatomic.so
-      # create a link with the original soname as well, so it's found at runtime
-      ln -s $out/lib/*/libclang_rt.atomic-*.so $out/lib/
-    '';
+    + lib.optionalString (withAtomics && withAtomicsLib) (
+      let
+        isMinGW = stdenv.hostPlatform.isMinGW;
+        sharedLibrary = stdenv.hostPlatform.extensions.sharedLibrary;
+        linkLibrarySuffix = lib.optionalString isMinGW ".a";
+        runtimeDirectory = if isMinGW then "$out/bin" else "$out/lib";
+        atomicLibrary = "libclang_rt.atomic" + lib.optionalString isMinGW "_dynamic" + "-*${sharedLibrary}";
+      in
+      ''
+        mkdir -p ${runtimeDirectory}
+        ln -s $out/lib/*/${atomicLibrary}${linkLibrarySuffix} $out/lib/libatomic${sharedLibrary}${linkLibrarySuffix}
+        # Link the original runtime name where the loader searches for shared libraries.
+        ln -s $out/lib/*/${atomicLibrary} ${runtimeDirectory}/
+      ''
+    );
 
   meta = llvm_meta // {
     homepage = "https://compiler-rt.llvm.org/";

--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -308,9 +308,11 @@ makeScopeWithSplicing' {
           && stdenv.targetPlatform.useLLVM or false
         ) "-lunwind"
         ++ lib.optional stdenv.targetPlatform.isWasm "-fno-exceptions";
-        nixSupport.cc-ldflags = lib.optionals (
-          !stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD
-        ) [ "-L${targetLlvmPackages.libunwind}/lib" ];
+        nixSupport.cc-ldflags =
+          lib.optionals (!stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD) [
+            "-L${targetLlvmPackages.libunwind}/lib"
+          ]
+          ++ lib.optional stdenv.targetPlatform.isMinGW "-L${targetLlvmPackages.compiler-rt}/lib";
       };
 
       clangWithLibcAndBasicRtAndLibcxx = wrapCCWith rec {
@@ -424,6 +426,11 @@ makeScopeWithSplicing' {
 
       compiler-rt-no-libc = callPackage ./compiler-rt {
         doFakeLibgcc = stdenv.hostPlatform.useLLVM or false;
+        # This runtime is used to bootstrap the libc-capable toolchain.  Keep
+        # atomics in builtins.a until that toolchain can link the shared atomic
+        # runtime against libc (and pthreads, when enabled).
+        withAtomicsLib = false;
+        withAtomicsPthread = false;
         stdenv =
           # Darwin needs to use a bootstrap stdenv to avoid an infinite recursion when cross-compiling.
           if stdenv.hostPlatform.isDarwin then


### PR DESCRIPTION
Fixes #534236.

`pkgsCross.ucrtAarch64.stdenv.cc` failed while bootstrapping compiler-rt for `aarch64-w64-mingw32`. The no-libc stage attempted to build the standalone atomic runtime using pthreads before the MinGW CRT and winpthreads were available.

The initial version of this PR disabled the standalone atomic runtime for Windows entirely. That was too broad: dynamically linked PE modules need to share compiler-rt's lock state through one runtime DLL.

This revision limits the exception to the bootstrap stage:

- `compiler-rt-no-libc` keeps the atomic routines in `builtins.a` and disables pthreads.
- The final MinGW compiler-rt builds the shared atomic DLL and excludes those routines from `builtins.a`.
- MinGW uses compiler-rt's libc-independent locking implementation because winpthreads is unavailable at this point in the bootstrap graph.
- The DLL and import library are installed in the expected outputs, and Clang's linker search path allows ordinary `-latomic` linking.

## Verification

On `x86_64-linux`:

```console
nix build --impure --expr \
  'let pkgs = import ./. {}; in pkgs.pkgsCross.ucrtAarch64.llvmPackages.compiler-rt' \
  --no-link

nix build --impure --expr \
  'let pkgs = import ./. {}; in pkgs.pkgsCross.ucrtAarch64.stdenv.cc' \
  --no-link

nixfmt --check \
  pkgs/development/compilers/llvm/common/compiler-rt/default.nix \
  pkgs/development/compilers/llvm/common/default.nix
```

I also compiled a non-lock-free three-byte atomic operation with the resulting cross compiler using plain `-latomic`. The result is an ARM64 PE executable whose import table references:

```text
libclang_rt.atomic_dynamic-aarch64.dll
__atomic_load
```

The resulting runtime was tested on native Windows on ARM hardware by @greg-hellings: Windows 11 Home 25H2 (build 26200) on a Snapdragon 8cx Gen 2. The distributed binary hashes matched, and the cross-module stress test passed three times with 8 threads and three times with 16 threads. The test alternates non-lock-free three-byte atomic operations between an ARM64 PE executable and helper DLL using the shared compiler-rt atomic DLL.

Results: [8-thread test](https://github.com/NixOS/nixpkgs/pull/539430#issuecomment-5287942427), [16-thread test](https://github.com/NixOS/nixpkgs/pull/539430#issuecomment-5287972061).

## Automation disclosure

This is my first nixpkgs contribution, though I have used Nix and NixOS for
several years across development machines and CI systems. OpenAI Codex 5.6 Sol
High assisted with the investigation, patch refinement, PR text, substantive
technical discussion, and preparation of the runtime test.

I manually reviewed the resulting changes and test evidence, understand the
bootstrap-stage versus shared-runtime distinction described above, and take
responsibility for the contribution. The original broader approach was revised
after @mildsunrise identified the cross-module lock-state problem. The resulting
stage-specific design was built on x86_64-linux and independently exercised by
@greg-hellings on native ARM64 Windows hardware with repeated EXE/DLL contention
tests.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits the relevant contribution guidelines.
- [x] Follows the automation/AI policy.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review]: https://github.com/Mic92/nixpkgs-review
[lib/tests]: https://github.com/NixOS/nixpkgs/tree/master/lib/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/tree/master/pkgs/test
