### PR TITLE
lib.meta.getDarwinApp{,'}: init

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -444,6 +444,7 @@ let
         getLicenseFromSpdxIdOr
         getExe
         getExe'
+        getDarwinApp'
         ;
       inherit (self.filesystem)
         pathType

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -444,6 +444,7 @@ let
         getLicenseFromSpdxIdOr
         getExe
         getExe'
+        getDarwinApp
         getDarwinApp'
         ;
       inherit (self.filesystem)

--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -530,7 +530,7 @@ rec {
         lib.warn
           "getExe: Package ${
             lib.strings.escapeNixIdentifier x.meta.name or x.pname or x.name
-          } does not have the meta.mainProgram attribute. We'll assume that the main program has the same name for now, but this behavior is deprecated, because it leads to surprising errors when the assumption does not hold. If the package has a main program, please set `meta.mainProgram` in its definition to make this warning go away. Otherwise, if the package does not have a main program, or if you don't control its definition, use getExe' to specify the name to the program, such as lib.getExe' foo \"bar\"."
+          } does not have the meta.mainProgram attribute. We'll assume that the main program has the same name for now, but this behavior is deprecated, because it leads to surprising errors when the assumption does not hold. If the package has a main program, please set `meta.mainProgram` in its definition to make this error go away. Otherwise, if the package does not have a main program, or if you don't control its definition, use getExe' to specify the name to the program, such as lib.getExe' foo \"bar\"."
           lib.getName
           x
       )
@@ -580,6 +580,42 @@ rec {
       match ".*/.*" y == null
       || throw "lib.meta.getExe': The second argument \"${y}\" is a nested path with a \"/\" character, but it should just be the name of the executable instead.";
     "${getBin x}/bin/${y}";
+
+  /**
+    Get the path to the main darwin app of a package based on `meta.mainDarwinApp`
+
+    # Inputs
+
+    `x`
+
+    : 1\. Function argument
+
+    # Type
+
+    ```
+    getDarwinApp :: Derivation -> StorePath
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.meta.getDarwinApp` usage example
+
+    ```nix
+    getDarwinApp pkgs.vscodium
+    => "/nix/store/0y95mgmlrs8cayv2cnj23xjfljwhlib0-vscodium-1.121.03429/Applications/VSCodium.app"
+    getDarwinApp pkgs.slack
+    => "/nix/store/g52cl8dblki8dr5bkr0vajpkralkmhi0-slack-4.49.89/Applications/Slack.app"
+    ```
+
+    :::
+  */
+  getDarwinApp =
+    x:
+    getDarwinApp' x (
+      x.meta.mainDarwinApp or (builtins.throw "getDarwinApp: Package ${
+        lib.strings.escapeNixIdentifier x.meta.name or x.pname or x.name
+      } does not have the meta.mainDarwinApp attribute. If the package has a main darwin app, please set `meta.mainDarwinApp` in its definition to make this warning go away. Otherwise, if the package does not have a main darwin app, or if you don't control its definition, use getDarwinApp' to specify the name to the program, such as lib.getDarwinApp' vscodium \"VSCodium.app\".")
+    );
 
   /**
     Get the path of an darwin app for a derivation.

--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -582,6 +582,54 @@ rec {
     "${getBin x}/bin/${y}";
 
   /**
+    Get the path of an darwin app for a derivation.
+
+    # Inputs
+
+    `x`
+
+    : 1\. Function argument
+
+    `y`
+
+    : 2\. Function argument
+
+    # Type
+
+    ```
+    getDarwinApp' :: Derivation -> String -> StorePath
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.meta.getDarwinApp'` usage example
+
+    ```nix
+    getDarwinApp' pkgs.linear "Linear.app"
+    => "/nix/store/z4vh6ldb2vpspv307q7mk6wazfmh5dic-linear-1.30.2/Applications/Linear.app"
+    getDarwinApp' pkgs.vscodium "VSCodium.app"
+    => "/nix/store/0y95mgmlrs8cayv2cnj23xjfljwhlib0-vscodium-1.121.03429/Applications/VSCodium.app"
+    ```
+
+    :::
+  */
+  getDarwinApp' =
+    x: y:
+    assert
+      isDerivation x
+      || throw "lib.meta.getDarwinApp': The first argument is of type ${typeOf x}, but it should be a derivation instead.";
+    assert
+      isString y
+      || throw "lib.meta.getDarwinApp': The second argument is of type ${typeOf y}, but it should be a string instead.";
+    assert
+      lib.hasInfix "/" y == false
+      || throw "lib.meta.getDarwinApp': The second argument \"${y}\" is a nested path with a \"/\" character, but it should just be the name of the app instead.";
+    assert
+      lib.hasSuffix ".app" y
+      || throw "lib.meta.getDarwinApp': The second argument \"${y}\" must end in `.app`";
+    "${lib.getOutput "out" x}/Applications/${y}";
+
+  /**
     Generate [CPE parts](#var-meta-identifiers-cpeParts) from inputs. Copies `vendor` and `version` to the output, and sets `update` to `*`.
 
     # Inputs

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -61,6 +61,7 @@ let
     genList
     getExe
     getExe'
+    getDarwinApp
     getDarwinApp'
     getLicenseFromSpdxIdOr
     groupBy
@@ -4714,6 +4715,16 @@ runTests {
   testGetExe'FailureFirstArg = testingThrow (getExe' "not a derivation" "executable");
 
   testGetExe'FailureSecondArg = testingThrow (getExe' { type = "derivation"; } "dir/executable");
+
+  testGetDarwinAppOutput = {
+    expr = getDarwinApp {
+      type = "derivation";
+      out = "somelonghash";
+      bin = "somelonghash";
+      meta.mainDarwinApp = "mainDarwinApp.app";
+    };
+    expected = "somelonghash/Applications/mainDarwinApp.app";
+  };
 
   testGetDarwinApp'Output = {
     expr = getDarwinApp' {

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -61,6 +61,7 @@ let
     genList
     getExe
     getExe'
+    getDarwinApp'
     getLicenseFromSpdxIdOr
     groupBy
     groupBy'
@@ -4713,6 +4714,21 @@ runTests {
   testGetExe'FailureFirstArg = testingThrow (getExe' "not a derivation" "executable");
 
   testGetExe'FailureSecondArg = testingThrow (getExe' { type = "derivation"; } "dir/executable");
+
+  testGetDarwinApp'Output = {
+    expr = getDarwinApp' {
+      type = "derivation";
+      out = "somelonghash";
+      bin = "somelonghash";
+    } "app.app";
+    expected = "somelonghash/Applications/app.app";
+  };
+
+  testGetDarwinApp'FailureFirstArg = testingThrow (getDarwinApp' "not a derivation" "executable");
+
+  testGetDarwinApp'FailureSecondArg = testingThrow (
+    getDarwinApp' { type = "derivation"; } "dir/executable"
+  );
 
   testGetLicenseFromSpdxIdOrExamples = {
     expr = [

--- a/pkgs/applications/editors/vscode/vscodium.nix
+++ b/pkgs/applications/editors/vscode/vscodium.nix
@@ -82,6 +82,7 @@ buildVscode rec {
       bobby285271
     ];
     mainProgram = "codium";
+    mainDarwinApp = "VSCodium.app";
     platforms = [
       "x86_64-linux"
       "aarch64-linux"

--- a/pkgs/by-name/li/linear/package.nix
+++ b/pkgs/by-name/li/linear/package.nix
@@ -41,6 +41,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "App to manage software development and track bugs";
     homepage = "https://linear.app/";
     license = lib.licenses.unfree;
+    mainDarwinApp = "Linear.app";
     maintainers = with lib.maintainers; [
       wini
       pradyuman

--- a/pkgs/by-name/sl/slack/package.nix
+++ b/pkgs/by-name/sl/slack/package.nix
@@ -30,6 +30,7 @@ let
       "aarch64-darwin"
     ];
     mainProgram = "slack";
+    mainDarwinApp = "Slack.app";
   };
 in
 callPackage (if stdenvNoCC.hostPlatform.isDarwin then ./darwin.nix else ./linux.nix) {

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -263,6 +263,7 @@ let
       # These keys are documented
       description = str;
       mainProgram = str;
+      mainDarwinApp = str;
       longDescription = str;
       branch = str;
       homepage = either str (listOf str);


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This is useful for nix-darwin system.defaults.dock.persistent-apps where you can pin application .app's to your dock. Without these functions, you have to explicitly write out the application's full path.

Plus, keeping track of this metadata (mainDarwinApp) may be handy for interesting use cases like a hook that verifies that application `.app`'s are the correct format/are openable for macos.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
