### PR TITLE
satysfi: fix the ipaexfont is not bundled properly

### DIFF
--- a/pkgs/by-name/sa/satysfi/package.nix
+++ b/pkgs/by-name/sa/satysfi/package.nix
@@ -79,7 +79,7 @@ ocamlPackages.buildDunePackage {
     mkdir -p $out/share/satysfi/dist/fonts
     cp -r lib-satysfi/dist/ $out/share/satysfi/
     cp -r \
-      ${ipaexfont}/share/fonts/opentype/* \
+      ${ipaexfont}/share/fonts/truetype/* \
       ${lmodern}/share/fonts/opentype/public/lm/* \
       ${lmmath}/share/fonts/opentype/latinmodern-math.otf \
       ${junicode}/share/fonts/truetype/Junicode-{Bold,BoldItalic,Italic}.ttf \


### PR DESCRIPTION
## Problem

The ipaexfont package, which is an runtime dependency of SATySFi and should be bundled with the SATySFi package, used to install their font files at `$out/share/fonts/opentype`.  But from this commit, it installs their font files at `$out/share/fonts/truetype`: https://github.com/NixOS/nixpkgs/commit/af30ee15afe6cdb141d59f4827dba9b074666e93
Therefore currently the ipaexfonts are not bundled with the SATySFi package, results in build failure of documents that have Japanese letters.

## Reproduce steps

- Prepare this `main.saty`
    ```
    @require: stdjareport

    document (|
      title = {いろはにほへと}; % <- These are Japanese Hiragana letters.
      author = {satysfi-repro};
    |) '<>
    ```

- Build the `main.saty`: `satysfi main.saty`

## Actual behavior

The build fails.

```
! [Error] library file not found:
      dist/fonts/ipaexm.ttf
    candidate paths:
      /tmp/satysfi-test/.satysfi/dist/fonts/ipaexm.ttf
      /home/mityu/.satysfi/dist/fonts/ipaexm.ttf
      /nix/store/gry4psdxvhxch13f6ipa0hj6ry37k6jf-ocaml4.14.4-satysfi-0.0.11/share/satysfi/dist/fonts/ipaexm.ttf
```

<details>
    <summary>Full command-line output</summary>

    ```
     ---- ---- ---- ----
      target file: 'main.pdf'
      dump file: 'main.satysfi-aux' (will be created)
      parsing 'main.saty' ...
      parsing 'stdjareport.satyh' ...
      parsing 'pervasives.satyh' ...
      parsing 'gr.satyh' ...
      parsing 'geom.satyh' ...
      parsing 'list.satyg' ...
      parsing 'option.satyg' ...
      parsing 'math.satyh' ...
      parsing 'code.satyh' ...
      parsing 'color.satyh' ...
      parsing 'vdecoset.satyh' ...
      parsing 'annot.satyh' ...
      parsing 'footnote-scheme.satyh' ...
     ---- ---- ---- ----
      type checking 'color.satyh' ...
      type check passed.
     ---- ---- ---- ----
      type checking 'pervasives.satyh' ...
      type check passed.
     ---- ---- ---- ----
      type checking 'option.satyg' ...
      type check passed.
     ---- ---- ---- ----
      type checking 'geom.satyh' ...
      type check passed.
     ---- ---- ---- ----
      type checking 'list.satyg' ...
      type check passed.
     ---- ---- ---- ----
      type checking 'gr.satyh' ...
      type check passed.
     ---- ---- ---- ----
      type checking 'annot.satyh' ...
      type check passed.
     ---- ---- ---- ----
      type checking 'footnote-scheme.satyh' ...
      type check passed.
     ---- ---- ---- ----
      type checking 'math.satyh' ...
      type check passed.
     ---- ---- ---- ----
      type checking 'vdecoset.satyh' ...
      type check passed.
     ---- ---- ---- ----
      type checking 'code.satyh' ...
      type check passed.
     ---- ---- ---- ----
      type checking 'stdjareport.satyh' ...
      type check passed.
     ---- ---- ---- ----
      type checking 'main.saty' ...
      type check passed. (document)
      preprocessing 'color.satyh' ...
      preprocessing 'pervasives.satyh' ...
      evaluating 'option.satyg' ...
      preprocessing 'geom.satyh' ...
      evaluating 'list.satyg' ...
      preprocessing 'gr.satyh' ...
      preprocessing 'annot.satyh' ...
      preprocessing 'footnote-scheme.satyh' ...
      preprocessing 'math.satyh' ...
      preprocessing 'vdecoset.satyh' ...
      preprocessing 'code.satyh' ...
      preprocessing 'stdjareport.satyh' ...
      preprocessing 'main.saty' ...
      evaluating 'color.satyh' ...
      evaluating 'pervasives.satyh' ...
      evaluating 'geom.satyh' ...
      evaluating 'gr.satyh' ...
      evaluating 'annot.satyh' ...
      evaluating 'footnote-scheme.satyh' ...
      evaluating 'math.satyh' ...
      evaluating 'vdecoset.satyh' ...
      evaluating 'code.satyh' ...
      evaluating 'stdjareport.satyh' ...
     ---- ---- ---- ----
      evaluating texts ...
    ! [Error] library file not found:
          dist/fonts/ipaexm.ttf
        candidate paths:
          /tmp/satysfi-test/.satysfi/dist/fonts/ipaexm.ttf
          /home/mityu/.satysfi/dist/fonts/ipaexm.ttf
          /nix/store/gry4psdxvhxch13f6ipa0hj6ry37k6jf-ocaml4.14.4-satysfi-0.0.11/share/satysfi/dist/fonts/ipaexm.ttf
    ```

</details>

## Expected behavior

The build succeeds.
The SATySFi binary built with this PR can build the `main.saty` properly.
Note that I confirmed this on the environment that is provided by `nix run nixpkgs#nixpkgs-review -- wip`. 

Logs of `satysfi main.saty`:
<details>
<summary>Full command-line output</summary>

```
 ---- ---- ---- ----
  target file: 'main.pdf'
  dump file: 'main.satysfi-aux' (will be created)
  parsing 'main.saty' ...
  parsing 'stdjareport.satyh' ...
  parsing 'pervasives.satyh' ...
  parsing 'gr.satyh' ...
  parsing 'geom.satyh' ...
  parsing 'list.satyg' ...
  parsing 'option.satyg' ...
  parsing 'math.satyh' ...
  parsing 'code.satyh' ...
  parsing 'color.satyh' ...
  parsing 'vdecoset.satyh' ...
  parsing 'annot.satyh' ...
  parsing 'footnote-scheme.satyh' ...
 ---- ---- ---- ----
  type checking 'option.satyg' ...
  type check passed.
 ---- ---- ---- ----
  type checking 'color.satyh' ...
  type check passed.
 ---- ---- ---- ----
  type checking 'pervasives.satyh' ...
  type check passed.
 ---- ---- ---- ----
  type checking 'list.satyg' ...
  type check passed.
 ---- ---- ---- ----
  type checking 'geom.satyh' ...
  type check passed.
 ---- ---- ---- ----
  type checking 'gr.satyh' ...
  type check passed.
 ---- ---- ---- ----
  type checking 'annot.satyh' ...
  type check passed.
 ---- ---- ---- ----
  type checking 'footnote-scheme.satyh' ...
  type check passed.
 ---- ---- ---- ----
  type checking 'math.satyh' ...
  type check passed.
 ---- ---- ---- ----
  type checking 'vdecoset.satyh' ...
  type check passed.
 ---- ---- ---- ----
  type checking 'code.satyh' ...
  type check passed.
 ---- ---- ---- ----
  type checking 'stdjareport.satyh' ...
  type check passed.
 ---- ---- ---- ----
  type checking 'main.saty' ...
  type check passed. (document)
  evaluating 'option.satyg' ...
  preprocessing 'color.satyh' ...
  preprocessing 'pervasives.satyh' ...
  evaluating 'list.satyg' ...
  preprocessing 'geom.satyh' ...
  preprocessing 'gr.satyh' ...
  preprocessing 'annot.satyh' ...
  preprocessing 'footnote-scheme.satyh' ...
  preprocessing 'math.satyh' ...
  preprocessing 'vdecoset.satyh' ...
  preprocessing 'code.satyh' ...
  preprocessing 'stdjareport.satyh' ...
  preprocessing 'main.saty' ...
  evaluating 'color.satyh' ...
  evaluating 'pervasives.satyh' ...
  evaluating 'geom.satyh' ...
  evaluating 'gr.satyh' ...
  evaluating 'annot.satyh' ...
  evaluating 'footnote-scheme.satyh' ...
  evaluating 'math.satyh' ...
  evaluating 'vdecoset.satyh' ...
  evaluating 'code.satyh' ...
  evaluating 'stdjareport.satyh' ...
 ---- ---- ---- ----
  evaluating texts ...
  [Warning] GID 1808 is used as more than one kind of ligatures.
  [Warning] GID 1832 is used as more than one kind of ligatures.
  [Warning] GID 1805 is used as more than one kind of ligatures.
modified version of stdjareport.
  evaluation done.
 ---- ---- ---- ----
  breaking contents into pages ...
page content 1
column start.
reach last.
column end 1 (last: T, remains: F)
page parts 1
  needs another trial for solving cross references...
 ---- ---- ---- ----
  evaluating texts (2nd trial) ...
  [Warning] GID 1808 is used as more than one kind of ligatures.
  [Warning] GID 1832 is used as more than one kind of ligatures.
  [Warning] GID 1805 is used as more than one kind of ligatures.
modified version of stdjareport.
  evaluation done.
 ---- ---- ---- ----
  breaking contents into pages ...
page content 1
column start.
reach last.
column end 1 (last: T, remains: F)
page parts 1
  all cross references were solved.
 ---- ---- ---- ----
  embedding fonts ...
 ---- ---- ---- ----
  writing pages ...
 ---- ---- ---- ----
  output written on 'main.pdf'.
```

</details>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
