### PR TITLE
Clarify Security Support Status of Different Architectures

### DIFF
--- a/doc/using/platform-support.chapter.md
+++ b/doc/using/platform-support.chapter.md
@@ -1,16 +1,16 @@
 # Platform Support {#chap-platform-support}
 
-Packages receive varying degrees of support, both in terms of maintainer attention and available computation resources for continuous integration (CI). We have 7 defined tiers denoting how well supported each platform is.
+Packages receive varying degrees of support, both in terms of maintainer and security team attention and available computation resources for continuous integration (CI). We have 7 defined tiers denoting how well supported each platform is.
 
 ## Tiers {#sec-platform-tiers}
 
 ### Tier 1 {#sec-platform-tier1}
 
-[Tier 1](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-1) platforms receive the highest level of support where problems can block updates, platform-specific patches are freely applied, and most packages are expected to work.
+[Tier 1](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-1) platforms receive the highest level of support where problems can block updates, security fixes are treated with urgency, platform-specific patches are freely applied, and most packages are expected to work.
 
 ### Tier 2 {#sec-platform-tier2}
 
-[Tier 2](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-2) platforms are expected to remain functional with updates, receive platform-specific patches as needed, and have many packages built by Hydra with full ofBorg support.
+[Tier 2](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-2) platforms are expected to remain functional and secure with updates, receive platform-specific patches as needed, and have many packages built by Hydra with full ofBorg support.
 
 ### Tier 3 {#sec-platform-tier3}
 
@@ -22,25 +22,25 @@ Platform Tiers [4 through 7](https://github.com/NixOS/rfcs/blob/master/rfcs/0046
 
 ## Breakdown {#sec-platform-breakdown}
 
-| Triple                                | Support Tier | Channel Blockers | Hydra Support | Ofborg Support | Bootstrap Tarballs | Cross Compiling Support |
-| ------------------------------------- | ------------ | ---------------- | ------------- | -------------- | ------------------ | ----------------------- |
-| `x86_64-unknown-linux-gnu`            | [Tier 1](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-1) | Many | ✔️            | ✔️            | ✔️                 | ✔️                      |
-| `aarch64-unknown-linux-gnu`           | [Tier 2](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-2) | Some | ✔️            | ✔️            | ✔️                 | ✔️                      |
-| `x86_64-unknown-linux-musl`           | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None | Limited        | ❌             | ✔️                 | ✔️                      |
-| `aarch64-unknown-linux-musl`          | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None | Limited        | ❌             | ✔️                 | ✔️                      |
-| `x86_64-unknown-unknown-freebsd`      | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None | ❌             | ❌             | ✔️                 | ✔️                      |
-| `arm64-apple-darwin`                  | [Tier 2](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-2) | Some | ✔️            | ✔️            | ✔️                 | ❌                       |
-| `i686-unknown-linux-gnu`              | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None | Limited        | ❌             | ✔️                 | ✔️                      |
-| `riscv32-unknown-linux-gnu`           | [Tier 4](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-4) | None | ❌             | ❌             | ❌                  | ✔️                      |
-| `riscv64-unknown-linux-gnu`           | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None | ❌             | ❌             | ✔️                 | ✔️                      |
-| `loongarch64-unknown-linux-gnu`       | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None | ❌             | ❌             | ✔️                 | ✔️                      |
-| `armv6l-unknown-linux-gnueabihf`      | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None | ❌             | ❌             | ✔️                 | ✔️                      |
-| `armv6l-unknown-linux-musleabihf`     | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None | ❌             | ❌             | ✔️                 | ✔️                      |
-| `armv7l-unknown-linux-gnueabihf`      | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None | ❌             | ❌             | ✔️                 | ✔️                      |
-| `armv5tel-unknown-linux-gnueabi`      | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None | ❌             | ❌             | ✔️                 | ✔️                      |
-| `mips64el-unknown-linux-gnuabi64`     | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None | ❌             | ❌             | ✔️                 | ✔️                      |
-| `mips64el-unknown-linux-gnuabin32`    | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None | ❌             | ❌             | ✔️                 | ✔️                      |
-| `mipsel-unknown-linux-gnu`            | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None | ❌             | ❌             | ✔️                 | ✔️                      |
-| `powerpc64-unknown-linux-gnuabielfv2` | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None | ❌             | ❌             | ✔️                 | ✔️                      |
-| `powerpc64le-unknown-linux-gnu`       | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None | ❌             | ❌             | ✔️                 | ✔️                      |
-| `s390x-unknown-linux-gnu`             | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None | ❌             | ❌             | ✔️                 | ✔️                      |
+| Triple                                | Support Tier                                                                                   | Channel Blockers | Hydra Support | Security Support | Ofborg Support | Bootstrap Tarballs | Cross Compiling Support |
+|---------------------------------------|------------------------------------------------------------------------------------------------|------------------|---------------|------------------|----------------|--------------------|-------------------------|
+| `x86_64-unknown-linux-gnu`            | [Tier 1](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-1) | Many             | ✔️             | ✔️                | ✔️              | ✔️                  | ✔️                       |
+| `aarch64-unknown-linux-gnu`           | [Tier 2](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-2) | Some             | ✔️             | ✔️                | ✔️              | ✔️                  | ✔️                       |
+| `x86_64-unknown-linux-musl`           | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None             | Limited       | ❌               | ❌             | ✔️                  | ✔️                       |
+| `aarch64-unknown-linux-musl`          | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None             | Limited       | ❌               | ❌             | ✔️                  | ✔️                       |
+| `x86_64-unknown-unknown-freebsd`      | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None             | ❌            | ❌               | ❌             | ✔️                  | ✔️                       |
+| `arm64-apple-darwin`                  | [Tier 2](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-2) | Some             | ✔️             | ✔️                | ✔️              | ✔️                  | ❌                      |
+| `i686-unknown-linux-gnu`              | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None             | Limited       | ❌               | ❌             | ✔️                  | ✔️                       |
+| `riscv32-unknown-linux-gnu`           | [Tier 4](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-4) | None             | ❌            | ❌               | ❌             | ❌                 | ✔️                       |
+| `riscv64-unknown-linux-gnu`           | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None             | ❌            | ❌               | ❌             | ✔️                  | ✔️                       |
+| `loongarch64-unknown-linux-gnu`       | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None             | ❌            | ❌               | ❌             | ✔️                  | ✔️                       |
+| `armv6l-unknown-linux-gnueabihf`      | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None             | ❌            | ❌               | ❌             | ✔️                  | ✔️                       |
+| `armv6l-unknown-linux-musleabihf`     | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None             | ❌            | ❌               | ❌             | ✔️                  | ✔️                       |
+| `armv7l-unknown-linux-gnueabihf`      | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None             | ❌            | ❌               | ❌             | ✔️                  | ✔️                       |
+| `armv5tel-unknown-linux-gnueabi`      | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None             | ❌            | ❌               | ❌             | ✔️                  | ✔️                       |
+| `mips64el-unknown-linux-gnuabi64`     | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None             | ❌            | ❌               | ❌             | ✔️                  | ✔️                       |
+| `mips64el-unknown-linux-gnuabin32`    | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None             | ❌            | ❌               | ❌             | ✔️                  | ✔️                       |
+| `mipsel-unknown-linux-gnu`            | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None             | ❌            | ❌               | ❌             | ✔️                  | ✔️                       |
+| `powerpc64-unknown-linux-gnuabielfv2` | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None             | ❌            | ❌               | ❌             | ✔️                  | ✔️                       |
+| `powerpc64le-unknown-linux-gnu`       | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None             | ❌            | ❌               | ❌             | ✔️                  | ✔️                       |
+| `s390x-unknown-linux-gnu`             | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None             | ❌            | ❌               | ❌             | ✔️                  | ✔️                       |


### PR DESCRIPTION
This is currently the status quo as per discussion in the NixOS Security Discussions channel. Let's state it clearly to avoid people being surprised.

I'm happy to change the wording to whatever expresses our current policy best!


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
