### PR TITLE
terra: modernize, remove `cudatoolkit`

### DIFF
--- a/pkgs/by-name/te/terra/package.nix
+++ b/pkgs/by-name/te/terra/package.nix
@@ -1,4 +1,5 @@
 {
+  config,
   lib,
   stdenv,
   fetchFromGitHub,
@@ -8,7 +9,7 @@
   libxml2,
   symlinkJoin,
   cudaPackages,
-  enableCUDA ? false,
+  enableCUDA ? config.cudaSupport,
   libffi,
   libpfm,
 }:
@@ -37,8 +38,6 @@ let
     ];
   };
 
-  cuda = cudaPackages.cudatoolkit;
-
   clangVersion = llvmPackages.clang-unwrapped.version;
 
 in
@@ -60,7 +59,10 @@ stdenv.mkDerivation (finalAttrs: {
     libffi
     libxml2
   ]
-  ++ lib.optionals enableCUDA [ cuda ]
+  ++ lib.optionals enableCUDA (with cudaPackages; [
+    cuda_nvcc
+    cuda_cudart
+  ])
   ++ lib.optional (!stdenv.hostPlatform.isDarwin) libpfm;
 
   cmakeFlags =

--- a/pkgs/by-name/te/terra/package.nix
+++ b/pkgs/by-name/te/terra/package.nix
@@ -45,6 +45,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "terra";
   version = "1.2.0";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "terralang";
     repo = "terra";
@@ -52,17 +55,20 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-CukNCvTHZUhjdHyvDUSH0YCVNkThUFPaeyLepyEKodA=";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ] ++ lib.optionals enableCUDA [ cudaPackages.cuda_nvcc ];
   buildInputs = [
     llvmMerged
     ncurses
     libffi
     libxml2
   ]
-  ++ lib.optionals enableCUDA (with cudaPackages; [
-    cuda_nvcc
-    cuda_cudart
-  ])
+  ++ lib.optionals enableCUDA (
+    with cudaPackages;
+    [
+      cuda_nvcc # crt/host_config.h; even though we include this in nativeBuildInputs, it's needed here too
+      cuda_cudart
+    ]
+  )
   ++ lib.optional (!stdenv.hostPlatform.isDarwin) libpfm;
 
   cmakeFlags =

--- a/pkgs/by-name/te/terra/package.nix
+++ b/pkgs/by-name/te/terra/package.nix
@@ -12,6 +12,7 @@
   enableCUDA ? config.cudaSupport,
   libffi,
   libpfm,
+  versionCheckHook,
 }:
 
 let
@@ -21,7 +22,7 @@ let
   luajitSrc = fetchFromGitHub {
     owner = "LuaJIT";
     repo = "LuaJIT";
-    rev = luajitRev;
+    tag = luajitRev;
     hash = "sha256-L9T6lc32dDLAp9hPI5mKOzT0c4juW9JHA3FJCpm7HNQ=";
   };
 
@@ -51,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "terralang";
     repo = "terra";
-    rev = "release-${finalAttrs.version}";
+    tag = "release-${finalAttrs.version}";
     hash = "sha256-CukNCvTHZUhjdHyvDUSH0YCVNkThUFPaeyLepyEKodA=";
   };
 
@@ -108,13 +109,20 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   installPhase = ''
+    runHook preInstall
+
     install -Dm755 -t $bin/bin bin/terra
     install -Dm755 -t $out/lib lib/terra${stdenv.hostPlatform.extensions.sharedLibrary}
     install -Dm644 -t $static/lib lib/libterra_s.a
 
     mkdir -pv $dev/include
     cp -rv include/terra $dev/include
+
+    runHook postInstall
   '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "Low-level counterpart to Lua";
@@ -131,5 +139,6 @@ stdenv.mkDerivation (finalAttrs: {
     # Linux Aarch64 broken above LLVM11
     # https://github.com/terralang/terra/issues/597
     broken = stdenv.hostPlatform.isAarch64;
+    mainProgram = "terra";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Related: https://github.com/NixOS/nixpkgs/issues/232501

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
