### PR TITLE
merman-cli: init at 0.7.0

### DIFF
--- a/pkgs/by-name/me/merman-cli/package.nix
+++ b/pkgs/by-name/me/merman-cli/package.nix
@@ -1,0 +1,106 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+  jq,
+  runCommand,
+  writeText,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "merman-cli";
+  version = "0.7.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Latias94";
+    repo = "merman";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-PzGHYRUlLjica0OTWcz4BwUJz0ci/FrOabkranOr9gU=";
+  };
+
+  cargoHash = "sha256-FKqDPDOBfePUby8rFBflLyhEBrHTbeGhNCdZviNnfts=";
+
+  cargoBuildFlags = [ "--bin=merman-cli" ];
+
+  checkFlags = [
+    "--skip=rustdoc_outputs_inline_svg_for_mermaid_fence"
+    "--skip=rustdoc_reexports_preserve_upstream_inline_svg"
+    "--skip=svg_to_png_keeps_text_visible_when_requested_font_is_missing"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru = {
+    tests =
+      let
+        flowchart = writeText "flowchart.mmd" ''
+          flowchart TD
+            A[Start] --> B{Decision}
+            B -->|Yes| C[Do thing]
+            B -->|No| D[Do other thing]
+        '';
+        flowchart-ascii = writeText "flowchart-ascii" ''
+          +----------+
+          |          |
+          |  Start   |
+          |          |
+          +----------+
+                |
+                |
+                |
+                |
+                v
+          /----------\
+          /          \
+          < Decision |--------------+
+          \          /              |
+          \----------/              |
+                |                   |
+                |                  No
+               Yes                  |
+                |                   |
+                v                   v
+          +----------+     +----------------+
+          |          |     |                |
+          | Do thing |     | Do other thing |
+          |          |     |                |
+          +----------+     +----------------+
+        '';
+        merman-cli = lib.getExe finalAttrs.finalPackage;
+      in
+      {
+        detect = runCommand "merman-cli-detect-test" { } ''
+          ${merman-cli} detect ${flowchart} > $out
+          [ "$(cat $out)" = "flowchart-v2" ]
+        '';
+        parse = runCommand "merman-cli-parse-test" { } ''
+          ${merman-cli} parse ${flowchart} > $out
+          [ "$(cat $out | ${lib.getExe jq} -r .type)" = "flowchart-v2" ]
+        '';
+        render-ascii = runCommand "merman-cli-render-ascii-test" { } ''
+          ${merman-cli} render --format ascii ${flowchart} | sed 's/[[:space:]]*$//' > $out
+          [ "$(cat $out)" = "$(cat ${flowchart-ascii})" ]
+        '';
+      };
+
+    updateScript = nix-update-script {
+      extraArgs = [ "--use-github-releases" ];
+    };
+  };
+
+  meta = {
+    description = "Parity-focused, headless Rust implementation of Mermaid.js";
+    homepage = "https://github.com/Latias94/merman";
+    changelog = "https://github.com/Latias94/merman/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = with lib.maintainers; [ Br1ght0ne ];
+    mainProgram = "merman-cli";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/Latias94/merman - a headless Rust implementation of Mermaid.js
Latest stable release: https://github.com/Latias94/merman/releases/tag/v0.7.0
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
