### PR TITLE
python3Packages.pylacrosse: 0.4 -> 0.5, migrate to pyproject, enable __structuredAttrs, use finalAttrs

### DIFF
--- a/pkgs/development/python-modules/pylacrosse/default.nix
+++ b/pkgs/development/python-modules/pylacrosse/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch2,
   mock,
   pyserial,
   pytestCheckHook,
@@ -10,23 +9,15 @@
 
 buildPythonPackage rec {
   pname = "pylacrosse";
-  version = "0.4";
+  version = "0.5";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "hthiery";
     repo = "python-lacrosse";
     tag = version;
-    hash = "sha256-jrkehoPLYbutDfxMBO/vlx4nMylTNs/gtvoBTFHFsDw=";
+    hash = "sha256-z2OlYFFK/+BONg22+Vk0kQQ0KJoQnRkjP7OUS/TVpfI=";
   };
-
-  patches = [
-    # Migrate to pytest, https://github.com/hthiery/python-lacrosse/pull/17
-    (fetchpatch2 {
-      url = "https://github.com/hthiery/python-lacrosse/commit/cc2623c667bc252360a9b5ccb4fc05296cf23d9c.patch?full_index=1";
-      hash = "sha256-LKryLnXMKj1lVClneyHNVOWM5KPPhOGy0/FX/7Qy/jU=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace setup.py \

--- a/pkgs/development/python-modules/pylacrosse/default.nix
+++ b/pkgs/development/python-modules/pylacrosse/default.nix
@@ -7,7 +7,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pylacrosse";
   version = "0.5";
   format = "setuptools";
@@ -15,13 +15,13 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "hthiery";
     repo = "python-lacrosse";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-z2OlYFFK/+BONg22+Vk0kQQ0KJoQnRkjP7OUS/TVpfI=";
   };
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "version = version," "version = '${version}',"
+      --replace "version = version," "version = '${finalAttrs.version}',"
   '';
 
   propagatedBuildInputs = [ pyserial ];
@@ -40,4 +40,4 @@ buildPythonPackage rec {
     license = with lib.licenses; [ lgpl2Plus ];
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/development/python-modules/pylacrosse/default.nix
+++ b/pkgs/development/python-modules/pylacrosse/default.nix
@@ -12,6 +12,8 @@ buildPythonPackage (finalAttrs: {
   version = "0.5";
   format = "setuptools";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "hthiery";
     repo = "python-lacrosse";

--- a/pkgs/development/python-modules/pylacrosse/default.nix
+++ b/pkgs/development/python-modules/pylacrosse/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
   mock,
   pyserial,
   pytestCheckHook,
@@ -10,7 +11,7 @@
 buildPythonPackage (finalAttrs: {
   pname = "pylacrosse";
   version = "0.5";
-  format = "setuptools";
+  pyproject = true;
 
   __structuredAttrs = true;
 
@@ -26,7 +27,9 @@ buildPythonPackage (finalAttrs: {
       --replace "version = version," "version = '${finalAttrs.version}',"
   '';
 
-  propagatedBuildInputs = [ pyserial ];
+  build-system = [ setuptools ];
+
+  dependencies = [ pyserial ];
 
   nativeCheckInputs = [
     mock


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/515974
- enable `__structuredAttrs`
- enable tests
- 0.4 -> 0.5
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
