### PR TITLE
[Backport release-26.05] immich: 2.7.5 -> 3.0.1

### DIFF
--- a/nixos/tests/web-apps/immich.nix
+++ b/nixos/tests/web-apps/immich.nix
@@ -8,7 +8,7 @@
       # These tests need a little more juice
       virtualisation = {
         cores = 2;
-        memorySize = 2048;
+        memorySize = 4096;
         diskSize = 4096;
       };
 

--- a/pkgs/by-name/im/immich-cli/package.nix
+++ b/pkgs/by-name/im/immich-cli/package.nix
@@ -12,12 +12,6 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "immich-cli";
   inherit (immich) version src pnpmDeps;
 
-  postPatch = ''
-    local -r cli_version="$(jq -r .version cli/package.json)"
-    test "$cli_version" = ${finalAttrs.version} \
-      || (echo "error: update immich-cli version to $cli_version" && exit 1)
-  '';
-
   nativeBuildInputs = [
     jq
     makeWrapper
@@ -29,8 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildPhase = ''
     runHook preBuild
 
-    pnpm --filter @immich/sdk build
-    pnpm --filter @immich/cli build
+    pnpm --filter @immich/cli... build
 
     runHook postBuild
   '';

--- a/pkgs/by-name/im/immich/package.nix
+++ b/pkgs/by-name/im/immich/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   fetchPnpmDeps,
   pnpmConfigHook,
-  pnpm_10,
+  pnpm_11,
   python3,
   nodejs,
   node-gyp,
@@ -37,7 +37,7 @@
   buildPackages,
 }:
 let
-  pnpm = pnpm_10;
+  pnpm = pnpm_11;
 
   esbuild' = buildPackages.esbuild.override {
     buildGoModule =
@@ -45,12 +45,12 @@ let
       buildPackages.buildGoModule (
         args
         // rec {
-          version = "0.25.5";
+          version = "0.28.1";
           src = fetchFromGitHub {
             owner = "evanw";
             repo = "esbuild";
             tag = "v${version}";
-            hash = "sha256-jemGZkWmN1x2+ZzJ5cLp3MoXO0oDKjtZTmZS9Be/TDw=";
+            hash = "sha256-V+HKaWGAIs24ynFFIS9fQ0EAJJdNmlAMeL1sgDEAqWM=";
           };
           vendorHash = "sha256-+BfxCyg0KkDQpHt/wycy/8CTG6YBA/VJvJFhhzUnSiQ=";
         }
@@ -115,20 +115,20 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "immich";
-  version = "2.7.5";
+  version = "3.0.1";
 
   src = fetchFromGitHub {
     owner = "immich-app";
     repo = "immich";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-EC1IXM7KObAWfwG5KEao5VDp79d8WGNEI7E89lLOJ44=";
+    hash = "sha256-Z18SEjUdFP2/grQtHFI6J7CVcAMalshPt3Sd4tGXsDw=";
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     inherit pnpm;
-    fetcherVersion = 3;
-    hash = "sha256-FEesjbhxP7ydFfNshF3iFIk9N3Z53jrEZ9DRBjgEfs0=";
+    fetcherVersion = 4;
+    hash = "sha256-kCMFAPWcv2/qqVUoR5pbRxmkGg3mLPrpm8ce7R+9VYM=";
   };
 
   postPatch = ''
@@ -174,7 +174,7 @@ stdenv.mkDerivation (finalAttrs: {
     # If exiftool-vendored.pl isn't found, exiftool is searched for on the PATH
     rm node_modules/.pnpm/node_modules/exiftool-vendored.pl
 
-    pnpm --filter immich build
+    pnpm --filter immich... build
 
     runHook postBuild
   '';
@@ -196,8 +196,8 @@ stdenv.mkDerivation (finalAttrs: {
       -o -name '*.target.mk' \
     \) -exec rm -r {} +
 
-    mkdir -p "$packageOut/build"
-    ln -s '${finalAttrs.passthru.plugins}' "$packageOut/build/corePlugin"
+    mkdir -p "$packageOut/build/plugins"
+    ln -s '${finalAttrs.passthru.plugin-core}' "$packageOut/build/plugins/immich-plugin-core"
     ln -s '${finalAttrs.passthru.web}' "$packageOut/build/www"
     ln -s '${geodata}' "$packageOut/build/geodata"
 
@@ -231,8 +231,8 @@ stdenv.mkDerivation (finalAttrs: {
       immich = finalAttrs.finalPackage;
     };
 
-    plugins = stdenv.mkDerivation {
-      pname = "immich-plugins";
+    plugin-core = stdenv.mkDerivation {
+      pname = "immich-plugin-core";
       inherit (finalAttrs) version src pnpmDeps;
 
       nativeBuildInputs = [
@@ -246,7 +246,7 @@ stdenv.mkDerivation (finalAttrs: {
       buildPhase = ''
         runHook preBuild
 
-        pnpm --filter plugins build
+        pnpm --filter @immich/plugin-core... build
 
         runHook postBuild
       '';
@@ -254,7 +254,7 @@ stdenv.mkDerivation (finalAttrs: {
       installPhase = ''
         runHook preInstall
 
-        cd plugins
+        cd packages/plugin-core
         mkdir $out
         cp -r dist manifest.json $out
 
@@ -275,8 +275,7 @@ stdenv.mkDerivation (finalAttrs: {
       buildPhase = ''
         runHook preBuild
 
-        pnpm --filter @immich/sdk build
-        pnpm --filter immich-web build
+        pnpm --filter immich-web... build
 
         runHook postBuild
       '';


### PR DESCRIPTION
Manual backport of #538371 to `release-26.05`.

Cherry-picked `f76955e3860838cf1eb99e556b561e454e84efff` (`-x`). The only change to `immich-machine-learning` in the original PR — removing the `fix_tests_with_openvino_ep` patch — is a no-op here since `release-26.05` never carried that patch, so the resulting tree matches master's post-merge state for `immich`, `immich-cli`, and the NixOS test.

release notes:
- https://github.com/immich-app/immich/releases/tag/v3.0.0
- https://github.com/immich-app/immich/releases/tag/v3.0.1

### Verification

- `immich`, `immich-cli`, `immich-machine-learning` all evaluate to `3.0.1` and instantiate for `x86_64-linux`.
