### PR TITLE
wrapFirefox: add wrapped executable in $out/bin on macOS

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   makeDesktopItem,
+  makeBinaryWrapper,
   makeWrapper,
   lndir,
   config,
@@ -298,10 +299,11 @@ let
       );
 
       nativeBuildInputs = [
-        makeWrapper
         lndir
         jq
-      ];
+      ]
+      ++ (lib.optional isDarwin makeBinaryWrapper)
+      ++ (lib.optional (!isDarwin) makeWrapper);
       buildInputs = lib.optionals (!isDarwin) [ browser.gtk3 ];
 
       makeWrapperArgs = [
@@ -378,6 +380,7 @@ let
           sourceBinary = "${browser}/${executablePath}";
           libDir = if isDarwin then "${appPath}/Contents/Resources" else "lib/${libName}";
           prefsDir = if isDarwin then "${libDir}/browser/defaults/preferences" else "${libDir}/defaults/pref";
+          wrapperCommand = if isDarwin then "makeBinaryWrapper" else "makeWrapper";
         in
         ''
           if [ ! -x "${sourceBinary}" ]
@@ -491,7 +494,7 @@ let
         + ''
           concatTo makeWrapperArgs oldWrapperArgs
 
-          makeWrapper "$oldExe" "$out/${finalBinaryPath}" "''${makeWrapperArgs[@]}"
+          ${wrapperCommand} "$oldExe" "$out/${finalBinaryPath}" "''${makeWrapperArgs[@]}"
 
           #############################
           #                           #
@@ -584,7 +587,7 @@ let
         ''
         + lib.optionalString isDarwin ''
           mkdir -p "$out/bin"
-          makeWrapper "$out/${executablePath}" "$out/bin/${launcherName}"
+          ${wrapperCommand} "$out/${executablePath}" "$out/bin/${launcherName}"
         '';
 
       preferLocalBuild = true;

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -581,6 +581,10 @@ let
           #   END EXTRA PREF CHANGES  #
           #                           #
           #############################
+        ''
+        + lib.optionalString isDarwin ''
+          mkdir -p "$out/bin"
+          makeWrapper "$out/${executablePath}" "$out/bin/${launcherName}"
         '';
 
       preferLocalBuild = true;


### PR DESCRIPTION
Added a wrapper to $out/bin, conditioned on the system being a darwin system. Also switched from makeWrapper to makeBinaryWrapper on macOS (from my understanding, this is a best practice since the OS may sometimes refuse to execute a non-macho executable inside a `.app` bundle).

**N.B. Firefox was updated in nixpkgs rather recently, so I built `firefox-esr` for testing purposes.**

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test