### PR TITLE
ocp: init at 3.5.0, ancient: init at 2.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28699,6 +28699,12 @@
     githubId = 207457;
     name = "Matthieu Chevrier";
   };
+  treierxyz = {
+    name = "Oliver Jõgar";
+    email = "me@treier.xyz";
+    github = "treierxyz";
+    githubId = 33978534;
+  };
   trespaul = {
     email = "paul@trespaul.com";
     github = "trespaul";

--- a/pkgs/by-name/an/ancient/package.nix
+++ b/pkgs/by-name/an/ancient/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  autoconf-archive,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ancient";
+  version = "2.3.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "temisu";
+    repo = "ancient";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-raRKg4Gm4JFaTGbuBldCOGEAAAQjf92Ud99lyFa/u2w=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    autoconf-archive
+  ];
+
+  meta = {
+    description = "Modern decompressor for old data compression formats";
+    longDescription = ''
+      Collection of decompression routines for old formats
+      popular in the Amiga, Atari, and some other systems from
+      the 80's and 90's, as well as some that are currently
+      used which were used in some specific way in these old systems.
+    '';
+    homepage = "https://github.com/temisu/ancient/";
+    changelog = "https://github.com/temisu/ancient/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [
+      bsd2
+      bzip2
+    ];
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ treierxyz ];
+    mainProgram = "ancient";
+  };
+})

--- a/pkgs/by-name/oc/ocp/package.nix
+++ b/pkgs/by-name/oc/ocp/package.nix
@@ -1,0 +1,114 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  xa,
+  perl,
+  hexdump,
+  shared-mime-info,
+  desktop-file-utils,
+  ncurses,
+  zlib,
+  bzip2,
+  sdl3,
+  freetype,
+  libdiscid,
+  libpng,
+  libjpeg_turbo,
+  libogg,
+  libvorbis,
+  libopus,
+  game-music-emu,
+  libmad,
+  flac,
+  cjson,
+  alsa-lib,
+  speex,
+  wavpack,
+  ancient,
+  unifont,
+  unifont-csur,
+  unifont_upper,
+
+  withDefaultSoundfont ? true,
+  timidity,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ocp";
+  version = "3.5.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "mywave82";
+    repo = "opencubicplayer";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9LY4yIWdzfy6eHBX0Jkv2814+BBwzGVvY/cZwdV3naA=";
+    fetchSubmodules = true;
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    xa
+    perl
+    hexdump
+    shared-mime-info
+    desktop-file-utils
+  ];
+
+  buildInputs = [
+    ncurses
+    zlib
+    bzip2
+    sdl3
+    freetype
+    libdiscid
+    libpng
+    libjpeg_turbo
+    libogg
+    libvorbis
+    libopus
+    game-music-emu
+    libmad
+    flac
+    cjson
+    alsa-lib
+    speex
+    wavpack
+    ancient
+  ];
+
+  configureFlags = [
+    "--with-builtin=core"
+    "--without-update-desktop-database"
+    "--with-unifont-otf=${unifont}/share/fonts/opentype/unifont.otf"
+    "--with-unifont-csur-ttf=${unifont-csur}/share/fonts/truetype/unifont_csur.ttf"
+    "--with-unifont-upper-otf=${unifont_upper}/share/fonts/opentype/unifont_upper.otf"
+  ]
+  ++ lib.optionals withDefaultSoundfont [
+    "--with-timidity-default-path=${timidity}/share/timidity"
+  ];
+
+  postPatch = ''
+    patchShebangs --build playsndh/psgplay-git/script/tos
+  '';
+
+  meta = {
+    description = "Text-based music file player";
+    longDescription = ''
+      Open Cubic Player plays and visualizes various tracked
+      music formats (Amiga modules, S3M, IT), chiptunes and other
+      formats related to the demoscene. Visual output can be done through
+      nCurses, Linux console (VCSA + FrameBuffer) or SDL.
+    '';
+    homepage = "https://github.com/mywave82/opencubicplayer";
+    changelog = "https://github.com/mywave82/opencubicplayer/blob/v${finalAttrs.version}/Changelog";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ treierxyz ];
+    mainProgram = "ocp";
+  };
+})


### PR DESCRIPTION
[Open Cubic Player](https://github.com/mywave82/opencubicplayer) (ocp) is a text-based music file player for various tracked music formats (Amiga modules, S3M, IT etc.).
[Ancient](https://github.com/temisu/ancient) is a modern decompressor for old data compression formats. It is used as a dependency for ocp.
Additionally added myself as a new maintainer.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
