### PR TITLE
darwin: exclude ICO and CUR files from stripping

### DIFF
--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -58,6 +58,9 @@ let
     export NIX_ENFORCE_NO_NATIVE=''${NIX_ENFORCE_NO_NATIVE-1}
     export NIX_ENFORCE_PURITY=''${NIX_ENFORCE_PURITY-1}
     export NIX_IGNORE_LD_THROUGH_GCC=1
+
+    # llvm-strip can mis-detect ICO/CUR resources as COFF objects.
+    stripExclude+=("*.ico" "*.cur" "*.ICO" "*.CUR")
   '';
 
   bootstrapTools =


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Tested as follows:
- removed dontStrip from `reaper` package. The package build succeeded with this patch.
- then removed dontStrip from `reaper` on `upstream/master`. Build failed with:

```
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace.
Stack dump:
0.      Program arguments: /nix/store/zhb8xrwn0mp0xk3argfbh8w73c4cipqs-cctools-binutils-darwin-1010.6/bin/strip --enable-deterministic-archives -S /nix/store/nk19s6yj6v2adg
qyfbvl3crdgkb3rlby-reaper-7.76/Applications/Reaper.app/Contents/Resources/highlighter_xfade.cur
Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace.
Stack dump:
0.      Program arguments: /nix/store/zhb8xrwn0mp0xk3argfbh8w73c4cipqs-cctools-binutils-darwin-1010.6/bin/strip --enable-deterministic-archives -S /nix/store/nk19s6yj6v2adg
qyfbvl3crdgkb3rlby-reaper-7.76/Applications/Reaper.app/Contents/Resources/highlighter_move.cur
Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
/nix/store/zhb8xrwn0mp0xk3argfbh8w73c4cipqs-cctools-binutils-darwin-1010.6/bin/strip: error: '/nix/store/nk19s6yj6v2adgqyfbvl3crdgkb3rlby-reaper-7.76/Applications/Reaper.ap
p/Contents/Resources/highlighter_right.cur': SymbolTableIndex out of range
/nix/store/zhb8xrwn0mp0xk3argfbh8w73c4cipqs-cctools-binutils-darwin-1010.6/bin/strip: error: '/nix/store/nk19s6yj6v2adgqyfbvl3crdgkb3rlby-reaper-7.76/Applications/Reaper.ap
p/Contents/Resources/highlighter_select.cur': SymbolTableIndex out of range
/nix/store/zhb8xrwn0mp0xk3argfbh8w73c4cipqs-cctools-binutils-darwin-1010.6/bin/strip: error: '/nix/store/nk19s6yj6v2adgqyfbvl3crdgkb3rlby-reaper-7.76/Applications/Reaper.ap
p/Contents/Resources/insertrow.cur': The end of the file was unexpectedly encountered
0 0  libLLVM.dylib            0x000000010c196de8  libLLVM.dylib            0x000000010bd2ade8 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) + 72
1  libLLVM.dylib            0x000000010c1948b8 llvm::sys::RunSignalHandlers() + 164
2  libLLVM.dylib            0x000000010c1979a8 SignalHandler(int, __siginfo*, void*) + 324
3  libsystem_platform.dylib 0x0000000183ee3744 _sigtramp + 56
4  libLLVM.dylib            0x000000010de56988 std::__1::__wrap_iter<llvm::objcopy::coff::Relocation*> std::__1::vector<llvm::objcopy::coff::Relocation, std::__1::allocator
<llvm::objcopy::coff::Relocation>>::__insert_with_size[abi:fqn210106]<llvm::object::coff_relocation const*, llvm::object::coff_relocation const*>(std::__1::__wrap_iter<llvm
::objcopy::coff::Relocation const*>, llvm::object::coff_relocation const*, llvm::object::coff_relocation const*, long) + 192
5 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) + 72
1  libLLVM.dylib            0x000000010de554f8 llvm::objcopy::coff::COFFReader::readSections(llvm::objcopy::coff::Object&) const + 468
6  libLLVM.dylib            0x000000010bd288b8 llvm::sys::RunSignalHandlers() + 164
2  libLLVM.dylib            0x000000010de565a4 llvm::objcopy::coff::COFFReader::create() const + 236
7  libLLVM.dylib            0x000000010bd2b9a8 SignalHandler(int, __siginfo*, void*) + 324
3  libsystem_platform.dylib 0x0000000183ee3744 _sigtramp + 56
4  libLLVM.dylib            0x000000010de4fdd0 llvm::objcopy::coff::executeObjcopyOnBinary(llvm::objcopy::CommonConfig const&, llvm::objcopy::COFFConfig const&, llvm::objec
t::COFFObjectFile&, llvm::raw_ostream&) + 80
8  libLLVM.dylib            0x000000010d9ea988 std::__1::__wrap_iter<llvm::objcopy::coff::Relocation*> std::__1::vector<llvm::objcopy::coff::Relocation, std::__1::allocator
<llvm::objcopy::coff::Relocation>>::__insert_with_size[abi:fqn210106]<llvm::object::coff_relocation const*, llvm::object::coff_relocation const*>(std::__1::__wrap_iter<llvm
::objcopy::coff::Relocation const*>, llvm::object::coff_relocation const*, llvm::object::coff_relocation const*, long) + 192
5  libLLVM.dylib            0x000000010de4ea18 llvm::objcopy::executeObjcopyOnBinary(llvm::objcopy::MultiFormatConfig const&, llvm::object::Binary&, llvm::raw_ostream&) + 2
08
9  libLLVM.dylib            0x000000010c177e68 llvm::writeToOutput(llvm::StringRef, std::__1::function<llvm::Error (llvm::raw_ostream&)>) + 684 libLLVM.dylib            0x0
00000010d9e94f8
10 llvm-objcopy             0x0000000102ef13b4 llvm_objcopy_main(int, char**, llvm::ToolContext const&) + 2520
11 llvm-objcopy             0x0000000102ef2464 main + 88
12 dyld                     0x0000000183b1be00 start + 6992
 llvm::objcopy::coff::COFFReader::readSections(llvm::objcopy::coff::Object&) const + 468
6  libLLVM.dylib            0x000000010d9ea5a4 llvm::objcopy::coff::COFFReader::create() const + 236
7 xargs: strip: terminated by signal 11
 libLLVM.dylib            0x000000010d9e3dd0 llvm::objcopy::coff::executeObjcopyOnBinary(llvm::objcopy::CommonConfig const&, llvm::objcopy::COFFConfig const&, llvm::object:
:COFFObjectFile&, llvm::raw_ostream&) + 80
8  libLLVM.dylib            0x000000010d9e2a18 llvm::objcopy::executeObjcopyOnBinary(llvm::objcopy::MultiFormatConfig const&, llvm::object::Binary&, llvm::raw_ostream&) + 2
08
9  libLLVM.dylib            0x000000010bd0be68 llvm::writeToOutput(llvm::StringRef, std::__1::function<llvm::Error (llvm::raw_ostream&)>) + 684
10 llvm-objcopy             0x0000000102abd3b4 llvm_objcopy_main(int, char**, llvm::ToolContext const&) + 2520
11 llvm-objcopy             0x0000000102abe464 main + 88
12 dyld                     0x0000000183b1be00 start + 6992
xargs: strip: terminated by signal 11
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
