### PR TITLE
kitty-bin: init at 0.47.4

### DIFF
--- a/pkgs/by-name/ki/kitty-bin/package.nix
+++ b/pkgs/by-name/ki/kitty-bin/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  _7zz,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "kitty-bin";
+  version = "0.47.4";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchurl {
+    url = "https://github.com/kovidgoyal/kitty/releases/download/v${finalAttrs.version}/kitty-${finalAttrs.version}.dmg";
+    hash = "sha256-tTubGKJ9U61Eol3Wd2/ejEdIe04QOsUNaCrx7o57d+0=";
+  };
+
+  # undmg can't read the APFS dmg; -snld keeps the .app's symlinks intact.
+  nativeBuildInputs = [ _7zz ];
+  sourceRoot = ".";
+  unpackCmd = "7zz x -snld $curSrc";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications" "$out/bin"
+    cp -R kitty.app "$out/Applications/kitty.app"
+    ln -s "$out/Applications/kitty.app/Contents/MacOS/kitty" "$out/bin/kitty"
+    ln -s "$out/Applications/kitty.app/Contents/MacOS/kitten" "$out/bin/kitten"
+
+    runHook postInstall
+  '';
+
+  # leave the signed bundle untouched so its signature stays valid.
+  dontFixup = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://github.com/kovidgoyal/kitty";
+    description = "Fast, feature-rich, GPU based terminal emulator (prebuilt signed macOS app)";
+    changelog = "https://github.com/kovidgoyal/kitty/blob/v${finalAttrs.version}/docs/changelog.rst";
+    license = lib.licenses.gpl3Only;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = lib.platforms.darwin;
+    mainProgram = "kitty";
+    maintainers = with lib.maintainers; [ carlossless ];
+  };
+})


### PR DESCRIPTION
Adds kitty-bin, upstream's prebuilt signed macOS app, next to the source-built kitty. The source build signs ad-hoc, which macOS won't accept for desktop notifications, so this keeps kitty's original Developer ID signature to make them work.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
