### PR TITLE
python3Packages.persim: migrate to pyproject, enable __structuredAttrs, use finalAttrs, reenable disabled tests

### DIFF
--- a/pkgs/development/python-modules/persim/default.nix
+++ b/pkgs/development/python-modules/persim/default.nix
@@ -51,22 +51,6 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "persim" ];
 
-  disabledTests = [
-    # AttributeError: module 'collections' has no attribute 'Iterable'
-    "test_empyt_diagram_list"
-    "test_empty_diagram_list"
-    "test_fit_diagram"
-    "test_integer_diagrams"
-    "test_lists_of_lists"
-    "test_mixed_pairs"
-    "test_multiple_diagrams"
-    "test_n_pixels"
-    # https://github.com/scikit-tda/persim/issues/67
-    "test_persistenceimager"
-    # ValueError: setting an array element with a sequence
-    "test_exact_critical_pairs"
-  ];
-
   meta = {
     description = "Distances and representations of persistence diagrams";
     homepage = "https://persim.scikit-tda.org";

--- a/pkgs/development/python-modules/persim/default.nix
+++ b/pkgs/development/python-modules/persim/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   deprecated,
   hopcroftkarp,
   joblib,
@@ -15,7 +16,7 @@
 buildPythonPackage (finalAttrs: {
   pname = "persim";
   version = "0.3.8";
-  format = "setuptools";
+  pyproject = true;
 
   __structuredAttrs = true;
 
@@ -25,7 +26,11 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-4T0YWEF2uKdk0W1+Vt8I3Mi6ZsazJXoHI0W+O9WbpA0=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
     deprecated
     hopcroftkarp
     joblib

--- a/pkgs/development/python-modules/persim/default.nix
+++ b/pkgs/development/python-modules/persim/default.nix
@@ -12,13 +12,14 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "persim";
   version = "0.3.8";
   format = "setuptools";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) version;
+    pname = "persim";
     hash = "sha256-4T0YWEF2uKdk0W1+Vt8I3Mi6ZsazJXoHI0W+O9WbpA0=";
   };
 
@@ -62,8 +63,8 @@ buildPythonPackage rec {
   meta = {
     description = "Distances and representations of persistence diagrams";
     homepage = "https://persim.scikit-tda.org";
-    changelog = "https://github.com/scikit-tda/persim/releases/tag/v${version}";
+    changelog = "https://github.com/scikit-tda/persim/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/persim/default.nix
+++ b/pkgs/development/python-modules/persim/default.nix
@@ -17,6 +17,8 @@ buildPythonPackage (finalAttrs: {
   version = "0.3.8";
   format = "setuptools";
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
     inherit (finalAttrs) version;
     pname = "persim";


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/515974
- enable `__structuredAttrs`
- use finalAttrs
- reenable disabled tests
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
