### PR TITLE
wp-cli: avoid php.ini collision with PHP packages

### DIFF
--- a/pkgs/by-name/wp/wp-cli/package.nix
+++ b/pkgs/by-name/wp/wp-cli/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   formats,
+  buildEnv,
   installShellFiles,
   makeWrapper,
   versionCheckHook,
@@ -56,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     install -Dm444 ${finalAttrs.src} $out/share/wp-cli/wp-cli.phar
-    install -Dm444 ${ini}            $out/etc/${ini.name}
+    install -Dm444 ${ini}            $out/share/wp-cli/${ini.name}
     installShellCompletion --bash --name wp ${completion}
 
     makeWrapper ${lib.getExe php} $out/bin/${finalAttrs.meta.mainProgram} \
@@ -66,7 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
       --run 'export WP_CLI_CONFIG_PATH=''${WP_CLI_CONFIG_PATH-"$XDG_CONFIG_HOME/wp-cli"}' \
       --run 'export WP_CLI_PACKAGES_DIR=''${WP_CLI_PACKAGES_DIR-"$XDG_DATA_HOME/wp-cli"}' \
       --run 'export WP_CLI_CACHE_DIR=''${WP_CLI_CACHE_DIR-"$XDG_CACHE_HOME/wp-cli"}' \
-      --add-flags "-c $out/etc/${ini.name}" \
+      --add-flags "-c $out/share/wp-cli/${ini.name}" \
       --add-flags "-f $out/share/wp-cli/wp-cli.phar" \
       --add-flags "--"
 
@@ -83,6 +84,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     inherit completion;
+
+    tests.with-php = buildEnv {
+      name = "wp-cli-with-php";
+      paths = [
+        finalAttrs.finalPackage
+        php
+      ];
+    };
+
     updateScript = writeScript "update-wp-cli" ''
       ${lib.getExe nix-update}
       version=$(nix-instantiate --eval -E "with import ./. {}; wp-cli.version or (lib.getVersion wp-cli)" | tr -d '"')


### PR DESCRIPTION
Move wp-cli's private `php.ini` from `$out/etc` to `$out/share/wp-cli` and point the wrapper at the new path.

This avoids file collisions when `wp-cli` is installed together with another PHP package in a `buildEnv`.

Fixes #326908.

Assisted-by: pi coding agent / Mika (OpenAI GPT-5.5)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
