### PR TITLE
anytype: fix build that may not be deterministic

### DIFF
--- a/pkgs/by-name/an/anytype/package.nix
+++ b/pkgs/by-name/an/anytype/package.nix
@@ -143,6 +143,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     substituteInPlace scripts/generate-protos.sh \
       --replace-fail "/usr/bin/env" "${coreutils}/bin/env"
 
+    substituteInPlace package.json \
+      --replace-fail \
+        '"build:nmh": "go build -o dist/nativeMessagingHost ./go/nativeMessagingHost.go"' \
+        '"build:nmh": "go build -trimpath -ldflags=-buildid= -o dist/nativeMessagingHost ./go/nativeMessagingHost.go"'
+
     cp -r ${anytype-heart}/lib dist/
     cp -r ${anytype-heart}/bin/anytypeHelper dist/
 
@@ -168,7 +173,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   # remove unnecessary files
   preInstall = ''
     chmod u+w -R dist node_modules
-    find -type f \( -name "*.ts" -o -name "*.map" \) -exec rm -rf {} +
+    find dist node_modules -type f \( -name '*.ts' -o -name '*.map' \) -delete
+    rm -f node_modules/keytar/build/{Makefile,binding.Makefile,config.gypi,keytar.target.mk}
+    rm -rf node_modules/keytar/build/Release/{.deps,obj.target}
   '';
 
   installPhase = ''


### PR DESCRIPTION
nativeMessagingHost may embed build-specific Go metadata, and keytar node-gyp artifacts may retain build paths. Normalize the Go build and drop those intermediate artifacts before install.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
