### PR TITLE
python3Packages.opentelemetry-exporter-otlp-proto-grpc: disable timing-sensitive tests

### DIFF
--- a/pkgs/development/python-modules/opentelemetry-exporter-otlp-proto-grpc/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-exporter-otlp-proto-grpc/default.nix
@@ -36,6 +36,12 @@ buildPythonPackage {
 
   enabledTestPaths = [ "tests" ];
 
+  disabledTests = [
+    # Timing-sensitive
+    "test_retry_info_is_respected"
+    "test_timeout_set_correctly"
+  ];
+
   pythonImportsCheck = [ "opentelemetry.exporter.otlp.proto.grpc" ];
 
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION
Tests try to compare execution time with wall-clock time and fail under load. Disabled the tests.

(Package was just merged from `staging-next`)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
