### PR TITLE
linux-exploit-suggester: unstable-2022-04-01 -> 1.2-unstable-2026-03-20

### DIFF
--- a/pkgs/by-name/li/linux-exploit-suggester/package.nix
+++ b/pkgs/by-name/li/linux-exploit-suggester/package.nix
@@ -5,14 +5,14 @@
 }:
 
 stdenvNoCC.mkDerivation {
-  pname = "linux-exploit-suggester";
-  version = "unstable-2022-04-01";
+  pname = "937cf955501fe7da85994c98f0ca6151194e7c1d";
+  version = "1.2-unstable-2026-03-20";
 
   src = fetchFromGitHub {
     owner = "The-Z-Labs";
     repo = "linux-exploit-suggester";
-    rev = "54a5c01497d6655be88f6262ccad5bc5a5e4f4ec";
-    sha256 = "v0Q8O+aaXEqwWAwGP/u5Nkm4DzM6nM11GI4XbK2PeWM=";
+    rev = "937cf955501fe7da85994c98f0ca6151194e7c1d";
+    hash = "sha256-a6SS1GS0qc1BW0w9Er8LA7K4pRMYnfHtmjUNwBF5Gtg=";
   };
 
   installPhase = ''
@@ -25,10 +25,10 @@ stdenvNoCC.mkDerivation {
 
   meta = {
     description = "Tool designed to assist in detecting security deficiencies for given Linux kernel/Linux-based machine";
-    mainProgram = "linux-exploit-suggester";
     homepage = "https://github.com/The-Z-Labs/linux-exploit-suggester";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ emilytrau ];
     platforms = lib.platforms.linux;
+    mainProgram = "linux-exploit-suggester";
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
