### PR TITLE
{lomiri,lomiri-qt6}.lomiri-url-dispatcher: 0.1.4 -> 0.1.5

### DIFF
--- a/pkgs/desktops/lomiri/services/lomiri-url-dispatcher/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-url-dispatcher/default.nix
@@ -29,17 +29,17 @@
 }:
 
 let
-  withQt6 = lib.strings.versionAtLeast qtbase.version "6";
+  withQt6 = lib.versions.major qtbase.version == "6";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-url-dispatcher";
-  version = "0.1.4";
+  version = "0.1.5";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lomiri-url-dispatcher";
     tag = finalAttrs.version;
-    hash = "sha256-+3/C6z8wyiNSpt/eyMl+j/TGJW0gZ5T3Vd1NmghK67k=";
+    hash = "sha256-Qg3nYg8SThm6lYp/TB81XW4yEM5NhzK3wPU8bB/g/ks=";
   };
 
   outputs = [
@@ -81,7 +81,9 @@ stdenv.mkDerivation (finalAttrs: {
         setuptools
       ]
       ++ lib.optionals finalAttrs.finalPackage.doCheck [
+        fixtures
         python-dbusmock
+        testtools
       ]
     ))
     wrapQtAppsHook
@@ -103,6 +105,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeCheckInputs = [
     dbus
+    dbus-test-runner
     sqlite
   ];
 


### PR DESCRIPTION
https://gitlab.com/ubports/development/core/lomiri-url-dispatcher/-/blob/0.1.5/ChangeLog

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
