### PR TITLE
python3Packages.vdirsyncer: fix build

### DIFF
--- a/pkgs/by-name/vd/vdirsyncer/package.nix
+++ b/pkgs/by-name/vd/vdirsyncer/package.nix
@@ -1,0 +1,10 @@
+{
+  lib,
+  python3Packages,
+}:
+
+python3Packages.toPythonApplication (
+  python3Packages.vdirsyncer.overridePythonAttrs (old: {
+    dependencies = old.dependencies ++ lib.concatAttrValues old.optional-dependencies;
+  })
+)

--- a/pkgs/development/python-modules/vdirsyncer/default.nix
+++ b/pkgs/development/python-modules/vdirsyncer/default.nix
@@ -21,13 +21,13 @@
   versionCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "vdirsyncer";
   version = "0.20.0";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-/rGlM1AKlcFP0VVzOhBW/jWRklU9gsB8a6BPy/xAsS0=";
   };
 
@@ -78,9 +78,9 @@ buildPythonPackage rec {
   meta = {
     description = "Synchronize calendars and contacts";
     homepage = "https://github.com/pimutils/vdirsyncer";
-    changelog = "https://github.com/pimutils/vdirsyncer/blob/v${version}/CHANGELOG.rst";
+    changelog = "https://github.com/pimutils/vdirsyncer/blob/v${finalAttrs.version}/CHANGELOG.rst";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ stephen-huan ];
     mainProgram = "vdirsyncer";
   };
-}
+})

--- a/pkgs/development/python-modules/vdirsyncer/default.nix
+++ b/pkgs/development/python-modules/vdirsyncer/default.nix
@@ -17,8 +17,7 @@
   pytest-asyncio,
   trustme,
   aioresponses,
-  vdirsyncer,
-  testers,
+  versionCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -67,7 +66,9 @@ buildPythonPackage rec {
     "test_verbosity"
   ];
 
-  passthru.tests.version = testers.testVersion { package = vdirsyncer; };
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
 
   meta = {
     description = "Synchronize calendars and contacts";

--- a/pkgs/development/python-modules/vdirsyncer/default.nix
+++ b/pkgs/development/python-modules/vdirsyncer/default.nix
@@ -17,6 +17,7 @@
   pytest-asyncio,
   trustme,
   aioresponses,
+  nixosTests,
   versionCheckHook,
 }:
 
@@ -69,6 +70,10 @@ buildPythonPackage rec {
   nativeInstallCheckInputs = [
     versionCheckHook
   ];
+
+  passthru.tests = {
+    inherit (nixosTests) vdirsyncer;
+  };
 
   meta = {
     description = "Synchronize calendars and contacts";

--- a/pkgs/development/python-modules/vdirsyncer/default.nix
+++ b/pkgs/development/python-modules/vdirsyncer/default.nix
@@ -5,17 +5,12 @@
   fetchpatch,
   click,
   click-log,
-  click-threading,
-  requests-toolbelt,
   requests,
-  atomicwrites,
   hypothesis,
   pytestCheckHook,
   pytest-cov-stub,
-  pytest-subtesthack,
   setuptools,
   setuptools-scm,
-  wheel,
   aiostream,
   aiohttp-oauthlib,
   aiohttp,
@@ -42,22 +37,21 @@ buildPythonPackage rec {
   ];
 
   dependencies = [
-    atomicwrites
     click
     click-log
-    click-threading
     requests
-    requests-toolbelt
     aiostream
     aiohttp
-    aiohttp-oauthlib
   ];
+
+  optional-dependencies = {
+    google = [ aiohttp-oauthlib ];
+  };
 
   nativeCheckInputs = [
     hypothesis
     pytestCheckHook
     pytest-cov-stub
-    pytest-subtesthack
     pytest-asyncio
     trustme
     aioresponses

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9577,8 +9577,6 @@ with pkgs;
 
   uuagc = haskell.lib.compose.justStaticExecutables haskellPackages.uuagc;
 
-  vdirsyncer = with python3Packages; toPythonApplication vdirsyncer;
-
   vim = vimUtils.makeCustomizable (
     callPackage ../applications/editors/vim {
     }


### PR DESCRIPTION
closes https://github.com/NixOS/nixpkgs/pull/539935

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
