### PR TITLE
empire-compiler: 0.4.3 -> 2.0.0

### DIFF
--- a/pkgs/by-name/em/empire-compiler/deps.json
+++ b/pkgs/by-name/em/empire-compiler/deps.json
@@ -1,72 +1,37 @@
 [
   {
+    "pname": "ILRepack.Lib",
+    "version": "2.0.44",
+    "hash": "sha256-HgS8pt21vlcdvvwzBj+D5LiafXMsayckfczaFX6UP+8="
+  },
+  {
     "pname": "Microsoft.CodeAnalysis.Analyzers",
-    "version": "3.0.0-beta2.20059.3",
-    "hash": "sha256-A62m36Ra9xx6qdU8t5ie7hIBcU+uCZUJUU4Smto90xM="
+    "version": "3.11.0",
+    "hash": "sha256-hQ2l6E6PO4m7i+ZsfFlEx+93UsLPo4IY3wDkNG11/Sw="
   },
   {
     "pname": "Microsoft.CodeAnalysis.Common",
-    "version": "3.5.0",
-    "hash": "sha256-k6PiYI8QqWXWxUL4oSbvPHVBFRolS1ZApphnSQW+ITg="
+    "version": "4.13.0",
+    "hash": "sha256-Bu5ev3JM+fyf9USnLM7AJbd5lFmpVfaxm6EQYoYM9Vc="
   },
   {
     "pname": "Microsoft.CodeAnalysis.CSharp",
-    "version": "3.5.0",
-    "hash": "sha256-D/1EQqFrTiwACdknW0fpodraz9JaA+ebIrQVLMw8pc8="
-  },
-  {
-    "pname": "Microsoft.NETCore.Platforms",
-    "version": "2.1.2",
-    "hash": "sha256-gYQQO7zsqG+OtN4ywYQyfsiggS2zmxw4+cPXlK+FB5Q="
+    "version": "4.13.0",
+    "hash": "sha256-jzO7/2j7rPqu4Xtm4lhh2Ijaiw+aUkiR+yYn+a8mg/M="
   },
   {
     "pname": "Newtonsoft.Json",
-    "version": "13.0.1",
-    "hash": "sha256-K2tSVW4n4beRPzPu3rlVaBEMdGvWSv/3Q1fxaDh4Mjo="
-  },
-  {
-    "pname": "System.Collections.Immutable",
-    "version": "1.5.0",
-    "hash": "sha256-BliqYlL9ntbMXo5d7NUrKXwYN+PqdyqDIS5bp4qVr7Q="
+    "version": "13.0.3",
+    "hash": "sha256-hy/BieY4qxBWVVsDqqOPaLy1QobiIapkbrESm6v2PHc="
   },
   {
     "pname": "System.CommandLine",
-    "version": "2.0.0-beta4.22272.1",
-    "hash": "sha256-zSO+CYnMH8deBHDI9DHhCPj79Ce3GOzHCyH1/TiHxcc="
-  },
-  {
-    "pname": "System.Memory",
-    "version": "4.5.3",
-    "hash": "sha256-Cvl7RbRbRu9qKzeRBWjavUkseT2jhZBUWV1SPipUWFk="
-  },
-  {
-    "pname": "System.Reflection.Metadata",
-    "version": "1.6.0",
-    "hash": "sha256-JJfgaPav7UfEh4yRAQdGhLZF1brr0tUWPl6qmfNWq/E="
-  },
-  {
-    "pname": "System.Runtime.CompilerServices.Unsafe",
-    "version": "4.5.2",
-    "hash": "sha256-8eUXXGWO2LL7uATMZye2iCpQOETn2jCcjUhG6coR5O8="
-  },
-  {
-    "pname": "System.Runtime.CompilerServices.Unsafe",
-    "version": "4.6.0",
-    "hash": "sha256-FTjQeMuvqnKxpoVsVh/OlQ21NMaZiFtOdv7VdZ+Iv3Y="
-  },
-  {
-    "pname": "System.Text.Encoding.CodePages",
-    "version": "4.5.1",
-    "hash": "sha256-PIhkv59IXjyiuefdhKxS9hQfEwO9YWRuNudpo53HQfw="
-  },
-  {
-    "pname": "System.Threading.Tasks.Extensions",
-    "version": "4.5.3",
-    "hash": "sha256-8TglbC6KBHlDeSfgr6d5dGn7wu8td4XERl2JUyo0+Tw="
+    "version": "2.0.0",
+    "hash": "sha256-cUJTPCLcnA6959PGdwWw8zsjFxhYGI+SZeIxnMC/Cwc="
   },
   {
     "pname": "YamlDotNet",
-    "version": "8.1.1",
-    "hash": "sha256-B6yNYjnIAGI31fTiTlfZ4eXU3l9qYFgm0Q0ALBNmPTw="
+    "version": "16.3.0",
+    "hash": "sha256-4Gi8wSQ8Rsi/3+LyegJr//A83nxn2fN8LN1wvSSp39Q="
   }
 ]

--- a/pkgs/by-name/em/empire-compiler/package.nix
+++ b/pkgs/by-name/em/empire-compiler/package.nix
@@ -9,22 +9,17 @@
 
 buildDotnetModule (finalAttrs: {
   pname = "empire-compiler";
-  version = "0.4.3";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "bc-security";
     repo = "empire-compiler";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-HNT1sELoyibXDoRcKkBZiJHIsNY7Hz2fZfHEM93UCBE=";
+    hash = "sha256-hquqUEQHdID+2dTWiSkMjcYi4wc6KlSllAD9vUzdH10=";
   };
 
-  postPatch = ''
-    substituteInPlace EmpireCompiler/EmpireCompiler.csproj \
-      --replace-fail 'net6.0' 'net9.0'
-  '';
-
-  dotnet-sdk = dotnetCorePackages.sdk_9_0;
-  dotnet-runtime = dotnetCorePackages.aspnetcore_9_0;
+  dotnet-sdk = dotnetCorePackages.sdk_10_0;
+  dotnet-runtime = dotnetCorePackages.aspnetcore_10_0;
   nugetDeps = ./deps.json;
 
   projectFile = "EmpireCompiler/EmpireCompiler.csproj";
@@ -41,7 +36,7 @@ buildDotnetModule (finalAttrs: {
   meta = {
     homepage = "https://github.com/BC-SECURITY/Empire-Compiler";
     license = lib.licenses.mit;
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ [ "aarch64-darwin" ];
     description = "C# Compiler for Empire";
     maintainers = with lib.maintainers; [
       fzakaria


### PR DESCRIPTION
What:
Update empire-compiler from 0.4.3 to 2.0.0

Why:
New release https://github.com/BC-SECURITY/Empire-Compiler/releases/tag/v2.0.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
