### PR TITLE
xvfb: 21.1.23 -> 21.1.24, drop rebuild avoidance

### DIFF
--- a/pkgs/by-name/xv/xvfb/package.nix
+++ b/pkgs/by-name/xv/xvfb/package.nix
@@ -38,14 +38,7 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "xvfb";
 
-  # TODO: commented out for rebuild avoidance after xorg-server update. revert
-  # on staging.
-  # inherit (xorg-server) src version;
-  version = "21.1.23";
-  src = fetchurl {
-    url = "mirror://xorg/individual/xserver/xorg-server-${finalAttrs.version}.tar.xz";
-    hash = "sha256-45gy5WF9ra8HL9+fDhnl0uHCoTYHrCgLrBq6n4/hRjQ=";
-  };
+  inherit (xorg-server) src version;
 
   strictDeps = true;
 


### PR DESCRIPTION
announcement: https://lists.x.org/archives/xorg-announce/2026-July/003718.html
advisory: https://lists.x.org/archives/xorg-announce/2026-July/003716.html

dropping rebuild avoidance from #539439. ~~will need backport only after the 24-hour periodic merge cycle for stable runs.~~ that happened.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
