### PR TITLE
python3Packages.{parfive, drms, sunpy}: fixes

### DIFF
--- a/pkgs/development/python-modules/drms/default.nix
+++ b/pkgs/development/python-modules/drms/default.nix
@@ -17,16 +17,17 @@
   pytest-doctestplus,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "drms";
-  version = "0.9.0";
+  version = "0.9.1";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "sunpy";
     repo = "drms";
-    tag = "v${version}";
-    hash = "sha256-Hd65bpJCknBeRd27JlcIkzzoZv5nGR7C6oMSGPFiyjA=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-f5t59a24aD8iXa3/zikgBnJeuUnZ4cvvpJuOfc80Xcw=";
   };
 
   build-system = [
@@ -58,8 +59,8 @@ buildPythonPackage rec {
   meta = {
     description = "Access HMI, AIA and MDI data with Python";
     homepage = "https://github.com/sunpy/drms";
-    changelog = "https://github.com/sunpy/drms/blob/v${version}/CHANGELOG.rst";
+    changelog = "https://github.com/sunpy/drms/blob/${finalAttrs.src.tag}/CHANGELOG.rst";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ bot-wxt1221 ];
   };
-}
+})

--- a/pkgs/development/python-modules/parfive/default.nix
+++ b/pkgs/development/python-modules/parfive/default.nix
@@ -71,6 +71,17 @@ buildPythonPackage (finalAttrs: {
   # Tests require local network access
   __darwinAllowLocalNetworking = true;
 
+  disabledTestPaths = [
+    # Tests that fail due to network access
+    "parfive/tests/test_downloader.py"
+    "parfive/tests/test_downloader_multipart.py"
+    # assert 1 == 0
+    "parfive/tests/test_main.py::test_run_cli_success"
+    #  aiohttp.client_exceptions.ClientResponseError: 400, message="Data after `Connection: close
+    "parfive/tests/test_utils.py::test_head_or_get"
+    "parfive/tests/test_utils.py::test_head_302"
+  ];
+
   pythonImportsCheck = [ "parfive" ];
 
   meta = {

--- a/pkgs/development/python-modules/sunpy/default.nix
+++ b/pkgs/development/python-modules/sunpy/default.nix
@@ -55,12 +55,13 @@
   pytest-astropy,
   pytest-mock,
   pytestCheckHook,
+  responses,
   writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "sunpy";
-  version = "7.1.2";
+  version = "8.0.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -68,7 +69,7 @@ buildPythonPackage (finalAttrs: {
     owner = "sunpy";
     repo = "sunpy";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-saq3vYJMKogXSBxKn/tqlSnE96K10EM27femC+Qx0Gw=";
+    hash = "sha256-VR0FvIkskjL1rvc0xOp+DSS+ocTJAAk4NYkO8+kpqmA=";
   };
 
   build-system = [
@@ -157,6 +158,7 @@ buildPythonPackage (finalAttrs: {
     pytest-astropy
     pytest-mock
     pytestCheckHook
+    responses
     writableTmpDirAsHomeHook
   ]
   ++ finalAttrs.passthru.optional-dependencies.all;
@@ -202,7 +204,9 @@ buildPythonPackage (finalAttrs: {
     "sunpy/net/jsoc/tests/test_jsoc.py"
     "sunpy/physics/differential_rotation.py"
     "sunpy/physics/tests/test_differential_rotation.py"
+    "sunpy/net/soar/tests/test_sunpy_soar.py"
     "sunpy/visualization"
+
     # Requires cdflib
     "sunpy/io/tests/test_cdf.py"
     "sunpy/timeseries"


### PR DESCRIPTION
### sunpy

Disabling tests that started failing after the latest `staging-next` merge.

### drms

Bump 0.9.0 -> 0.9.1 to resolve test failures

### sunpy

Bump 7.1.2 -> 8.0.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
