### PR TITLE
fnox: 1.20.0 -> 1.29.0

### DIFF
--- a/pkgs/by-name/fn/fnox/package.nix
+++ b/pkgs/by-name/fn/fnox/package.nix
@@ -1,35 +1,44 @@
 {
   lib,
   fetchFromGitHub,
+  stdenv,
   rustPlatform,
   perl,
   pkg-config,
   testers,
+  dbus,
   udev,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   __structuredAttrs = true;
   pname = "fnox";
-  version = "1.20.0";
+  version = "1.29.0";
 
   src = fetchFromGitHub {
     owner = "jdx";
     repo = "fnox";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-8LNMJEZNUlwpPT674/6SfR5dmFRALDI6X1WLKeaJ06M=";
+    hash = "sha256-sXFcvpAcHrzRbqYLIrq844TH1dHY1G23QIQoIcsCLGY=";
   };
 
-  cargoHash = "sha256-SoQseyrRqvq/XRmd/HhMX8r42pyn4Ncw6r9G4596bGc=";
+  cargoHash = "sha256-BhBWghjPC8qs5oKECmddV250YO4/hSWupOz+J9DYKog=";
 
   nativeBuildInputs = [
     perl
     pkg-config
   ];
 
-  buildInputs = [ udev ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    dbus
+    udev
+  ];
 
-  passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
+  passthru = {
+    tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
+    updateScript = nix-update-script { };
+  };
 
   checkFlags = [
     # requires a D-Bus session unavailable in the sandbox
@@ -39,8 +48,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Flexible secret management tool supporting multiple providers and encryption methods";
     homepage = "https://github.com/jdx/fnox";
+    changelog = "https://github.com/jdx/fnox/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ tiptenbrink ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })

--- a/pkgs/by-name/fn/fnox/package.nix
+++ b/pkgs/by-name/fn/fnox/package.nix
@@ -50,7 +50,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/jdx/fnox";
     changelog = "https://github.com/jdx/fnox/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ tiptenbrink ];
+    maintainers = with lib.maintainers; [
+      tiptenbrink
+      Br1ght0ne
+    ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/jdx/fnox/releases/tag/v1.29.0
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
