### PR TITLE
python3Packages.json-schema-to-pydantic: fix tests for pydantic 2.13

### DIFF
--- a/pkgs/development/python-modules/json-schema-to-pydantic/default.nix
+++ b/pkgs/development/python-modules/json-schema-to-pydantic/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   hatchling,
   hatch-vcs,
   pydantic,
@@ -19,6 +20,15 @@ buildPythonPackage (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-9T7ScIf5jJBbldNwLHEchrctr3V4LmqxNGhor6QIzO4=";
   };
+
+  patches = [
+    # Pull test fixes for Pydantic 2.13+ from https://github.com/richard-gyiko/json-schema-to-pydantic/pull/46
+    (fetchpatch {
+      name = "pydantic-2.13-test-compat.patch";
+      url = "https://github.com/richard-gyiko/json-schema-to-pydantic/commit/acfacd19f282011cfb96b8901d72867a39f57bff.patch";
+      hash = "sha256-+dDFF/eloYuc+ANTjlr9tvI5ycX21o8G1xJOjGlrmTg=";
+    })
+  ];
 
   build-system = [
     hatchling


### PR DESCRIPTION
The package has two tests (`test_one_of_with_ref` and `test_one_of_populate_by_name`) which hardcoded accesses to `annotation.__args__`, but pydantic 2.13 wraps the field annotation in `Annotated`, raising `AttributeError` when the tests try to get at these guts. Yuck.

I chose to fix it by backporting the [upstream test fix](https://github.com/richard-gyiko/json-schema-to-pydantic/pull/46) which unwraps Annotated before reading the union members.

No change to the production library code.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
