### PR TITLE
[Backport release-26.05] nixos/fish: `programs.fish.generateCompletions` fix spaces in filenames

### DIFF
--- a/nixos/modules/programs/fish.nix
+++ b/nixos/modules/programs/fish.nix
@@ -298,7 +298,7 @@ in
                 ''
                   mkdir -p $out
                   if [ -d $package/share/man ]; then
-                    find -L $package/share/man -type f | xargs ${pkgs.python3.pythonOnBuildForHost.interpreter} ${patchedGenerator}/create_manpage_completions.py --directory $out >/dev/null
+                    find -L $package/share/man -type f -print0 | xargs -0 ${pkgs.python3.pythonOnBuildForHost.interpreter} ${patchedGenerator}/create_manpage_completions.py --directory $out >/dev/null
                   fi
                 '';
             packages =


### PR DESCRIPTION
Manual backport of https://github.com/NixOS/nixpkgs/pull/538723, resolving conflicts due to non-backported https://github.com/NixOS/nixpkgs/commit/1260b0727b5458aa7b69ee7cda483a2d5558316d