### PR TITLE
minion: fix JavaFX NoClassDefFoundError on launch

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26239,6 +26239,12 @@
     keys = [ { fingerprint = "94AD E7C4 73B5 3DC7 7615  D946 3E76 7D8C 58D4 8C78"; } ];
     name = "Miran Tuten";
   };
+  shr3yas-k = {
+    name = "Shreyas Kamalapuram";
+    email = "shreyas.2007.oct@gmail.com";
+    github = "shr3yas-k";
+    githubId = 71091209;
+  };
   shunueda = {
     name = "Shun Ueda";
     github = "shunueda";

--- a/pkgs/by-name/mi/minion/package.nix
+++ b/pkgs/by-name/mi/minion/package.nix
@@ -16,17 +16,17 @@ let
     inherit openjfx_jdk;
   };
 
-  jvmArgs = [
-    "-cp $out/share/minion/lib"
-    "--add-exports=javafx.graphics/com.sun.javafx.css=ALL-UNNAMED"
-    "--add-exports=javafx.graphics/javafx.scene.image=ALL-UNNAMED"
-    "--add-opens=javafx.graphics/javafx.scene.image=ALL-UNNAMED"
-    "--add-opens=java.base/java.lang=ALL-UNNAMED"
-  ];
+  launcherSrc = builtins.toFile "Launcher.java" ''
+    public class Launcher {
+        public static void main(String[] args) {
+            gg.minion.Minion.main(args);
+        }
+    }
+  '';
 in
 stdenvNoCC.mkDerivation rec {
-  version = "3.0.12";
   pname = "minion";
+  version = "3.0.12";
 
   src = fetchzip {
     url = "https://cdn.mmoui.com/minion/v3/Minion${version}-java.zip";
@@ -41,15 +41,39 @@ stdenvNoCC.mkDerivation rec {
 
   dontWrapGApps = true;
 
+  buildPhase = ''
+    runHook preBuild
+
+    cp ${launcherSrc} Launcher.java
+
+    JFX_MODULES="${openjfx_jdk}/modules/javafx.base:${openjfx_jdk}/modules/javafx.controls:${openjfx_jdk}/modules/javafx.graphics:${openjfx_jdk}/modules/javafx.fxml:${openjfx_jdk}/modules/javafx.web:${openjfx_jdk}/modules/javafx.media:${openjfx_jdk}/modules/javafx.swing"
+
+    ${openjdk}/bin/javac -cp "Minion-jfx.jar:lib/*:$JFX_MODULES" Launcher.java -d .
+
+    runHook postBuild
+  '';
+
   installPhase = ''
     runHook preInstall
 
+    mkdir -p "$out/share/minion"
+
+    install -D Launcher.class "$out/share/minion/Launcher.class"
     install -D Minion-jfx.jar "$out/share/minion/Minion-jfx.jar"
     cp -r ./lib "$out/share/minion/"
 
+    JFX_MODULES="${openjfx_jdk}/modules/javafx.base:${openjfx_jdk}/modules/javafx.controls:${openjfx_jdk}/modules/javafx.graphics:${openjfx_jdk}/modules/javafx.fxml:${openjfx_jdk}/modules/javafx.web:${openjfx_jdk}/modules/javafx.media:${openjfx_jdk}/modules/javafx.swing"
+    JFX_NATIVE="${openjfx_jdk}/modules_libs/javafx.graphics:${openjfx_jdk}/modules_libs/javafx.web:${openjfx_jdk}/modules_libs/javafx.media"
+
     makeWrapper ${lib.getExe openjdk} $out/bin/minion \
       "''${gappsWrapperArgs[@]}" \
-      --add-flags "${lib.concatStringsSep " " jvmArgs} -jar $out/share/minion/Minion-jfx.jar"
+      --add-flags "-Djava.library.path=$JFX_NATIVE" \
+      --add-flags "-cp $out/share/minion:$out/share/minion/Minion-jfx.jar:$out/share/minion/lib/*:$JFX_MODULES" \
+      --add-flags "--add-opens=java.base/java.lang=ALL-UNNAMED" \
+      --add-flags "--add-exports=javafx.graphics/com.sun.javafx.css=ALL-UNNAMED" \
+      --add-flags "--add-exports=javafx.graphics/javafx.scene.image=ALL-UNNAMED" \
+      --add-flags "--add-opens=javafx.graphics/javafx.scene.image=ALL-UNNAMED" \
+      --add-flags "Launcher"
 
     runHook postInstall
   '';

--- a/pkgs/by-name/mi/minion/package.nix
+++ b/pkgs/by-name/mi/minion/package.nix
@@ -16,6 +16,10 @@ let
     inherit openjfx_jdk;
   };
 
+  # Wrapper class to bypass "JavaFX runtime components are missing" error
+  # which occurs when the main entrypoint class directly extends Application.
+  # This fix was mentioned in https://www.reddit.com/r/JavaFX/comments/k7aa9q/javafx_error_error_javafx_runtime_components_are
+
   launcherSrc = builtins.toFile "Launcher.java" ''
     public class Launcher {
         public static void main(String[] args) {
@@ -62,6 +66,14 @@ stdenvNoCC.mkDerivation rec {
     install -D Minion-jfx.jar "$out/share/minion/Minion-jfx.jar"
     cp -r ./lib "$out/share/minion/"
 
+    runHook postInstall
+  '';
+
+  # gappsWrapperArgs is populated during fixupPhase, so makeWrapper must run in preFixup.
+  # Reference: https://ryantm.github.io/nixpkgs/languages-frameworks/gnome/
+  # JFX_NATIVE prevents "Graphics Device initialization failed" errors.
+
+  preFixup = ''
     JFX_MODULES="${openjfx_jdk}/modules/javafx.base:${openjfx_jdk}/modules/javafx.controls:${openjfx_jdk}/modules/javafx.graphics:${openjfx_jdk}/modules/javafx.fxml:${openjfx_jdk}/modules/javafx.web:${openjfx_jdk}/modules/javafx.media:${openjfx_jdk}/modules/javafx.swing"
     JFX_NATIVE="${openjfx_jdk}/modules_libs/javafx.graphics:${openjfx_jdk}/modules_libs/javafx.web:${openjfx_jdk}/modules_libs/javafx.media"
 
@@ -74,8 +86,6 @@ stdenvNoCC.mkDerivation rec {
       --add-flags "--add-exports=javafx.graphics/javafx.scene.image=ALL-UNNAMED" \
       --add-flags "--add-opens=javafx.graphics/javafx.scene.image=ALL-UNNAMED" \
       --add-flags "Launcher"
-
-    runHook postInstall
   '';
 
   desktopItems = [


### PR DESCRIPTION
### Summary

Resolves `minion` crashing with:
```
Error: Could not find or load main class gg.minion.Minion. 
Caused by: java.lang.NoClassDefFoundError: javafx/application/Application
```

Closes #538978

#### Changes made:
- Added a `Launcher.java` wrapper class to bypass the JavaFX entrypoint restriction for classes extending `javafx.application.Application`, which throws `JavaFX runtime components are missing` when executed directly. ([reference](https://www.reddit.com/r/JavaFX/comments/k7aa9q/javafx_error_error_javafx_runtime_components_are/)).
- Incorporated fixes discussed in #537798.
- Passed JavaFX modules via `-cp` instead of `--module-path`.
- Moved `makeWrapper` into `preFixup` so `wrapGAppsHook3` populates `gappsWrapperArgs` before wrapper generation, fixing `"GLib-GIO-ERROR: No GSettings schemas are installed on the system"` ([reference](https://ryantm.github.io/nixpkgs/languages-frameworks/gnome/)). 
- Added native JavaFX libraries to `java.library.path` to fix `Graphics Device initialization failed` errors.

---

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test