### PR TITLE
maskromtool: 2024-08-18 -> 2026-07-04

### DIFF
--- a/pkgs/by-name/ma/maskromtool/package.nix
+++ b/pkgs/by-name/ma/maskromtool/package.nix
@@ -4,37 +4,60 @@
   fetchFromGitHub,
   cmake,
   qt6,
+  yara-x,
+  replxx,
+  readline,
+  pkg-config,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "maskromtool";
-  version = "2024-08-18";
+  version = "2026-07-04";
 
   src = fetchFromGitHub {
     owner = "travisgoodspeed";
     repo = "maskromtool";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-iuCjAAVEKVwJuAgKITwkXGhKau2DVWhFQLPjp28tjIo=";
+    hash = "sha256-QO2s+nGmf0XTq+PRcIqjEeuc6djzQv8TcJjlYYs/X5c=";
+    fetchSubmodules = true;
   };
+
+  postPatch = ''
+    # remove hardcoded PKG_CONFIG_PATH
+    substituteInPlace CMakeLists.txt \
+      --replace-fail \
+        'set(ENV{PKG_CONFIG_PATH} "c:/lib/pkgconfig;/usr/local/lib64")' \
+        ""
+  '';
+
+  cmakeFlags = [
+    (lib.cmakeFeature "FETCHCONTENT_TRY_FIND_PACKAGE_MODE" "ALWAYS")
+  ];
 
   buildInputs = [
     qt6.qtbase
     qt6.qtcharts
     qt6.qttools
+    yara-x
+    replxx
+    readline
   ];
 
   nativeBuildInputs = [
     cmake
+    pkg-config
     qt6.wrapQtAppsHook
   ];
 
   meta = {
     description = "CAD tool for extracting bits from Mask ROM photographs";
     homepage = "https://github.com/travisgoodspeed/maskromtool";
+    changelog = "https://github.com/travisgoodspeed/maskromtool/releases/tag/v${finalAttrs.version}";
     license = with lib.licenses; [
       beerware
       gpl1Plus
     ];
     maintainers = with lib.maintainers; [ evanrichter ];
+    mainProgram = "maskromtool";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updated maskromtool to the new release: https://github.com/travisgoodspeed/maskromtool/releases/tag/v2026-07-04

Some patches to upstream's cmake were needed to remove hardcoded paths and package search behavior.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (aarch64-darwin and x86_64-linux wayland)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
