### PR TITLE
picgo: 2.5.3 -> 3.0.0

### DIFF
--- a/pkgs/by-name/pi/picgo/package.nix
+++ b/pkgs/by-name/pi/picgo/package.nix
@@ -6,7 +6,7 @@
   pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
-  electron_40,
+  electron_41,
   makeWrapper,
   copyDesktopItems,
   makeDesktopItem,
@@ -18,20 +18,20 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "picgo";
-  version = "2.5.3";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "Molunerfinn";
     repo = "PicGo";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-4Ih7PPBo6scJoUS8yTAR0iyG5vxNc/c0CCw5FGaIbHM=";
+    hash = "sha256-ruTgNgZsjpdu2Cc2Q4HxPdoQHUww1UTbvLazglaz75c=";
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) version src;
     inherit pnpm;
     pname = "picgo";
-    hash = "sha256-tILvWDoHAN5XT1F/cJYgfeMzowuO/fhiughI+0FvHzc=";
+    hash = "sha256-IAuTtI0Ljm4+xCeMGIQAf7lK37CQ6qf7PJsksLIti7Q=";
     fetcherVersion = 3; # lockfileVersion 9.0 corresponds to fetcherVersion 3
   };
 
@@ -56,6 +56,17 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postBuild
   '';
 
+  postBuild = ''
+    cp -r src/renderer/public/. dist_electron/renderer/
+
+    # Renderer assets are loaded from a file:// URL, so root-relative paths like
+    # /squareLogo.png resolve to the filesystem root. Copy the renderer public assets
+    # next to index.html and rewrite those references to relative paths.
+    # https://github.com/Molunerfinn/PicGo/blob/dev/src/renderer/components/independent-window/mini/picgo-mini-page.tsx
+    substituteInPlace dist_electron/renderer/assets/mini-*.js \
+      --replace-fail '"/squareLogo.png"' '"./squareLogo.png"'
+  '';
+
   installPhase = ''
     runHook preInstall
 
@@ -73,10 +84,20 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Create startup script
     mkdir -p $out/bin
-    makeWrapper ${lib.getExe electron_40} $out/bin/picgo \
+    # PicGo uses app.isPackaged to decide whether it is running in development mode.
+    # With the nixpkgs Electron wrapper the executable is still the generic electron
+    # binary, so app.isPackaged is false unless we force the packaged code path.
+    # https://github.com/Molunerfinn/PicGo/blob/4d92ca199b7afead168785d7375a525ca156b25f/src/main/utils/env.ts#L17-L22
+
+    # ELECTRON_FORCE_IS_PACKAGED makes PicGo use its production resource path,
+    # but with the nixpkgs Electron wrapper process.resourcesPath points to Electron
+    # itself, so point PicGo at the installed public assets
+    makeWrapper ${lib.getExe electron_41} $out/bin/picgo \
+      --add-flags "--class=picgo" \
       --add-flags "$out/lib/picgo/.launcher.cjs" \
-      --add-flags "--name picgo" \
       --set NODE_ENV production \
+      --set ELECTRON_FORCE_IS_PACKAGED 1 \
+      --set STATIC_PATH "$out/lib/picgo/public" \
       --set-default ELECTRON_OZONE_PLATFORM_HINT auto \
       --chdir "$out/lib/picgo"
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Changelog](https://github.com/Molunerfinn/PicGo/blob/dev/CHANGELOG.md)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
