### PR TITLE
mcpelauncher-{client,ui-qt}: 1.6.4-qt6 -> 1.7.6-qt6

### DIFF
--- a/pkgs/by-name/mc/mcpelauncher-client/dont_download_glfw_client.patch
+++ b/pkgs/by-name/mc/mcpelauncher-client/dont_download_glfw_client.patch
@@ -12,7 +12,7 @@ index 5487f32..feeb89f 100644
 -
 -FetchContent_Declare(
 -        glfw3_ext
--        URL "https://github.com/minecraft-linux/glfw/archive/fce9121962bc0a21c39e2d6f8e08bad30c566c72.zip"
+-        URL "https://github.com/minecraft-linux/glfw/archive/446707b4d9558cd2ef3024622bad320728b974c2.zip"
 -)
 -
 -FetchContent_GetProperties(glfw3_ext)

--- a/pkgs/by-name/mc/mcpelauncher-client/package.nix
+++ b/pkgs/by-name/mc/mcpelauncher-client/package.nix
@@ -25,10 +25,14 @@
   sdl3,
 }:
 
+let
+  # Xbox Live multiplayer requires libcurl WebSocket support.
+  curlWithWebsockets = curl.override { websocketSupport = true; };
+in
 # Bionic libc part doesn't compile with GCC
 clangStdenv.mkDerivation (finalAttrs: {
   pname = "mcpelauncher-client";
-  version = "1.6.4-qt6";
+  version = "1.7.6-qt6";
 
   # NOTE: check mcpelauncher-ui-qt when updating
   src = fetchFromGitHub {
@@ -36,7 +40,7 @@ clangStdenv.mkDerivation (finalAttrs: {
     repo = "mcpelauncher-manifest";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-L9QWA50T4bhpFmKodGpu2Y5Vea5HckeKs0OkH3O7lTY=";
+    hash = "sha256-KAHAr1cAkG6B15CTwxRWZWT9IdTcvCSal3jrPe8C4wE=";
   };
 
   patches = [
@@ -74,7 +78,7 @@ clangStdenv.mkDerivation (finalAttrs: {
     libxi
     libxtst
     libevdev
-    curl
+    curlWithWebsockets
     pulseaudio
     glfw
     sdl3

--- a/pkgs/by-name/mc/mcpelauncher-ui-qt/package.nix
+++ b/pkgs/by-name/mc/mcpelauncher-ui-qt/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
     repo = "mcpelauncher-ui-manifest";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-9NeUiiQ595lE6M/tD5G20l5W9PoInSPM2DgRqK92Bsk=";
+    hash = "sha256-Oibi7+LJK7K1a1fFN2SKy4XiA0gSC4u7Wmk0t86SHaw=";
   };
 
   patches = [


### PR DESCRIPTION
Updates `mcpelauncher-client` and `mcpelauncher-ui-qt` to upstream `v1.7.6-qt6` and enables libcurl WebSocket support required by Xbox Live multiplayer.

Client release: https://github.com/minecraft-linux/mcpelauncher-manifest/releases/tag/v1.7.6-qt6
UI release: https://github.com/minecraft-linux/mcpelauncher-ui-manifest/releases/tag/v1.7.6-qt6
Closes #539423

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

