### PR TITLE
diun: fix env.CGO_ENABLED set to "" instead of 0

### DIFF
--- a/pkgs/by-name/di/diun/package.nix
+++ b/pkgs/by-name/di/diun/package.nix
@@ -19,7 +19,7 @@ buildGoModule (finalAttrs: {
 
   # upstream disable CGO in release build
   # https://github.com/crazy-max/diun/blob/76c0fe99212adc58d6a3433bbcde1ffa9fb879c4/Dockerfile#L11
-  env.CGO_ENABLED = false;
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s"


### PR DESCRIPTION
`env.CGO_ENABLED` should be either `1` or `0`, not a `boolean`.
See https://pkg.go.dev/cmd/cgo and look for `CGO_ENABLED`.

If set to `false`, it is then rendered as an empty string, which can be verified by running

```console
$ nix derivation show nixpkgs#diun | jq '.derivations[].env | {CGO_ENABLED}'
{
  "CGO_ENABLED": ""
}
```

Also, the executable is, in fact, a dynamic one:

```console
$ nix shell nixpkgs#diun
$ ldd $(which diun)
	linux-vdso.so.1 (0x000076b5e6e4e000)
	libresolv.so.2 => /nix/store/8kvxvr3pmsypxiypq4g8zy13glnfr7nx-glibc-2.42-67/lib/libresolv.so.2 (0x000076b5e6e33000)
	libpthread.so.0 => /nix/store/8kvxvr3pmsypxiypq4g8zy13glnfr7nx-glibc-2.42-67/lib/libpthread.so.0 (0x000076b5e6e2e000)
	libc.so.6 => /nix/store/8kvxvr3pmsypxiypq4g8zy13glnfr7nx-glibc-2.42-67/lib/libc.so.6 (0x000076b5e6c00000)
	/nix/store/8kvxvr3pmsypxiypq4g8zy13glnfr7nx-glibc-2.42-67/lib/ld-linux-x86-64.so.2 => /nix/store/8kvxvr3pmsypxiypq4g8zy13glnfr7nx-glibc-2.42-67/lib64/ld-linux-x86-64.so.2 (0x000076b5e6e50000)
```

After setting it to `0`,

```console
$ nix derivation show .#diun | jq '.derivations[].env | {CGO_ENABLED}'
{
  "CGO_ENABLED": "0"
}
```

and the executable:

```console
$ ldd $(which diun)
	not a dynamic executable
```

which is the intended effect.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
