### PR TITLE
miracle-wm: 0.9.1 -> 0.10.1

### DIFF
--- a/pkgs/by-name/mi/miracle-wm/package.nix
+++ b/pkgs/by-name/mi/miracle-wm/package.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  fetchpatch,
   gitUpdater,
   nixosTests,
   boost,
@@ -12,6 +11,8 @@
   glib,
   glm,
   gtest,
+  gtk4,
+  gtk4-layer-shell,
   json_c,
   libevdev,
   libglvnd,
@@ -29,30 +30,20 @@
   wasmedge,
   wayland,
   wayland-scanner,
+  wrapGAppsHook4,
   yaml-cpp,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "miracle-wm";
-  version = "0.9.1";
+  version = "0.10.1";
 
   src = fetchFromGitHub {
     owner = "miracle-wm-org";
     repo = "miracle-wm";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-7JtdSopKBHfFK0KsV0+9OxrOx3vrSydmZSmAiBvKQiI=";
+    hash = "sha256-htFgvXYgxQXV2U3F+tXEoaTb0udc2H1aHsIg5E8nRL8=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "0001-miracle-wm-mir2.28.patch";
-      url = "https://github.com/miracle-wm-org/miracle-wm/commit/0fcfb54c59327d0776f6e8074e885080731a95c4.patch";
-      excludes = [
-        ".github/workflows/test-deb-install.yml"
-      ];
-      hash = "sha256-HuXwPkM0whLFIy8HM6n9bG9I/DZOuzAajmDpJMZt9BQ=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \
@@ -67,12 +58,15 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper
     pkg-config
     wayland-scanner
+    wrapGAppsHook4
   ];
 
   buildInputs = [
     boost
     glib
     glm
+    gtk4
+    gtk4-layer-shell
     json_c
     libevdev
     libglvnd
@@ -96,11 +90,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   checkInputs = [ gtest ];
 
+  # Manually wrapping the few binaries that needs it
+  dontWrapGApps = true;
+
   cmakeFlags = [
+    (lib.cmakeBool "BUILD_DEBUG_OVERLAY" true)
+    (lib.cmakeBool "BUILD_ERROR_REPORTER" true)
     (lib.cmakeBool "ENABLE_LTO" true)
     (lib.cmakeBool "ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
-    # https://github.com/miracle-wm-org/miracle-wm/issues/865
-    (lib.cmakeBool "FEATURE_PLUGIN_SYSTEM" false)
+    (lib.cmakeBool "FEATURE_PLUGIN_SYSTEM" true)
     (lib.cmakeBool "SYSTEMD_INTEGRATION" true)
     (lib.cmakeBool "END_TO_END_TESTS" finalAttrs.finalPackage.doCheck)
   ];
@@ -119,6 +117,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postFixup = ''
     patchShebangs $out/libexec/miracle-wm-session-setup
+
     wrapProgram $out/libexec/miracle-wm-session-setup \
       --prefix PATH : "$out/bin:${
         lib.makeBinPath [
@@ -127,6 +126,9 @@ stdenv.mkDerivation (finalAttrs: {
           systemd # systemctl
         ]
       }"
+
+    wrapGApp $out/bin/miracle-wm-basic-error-reporter
+    wrapGApp $out/bin/miracle-wm-debug-overlay
   '';
 
   passthru = {


### PR DESCRIPTION
https://github.com/miracle-wm-org/miracle-wm/releases/tag/v0.10.0
https://github.com/miracle-wm-org/miracle-wm/releases/tag/v0.10.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
