### PR TITLE
openboardview: 9.95.2 -> 10.0.0

### DIFF
--- a/pkgs/by-name/op/openboardview/package.nix
+++ b/pkgs/by-name/op/openboardview/package.nix
@@ -13,14 +13,14 @@
   wrapGAppsHook3,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "openboardview";
   version = "9.95.2";
 
   src = fetchFromGitHub {
     owner = "OpenBoardView";
     repo = "OpenBoardView";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-B5VnuycRt8h7Cz3FTIbhcGcXuA60zPCz0FMvFENTwws=";
     fetchSubmodules = true;
   };
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
       mv "$out/openboardview.app" "$out/Applications/OpenBoardView.app"
     ''
     + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
-      wrapGApp "$out/bin/${pname}" \
+      wrapGApp "$out/bin/${finalAttrs.pname}" \
         --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ gtk3 ]}
     '';
 
@@ -78,4 +78,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ k3a ];
   };
-}
+})

--- a/pkgs/by-name/op/openboardview/package.nix
+++ b/pkgs/by-name/op/openboardview/package.nix
@@ -11,32 +11,26 @@
   fontconfig,
   gtk3,
   wrapGAppsHook3,
+  python3Packages,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "openboardview";
-  version = "9.95.2";
+  version = "10.0.0";
 
   src = fetchFromGitHub {
     owner = "OpenBoardView";
     repo = "OpenBoardView";
     tag = finalAttrs.version;
-    hash = "sha256-B5VnuycRt8h7Cz3FTIbhcGcXuA60zPCz0FMvFENTwws=";
+    hash = "sha256-rvCWzIbjEZOHh5diaeP4xVIRsMHqt4PGMuYOGfWvwhA=";
     fetchSubmodules = true;
   };
-
-  patches = [
-    (fetchpatch {
-      name = "fix-darwin-build.patch";
-      url = "https://github.com/OpenBoardView/OpenBoardView/commit/a1de2e5de908afd83eceed757260f6425314af2e.patch?full_index=1";
-      hash = "sha256-DK+K4F0+QGqaoWCyc8AvuIsaiTCqhAG6AsTNg2hegh0=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake
     pkg-config
     python3
+    python3Packages.jinja2
     wrapGAppsHook3
   ];
   buildInputs = [

--- a/pkgs/by-name/op/openboardview/package.nix
+++ b/pkgs/by-name/op/openboardview/package.nix
@@ -74,6 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Linux SDL/ImGui edition software for viewing .brd files";
     mainProgram = "openboardview";
     homepage = "https://github.com/OpenBoardView/OpenBoardView";
+    changelog = "https://github.com/OpenBoardView/OpenBoardView/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ k3a ];


### PR DESCRIPTION
Tested and works

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
