### PR TITLE
clash-verge-rev: stop adding `x-scheme-handler/clash{,-verge}=clash-verge.desktop` to `~/.config/mimeapps.list` while launching

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -63,6 +63,8 @@
 
 - When Avahi's mDNS resolver is enabled (`services.avahi.nssmdns4` or `services.avahi.nssmdns6`), only the minimal mDNS resolver is enabled by default to avoid adding a 5 second delay to every failed reverse hostname lookup (e.g., delaying ping by 5 seconds). The "full" mDNS resolver now remains disabled unless `services.avahi.nssmdnsFull` is also enabled. Users who have customized [`/etc/mdns.allow`](https://github.com/avahi/nss-mdns/tree/master#etcmdnsallow) to allow mDNS domains not ending `.local` must enable `services.avahi.nssmdnsFull` to continue to resolve such domains.
 
+- The package `clash-verge-rev` now no longer adding `x-scheme-handler/clash{,-verge}=clash-verge.desktop` to `~/.config/mimeapps.list` while launching. You may use home-manager option `xdg.mimeApps` to restore them.
+
 - `systemd.user.extraConfig` has been removed in favor of the structured [](#opt-systemd.user.settings.Manager) option. Use `systemd.user.settings.Manager` to set any `systemd-user.conf(5)` option directly. For example, replace `systemd.user.extraConfig = "DefaultTimeoutStartSec=60";` with `systemd.user.settings.Manager.DefaultTimeoutStartSec = 60;`.
 
 - `services.timesyncd.extraConfig` has been removed in favor of the structured [](#opt-services.timesyncd.settings.Time) option. Use `services.timesyncd.settings.Time` to set any `timesyncd.conf(5)` option directly. For example, replace `services.timesyncd.extraConfig = "PollIntervalMaxSec=180";` with `services.timesyncd.settings.Time.PollIntervalMaxSec = 180;`.

--- a/pkgs/by-name/cl/clash-verge-rev/prevent-writing-mimeapps.patch
+++ b/pkgs/by-name/cl/clash-verge-rev/prevent-writing-mimeapps.patch
@@ -1,0 +1,29 @@
+diff --git a/src-tauri/src/utils/init.rs b/src-tauri/src/utils/init.rs
+index 43b61c8f..5094667a 100644
+--- a/src-tauri/src/utils/init.rs
++++ b/src-tauri/src/utils/init.rs
+@@ -384,24 +384,6 @@ pub fn init_scheme() -> Result<()> {
+ }
+ #[cfg(target_os = "linux")]
+ pub fn init_scheme() -> Result<()> {
+-    const DESKTOP_FILE: &str = "clash-verge.desktop";
+-
+-    for scheme in DEEP_LINK_SCHEMES {
+-        let handler = format!("x-scheme-handler/{scheme}");
+-        let output = std::process::Command::new("xdg-mime")
+-            .arg("default")
+-            .arg(DESKTOP_FILE)
+-            .arg(&handler)
+-            .output()?;
+-        if !output.status.success() {
+-            return Err(anyhow::anyhow!(
+-                "failed to set {handler}, {}",
+-                String::from_utf8_lossy(&output.stderr)
+-            ));
+-        }
+-    }
+-
+-    crate::utils::linux::mime::ensure_mimeapps_entries(DESKTOP_FILE, DEEP_LINK_SCHEMES)?;
+     Ok(())
+ }
+ #[cfg(target_os = "macos")]

--- a/pkgs/by-name/cl/clash-verge-rev/unwrapped.nix
+++ b/pkgs/by-name/cl/clash-verge-rev/unwrapped.nix
@@ -20,7 +20,6 @@
   glib,
   kdePackages,
   libayatana-appindicator,
-  libsForQt5,
   libsoup_3,
   openssl,
   webkitgtk_4_1,
@@ -45,6 +44,8 @@ rustPlatform.buildRustPackage {
   env = {
     OPENSSL_NO_VENDOR = 1;
   };
+
+  patches = [ ./prevent-writing-mimeapps.patch ];
 
   postPatch = ''
     # We disable the option to try to use the bleeding-edge version of mihomo


### PR DESCRIPTION
that cause home-manager option [`xdg.mimeApps`](https://home-manager-options.extranix.com/?query=xdg.mimeApps) being clobbered
Upstream introduced this in https://github.com/clash-verge-rev/clash-verge-rev/pull/5154


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
