### PR TITLE
open-bamboo-networking: init at 1.1.0

### DIFF
--- a/pkgs/by-name/op/open-bamboo-networking/package.nix
+++ b/pkgs/by-name/op/open-bamboo-networking/package.nix
@@ -1,0 +1,88 @@
+# Copyright (c) 2024 Tom Sievers
+# SPDX-License-Identifier: MIT
+#
+# NixOS packaging logic is originally inspired by and adapted from:
+# https://codeberg.org/TomSievers/open-bamboo-networking-nixos.git
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  openssl,
+  zlib,
+  curl,
+  uthash,
+  client ? "bambu_studio",
+  pluginVersion ? "02.05.00.99",
+}:
+
+let
+  mosquittoSrc = fetchFromGitHub {
+    owner = "eclipse";
+    repo = "mosquitto";
+    rev = "v2.1.2";
+    hash = "sha256-Zl55yjuzQY2fyaKs/zLaJ7a3OONKTDQPaT+DpPURdZI=";
+  };
+
+  cJsonSrc = fetchFromGitHub {
+    owner = "DaveGamble";
+    repo = "cJSON";
+    rev = "v1.7.18";
+    hash = "sha256-UgUWc/+Zie2QNijxKK5GFe4Ypk97EidG8nTiiHhn5Ys=";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "open-bamboo-networking-${client}";
+  version = "1.1.0";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "ClusterM";
+    repo = "open-bamboo-networking";
+    rev = "v${version}";
+    hash = "sha256-bxkOwCnlKu2fA3cEiTZq15anSwLkuJIyko19wqul6Fw=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+    zlib
+    curl
+    uthash
+  ];
+
+  cmakeFlags = [
+    "-DOBN_VERSION=${pluginVersion}"
+    "-DOBN_CLIENT_TYPE=${client}"
+    "-DOBN_PATCH_CLIENT_CONF=OFF"
+    "-DOBN_BUILD_TESTS=OFF"
+
+    # Prefer a staged Nix install, not ~/.config/BambuStudio
+    "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}"
+    "-DFETCHCONTENT_SOURCE_DIR_CJSON=${cJsonSrc}"
+  ];
+
+  preConfigure = ''
+    cp -r ${mosquittoSrc} $TMPDIR/source/mosquitto-src
+    chmod -R u+w $TMPDIR/source/mosquitto-src
+
+    cmakeFlagsArray+=(
+      "-DFETCHCONTENT_SOURCE_DIR_ECLIPSE_MOSQUITTO=$TMPDIR/source/mosquitto-src"
+    )
+  '';
+
+  meta = {
+    description = "Open-source Bambu/Orca network plugin replacement";
+    homepage = "https://github.com/ClusterM/open-bamboo-networking";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ mio ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
