### PR TITLE
openmotor: 0.6.1 -> 0.6.2

### DIFF
--- a/pkgs/by-name/op/openmotor/package.nix
+++ b/pkgs/by-name/op/openmotor/package.nix
@@ -13,14 +13,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "openmotor";
-  version = "0.6.1";
+  version = "0.6.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "reilleya";
     repo = "openMotor";
     tag = "v${version}";
-    hash = "sha256-5b/Q/qjd2EH+OG6pAZhPTnEnFy0e/reBH8sIH0DZORo=";
+    hash = "sha256-DPEC0nW2z7kuOAZE6ZWk1Ge+cx2V9XdwjWMDOcKPLdY=";
   };
 
   patches = [

--- a/pkgs/by-name/op/openmotor/package.nix
+++ b/pkgs/by-name/op/openmotor/package.nix
@@ -11,16 +11,20 @@
   nix-update-script,
 }:
 
+let
+  # openMotor does not use QtPdf, which pulls in QtWebEngine.
+  pyqt6 = python3Packages.pyqt6.override { withPdf = false; };
+in
 python3Packages.buildPythonApplication rec {
   pname = "openmotor";
-  version = "0.6.1";
+  version = "0.6.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "reilleya";
     repo = "openMotor";
     tag = "v${version}";
-    hash = "sha256-5b/Q/qjd2EH+OG6pAZhPTnEnFy0e/reBH8sIH0DZORo=";
+    hash = "sha256-DPEC0nW2z7kuOAZE6ZWk1Ge+cx2V9XdwjWMDOcKPLdY=";
   };
 
   patches = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: https://github.com/reilleya/openMotor/releases/tag/v0.6.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
