### PR TITLE
arduino-ide: build from source

### DIFF
--- a/pkgs/by-name/ar/arduino-ide/generate-examples-json.js
+++ b/pkgs/by-name/ar/arduino-ide/generate-examples-json.js
@@ -1,0 +1,64 @@
+// @ts-check
+
+// near exact copy of the tail of arduino-ide-extension/scripts/download-examples.js
+// (everything after the git clone/checkout)
+(async () => {
+  const path = require('node:path');
+  const { promises: fs } = require('node:fs');
+  const destination = process.argv[2];
+  if (!destination) {
+    console.error('usage: node generate-examples-json.js <destination>');
+    process.exit(1);
+  }
+  const isSketch = async (pathLike) => {
+    try {
+      const names = await fs.readdir(pathLike);
+      const dirName = path.basename(pathLike);
+      return names.indexOf(`${dirName}.ino`) !== -1;
+    } catch (e) {
+      if (e.code === 'ENOTDIR') {
+        return false;
+      }
+      throw e;
+    }
+  };
+  const examples = [];
+  const categories = await fs.readdir(destination);
+  const visit = async (pathLike, container) => {
+    const stat = await fs.lstat(pathLike);
+    if (stat.isDirectory()) {
+      if (await isSketch(pathLike)) {
+        container.sketches.push({
+          name: path.basename(pathLike),
+          relativePath: path.relative(destination, pathLike),
+        });
+      } else {
+        const names = await fs.readdir(pathLike);
+        for (const name of names) {
+          const childPath = path.join(pathLike, name);
+          if (await isSketch(childPath)) {
+            container.sketches.push({
+              name,
+              relativePath: path.relative(destination, childPath),
+            });
+          } else {
+            const child = { label: name, children: [], sketches: [] };
+            container.children.push(child);
+            await visit(childPath, child);
+          }
+        }
+      }
+    }
+  };
+  for (const category of categories) {
+    const example = { label: category, children: [], sketches: [] };
+    await visit(path.join(destination, category), example);
+    examples.push(example);
+  }
+  await fs.writeFile(
+    path.join(destination, 'examples.json'),
+    JSON.stringify(examples, null, 2),
+    { encoding: 'utf8' }
+  );
+  console.log(`Generated output to ${path.join(destination, 'examples.json')}`);
+})();

--- a/pkgs/by-name/ar/arduino-ide/package.nix
+++ b/pkgs/by-name/ar/arduino-ide/package.nix
@@ -1,44 +1,257 @@
 {
-  appimageTools,
-  fetchurl,
   lib,
+  stdenv,
+  applyPatches,
+  copyDesktopItems,
+  electron,
+  fetchFromGitHub,
+  fetchurl,
+  fetchYarnDeps,
+  llvmPackages,
+  makeWrapper,
+  makeDesktopItem,
+  nodejs,
+  pkg-config,
   python3,
-}:
+  ripgrep,
+  yarnConfigHook,
+  zip,
 
+  arduino-cli,
+
+  libdrm,
+  libsecret,
+  libx11,
+  libxkbfile,
+
+  clang_20,
+  darwin,
+  xcbuild,
+}:
 let
+  inherit (stdenv.hostPlatform) system;
+
+  # see the @electron/get fix in buildPhase below.
+  electronPlatform =
+    {
+      x86_64-linux = "linux-x64";
+      aarch64-linux = "linux-arm64";
+      aarch64-darwin = "darwin-arm64";
+    }
+    .${system} or (throw "arduino-ide: unsupported platform ${system}");
+
+  # seperate tools fetched as binary
+  arduinoToolPlatform =
+    {
+      x86_64-linux = "Linux_64bit";
+      aarch64-linux = "Linux_ARM64";
+      aarch64-darwin = "macOS_ARM64";
+    }
+    .${system} or (throw "arduino-ide: unsupported platform ${system}");
+
+  arduino-fwuploader-bin = fetchurl {
+    url = "https://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.4.1_${arduinoToolPlatform}.tar.gz";
+    hash =
+      {
+        x86_64-linux = "sha256-oh6nWW0LiDsk/Am8/DAA86d7GVAE61CPmi3rcAA/U44=";
+        aarch64-linux = "sha256-AEEnFaTR3KSypSS/2fhWvAqvvdHRTIuAVUP8+dYyyhg=";
+        aarch64-darwin = "sha256-gvRdlgsdDWEwAjLkfDlMhlI3yNcKm/hShd5KngziXnI=";
+      }
+      .${system};
+  };
+
+  # normally cloned via git by arduino-ide-extension/scripts/download-examples.js.
+  arduino-examples-src = fetchFromGitHub {
+    owner = "arduino";
+    repo = "arduino-examples";
+    tag = "1.10.3";
+    hash = "sha256-ZaUmof7M4x9PTrdsPas4XqxqC4QKDCPe8vIiV0KUM7Q=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
   pname = "arduino-ide";
   version = "2.3.10";
 
-  src = fetchurl {
-    url = "https://github.com/arduino/arduino-ide/releases/download/${version}/arduino-ide_${version}_Linux_64bit.AppImage";
-    hash = "sha256-echZChdEwiDXLL7Q6pHG4qf0WUKSaZsvszZOvXE81WY=";
+  src = applyPatches {
+    src = fetchFromGitHub {
+      owner = "arduino";
+      repo = "arduino-ide";
+      tag = finalAttrs.version;
+      hash = "sha256-zrDdrIzO7AEMSW8JGPnAN+4DGqznfFkCxha5C8K4xKA=";
+    };
+    patches = [ ./update-dependencies.patch ];
   };
 
-  appimageContents = appimageTools.extract { inherit pname version src; };
-in
-appimageTools.wrapType2 {
-  inherit pname version src;
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = "${finalAttrs.src}/yarn.lock";
+    hash = "sha256-2SRdPCLRyh2X62npjbSmWfiafw03wsJ9XoaA1W9v4HU=";
+  };
 
-  extraInstallCommands = ''
-    install -Dm444 ${appimageContents}/arduino-ide.desktop -t $out/share/applications/
-    install -Dm444 ${appimageContents}/arduino-ide.png -t $out/share/icons/hicolor/512x512/apps
-    substituteInPlace $out/share/applications/arduino-ide.desktop --replace-fail 'Exec=AppRun --no-sandbox %U' 'Exec=arduino-ide %U'
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+    PUPPETEER_SKIP_DOWNLOAD = "1";
+    ELECTRON_OVERRIDE_DIST_PATH = "node_modules/electron/dist";
+    THEIA_ELECTRON_SKIP_REPLACE_FFMPEG = "1";
+    CI = "true";
+  };
+
+  nativeBuildInputs = [
+    yarnConfigHook
+    nodejs
+    makeWrapper
+    copyDesktopItems
+    pkg-config
+    python3
+    zip
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    clang_20 # newer clang breaks node-addon-api on darwin
+    darwin.autoSignDarwinBinariesHook
+    xcbuild
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    libdrm
+    libsecret
+    libx11
+    libxkbfile
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    # manual placement of required resources
+    RESOURCES=arduino-ide-extension/src/node/resources
+    mkdir -p "$RESOURCES"
+    mkdir "$RESOURCES/Examples"
+    yarn --cwd arduino-ide-extension --offline copy-i18n
+    tar -xzf ${arduino-fwuploader-bin} -C "$RESOURCES"
+    chmod +x "$RESOURCES"/arduino-fwuploader
+    cp ${llvmPackages.clang-tools}/bin/{clangd,clang-format} "$RESOURCES/"
+    cp ${arduino-cli}/bin/arduino-cli "$RESOURCES/"
+    cp -r ${arduino-examples-src}/examples/. "$RESOURCES/Examples/"
+    node ${./generate-examples-json.js} "$RESOURCES/Examples"
+
+    # Put ripgrep binary into bin, so post-install does not try to download it.
+    find -name ripgrep -type d \
+      -execdir mkdir -p {}/bin \; \
+      -execdir ln -s ${ripgrep}/bin/rg {}/bin/rg \;
+
+    # rebuild the extension's native addons against plain nodejs first
+    export npm_config_nodedir="${nodejs}"
+    npm rebuild --verbose --no-progress --offline \
+      @parcel/watcher \
+      @theia/ffmpeg \
+      drivelist \
+      keytar \
+      msgpackr-extract \
+      native-keymap \
+      node-pty
+
+    mkdir -p node_modules/electron
+    cp -R ${electron.dist} node_modules/electron/dist
+    chmod -R u+w node_modules/electron/dist
+    echo -n "${electron.version}" > node_modules/electron/dist/version
+
+    # stop theia from checking for proprietary codecs
+    cat <<EOF > node_modules/@theia/ffmpeg/lib/check-ffmpeg.js
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.checkFfmpeg = async () => {};
+    EOF
+
+    # stop @electron/get from trying to download electron
+    ELECTRON_ZIP="$PWD/electron-v${electron.version}-${electronPlatform}.zip"
+    zip -r "$ELECTRON_ZIP" node_modules/electron/dist
+    cat <<EOF > node_modules/@electron/get/dist/cjs/index.js
+    exports.downloadArtifact = async () => "$ELECTRON_ZIP";
+    exports.download = async () => "$ELECTRON_ZIP";
+    EOF
+
+    yarn --verbose --no-progress --offline build
+
+    pushd electron-app
+
+    # rebuild electron-app's native addons against electron headers
+    export npm_config_nodedir=${electron.headers}
+    yarn --verbose --no-progress --offline rebuild
+    yarn --verbose --no-progress --offline build
+
+    npm exec electron-builder -- \
+      --publish=never \
+      --dir \
+      ${lib.optionalString stdenv.hostPlatform.isDarwin "-c.mac.identity=null"} \
+      -c.electronDist=../node_modules/electron/dist \
+      -c.electronVersion=${electron.version} \
+      -c.extraMetadata.version=${finalAttrs.version} \
+      -c.extraMetadata.name=arduino-ide \
+      -c.extraMetadata.theia.frontend.config.appVersion=${finalAttrs.version} \
+      -c.extraMetadata.theia.frontend.config.cliVersion=${arduino-cli.version} \
+      -c.extraMetadata.theia.frontend.config.buildDate=$(date -u +%Y-%m-%dT%H:%M:%S.000Z) \
+      -c.extraMetadata.main=./arduino-ide-electron-main.js
+
+    popd
+
+    runHook postBuild
   '';
 
-  extraPkgs = pkgs: [
-    pkgs.libsecret
-    (python3.withPackages (ps: [
-      ps.pyserial # for esptool
-    ]))
+  installPhase = ''
+    runHook preInstall
+
+  ''
+  + (
+    if stdenv.hostPlatform.isDarwin then
+      ''
+        mkdir -p $out/{Applications,bin}
+        cp -r electron-app/dist/mac*/"Arduino IDE.app" $out/Applications
+        makeWrapper $out/Applications/"Arduino IDE.app"/Contents/MacOS/"Arduino IDE" $out/bin/arduino-ide
+      ''
+    else
+      ''
+        mkdir -p $out/share/lib/arduino-ide
+        cp -r electron-app/dist/*-unpacked/{locales,resources{,.pak}} $out/share/lib/arduino-ide
+        install -Dm444 electron-app/resources/icons/512x512.png $out/share/icons/hicolor/512x512/apps/arduino-ide.png
+
+        makeWrapper ${electron}/bin/electron $out/bin/arduino-ide \
+          --add-flags $out/share/lib/arduino-ide/resources/app \
+          --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+          --inherit-argv0
+      ''
+  )
+  + ''
+
+    runHook postInstall
+  '';
+
+  desktopItems = lib.optionals stdenv.hostPlatform.isLinux [
+    (makeDesktopItem {
+      name = "arduino-ide";
+      exec = "arduino-ide";
+      icon = "arduino-ide";
+      desktopName = "Arduino IDE";
+      comment = finalAttrs.meta.description;
+      categories = [ "Development" ];
+      startupWMClass = "arduino-ide";
+    })
   ];
 
   meta = {
     description = "Open-source electronics prototyping platform";
     homepage = "https://www.arduino.cc/en/software";
-    changelog = "https://github.com/arduino/arduino-ide/releases/tag/${version}";
+    changelog = "https://github.com/arduino/arduino-ide/releases/tag/${finalAttrs.version}";
     license = lib.licenses.agpl3Only;
     mainProgram = "arduino-ide";
-    maintainers = with lib.maintainers; [ clerie ];
-    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [
+      clerie
+      ern775
+    ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
   };
-}
+})

--- a/pkgs/by-name/ar/arduino-ide/update-dependencies.patch
+++ b/pkgs/by-name/ar/arduino-ide/update-dependencies.patch
@@ -1,0 +1,496 @@
+diff --git a/package.json b/package.json
+index 6270dc94..419052b3 100644
+--- a/package.json
++++ b/package.json
+@@ -7,19 +7,22 @@
+   "license": "AGPL-3.0-or-later",
+   "private": true,
+   "engines": {
+-    "node": ">=18.17.0 <21"
++    "node": ">=18.17.0 <25"
+   },
+   "resolutions": {
+     "@theia/cli/@babel/traverse": "^7.23.2",
+     "@theia/cli/@theia/application-package/nano": "^10.1.3",
+     "**/@theia/application-manager/node-abi": "^3.0.0",
++    "**/@theia/application-manager/electron-rebuild": "npm:@electron/rebuild@^3.7.0",
++    "**/electron-rebuild/@electron/node-gyp": "10.2.0-electron.2",
+     "**/@theia/core/msgpackr": "^1.10.1",
+     "**/@types/react-dom": "18.3.1",
+     "**/@types/react": "18.3.1",
+     "**/inversify": "6.0.2",
+     "**/ip": "^2.0.1",
+     "**/perfect-scrollbar": "1.5.5",
+-    "nx/axios": "^1.6.7"
++    "nx/axios": "^1.6.7",
++    "nan": "2.28.0"
+   },
+   "devDependencies": {
+     "@theia/cli": "1.57.0",
+@@ -38,7 +41,7 @@
+     "lerna": "^7.1.4",
+     "lint-staged": "^11.0.0",
+     "node-fetch": "^2.6.1",
+-    "node-gyp": "^9.3.0",
++    "node-gyp": "^10.0.0",
+     "prettier": "^2.3.1",
+     "reflect-metadata": "^0.1.10",
+     "rimraf": "^5.0.0",
+diff --git a/yarn.lock b/yarn.lock
+index ff680ad3..fe5d9e4b 100644
+--- a/yarn.lock
++++ b/yarn.lock
+@@ -849,6 +849,22 @@
+   optionalDependencies:
+     global-agent "^3.0.0"
+ 
++"@electron/node-gyp@10.2.0-electron.2", "@electron/node-gyp@https://github.com/electron/node-gyp#06b29aafb7708acef8b3669835c8a7857ebc92d2":
++  version "10.2.0-electron.2"
++  resolved "https://registry.yarnpkg.com/@electron/node-gyp/-/node-gyp-10.2.0-electron.2.tgz#391b28473d7c9dc1fc2b5407d314579a49f4bf24"
++  integrity sha512-OhO6fwqpetMO1vWI3+J8mb3a4s4A405tgKoUCJsgd4nyQDdFh0VvZm+gj/Cc70iRLQoIYUfSaAgYSVwmLsQHig==
++  dependencies:
++    env-paths "^2.2.0"
++    exponential-backoff "^3.1.1"
++    glob "^8.1.0"
++    graceful-fs "^4.2.6"
++    make-fetch-happen "^10.2.1"
++    nopt "^6.0.0"
++    proc-log "^2.0.1"
++    semver "^7.3.5"
++    tar "^6.2.1"
++    which "^2.0.2"
++
+ "@electron/notarize@2.2.1":
+   version "2.2.1"
+   resolved "https://registry.yarnpkg.com/@electron/notarize/-/notarize-2.2.1.tgz#d0aa6bc43cba830c41bfd840b85dbe0e273f59fe"
+@@ -1309,6 +1325,17 @@
+     "@nodelib/fs.scandir" "2.1.5"
+     fastq "^1.6.0"
+ 
++"@npmcli/agent@^2.0.0":
++  version "2.2.2"
++  resolved "https://registry.yarnpkg.com/@npmcli/agent/-/agent-2.2.2.tgz#967604918e62f620a648c7975461c9c9e74fc5d5"
++  integrity sha512-OrcNPXdpSl9UX7qPVRWbmWMCSXrcDa2M9DvrbOTj7ao1S4PlqVFYv9/yLKMkrJKZ/V5A/kDBC690or307i26Og==
++  dependencies:
++    agent-base "^7.1.0"
++    http-proxy-agent "^7.0.0"
++    https-proxy-agent "^7.0.1"
++    lru-cache "^10.0.1"
++    socks-proxy-agent "^8.0.3"
++
+ "@npmcli/fs@^2.1.0":
+   version "2.1.2"
+   resolved "https://registry.yarnpkg.com/@npmcli/fs/-/fs-2.1.2.tgz#a9e2541a4a2fec2e69c29b35e6060973da79b865"
+@@ -3671,6 +3698,11 @@ abbrev@1, abbrev@^1.0.0:
+   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
+   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+ 
++abbrev@^2.0.0:
++  version "2.0.0"
++  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-2.0.0.tgz#cf59829b8b4f03f89dda2771cb7f3653828c89bf"
++  integrity sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==
++
+ abort-controller@^3.0.0:
+   version "3.0.0"
+   resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+@@ -4617,6 +4649,24 @@ cacache@^17.0.0:
+     tar "^6.1.11"
+     unique-filename "^3.0.0"
+ 
++cacache@^18.0.0:
++  version "18.0.4"
++  resolved "https://registry.yarnpkg.com/cacache/-/cacache-18.0.4.tgz#4601d7578dadb59c66044e157d02a3314682d6a5"
++  integrity sha512-B+L5iIa9mgcjLbliir2th36yEwPftrzteHYujzsx3dFP/31GCHcIeS8f5MGd80odLOjaOvSpU3EEAmRQptkxLQ==
++  dependencies:
++    "@npmcli/fs" "^3.1.0"
++    fs-minipass "^3.0.0"
++    glob "^10.2.2"
++    lru-cache "^10.0.1"
++    minipass "^7.0.3"
++    minipass-collect "^2.0.1"
++    minipass-flush "^1.0.5"
++    minipass-pipeline "^1.2.4"
++    p-map "^4.0.0"
++    ssri "^10.0.0"
++    tar "^6.1.11"
++    unique-filename "^3.0.0"
++
+ cacheable-lookup@^5.0.3:
+   version "5.0.4"
+   resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz#5a6b865b2c44357be3d5ebc2a467b032719a7005"
+@@ -6045,22 +6095,22 @@ electron-publish@24.13.1:
+     lazy-val "^1.0.5"
+     mime "^2.5.2"
+ 
+-electron-rebuild@^3.2.7:
+-  version "3.2.9"
+-  resolved "https://registry.yarnpkg.com/electron-rebuild/-/electron-rebuild-3.2.9.tgz#ea372be15f591f8d6d978ee9bca6526dadbcf20f"
+-  integrity sha512-FkEZNFViUem3P0RLYbZkUjC8LUFIK+wKq09GHoOITSJjfDAVQv964hwaNseTTWt58sITQX3/5fHNYcTefqaCWw==
++electron-rebuild@^3.2.7, "electron-rebuild@npm:@electron/rebuild@^3.7.0":
++  version "3.7.2"
++  resolved "https://registry.yarnpkg.com/@electron/rebuild/-/rebuild-3.7.2.tgz#8d808b29159c50086d27a5dec72b40bf16b4b582"
++  integrity sha512-19/KbIR/DAxbsCkiaGMXIdPnMCJLkcf8AvGnduJtWBs/CBwiAjY1apCqOLVxrXg+rtXFCngbXhBanWjxLUt1Mg==
+   dependencies:
++    "@electron/node-gyp" "https://github.com/electron/node-gyp#06b29aafb7708acef8b3669835c8a7857ebc92d2"
+     "@malept/cross-spawn-promise" "^2.0.0"
+     chalk "^4.0.0"
+     debug "^4.1.1"
+     detect-libc "^2.0.1"
+     fs-extra "^10.0.0"
+     got "^11.7.0"
+-    lzma-native "^8.0.5"
+-    node-abi "^3.0.0"
+-    node-api-version "^0.1.4"
+-    node-gyp "^9.0.0"
++    node-abi "^3.45.0"
++    node-api-version "^0.2.0"
+     ora "^5.1.0"
++    read-binary-file-arch "^1.0.6"
+     semver "^7.3.5"
+     tar "^6.0.5"
+     yargs "^17.0.1"
+@@ -7922,7 +7972,7 @@ https-proxy-agent@^5.0.0, https-proxy-agent@^5.0.1:
+     agent-base "6"
+     debug "4"
+ 
+-https-proxy-agent@^7.0.2, https-proxy-agent@^7.0.6:
++https-proxy-agent@^7.0.1, https-proxy-agent@^7.0.2, https-proxy-agent@^7.0.6:
+   version "7.0.6"
+   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz#da8dfeac7da130b05c2ba4b59c9b6cd66611a6b9"
+   integrity sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==
+@@ -8593,6 +8643,11 @@ isexe@^2.0.0:
+   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+ 
++isexe@^3.1.1:
++  version "3.1.5"
++  resolved "https://registry.yarnpkg.com/isexe/-/isexe-3.1.5.tgz#42e368f68d5e10dadfee4fda7b550bc2d8892dc9"
++  integrity sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==
++
+ isobject@^3.0.1:
+   version "3.0.1"
+   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
+@@ -9291,7 +9346,7 @@ lowercase-keys@^3.0.0:
+   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-3.0.0.tgz#c5e7d442e37ead247ae9db117a9d0a467c89d4f2"
+   integrity sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==
+ 
+-lru-cache@^10.2.0:
++lru-cache@^10.0.1, lru-cache@^10.2.0:
+   version "10.4.3"
+   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
+   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
+@@ -9323,15 +9378,6 @@ lru-cache@^7.14.1, lru-cache@^7.4.4, lru-cache@^7.5.1, lru-cache@^7.7.1:
+   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
+   integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
+ 
+-lzma-native@^8.0.5:
+-  version "8.0.6"
+-  resolved "https://registry.yarnpkg.com/lzma-native/-/lzma-native-8.0.6.tgz#3ea456209d643bafd9b5d911781bdf0b396b2665"
+-  integrity sha512-09xfg67mkL2Lz20PrrDeNYZxzeW7ADtpYFbwSQh9U8+76RIzx5QsJBMy8qikv3hbUPfpy6hqwxt6FcGK81g9AA==
+-  dependencies:
+-    node-addon-api "^3.1.0"
+-    node-gyp-build "^4.2.1"
+-    readable-stream "^3.6.0"
+-
+ macaddress@^0.5.3:
+   version "0.5.3"
+   resolved "https://registry.yarnpkg.com/macaddress/-/macaddress-0.5.3.tgz#2b9d6832be934cb775749f30f57d6537184a2bda"
+@@ -9366,7 +9412,7 @@ make-dir@^3.0.2, make-dir@^3.1.0:
+   dependencies:
+     semver "^6.0.0"
+ 
+-make-fetch-happen@^10.0.3:
++make-fetch-happen@^10.0.3, make-fetch-happen@^10.2.1:
+   version "10.2.1"
+   resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz#f5e3835c5e9817b617f2770870d9492d28678164"
+   integrity sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==
+@@ -9409,6 +9455,24 @@ make-fetch-happen@^11.0.0, make-fetch-happen@^11.0.1, make-fetch-happen@^11.1.1:
+     socks-proxy-agent "^7.0.0"
+     ssri "^10.0.0"
+ 
++make-fetch-happen@^13.0.0:
++  version "13.0.1"
++  resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-13.0.1.tgz#273ba2f78f45e1f3a6dca91cede87d9fa4821e36"
++  integrity sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA==
++  dependencies:
++    "@npmcli/agent" "^2.0.0"
++    cacache "^18.0.0"
++    http-cache-semantics "^4.1.1"
++    is-lambda "^1.0.1"
++    minipass "^7.0.2"
++    minipass-fetch "^3.0.0"
++    minipass-flush "^1.0.5"
++    minipass-pipeline "^1.2.4"
++    negotiator "^0.6.3"
++    proc-log "^4.2.0"
++    promise-retry "^2.0.1"
++    ssri "^10.0.0"
++
+ map-obj@^1.0.0:
+   version "1.0.1"
+   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
+@@ -9897,6 +9961,13 @@ minipass-collect@^1.0.2:
+   dependencies:
+     minipass "^3.0.0"
+ 
++minipass-collect@^2.0.1:
++  version "2.0.1"
++  resolved "https://registry.yarnpkg.com/minipass-collect/-/minipass-collect-2.0.1.tgz#1621bc77e12258a12c60d34e2276ec5c20680863"
++  integrity sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==
++  dependencies:
++    minipass "^7.0.3"
++
+ minipass-fetch@^2.0.3:
+   version "2.1.2"
+   resolved "https://registry.yarnpkg.com/minipass-fetch/-/minipass-fetch-2.1.2.tgz#95560b50c472d81a3bc76f20ede80eaed76d8add"
+@@ -9970,6 +10041,11 @@ minipass@^5.0.0:
+   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
+   integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
+ 
++minipass@^7.0.2:
++  version "7.1.3"
++  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
++  integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
++
+ minizlib@^2.1.1, minizlib@^2.1.2:
+   version "2.1.2"
+   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
+@@ -10127,10 +10203,10 @@ mute-stream@^1.0.0, mute-stream@~1.0.0:
+   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-1.0.0.tgz#e31bd9fe62f0aed23520aa4324ea6671531e013e"
+   integrity sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==
+ 
+-nan@^2.14.0, nan@^2.17.0:
+-  version "2.22.2"
+-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.22.2.tgz#6b504fd029fb8f38c0990e52ad5c26772fdacfbb"
+-  integrity sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==
++nan@2.28.0, nan@^2.14.0, nan@^2.17.0:
++  version "2.28.0"
++  resolved "https://registry.yarnpkg.com/nan/-/nan-2.28.0.tgz#126717fd359d5a03d3edf7c44e6ce9b707fb57f5"
++  integrity sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==
+ 
+ nano@^10.1.3:
+   version "10.1.4"
+@@ -10225,6 +10301,13 @@ node-abi@^2.21.0, node-abi@^2.7.0:
+   dependencies:
+     semver "^5.4.1"
+ 
++node-abi@^3.45.0:
++  version "3.94.0"
++  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.94.0.tgz#007181ed0d1b56ae9670ea6c084d2bf83538405f"
++  integrity sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==
++  dependencies:
++    semver "^7.3.5"
++
+ node-abort-controller@^3.1.1:
+   version "3.1.1"
+   resolved "https://registry.yarnpkg.com/node-abort-controller/-/node-abort-controller-3.1.1.tgz#a94377e964a9a37ac3976d848cb5c765833b8548"
+@@ -10235,7 +10318,7 @@ node-addon-api@^1.6.3:
+   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d"
+   integrity sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==
+ 
+-node-addon-api@^3.0.0, node-addon-api@^3.1.0, node-addon-api@^3.2.1:
++node-addon-api@^3.0.0, node-addon-api@^3.2.1:
+   version "3.2.1"
+   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
+   integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
+@@ -10250,10 +10333,10 @@ node-addon-api@^8.2.0:
+   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-8.3.1.tgz#53bc8a4f8dbde3de787b9828059da94ba9fd4eed"
+   integrity sha512-lytcDEdxKjGJPTLEfW4mYMigRezMlyJY8W4wxJK8zE533Jlb8L8dRuObJFWg2P+AuOIxoCgKF+2Oq4d4Zd0OUA==
+ 
+-node-api-version@^0.1.4:
+-  version "0.1.4"
+-  resolved "https://registry.yarnpkg.com/node-api-version/-/node-api-version-0.1.4.tgz#1ed46a485e462d55d66b5aa1fe2821720dedf080"
+-  integrity sha512-KGXihXdUChwJAOHO53bv9/vXcLmdUsZ6jIptbvYvkpKfth+r7jw44JkVxQFA3kX5nQjzjmGu1uAu/xNNLNlI5g==
++node-api-version@^0.2.0:
++  version "0.2.1"
++  resolved "https://registry.yarnpkg.com/node-api-version/-/node-api-version-0.2.1.tgz#19bad54f6d65628cbee4e607a325e4488ace2de9"
++  integrity sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==
+   dependencies:
+     semver "^7.3.5"
+ 
+@@ -10292,12 +10375,28 @@ node-gyp-build-optional-packages@5.2.2:
+   dependencies:
+     detect-libc "^2.0.1"
+ 
+-node-gyp-build@^4.2.1, node-gyp-build@^4.3.0:
++node-gyp-build@^4.3.0:
+   version "4.8.4"
+   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.8.4.tgz#8a70ee85464ae52327772a90d66c6077a900cfc8"
+   integrity sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==
+ 
+-node-gyp@^9.0.0, node-gyp@^9.3.0:
++node-gyp@^10.0.0:
++  version "10.3.1"
++  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-10.3.1.tgz#1dd1a1a1c6c5c59da1a76aea06a062786b2c8a1a"
++  integrity sha512-Pp3nFHBThHzVtNY7U6JfPjvT/DTE8+o/4xKsLQtBoU+j2HLsGlhcfzflAoUreaJbNmYnX+LlLi0qjV8kpyO6xQ==
++  dependencies:
++    env-paths "^2.2.0"
++    exponential-backoff "^3.1.1"
++    glob "^10.3.10"
++    graceful-fs "^4.2.6"
++    make-fetch-happen "^13.0.0"
++    nopt "^7.0.0"
++    proc-log "^4.1.0"
++    semver "^7.3.5"
++    tar "^6.2.1"
++    which "^4.0.0"
++
++node-gyp@^9.0.0:
+   version "9.4.1"
+   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-9.4.1.tgz#8a1023e0d6766ecb52764cc3a734b36ff275e185"
+   integrity sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ==
+@@ -10366,6 +10465,13 @@ nopt@^6.0.0:
+   dependencies:
+     abbrev "^1.0.0"
+ 
++nopt@^7.0.0:
++  version "7.2.1"
++  resolved "https://registry.yarnpkg.com/nopt/-/nopt-7.2.1.tgz#1cac0eab9b8e97c9093338446eddd40b2c8ca1e7"
++  integrity sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==
++  dependencies:
++    abbrev "^2.0.0"
++
+ normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
+   version "2.5.0"
+   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
+@@ -11400,11 +11506,21 @@ private@~0.1.5:
+   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
+   integrity sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==
+ 
++proc-log@^2.0.1:
++  version "2.0.1"
++  resolved "https://registry.yarnpkg.com/proc-log/-/proc-log-2.0.1.tgz#8f3f69a1f608de27878f91f5c688b225391cb685"
++  integrity sha512-Kcmo2FhfDTXdcbfDH76N7uBYHINxc/8GW7UAVuVP9I+Va3uHSerrnKV6dLooga/gh7GlgzuCCr/eoldnL1muGw==
++
+ proc-log@^3.0.0:
+   version "3.0.0"
+   resolved "https://registry.yarnpkg.com/proc-log/-/proc-log-3.0.0.tgz#fb05ef83ccd64fd7b20bbe9c8c1070fc08338dd8"
+   integrity sha512-++Vn7NS4Xf9NacaU9Xq3URUuqZETPsf8L4j5/ckhaRYsfPeRyzGw+iDjFhV/Jr3uNmTvvddEJFWh5R1gRgUH8A==
+ 
++proc-log@^4.1.0, proc-log@^4.2.0:
++  version "4.2.0"
++  resolved "https://registry.yarnpkg.com/proc-log/-/proc-log-4.2.0.tgz#b6f461e4026e75fdfe228b265e9f7a00779d7034"
++  integrity sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==
++
+ process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
+   version "2.0.1"
+   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
+@@ -11793,6 +11909,13 @@ react@^18.2.0:
+   dependencies:
+     loose-envify "^1.1.0"
+ 
++read-binary-file-arch@^1.0.6:
++  version "1.0.6"
++  resolved "https://registry.yarnpkg.com/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz#959c4637daa932280a9b911b1a6766a7e44288fc"
++  integrity sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==
++  dependencies:
++    debug "^4.3.4"
++
+ read-cmd-shim@4.0.0:
+   version "4.0.0"
+   resolved "https://registry.yarnpkg.com/read-cmd-shim/-/read-cmd-shim-4.0.0.tgz#640a08b473a49043e394ae0c7a34dd822c73b9bb"
+@@ -12711,7 +12834,7 @@ socks-proxy-agent@^7.0.0:
+     debug "^4.3.3"
+     socks "^2.6.2"
+ 
+-socks-proxy-agent@^8.0.5:
++socks-proxy-agent@^8.0.3, socks-proxy-agent@^8.0.5:
+   version "8.0.5"
+   resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz#b9cdb4e7e998509d7659d689ce7697ac21645bee"
+   integrity sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==
+@@ -12927,7 +13050,7 @@ string-natural-compare@^2.0.3:
+   resolved "https://registry.yarnpkg.com/string-natural-compare/-/string-natural-compare-2.0.3.tgz#9dbe1dd65490a5fe14f7a5c9bc686fc67cb9c6e4"
+   integrity sha512-4Kcl12rNjc+6EKhY8QyDVuQTAlMWwRiNbsxnVwBUKFr7dYPQuXVrtNU4sEkjF9LHY0AY6uVbB3ktbkIH4LC+BQ==
+ 
+-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
++"string-width-cjs@npm:string-width@^4.2.0":
+   version "4.2.3"
+   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+@@ -12945,6 +13068,15 @@ string-width@^1.0.1:
+     is-fullwidth-code-point "^1.0.0"
+     strip-ansi "^3.0.0"
+ 
++"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
++  version "4.2.3"
++  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
++  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
++  dependencies:
++    emoji-regex "^8.0.0"
++    is-fullwidth-code-point "^3.0.0"
++    strip-ansi "^6.0.1"
++
+ string-width@^5.0.1, string-width@^5.1.2:
+   version "5.1.2"
+   resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
+@@ -13036,7 +13168,7 @@ stringify-object@3.3.0, stringify-object@^3.3.0:
+     is-obj "^1.0.1"
+     is-regexp "^1.0.0"
+ 
+-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
++"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+   version "6.0.1"
+   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+@@ -13050,6 +13182,13 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
+   dependencies:
+     ansi-regex "^2.0.0"
+ 
++strip-ansi@^6.0.0, strip-ansi@^6.0.1:
++  version "6.0.1"
++  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
++  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
++  dependencies:
++    ansi-regex "^5.0.1"
++
+ strip-ansi@^7.0.1:
+   version "7.1.0"
+   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.1.0.tgz#d5b6568ca689d8561370b0707685d22434faff45"
+@@ -13307,7 +13446,7 @@ tar@6.1.11:
+     mkdirp "^1.0.3"
+     yallist "^4.0.0"
+ 
+-tar@^6.0.5, tar@^6.1.11, tar@^6.1.12, tar@^6.1.2:
++tar@^6.0.5, tar@^6.1.11, tar@^6.1.12, tar@^6.1.2, tar@^6.2.1:
+   version "6.2.1"
+   resolved "https://registry.yarnpkg.com/tar/-/tar-6.2.1.tgz#717549c541bc3c2af15751bea94b1dd068d4b03a"
+   integrity sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==
+@@ -14404,6 +14543,13 @@ which@^3.0.0:
+   dependencies:
+     isexe "^2.0.0"
+ 
++which@^4.0.0:
++  version "4.0.0"
++  resolved "https://registry.yarnpkg.com/which/-/which-4.0.0.tgz#cd60b5e74503a3fbcfbf6cd6b4138a8bae644c1a"
++  integrity sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==
++  dependencies:
++    isexe "^3.1.1"
++
+ wide-align@^1.1.0, wide-align@^1.1.2, wide-align@^1.1.5:
+   version "1.1.5"
+   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.5.tgz#df1d4c206854369ecf3c9a4898f1b23fbd9d15d3"
+@@ -14444,7 +14590,7 @@ workerpool@^6.5.1:
+   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
+   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
+ 
+-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
++"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+   version "7.0.0"
+   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+@@ -14462,6 +14608,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
+     string-width "^4.1.0"
+     strip-ansi "^6.0.0"
+ 
++wrap-ansi@^7.0.0:
++  version "7.0.0"
++  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
++  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
++  dependencies:
++    ansi-styles "^4.0.0"
++    string-width "^4.1.0"
++    strip-ansi "^6.0.0"
++
+ wrap-ansi@^8.1.0:
+   version "8.1.0"
+   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Changed arduino-ide to building from source.
This needed a lot of different fixes everywhere, these fixes include:
- Node version upgrade to 24
- Several upgrades in package.json to get everything to work with a newer supported electron version
- Manually downloading and placing needed binaries and some other files
- Adding a `.js` file to generate some needed files mentioned also on the point before
- Some manual file edits in the buildPhase to stop some checks that otherwise cause the build to fail due to no network
- Manual packaging of the electron app

And some other small fixes as well.
I tried as best as I could to gather the fixes from existing nixpkgs packages.

It builds successfully for all 3 platforms and the basic functionality seems to work (it launches properly). However, I haven't tested the actual in-app features at all.

Right now this pr needs:
- Testers for all platforms (at the very least using some base features like connecting to a board etc.)
- Someone to review the `buildPhase`, I feel it's a little hacky as it is right now.
- A decision to be made on whether the `arduino-ide` package should use `arduino-cli` from nixpkgs or pull the pinned version on that specific IDE version from upstream arduino repos.

I will add, everything this app uses is very old, and most of it is unsupported. There's a good chance the specific fixes for upgrading dependencies could be done upstream instead.

Closes: https://github.com/NixOS/nixpkgs/issues/433319
Relevant issues: https://github.com/NixOS/nixpkgs/issues/296939, https://github.com/NixOS/nixpkgs/issues/388911
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
