### PR TITLE
nixos/locate: remove bash wrapper from systemd

### DIFF
--- a/nixos/modules/misc/locate.nix
+++ b/nixos/modules/misc/locate.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  utils,
   pkgs,
   ...
 }:
@@ -59,7 +60,7 @@ in
     };
 
     output = lib.mkOption {
-      type = lib.types.path;
+      type = lib.types.externalPath;
       default = "/var/cache/locatedb";
       description = ''
         The database file to build.
@@ -249,27 +250,35 @@ in
     systemd.services.update-locatedb = {
       description = "Update Locate Database";
 
-      # mlocate's updatedb takes flags via a configuration file or
-      # on the command line, but not by environment variable.
-      script =
-        let
-          toFlags =
-            x: lib.optional (cfg.${x} != [ ]) "--${lib.toLower x} '${lib.concatStringsSep " " cfg.${x}}'";
-          args = lib.concatLists (
-            map toFlags [
+      serviceConfig = {
+        # mlocate's updatedb takes flags via a configuration file or
+        # on the command line, but not by environment variable.
+        ExecStart =
+          let
+            toFlags =
+              x:
+              lib.optionals (cfg.${x} != [ ]) [
+                "--${lib.toLower x}"
+                (lib.concatStringsSep " " cfg.${x})
+              ];
+            args = lib.concatMap toFlags [
               "pruneFS"
               "pruneNames"
               "prunePaths"
+            ];
+          in
+          utils.escapeSystemdExecArgs (
+            [
+              (lib.getExe' cfg.package "updatedb")
+              "--output"
+              cfg.output
+              "--prune-bind-mounts"
+              (lib.boolToYesNo cfg.pruneBindMounts)
             ]
+            ++ args
+            ++ cfg.extraFlags
           );
-        in
-        ''
-          exec ${cfg.package}/bin/updatedb \
-            --output ${toString cfg.output} ${lib.concatStringsSep " " args} \
-            --prune-bind-mounts ${lib.boolToYesNo cfg.pruneBindMounts} \
-            ${lib.concatStringsSep " " cfg.extraFlags}
-        '';
-      serviceConfig = {
+
         CapabilityBoundingSet = "CAP_DAC_READ_SEARCH CAP_CHOWN";
         Nice = 19;
         IOSchedulingClass = "idle";


### PR DESCRIPTION
There's a few reasons this is useful:

- it makes it easier to override the unit temporarily with, say,
  `systemctl edit --runtime update-locatedb.service` because you can see
  the actual command that's in use -- this was my initial motivation
- it removes an unnecessary layer of indirection when systemd executes
  the updatedb command
- it permits using locate with a bashless image
- not strictly necessary -- we could have done this with the bash script
  as well -- but the change is a chance to make sure every argument is
  properly escaped

In passing, update the type for the `services.locate.output` to
`externalPath`.  This prevents specifying a path in the Nix store to
house the locate database, since updatedb is never going to be able to
rewrite the database when running as a systemd unit.  We could revert
this if we somehow find a way and a use case for having the database
created while building a NixOS image, but that seems unlikely to me.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux *specifically, built `config.system.build.etc` with the tip of this branch as nixpkgs for one of my systems, and verified the unit looks as I expected*
  - ~[ ] aarch64-darwin~ *not applicable*
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests] *specifically, `nixosTests.locate`*
  - ~[ ] [Package tests] at `passthru.tests`~ *not applicable*
  - ~[ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality~ *not applicable*
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- ~[ ] Tested basic functionality of all binary files, usually in `./result/bin/`~ *not applicable*
- Nixpkgs Release Notes
  - ~[ ] Package update: when the change is major or breaking~ *not applicable*
- NixOS Release Notes
  - ~[ ] Module addition: when adding a new NixOS module~ *not applicable*
  - ~[ ] Module update: when the change is significant~ *not applicable*
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs
- [x] Follows the [automation/AI policy]

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
