### PR TITLE
bundled-common, bundlerEnv: always use `__structuredAttrs = true`

### DIFF
--- a/pkgs/development/ruby-modules/bundled-common/default.nix
+++ b/pkgs/development/ruby-modules/bundled-common/default.nix
@@ -243,7 +243,7 @@ let
 
   basicEnv =
     if copyGemFiles then
-      runCommand name' basicEnvArgs ''
+      runCommand name' (basicEnvArgs // { __structuredAttrs = true; }) ''
         mkdir -p $out
         for i in $paths; do
           ${buildPackages.rsync}/bin/rsync -a $i/lib $out/

--- a/pkgs/development/ruby-modules/bundler-env/default.nix
+++ b/pkgs/development/ruby-modules/bundler-env/default.nix
@@ -102,7 +102,7 @@ else
     };
   in
   if copyGemFiles then
-    runCommand basicEnv.name bundlerEnvArgs ''
+    runCommand basicEnv.name (bundlerEnvArgs // { __structuredAttrs = true; }) ''
       mkdir -p $out
       for i in $paths; do
         ${buildPackages.rsync}/bin/rsync -a $i/lib $out/


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

~It turns out that `bundlerApp` uses the env package constructed with bundled-common by default.~ (Update: This is not the case.)

`bundled-common` and `bundlerEnv` construct their result packages with `buildEnv` by default, and current `buildEnv` constructs its result package with structured attributes.

This PR deals with the situation where `copyGemFiles` argument is set to `true`, and make them use structured attributes also.
Nevertheless, there's currently no packages using such option in Nixpkgs, so this PR causes no rebuild.

This PR is complimentary to #539303
- #539303

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
