### PR TITLE
jrl-cmakemodules: run tests + add passthru helpers, cmake-parser: init at v0.9.2, jrl-cmakemodules-scripts: init at v2.1.0 

### DIFF
--- a/pkgs/by-name/al/aligator/package.nix
+++ b/pkgs/by-name/al/aligator/package.nix
@@ -6,14 +6,9 @@
   nix-update-script,
   stdenv,
 
-  # nativeBuildInputs
-  doxygen,
-  cmake,
-  graphviz,
-  pkg-config,
-
   # buildInputs
   fmt,
+  jrl-cmakemodules,
   mimalloc,
 
   # propagatedBuildInputs
@@ -57,15 +52,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  nativeBuildInputs = [
-    doxygen
-    cmake
-    graphviz
-    pkg-config
-  ];
+  nativeBuildInputs = jrl-cmakemodules.docsNativeBuildInputs;
 
   buildInputs = [
     fmt
+    jrl-cmakemodules
     mimalloc
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
@@ -82,7 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
     gbenchmark
   ];
 
-  cmakeFlags = [
+  cmakeFlags = jrl-cmakemodules.docsCmakeFlags ++ [
     (lib.cmakeBool "BUILD_PYTHON_INTERFACE" false)
     (lib.cmakeBool "BUILD_WITH_PINOCCHIO_SUPPORT" true)
     (lib.cmakeBool "BUILD_CROCODDYL_COMPAT" true)

--- a/pkgs/by-name/co/coal/package.nix
+++ b/pkgs/by-name/co/coal/package.nix
@@ -2,14 +2,11 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  cmake,
-  doxygen,
   boost,
   eigen,
   jrl-cmakemodules,
   assimp,
   octomap,
-  pkg-config,
   qhull,
   zlib,
 }:
@@ -27,15 +24,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  nativeBuildInputs = [
-    cmake
-    doxygen
-    pkg-config
+  nativeBuildInputs = jrl-cmakemodules.docsNativeBuildInputs;
+
+  buildInputs = [
+    jrl-cmakemodules
   ];
 
   propagatedBuildInputs = [
     assimp
-    jrl-cmakemodules
     octomap
     qhull
     zlib
@@ -43,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     eigen
   ];
 
-  cmakeFlags = [
+  cmakeFlags = jrl-cmakemodules.docsCmakeFlags ++ [
     (lib.cmakeBool "COAL_BACKWARD_COMPATIBILITY_WITH_HPP_FCL" true)
     (lib.cmakeBool "COAL_HAS_QHULL" true)
     (lib.cmakeBool "INSTALL_DOCUMENTATION" true)

--- a/pkgs/by-name/cr/crocoddyl/package.nix
+++ b/pkgs/by-name/cr/crocoddyl/package.nix
@@ -3,6 +3,7 @@
   example-robot-data,
   jrl-cmakemodules,
   fetchFromGitHub,
+  fontconfig,
   ffmpeg,
   ipopt,
   lapack,
@@ -70,6 +71,9 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   doCheck = true;
+
+  # Fontconfig error: Cannot load default config file: No such file: (null)
+  env.FONTCONFIG_FILE = "${fontconfig.out}/etc/fonts/fonts.conf";
 
   meta = {
     description = "Crocoddyl optimal control library";

--- a/pkgs/by-name/cr/crocoddyl/package.nix
+++ b/pkgs/by-name/cr/crocoddyl/package.nix
@@ -1,8 +1,7 @@
 {
   blas,
-  cmake,
-  doxygen,
   example-robot-data,
+  jrl-cmakemodules,
   fetchFromGitHub,
   ffmpeg,
   ipopt,
@@ -10,7 +9,6 @@
   llvmPackages,
   lib,
   pinocchio,
-  pkg-config,
   stdenv,
 
   withMultithread ? true,
@@ -34,11 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  nativeBuildInputs = [
-    cmake
-    doxygen
-    pkg-config
-  ];
+  nativeBuildInputs = jrl-cmakemodules.docsNativeBuildInputs;
 
   propagatedBuildInputs = [
     blas
@@ -48,7 +42,10 @@ stdenv.mkDerivation (finalAttrs: {
     pinocchio
   ];
 
-  buildInputs = lib.optionals (stdenv.hostPlatform.isDarwin && withMultithread) [
+  buildInputs = [
+    jrl-cmakemodules
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isDarwin && withMultithread) [
     llvmPackages.openmp
   ];
 
@@ -56,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
     ffmpeg
   ];
 
-  cmakeFlags = [
+  cmakeFlags = jrl-cmakemodules.docsCmakeFlags ++ [
     (lib.cmakeBool "INSTALL_DOCUMENTATION" true)
     (lib.cmakeBool "BUILD_EXAMPLES" false)
     (lib.cmakeBool "BUILD_PYTHON_INTERFACE" false)

--- a/pkgs/by-name/ei/eiquadprog/package.nix
+++ b/pkgs/by-name/ei/eiquadprog/package.nix
@@ -1,12 +1,9 @@
 {
   boost,
-  cmake,
-  doxygen,
   eigen,
   fetchFromGitHub,
   jrl-cmakemodules,
   lib,
-  pkg-config,
   stdenv,
 }:
 
@@ -26,12 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
     "doc"
   ];
 
-  nativeBuildInputs = [
-    cmake
-    doxygen
-    pkg-config
-    jrl-cmakemodules
-  ];
+  cmakeFlags = jrl-cmakemodules.docsCmakeFlags;
+
+  nativeBuildInputs = jrl-cmakemodules.docsNativeBuildInputs;
+  buildInputs = [ jrl-cmakemodules ];
   propagatedBuildInputs = [ eigen ];
   checkInputs = [ boost ];
 

--- a/pkgs/by-name/ex/example-robot-data/package.nix
+++ b/pkgs/by-name/ex/example-robot-data/package.nix
@@ -1,10 +1,7 @@
 {
-  cmake,
-  doxygen,
   fetchFromGitHub,
   lib,
   jrl-cmakemodules,
-  pkg-config,
   stdenv,
 }:
 
@@ -26,17 +23,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  nativeBuildInputs = [
-    cmake
-    doxygen
-    pkg-config
-  ];
+  nativeBuildInputs = jrl-cmakemodules.docsNativeBuildInputs;
 
-  propagatedBuildInputs = [
+  buildInputs = [
     jrl-cmakemodules
   ];
 
-  cmakeFlags = [ (lib.cmakeBool "BUILD_PYTHON_INTERFACE" false) ];
+  cmakeFlags = jrl-cmakemodules.docsCmakeFlags ++ [ (lib.cmakeBool "BUILD_PYTHON_INTERFACE" false) ];
 
   doCheck = true;
 

--- a/pkgs/by-name/jr/jrl-cmakemodules-scripts/package.nix
+++ b/pkgs/by-name/jr/jrl-cmakemodules-scripts/package.nix
@@ -1,0 +1,35 @@
+{
+  jrl-cmakemodules,
+  python3Packages,
+}:
+python3Packages.buildPythonApplication (finalAttrs: {
+  inherit (jrl-cmakemodules) version src;
+
+  pname = "jrl-cmakemodules-scripts";
+  pyproject = true;
+
+  sourceRoot = "${finalAttrs.src.name}/v2/scripts";
+
+  build-system = [ python3Packages.setuptools ];
+
+  dependencies = [
+    python3Packages.cmake-parser
+    python3Packages.packaging
+    python3Packages.rich
+    python3Packages.ruamel-yaml
+    python3Packages.tomlkit
+  ];
+
+  nativeCheckInputs = [
+    python3Packages.pytest-mock
+    python3Packages.pytestCheckHook
+  ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  meta = jrl-cmakemodules.meta // {
+    description = "Release scripting tools for JRL CMake modules";
+    mainProgram = "jrl-release";
+  };
+})

--- a/pkgs/by-name/jr/jrl-cmakemodules/package.nix
+++ b/pkgs/by-name/jr/jrl-cmakemodules/package.nix
@@ -4,6 +4,12 @@
   fetchFromGitHub,
   nix-update-script,
   cmake,
+
+  catch2_3,
+  matio,
+  python3Packages,
+  simde,
+  suitesparse,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -18,6 +24,24 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "JRL_CMAKEMODULES_GENERATE_API_DOC" true)
+    (lib.cmakeBool "JRL_CMAKEMODULES_BUILD_TESTS" finalAttrs.doCheck)
+  ];
+
+  doCheck = true;
+
+  checkInputs = [
+    catch2_3
+    matio
+    python3Packages.boost
+    python3Packages.nanobind
+    python3Packages.numpy
+    python3Packages.pytest
+    simde
+    suitesparse
+  ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/jr/jrl-cmakemodules/package.nix
+++ b/pkgs/by-name/jr/jrl-cmakemodules/package.nix
@@ -5,12 +5,30 @@
   nix-update-script,
   cmake,
 
+  # docs
+  doxygen,
+  graphviz,
+  ghostscript,
+  pdf2svg,
+  pkg-config,
+  texliveBasic,
+  writableTmpDirAsHomeHook,
+
+  # tests
   catch2_3,
   matio,
   python3Packages,
   simde,
   suitesparse,
 }:
+
+let
+  doxygenTexlive = texliveBasic.withPackages (ps: [
+    ps.newunicodechar
+    ps.stmaryrd
+    ps.xcolor
+  ]);
+in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "jrl-cmakemodules";
@@ -43,7 +61,25 @@ stdenv.mkDerivation (finalAttrs: {
     suitesparse
   ];
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+    docsNativeBuildInputs = [
+      cmake
+      doxygen
+      doxygenTexlive
+      graphviz
+      ghostscript
+      pdf2svg
+      pkg-config
+      writableTmpDirAsHomeHook
+    ];
+    docsCmakeFlags = [
+      (lib.cmakeFeature "DOXYGEN_FORMULA_FONTSIZE" "13")
+      (lib.cmakeFeature "DOXYGEN_HTML_FORMULA_FORMAT" "svg")
+      (lib.cmakeFeature "DOXYGEN_HTML_OUTPUT" "doxygen-html")
+      (lib.cmakeBool "DOXYGEN_USE_MATHJAX" false)
+    ];
+  };
 
   meta = {
     description = "CMake utility toolbox";

--- a/pkgs/by-name/mi/mim-solvers/package.nix
+++ b/pkgs/by-name/mi/mim-solvers/package.nix
@@ -1,12 +1,10 @@
 {
-  cmake,
   crocoddyl,
   ctestCheckHook,
   fetchFromGitHub,
-  fetchpatch,
+  jrl-cmakemodules,
   lib,
   llvmPackages,
-  pkg-config,
   proxsuite,
   stdenv,
   nix-update-script,
@@ -23,21 +21,19 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-t21zzUo+Oiqvr3lYN9v1lCeoki3I1FWPqo3gWzM6Kdw=";
   };
 
-  nativeBuildInputs = [
-    cmake
-    pkg-config
-  ];
+  nativeBuildInputs = jrl-cmakemodules.docsNativeBuildInputs;
 
-  buildInputs = lib.optional (
-    stdenv.hostPlatform.isDarwin && crocoddyl.withMultithread
-  ) llvmPackages.openmp;
+  buildInputs = [
+    jrl-cmakemodules
+  ]
+  ++ lib.optional (stdenv.hostPlatform.isDarwin && crocoddyl.withMultithread) llvmPackages.openmp;
 
   propagatedBuildInputs = [
     crocoddyl
     proxsuite
   ];
 
-  cmakeFlags = [
+  cmakeFlags = jrl-cmakemodules.docsCmakeFlags ++ [
     (lib.cmakeBool "BUILD_PYTHON_INTERFACE" false)
     (lib.cmakeBool "BUILD_WITH_PROXSUITE" true)
     (lib.cmakeBool "BUILD_WITH_MULTITHREADS" crocoddyl.withMultithread)

--- a/pkgs/by-name/nd/ndcurves/package.nix
+++ b/pkgs/by-name/nd/ndcurves/package.nix
@@ -29,34 +29,32 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  nativeBuildInputs = [
-    cmake
-    doxygen
-    pkg-config
-  ]
-  ++ lib.optionals pythonSupport [
-    python3Packages.python
-    python3Packages.pythonImportsCheckHook
-  ];
-  propagatedBuildInputs = [
-    jrl-cmakemodules
-  ]
-  ++ lib.optionals pythonSupport [
-    python3Packages.eigenpy
-    python3Packages.pinocchio
-  ]
-  ++ lib.optional (!pythonSupport) pinocchio;
+  buildInputs = [ jrl-cmakemodules ];
+  nativeBuildInputs =
+    jrl-cmakemodules.docsNativeBuildInputs
+    ++ lib.optionals pythonSupport [
+      python3Packages.python
+      python3Packages.pythonImportsCheckHook
+    ];
+  propagatedBuildInputs =
+    lib.optionals pythonSupport [
+      python3Packages.eigenpy
+      python3Packages.pinocchio
+    ]
+    ++ lib.optional (!pythonSupport) pinocchio;
 
-  cmakeFlags = [
-    (lib.cmakeBool "BUILD_PYTHON_INTERFACE" pythonSupport)
-    (lib.cmakeBool "CURVES_WITH_PINOCCHIO_SUPPORT" true)
-  ]
-  ++ lib.optional stdenv.hostPlatform.isAarch64 (
-    lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" "--exclude-regex;'curves_tests|python-curves'"
-  )
-  ++ lib.optional (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) (
-    lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" "--exclude-regex;'test-so3-smooth'"
-  );
+  cmakeFlags =
+    jrl-cmakemodules.docsCmakeFlags
+    ++ [
+      (lib.cmakeBool "BUILD_PYTHON_INTERFACE" pythonSupport)
+      (lib.cmakeBool "CURVES_WITH_PINOCCHIO_SUPPORT" true)
+    ]
+    ++ lib.optional stdenv.hostPlatform.isAarch64 (
+      lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" "--exclude-regex;'curves_tests|python-curves'"
+    )
+    ++ lib.optional (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) (
+      lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" "--exclude-regex;'test-so3-smooth'"
+    );
 
   doCheck = true;
 

--- a/pkgs/by-name/pi/pinocchio/package.nix
+++ b/pkgs/by-name/pi/pinocchio/package.nix
@@ -5,10 +5,8 @@
   nix-update-script,
   stdenv,
 
-  # nativeBuildInputs
-  cmake,
-  doxygen,
-  pkg-config,
+  # buildInputs
+  jrl-cmakemodules,
 
   # propagatedBuildInputs
   boost,
@@ -16,7 +14,6 @@
   coal,
   console-bridge,
   eigen,
-  jrl-cmakemodules,
   urdfdom,
 
   # nativeCheckInputs
@@ -52,10 +49,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  nativeBuildInputs = [
-    cmake
-    doxygen
-    pkg-config
+  nativeBuildInputs = jrl-cmakemodules.docsNativeBuildInputs;
+
+  buildInputs = [
+    jrl-cmakemodules
   ];
 
   propagatedBuildInputs = [
@@ -63,7 +60,6 @@ stdenv.mkDerivation (finalAttrs: {
     coal
     console-bridge
     eigen
-    jrl-cmakemodules
     urdfdom
   ]
   ++ lib.optionals collisionSupport [ coal ]
@@ -88,7 +84,7 @@ stdenv.mkDerivation (finalAttrs: {
       "test-cpp-algorithm-utils-force"
     ];
 
-  cmakeFlags = [
+  cmakeFlags = jrl-cmakemodules.docsCmakeFlags ++ [
     (lib.cmakeBool "BUILD_PYTHON_INTERFACE" false)
     (lib.cmakeBool "BUILD_WITH_CASADI_SUPPORT" casadiSupport)
     (lib.cmakeBool "BUILD_WITH_COLLISION_SUPPORT" collisionSupport)

--- a/pkgs/by-name/pr/proxsuite/package.nix
+++ b/pkgs/by-name/pr/proxsuite/package.nix
@@ -7,15 +7,12 @@
   pythonSupport ? false,
   python3Packages,
 
-  # nativeBuildInputs
-  cmake,
-  doxygen,
-  graphviz,
+  # buildInputs
+  jrl-cmakemodules,
 
   # propagatedBuildInputs
   cereal,
   eigen,
-  jrl-cmakemodules,
   simde,
 
   # nativeCheckInputs
@@ -46,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     "out"
   ];
 
-  cmakeFlags = [
+  cmakeFlags = jrl-cmakemodules.docsCmakeFlags ++ [
     (lib.cmakeBool "BUILD_DOCUMENTATION" true)
     (lib.cmakeBool "INSTALL_DOCUMENTATION" true)
     (lib.cmakeBool "BUILD_PYTHON_INTERFACE" pythonSupport)
@@ -54,20 +51,18 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  nativeBuildInputs = [
-    cmake
-    doxygen
-    graphviz
-  ]
-  ++ lib.optionals pythonSupport [
-    python3Packages.python
-    python3Packages.pythonImportsCheckHook
-  ];
+  nativeBuildInputs =
+    jrl-cmakemodules.docsNativeBuildInputs
+    ++ lib.optionals pythonSupport [
+      python3Packages.python
+      python3Packages.pythonImportsCheckHook
+    ];
+
+  buildInputs = [ jrl-cmakemodules ];
 
   propagatedBuildInputs = [
     cereal
     eigen
-    jrl-cmakemodules
     simde
   ]
   ++ lib.optionals pythonSupport [ python3Packages.nanobind ];

--- a/pkgs/by-name/ts/tsid/package.nix
+++ b/pkgs/by-name/ts/tsid/package.nix
@@ -1,11 +1,9 @@
 {
-  cmake,
-  doxygen,
   eiquadprog,
   fetchFromGitHub,
+  jrl-cmakemodules,
   lib,
   osqp-eigen,
-  pkg-config,
   pinocchio,
   proxsuite,
   stdenv,
@@ -22,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-f/SecQfEmrlelVR5584KIHFwwrp5Cy2aBMKI/rxuPmc=";
   };
 
-  cmakeFlags = [
+  cmakeFlags = jrl-cmakemodules.docsCmakeFlags ++ [
     (lib.cmakeBool "BUILD_PYTHON_INTERFACE" false)
     (lib.cmakeBool "BUILD_WITH_OSQP" true)
     (lib.cmakeBool "BUILD_WITH_PROXQP" true)
@@ -34,10 +32,10 @@ stdenv.mkDerivation (finalAttrs: {
     "doc"
   ];
 
-  nativeBuildInputs = [
-    doxygen
-    cmake
-    pkg-config
+  nativeBuildInputs = jrl-cmakemodules.docsNativeBuildInputs;
+
+  buildInputs = [
+    jrl-cmakemodules
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/cmake-parser/default.nix
+++ b/pkgs/development/python-modules/cmake-parser/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  setuptools-scm,
+  attrs,
+  nix-update-script,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "cmake-parser";
+  version = "0.9.2";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "roehling";
+    repo = "cmake_parser";
+    tag = finalAttrs.version;
+    hash = "sha256-4hJYlnDOuO+Rs1r9/scWK+BZAU9zSH5BTEvkiS3LUh8=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    attrs
+  ];
+
+  pythonImportsCheck = [
+    "cmake_parser"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Parse CMake files with Python";
+    homepage = "https://github.com/roehling/cmake_parser";
+    changelog = "https://github.com/roehling/cmake_parser/blob/${finalAttrs.src.rev}/CHANGELOG.rst";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nim65s ];
+  };
+})

--- a/pkgs/development/python-modules/eigenpy/default.nix
+++ b/pkgs/development/python-modules/eigenpy/default.nix
@@ -3,22 +3,17 @@
 
   buildPythonPackage,
   fetchFromGitHub,
-  writableTmpDirAsHomeHook,
   fontconfig,
 
   # nativeBuildInputs
-  cmake,
-  doxygen,
-  graphviz,
-  pkg-config,
   scipy,
 
   # buildInputs
   boost,
+  jrl-cmakemodules,
 
   # propagatedBuildInputs
   eigen,
-  jrl-cmakemodules,
   numpy,
 }:
 
@@ -40,7 +35,7 @@ buildPythonPackage rec {
     "out"
   ];
 
-  cmakeFlags = [
+  cmakeFlags = jrl-cmakemodules.docsCmakeFlags ++ [
     "-DINSTALL_DOCUMENTATION=ON"
     "-DBUILD_TESTING=ON"
     "-DBUILD_TESTING_SCIPY=ON"
@@ -51,20 +46,17 @@ buildPythonPackage rec {
   # Fontconfig error: Cannot load default config file: No such file: (null)
   env.FONTCONFIG_FILE = "${fontconfig.out}/etc/fonts/fonts.conf";
 
-  nativeBuildInputs = [
-    cmake
-    doxygen
-    graphviz
-    pkg-config
+  nativeBuildInputs = jrl-cmakemodules.docsNativeBuildInputs ++ [
     scipy
-    writableTmpDirAsHomeHook
   ];
 
-  buildInputs = [ boost ];
+  buildInputs = [
+    boost
+    jrl-cmakemodules
+  ];
 
   propagatedBuildInputs = [
     eigen
-    jrl-cmakemodules
     numpy
   ];
 

--- a/pkgs/development/python-modules/example-robot-data/default.nix
+++ b/pkgs/development/python-modules/example-robot-data/default.nix
@@ -27,7 +27,6 @@ toPythonModule (
     propagatedBuildInputs = [
       pinocchio
     ]
-    ++ super.propagatedBuildInputs
     ++ lib.optional buildStandalone example-robot-data;
 
     nativeCheckInputs = [

--- a/pkgs/development/python-modules/nanoeigenpy/default.nix
+++ b/pkgs/development/python-modules/nanoeigenpy/default.nix
@@ -6,8 +6,6 @@
   python,
 
   # nativeBuildInputs
-  cmake,
-  doxygen,
   nanobind,
 
   # propagatedBuildInputs
@@ -50,7 +48,7 @@ buildPythonPackage rec {
     "out"
   ];
 
-  cmakeFlags = [
+  cmakeFlags = jrl-cmakemodules.docsCmakeFlags ++ [
     (lib.cmakeBool "INSTALL_DOCUMENTATION" true)
     (lib.cmakeBool "BUILD_TESTING" true)
     (lib.cmakeBool "BUILD_WITH_CHOLMOD_SUPPORT" true)
@@ -62,16 +60,11 @@ buildPythonPackage rec {
 
   strictDeps = true;
 
-  nativeBuildInputs = [
-    cmake
-    doxygen
-    nanobind
-  ];
-
+  buildInputs = [ jrl-cmakemodules ];
+  nativeBuildInputs = jrl-cmakemodules.docsNativeBuildInputs ++ [ nanobind ];
   propagatedBuildInputs = [
     suitesparse
     eigen
-    jrl-cmakemodules
   ];
 
   dependencies = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5343,9 +5343,7 @@ self: super: with self; {
 
   eheimdigital = callPackage ../development/python-modules/eheimdigital { };
 
-  eigenpy = callPackage ../development/python-modules/eigenpy {
-    inherit (pkgs) graphviz; # need the `dot` program, not the python module
-  };
+  eigenpy = callPackage ../development/python-modules/eigenpy { };
 
   einops = callPackage ../development/python-modules/einops { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3289,6 +3289,8 @@ self: super: with self; {
 
   cmake-build-extension = callPackage ../development/python-modules/cmake-build-extension { };
 
+  cmake-parser = callPackage ../development/python-modules/cmake-parser { };
+
   cmarkgfm = callPackage ../development/python-modules/cmarkgfm { };
 
   cmd2 = callPackage ../development/python-modules/cmd2 { };


### PR DESCRIPTION
Hi,

This follow https://github.com/NixOS/nixpkgs/pull/538672
jrl-cmakemodules v2 include a python app to help with new package releases

While here, I'm also trying to improve the situation with the documentation, by helping packages depending on jrl-cmakemodules doxygen setup with common things to use in passthru. Here is an example of this deployed, with links between the documentations of the different projects: https://gepetto.github.io/doc/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
