### PR TITLE
maintainers: rename Holiu0618 -> Holiu618

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11156,9 +11156,9 @@
     github = "HolgerPeters";
     githubId = 4097049;
   };
-  Holiu0618 = {
+  Holiu618 = {
     email = "zvttt9db@anonaddy.me";
-    github = "Holiu0618";
+    github = "Holiu618";
     githubId = 165534185;
     name = "Holiu";
   };

--- a/pkgs/by-name/no/notepad-next/package.nix
+++ b/pkgs/by-name/no/notepad-next/package.nix
@@ -114,7 +114,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Cross-platform, reimplementation of Notepad++";
     license = licenses.gpl3Plus;
     platforms = platforms.unix;
-    maintainers = with lib.maintainers; [ Holiu0618 ];
+    maintainers = with lib.maintainers; [ Holiu618 ];
     broken = stdenv.hostPlatform.isAarch64;
     mainProgram = "NotepadNext";
   };


### PR DESCRIPTION
This PR corrects a typo in my maintainer username within `maintainer-list.nix`, changing it from `Holiu0618` to `Holiu618` to accurately match my actual GitHub account.

To prevent any evaluation errors across the repository, the affected package (`notepad-next`) has also been updated in the same commit.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test