### PR TITLE
godot-mono: remove runtime dependency on .NET SDK

### DIFF
--- a/pkgs/development/tools/godot/common.nix
+++ b/pkgs/development/tools/godot/common.nix
@@ -95,7 +95,6 @@ let
   arch = stdenv.hostPlatform.linuxArch;
 
   dotnet-sdk = if withMono then dotnetCorePackages.sdk_8_0-source else null;
-  dotnet-sdk_alt = if withMono then dotnetCorePackages.sdk_9_0-source else null;
 
   dottedVersion = lib.replaceStrings [ "-" ] [ "." ] version + lib.optionalString withMono ".mono";
 
@@ -594,7 +593,6 @@ let
               sdl3
             ]
           )
-          ++ lib.optionals (editor && withMono) dotnet-sdk.packages
           ++ lib.optional withAlsa alsa-lib
           ++ lib.optional (withX11 || withWayland) libxkbcommon
           ++ lib.optionals withX11 [
@@ -754,11 +752,7 @@ let
 
         passthru = {
           inherit updateScript;
-          tests =
-            mkTests finalAttrs.finalPackage dotnet-sdk
-            // lib.optionalAttrs (editor && withMono) {
-              sdk-override = mkTests finalAttrs.finalPackage dotnet-sdk_alt;
-            };
+          tests = mkTests finalAttrs.finalPackage dotnet-sdk;
         }
         // lib.optionalAttrs editor {
           export-template = mkTarget "template_release";
@@ -821,7 +815,7 @@ let
 
             pname = finalAttrs.unwrapped.pname + "-wrapper";
             inherit (finalAttrs.unwrapped) version outputs meta;
-            inherit unwrapped dotnet-sdk;
+            inherit unwrapped;
 
             dontUnpack = true;
             dontConfigure = true;
@@ -833,7 +827,7 @@ let
             installPhase = ''
               runHook preInstall
 
-              mkdir -p "$out"/{bin,libexec,share/applications,nix-support}
+              mkdir -p "$out"/{bin,libexec,share/applications}
 
               cp -d "$unwrapped"/bin/* "$out"/bin/
               ln -s "$unwrapped"/libexec/* "$out"/libexec/
@@ -845,12 +839,6 @@ let
                 --replace-fail "Exec=$unwrapped/bin/godot${suffix}" "Exec=$out/bin/godot${suffix}"
               ln -s "$unwrapped"/share/icons $out/share/
 
-              # ensure dotnet hooks get run
-              echo "${finalAttrs.dotnet-sdk}" >> "$out"/nix-support/propagated-build-inputs
-
-              wrapProgram "$out"/libexec/${binary} \
-                --prefix PATH : "${lib.makeBinPath [ finalAttrs.dotnet-sdk ]}"
-
               runHook postInstall
             '';
 
@@ -859,11 +847,8 @@ let
             '') finalAttrs.unwrapped.outputs;
 
             passthru = unwrapped.passthru // {
-              tests = mkTests finalAttrs.finalPackage null // {
+              tests = mkTests finalAttrs.finalPackage dotnet-sdk // {
                 unwrapped = lib.recurseIntoAttrs unwrapped.tests;
-                sdk-override = lib.recurseIntoAttrs (
-                  mkTests (finalAttrs.finalPackage.overrideAttrs { dotnet-sdk = dotnet-sdk_alt; }) null
-                );
               };
             };
           })


### PR DESCRIPTION
Fixes #539753
The code changes in this PR are minor. It only removes some functionality without adding anything new. So it shouldn't break anything.
It also removes some tests related to the ability to override the .NET version as this ability was removed as well.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - The `godot-mono` package now doesn't allow to specify the .NET version and needs an explicitly installed .NET SDK version, that is supported by Godot Mono (8.0 and above), for the C# support.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
