### PR TITLE
postgresqlPackages.{plperl,plpython3,plr}.withPackages: fix

### DIFF
--- a/pkgs/servers/sql/postgresql/wrapper.nix
+++ b/pkgs/servers/sql/postgresql/wrapper.nix
@@ -40,14 +40,15 @@ buildEnv (finalAttrs: {
   derivationArgs = {
     strictDeps = true;
     nativeBuildInputs = [ makeBinaryWrapper ];
-    postBuild =
-      let
-        args = lib.concatMap (ext: ext.wrapperArgs or [ ]) installedExtensions;
-      in
-      ''
-        wrapProgram "$out/bin/postgres" ${lib.concatStringsSep " " args}
-      '';
   };
+
+  postBuild =
+    let
+      args = lib.concatMap (ext: ext.wrapperArgs or [ ]) installedExtensions;
+    in
+    ''
+      wrapProgram "$out/bin/postgres" ${lib.concatStringsSep " " args}
+    '';
 
   passthru = {
     inherit installedExtensions;


### PR DESCRIPTION
This broke in #533324 - `postBuild` is a regular argument for `buildEnv`, not part of `derivationArgs`.

Resolves #539578

## Things done

- Tested, as applicable:
  - [x] `postgresqlPackages.plperl.tests`
  - [x] `postgresqlPackages.plpython3.tests`
  - [x] `postgresqlPackages.plr.tests`
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
