### PR TITLE
treewide: remove knl from maintainers

### DIFF
--- a/pkgs/by-name/gr/grpcurl/package.nix
+++ b/pkgs/by-name/gr/grpcurl/package.nix
@@ -29,7 +29,7 @@ buildGoModule (finalAttrs: {
     description = "Like cURL, but for gRPC: Command-line tool for interacting with gRPC servers";
     homepage = "https://github.com/fullstorydev/grpcurl";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ knl ];
+    maintainers = [ ];
     mainProgram = "grpcurl";
   };
 })

--- a/pkgs/by-name/is/isomd5sum/package.nix
+++ b/pkgs/by-name/is/isomd5sum/package.nix
@@ -41,6 +41,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Utilities for working with md5sum implanted in ISO images";
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ knl ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/pr/prek/package.nix
+++ b/pkgs/by-name/pr/prek/package.nix
@@ -56,6 +56,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mainProgram = "prek";
     changelog = "https://github.com/j178/prek/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = [ lib.licenses.mit ];
-    maintainers = [ lib.maintainers.knl ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/re/refurb/package.nix
+++ b/pkgs/by-name/re/refurb/package.nix
@@ -57,6 +57,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
     mainProgram = "refurb";
     homepage = "https://github.com/dosisod/refurb";
     license = with lib.licenses; [ gpl3Only ];
-    maintainers = with lib.maintainers; [ knl ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/ze/zed/package.nix
+++ b/pkgs/by-name/ze/zed/package.nix
@@ -45,8 +45,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://zed.brimdata.io";
     changelog = "https://github.com/brimdata/zed/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [
-      knl
-    ];
+    maintainers = [ ];
   };
 })


### PR DESCRIPTION
I have no capacity at the moment to work on any of these packages, that I don't use anymore.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
