### PR TITLE
regexplain: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26291,6 +26291,12 @@
     github = "snpschaaf";
     githubId = 105843013;
   };
+  sntx = {
+    name = "sntx";
+    email = "sntx@sntx.space";
+    github = "Sntx626";
+    githubId = 48636286;
+  };
   snu = {
     email = "kabelfrickler@gmail.com";
     github = "snue";

--- a/pkgs/by-name/re/regexplain/package.nix
+++ b/pkgs/by-name/re/regexplain/package.nix
@@ -1,0 +1,29 @@
+{
+  fetchFromGitHub,
+  lib,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "regexplain";
+  version = "1.0.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "kapilpokhrel";
+    repo = "regexplain";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-UtwRDFUjpgxgY+geAX4xmTYGgH897tKqxkIShzQEhWA=";
+  };
+  cargoHash = "sha256-6kNiF1ZEl25UuGoTrIph0NhJg422OW/dKtgOSYV7zxo=";
+
+  meta = {
+    description = "A terminal UI for explaining and visualizing regular expressions, kindof like regex101.";
+    homepage = "https://github.com/kapilpokhrel/regexplain";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      sntx
+    ];
+    mainProgram = "regexplain";
+  };
+})


### PR DESCRIPTION
A terminal UI for explaining and visualizing regular expressions, kindof like regex101: https://github.com/kapilpokhrel/regexplain

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
