### PR TITLE
spideroak: 7.5.0 -> 7.5.2

### DIFF
--- a/pkgs/by-name/sp/spideroak/package.nix
+++ b/pkgs/by-name/sp/spideroak/package.nix
@@ -16,7 +16,7 @@
 }:
 
 let
-  sha256 = "6d6ca2b383bcc81af1217c696eb77864a2b6db7428f4b5bde5b5913ce705eec5";
+  hash = "sha256-L9AF5gOmvbN+Ur1k0oIjJJT15RZvWA7mhDgveVowu7E=";
 
   ldpath = lib.makeLibraryPath [
     fontconfig
@@ -30,7 +30,7 @@ let
     zlib
   ];
 
-  version = "7.5.0";
+  version = "7.5.2";
 
 in
 stdenv.mkDerivation {
@@ -38,9 +38,9 @@ stdenv.mkDerivation {
   inherit version;
 
   src = fetchurl {
-    name = "SpiderOakONE-${version}-slack_tar_x64.tgz";
-    url = "https://spideroak-releases.s3.us-east-2.amazonaws.com/SpiderOakONE-${version}-slack_tar_x64.tgz";
-    inherit sha256;
+    name = "SpiderOakONE-${version}-x86_64-1.tgz";
+    url = "https://spideroak-releases.s3.us-east-2.amazonaws.com/SpiderOakONE-${version}-x86_64-1.tgz";
+    inherit hash;
   };
 
   sourceRoot = ".";
@@ -48,6 +48,8 @@ stdenv.mkDerivation {
   unpackCmd = "tar -xzf $curSrc";
 
   installPhase = ''
+    runHook preInstall
+
     mkdir "$out"
     cp -r "./"* "$out"
     mkdir "$out/bin"
@@ -66,6 +68,8 @@ stdenv.mkDerivation {
       --set SpiderOak_EXEC_SCRIPT $out/bin/spideroak
 
     sed -i 's/^Exec=.*/Exec=spideroak/' $out/share/applications/SpiderOakONE.desktop
+
+    runHook postInstall
   '';
 
   nativeBuildInputs = [
@@ -80,5 +84,6 @@ stdenv.mkDerivation {
     license = lib.licenses.unfree;
     platforms = lib.platforms.linux;
     mainProgram = "spideroak";
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
https://spideroak.support/hc/en-us/articles/36091792308763-One-Backup-7-5-2-Release-Notes-2025-04-16

Closes #486024

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. Launches to login screen
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
