### PR TITLE
quartus-prime-lite: Fix crash under Rosetta Linux

### DIFF
--- a/pkgs/by-name/qu/quartus-prime-lite/quartus.nix
+++ b/pkgs/by-name/qu/quartus-prime-lite/quartus.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   unstick,
+  radare2,
   fetchurl,
   withQuesta ? true,
   supportedDevices ? [
@@ -81,7 +82,10 @@ stdenv.mkDerivation {
   inherit version;
   pname = "quartus-prime-lite-unwrapped";
 
-  nativeBuildInputs = [ unstick ];
+  nativeBuildInputs = [
+    unstick
+    radare2
+  ];
 
   buildCommand =
     let
@@ -120,6 +124,9 @@ stdenv.mkDerivation {
       # replace /proc pentium check with a true statement. this allows usage under emulation.
       substituteInPlace $out/quartus/adm/qenv.sh \
         --replace-fail 'grep sse /proc/cpuinfo > /dev/null 2>&1' ':'
+
+      # vendored copy of sqlite3 contains undocumented x87 instructions that rosetta does not support; patch them out with equivalent instructions
+      r2 -q -w -c '(patch; wx+ 0xdd; wx 0xd); .(patch) @@/ao ffreep' $out/quartus/linux64/libccl_sqlite3.so
     '';
 
   meta = {


### PR DESCRIPTION
There is an excellent [writeup](https://github.com/lambadalambda/quartus-mister/blob/main/README.md) of issues someone else faced with getting Quartus working in an Ubuntu VM; one such problem is that Rosetta (x86 to ARM JIT available on aarch64-linux VMs hosted on a macOS) can't handle the x87 instruction `ffreep` and will stop the process with an illegal instruction trap.
For better or worse, in my usage I have not hit either of the other bugs the writeup describes, so this patch suffices to get Quartus working (the programmer working or not is a moot point because to my knowledge there is no way to passthrough USB to a VM running under Apple's Virtualization.framework, not even USB-IP).

The performance gap between QEMU and Rosetta is wide enough that it's worth the annoyance of problems like this if you're working with Quartus on an Apple device.

#### Why no flag?
This patch could be gated behind a flag, but seeing as this is a semantically equivalent change (in a vendored dependency no less) I don't believe there's any harm in unconditionally enabling this (aside from the additional build-time dependency on Radare2).
Naturally, as far as Nix is concerned it is unknowable whether Quartus will be running under an emulator, so there's nothing in `stdenv` we could query either.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (with Rosetta)
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

<!-- Message of single commit: -->