### PR TITLE
python313Packages.click-threading: drop docs dir before check phase

### DIFF
--- a/pkgs/development/python-modules/click-threading/default.nix
+++ b/pkgs/development/python-modules/click-threading/default.nix
@@ -23,6 +23,10 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  preCheck = ''
+    rm -rf docs
+  '';
+
   pythonImportsCheck = [ "click_threading" ];
 
   meta = {


### PR DESCRIPTION
Pytest collects docs/conf.py during the check phase because `setup.cfg` configures `--doctest-modules`, which makes pytest collect all .py files.

The collected `docs/conf.py` does:

```python
    import pkg_resources
```

This fails with ModuleNotFoundError since pkg_resources was removed in setuptools 82.0.1+.

Build error:

```bash
click-threading> pytest flags: -m pytest
click-threading> ============================= test session starts ==============================
click-threading> platform linux -- Python 3.14.6, pytest-9.0.3, pluggy-1.6.0
click-threading> rootdir: /build/click-threading-0.5.0
click-threading> configfile: setup.cfg
click-threading> collected 4 items / 1 error
click-threading>
click-threading> ==================================== ERRORS ====================================
click-threading> ________________________ ERROR collecting docs/conf.py _________________________
click-threading> ImportError while importing test module '/build/click-threading-0.5.0/docs/conf.py'.
click-threading> Hint: make sure your test modules/packages have valid Python names.
click-threading> Traceback:
click-threading> /nix/store/jxyrvv4gbpnp3ap5iy7wxwl1sg4x2x88-python3-3.14.6/lib/python3.14/importlib/__init_
click-threading>     return _bootstrap._gcd_import(name[level:], package, level)
click-threading>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
click-threading> docs/conf.py:5: in <module>
click-threading>     import pkg_resources
click-threading> E   ModuleNotFoundError: No module named 'pkg_resources'
click-threading> =========================== short test summary info ============================
click-threading> ERROR docs/conf.py
click-threading> !!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
click-threading> =============================== 1 error in 0.15s ===============================
```

Remove docs/ before pytest runs so it only discovers the 4 real tests under tests/.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
