### PR TITLE
bitcoin: 31.0 -> 31.1

### DIFF
--- a/pkgs/by-name/bi/bitcoin/package.nix
+++ b/pkgs/by-name/bi/bitcoin/package.nix
@@ -28,10 +28,9 @@
   builderKeys ? [
     "152812300785C96444D3334D17565732E08E5E41" # achow101.gpg
     "9EDAFF80E080659604F4A76B2EBB056FD847F8A7" # Emzy.gpg
-    # "6B002C6EA3F91B1B0DF0C9BC8F617F1200A6D25C" # glozow.gpg (not signed 31.0)
     "D1DBF2C4B96F2DEBF4C16654410108112E7EA81F" # hebasto.gpg
-    # "71A3B16735405025D447E8F274810B012346C9A6" # laanwj.gpg (not signed 31.0)
-    "67AA5B46E7AF78053167FE343B8F814A784218F8"
+    # "71A3B16735405025D447E8F274810B012346C9A6" # laanwj.gpg (not signed 31.1)
+    "67AA5B46E7AF78053167FE343B8F814A784218F8" # willcl-ark.gpg
   ],
 }:
 
@@ -47,14 +46,14 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = if withGui then "bitcoin" else "bitcoind";
-  version = "31.0";
+  version = "31.1";
 
   src = fetchurl {
     urls = [
       "https://bitcoincore.org/bin/bitcoin-core-${finalAttrs.version}/bitcoin-${finalAttrs.version}.tar.gz"
     ];
     # hash retrieved from signed SHA256SUMS
-    sha256 = "0ba0ef5eea3aefd96cc1774be274c3d594812cfac0988809d706738bb067b3e3";
+    sha256 = "50411d5b43c7e4c90099394759eb6c2add6e7c2dbe728840893d638b6fc6afc9";
   };
 
   nativeBuildInputs = [
@@ -98,12 +97,12 @@ stdenv.mkDerivation (finalAttrs: {
 
       checksums = fetchurl {
         url = "https://bitcoincore.org/bin/bitcoin-core-${finalAttrs.version}/SHA256SUMS";
-        hash = "sha256-w/4sIOBYR1d/YzzMqwzH6wRHOPQnNg8x7yS96+eWk8g=";
+        hash = "sha256-5jAo0Lsz0iyEdHnXOGa+jBFCJGkRdlwAXvv2EbZF5wY=";
       };
 
       signatures = fetchurl {
         url = "https://bitcoincore.org/bin/bitcoin-core-${finalAttrs.version}/SHA256SUMS.asc";
-        hash = "sha256-hkztGd2fUel7JJbe9RGSfJXGozhb085XvmqPjks96l4=";
+        hash = "sha256-wi4TibZR36L3EDReI/OtxS1OOz2tjteXen4p1VxVmV8=";
       };
 
       verifyBuilderKeys =


### PR DESCRIPTION
https://bitcoincore.org/en/releases/31.1/


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
