### PR TITLE
gdal: fix cross-compilation

### DIFF
--- a/pkgs/by-name/gd/gdal/package.nix
+++ b/pkgs/by-name/gd/gdal/package.nix
@@ -79,8 +79,8 @@
   xz,
   zlib,
   zstd,
+  buildPackages,
 }:
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "gdal" + lib.optionalString useMinimalFeatures "-minimal";
   version = "3.13.1";
@@ -132,6 +132,9 @@ stdenv.mkDerivation (finalAttrs: {
     # This is not strictly needed as the Java bindings wouldn't build anyway if
     # ant/jdk were not available.
     "-DBUILD_JAVA_BINDINGS=OFF"
+  ]
+  ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    "-DCMAKE_CROSSCOMPILING_EMULATOR=${stdenv.hostPlatform.emulator buildPackages}"
   ];
 
   buildInputs =


### PR DESCRIPTION
fixes gdal cross-compilation

tested with
```
nix build -L .#pkgsCross.riscv64.gdal
```

fixes error
```
gdal-riscv64-unknown-linux-gnu> -- Detecting CXX compile features
gdal-riscv64-unknown-linux-gnu> -- Detecting CXX compile features - done
gdal-riscv64-unknown-linux-gnu> -- Performing Test SSE2NEON_COMPILES
gdal-riscv64-unknown-linux-gnu> -- Performing Test SSE2NEON_COMPILES - Failed
gdal-riscv64-unknown-linux-gnu> -- Performing Test HAVE_STD_FLOAT16_T
gdal-riscv64-unknown-linux-gnu> -- Performing Test HAVE_STD_FLOAT16_T - Failed
gdal-riscv64-unknown-linux-gnu> -- Found SWIG: /nix/store/wz68mkc0rbzswn5y70xmzwayx3zd7dif-swig-4.4.1/bin/swig (found version "4.4.1")
gdal-riscv64-unknown-linux-gnu> CMake Error at /nix/store/rfad6gqp02yfhjkh7m080jzcrq104jq8-cmake-4.1.2/share/cmake-4.1/Modules/FindPython/Support.cmake:46 (message):
gdal-riscv64-unknown-linux-gnu>   Python: When cross-compiling, Interpreter and/or Compiler components cannot
gdal-riscv64-unknown-linux-gnu>   be searched when CMAKE_CROSSCOMPILING_EMULATOR variable is not specified
gdal-riscv64-unknown-linux-gnu>   (see policy CMP0190).
gdal-riscv64-unknown-linux-gnu> Call Stack (most recent call first):
gdal-riscv64-unknown-linux-gnu>   /nix/store/rfad6gqp02yfhjkh7m080jzcrq104jq8-cmake-4.1.2/share/cmake-4.1/Modules/FindPython/Support.cmake:1505 (_python_display_failure)
gdal-riscv64-unknown-linux-gnu>   /nix/store/rfad6gqp02yfhjkh7m080jzcrq104jq8-cmake-4.1.2/share/cmake-4.1/Modules/FindPython.cmake:685 (include)
gdal-riscv64-unknown-linux-gnu>   CMakeLists.txt:229 (find_package)
gdal-riscv64-unknown-linux-gnu> 
gdal-riscv64-unknown-linux-gnu> -- Configuring incomplete, errors occurred!
```
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
