### PR TITLE
commitizen: 4.13.9 -> 4.16.4

### DIFF
--- a/pkgs/by-name/co/commitizen/package.nix
+++ b/pkgs/by-name/co/commitizen/package.nix
@@ -12,19 +12,19 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "commitizen";
-  version = "4.13.9";
+  version = "4.16.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "commitizen-tools";
     repo = "commitizen";
     tag = "v${version}";
-    hash = "sha256-bT154qRnZCf3StYs+acv4Be/SUCA5ovGjY/j2EDmUEc=";
+    hash = "sha256-lVc1Kdy/IWRa8uoPZfOSSa379bDDknE3dpm0U7DVv0s=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail "uv_build >= 0.9.17, <0.10.0" "uv-build"
+      --replace-fail "uv_build >= 0.9.17, <0.12" "uv-build"
   '';
 
   pythonRelaxDeps = [
@@ -52,6 +52,13 @@ python3Packages.buildPythonPackage rec {
     questionary
     termcolor
     tomlkit
+  ];
+
+  makeWrapperArgs = [
+    "--prefix"
+    "PATH"
+    ":"
+    (lib.makeBinPath [ gitMinimal ])
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
## Summary

- Update commitizen from 4.13.9 to 4.16.4.
- Refresh the `uv_build` postPatch match for the updated upstream `pyproject.toml`.
- Wrap `gitMinimal` into the installed CLI PATH for runtime config discovery.

## Why both changes are needed

The postPatch replacement was keyed to the old upstream build-system constraint, `uv_build >= 0.9.17, <0.10.0`. In commitizen 4.16.4, upstream changed that to `uv_build >= 0.9.17, <0.12`, so the old `--replace-fail` string aborts in `patchPhase`.

After that is fixed, the build reaches `versionCheckHook`. `cz version` now invokes `git` directly during config discovery. Without `git` in the installed wrapper PATH, that fails with `FileNotFoundError`; wrapping `gitMinimal` makes the runtime dependency explicit and keeps `cz version` working.

Automation/AI disclosure: Assisted by OpenAI Codex (GPT-5); the diff and verification output were reviewed before submission.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Verification:

- `nix-build --option sandbox true --arg config "{ allowUnfree = true; allowAliases = false; }" --arg overlays "[ ]" -A commitizen`
- `env PATH=/nonexistent ./result/bin/cz version`

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
