### PR TITLE
xorg-server: 21.1.23 -> 21.1.24

### DIFF
--- a/pkgs/by-name/xo/xorg-server/package.nix
+++ b/pkgs/by-name/xo/xorg-server/package.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
   # `xvfb` inherits `version` and `src` from here, leading to many rebuilds. If
   # necessary, these can be moved out of lockstep in order to merge updates
   # quickly.
-  version = "21.1.23";
+  version = "21.1.24";
 
   outputs = [
     "out"
@@ -69,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://xorg/individual/xserver/xorg-server-${finalAttrs.version}.tar.xz";
-    hash = "sha256-45gy5WF9ra8HL9+fDhnl0uHCoTYHrCgLrBq6n4/hRjQ=";
+    hash = "sha256-Gk6zbKZcw7G5NlZtZ3qXhuE8Ec1YBulRrFXz9c45hK8=";
   };
 
   patches = lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/by-name/xv/xvfb/package.nix
+++ b/pkgs/by-name/xv/xvfb/package.nix
@@ -38,7 +38,14 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "xvfb";
 
-  inherit (xorg-server) src version;
+  # TODO: commented out for rebuild avoidance after xorg-server update. revert
+  # on staging.
+  # inherit (xorg-server) src version;
+  version = "21.1.23";
+  src = fetchurl {
+    url = "mirror://xorg/individual/xserver/xorg-server-${finalAttrs.version}.tar.xz";
+    hash = "sha256-45gy5WF9ra8HL9+fDhnl0uHCoTYHrCgLrBq6n4/hRjQ=";
+  };
 
   strictDeps = true;
 


### PR DESCRIPTION
announcement: https://lists.x.org/archives/xorg-announce/2026-July/003718.html
advisory: https://lists.x.org/archives/xorg-announce/2026-July/003716.html

Fixes: CVE-2026-55999, CVE-2026-56000

we get to do the xvfb rebuild avoidance dance again :upside down: we'll send a revert once this hits staging via periodic merges, i suppose.

xwayland: #539432

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. (`nixosTests.xfce`, `nixosTests.lxqt`)
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (tested xfce in a vm for a little bit)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
