### PR TITLE
python3Packages.pyaqvify: init at 0.0.12

### DIFF
--- a/pkgs/development/python-modules/pyaqvify/default.nix
+++ b/pkgs/development/python-modules/pyaqvify/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  aiohttp,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pyaqvify";
+  version = "0.0.12";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "astrandb";
+    repo = "pyaqvify";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ZSSr7cWDvPxVq8YIqCPpE+nxrk/UHuNGZ/muyiGyp/c=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ aiohttp ];
+
+  pythonImportsCheck = [ "pyaqvify" ];
+
+  doCheck = false; # no tests
+
+  meta = {
+    description = "Python async library for Aqvify integration with Home Assistant";
+    homepage = "https://github.com/astrandb/pyaqvify";
+    changelog = "https://github.com/astrandb/pyaqvify/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -363,7 +363,8 @@
       ];
     "aqvify" =
       ps: with ps; [
-      ]; # missing inputs: pyaqvify
+        pyaqvify
+      ];
     "aranet" =
       ps: with ps; [
         aioesphomeapi
@@ -7842,6 +7843,7 @@
     "apsystems"
     "aquacell"
     "aqualogic"
+    "aqvify"
     "aranet"
     "arcam_fmj"
     "arve"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14024,6 +14024,8 @@ self: super: with self; {
 
   pyaprilaire = callPackage ../development/python-modules/pyaprilaire { };
 
+  pyaqvify = callPackage ../development/python-modules/pyaqvify { };
+
   pyarlo = callPackage ../development/python-modules/pyarlo { };
 
   pyarr = callPackage ../development/python-modules/pyarr { };


### PR DESCRIPTION
- https://pypi.org/project/pyaqvify/
- https://github.com/astrandb/pyaqvify
- https://www.home-assistant.io/integrations/aqvify

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
