### PR TITLE
livekit-libwebrtc: link with lld on darwin, fix compiler warnings

### DIFF
--- a/pkgs/by-name/li/livekit-libwebrtc/package.nix
+++ b/pkgs/by-name/li/livekit-libwebrtc/package.nix
@@ -139,6 +139,10 @@ stdenv.mkDerivation {
       --replace-fail "rtc_static_library" "rtc_shared_library" \
       --replace-fail "complete_static_lib = true" ""
 
+    # Remove the libcxx hardening config to avoid clashes with nixpkgs' own compiler wrapper,
+    # which already defines the hardening macros.
+    sed -i '/config("libcxx_hardening") {/,/^}/c\config("libcxx_hardening") {}' build/config/compiler/BUILD.gn
+
     substituteInPlace webrtc.gni \
       --replace-fail "!build_with_chromium && is_component_build" "false"
 
@@ -179,6 +183,11 @@ stdenv.mkDerivation {
     chmod +x build/toolchain/apple/linker_driver.py
     patchShebangs build/toolchain/apple/linker_driver.py
     substituteInPlace build/toolchain/apple/toolchain.gni --replace-fail "/bin/cp -Rc" "cp -a"
+
+    # nixpkgs calls the target "darwin" instead of "macos", and passing a different target
+    # results in warnings by the nixpkgs compiler wrapper
+    substituteInPlace build/config/mac/BUILD.gn \
+      --replace-fail '$clang_arch-apple-macos' '$clang_arch-apple-darwin'
   '';
 
   outputs = [

--- a/pkgs/by-name/li/livekit-libwebrtc/package.nix
+++ b/pkgs/by-name/li/livekit-libwebrtc/package.nix
@@ -7,6 +7,8 @@
   fetchurl,
   fetchpatch,
   xcbuild,
+  lld,
+  llvm,
   python3,
   ninja,
   git,
@@ -182,7 +184,13 @@ stdenv.mkDerivation {
     ln -sf ${lib.getExe gn} buildtools/mac/gn
     chmod +x build/toolchain/apple/linker_driver.py
     patchShebangs build/toolchain/apple/linker_driver.py
-    substituteInPlace build/toolchain/apple/toolchain.gni --replace-fail "/bin/cp -Rc" "cp -a"
+
+    # When 'use_lld=true' is set, llvm-ar is used instead of ar.
+    # The build config expects llvm-ar to be inside the provided clang base path,
+    # but this is not the case in nixpkgs.
+    substituteInPlace build/toolchain/apple/toolchain.gni \
+      --replace-fail "/bin/cp -Rc" "cp -a" \
+      --replace-fail '${"$"}{prefix}llvm-ar' '${lib.getExe' llvm "llvm-ar"}'
 
     # nixpkgs calls the target "darwin" instead of "macos", and passing a different target
     # results in warnings by the nixpkgs compiler wrapper
@@ -210,7 +218,10 @@ stdenv.mkDerivation {
       cpio
       pkg-config
     ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [ xcbuild ];
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      xcbuild
+      lld
+    ];
 
   buildInputs = [
     nasm
@@ -279,7 +290,8 @@ stdenv.mkDerivation {
     "rtc_enable_objc_symbol_export=true"
     "rtc_include_dav1d_in_internal_decoder_factory=true"
     "clang_use_chrome_plugins=false"
-    "use_lld=false"
+    # ld64 traps on linking because of C++ hardening
+    "use_lld=true"
     ''clang_base_path="${clang}"''
   ]);
 
@@ -296,6 +308,12 @@ stdenv.mkDerivation {
     "sdk:mac_framework_objc"
     "desktop_capture_objc"
   ];
+
+  env = {
+    # ensure install_name_tool has enough space in binary headers
+    # to replace rpaths with very long nix store paths
+    NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-headerpad_max_install_names";
+  };
 
   postBuild =
     lib.optionalString stdenv.hostPlatform.isLinux ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Recently landed changes to ld64 hardening make it unusable for linking livekit-libwebrtc, so we have to switch to lld.
I also fixed some annoying compiler warnings in a separate commit.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
