### PR TITLE
python3Packages.orjson: fix cross compilation patch

### DIFF
--- a/pkgs/development/python-modules/orjson/cross-arch-compat.patch
+++ b/pkgs/development/python-modules/orjson/cross-arch-compat.patch
@@ -1,6 +1,6 @@
-From 8a6c16fd79e78aaaf1223090e673bdbe11451abc Mon Sep 17 00:00:00 2001
-From: DavHau <hsngrmpf+github@gmail.com>
-Date: Wed, 22 Oct 2025 10:40:03 +0700
+From 7e2adf4811f9109f1bb35d8da46f1d0cb7e53183 Mon Sep 17 00:00:00 2001
+From: FlashOnFire_ <flashonfire@proton.me>
+Date: Thu, 9 Jul 2026 09:27:58 +0200
 Subject: [PATCH] Fix cross-compilation by checking target arch in build.rs
 
 Previously, build.rs used #[cfg(target_arch)] attributes which check
@@ -11,38 +11,49 @@ riscv64, leading to compilation errors.
 
 Now uses CARGO_CFG_TARGET_ARCH environment variable to correctly
 detect the target architecture during cross-compilation.
+
+Co-authored-by: DavHau <hsngrmpf+github@gmail.com>
 ---
- build.rs | 7 ++++++--
- 1 file changed, 6 insertions(+), 1 deletion(-)
+ build.rs | 13 +++++++++----
+ 1 file changed, 9 insertions(+), 4 deletions(-)
 
 diff --git a/build.rs b/build.rs
-index 49a9a9a4..0a99698d 100644
+index 09b723e..4093c9e 100644
 --- a/build.rs
 +++ b/build.rs
-@@ -11,6 +11,9 @@ fn main() {
+@@ -11,14 +11,20 @@ fn main() {
      #[allow(unused_variables)]
      let is_64_bit_python = matches!(python_config.pointer_width, Some(64));
-
+ 
 +    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
 +    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
 +
      match python_config.implementation {
          pyo3_build_config::PythonImplementation::CPython => {
              println!("cargo:rustc-cfg=CPython");
-@@ -18,7 +21,7 @@ fn main() {
-             println!("cargo:rustc-cfg=CPython");
-             #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
--            if is_64_bit_python {
-+            if (target_arch == "x86_64" || target_arch == "aarch64") && is_64_bit_python {
+             if python_config.abi3 {
+                 println!("cargo:rustc-cfg=Py_LIMITED_ABI");
+             }
+-            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+-            if is_64_bit_python && !python_config.abi3 {
++
++            if (target_arch == "x86_64" || target_arch == "aarch64")
++                && is_64_bit_python
++                && !python_config.abi3
++            {
                  println!("cargo:rustc-cfg=feature=\"inline_int\"");
                  #[cfg(target_endian = "little")]
                  println!("cargo:rustc-cfg=feature=\"inline_str\"");
-             }
-@@ -50,7 +53,7 @@ fn main() {
+@@ -51,8 +57,7 @@ fn main() {
+     println!("cargo:rustc-check-cfg=cfg(Py_LIMITED_ABI)");
      println!("cargo:rustc-check-cfg=cfg(PyPy)");
-
-     #[cfg(all(target_arch = "x86_64", not(target_os = "macos")))]
+ 
+-    #[cfg(all(target_arch = "x86_64", not(target_os = "macos")))]
 -    if is_64_bit_python {
 +    if target_arch == "x86_64" && target_os != "macos" && is_64_bit_python {
          println!("cargo:rustc-cfg=feature=\"avx512\"");
      }
+ 
+-- 
+2.54.0
+

--- a/pkgs/development/python-modules/orjson/default.nix
+++ b/pkgs/development/python-modules/orjson/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
   };
 
   patches = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
-    # fix architecture checks in build.rs to fix build for riscv
+    # fix architecture checks in build.rs to fix build for non x86_64
     ./cross-arch-compat.patch
   ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Orjson cross compilation broke after #527386, so here's your next batch of cross compilation fixes :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
  - [x] x86_64-linux -> aarch64-multiplatform cross
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
