### PR TITLE
rPackages.V8: fixed build

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -999,7 +999,7 @@ let
       rustc
     ];
     vdiffr = [ pkgs.libpng.dev ];
-    V8 = [ pkgs.nodejs-slim_22.libv8 ]; # when unpinning the version, don't forget about the other usages later
+    V8 = [ pkgs.pkg-config ];
     xactonomial = with pkgs; [
       cargo
       rustc
@@ -1150,6 +1150,10 @@ let
     svKomodo = [ pkgs.which ];
     transmogR = [ pkgs.zlib.dev ];
     ulid = [ pkgs.zlib.dev ];
+    V8 = with pkgs; [
+      nodejs-slim_22.libv8
+      icu78 # use same icu version as in pkgs/development/web/nodejs/nodejs.nix
+    ];
     unrtf = with pkgs; [
       bzip2.dev
       icu.dev
@@ -2643,18 +2647,9 @@ let
     });
 
     V8 = old.V8.overrideAttrs (attrs: {
-      postPatch = ''
-        substituteInPlace configure \
-          --replace-fail " -lv8_libplatform" ""
-        # Bypass the test checking if pointer compression is needed
-        substituteInPlace configure \
-          --replace-fail "./pctest1" "true"
-      '';
-
       preConfigure = ''
-        # when unpinning the version, don't forget about the other usage earlier
-        export INCLUDE_DIR=${pkgs.nodejs-slim_22.libv8}/include
-        export LIB_DIR=${pkgs.nodejs-slim_22.libv8}/lib
+        export V8_PKG_CFLAGS="$(pkg-config --cflags v8)";
+        export V8_PKG_LIBS="$(pkg-config --libs v8)";
         patchShebangs configure
       '';
 


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/539315

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
