### PR TITLE
nixos/cosmic: migrate from gnome-keyring to oo7

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -156,3 +156,8 @@
   - Please note that Nextcloud prohibits skipping major versions while upgrading. You can upgrade to specific versions by declaring `services.nextcloud.package = pkgs.nextcloud33;`.
 
 - `trilium-desktop` and `trilium-server` have been updated to 0.104.0. This release includes security hardening fixes that may break functionality. [See upstream release note for details](https://github.com/TriliumNext/Trilium/releases/tag/v0.104.0).
+
+- The COSMIC DE module has been updated to use `oo7` instead of `gnome-keyring` as the default Secret Service provider. Current keyrings should be automatically migrated to use oo7's specification. A successfully migrated keyring will leave behind the old keyring under the name `<keyring-name>.stamp`, letting you restore previous functionality by rolling back to `gnome-keyring` or manually delete old user data.
+  Rollback can be done by setting the following options:
+  `services.gnome.gnome-keyring.enable = true`
+  and `services.oo7.enable = false`

--- a/nixos/modules/services/desktop-managers/cosmic.nix
+++ b/nixos/modules/services/desktop-managers/cosmic.nix
@@ -165,15 +165,17 @@ in
     networking.networkmanager.enable = lib.mkDefault true;
     services.acpid.enable = lib.mkDefault true;
     services.avahi.enable = lib.mkDefault true;
-    services.gnome.gnome-keyring.enable = lib.mkDefault true;
+    services.gnome.gnome-keyring.enable = lib.mkDefault (lib.versionOlder lib.version "26.11");
+    services.gnome.gcr-ssh-agent.enable = lib.mkDefault true;
+    services.oo7.enable = lib.mkDefault (lib.versionAtLeast lib.version "26.11");
     services.gvfs.enable = lib.mkDefault true;
     services.orca.enable = lib.mkDefault (notExcluded pkgs.orca);
     services.power-profiles-daemon.enable = lib.mkDefault (
       !config.hardware.system76.power-daemon.enable
     );
 
-    warnings = lib.optionals (cfg.showExcludedPkgsWarning && excludedCorePkgs != [ ]) [
-      ''
+    warnings = [
+      (lib.mkIf (cfg.showExcludedPkgsWarning && excludedCorePkgs != [ ]) ''
         The `environment.cosmic.excludePackages` option was used to exclude some
         packages from the environment which also includes some packages that the
         maintainers of the COSMIC DE deem necessary for the COSMIC DE to start
@@ -186,7 +188,19 @@ in
 
         You can stop this warning from appearing by setting the option
         `services.desktopManager.cosmic.showExcludedPkgsWarning` to `false`.
-      ''
+      '')
+
+      (lib.mkIf (config.services.gnome.gnome-keyring.enable) ''
+        The Secret Service provider used by COSMIC `gnome-keyring` has been
+        replaced by `oo7` starting with 26.11.
+
+        You can migrate to this new service by setting the option
+        `services.gnome.gnome-keyring.enable` to `false` and `services.oo7.enable`
+        to `true`.
+
+        After the migration has been completed (which hapens on first login),
+        `gnome-keyring` will no longer be able to read the current keyring.
+      '')
     ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This pr depends on from https://github.com/NixOS/nixpkgs/pull/526624
I would appreciate if I could have a double check on the warning message as english is not my main language, thanks!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
