### PR TITLE
dua: add shell completions

### DIFF
--- a/pkgs/by-name/du/dua/package.nix
+++ b/pkgs/by-name/du/dua/package.nix
@@ -1,9 +1,11 @@
 {
+  stdenv,
   lib,
   rustPlatform,
   fetchFromGitHub,
   versionCheckHook,
   nix-update-script,
+  installShellFiles,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -37,6 +39,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
+
+  nativeBuildInputs = [ installShellFiles ];
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    # TODO: Upstream also provides Elvish and PowerShell completions,
+    # but `installShellCompletion` only has support for Bash, Zsh and Fish at the moment.
+      installShellCompletion --cmd dua \
+        --bash <($out/bin/dua completions bash) \
+        --fish <($out/bin/dua completions fish) \
+        --zsh  <($out/bin/dua completions zsh)
+  '';
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
Adds shell completions provided by the `dua` package. Inspired by this commit: https://github.com/NixOS/nixpkgs/pull/537602.

Tested on all three shells:

**Bash**

```shell
bash --noprofile --norc  # Starts a clean bash env

export PATH="$PWD/result/bin:$PATH"
source "$PWD/result/share/bash-completion/completions/dua"

complete -p dua # This should show "complete -o bashdefault -o default -o nosort -F _dua dua"

dua <TAB> # check that it works
```

**Zsh**

```shell
zsh -f  # Starts a clean zsh env

fpath=("$PWD/result/share/zsh/site-functions" $fpath)
autload -U compinit
compinit
path=("$PWD/result/bin" $path)

dua <TAB>
dua --<TAB>
```

**Fish**

I do not have Fish installed, but used the temp shell:

```shell
nix shell nixpkgs#fish -c fish --no-config # Starts a clean fish env

set -gx PATH $PWD/result/bin $PATH
source $PWD/result/share/fish/vendor_completions.d/dua.fish

dua <TAB>
dua --<TAB>
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
