### PR TITLE
[26.05] vikunja-desktop: fix darwin build, pnpm_10_29_2 -> pnpm_10 

### DIFF
--- a/pkgs/by-name/vi/vikunja-desktop/electron-builder-26.15.3.patch
+++ b/pkgs/by-name/vi/vikunja-desktop/electron-builder-26.15.3.patch
@@ -1,0 +1,3030 @@
+diff --git a/package.json b/package.json
+index cc83217..8664746 100644
+--- a/package.json
++++ b/package.json
+@@ -62,7 +62,7 @@
+   },
+   "devDependencies": {
+     "electron": "40.8.5",
+-    "electron-builder": "26.8.1",
++    "electron-builder": "26.15.3",
+     "unzipper": "0.12.3"
+   },
+   "dependencies": {
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index a35826f..443b8ae 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -22,21 +22,14 @@ importers:
+         specifier: 40.8.5
+         version: 40.8.5
+       electron-builder:
+-        specifier: 26.8.1
+-        version: 26.8.1(electron-builder-squirrel-windows@24.13.3)
++        specifier: 26.15.3
++        version: 26.15.3(electron-builder-squirrel-windows@26.15.3)
+       unzipper:
+         specifier: 0.12.3
+         version: 0.12.3
+ 
+ packages:
+ 
+-  7zip-bin@5.2.0:
+-    resolution: {integrity: sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==}
+-
+-  '@develar/schema-utils@2.6.5':
+-    resolution: {integrity: sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==}
+-    engines: {node: '>= 8.9.0'}
+-
+   '@electron/asar@3.4.1':
+     resolution: {integrity: sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==}
+     engines: {node: '>=10.12.0'}
+@@ -54,49 +47,33 @@ packages:
+     resolution: {integrity: sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==}
+     engines: {node: '>=14'}
+ 
+-  '@electron/notarize@2.2.1':
+-    resolution: {integrity: sha512-aL+bFMIkpR0cmmj5Zgy0LMKEpgy43/hw5zadEArgmAMWWlKc5buwFvFT9G/o/YJkvXAJm5q3iuTuLaiaXW39sg==}
+-    engines: {node: '>= 10.0.0'}
+-
+   '@electron/notarize@2.5.0':
+     resolution: {integrity: sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==}
+     engines: {node: '>= 10.0.0'}
+ 
+-  '@electron/osx-sign@1.0.5':
+-    resolution: {integrity: sha512-k9ZzUQtamSoweGQDV2jILiRIHUu7lYlJ3c6IEmjv1hC17rclE+eb9U+f6UFlOOETo0JzY1HNlXy4YOlCvl+Lww==}
+-    engines: {node: '>=12.0.0'}
+-    hasBin: true
+-
+   '@electron/osx-sign@1.3.3':
+     resolution: {integrity: sha512-KZ8mhXvWv2rIEgMbWZ4y33bDHyUKMXnx4M0sTyPNK/vcB81ImdeY9Ggdqy0SWbMDgmbqyQ+phgejh6V3R2QuSg==}
+     engines: {node: '>=12.0.0'}
+     hasBin: true
+ 
+-  '@electron/rebuild@4.0.3':
+-    resolution: {integrity: sha512-u9vpTHRMkOYCs/1FLiSVAFZ7FbjsXK+bQuzviJZa+lG7BHZl1nz52/IcGvwa3sk80/fc3llutBkbCq10Vh8WQA==}
++  '@electron/rebuild@4.1.0':
++    resolution: {integrity: sha512-GFky+1JeO8fpSqtZCh+2wFRN/MVbAhm7tXI2M7BA1Os79OR8LEoxRtAbRPyxvmKWhEMF/p10rNJkkgP1klI13g==}
+     engines: {node: '>=22.12.0'}
+     hasBin: true
+ 
+-  '@electron/universal@1.5.1':
+-    resolution: {integrity: sha512-kbgXxyEauPJiQQUNG2VgUeyfQNFk6hBF11ISN2PNI6agUgPl55pv4eQmaqHzTAzchBvqZ2tQuRVaPStGf0mxGw==}
+-    engines: {node: '>=8.6'}
+-
+   '@electron/universal@2.0.3':
+     resolution: {integrity: sha512-Wn9sPYIVFRFl5HmwMJkARCCf7rqK/EurkfQ/rJZ14mHP3iYTjZSIOSVonEAnhWeAXwtw7zOekGRlc6yTtZ0t+g==}
+     engines: {node: '>=16.4'}
+ 
+-  '@isaacs/cliui@8.0.2':
+-    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+-    engines: {node: '>=12'}
++  '@electron/windows-sign@1.2.2':
++    resolution: {integrity: sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==}
++    engines: {node: '>=14.14'}
++    hasBin: true
+ 
+   '@isaacs/fs-minipass@4.0.1':
+     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+     engines: {node: '>=18.0.0'}
+ 
+-  '@malept/cross-spawn-promise@1.1.1':
+-    resolution: {integrity: sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==}
+-    engines: {node: '>= 10'}
+-
+   '@malept/cross-spawn-promise@2.0.0':
+     resolution: {integrity: sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==}
+     engines: {node: '>= 12.13.0'}
+@@ -105,17 +82,27 @@ packages:
+     resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
+     engines: {node: '>= 10.0.0'}
+ 
+-  '@npmcli/agent@3.0.0':
+-    resolution: {integrity: sha512-S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q==}
+-    engines: {node: ^18.17.0 || >=20.5.0}
++  '@noble/hashes@1.4.0':
++    resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
++    engines: {node: '>= 16'}
+ 
+-  '@npmcli/fs@4.0.0':
+-    resolution: {integrity: sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==}
+-    engines: {node: ^18.17.0 || >=20.5.0}
++  '@noble/hashes@2.2.0':
++    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
++    engines: {node: '>= 20.19.0'}
+ 
+-  '@pkgjs/parseargs@0.11.0':
+-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+-    engines: {node: '>=14'}
++  '@peculiar/asn1-schema@2.8.0':
++    resolution: {integrity: sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==}
++
++  '@peculiar/json-schema@1.1.12':
++    resolution: {integrity: sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==}
++    engines: {node: '>=8.0.0'}
++
++  '@peculiar/utils@2.0.3':
++    resolution: {integrity: sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==}
++
++  '@peculiar/webcrypto@1.7.1':
++    resolution: {integrity: sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ==}
++    engines: {node: '>=14.18.0'}
+ 
+   '@sindresorhus/is@4.6.0':
+     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
+@@ -125,16 +112,9 @@ packages:
+     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
+     engines: {node: '>=10'}
+ 
+-  '@tootallnate/once@3.0.1':
+-    resolution: {integrity: sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==}
+-    engines: {node: '>= 10'}
+-
+   '@types/cacheable-request@6.0.3':
+     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
+ 
+-  '@types/debug@4.1.12':
+-    resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+-
+   '@types/debug@4.1.13':
+     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+ 
+@@ -147,113 +127,61 @@ packages:
+   '@types/keyv@3.1.4':
+     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
+ 
+-  '@types/ms@0.7.34':
+-    resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
+-
+   '@types/ms@2.1.0':
+     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+ 
+   '@types/node@24.10.9':
+     resolution: {integrity: sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==}
+ 
+-  '@types/plist@3.0.2':
+-    resolution: {integrity: sha512-ULqvZNGMv0zRFvqn8/4LSPtnmN4MfhlPNtJCTpKuIIxGVGZ2rYWzFXrvEBoh9CVyqSE7D6YFRJ1hydLHI6kbWw==}
++  '@types/node@26.1.0':
++    resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
+ 
+   '@types/responselike@1.0.3':
+     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
+ 
+-  '@types/verror@1.10.4':
+-    resolution: {integrity: sha512-OjJdqx6QlbyZw9LShPwRW+Kmiegeg3eWNI41MQQKaG3vjdU2L9SRElntM51HmHBY1cu7izxQJ1lMYioQh3XMBg==}
+-
+   '@types/yauzl@2.10.3':
+     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
+ 
+-  '@xmldom/xmldom@0.8.12':
+-    resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
++  '@xmldom/xmldom@0.8.13':
++    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
+     engines: {node: '>=10.0.0'}
+ 
+-  abbrev@3.0.1:
+-    resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
+-    engines: {node: ^18.17.0 || >=20.5.0}
++  abbrev@4.0.0:
++    resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
++    engines: {node: ^20.17.0 || >=22.9.0}
+ 
+   accepts@2.0.0:
+     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+     engines: {node: '>= 0.6'}
+ 
+-  agent-base@6.0.2:
+-    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+-    engines: {node: '>= 6.0.0'}
+-
+   agent-base@7.1.4:
+     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+     engines: {node: '>= 14'}
+ 
+-  ajv-keywords@3.5.2:
+-    resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
+-    peerDependencies:
+-      ajv: ^6.9.1
+-
+-  ajv@6.14.0:
+-    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
++  ajv@8.20.0:
++    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+ 
+   ansi-regex@5.0.1:
+     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+     engines: {node: '>=8'}
+ 
+-  ansi-regex@6.0.1:
+-    resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
+-    engines: {node: '>=12'}
+-
+   ansi-styles@4.3.0:
+     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+     engines: {node: '>=8'}
+ 
+-  ansi-styles@6.2.1:
+-    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+-    engines: {node: '>=12'}
+-
+-  app-builder-bin@4.0.0:
+-    resolution: {integrity: sha512-xwdG0FJPQMe0M0UA4Tz0zEB8rBJTRA5a476ZawAqiBkMv16GRK5xpXThOjMaEOFnZ6zabejjG4J3da0SXG63KA==}
+-
+-  app-builder-bin@5.0.0-alpha.12:
+-    resolution: {integrity: sha512-j87o0j6LqPL3QRr8yid6c+Tt5gC7xNfYo6uQIQkorAC6MpeayVMZrEDzKmJJ/Hlv7EnOQpaRm53k6ktDYZyB6w==}
+-
+-  app-builder-lib@24.13.3:
+-    resolution: {integrity: sha512-FAzX6IBit2POXYGnTCT8YHFO/lr5AapAII6zzhQO3Rw4cEDOgK+t1xhLc5tNcKlicTHlo9zxIwnYCX9X2DLkig==}
++  app-builder-lib@26.15.3:
++    resolution: {integrity: sha512-2VnyWkqsP5v5XbBhL3tD5Syx8iNPBYsoU7kY4S2fz7wg8Rj/nztWKCUzGKaFRTv0Xwf3/H058CR1Kvtd/3lRow==}
+     engines: {node: '>=14.0.0'}
+     peerDependencies:
+-      dmg-builder: 24.13.3
+-      electron-builder-squirrel-windows: 24.13.3
+-
+-  app-builder-lib@26.8.1:
+-    resolution: {integrity: sha512-p0Im/Dx5C4tmz8QEE1Yn4MkuPC8PrnlRneMhWJj7BBXQfNTJUshM/bp3lusdEsDbvvfJZpXWnYesgSLvwtM2Zw==}
+-    engines: {node: '>=14.0.0'}
+-    peerDependencies:
+-      dmg-builder: 26.8.1
+-      electron-builder-squirrel-windows: 26.8.1
+-
+-  archiver-utils@2.1.0:
+-    resolution: {integrity: sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==}
+-    engines: {node: '>= 6'}
+-
+-  archiver-utils@3.0.4:
+-    resolution: {integrity: sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==}
+-    engines: {node: '>= 10'}
+-
+-  archiver@5.3.2:
+-    resolution: {integrity: sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==}
+-    engines: {node: '>= 10'}
++      dmg-builder: 26.15.3
++      electron-builder-squirrel-windows: 26.15.3
+ 
+   argparse@2.0.1:
+     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+ 
+-  assert-plus@1.0.0:
+-    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
+-    engines: {node: '>=0.8'}
+-
+-  astral-regex@2.0.0:
+-    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
+-    engines: {node: '>=8'}
++  asn1js@3.0.10:
++    resolution: {integrity: sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==}
++    engines: {node: '>=12.0.0'}
+ 
+   async-exit-hook@2.0.1:
+     resolution: {integrity: sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==}
+@@ -269,6 +197,9 @@ packages:
+     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
+     engines: {node: '>= 4.0.0'}
+ 
++  aws4@1.13.2:
++    resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
++
+   balanced-match@4.0.4:
+     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+     engines: {node: 18 || 20 || >=22}
+@@ -276,12 +207,6 @@ packages:
+   base64-js@1.5.1:
+     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+ 
+-  bl@4.1.0:
+-    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+-
+-  bluebird-lst@1.0.9:
+-    resolution: {integrity: sha512-7B1Rtx82hjnSD4PGLAjVWeYH3tHAcVUmChh85a3lltKQm6FresXh9ErQo6oAv6CqxttczC3/kEg8SY5NluPuUw==}
+-
+   bluebird@3.7.2:
+     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
+ 
+@@ -293,44 +218,31 @@ packages:
+     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
+     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+ 
+-  brace-expansion@5.0.5:
+-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
++  brace-expansion@5.0.7:
++    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
+     engines: {node: 18 || 20 || >=22}
+ 
+   buffer-crc32@0.2.13:
+     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+ 
+-  buffer-equal@1.0.1:
+-    resolution: {integrity: sha512-QoV3ptgEaQpvVwbXdSO39iqPQTCxSF7A5U99AxbHYqUdCizL/lH2Z0A2y6nbZucxMEOtNyZfG2s6gsVugGpKkg==}
+-    engines: {node: '>=0.4'}
+-
+   buffer-from@1.1.2:
+     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+ 
+-  buffer@5.7.1:
+-    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+-
+-  builder-util-runtime@9.2.4:
+-    resolution: {integrity: sha512-upp+biKpN/XZMLim7aguUyW8s0FUpDvOtK6sbanMFDAMBzpHDqdhgVYm6zc9HJ6nWo7u2Lxk60i2M6Jd3aiNrA==}
++  builder-util-runtime@9.7.0:
++    resolution: {integrity: sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==}
+     engines: {node: '>=12.0.0'}
+ 
+-  builder-util-runtime@9.5.1:
+-    resolution: {integrity: sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==}
+-    engines: {node: '>=12.0.0'}
+-
+-  builder-util@24.13.1:
+-    resolution: {integrity: sha512-NhbCSIntruNDTOVI9fdXz0dihaqX2YuE1D6zZMrwiErzH4ELZHE6mdiB40wEgZNprDia+FghRFgKoAqMZRRjSA==}
+-
+-  builder-util@26.8.1:
+-    resolution: {integrity: sha512-pm1lTYbGyc90DHgCDO7eo8Rl4EqKLciayNbZqGziqnH9jrlKe8ZANGdityLZU+pJh16dfzjAx2xQq9McuIPEtw==}
++  builder-util@26.15.3:
++    resolution: {integrity: sha512-q2hn7Mbo2nFNkVekPiHFx6Nfo3hURmES3tfBn+k5Pqxl2RkmP3QGqZUhH/q9Pch/4G05NRhPjDlVj1O8q4Txvw==}
++    engines: {node: '>=14.0.0'}
+ 
+   bytes@3.1.2:
+     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+     engines: {node: '>= 0.8'}
+ 
+-  cacache@19.0.1:
+-    resolution: {integrity: sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ==}
+-    engines: {node: ^18.17.0 || >=20.5.0}
++  bytestreamjs@2.0.1:
++    resolution: {integrity: sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==}
++    engines: {node: '>=6.0.0'}
+ 
+   cacheable-lookup@5.0.4:
+     resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
+@@ -359,24 +271,12 @@ packages:
+   chromium-pickle-js@0.2.0:
+     resolution: {integrity: sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==}
+ 
+-  ci-info@3.9.0:
+-    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
+-    engines: {node: '>=8'}
+-
+   ci-info@4.3.1:
+     resolution: {integrity: sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==}
+     engines: {node: '>=8'}
+ 
+-  cli-cursor@3.1.0:
+-    resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
+-    engines: {node: '>=8'}
+-
+-  cli-spinners@2.9.2:
+-    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
+-    engines: {node: '>=6'}
+-
+-  cli-truncate@2.1.0:
+-    resolution: {integrity: sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==}
++  ci-info@4.4.0:
++    resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
+     engines: {node: '>=8'}
+ 
+   cliui@8.0.1:
+@@ -386,10 +286,6 @@ packages:
+   clone-response@1.0.3:
+     resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
+ 
+-  clone@1.0.4:
+-    resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
+-    engines: {node: '>=0.8'}
+-
+   color-convert@2.0.1:
+     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+     engines: {node: '>=7.0.0'}
+@@ -405,17 +301,14 @@ packages:
+     resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
+     engines: {node: '>= 6'}
+ 
++  commander@9.5.0:
++    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
++    engines: {node: ^12.20.0 || >=14}
++
+   compare-version@0.1.2:
+     resolution: {integrity: sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==}
+     engines: {node: '>=0.10.0'}
+ 
+-  compress-commons@4.1.2:
+-    resolution: {integrity: sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==}
+-    engines: {node: '>= 10'}
+-
+-  config-file-ts@0.2.6:
+-    resolution: {integrity: sha512-6boGVaglwblBgJqGyxm4+xCmEGcWgnWHSWHY5jad58awQhB6gftq0G8HbzU39YqCIYHMLAiL1yjwiZ36m/CL8w==}
+-
+   content-disposition@1.0.1:
+     resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+     engines: {node: '>=18'}
+@@ -432,23 +325,11 @@ packages:
+     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+     engines: {node: '>= 0.6'}
+ 
+-  core-util-is@1.0.2:
+-    resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
+-
+   core-util-is@1.0.3:
+     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+ 
+-  crc-32@1.2.2:
+-    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+-    engines: {node: '>=0.8'}
+-    hasBin: true
+-
+-  crc32-stream@4.0.3:
+-    resolution: {integrity: sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==}
+-    engines: {node: '>= 10'}
+-
+-  crc@3.8.0:
+-    resolution: {integrity: sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==}
++  cross-dirname@0.1.0:
++    resolution: {integrity: sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==}
+ 
+   cross-spawn@7.0.6:
+     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+@@ -467,9 +348,6 @@ packages:
+     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+     engines: {node: '>=10'}
+ 
+-  defaults@1.0.4:
+-    resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
+-
+   defer-to-connect@2.0.1:
+     resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
+     engines: {node: '>=10'}
+@@ -490,43 +368,23 @@ packages:
+     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+     engines: {node: '>= 0.8'}
+ 
+-  detect-libc@2.0.3:
+-    resolution: {integrity: sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==}
+-    engines: {node: '>=8'}
+-
+   detect-node@2.1.0:
+     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
+ 
+-  dir-compare@3.3.0:
+-    resolution: {integrity: sha512-J7/et3WlGUCxjdnD3HAAzQ6nsnc0WL6DD7WcwJb7c39iH1+AWfg+9OqzJNaI6PkBwBvm1mhZNL9iY/nRiZXlPg==}
+-
+   dir-compare@4.2.0:
+     resolution: {integrity: sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==}
+ 
+-  dmg-builder@26.8.1:
+-    resolution: {integrity: sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==}
++  dmg-builder@26.15.3:
++    resolution: {integrity: sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==}
+ 
+-  dmg-license@1.0.11:
+-    resolution: {integrity: sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==}
+-    engines: {node: '>=8'}
+-    os: [darwin]
+-    hasBin: true
+-
+-  dotenv-expand@11.0.6:
+-    resolution: {integrity: sha512-8NHi73otpWsZGBSZwwknTXS5pqMOrk9+Ssrna8xCaxkzEpU9OTf9R5ArQGVw03//Zmk9MOwLPng9WwndvpAJ5g==}
++  dotenv-expand@11.0.7:
++    resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
+     engines: {node: '>=12'}
+ 
+-  dotenv-expand@5.1.0:
+-    resolution: {integrity: sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==}
+-
+-  dotenv@16.4.5:
+-    resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
++  dotenv@16.6.1:
++    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+     engines: {node: '>=12'}
+ 
+-  dotenv@9.0.2:
+-    resolution: {integrity: sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg==}
+-    engines: {node: '>=10'}
+-
+   dunder-proto@1.0.1:
+     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+     engines: {node: '>= 0.4'}
+@@ -534,9 +392,6 @@ packages:
+   duplexer2@0.1.4:
+     resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
+ 
+-  eastasianwidth@0.2.0:
+-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+-
+   ee-first@1.1.1:
+     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+ 
+@@ -545,19 +400,20 @@ packages:
+     engines: {node: '>=0.10.0'}
+     hasBin: true
+ 
+-  electron-builder-squirrel-windows@24.13.3:
+-    resolution: {integrity: sha512-oHkV0iogWfyK+ah9ZIvMDpei1m9ZRpdXcvde1wTpra2U8AFDNNpqJdnin5z+PM1GbQ5BoaKCWas2HSjtR0HwMg==}
++  electron-builder-squirrel-windows@26.15.3:
++    resolution: {integrity: sha512-Jc19XPV9y9+2bAdZPkXuVNGNIEFBq9poHC61l8Kv6FdK7DRG3+Ic0rerC0DXOaeHNz8yW0fg/JnF8GQROOF5MA==}
+ 
+-  electron-builder@26.8.1:
+-    resolution: {integrity: sha512-uWhx1r74NGpCagG0ULs/P9Nqv2nsoo+7eo4fLUOB8L8MdWltq9odW/uuLXMFCDGnPafknYLZgjNX0ZIFRzOQAw==}
++  electron-builder@26.15.3:
++    resolution: {integrity: sha512-a1KM5heqS3gQCZzizXEI8RjJy3QVogULPdeSknt76uLDpBIW/HDGsMg/XgP0riP6PI9COsRvFITKKGDqA8fJxA==}
+     engines: {node: '>=14.0.0'}
+     hasBin: true
+ 
+-  electron-publish@24.13.1:
+-    resolution: {integrity: sha512-2ZgdEqJ8e9D17Hwp5LEq5mLQPjqU3lv/IALvgp+4W8VeNhryfGhYEQC/PgDPMrnWUp+l60Ou5SJLsu+k4mhQ8A==}
++  electron-publish@26.15.3:
++    resolution: {integrity: sha512-g/2bn8YTavY4cuS5F+jOS7zmZbXXBV8KZ8yHKfJjFPoKtzBqrpCdNPxBd3tqdBwP7BVd0lGzf7Bk2s0KesWZ4Q==}
+ 
+-  electron-publish@26.8.1:
+-    resolution: {integrity: sha512-q+jrSTIh/Cv4eGZa7oVR+grEJo/FoLMYBAnSL5GCtqwUpr1T+VgKB/dn1pnzxIxqD8S/jP1yilT9VrwCqINR4w==}
++  electron-winstaller@5.4.0:
++    resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
++    engines: {node: '>=8.0.0'}
+ 
+   electron@40.8.5:
+     resolution: {integrity: sha512-pgTY/VPQKaiU4sTjfU96iyxCXrFm4htVPCMRT4b7q9ijNTRgtLmLvcmzp2G4e7xDrq9p7OLHSmu1rBKFf6Y1/A==}
+@@ -567,16 +423,10 @@ packages:
+   emoji-regex@8.0.0:
+     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+ 
+-  emoji-regex@9.2.2:
+-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+-
+   encodeurl@2.0.0:
+     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+     engines: {node: '>= 0.8'}
+ 
+-  encoding@0.1.13:
+-    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
+-
+   end-of-stream@1.4.5:
+     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+ 
+@@ -606,8 +456,8 @@ packages:
+   es6-error@4.1.1:
+     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
+ 
+-  escalade@3.1.2:
+-    resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
++  escalade@3.2.0:
++    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+     engines: {node: '>=6'}
+ 
+   escape-html@1.0.3:
+@@ -633,15 +483,11 @@ packages:
+     engines: {node: '>= 10.17.0'}
+     hasBin: true
+ 
+-  extsprintf@1.4.0:
+-    resolution: {integrity: sha512-6NW8DZ8pWBc5NbGYUiqqccj9dXnuSzilZYqprdKJBZsQodGH9IyUoFOGxIWVDcBzHMb8ET24aqx9p66tZEWZkA==}
+-    engines: {'0': node >=0.6.0}
+-
+   fast-deep-equal@3.1.3:
+     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+ 
+-  fast-json-stable-stringify@2.1.0:
+-    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
++  fast-uri@3.1.3:
++    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+ 
+   fd-slicer@1.1.0:
+     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
+@@ -655,19 +501,15 @@ packages:
+       picomatch:
+         optional: true
+ 
+-  filelist@1.0.4:
+-    resolution: {integrity: sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==}
++  filelist@1.0.6:
++    resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
+ 
+   finalhandler@2.1.1:
+     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+     engines: {node: '>= 18.0.0'}
+ 
+-  foreground-child@3.3.0:
+-    resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
+-    engines: {node: '>=14'}
+-
+-  form-data@4.0.5:
+-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
++  form-data@4.0.6:
++    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
+     engines: {node: '>= 6'}
+ 
+   forwarded@0.2.0:
+@@ -678,9 +520,6 @@ packages:
+     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+     engines: {node: '>= 0.8'}
+ 
+-  fs-constants@1.0.0:
+-    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+-
+   fs-extra@10.1.0:
+     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
+     engines: {node: '>=12'}
+@@ -689,10 +528,14 @@ packages:
+     resolution: {integrity: sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==}
+     engines: {node: '>=14.14'}
+ 
+-  fs-extra@11.3.1:
+-    resolution: {integrity: sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==}
++  fs-extra@11.3.6:
++    resolution: {integrity: sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==}
+     engines: {node: '>=14.14'}
+ 
++  fs-extra@7.0.1:
++    resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
++    engines: {node: '>=6 <7 || >=8'}
++
+   fs-extra@8.1.0:
+     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
+     engines: {node: '>=6 <7 || >=8'}
+@@ -701,10 +544,6 @@ packages:
+     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
+     engines: {node: '>=10'}
+ 
+-  fs-minipass@3.0.3:
+-    resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
+-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+-
+   fs.realpath@1.0.0:
+     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+ 
+@@ -727,11 +566,6 @@ packages:
+     resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+     engines: {node: '>=8'}
+ 
+-  glob@10.5.0:
+-    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+-    hasBin: true
+-
+   glob@7.2.3:
+     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+@@ -774,6 +608,10 @@ packages:
+     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+     engines: {node: '>= 0.4'}
+ 
++  hasown@2.0.4:
++    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
++    engines: {node: '>= 0.4'}
++
+   hosted-git-info@4.1.0:
+     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
+     engines: {node: '>=10'}
+@@ -785,10 +623,6 @@ packages:
+     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+     engines: {node: '>= 0.8'}
+ 
+-  http-proxy-agent@5.0.0:
+-    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
+-    engines: {node: '>= 6'}
+-
+   http-proxy-agent@7.0.2:
+     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+     engines: {node: '>= 14'}
+@@ -797,34 +631,14 @@ packages:
+     resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
+     engines: {node: '>=10.19.0'}
+ 
+-  https-proxy-agent@5.0.1:
+-    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+-    engines: {node: '>= 6'}
+-
+-  https-proxy-agent@7.0.5:
+-    resolution: {integrity: sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==}
++  https-proxy-agent@7.0.6:
++    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+     engines: {node: '>= 14'}
+ 
+-  iconv-corefoundation@1.1.7:
+-    resolution: {integrity: sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==}
+-    engines: {node: ^8.11.2 || >=10}
+-    os: [darwin]
+-
+-  iconv-lite@0.6.3:
+-    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+-    engines: {node: '>=0.10.0'}
+-
+   iconv-lite@0.7.0:
+     resolution: {integrity: sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==}
+     engines: {node: '>=0.10.0'}
+ 
+-  ieee754@1.2.1:
+-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+-
+-  imurmurhash@0.1.4:
+-    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+-    engines: {node: '>=0.8.19'}
+-
+   inflight@1.0.6:
+     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+@@ -832,33 +646,17 @@ packages:
+   inherits@2.0.4:
+     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+ 
+-  ip-address@10.1.0:
+-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+-    engines: {node: '>= 12'}
+-
+   ipaddr.js@1.9.1:
+     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+     engines: {node: '>= 0.10'}
+ 
+-  is-ci@3.0.1:
+-    resolution: {integrity: sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==}
+-    hasBin: true
+-
+   is-fullwidth-code-point@3.0.0:
+     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+     engines: {node: '>=8'}
+ 
+-  is-interactive@1.0.0:
+-    resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
+-    engines: {node: '>=8'}
+-
+   is-promise@4.0.0:
+     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+ 
+-  is-unicode-supported@0.1.0:
+-    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
+-    engines: {node: '>=10'}
+-
+   isarray@1.0.0:
+     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+ 
+@@ -873,31 +671,32 @@ packages:
+   isexe@2.0.0:
+     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+ 
+-  isexe@3.1.1:
+-    resolution: {integrity: sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==}
+-    engines: {node: '>=16'}
++  isexe@3.1.5:
++    resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
++    engines: {node: '>=18'}
+ 
+-  jackspeak@3.4.3:
+-    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
++  isexe@4.0.0:
++    resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
++    engines: {node: '>=20'}
+ 
+-  jake@10.8.7:
+-    resolution: {integrity: sha512-ZDi3aP+fG/LchyBzUM804VjddnwfSfsdeYkwt8NcbKRvo4rFkjhs456iLFn3k2ZUWvNe4i48WACDbza8fhq2+w==}
++  jake@10.9.4:
++    resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
+     engines: {node: '>=10'}
+     hasBin: true
+ 
+-  jiti@2.6.1:
+-    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
++  jiti@2.7.0:
++    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+     hasBin: true
+ 
+-  js-yaml@4.1.1:
+-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
++  js-yaml@4.3.0:
++    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+     hasBin: true
+ 
+   json-buffer@3.0.1:
+     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+ 
+-  json-schema-traverse@0.4.1:
+-    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
++  json-schema-traverse@1.0.0:
++    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+ 
+   json-stringify-safe@5.0.1:
+     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+@@ -913,8 +712,8 @@ packages:
+   jsonfile@6.1.0:
+     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
+ 
+-  jsonfile@6.2.0:
+-    resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
++  jsonfile@6.2.1:
++    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+ 
+   keyv@4.5.4:
+     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+@@ -922,47 +721,17 @@ packages:
+   lazy-val@1.0.5:
+     resolution: {integrity: sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==}
+ 
+-  lazystream@1.0.1:
+-    resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
+-    engines: {node: '>= 0.6.3'}
+-
+-  lodash.defaults@4.2.0:
+-    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+-
+-  lodash.difference@4.5.0:
+-    resolution: {integrity: sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==}
+-
+-  lodash.flatten@4.4.0:
+-    resolution: {integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==}
+-
+-  lodash.isplainobject@4.0.6:
+-    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+-
+-  lodash.union@4.6.0:
+-    resolution: {integrity: sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==}
+-
+   lodash@4.18.1:
+     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+ 
+-  log-symbols@4.1.0:
+-    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
+-    engines: {node: '>=10'}
+-
+   lowercase-keys@2.0.0:
+     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
+     engines: {node: '>=8'}
+ 
+-  lru-cache@10.4.3:
+-    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+-
+   lru-cache@6.0.0:
+     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+     engines: {node: '>=10'}
+ 
+-  make-fetch-happen@14.0.3:
+-    resolution: {integrity: sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==}
+-    engines: {node: ^18.17.0 || >=20.5.0}
+-
+   matcher@3.0.0:
+     resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
+     engines: {node: '>=10'}
+@@ -1000,10 +769,6 @@ packages:
+     engines: {node: '>=4.0.0'}
+     hasBin: true
+ 
+-  mimic-fn@2.1.0:
+-    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+-    engines: {node: '>=6'}
+-
+   mimic-response@1.0.1:
+     resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
+     engines: {node: '>=4'}
+@@ -1012,10 +777,6 @@ packages:
+     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+     engines: {node: '>=10'}
+ 
+-  minimatch@10.2.4:
+-    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
+-    engines: {node: 18 || 20 || >=22}
+-
+   minimatch@10.2.5:
+     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+     engines: {node: 18 || 20 || >=22}
+@@ -1023,34 +784,6 @@ packages:
+   minimist@1.2.8:
+     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+ 
+-  minipass-collect@2.0.1:
+-    resolution: {integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==}
+-    engines: {node: '>=16 || 14 >=14.17'}
+-
+-  minipass-fetch@4.0.1:
+-    resolution: {integrity: sha512-j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ==}
+-    engines: {node: ^18.17.0 || >=20.5.0}
+-
+-  minipass-flush@1.0.5:
+-    resolution: {integrity: sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==}
+-    engines: {node: '>= 8'}
+-
+-  minipass-pipeline@1.2.4:
+-    resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
+-    engines: {node: '>=8'}
+-
+-  minipass-sized@1.0.3:
+-    resolution: {integrity: sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==}
+-    engines: {node: '>=8'}
+-
+-  minipass@3.3.6:
+-    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+-    engines: {node: '>=8'}
+-
+-  minipass@7.1.2:
+-    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+-    engines: {node: '>=16 || 14 >=14.17'}
+-
+   minipass@7.1.3:
+     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+     engines: {node: '>=16 || 14 >=14.17'}
+@@ -1059,6 +792,10 @@ packages:
+     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+     engines: {node: '>= 18'}
+ 
++  mkdirp@0.5.6:
++    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
++    hasBin: true
++
+   ms@2.1.3:
+     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+ 
+@@ -1066,33 +803,26 @@ packages:
+     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+     engines: {node: '>= 0.6'}
+ 
+-  node-abi@4.24.0:
+-    resolution: {integrity: sha512-u2EC1CeNe25uVtX3EZbdQ275c74zdZmmpzrHEQh2aIYqoVjlglfUpOX9YY85x1nlBydEKDVaSmMNhR7N82Qj8A==}
++  node-abi@4.32.0:
++    resolution: {integrity: sha512-2cvOMwK7aQ8eQhHTG9DBK/akKfNaJDwtbxgUaA1u3BHGpd6cbUvWCbA0u3aKan+s7Nl60tMGx4tn11+VS1fiUA==}
+     engines: {node: '>=22.12.0'}
+ 
+-  node-addon-api@1.7.2:
+-    resolution: {integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==}
+-
+   node-api-version@0.2.1:
+     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
+ 
+-  node-gyp@11.5.0:
+-    resolution: {integrity: sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ==}
+-    engines: {node: ^18.17.0 || >=20.5.0}
++  node-gyp@12.4.0:
++    resolution: {integrity: sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==}
++    engines: {node: ^20.17.0 || >=22.9.0}
+     hasBin: true
+ 
+   node-int64@0.4.0:
+     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
+ 
+-  nopt@8.1.0:
+-    resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
+-    engines: {node: ^18.17.0 || >=20.5.0}
++  nopt@9.0.0:
++    resolution: {integrity: sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==}
++    engines: {node: ^20.17.0 || >=22.9.0}
+     hasBin: true
+ 
+-  normalize-path@3.0.0:
+-    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+-    engines: {node: '>=0.10.0'}
+-
+   normalize-url@6.1.0:
+     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
+     engines: {node: '>=10'}
+@@ -1112,14 +842,6 @@ packages:
+   once@1.4.0:
+     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+ 
+-  onetime@5.1.2:
+-    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+-    engines: {node: '>=6'}
+-
+-  ora@5.4.1:
+-    resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
+-    engines: {node: '>=10'}
+-
+   p-cancelable@2.1.1:
+     resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
+     engines: {node: '>=8'}
+@@ -1128,13 +850,6 @@ packages:
+     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+     engines: {node: '>=10'}
+ 
+-  p-map@7.0.4:
+-    resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
+-    engines: {node: '>=18'}
+-
+-  package-json-from-dist@1.0.1:
+-    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+-
+   parseurl@1.3.3:
+     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+     engines: {node: '>= 0.8'}
+@@ -1147,10 +862,6 @@ packages:
+     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+     engines: {node: '>=8'}
+ 
+-  path-scurry@1.11.1:
+-    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+-    engines: {node: '>=16 || 14 >=14.18'}
+-
+   path-to-regexp@8.4.1:
+     resolution: {integrity: sha512-fvU78fIjZ+SBM9YwCknCvKOUKkLVqtWDVctl0s7xIqfmfb38t2TT4ZU2gHm+Z8xGwgW+QWEU3oQSAzIbo89Ggw==}
+ 
+@@ -1161,17 +872,29 @@ packages:
+   pend@1.2.0:
+     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+ 
++  picocolors@1.1.1:
++    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
++
+   picomatch@4.0.4:
+     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+     engines: {node: '>=12'}
+ 
++  pkijs@3.4.0:
++    resolution: {integrity: sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==}
++    engines: {node: '>=16.0.0'}
++
+   plist@3.1.0:
+     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
+     engines: {node: '>=10.4.0'}
+ 
+-  proc-log@5.0.0:
+-    resolution: {integrity: sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==}
+-    engines: {node: ^18.17.0 || >=20.5.0}
++  postject@1.0.0-alpha.6:
++    resolution: {integrity: sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==}
++    engines: {node: '>=14.0.0'}
++    hasBin: true
++
++  proc-log@6.1.0:
++    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
++    engines: {node: ^20.17.0 || >=22.9.0}
+ 
+   process-nextick-args@2.0.1:
+     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+@@ -1194,9 +917,12 @@ packages:
+   pump@3.0.3:
+     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
+ 
+-  punycode@2.3.1:
+-    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+-    engines: {node: '>=6'}
++  pvtsutils@1.3.6:
++    resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
++
++  pvutils@1.1.5:
++    resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
++    engines: {node: '>=16.0.0'}
+ 
+   qs@6.15.0:
+     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+@@ -1218,24 +944,17 @@ packages:
+     resolution: {integrity: sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==}
+     hasBin: true
+ 
+-  read-config-file@6.3.2:
+-    resolution: {integrity: sha512-M80lpCjnE6Wt6zb98DoW8WHR09nzMSpu8XHtPkiTHrJ5Az9CybfeQhTJ8D7saeBHpGhLPIVyA8lcL6ZmdKwY6Q==}
+-    engines: {node: '>=12.0.0'}
+-
+   readable-stream@2.3.8:
+     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+ 
+-  readable-stream@3.6.2:
+-    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+-    engines: {node: '>= 6'}
+-
+-  readdir-glob@1.1.3:
+-    resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
+-
+   require-directory@2.1.1:
+     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+     engines: {node: '>=0.10.0'}
+ 
++  require-from-string@2.0.2:
++    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
++    engines: {node: '>=0.10.0'}
++
+   resedit@1.7.2:
+     resolution: {integrity: sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==}
+     engines: {node: '>=12', npm: '>=6'}
+@@ -1246,14 +965,15 @@ packages:
+   responselike@2.0.1:
+     resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
+ 
+-  restore-cursor@3.1.0:
+-    resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
+-    engines: {node: '>=8'}
+-
+   retry@0.12.0:
+     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+     engines: {node: '>= 4'}
+ 
++  rimraf@2.6.3:
++    resolution: {integrity: sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==}
++    deprecated: Rimraf versions prior to v4 are no longer supported
++    hasBin: true
++
+   roarr@2.15.4:
+     resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
+     engines: {node: '>=8.0'}
+@@ -1265,22 +985,12 @@ packages:
+   safe-buffer@5.1.2:
+     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+ 
+-  safe-buffer@5.2.1:
+-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+-
+   safer-buffer@2.1.2:
+     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+ 
+-  sanitize-filename@1.6.3:
+-    resolution: {integrity: sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==}
+-
+   sanitize-filename@1.6.4:
+     resolution: {integrity: sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==}
+ 
+-  sax@1.4.4:
+-    resolution: {integrity: sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==}
+-    engines: {node: '>=11.0.0'}
+-
+   sax@1.6.0:
+     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
+     engines: {node: '>=11.0.0'}
+@@ -1301,6 +1011,11 @@ packages:
+     engines: {node: '>=10'}
+     hasBin: true
+ 
++  semver@7.8.5:
++    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
++    engines: {node: '>=10'}
++    hasBin: true
++
+   send@1.2.0:
+     resolution: {integrity: sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==}
+     engines: {node: '>= 18'}
+@@ -1343,30 +1058,10 @@ packages:
+   signal-exit@3.0.7:
+     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+ 
+-  signal-exit@4.1.0:
+-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+-    engines: {node: '>=14'}
+-
+   simple-update-notifier@2.0.0:
+     resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
+     engines: {node: '>=10'}
+ 
+-  slice-ansi@3.0.0:
+-    resolution: {integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==}
+-    engines: {node: '>=8'}
+-
+-  smart-buffer@4.2.0:
+-    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+-    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+-
+-  socks-proxy-agent@8.0.5:
+-    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+-    engines: {node: '>= 14'}
+-
+-  socks@2.8.7:
+-    resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
+-    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+-
+   source-map-support@0.5.21:
+     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+ 
+@@ -1377,10 +1072,6 @@ packages:
+   sprintf-js@1.1.3:
+     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+ 
+-  ssri@12.0.0:
+-    resolution: {integrity: sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==}
+-    engines: {node: ^18.17.0 || >=20.5.0}
+-
+   stat-mode@1.0.0:
+     resolution: {integrity: sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==}
+     engines: {node: '>= 6'}
+@@ -1393,24 +1084,13 @@ packages:
+     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+     engines: {node: '>=8'}
+ 
+-  string-width@5.1.2:
+-    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+-    engines: {node: '>=12'}
+-
+   string_decoder@1.1.1:
+     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+ 
+-  string_decoder@1.3.0:
+-    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+-
+   strip-ansi@6.0.1:
+     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+     engines: {node: '>=8'}
+ 
+-  strip-ansi@7.1.0:
+-    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+-    engines: {node: '>=12'}
+-
+   sumchecker@3.0.1:
+     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
+     engines: {node: '>= 8.0'}
+@@ -1419,33 +1099,29 @@ packages:
+     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+     engines: {node: '>=8'}
+ 
+-  tar-stream@2.2.0:
+-    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+-    engines: {node: '>=6'}
+-
+-  tar@7.5.11:
+-    resolution: {integrity: sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==}
+-    engines: {node: '>=18'}
+-
+-  tar@7.5.13:
+-    resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
++  tar@7.5.19:
++    resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
+     engines: {node: '>=18'}
+ 
+   temp-file@3.4.0:
+     resolution: {integrity: sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==}
+ 
++  temp@0.9.4:
++    resolution: {integrity: sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==}
++    engines: {node: '>=6.0.0'}
++
+   tiny-async-pool@1.3.0:
+     resolution: {integrity: sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==}
+ 
+-  tinyglobby@0.2.15:
+-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
++  tinyglobby@0.2.17:
++    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+     engines: {node: '>=12.0.0'}
+ 
+   tmp-promise@3.0.3:
+     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
+ 
+-  tmp@0.2.3:
+-    resolution: {integrity: sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==}
++  tmp@0.2.7:
++    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
+     engines: {node: '>=14.14'}
+ 
+   toidentifier@1.0.1:
+@@ -1455,6 +1131,9 @@ packages:
+   truncate-utf8-bytes@1.0.2:
+     resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
+ 
++  tslib@2.8.1:
++    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
++
+   type-fest@0.13.1:
+     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
+     engines: {node: '>=10'}
+@@ -1463,21 +1142,15 @@ packages:
+     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+     engines: {node: '>= 0.6'}
+ 
+-  typescript@5.9.3:
+-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+-    engines: {node: '>=14.17'}
+-    hasBin: true
+-
+   undici-types@7.16.0:
+     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+ 
+-  unique-filename@4.0.0:
+-    resolution: {integrity: sha512-XSnEewXmQ+veP7xX2dS5Q4yZAvO40cBN2MWkJ7D/6sW4Dg6wYBNwM1Vrnz1FhH5AdeLIlUXRI9e28z1YZi71NQ==}
+-    engines: {node: ^18.17.0 || >=20.5.0}
++  undici-types@8.3.0:
++    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+ 
+-  unique-slug@5.0.0:
+-    resolution: {integrity: sha512-9OdaqO5kwqR+1kVgHAhsp5vPNU0hnxRa26rBFNfNgM7M6pNtgzeBn3s/xbyCQL3dcjzOatcef6UUHpB/6MaETg==}
+-    engines: {node: ^18.17.0 || >=20.5.0}
++  undici@6.27.0:
++    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
++    engines: {node: '>=18.17'}
+ 
+   universalify@0.1.2:
+     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
+@@ -1494,11 +1167,8 @@ packages:
+   unzipper@0.12.3:
+     resolution: {integrity: sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==}
+ 
+-  uri-js@4.4.1:
+-    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+-
+-  utf8-byte-length@1.0.4:
+-    resolution: {integrity: sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA==}
++  utf8-byte-length@1.0.5:
++    resolution: {integrity: sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==}
+ 
+   util-deprecate@1.0.2:
+     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+@@ -1507,12 +1177,8 @@ packages:
+     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+     engines: {node: '>= 0.8'}
+ 
+-  verror@1.10.0:
+-    resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
+-    engines: {'0': node >=0.6.0}
+-
+-  wcwidth@1.0.1:
+-    resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
++  webcrypto-core@1.9.2:
++    resolution: {integrity: sha512-gsXecm82UQNlTBURJGuqOWy1Ww08S3kZUcr3aOJS02Pk0xLtkfeUAVC0u0xhgdonFme80edSJUIJyuvL/7250Q==}
+ 
+   which@2.0.2:
+     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+@@ -1524,14 +1190,15 @@ packages:
+     engines: {node: ^18.17.0 || >=20.5.0}
+     hasBin: true
+ 
++  which@6.0.1:
++    resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
++    engines: {node: ^20.17.0 || >=22.9.0}
++    hasBin: true
++
+   wrap-ansi@7.0.0:
+     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+     engines: {node: '>=10'}
+ 
+-  wrap-ansi@8.1.0:
+-    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+-    engines: {node: '>=12'}
+-
+   wrappy@1.0.2:
+     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+ 
+@@ -1554,8 +1221,8 @@ packages:
+     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+     engines: {node: '>=12'}
+ 
+-  yargs@17.7.2:
+-    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
++  yargs@17.7.3:
++    resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
+     engines: {node: '>=12'}
+ 
+   yauzl@2.10.0:
+@@ -1565,24 +1232,13 @@ packages:
+     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+     engines: {node: '>=10'}
+ 
+-  zip-stream@4.1.1:
+-    resolution: {integrity: sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==}
+-    engines: {node: '>= 10'}
+-
+ snapshots:
+ 
+-  7zip-bin@5.2.0: {}
+-
+-  '@develar/schema-utils@2.6.5':
+-    dependencies:
+-      ajv: 6.14.0
+-      ajv-keywords: 3.5.2(ajv@6.14.0)
+-
+   '@electron/asar@3.4.1':
+     dependencies:
+       commander: 5.1.0
+       glob: 7.2.3
+-      minimatch: 10.2.4
++      minimatch: 10.2.5
+ 
+   '@electron/fuses@1.8.0':
+     dependencies:
+@@ -1618,14 +1274,6 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
+-  '@electron/notarize@2.2.1':
+-    dependencies:
+-      debug: 4.4.3
+-      fs-extra: 9.1.0
+-      promise-retry: 2.0.1
+-    transitivePeerDependencies:
+-      - supports-color
+-
+   '@electron/notarize@2.5.0':
+     dependencies:
+       debug: 4.4.3
+@@ -1634,17 +1282,6 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
+-  '@electron/osx-sign@1.0.5':
+-    dependencies:
+-      compare-version: 0.1.2
+-      debug: 4.4.3
+-      fs-extra: 10.1.0
+-      isbinaryfile: 4.0.10
+-      minimist: 1.2.8
+-      plist: 3.1.0
+-    transitivePeerDependencies:
+-      - supports-color
+-
+   '@electron/osx-sign@1.3.3':
+     dependencies:
+       compare-version: 0.1.2
+@@ -1656,33 +1293,14 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
+-  '@electron/rebuild@4.0.3':
++  '@electron/rebuild@4.1.0':
+     dependencies:
+       '@malept/cross-spawn-promise': 2.0.0
+       debug: 4.4.3
+-      detect-libc: 2.0.3
+-      got: 11.8.6
+-      graceful-fs: 4.2.11
+-      node-abi: 4.24.0
++      node-abi: 4.32.0
+       node-api-version: 0.2.1
+-      node-gyp: 11.5.0
+-      ora: 5.4.1
++      node-gyp: 12.4.0
+       read-binary-file-arch: 1.0.6
+-      semver: 7.7.4
+-      tar: 7.5.11
+-      yargs: 17.7.2
+-    transitivePeerDependencies:
+-      - supports-color
+-
+-  '@electron/universal@1.5.1':
+-    dependencies:
+-      '@electron/asar': 3.4.1
+-      '@malept/cross-spawn-promise': 1.1.1
+-      debug: 4.4.3
+-      dir-compare: 3.3.0
+-      fs-extra: 9.1.0
+-      minimatch: 10.2.5
+-      plist: 3.1.0
+     transitivePeerDependencies:
+       - supports-color
+ 
+@@ -1692,29 +1310,27 @@ snapshots:
+       '@malept/cross-spawn-promise': 2.0.0
+       debug: 4.4.3
+       dir-compare: 4.2.0
+-      fs-extra: 11.3.1
+-      minimatch: 10.2.4
++      fs-extra: 11.3.6
++      minimatch: 10.2.5
+       plist: 3.1.0
+     transitivePeerDependencies:
+       - supports-color
+ 
+-  '@isaacs/cliui@8.0.2':
++  '@electron/windows-sign@1.2.2':
+     dependencies:
+-      string-width: 5.1.2
+-      string-width-cjs: string-width@4.2.3
+-      strip-ansi: 7.1.0
+-      strip-ansi-cjs: strip-ansi@6.0.1
+-      wrap-ansi: 8.1.0
+-      wrap-ansi-cjs: wrap-ansi@7.0.0
++      cross-dirname: 0.1.0
++      debug: 4.4.3
++      fs-extra: 11.3.6
++      minimist: 1.2.8
++      postject: 1.0.0-alpha.6
++    transitivePeerDependencies:
++      - supports-color
++    optional: true
+ 
+   '@isaacs/fs-minipass@4.0.1':
+     dependencies:
+       minipass: 7.1.3
+ 
+-  '@malept/cross-spawn-promise@1.1.1':
+-    dependencies:
+-      cross-spawn: 7.0.6
+-
+   '@malept/cross-spawn-promise@2.0.0':
+     dependencies:
+       cross-spawn: 7.0.6
+@@ -1728,22 +1344,31 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
+-  '@npmcli/agent@3.0.0':
+-    dependencies:
+-      agent-base: 7.1.4
+-      http-proxy-agent: 7.0.2
+-      https-proxy-agent: 7.0.5
+-      lru-cache: 10.4.3
+-      socks-proxy-agent: 8.0.5
+-    transitivePeerDependencies:
+-      - supports-color
++  '@noble/hashes@1.4.0': {}
+ 
+-  '@npmcli/fs@4.0.0':
+-    dependencies:
+-      semver: 7.7.4
++  '@noble/hashes@2.2.0': {}
+ 
+-  '@pkgjs/parseargs@0.11.0':
+-    optional: true
++  '@peculiar/asn1-schema@2.8.0':
++    dependencies:
++      '@peculiar/utils': 2.0.3
++      asn1js: 3.0.10
++      tslib: 2.8.1
++
++  '@peculiar/json-schema@1.1.12':
++    dependencies:
++      tslib: 2.8.1
++
++  '@peculiar/utils@2.0.3':
++    dependencies:
++      tslib: 2.8.1
++
++  '@peculiar/webcrypto@1.7.1':
++    dependencies:
++      '@peculiar/asn1-schema': 2.8.0
++      '@peculiar/json-schema': 1.1.12
++      '@peculiar/utils': 2.0.3
++      tslib: 2.8.1
++      webcrypto-core: 1.9.2
+ 
+   '@sindresorhus/is@4.6.0': {}
+ 
+@@ -1751,8 +1376,6 @@ snapshots:
+     dependencies:
+       defer-to-connect: 2.0.1
+ 
+-  '@tootallnate/once@3.0.1': {}
+-
+   '@types/cacheable-request@6.0.3':
+     dependencies:
+       '@types/http-cache-semantics': 4.0.4
+@@ -1760,17 +1383,13 @@ snapshots:
+       '@types/node': 24.10.9
+       '@types/responselike': 1.0.3
+ 
+-  '@types/debug@4.1.12':
+-    dependencies:
+-      '@types/ms': 0.7.34
+-
+   '@types/debug@4.1.13':
+     dependencies:
+       '@types/ms': 2.1.0
+ 
+   '@types/fs-extra@9.0.13':
+     dependencies:
+-      '@types/node': 24.10.9
++      '@types/node': 26.1.0
+ 
+   '@types/http-cache-semantics@4.0.4': {}
+ 
+@@ -1778,194 +1397,104 @@ snapshots:
+     dependencies:
+       '@types/node': 24.10.9
+ 
+-  '@types/ms@0.7.34': {}
+-
+   '@types/ms@2.1.0': {}
+ 
+   '@types/node@24.10.9':
+     dependencies:
+       undici-types: 7.16.0
+ 
+-  '@types/plist@3.0.2':
++  '@types/node@26.1.0':
+     dependencies:
+-      '@types/node': 24.10.9
+-      xmlbuilder: 15.1.1
+-    optional: true
++      undici-types: 8.3.0
+ 
+   '@types/responselike@1.0.3':
+     dependencies:
+       '@types/node': 24.10.9
+ 
+-  '@types/verror@1.10.4':
+-    optional: true
+-
+   '@types/yauzl@2.10.3':
+     dependencies:
+       '@types/node': 24.10.9
+     optional: true
+ 
+-  '@xmldom/xmldom@0.8.12': {}
++  '@xmldom/xmldom@0.8.13': {}
+ 
+-  abbrev@3.0.1: {}
++  abbrev@4.0.0: {}
+ 
+   accepts@2.0.0:
+     dependencies:
+       mime-types: 3.0.2
+       negotiator: 1.0.0
+ 
+-  agent-base@6.0.2:
+-    dependencies:
+-      debug: 4.4.3
+-    transitivePeerDependencies:
+-      - supports-color
+-
+   agent-base@7.1.4: {}
+ 
+-  ajv-keywords@3.5.2(ajv@6.14.0):
+-    dependencies:
+-      ajv: 6.14.0
+-
+-  ajv@6.14.0:
++  ajv@8.20.0:
+     dependencies:
+       fast-deep-equal: 3.1.3
+-      fast-json-stable-stringify: 2.1.0
+-      json-schema-traverse: 0.4.1
+-      uri-js: 4.4.1
++      fast-uri: 3.1.3
++      json-schema-traverse: 1.0.0
++      require-from-string: 2.0.2
+ 
+   ansi-regex@5.0.1: {}
+ 
+-  ansi-regex@6.0.1: {}
+-
+   ansi-styles@4.3.0:
+     dependencies:
+       color-convert: 2.0.1
+ 
+-  ansi-styles@6.2.1: {}
+-
+-  app-builder-bin@4.0.0: {}
+-
+-  app-builder-bin@5.0.0-alpha.12: {}
+-
+-  app-builder-lib@24.13.3(dmg-builder@26.8.1)(electron-builder-squirrel-windows@24.13.3):
++  app-builder-lib@26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3):
+     dependencies:
+-      '@develar/schema-utils': 2.6.5
+-      '@electron/notarize': 2.2.1
+-      '@electron/osx-sign': 1.0.5
+-      '@electron/universal': 1.5.1
+-      '@malept/flatpak-bundler': 0.4.0
+-      '@types/fs-extra': 9.0.13
+-      async-exit-hook: 2.0.1
+-      bluebird-lst: 1.0.9
+-      builder-util: 24.13.1
+-      builder-util-runtime: 9.2.4
+-      chromium-pickle-js: 0.2.0
+-      debug: 4.4.3
+-      dmg-builder: 26.8.1(electron-builder-squirrel-windows@24.13.3)
+-      ejs: 3.1.10
+-      electron-builder-squirrel-windows: 24.13.3(dmg-builder@26.8.1)
+-      electron-publish: 24.13.1
+-      form-data: 4.0.5
+-      fs-extra: 10.1.0
+-      hosted-git-info: 4.1.0
+-      is-ci: 3.0.1
+-      isbinaryfile: 5.0.7
+-      js-yaml: 4.1.1
+-      lazy-val: 1.0.5
+-      minimatch: 10.2.5
+-      read-config-file: 6.3.2
+-      sanitize-filename: 1.6.4
+-      semver: 7.7.4
+-      tar: 7.5.13
+-      temp-file: 3.4.0
+-    transitivePeerDependencies:
+-      - supports-color
+-
+-  app-builder-lib@26.8.1(dmg-builder@26.8.1)(electron-builder-squirrel-windows@24.13.3):
+-    dependencies:
+-      '@develar/schema-utils': 2.6.5
+       '@electron/asar': 3.4.1
+       '@electron/fuses': 1.8.0
+       '@electron/get': 3.1.0
+       '@electron/notarize': 2.5.0
+       '@electron/osx-sign': 1.3.3
+-      '@electron/rebuild': 4.0.3
++      '@electron/rebuild': 4.1.0
+       '@electron/universal': 2.0.3
+       '@malept/flatpak-bundler': 0.4.0
++      '@noble/hashes': 2.2.0
++      '@peculiar/webcrypto': 1.7.1
+       '@types/fs-extra': 9.0.13
++      ajv: 8.20.0
++      asn1js: 3.0.10
+       async-exit-hook: 2.0.1
+-      builder-util: 26.8.1
+-      builder-util-runtime: 9.5.1
++      builder-util: 26.15.3
++      builder-util-runtime: 9.7.0
+       chromium-pickle-js: 0.2.0
+       ci-info: 4.3.1
+       debug: 4.4.3
+-      dmg-builder: 26.8.1(electron-builder-squirrel-windows@24.13.3)
+-      dotenv: 16.4.5
+-      dotenv-expand: 11.0.6
++      dmg-builder: 26.15.3(electron-builder-squirrel-windows@26.15.3)
++      dotenv: 16.6.1
++      dotenv-expand: 11.0.7
+       ejs: 3.1.10
+-      electron-builder-squirrel-windows: 24.13.3(dmg-builder@26.8.1)
+-      electron-publish: 26.8.1
++      electron-builder-squirrel-windows: 26.15.3(dmg-builder@26.15.3)
++      electron-publish: 26.15.3
+       fs-extra: 10.1.0
+       hosted-git-info: 4.1.0
+       isbinaryfile: 5.0.7
+-      jiti: 2.6.1
+-      js-yaml: 4.1.1
++      jiti: 2.7.0
++      js-yaml: 4.3.0
+       json5: 2.2.3
+       lazy-val: 1.0.5
+-      minimatch: 10.2.4
++      minimatch: 10.2.5
++      pkijs: 3.4.0
+       plist: 3.1.0
+       proper-lockfile: 4.1.2
+       resedit: 1.7.2
+       semver: 7.7.4
+-      tar: 7.5.11
++      tar: 7.5.19
+       temp-file: 3.4.0
+       tiny-async-pool: 1.3.0
++      unzipper: 0.12.3
+       which: 5.0.0
+     transitivePeerDependencies:
+       - supports-color
+ 
+-  archiver-utils@2.1.0:
+-    dependencies:
+-      glob: 7.2.3
+-      graceful-fs: 4.2.11
+-      lazystream: 1.0.1
+-      lodash.defaults: 4.2.0
+-      lodash.difference: 4.5.0
+-      lodash.flatten: 4.4.0
+-      lodash.isplainobject: 4.0.6
+-      lodash.union: 4.6.0
+-      normalize-path: 3.0.0
+-      readable-stream: 2.3.8
+-
+-  archiver-utils@3.0.4:
+-    dependencies:
+-      glob: 7.2.3
+-      graceful-fs: 4.2.11
+-      lazystream: 1.0.1
+-      lodash.defaults: 4.2.0
+-      lodash.difference: 4.5.0
+-      lodash.flatten: 4.4.0
+-      lodash.isplainobject: 4.0.6
+-      lodash.union: 4.6.0
+-      normalize-path: 3.0.0
+-      readable-stream: 3.6.2
+-
+-  archiver@5.3.2:
+-    dependencies:
+-      archiver-utils: 2.1.0
+-      async: 3.2.6
+-      buffer-crc32: 0.2.13
+-      readable-stream: 3.6.2
+-      readdir-glob: 1.1.3
+-      tar-stream: 2.2.0
+-      zip-stream: 4.1.1
+-
+   argparse@2.0.1: {}
+ 
+-  assert-plus@1.0.0:
+-    optional: true
+-
+-  astral-regex@2.0.0:
+-    optional: true
++  asn1js@3.0.10:
++    dependencies:
++      pvtsutils: 1.3.6
++      pvutils: 1.1.5
++      tslib: 2.8.1
+ 
+   async-exit-hook@2.0.1: {}
+ 
+@@ -1975,20 +1504,12 @@ snapshots:
+ 
+   at-least-node@1.0.0: {}
+ 
++  aws4@1.13.2: {}
++
+   balanced-match@4.0.4: {}
+ 
+   base64-js@1.5.1: {}
+ 
+-  bl@4.1.0:
+-    dependencies:
+-      buffer: 5.7.1
+-      inherits: 2.0.4
+-      readable-stream: 3.6.2
+-
+-  bluebird-lst@1.0.9:
+-    dependencies:
+-      bluebird: 3.7.2
+-
+   bluebird@3.7.2: {}
+ 
+   body-parser@2.2.1:
+@@ -2008,70 +1529,33 @@ snapshots:
+   boolean@3.2.0:
+     optional: true
+ 
+-  brace-expansion@5.0.5:
++  brace-expansion@5.0.7:
+     dependencies:
+       balanced-match: 4.0.4
+ 
+   buffer-crc32@0.2.13: {}
+ 
+-  buffer-equal@1.0.1: {}
+-
+   buffer-from@1.1.2: {}
+ 
+-  buffer@5.7.1:
+-    dependencies:
+-      base64-js: 1.5.1
+-      ieee754: 1.2.1
+-
+-  builder-util-runtime@9.2.4:
++  builder-util-runtime@9.7.0:
+     dependencies:
+       debug: 4.4.3
+       sax: 1.6.0
+     transitivePeerDependencies:
+       - supports-color
+ 
+-  builder-util-runtime@9.5.1:
++  builder-util@26.15.3:
+     dependencies:
+-      debug: 4.4.3
+-      sax: 1.4.4
+-    transitivePeerDependencies:
+-      - supports-color
+-
+-  builder-util@24.13.1:
+-    dependencies:
+-      7zip-bin: 5.2.0
+       '@types/debug': 4.1.13
+-      app-builder-bin: 4.0.0
+-      bluebird-lst: 1.0.9
+-      builder-util-runtime: 9.2.4
+-      chalk: 4.1.2
+-      cross-spawn: 7.0.6
+-      debug: 4.4.3
+-      fs-extra: 10.1.0
+-      http-proxy-agent: 5.0.0
+-      https-proxy-agent: 5.0.1
+-      is-ci: 3.0.1
+-      js-yaml: 4.1.1
+-      source-map-support: 0.5.21
+-      stat-mode: 1.0.0
+-      temp-file: 3.4.0
+-    transitivePeerDependencies:
+-      - supports-color
+-
+-  builder-util@26.8.1:
+-    dependencies:
+-      7zip-bin: 5.2.0
+-      '@types/debug': 4.1.12
+-      app-builder-bin: 5.0.0-alpha.12
+-      builder-util-runtime: 9.5.1
++      builder-util-runtime: 9.7.0
+       chalk: 4.1.2
+       cross-spawn: 7.0.6
+       debug: 4.4.3
+       fs-extra: 10.1.0
+       http-proxy-agent: 7.0.2
+-      https-proxy-agent: 7.0.5
+-      js-yaml: 4.1.1
+-      sanitize-filename: 1.6.3
++      https-proxy-agent: 7.0.6
++      js-yaml: 4.3.0
++      sanitize-filename: 1.6.4
+       source-map-support: 0.5.21
+       stat-mode: 1.0.0
+       temp-file: 3.4.0
+@@ -2081,20 +1565,7 @@ snapshots:
+ 
+   bytes@3.1.2: {}
+ 
+-  cacache@19.0.1:
+-    dependencies:
+-      '@npmcli/fs': 4.0.0
+-      fs-minipass: 3.0.3
+-      glob: 10.5.0
+-      lru-cache: 10.4.3
+-      minipass: 7.1.2
+-      minipass-collect: 2.0.1
+-      minipass-flush: 1.0.5
+-      minipass-pipeline: 1.2.4
+-      p-map: 7.0.4
+-      ssri: 12.0.0
+-      tar: 7.5.11
+-      unique-filename: 4.0.0
++  bytestreamjs@2.0.1: {}
+ 
+   cacheable-lookup@5.0.4: {}
+ 
+@@ -2127,21 +1598,9 @@ snapshots:
+ 
+   chromium-pickle-js@0.2.0: {}
+ 
+-  ci-info@3.9.0: {}
+-
+   ci-info@4.3.1: {}
+ 
+-  cli-cursor@3.1.0:
+-    dependencies:
+-      restore-cursor: 3.1.0
+-
+-  cli-spinners@2.9.2: {}
+-
+-  cli-truncate@2.1.0:
+-    dependencies:
+-      slice-ansi: 3.0.0
+-      string-width: 4.2.3
+-    optional: true
++  ci-info@4.4.0: {}
+ 
+   cliui@8.0.1:
+     dependencies:
+@@ -2153,8 +1612,6 @@ snapshots:
+     dependencies:
+       mimic-response: 1.0.1
+ 
+-  clone@1.0.4: {}
+-
+   color-convert@2.0.1:
+     dependencies:
+       color-name: 1.1.4
+@@ -2167,20 +1624,11 @@ snapshots:
+ 
+   commander@5.1.0: {}
+ 
++  commander@9.5.0:
++    optional: true
++
+   compare-version@0.1.2: {}
+ 
+-  compress-commons@4.1.2:
+-    dependencies:
+-      buffer-crc32: 0.2.13
+-      crc32-stream: 4.0.3
+-      normalize-path: 3.0.0
+-      readable-stream: 3.6.2
+-
+-  config-file-ts@0.2.6:
+-    dependencies:
+-      glob: 10.5.0
+-      typescript: 5.9.3
+-
+   content-disposition@1.0.1: {}
+ 
+   content-type@1.0.5: {}
+@@ -2189,21 +1637,9 @@ snapshots:
+ 
+   cookie@0.7.2: {}
+ 
+-  core-util-is@1.0.2:
+-    optional: true
+-
+   core-util-is@1.0.3: {}
+ 
+-  crc-32@1.2.2: {}
+-
+-  crc32-stream@4.0.3:
+-    dependencies:
+-      crc-32: 1.2.2
+-      readable-stream: 3.6.2
+-
+-  crc@3.8.0:
+-    dependencies:
+-      buffer: 5.7.1
++  cross-dirname@0.1.0:
+     optional: true
+ 
+   cross-spawn@7.0.6:
+@@ -2220,10 +1656,6 @@ snapshots:
+     dependencies:
+       mimic-response: 3.1.0
+ 
+-  defaults@1.0.4:
+-    dependencies:
+-      clone: 1.0.4
+-
+   defer-to-connect@2.0.1: {}
+ 
+   define-data-property@1.1.4:
+@@ -2244,55 +1676,29 @@ snapshots:
+ 
+   depd@2.0.0: {}
+ 
+-  detect-libc@2.0.3: {}
+-
+   detect-node@2.1.0:
+     optional: true
+ 
+-  dir-compare@3.3.0:
+-    dependencies:
+-      buffer-equal: 1.0.1
+-      minimatch: 10.2.5
+-
+   dir-compare@4.2.0:
+     dependencies:
+-      minimatch: 10.2.4
++      minimatch: 10.2.5
+       p-limit: 3.1.0
+ 
+-  dmg-builder@26.8.1(electron-builder-squirrel-windows@24.13.3):
++  dmg-builder@26.15.3(electron-builder-squirrel-windows@26.15.3):
+     dependencies:
+-      app-builder-lib: 26.8.1(dmg-builder@26.8.1)(electron-builder-squirrel-windows@24.13.3)
+-      builder-util: 26.8.1
++      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
++      builder-util: 26.15.3
+       fs-extra: 10.1.0
+-      iconv-lite: 0.6.3
+-      js-yaml: 4.1.1
+-    optionalDependencies:
+-      dmg-license: 1.0.11
++      js-yaml: 4.3.0
+     transitivePeerDependencies:
+       - electron-builder-squirrel-windows
+       - supports-color
+ 
+-  dmg-license@1.0.11:
++  dotenv-expand@11.0.7:
+     dependencies:
+-      '@types/plist': 3.0.2
+-      '@types/verror': 1.10.4
+-      ajv: 6.14.0
+-      crc: 3.8.0
+-      iconv-corefoundation: 1.1.7
+-      plist: 3.1.0
+-      smart-buffer: 4.2.0
+-      verror: 1.10.0
+-    optional: true
++      dotenv: 16.6.1
+ 
+-  dotenv-expand@11.0.6:
+-    dependencies:
+-      dotenv: 16.4.5
+-
+-  dotenv-expand@5.1.0: {}
+-
+-  dotenv@16.4.5: {}
+-
+-  dotenv@9.0.2: {}
++  dotenv@16.6.1: {}
+ 
+   dunder-proto@1.0.1:
+     dependencies:
+@@ -2304,62 +1710,60 @@ snapshots:
+     dependencies:
+       readable-stream: 2.3.8
+ 
+-  eastasianwidth@0.2.0: {}
+-
+   ee-first@1.1.1: {}
+ 
+   ejs@3.1.10:
+     dependencies:
+-      jake: 10.8.7
++      jake: 10.9.4
+ 
+-  electron-builder-squirrel-windows@24.13.3(dmg-builder@26.8.1):
++  electron-builder-squirrel-windows@26.15.3(dmg-builder@26.15.3):
+     dependencies:
+-      app-builder-lib: 24.13.3(dmg-builder@26.8.1)(electron-builder-squirrel-windows@24.13.3)
+-      archiver: 5.3.2
+-      builder-util: 24.13.1
+-      fs-extra: 10.1.0
++      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
++      builder-util: 26.15.3
++      electron-winstaller: 5.4.0
+     transitivePeerDependencies:
+       - dmg-builder
+       - supports-color
+ 
+-  electron-builder@26.8.1(electron-builder-squirrel-windows@24.13.3):
++  electron-builder@26.15.3(electron-builder-squirrel-windows@26.15.3):
+     dependencies:
+-      app-builder-lib: 26.8.1(dmg-builder@26.8.1)(electron-builder-squirrel-windows@24.13.3)
+-      builder-util: 26.8.1
+-      builder-util-runtime: 9.5.1
++      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
++      builder-util: 26.15.3
++      builder-util-runtime: 9.7.0
+       chalk: 4.1.2
+-      ci-info: 4.3.1
+-      dmg-builder: 26.8.1(electron-builder-squirrel-windows@24.13.3)
++      ci-info: 4.4.0
++      dmg-builder: 26.15.3(electron-builder-squirrel-windows@26.15.3)
+       fs-extra: 10.1.0
+       lazy-val: 1.0.5
+       simple-update-notifier: 2.0.0
+-      yargs: 17.7.2
++      yargs: 17.7.3
+     transitivePeerDependencies:
+       - electron-builder-squirrel-windows
+       - supports-color
+ 
+-  electron-publish@24.13.1:
++  electron-publish@26.15.3:
+     dependencies:
+       '@types/fs-extra': 9.0.13
+-      builder-util: 24.13.1
+-      builder-util-runtime: 9.2.4
++      aws4: 1.13.2
++      builder-util: 26.15.3
++      builder-util-runtime: 9.7.0
+       chalk: 4.1.2
++      form-data: 4.0.6
+       fs-extra: 10.1.0
+       lazy-val: 1.0.5
+       mime: 2.6.0
+     transitivePeerDependencies:
+       - supports-color
+ 
+-  electron-publish@26.8.1:
++  electron-winstaller@5.4.0:
+     dependencies:
+-      '@types/fs-extra': 9.0.13
+-      builder-util: 26.8.1
+-      builder-util-runtime: 9.5.1
+-      chalk: 4.1.2
+-      form-data: 4.0.5
+-      fs-extra: 10.1.0
+-      lazy-val: 1.0.5
+-      mime: 2.6.0
++      '@electron/asar': 3.4.1
++      debug: 4.4.3
++      fs-extra: 7.0.1
++      lodash: 4.18.1
++      temp: 0.9.4
++    optionalDependencies:
++      '@electron/windows-sign': 1.2.2
+     transitivePeerDependencies:
+       - supports-color
+ 
+@@ -2373,15 +1777,8 @@ snapshots:
+ 
+   emoji-regex@8.0.0: {}
+ 
+-  emoji-regex@9.2.2: {}
+-
+   encodeurl@2.0.0: {}
+ 
+-  encoding@0.1.13:
+-    dependencies:
+-      iconv-lite: 0.6.3
+-    optional: true
+-
+   end-of-stream@1.4.5:
+     dependencies:
+       once: 1.4.0
+@@ -2403,12 +1800,12 @@ snapshots:
+       es-errors: 1.3.0
+       get-intrinsic: 1.3.0
+       has-tostringtag: 1.0.2
+-      hasown: 2.0.2
++      hasown: 2.0.4
+ 
+   es6-error@4.1.1:
+     optional: true
+ 
+-  escalade@3.1.2: {}
++  escalade@3.2.0: {}
+ 
+   escape-html@1.0.3: {}
+ 
+@@ -2462,12 +1859,9 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
+-  extsprintf@1.4.0:
+-    optional: true
+-
+   fast-deep-equal@3.1.3: {}
+ 
+-  fast-json-stable-stringify@2.1.0: {}
++  fast-uri@3.1.3: {}
+ 
+   fd-slicer@1.1.0:
+     dependencies:
+@@ -2477,9 +1871,9 @@ snapshots:
+     optionalDependencies:
+       picomatch: 4.0.4
+ 
+-  filelist@1.0.4:
++  filelist@1.0.6:
+     dependencies:
+-      minimatch: 10.2.4
++      minimatch: 10.2.5
+ 
+   finalhandler@2.1.1:
+     dependencies:
+@@ -2492,29 +1886,22 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
+-  foreground-child@3.3.0:
+-    dependencies:
+-      cross-spawn: 7.0.6
+-      signal-exit: 4.1.0
+-
+-  form-data@4.0.5:
++  form-data@4.0.6:
+     dependencies:
+       asynckit: 0.4.0
+       combined-stream: 1.0.8
+       es-set-tostringtag: 2.1.0
+-      hasown: 2.0.2
++      hasown: 2.0.4
+       mime-types: 2.1.35
+ 
+   forwarded@0.2.0: {}
+ 
+   fresh@2.0.0: {}
+ 
+-  fs-constants@1.0.0: {}
+-
+   fs-extra@10.1.0:
+     dependencies:
+       graceful-fs: 4.2.11
+-      jsonfile: 6.2.0
++      jsonfile: 6.2.1
+       universalify: 2.0.1
+ 
+   fs-extra@11.2.0:
+@@ -2523,12 +1910,18 @@ snapshots:
+       jsonfile: 6.1.0
+       universalify: 2.0.1
+ 
+-  fs-extra@11.3.1:
++  fs-extra@11.3.6:
+     dependencies:
+       graceful-fs: 4.2.11
+-      jsonfile: 6.2.0
++      jsonfile: 6.2.1
+       universalify: 2.0.1
+ 
++  fs-extra@7.0.1:
++    dependencies:
++      graceful-fs: 4.2.11
++      jsonfile: 4.0.0
++      universalify: 0.1.2
++
+   fs-extra@8.1.0:
+     dependencies:
+       graceful-fs: 4.2.11
+@@ -2539,13 +1932,9 @@ snapshots:
+     dependencies:
+       at-least-node: 1.0.0
+       graceful-fs: 4.2.11
+-      jsonfile: 6.2.0
++      jsonfile: 6.2.1
+       universalify: 2.0.1
+ 
+-  fs-minipass@3.0.3:
+-    dependencies:
+-      minipass: 7.1.2
+-
+   fs.realpath@1.0.0: {}
+ 
+   function-bind@1.1.2: {}
+@@ -2574,21 +1963,12 @@ snapshots:
+     dependencies:
+       pump: 3.0.3
+ 
+-  glob@10.5.0:
+-    dependencies:
+-      foreground-child: 3.3.0
+-      jackspeak: 3.4.3
+-      minimatch: 10.2.4
+-      minipass: 7.1.2
+-      package-json-from-dist: 1.0.1
+-      path-scurry: 1.11.1
+-
+   glob@7.2.3:
+     dependencies:
+       fs.realpath: 1.0.0
+       inflight: 1.0.6
+       inherits: 2.0.4
+-      minimatch: 10.2.4
++      minimatch: 10.2.5
+       once: 1.4.0
+       path-is-absolute: 1.0.1
+ 
+@@ -2598,7 +1978,7 @@ snapshots:
+       es6-error: 4.1.1
+       matcher: 3.0.0
+       roarr: 2.15.4
+-      semver: 7.7.4
++      semver: 7.8.5
+       serialize-error: 7.0.1
+     optional: true
+ 
+@@ -2643,6 +2023,10 @@ snapshots:
+     dependencies:
+       function-bind: 1.1.2
+ 
++  hasown@2.0.4:
++    dependencies:
++      function-bind: 1.1.2
++
+   hosted-git-info@4.1.0:
+     dependencies:
+       lru-cache: 6.0.0
+@@ -2657,14 +2041,6 @@ snapshots:
+       statuses: 2.0.2
+       toidentifier: 1.0.1
+ 
+-  http-proxy-agent@5.0.0:
+-    dependencies:
+-      '@tootallnate/once': 3.0.1
+-      agent-base: 6.0.2
+-      debug: 4.4.3
+-    transitivePeerDependencies:
+-      - supports-color
+-
+   http-proxy-agent@7.0.2:
+     dependencies:
+       agent-base: 7.1.4
+@@ -2677,38 +2053,17 @@ snapshots:
+       quick-lru: 5.1.1
+       resolve-alpn: 1.2.1
+ 
+-  https-proxy-agent@5.0.1:
+-    dependencies:
+-      agent-base: 6.0.2
+-      debug: 4.4.3
+-    transitivePeerDependencies:
+-      - supports-color
+-
+-  https-proxy-agent@7.0.5:
++  https-proxy-agent@7.0.6:
+     dependencies:
+       agent-base: 7.1.4
+       debug: 4.4.3
+     transitivePeerDependencies:
+       - supports-color
+ 
+-  iconv-corefoundation@1.1.7:
+-    dependencies:
+-      cli-truncate: 2.1.0
+-      node-addon-api: 1.7.2
+-    optional: true
+-
+-  iconv-lite@0.6.3:
+-    dependencies:
+-      safer-buffer: 2.1.2
+-
+   iconv-lite@0.7.0:
+     dependencies:
+       safer-buffer: 2.1.2
+ 
+-  ieee754@1.2.1: {}
+-
+-  imurmurhash@0.1.4: {}
+-
+   inflight@1.0.6:
+     dependencies:
+       once: 1.4.0
+@@ -2716,22 +2071,12 @@ snapshots:
+ 
+   inherits@2.0.4: {}
+ 
+-  ip-address@10.1.0: {}
+-
+   ipaddr.js@1.9.1: {}
+ 
+-  is-ci@3.0.1:
+-    dependencies:
+-      ci-info: 3.9.0
+-
+   is-fullwidth-code-point@3.0.0: {}
+ 
+-  is-interactive@1.0.0: {}
+-
+   is-promise@4.0.0: {}
+ 
+-  is-unicode-supported@0.1.0: {}
+-
+   isarray@1.0.0: {}
+ 
+   isbinaryfile@4.0.10: {}
+@@ -2740,30 +2085,25 @@ snapshots:
+ 
+   isexe@2.0.0: {}
+ 
+-  isexe@3.1.1: {}
++  isexe@3.1.5: {}
+ 
+-  jackspeak@3.4.3:
+-    dependencies:
+-      '@isaacs/cliui': 8.0.2
+-    optionalDependencies:
+-      '@pkgjs/parseargs': 0.11.0
++  isexe@4.0.0: {}
+ 
+-  jake@10.8.7:
++  jake@10.9.4:
+     dependencies:
+       async: 3.2.6
+-      chalk: 4.1.2
+-      filelist: 1.0.4
+-      minimatch: 10.2.4
++      filelist: 1.0.6
++      picocolors: 1.1.1
+ 
+-  jiti@2.6.1: {}
++  jiti@2.7.0: {}
+ 
+-  js-yaml@4.1.1:
++  js-yaml@4.3.0:
+     dependencies:
+       argparse: 2.0.1
+ 
+   json-buffer@3.0.1: {}
+ 
+-  json-schema-traverse@0.4.1: {}
++  json-schema-traverse@1.0.0: {}
+ 
+   json-stringify-safe@5.0.1:
+     optional: true
+@@ -2780,7 +2120,7 @@ snapshots:
+     optionalDependencies:
+       graceful-fs: 4.2.11
+ 
+-  jsonfile@6.2.0:
++  jsonfile@6.2.1:
+     dependencies:
+       universalify: 2.0.1
+     optionalDependencies:
+@@ -2792,51 +2132,14 @@ snapshots:
+ 
+   lazy-val@1.0.5: {}
+ 
+-  lazystream@1.0.1:
+-    dependencies:
+-      readable-stream: 2.3.8
+-
+-  lodash.defaults@4.2.0: {}
+-
+-  lodash.difference@4.5.0: {}
+-
+-  lodash.flatten@4.4.0: {}
+-
+-  lodash.isplainobject@4.0.6: {}
+-
+-  lodash.union@4.6.0: {}
+-
+   lodash@4.18.1: {}
+ 
+-  log-symbols@4.1.0:
+-    dependencies:
+-      chalk: 4.1.2
+-      is-unicode-supported: 0.1.0
+-
+   lowercase-keys@2.0.0: {}
+ 
+-  lru-cache@10.4.3: {}
+-
+   lru-cache@6.0.0:
+     dependencies:
+       yallist: 4.0.0
+ 
+-  make-fetch-happen@14.0.3:
+-    dependencies:
+-      '@npmcli/agent': 3.0.0
+-      cacache: 19.0.1
+-      http-cache-semantics: 4.2.0
+-      minipass: 7.1.2
+-      minipass-fetch: 4.0.1
+-      minipass-flush: 1.0.5
+-      minipass-pipeline: 1.2.4
+-      negotiator: 1.0.0
+-      proc-log: 5.0.0
+-      promise-retry: 2.0.1
+-      ssri: 12.0.0
+-    transitivePeerDependencies:
+-      - supports-color
+-
+   matcher@3.0.0:
+     dependencies:
+       escape-string-regexp: 4.0.0
+@@ -2862,95 +2165,56 @@ snapshots:
+ 
+   mime@2.6.0: {}
+ 
+-  mimic-fn@2.1.0: {}
+-
+   mimic-response@1.0.1: {}
+ 
+   mimic-response@3.1.0: {}
+ 
+-  minimatch@10.2.4:
+-    dependencies:
+-      brace-expansion: 5.0.5
+-
+   minimatch@10.2.5:
+     dependencies:
+-      brace-expansion: 5.0.5
++      brace-expansion: 5.0.7
+ 
+   minimist@1.2.8: {}
+ 
+-  minipass-collect@2.0.1:
+-    dependencies:
+-      minipass: 7.1.2
+-
+-  minipass-fetch@4.0.1:
+-    dependencies:
+-      minipass: 7.1.2
+-      minipass-sized: 1.0.3
+-      minizlib: 3.1.0
+-    optionalDependencies:
+-      encoding: 0.1.13
+-
+-  minipass-flush@1.0.5:
+-    dependencies:
+-      minipass: 3.3.6
+-
+-  minipass-pipeline@1.2.4:
+-    dependencies:
+-      minipass: 3.3.6
+-
+-  minipass-sized@1.0.3:
+-    dependencies:
+-      minipass: 3.3.6
+-
+-  minipass@3.3.6:
+-    dependencies:
+-      yallist: 4.0.0
+-
+-  minipass@7.1.2: {}
+-
+   minipass@7.1.3: {}
+ 
+   minizlib@3.1.0:
+     dependencies:
+       minipass: 7.1.3
+ 
++  mkdirp@0.5.6:
++    dependencies:
++      minimist: 1.2.8
++
+   ms@2.1.3: {}
+ 
+   negotiator@1.0.0: {}
+ 
+-  node-abi@4.24.0:
++  node-abi@4.32.0:
+     dependencies:
+       semver: 7.7.4
+ 
+-  node-addon-api@1.7.2:
+-    optional: true
+-
+   node-api-version@0.2.1:
+     dependencies:
+       semver: 7.7.4
+ 
+-  node-gyp@11.5.0:
++  node-gyp@12.4.0:
+     dependencies:
+       env-paths: 2.2.1
+       exponential-backoff: 3.1.3
+       graceful-fs: 4.2.11
+-      make-fetch-happen: 14.0.3
+-      nopt: 8.1.0
+-      proc-log: 5.0.0
++      nopt: 9.0.0
++      proc-log: 6.1.0
+       semver: 7.7.4
+-      tar: 7.5.11
+-      tinyglobby: 0.2.15
+-      which: 5.0.0
+-    transitivePeerDependencies:
+-      - supports-color
++      tar: 7.5.19
++      tinyglobby: 0.2.17
++      undici: 6.27.0
++      which: 6.0.1
+ 
+   node-int64@0.4.0: {}
+ 
+-  nopt@8.1.0:
++  nopt@9.0.0:
+     dependencies:
+-      abbrev: 3.0.1
+-
+-  normalize-path@3.0.0: {}
++      abbrev: 4.0.0
+ 
+   normalize-url@6.1.0: {}
+ 
+@@ -2967,58 +2231,49 @@ snapshots:
+     dependencies:
+       wrappy: 1.0.2
+ 
+-  onetime@5.1.2:
+-    dependencies:
+-      mimic-fn: 2.1.0
+-
+-  ora@5.4.1:
+-    dependencies:
+-      bl: 4.1.0
+-      chalk: 4.1.2
+-      cli-cursor: 3.1.0
+-      cli-spinners: 2.9.2
+-      is-interactive: 1.0.0
+-      is-unicode-supported: 0.1.0
+-      log-symbols: 4.1.0
+-      strip-ansi: 6.0.1
+-      wcwidth: 1.0.1
+-
+   p-cancelable@2.1.1: {}
+ 
+   p-limit@3.1.0:
+     dependencies:
+       yocto-queue: 0.1.0
+ 
+-  p-map@7.0.4: {}
+-
+-  package-json-from-dist@1.0.1: {}
+-
+   parseurl@1.3.3: {}
+ 
+   path-is-absolute@1.0.1: {}
+ 
+   path-key@3.1.1: {}
+ 
+-  path-scurry@1.11.1:
+-    dependencies:
+-      lru-cache: 10.4.3
+-      minipass: 7.1.2
+-
+   path-to-regexp@8.4.1: {}
+ 
+   pe-library@0.4.1: {}
+ 
+   pend@1.2.0: {}
+ 
++  picocolors@1.1.1: {}
++
+   picomatch@4.0.4: {}
+ 
++  pkijs@3.4.0:
++    dependencies:
++      '@noble/hashes': 1.4.0
++      asn1js: 3.0.10
++      bytestreamjs: 2.0.1
++      pvtsutils: 1.3.6
++      pvutils: 1.1.5
++      tslib: 2.8.1
++
+   plist@3.1.0:
+     dependencies:
+-      '@xmldom/xmldom': 0.8.12
++      '@xmldom/xmldom': 0.8.13
+       base64-js: 1.5.1
+       xmlbuilder: 15.1.1
+ 
+-  proc-log@5.0.0: {}
++  postject@1.0.0-alpha.6:
++    dependencies:
++      commander: 9.5.0
++    optional: true
++
++  proc-log@6.1.0: {}
+ 
+   process-nextick-args@2.0.1: {}
+ 
+@@ -3045,7 +2300,11 @@ snapshots:
+       end-of-stream: 1.4.5
+       once: 1.4.0
+ 
+-  punycode@2.3.1: {}
++  pvtsutils@1.3.6:
++    dependencies:
++      tslib: 2.8.1
++
++  pvutils@1.1.5: {}
+ 
+   qs@6.15.0:
+     dependencies:
+@@ -3068,15 +2327,6 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
+-  read-config-file@6.3.2:
+-    dependencies:
+-      config-file-ts: 0.2.6
+-      dotenv: 9.0.2
+-      dotenv-expand: 5.1.0
+-      js-yaml: 4.1.1
+-      json5: 2.2.3
+-      lazy-val: 1.0.5
+-
+   readable-stream@2.3.8:
+     dependencies:
+       core-util-is: 1.0.3
+@@ -3087,18 +2337,10 @@ snapshots:
+       string_decoder: 1.1.1
+       util-deprecate: 1.0.2
+ 
+-  readable-stream@3.6.2:
+-    dependencies:
+-      inherits: 2.0.4
+-      string_decoder: 1.3.0
+-      util-deprecate: 1.0.2
+-
+-  readdir-glob@1.1.3:
+-    dependencies:
+-      minimatch: 10.2.5
+-
+   require-directory@2.1.1: {}
+ 
++  require-from-string@2.0.2: {}
++
+   resedit@1.7.2:
+     dependencies:
+       pe-library: 0.4.1
+@@ -3109,13 +2351,12 @@ snapshots:
+     dependencies:
+       lowercase-keys: 2.0.0
+ 
+-  restore-cursor@3.1.0:
+-    dependencies:
+-      onetime: 5.1.2
+-      signal-exit: 3.0.7
+-
+   retry@0.12.0: {}
+ 
++  rimraf@2.6.3:
++    dependencies:
++      glob: 7.2.3
++
+   roarr@2.15.4:
+     dependencies:
+       boolean: 3.2.0
+@@ -3138,20 +2379,12 @@ snapshots:
+ 
+   safe-buffer@5.1.2: {}
+ 
+-  safe-buffer@5.2.1: {}
+-
+   safer-buffer@2.1.2: {}
+ 
+-  sanitize-filename@1.6.3:
+-    dependencies:
+-      truncate-utf8-bytes: 1.0.2
+-
+   sanitize-filename@1.6.4:
+     dependencies:
+       truncate-utf8-bytes: 1.0.2
+ 
+-  sax@1.4.4: {}
+-
+   sax@1.6.0: {}
+ 
+   semver-compare@1.0.0:
+@@ -3163,6 +2396,8 @@ snapshots:
+ 
+   semver@7.7.4: {}
+ 
++  semver@7.8.5: {}
++
+   send@1.2.0:
+     dependencies:
+       debug: 4.4.3
+@@ -3231,33 +2466,9 @@ snapshots:
+ 
+   signal-exit@3.0.7: {}
+ 
+-  signal-exit@4.1.0: {}
+-
+   simple-update-notifier@2.0.0:
+     dependencies:
+-      semver: 7.7.4
+-
+-  slice-ansi@3.0.0:
+-    dependencies:
+-      ansi-styles: 4.3.0
+-      astral-regex: 2.0.0
+-      is-fullwidth-code-point: 3.0.0
+-    optional: true
+-
+-  smart-buffer@4.2.0: {}
+-
+-  socks-proxy-agent@8.0.5:
+-    dependencies:
+-      agent-base: 7.1.4
+-      debug: 4.4.3
+-      socks: 2.8.7
+-    transitivePeerDependencies:
+-      - supports-color
+-
+-  socks@2.8.7:
+-    dependencies:
+-      ip-address: 10.1.0
+-      smart-buffer: 4.2.0
++      semver: 7.8.5
+ 
+   source-map-support@0.5.21:
+     dependencies:
+@@ -3269,10 +2480,6 @@ snapshots:
+   sprintf-js@1.1.3:
+     optional: true
+ 
+-  ssri@12.0.0:
+-    dependencies:
+-      minipass: 7.1.2
+-
+   stat-mode@1.0.0: {}
+ 
+   statuses@2.0.2: {}
+@@ -3283,28 +2490,14 @@ snapshots:
+       is-fullwidth-code-point: 3.0.0
+       strip-ansi: 6.0.1
+ 
+-  string-width@5.1.2:
+-    dependencies:
+-      eastasianwidth: 0.2.0
+-      emoji-regex: 9.2.2
+-      strip-ansi: 7.1.0
+-
+   string_decoder@1.1.1:
+     dependencies:
+       safe-buffer: 5.1.2
+ 
+-  string_decoder@1.3.0:
+-    dependencies:
+-      safe-buffer: 5.2.1
+-
+   strip-ansi@6.0.1:
+     dependencies:
+       ansi-regex: 5.0.1
+ 
+-  strip-ansi@7.1.0:
+-    dependencies:
+-      ansi-regex: 6.0.1
+-
+   sumchecker@3.0.1:
+     dependencies:
+       debug: 4.4.3
+@@ -3315,23 +2508,7 @@ snapshots:
+     dependencies:
+       has-flag: 4.0.0
+ 
+-  tar-stream@2.2.0:
+-    dependencies:
+-      bl: 4.1.0
+-      end-of-stream: 1.4.5
+-      fs-constants: 1.0.0
+-      inherits: 2.0.4
+-      readable-stream: 3.6.2
+-
+-  tar@7.5.11:
+-    dependencies:
+-      '@isaacs/fs-minipass': 4.0.1
+-      chownr: 3.0.0
+-      minipass: 7.1.3
+-      minizlib: 3.1.0
+-      yallist: 5.0.0
+-
+-  tar@7.5.13:
++  tar@7.5.19:
+     dependencies:
+       '@isaacs/fs-minipass': 4.0.1
+       chownr: 3.0.0
+@@ -3344,26 +2521,33 @@ snapshots:
+       async-exit-hook: 2.0.1
+       fs-extra: 10.1.0
+ 
++  temp@0.9.4:
++    dependencies:
++      mkdirp: 0.5.6
++      rimraf: 2.6.3
++
+   tiny-async-pool@1.3.0:
+     dependencies:
+       semver: 5.7.2
+ 
+-  tinyglobby@0.2.15:
++  tinyglobby@0.2.17:
+     dependencies:
+       fdir: 6.5.0(picomatch@4.0.4)
+       picomatch: 4.0.4
+ 
+   tmp-promise@3.0.3:
+     dependencies:
+-      tmp: 0.2.3
++      tmp: 0.2.7
+ 
+-  tmp@0.2.3: {}
++  tmp@0.2.7: {}
+ 
+   toidentifier@1.0.1: {}
+ 
+   truncate-utf8-bytes@1.0.2:
+     dependencies:
+-      utf8-byte-length: 1.0.4
++      utf8-byte-length: 1.0.5
++
++  tslib@2.8.1: {}
+ 
+   type-fest@0.13.1:
+     optional: true
+@@ -3374,17 +2558,11 @@ snapshots:
+       media-typer: 1.1.0
+       mime-types: 3.0.2
+ 
+-  typescript@5.9.3: {}
+-
+   undici-types@7.16.0: {}
+ 
+-  unique-filename@4.0.0:
+-    dependencies:
+-      unique-slug: 5.0.0
++  undici-types@8.3.0: {}
+ 
+-  unique-slug@5.0.0:
+-    dependencies:
+-      imurmurhash: 0.1.4
++  undici@6.27.0: {}
+ 
+   universalify@0.1.2: {}
+ 
+@@ -3400,26 +2578,19 @@ snapshots:
+       graceful-fs: 4.2.11
+       node-int64: 0.4.0
+ 
+-  uri-js@4.4.1:
+-    dependencies:
+-      punycode: 2.3.1
+-
+-  utf8-byte-length@1.0.4: {}
++  utf8-byte-length@1.0.5: {}
+ 
+   util-deprecate@1.0.2: {}
+ 
+   vary@1.1.2: {}
+ 
+-  verror@1.10.0:
++  webcrypto-core@1.9.2:
+     dependencies:
+-      assert-plus: 1.0.0
+-      core-util-is: 1.0.2
+-      extsprintf: 1.4.0
+-    optional: true
+-
+-  wcwidth@1.0.1:
+-    dependencies:
+-      defaults: 1.0.4
++      '@peculiar/asn1-schema': 2.8.0
++      '@peculiar/json-schema': 1.1.12
++      '@peculiar/utils': 2.0.3
++      asn1js: 3.0.10
++      tslib: 2.8.1
+ 
+   which@2.0.2:
+     dependencies:
+@@ -3427,7 +2598,11 @@ snapshots:
+ 
+   which@5.0.0:
+     dependencies:
+-      isexe: 3.1.1
++      isexe: 3.1.5
++
++  which@6.0.1:
++    dependencies:
++      isexe: 4.0.0
+ 
+   wrap-ansi@7.0.0:
+     dependencies:
+@@ -3435,12 +2610,6 @@ snapshots:
+       string-width: 4.2.3
+       strip-ansi: 6.0.1
+ 
+-  wrap-ansi@8.1.0:
+-    dependencies:
+-      ansi-styles: 6.2.1
+-      string-width: 5.1.2
+-      strip-ansi: 7.1.0
+-
+   wrappy@1.0.2: {}
+ 
+   xmlbuilder@15.1.1: {}
+@@ -3453,10 +2622,10 @@ snapshots:
+ 
+   yargs-parser@21.1.1: {}
+ 
+-  yargs@17.7.2:
++  yargs@17.7.3:
+     dependencies:
+       cliui: 8.0.1
+-      escalade: 3.1.2
++      escalade: 3.2.0
+       get-caller-file: 2.0.5
+       require-directory: 2.1.1
+       string-width: 4.2.3
+@@ -3469,9 +2638,3 @@ snapshots:
+       fd-slicer: 1.1.0
+ 
+   yocto-queue@0.1.0: {}
+-
+-  zip-stream@4.1.1:
+-    dependencies:
+-      archiver-utils: 3.0.4
+-      compress-commons: 4.1.2
+-      readable-stream: 3.6.2

--- a/pkgs/by-name/vi/vikunja-desktop/package.nix
+++ b/pkgs/by-name/vi/vikunja-desktop/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   makeWrapper,
   makeDesktopItem,
+  darwin,
   pnpm_10_29_2,
   pnpmConfigHook,
   nodejs,
@@ -52,6 +53,9 @@ stdenv.mkDerivation (finalAttrs: {
     pnpm_10_29_2
     pnpmConfigHook
     vikunja.passthru.frontend
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    darwin.autoSignDarwinBinariesHook
   ];
 
   buildPhase = ''
@@ -60,7 +64,18 @@ stdenv.mkDerivation (finalAttrs: {
     sed -i "s/\$${version}/${version}/g" package.json
     sed -i "s/\"version\": \".*\"/\"version\": \"${version}\"/" package.json
     ln -s '${vikunja.passthru.frontend}' frontend
-    pnpm run pack -c.electronDist="${electron.dist}" -c.electronVersion="${electron.version}"
+
+    electronDist="${electron.dist}"
+    ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+      electronDist="$(mktemp -d)"
+      cp -R "${electron.dist}/." "$electronDist"
+      chmod -R u+w "$electronDist"
+      export CSC_IDENTITY_AUTO_DISCOVERY=false
+    ''}
+    pnpm run pack \
+      -c.electronDist="$electronDist" \
+      -c.electronVersion="${electron.version}" \
+      ${lib.optionalString stdenv.hostPlatform.isDarwin "-c.mac.identity=null"}
 
     runHook postBuild
   '';
@@ -70,20 +85,30 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p "$out/share/lib/vikunja-desktop"
-    cp -r ./dist/*-unpacked/{locales,resources{,.pak}} "$out/share/lib/vikunja-desktop"
-    cp -r ./node_modules "$out/share/lib/vikunja-desktop/resources"
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      mkdir -p "$out/share/lib/vikunja-desktop"
+      cp -r ./dist/*-unpacked/{locales,resources{,.pak}} "$out/share/lib/vikunja-desktop"
+      cp -r ./node_modules "$out/share/lib/vikunja-desktop/resources"
 
-    install -Dm644 "build/icon.png" "$out/share/icons/hicolor/256x256/apps/vikunja-desktop.png"
+      install -Dm644 "build/icon.png" "$out/share/icons/hicolor/256x256/apps/vikunja-desktop.png"
 
-    # use makeShellWrapper (instead of the makeBinaryWrapper provided by wrapGAppsHook3) for proper shell variable expansion
-    # see https://github.com/NixOS/nixpkgs/issues/172583
-    makeShellWrapper "${lib.getExe electron}" "$out/bin/vikunja-desktop" \
-      --add-flags "$out/share/lib/vikunja-desktop/resources/app.asar" \
-      "''${gappsWrapperArgs[@]}" \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=UseOzonePlatform,WaylandWindowDecorations,WebRTCPipeWireCapturer}}" \
-      --set-default ELECTRON_IS_DEV 0 \
-      --inherit-argv0
+      # use makeShellWrapper (instead of the makeBinaryWrapper provided by wrapGAppsHook3) for proper shell variable expansion
+      # see https://github.com/NixOS/nixpkgs/issues/172583
+      makeShellWrapper "${lib.getExe electron}" "$out/bin/vikunja-desktop" \
+        --add-flags "$out/share/lib/vikunja-desktop/resources/app.asar" \
+        "''${gappsWrapperArgs[@]}" \
+        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=UseOzonePlatform,WaylandWindowDecorations,WebRTCPipeWireCapturer}}" \
+        --set-default ELECTRON_IS_DEV 0 \
+        --inherit-argv0
+    ''}
+
+    ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+      mkdir -p "$out/Applications" "$out/bin"
+      mv ./dist/mac*/*.app "$out/Applications"
+      makeWrapper \
+        "$out/Applications/Vikunja Desktop.app/Contents/MacOS/Vikunja Desktop" \
+        "$out/bin/vikunja-desktop"
+    ''}
 
     runHook postInstall
   '';

--- a/pkgs/by-name/vi/vikunja-desktop/package.nix
+++ b/pkgs/by-name/vi/vikunja-desktop/package.nix
@@ -4,7 +4,7 @@
   makeWrapper,
   makeDesktopItem,
   darwin,
-  pnpm_10_29_2,
+  pnpm_10,
   pnpmConfigHook,
   nodejs,
   electron,
@@ -37,11 +37,19 @@ stdenv.mkDerivation (finalAttrs: {
       version
       src
       sourceRoot
+      patches
       ;
-    pnpm = pnpm_10_29_2;
-    fetcherVersion = 3;
-    hash = "sha256-phvNUUYh858CDt0O8GCWkgO402C0wiYtzEorOIV789M=";
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-2jyb5BYEkopZCbS19flUgCopiJWngyFxkXsyMuOpJEU=";
   };
+
+  patches = [
+    # pnpm 10.29.3 changed `pnpm ls --json`; older electron-builder omits runtime deps.
+    # This patch was generated from the v2.3.0 lockfile with pnpm_10, using the
+    # electron-builder 26.15.3 version already present in upstream main.
+    ./electron-builder-26.15.3.patch
+  ];
 
   env = {
     ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
@@ -50,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     makeWrapper
     nodejs
-    pnpm_10_29_2
+    pnpm_10
     pnpmConfigHook
     vikunja.passthru.frontend
   ]


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/537731 and https://github.com/NixOS/nixpkgs/pull/519259

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
