### PR TITLE
go-mockery: fix env.CGO_ENABLED set to ""

### DIFF
--- a/pkgs/by-name/go/go-mockery/package.nix
+++ b/pkgs/by-name/go/go-mockery/package.nix
@@ -28,7 +28,7 @@ buildGoModule (finalAttrs: {
     "-X github.com/vektra/mockery/v${lib.versions.major finalAttrs.version}/internal/logging.SemVer=v${finalAttrs.version}"
   ];
 
-  env.CGO_ENABLED = false;
+  env.CGO_ENABLED = 0;
 
   subPackages = [ "." ];
 

--- a/pkgs/by-name/go/go-mockery_2/package.nix
+++ b/pkgs/by-name/go/go-mockery_2/package.nix
@@ -30,7 +30,7 @@ buildGoModule (finalAttrs: {
     "-X github.com/vektra/mockery/v${lib.versions.major finalAttrs.version}/pkg/logging.SemVer=v${finalAttrs.version}"
   ];
 
-  env.CGO_ENABLED = false;
+  env.CGO_ENABLED = 0;
 
   subPackages = [ "." ];
 


### PR DESCRIPTION
instead of `0`.

Note that the official docs specify that only `1` or `0` are valid:
https://pkg.go.dev/cmd/cgo and look for `CGO_ENABLED`.

If set to `false`, it gets rendered as an empty string:

```console
$ nix derivation show nixpkgs#go-mockery | jq '.derivations[].env | {CGO_ENABLED}'
{
  "CGO_ENABLED": ""
}
$ nix derivation show nixpkgs#go-mockery_2 | jq '.derivations[].env | {CGO_ENABLED}'
{
  "CGO_ENABLED": ""
}
```

which has the same effect as not defining `env.CGO_ENABLED` at all, i.e., it generates a dynamically linked executable:

```console
$ nix shell nixpkgs#go-mockery
$ ldd $(which mockery)
	linux-vdso.so.1 (0x00007c440bdd3000)
	libresolv.so.2 => /nix/store/8kvxvr3pmsypxiypq4g8zy13glnfr7nx-glibc-2.42-67/lib/libresolv.so.2 (0x00007c440bdb8000)
	libpthread.so.0 => /nix/store/8kvxvr3pmsypxiypq4g8zy13glnfr7nx-glibc-2.42-67/lib/libpthread.so.0 (0x00007c440bdb3000)
	libc.so.6 => /nix/store/8kvxvr3pmsypxiypq4g8zy13glnfr7nx-glibc-2.42-67/lib/libc.so.6 (0x00007c440ba00000)
	/nix/store/8kvxvr3pmsypxiypq4g8zy13glnfr7nx-glibc-2.42-67/lib/ld-linux-x86-64.so.2 => /nix/store/8kvxvr3pmsypxiypq4g8zy13glnfr7nx-glibc-2.42-67/lib64/ld-linux-x86-64.so.2 (0x00007c440bdd5000)
```

ditto for _v2:

```console
$ nix shell nixpkgs#go-mockery_2
$ ldd $(which mockery)
	linux-vdso.so.1 (0x000077377575f000)
	libresolv.so.2 => /nix/store/8kvxvr3pmsypxiypq4g8zy13glnfr7nx-glibc-2.42-67/lib/libresolv.so.2 (0x0000773775744000)
	libpthread.so.0 => /nix/store/8kvxvr3pmsypxiypq4g8zy13glnfr7nx-glibc-2.42-67/lib/libpthread.so.0 (0x000077377573f000)
	libc.so.6 => /nix/store/8kvxvr3pmsypxiypq4g8zy13glnfr7nx-glibc-2.42-67/lib/libc.so.6 (0x0000773775400000)
	/nix/store/8kvxvr3pmsypxiypq4g8zy13glnfr7nx-glibc-2.42-67/lib/ld-linux-x86-64.so.2 => /nix/store/8kvxvr3pmsypxiypq4g8zy13glnfr7nx-glibc-2.42-67/lib64/ld-linux-x86-64.so.2 (0x0000773775761000)
```

whereas after setting it to `0`:

```console
$ nix derivation show .#go-mockery | jq '.derivations[].env | {CGO_ENABLED}'
{
  "CGO_ENABLED": "0"
}
$ nix derivation show .#go-mockery_2 | jq '.derivations[].env | {CGO_ENABLED}'
{
  "CGO_ENABLED": "0"
}
```

and now the executables are not dynamic, as intended:

```console
$ nix shell .#go-mockery
$ ldd $(which mockery)
	not a dynamic executable

$ nix shell .#go-mockery_2
$ ldd $(which mockery)
	not a dynamic executable
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
