### PR TITLE
libxfont_2: 2.0.7 -> 2.0.8

### DIFF
--- a/pkgs/by-name/li/libxfont_2/package.nix
+++ b/pkgs/by-name/li/libxfont_2/package.nix
@@ -15,7 +15,7 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "libxfont_2";
-  version = "2.0.7";
+  version = "2.0.8";
 
   outputs = [
     "out"
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://xorg/individual/lib/libXfont2-${finalAttrs.version}.tar.xz";
-    hash = "sha256-i3uC/eukh2m2lDPo4/u5hKX2vzaLDV9Hq+7EnePljvs=";
+    hash = "sha256-9VbA4Qk6TmkRzJC8SxBtIBkC7hh/10ryBv8WL35qJNU=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
announcement: https://lists.x.org/archives/xorg-announce/2026-July/003715.html
advisory: https://lists.x.org/archives/xorg-announce/2026-July/003714.html

Fixes: CVE-2026-56001, CVE-2026-56002, CVE-2026-56003

we're not sure on whether we should backport this or try to pick the patches. as per the release announcement, this comes with "the removal of a decades-obsolete compat API.", but we don't know if that's likely to cause issues. would appreciate the judgement of others, we can try to do either :)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
