### PR TITLE
cpython: strip llvm IR LTO debuginfo

### DIFF
--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -232,6 +232,8 @@ let
       ];
     };
 
+  configDirPrefix = "lib/${passthru.libPrefix}/config-${passthru.pythonVersion}";
+
   version = with sourceVersion; "${major}.${minor}.${patch}${suffix}";
 
   nativeBuildInputs = [
@@ -510,7 +512,10 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-suffix=${execSuffix}"
   ]
   ++ optionals enableLTO [
-    "--with-lto"
+    # The fixup below assumes ThinLTO bitcode. Request it explicitly with Clang
+    # instead of relying on CPython's version-dependent default policy; Python
+    # 3.11, in particular, preserves the historical full-LTO default.
+    (if stdenv.cc.isClang then "--with-lto=thin" else "--with-lto")
   ]
   ++ optionals (!static && !enableFramework) [
     "--enable-shared"
@@ -674,7 +679,7 @@ stdenv.mkDerivation (finalAttrs: {
       # Get rid of retained dependencies on -dev packages, and remove
       # some $TMPDIR references to improve binary reproducibility.
       # Note that the .pyc file of _sysconfigdata.py should be regenerated!
-      for i in $out/lib/${libPrefix}/_sysconfigdata*.py $out/lib/${libPrefix}/config-${sourceVersion.major}.${sourceVersion.minor}*/Makefile; do
+      for i in $out/lib/${libPrefix}/_sysconfigdata*.py "$out/${configDirPrefix}"*/Makefile; do
          sed -i $i -e "s|$TMPDIR|/no-such-path|g"
       done
 
@@ -758,10 +763,44 @@ stdenv.mkDerivation (finalAttrs: {
       linkDLLsInfolder $out/lib/python*/lib-dynload/
     '';
 
-  preFixup = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
-    # Ensure patch-shebangs uses shebangs of host interpreter.
-    export PATH=${lib.makeBinPath [ "$out" ]}:$PATH
-  '';
+  preFixup =
+    lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+      # Ensure patch-shebangs uses shebangs of host interpreter.
+      export PATH=${lib.makeBinPath [ "$out" ]}:$PATH
+    ''
+    + lib.optionalString (enableLTO && stdenv.cc.isClang && !enableDebug) ''
+      # ThinLTO debug metadata in libpython.a retains references to the SDK.
+      opt=${lib.getExe' stdenv.cc.cc.libllvm "opt"}
+      llvmAr=${lib.getExe' stdenv.cc.cc.libllvm "llvm-ar"}
+
+      for archive in "$out/${configDirPrefix}"*/libpython*.a; do
+        work="$(mktemp -d)"
+        mapfile -t members < <("$llvmAr" t "$archive")
+
+        # Sanity check: bulk extraction cannot distinguish duplicate archive
+        # members. Revisit this if libpython ever contains duplicate names.
+        duplicateMembers="$(printf '%s\n' "''${members[@]}" | sort | uniq -d)"
+        if [[ -n "$duplicateMembers" ]]; then
+          echo "duplicate members in $archive:" >&2
+          printf '%s\n' "$duplicateMembers" >&2
+          exit 1
+        fi
+
+        "$llvmAr" x --output "$work" "$archive"
+
+        for member in "''${members[@]}"; do
+          "$opt" -strip-debug -module-summary -module-hash \
+            "$work/$member" -o "$work/$member.stripped"
+          mv "$work/$member.stripped" "$work/$member"
+        done
+
+        (
+          cd "$work"
+          "$llvmAr" rs "$archive" "''${members[@]}"
+        )
+        rm -rf "$work"
+      done
+    '';
 
   # Add CPython specific setup-hook that configures distutils.sysconfig to
   # always load sysconfigdata from host Python.


### PR DESCRIPTION
This reduces Darwin cpython closure size from \~1.44GB to \~110MB (\~92.5% size reduction).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
