### PR TITLE
Handle the other optional attributes

### DIFF
--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -34,6 +34,7 @@ let
   osReleaseContents =
     let
       isNixos = cfg.distroId == "nixos";
+      optionalAttr = cond: attr: if cond then attr else null;
     in
     {
       NAME = "${cfg.distroName}";
@@ -54,8 +55,7 @@ let
       BUG_REPORT_URL = optionalString isNixos "https://github.com/NixOS/nixpkgs/issues";
       ANSI_COLOR = optionalString isNixos "0;38;2;126;186;228";
       IMAGE_ID = optionalString (config.system.image.id != null) config.system.image.id;
-      ${if config.system.image.version != null then "IMAGE_VERSION" else null} =
-        config.system.image.version;
+      ${optionalAttr (config.system.image.version != null) "IMAGE_VERSION"} = config.system.image.version;
       VARIANT = optionalString (cfg.variantName != null) cfg.variantName;
       VARIANT_ID = optionalString (cfg.variant_id != null) cfg.variant_id;
       DEFAULT_HOSTNAME = config.system.nixos.distroId;

--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -14,7 +14,6 @@ let
     concatStringsSep
     mapAttrsToList
     toLower
-    optionalString
     literalExpression
     match
     mkRenamedOptionModule
@@ -39,7 +38,7 @@ let
     {
       NAME = "${cfg.distroName}";
       ID = "${cfg.distroId}";
-      ID_LIKE = optionalString (!isNixos) "nixos";
+      ${optionalAttr (!isNixos) "ID_LIKE"} = "nixos";
       VENDOR_NAME = cfg.vendorName;
       VERSION = "${cfg.release} (${cfg.codeName})";
       VERSION_CODENAME = toLower cfg.codeName;
@@ -48,16 +47,16 @@ let
       PRETTY_NAME = "${cfg.distroName} ${cfg.release} (${cfg.codeName})";
       CPE_NAME = "cpe:/o:${cfg.vendorId}:${cfg.distroId}:${cfg.release}";
       LOGO = "nix-snowflake";
-      HOME_URL = optionalString isNixos "https://nixos.org/";
-      VENDOR_URL = optionalString isNixos "https://nixos.org/";
-      DOCUMENTATION_URL = optionalString isNixos "https://nixos.org/learn.html";
-      SUPPORT_URL = optionalString isNixos "https://nixos.org/community.html";
-      BUG_REPORT_URL = optionalString isNixos "https://github.com/NixOS/nixpkgs/issues";
-      ANSI_COLOR = optionalString isNixos "0;38;2;126;186;228";
-      IMAGE_ID = optionalString (config.system.image.id != null) config.system.image.id;
+      ${optionalAttr isNixos "HOME_URL"} = "https://nixos.org/";
+      ${optionalAttr isNixos "VENDOR_URL"} = "https://nixos.org/";
+      ${optionalAttr isNixos "DOCUMENTATION_URL"} = "https://nixos.org/learn.html";
+      ${optionalAttr isNixos "SUPPORT_URL"} = "https://nixos.org/community.html";
+      ${optionalAttr isNixos "BUG_REPORT_URL"} = "https://github.com/NixOS/nixpkgs/issues";
+      ${optionalAttr isNixos "ANSI_COLOR"} = "0;38;2;126;186;228";
+      ${optionalAttr (config.system.image.id != null) "IMAGE_ID"} = config.system.image.id;
       ${optionalAttr (config.system.image.version != null) "IMAGE_VERSION"} = config.system.image.version;
-      VARIANT = optionalString (cfg.variantName != null) cfg.variantName;
-      VARIANT_ID = optionalString (cfg.variant_id != null) cfg.variant_id;
+      ${optionalAttr (cfg.variantName != null) "VARIANT"} = cfg.variantName;
+      ${optionalAttr (cfg.variant_id != null) "VARIANT_ID"} = cfg.variant_id;
       DEFAULT_HOSTNAME = config.system.nixos.distroId;
     }
     // cfg.extraOSReleaseArgs;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test