### PR TITLE
typescript-go: 0-unstable-2026-06-25 -> 7.0.2

### DIFF
--- a/pkgs/by-name/ty/typescript-go/package.nix
+++ b/pkgs/by-name/ty/typescript-go/package.nix
@@ -3,6 +3,7 @@
   buildGo126Module,
   fetchFromGitHub,
   _experimental-update-script-combinators,
+  versionCheckHook,
   nix-update-script,
   writeShellApplication,
   nix,
@@ -13,19 +14,19 @@
 let
   buildGoModule = buildGo126Module;
 in
-buildGoModule {
+buildGoModule (finalAttrs: {
   pname = "typescript-go";
-  version = "0-unstable-2026-06-25";
+  version = "7.0.2";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "typescript-go";
-    rev = "c080da62e73c5ea066b381303c74ae00b53368ac";
-    hash = "sha256-B8CktiQg+JJKE6Lb19LgpAluXI2+ubo5dikEhQQxDs8=";
+    tag = "typescript/v${finalAttrs.version}";
+    hash = "sha256-fRejdQSwaxSS2pjHrbJO2CQgZS5lWJmBNEM/TgbJTJ8=";
     fetchSubmodules = false;
   };
 
-  vendorHash = "sha256-RKlkRodWH6DaAi1CZziBgIOfzFLm8aih+a0kHNekf5U=";
+  vendorHash = "sha256-q6dMb2ab4uZ3GTrcA7v2JzfmOM+ZzBcJN6gKOpLfM/k=";
 
   ldflags = [
     "-s"
@@ -38,21 +39,21 @@ buildGoModule {
     "cmd/tsgo"
   ];
 
-  doInstallCheck = true;
-  installCheckPhase = ''
-    runHook preInstallCheck
-
-    version="$("$out/bin/tsgo" --version)"
-    [[ "$version" == *"7.0.0"* ]]
-
-    runHook postInstallCheck
+  postInstall = ''
+    ln -s "$out/bin/tsgo" "$out/bin/tsc"
   '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
 
   passthru = {
     updateScript = _experimental-update-script-combinators.sequence [
       (nix-update-script {
         extraArgs = [
-          "--version=branch"
+          "--use-github-releases"
+          "--version-regex=^typescript/v([\\d.]+)$"
           "--src-only"
         ];
       })
@@ -81,10 +82,11 @@ buildGoModule {
   meta = {
     description = "Go implementation of TypeScript";
     homepage = "https://github.com/microsoft/typescript-go";
+    changelog = "https://github.com/microsoft/typescript-go/releases/tag/typescript/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       kachick
     ];
-    mainProgram = "tsgo";
+    mainProgram = "tsc";
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Diff: https://github.com/microsoft/typescript-go/compare/c080da62e73c5ea066b381303c74ae00b53368ac...typescript/v7.0.2
- Changelog: https://github.com/microsoft/typescript-go/releases/tag/typescript/v7.0.2
- Blog: https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
