### PR TITLE
nvidia-container-toolkit: mount EGL/Vulkan loader manifests

### DIFF
--- a/nixos/modules/services/hardware/nvidia-container-toolkit/default.nix
+++ b/nixos/modules/services/hardware/nvidia-container-toolkit/default.nix
@@ -269,23 +269,6 @@
         nvidia-container-toolkit.mounts =
           let
             nvidia-driver = config.hardware.nvidia.package;
-            egl-vendor-manifest = pkgs.writeText "nvidia-egl-vendor.json" (
-              builtins.toJSON {
-                file_format_version = "1.0.0";
-                ICD.library_path = "libEGL_nvidia.so.0";
-              }
-            );
-            # api_version is required by the Vulkan loader but its value is
-            # ignored, as the loader queries the driver directly.
-            vulkan-icd-manifest = pkgs.writeText "nvidia-icd.json" (
-              builtins.toJSON {
-                file_format_version = "1.0.0";
-                ICD = {
-                  library_path = "libGLX_nvidia.so.0";
-                  api_version = "1.3.0";
-                };
-              }
-            );
           in
           (lib.mkMerge [
             [
@@ -344,11 +327,11 @@
             ])
             (lib.mkIf config.hardware.nvidia-container-toolkit.mount-nvidia-graphics-config [
               {
-                hostPath = "${egl-vendor-manifest}";
+                hostPath = "${lib.getLib nvidia-driver}/share/glvnd/egl_vendor.d/10_nvidia.json";
                 containerPath = "/usr/share/glvnd/egl_vendor.d/10_nvidia.json";
               }
               {
-                hostPath = "${vulkan-icd-manifest}";
+                hostPath = "${lib.getLib nvidia-driver}/share/vulkan/icd.d/nvidia_icd.json";
                 containerPath = "/usr/share/vulkan/icd.d/nvidia_icd.json";
               }
             ])

--- a/nixos/modules/services/hardware/nvidia-container-toolkit/default.nix
+++ b/nixos/modules/services/hardware/nvidia-container-toolkit/default.nix
@@ -109,6 +109,16 @@
           '';
         };
 
+        mount-nvidia-graphics-config = lib.mkOption {
+          default = true;
+          type = lib.types.bool;
+          description = ''
+            Mount the libglvnd EGL vendor and Vulkan ICD manifests
+            (10_nvidia.json, nvidia_icd.json) on containers, so EGL and Vulkan
+            applications can discover the Nvidia driver.
+          '';
+        };
+
         suppressNvidiaDriverAssertion = lib.mkOption {
           default = false;
           type = lib.types.bool;
@@ -259,6 +269,23 @@
         nvidia-container-toolkit.mounts =
           let
             nvidia-driver = config.hardware.nvidia.package;
+            egl-vendor-manifest = pkgs.writeText "nvidia-egl-vendor.json" (
+              builtins.toJSON {
+                file_format_version = "1.0.0";
+                ICD.library_path = "libEGL_nvidia.so.0";
+              }
+            );
+            # api_version is required by the Vulkan loader but its value is
+            # ignored, as the loader queries the driver directly.
+            vulkan-icd-manifest = pkgs.writeText "nvidia-icd.json" (
+              builtins.toJSON {
+                file_format_version = "1.0.0";
+                ICD = {
+                  library_path = "libGLX_nvidia.so.0";
+                  api_version = "1.3.0";
+                };
+              }
+            );
           in
           (lib.mkMerge [
             [
@@ -313,6 +340,16 @@
               {
                 hostPath = "${lib.getLib nvidia-driver}/lib";
                 containerPath = "/usr/local/nvidia/lib64";
+              }
+            ])
+            (lib.mkIf config.hardware.nvidia-container-toolkit.mount-nvidia-graphics-config [
+              {
+                hostPath = "${egl-vendor-manifest}";
+                containerPath = "/usr/share/glvnd/egl_vendor.d/10_nvidia.json";
+              }
+              {
+                hostPath = "${vulkan-icd-manifest}";
+                containerPath = "/usr/share/vulkan/icd.d/nvidia_icd.json";
               }
             ])
           ]);

--- a/nixos/tests/nvidia-container-toolkit.nix
+++ b/nixos/tests/nvidia-container-toolkit.nix
@@ -134,6 +134,12 @@ in
         }
       ];
     };
+
+    one-gpu-userspace-driver =
+      { config, ... }:
+      {
+        hardware.nvidia.package = lib.mkForce config.boot.kernelPackages.nvidiaPackages.stable;
+      };
   };
   testScript = ''
     start_all()
@@ -149,8 +155,9 @@ in
       one_gpu.succeed("podman run --pull=never --device=nvidia.com/gpu=all -v /run/opengl-driver:/run/opengl-driver:ro cdi-test:latest")
 
     with subtest("The generated CDI spec exposes the Nvidia EGL and Vulkan loader manifests"):
-      one_gpu.succeed("grep -q /usr/share/glvnd/egl_vendor.d/10_nvidia.json /var/run/cdi/nvidia-container-toolkit.json")
-      one_gpu.succeed("grep -q /usr/share/vulkan/icd.d/nvidia_icd.json /var/run/cdi/nvidia-container-toolkit.json")
+      one_gpu_userspace_driver.wait_for_unit("nvidia-container-toolkit-cdi-generator.service")
+      one_gpu_userspace_driver.succeed("jq -e --arg p /usr/share/glvnd/egl_vendor.d/10_nvidia.json '.containerEdits.mounts[] | select(.containerPath == $p)' /var/run/cdi/nvidia-container-toolkit.json")
+      one_gpu_userspace_driver.succeed("jq -e --arg p /usr/share/vulkan/icd.d/nvidia_icd.json '.containerEdits.mounts[] | select(.containerPath == $p)' /var/run/cdi/nvidia-container-toolkit.json")
 
     # Issue: https://github.com/NixOS/nixpkgs/issues/319201
     with subtest("The generated CDI spec skips specified non-existant paths in the host"):

--- a/nixos/tests/nvidia-container-toolkit.nix
+++ b/nixos/tests/nvidia-container-toolkit.nix
@@ -148,6 +148,10 @@ in
       one_gpu.succeed("podman load < ${testContainerImage}")
       one_gpu.succeed("podman run --pull=never --device=nvidia.com/gpu=all -v /run/opengl-driver:/run/opengl-driver:ro cdi-test:latest")
 
+    with subtest("The generated CDI spec exposes the Nvidia EGL and Vulkan loader manifests"):
+      one_gpu.succeed("grep -q /usr/share/glvnd/egl_vendor.d/10_nvidia.json /var/run/cdi/nvidia-container-toolkit.json")
+      one_gpu.succeed("grep -q /usr/share/vulkan/icd.d/nvidia_icd.json /var/run/cdi/nvidia-container-toolkit.json")
+
     # Issue: https://github.com/NixOS/nixpkgs/issues/319201
     with subtest("The generated CDI spec skips specified non-existant paths in the host"):
       one_gpu_invalid_host_paths.wait_for_unit("nvidia-container-toolkit-cdi-generator.service")


### PR DESCRIPTION
Fixes graphics inside GPU containers.

The generated CDI spec bind-mounts the NVIDIA driver libraries but leaves out the two files the loaders use to find them... The libglvnd EGL vendor config (egl_vendor.d/10_nvidia.json) and the Vulkan ICD manifest (vulkan/icd.d/nvidia_icd.json). On NixOS those live in the Nix store, not the /usr/share paths the loaders scan, so EGL and Vulkan apps never reach the driver even with its libraries mounted. vulkaninfo just prints "Found no drivers!" and anything GL or Vulkan falls back to software.

The module now mounts the driver's own manifests. Their `library_path` is an absolute store path, which resolves inside the container because the driver directory is already mounted there. New opt-out: `hardware.nvidia-container-toolkit.mount-nvidia-graphics-config`, on by default.

Verified on my 3080 (driver 610.43.02): with the mounts in place vulkaninfo reports the GPU inside a stock Ubuntu container, and dropping them reproduces the "Found no drivers!" from the issue. @niklaskorz confirmed the same locally, and `nixosTests.nvidia-container-toolkit` passes. The manifest check runs against a node pinned to the userspace driver, because the other nodes point `hardware.nvidia.package` at the kernel modules. This covers the desktop `hardware.nvidia` path. Tegra/Jetson goes through csv discovery and out-of-tree jetpack, so that's a separate follow-up.

Resolves #529876

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

cc @cpcloud @christoph-heiss

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test