### PR TITLE
basil: init at 0.7.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26857,6 +26857,12 @@
     githubId = 1181362;
     name = "Stefan Junker";
   };
+  stevelr = {
+    email = "stevelr.git@pm.me";
+    github = "stevelr";
+    githubId = 15311467;
+    name = "stevelr";
+  };
   stevenroose = {
     email = "github@stevenroose.org";
     github = "stevenroose";

--- a/pkgs/by-name/ba/basil/package.nix
+++ b/pkgs/by-name/ba/basil/package.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  buildPackages,
+  cacert,
+  fetchFromGitHub,
+  installShellFiles,
+  nix-update-script,
+  protobuf,
+  rustPlatform,
+  stdenv,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "basil";
+  version = "0.7.1";
+
+  src = fetchFromGitHub {
+    owner = "openbasil";
+    repo = "basil";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2ODBl5s8r4iGfGMg8StnIPMsEQhiUR8wEnzQWNieg3Q=";
+  };
+
+  cargoHash = "sha256-g0orXGEK3JiTboPtrtJuEZKxf3n2R6vppD6W5StifTk=";
+
+  # Build only the two shipped binaries, plus the xtask helper that renders
+  # their man pages. xtask is removed again in postInstall — it is a build
+  # tool, not part of the distribution.
+  cargoBuildFlags = [
+    "-p"
+    "basil-bin"
+    "-p"
+    "basil-nats-bridge"
+    "-p"
+    "xtask"
+  ];
+
+  nativeBuildInputs = [
+    installShellFiles
+    protobuf
+  ];
+
+  env = {
+    PROTOC = lib.getExe' protobuf "protoc";
+    PROTOC_INCLUDE = "${protobuf}/include";
+    # The test suite builds reqwest clients whose platform verifier loads the
+    # OS CA trust store even for tests that never touch the network; the
+    # build sandbox has no /etc/ssl, so point at nixpkgs' bundle.
+    SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+  };
+
+  # install man pages and shell completions
+  postInstall =
+    let
+      emulator = stdenv.hostPlatform.emulator buildPackages;
+    in
+    ''
+      mkdir -p $out/share/man/man1
+      ${emulator} $out/bin/xtask -o $out/share/man/man1
+      rm $out/bin/xtask
+
+      installShellCompletion --cmd basil \
+        --bash <(${emulator} $out/bin/basil completions bash)  \
+        --zsh <(${emulator} $out/bin/basil completions zsh) \
+        --fish <(${emulator} $out/bin/basil completions fish)
+    '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Host-local secrets broker that keeps keys in the backend, used in place";
+    homepage = "https://github.com/openbasil/basil";
+    changelog = "https://github.com/openbasil/basil/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ stevelr ];
+    mainProgram = "basil";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
New package: basil, a host-local secrets broker
New maintainer: stevelr

Homepage: https://github.com/openbasil/basil
Documentation: https://docs.openbasil.org

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
 - [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [X] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

## AI Disclosures

Claude Code (Fable 5, Opus 4.8) and Codex (gpt-5.5) were used in development of basil and its documentation.
All specs, plans, and documentation were reviewed, curated, and edited by me.
All code was reviewed and tested by me.
This PR was created and submitted by me.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
