### PR TITLE
gnat{13, 14, 15, 16}, gprbuild, gprbuild-boot, gnatcoll, gpr2, alire, gnatprove: fix build on aarch64-darwin

### DIFF
--- a/pkgs/by-name/al/alire/package.nix
+++ b/pkgs/by-name/al/alire/package.nix
@@ -1,12 +1,12 @@
 {
   lib,
-  stdenv,
+  stdenvNoCC,
   fetchFromGitHub,
   gprbuild,
   gnat,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "alire";
   version = "2.1.1";
 

--- a/pkgs/development/ada-modules/gnatcoll/bindings.nix
+++ b/pkgs/development/ada-modules/gnatcoll/bindings.nix
@@ -1,5 +1,5 @@
 {
-  stdenv,
+  stdenvNoCC,
   lib,
   fetchFromGitHub,
   gnat,
@@ -34,7 +34,7 @@ let
   };
 in
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "gnatcoll-${component}";
   version = "25.0.0";
 

--- a/pkgs/development/ada-modules/gnatcoll/core.nix
+++ b/pkgs/development/ada-modules/gnatcoll/core.nix
@@ -1,5 +1,5 @@
 {
-  stdenv,
+  stdenvNoCC,
   lib,
   gnat,
   gprbuild,
@@ -18,7 +18,7 @@
 # gnatcoll-projects depends on gnatcoll-core
 assert enableGnatcollProjects -> enableGnatcollCore;
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "gnatcoll-core";
   version = "25.0.0";
 
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
     "prefix=${placeholder "out"}"
     "PROCESSORS=$(NIX_BUILD_CORES)"
     # confusingly, for gprbuild --target is autoconf --host
-    "TARGET=${stdenv.hostPlatform.config}"
+    "TARGET=${stdenvNoCC.hostPlatform.config}"
     "GNATCOLL_MINIMAL_ONLY=${lib.boolToYesNo (!enableGnatcollCore)}"
     "GNATCOLL_PROJECTS=${lib.boolToYesNo enableGnatcollProjects}"
   ];

--- a/pkgs/development/ada-modules/gnatprove/default.nix
+++ b/pkgs/development/ada-modules/gnatprove/default.nix
@@ -149,6 +149,8 @@ stdenv.mkDerivation {
     # gnat2why/gnat_src points to the GNAT sources
     tar xf ${gnat.cc.src} --wildcards 'gcc-*/gcc/ada'
     mv gcc-*/gcc/ada gnat2why/gnat_src
+
+    mv src/common/aarch64-darwin src/common/arm64-darwin
   '';
 
   configurePhase = ''

--- a/pkgs/development/ada-modules/gnatprove/default.nix
+++ b/pkgs/development/ada-modules/gnatprove/default.nix
@@ -58,6 +58,9 @@ let
       };
       commit_date = "2023-01-05";
       patches = [
+        # Suppress warnings on aarch64: https://github.com/AdaCore/spark2014/issues/54
+        ./0002-mute-aarch64-warnings.patch
+
         # Changes to the GNAT frontend: https://github.com/AdaCore/spark2014/issues/58
         ./0003-Adjust-after-category-change-for-N_Formal_Package_De.patch
       ];

--- a/pkgs/development/ada-modules/gnatprove/default.nix
+++ b/pkgs/development/ada-modules/gnatprove/default.nix
@@ -1,7 +1,8 @@
 {
-  stdenv,
+  stdenvNoCC,
   lib,
   fetchFromGitHub,
+  clang,
   gnat,
   gnatcoll-core,
   gprbuild,
@@ -99,7 +100,7 @@ let
       or (throw "GNATprove depends on a specific GNAT version and can't be built using GNAT ${gnat_version}.");
 
 in
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "gnatprove";
   version = "fsf-${gnat_version}_${thisSpark.commit_date}";
 
@@ -117,7 +118,8 @@ stdenv.mkDerivation {
     ocaml
     findlib
     menhir
-  ]);
+  ])
+  ++ lib.optional stdenvNoCC.targetPlatform.isDarwin clang;
 
   buildInputs = [
     gnatcoll-core

--- a/pkgs/development/ada-modules/gpr2/default.nix
+++ b/pkgs/development/ada-modules/gpr2/default.nix
@@ -48,6 +48,7 @@ stdenv.mkDerivation rec {
   # fool make into thinking pregenerated targets are up to date
   preBuild = lib.optionalString (gpr2kbdir == null) ''
     touch .build/kb/{*.adb,*.ads,collect_kb}
+    chmod +x .build/kb/collect_kb
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/ada-modules/gprbuild/boot.nix
+++ b/pkgs/development/ada-modules/gprbuild/boot.nix
@@ -1,6 +1,7 @@
 {
   stdenv,
   lib,
+  applyPatches,
   fetchFromGitHub,
   fetchpatch2,
   gnat,
@@ -11,15 +12,36 @@
 let
   version = "25.0.0";
 
-  gprConfigKbSrc = fetchFromGitHub {
-    name = "gprconfig-kb-${version}-src";
-    owner = "AdaCore";
-    repo = "gprconfig_kb";
-    rev = "v${version}";
-    sha256 = "09x1njq0i0z7fbwg0mg39r5ghy7369avbqvdycfj67lpmw17gb1r";
+  gprconfig_kb = applyPatches {
+    src = fetchFromGitHub {
+      owner = "AdaCore";
+      repo = "gprconfig_kb";
+      tag = "v${version}";
+      hash = "sha256-Oax3Aq+XHiMd823jtVUy43j4Sk7jVfD4cueDCLC0oSc=";
+    };
+
+    patches = [
+      ./gprconfig_kb-darwin.patch
+    ];
+
+    postPatch = ''
+      # Install custom compiler description which can detect nixpkgs'
+      # GNAT wrapper as a proper Ada compiler. The default compiler
+      # description expects the runtime library to be installed in
+      # the same prefix which isn't the case for nixpkgs. As a
+      # result, it would detect the unwrapped GNAT as a proper
+      # compiler which is unable to produce working binaries.
+      #
+      # Our compiler description is very similar to the upstream
+      # GNAT description except that we use a symlink in $out/nix-support
+      # created by the cc-wrapper to find the associated runtime
+      # libraries and use gnatmake instead of gnatls to find GNAT's
+      # bin directory.
+
+      install -m644 ${./nixpkgs-gnat.xml} db/nixpkgs-gnat.xml
+    '';
   };
 in
-
 stdenv.mkDerivation {
   pname = "gprbuild-boot";
   inherit version;
@@ -29,7 +51,7 @@ stdenv.mkDerivation {
     owner = "AdaCore";
     repo = "gprbuild";
     rev = "v${version}";
-    sha256 = "1mqsmc0q5bzg8223ls18kbvaz6mhzjz7ik8d3sqhhn24c0j6wjaw";
+    hash = "sha256-XEluJGBEWAixHg3NeL78sJqv9pooaDqEQO+vggGrGtc=";
   };
 
   nativeBuildInputs = [
@@ -84,22 +106,8 @@ stdenv.mkDerivation {
 
     ./bootstrap.sh \
       --with-xmlada=${xmlada.src} \
-      --with-kb=${gprConfigKbSrc} \
+      --with-kb=${gprconfig_kb} \
       --prefix=$out
-
-    # Install custom compiler description which can detect nixpkgs'
-    # GNAT wrapper as a proper Ada compiler. The default compiler
-    # description expects the runtime library to be installed in
-    # the same prefix which isn't the case for nixpkgs. As a
-    # result, it would detect the unwrapped GNAT as a proper
-    # compiler which is unable to produce working binaries.
-    #
-    # Our compiler description is very similar to the upstream
-    # GNAT description except that we use a symlink in $out/nix-support
-    # created by the cc-wrapper to find the associated runtime
-    # libraries and use gnatmake instead of gnatls to find GNAT's
-    # bin directory.
-    install -m644 ${./nixpkgs-gnat.xml} $out/share/gprconfig/nixpkgs-gnat.xml
 
     runHook postInstall
   '';
@@ -110,11 +118,5 @@ stdenv.mkDerivation {
     license = lib.licenses.gpl3Plus;
     maintainers = [ lib.maintainers.sternenseemann ];
     platforms = lib.platforms.all;
-    # gprbuild-boot builds on darwin, but `gprconfig` stack overflows whenever
-    # it runs during the enumeration of available toolchains
-    # This doesn't seem to be a problem with our compiler definition `./nixpkgs-gnat.xml`
-    # as a gprbuild system without that configuration also stack faults.
-    # Maybe a linker issue?
-    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/development/ada-modules/gprbuild/default.nix
+++ b/pkgs/development/ada-modules/gprbuild/default.nix
@@ -47,13 +47,7 @@ stdenv.mkDerivation {
     NIX_LDFLAGS = "-headerpad_max_install_names";
   };
 
-  patches =
-    gprbuild-boot.patches
-    # Fixes gprbuild being linked statically always. Based on the AUR's patch:
-    # https://aur.archlinux.org/cgit/aur.git/plain/0001-Makefile-build-relocatable-instead-of-static-binary.patch?h=gprbuild&id=bac524c76cd59c68fb91ef4dfcbe427357b9f850
-    ++ lib.optionals (!stdenv.hostPlatform.isStatic) [
-      ./gprbuild-relocatable-build.patch
-    ];
+  patches = gprbuild-boot.patches;
 
   buildFlags = [
     "all"

--- a/pkgs/development/ada-modules/gprbuild/gprconfig_kb-darwin.patch
+++ b/pkgs/development/ada-modules/gprbuild/gprconfig_kb-darwin.patch
@@ -1,0 +1,49 @@
+--- a/db/fallback_targets.xml
++++ b/db/fallback_targets.xml
+@@ -14,6 +14,7 @@
+   <fallback_targets>
+     <target>x86_64-darwin</target>
+     <target>aarch64-darwin</target>
++    <target>arm64-darwin</target>
+   </fallback_targets>
+ 
+ </gprconfig>
+diff --git a/db/linker.xml b/db/linker.xml
+index e2489e88..0aa264e6 100644
+--- a/db/linker.xml
++++ b/db/linker.xml
+@@ -1207,6 +1207,7 @@
+        <target name="^powerpc-.*darwin.*$" />
+        <target name="^x86_64-.*darwin.*$" />
+        <target name="^aarch64-.*darwin.*$" />
++       <target name="^arm64-.*darwin.*$" />
+     </targets>
+     <config>
+    for Library_Builder use "${GPRCONFIG_PREFIX}libexec/gprbuild/gprlib";
+@@ -1242,6 +1243,8 @@
+        <target name="^i.86-.*darwin.*$" />
+        <target name="^powerpc-.*darwin.*$" />
+        <target name="^x86_64-.*darwin.*$" />
++       <target name="^aarch64.*darwin.*$" />
++       <target name="^arm64.*darwin.*$" />
+     </targets>
+     <config>
+     for Library_Rpath_Options ("C++") use ("-print-file-name=libstdc++.dylib");
+diff --git a/db/targetset.xml b/db/targetset.xml
+index 3fdda73e..a096e392 100644
+--- a/db/targetset.xml
++++ b/db/targetset.xml
+@@ -129,6 +129,13 @@
+     <target>x86_64-.*windows-gnu</target>
+   </targetset>
+ 
++  <!-- arm64-darwin -->
++  <targetset canonical="arm64-darwin">
++    <target>arm64-ios</target>
++    <target>arm64-darwin</target>
++    <target>arm64.*-darwin.*</target>
++  </targetset>
++
+   <!-- aarch64-darwin (iOS 64bit) -->
+   <targetset canonical="aarch64-darwin">
+     <target>aarch64-ios</target>

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -176,6 +176,8 @@ optionals noSysDirs (
   is13 && langAda && stdenv.targetPlatform.isDarwin
 ) ./13/gnat13-aarch64-darwin-trampoline.patch
 
+++ optional (langAda && stdenv.targetPlatform.isDarwin) ./gnat-darwin-trampoline.patch
+
 ++ optional (targetPlatform.isWindows || targetPlatform.isCygwin) (fetchpatch {
   name = "libstdc-fix-compilation-in-freestanding-win32.patch";
   url = "https://inbox.sourceware.org/gcc-patches/20250922182808.2599390-2-corngood@gmail.com/raw";

--- a/pkgs/development/compilers/gcc/patches/gnat-darwin-trampoline.patch
+++ b/pkgs/development/compilers/gcc/patches/gnat-darwin-trampoline.patch
@@ -1,0 +1,22 @@
+Ada makes extensive use of nested functions, and gcc by default uses trampolines
+to avoid using fat pointers (carry link to parent stack frame along with link to
+actual function body). However, executable stack has been disabled on darwin
+since version 20 (macOS 11). Thus, make heap trampolines unconditionally used on
+darwin as we only support macOS version 13+
+--- a/gcc/config.gcc
++++ b/gcc/config.gcc
+@@ -1177,13 +1177,13 @@ esac
+ # Figure out if we need to enable heap trampolines
+ # and variadic functions handling.
+ case ${target} in
+-aarch64*-*-darwin2*)
++aarch64*-*-darwin* | arm64*-*-darwin*)
+   # This applies to arm64 Darwin variadic funtions.
+   tm_defines="$tm_defines STACK_USE_CUMULATIVE_ARGS_INIT=1"
+   # Executable stack is forbidden.
+   tm_defines="$tm_defines HEAP_TRAMPOLINES_INIT=1"
+   ;;
+-*-*-darwin2*)
++*-*-darwin*)
+   tm_defines="$tm_defines STACK_USE_CUMULATIVE_ARGS_INIT=0"
+   # Currently, we do this for macOS 11 and above.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3410,84 +3410,99 @@ with pkgs;
     }
   );
 
-  gnat14 = wrapCC (
-    gcc14.cc.override {
-      name = "gnat";
-      langC = true;
-      langCC = false;
-      langAda = true;
-      profiledCompiler = false;
-      # As per upstream instructions building a cross compiler
-      # should be done with a (native) compiler of the same version.
-      # If we are cross-compiling GNAT, we may as well do the same.
-      gnat-bootstrap =
-        if stdenv.hostPlatform == stdenv.targetPlatform && stdenv.buildPlatform == stdenv.hostPlatform then
-          buildPackages.gnat-bootstrap14
-        else
-          buildPackages.gnat14;
-      stdenv =
-        if
-          stdenv.hostPlatform == stdenv.targetPlatform
-          && stdenv.buildPlatform == stdenv.hostPlatform
-          && stdenv.buildPlatform.isDarwin
-        then
-          overrideCC gccStdenv gnat-bootstrap14
-        else
-          stdenv;
+  gnat14 = wrapCCWith (
+    {
+      cc = gcc14.cc.override {
+        name = "gnat";
+        langC = true;
+        langCC = false;
+        langAda = true;
+        profiledCompiler = false;
+        # As per upstream instructions building a cross compiler
+        # should be done with a (native) compiler of the same version.
+        # If we are cross-compiling GNAT, we may as well do the same.
+        gnat-bootstrap =
+          if stdenv.hostPlatform == stdenv.targetPlatform && stdenv.buildPlatform == stdenv.hostPlatform then
+            buildPackages.gnat-bootstrap14
+          else
+            buildPackages.gnat14;
+        stdenv =
+          if
+            stdenv.hostPlatform == stdenv.targetPlatform
+            && stdenv.buildPlatform == stdenv.hostPlatform
+            && stdenv.buildPlatform.isDarwin
+          then
+            overrideCC gccStdenv gnat-bootstrap14
+          else
+            stdenv;
+      };
+    }
+    // lib.optionalAttrs stdenv.targetPlatform.isDarwin {
+      apple-sdk = apple-sdk_15;
     }
   );
 
-  gnat15 = wrapCC (
-    gcc15.cc.override {
-      name = "gnat";
-      langC = true;
-      langCC = false;
-      langAda = true;
-      profiledCompiler = false;
-      # As per upstream instructions building a cross compiler
-      # should be done with a (native) compiler of the same version.
-      # If we are cross-compiling GNAT, we may as well do the same.
-      gnat-bootstrap =
-        if stdenv.hostPlatform == stdenv.targetPlatform && stdenv.buildPlatform == stdenv.hostPlatform then
-          buildPackages.gnat-bootstrap15
-        else
-          buildPackages.gnat15;
-      stdenv =
-        if
-          stdenv.hostPlatform == stdenv.targetPlatform
-          && stdenv.buildPlatform == stdenv.hostPlatform
-          && stdenv.buildPlatform.isDarwin
-        then
-          overrideCC gccStdenv gnat-bootstrap15
-        else
-          stdenv;
+  gnat15 = wrapCCWith (
+    {
+      cc = gcc15.cc.override {
+        name = "gnat";
+        langC = true;
+        langCC = false;
+        langAda = true;
+        profiledCompiler = false;
+        # As per upstream instructions building a cross compiler
+        # should be done with a (native) compiler of the same version.
+        # If we are cross-compiling GNAT, we may as well do the same.
+        gnat-bootstrap =
+          if stdenv.hostPlatform == stdenv.targetPlatform && stdenv.buildPlatform == stdenv.hostPlatform then
+            buildPackages.gnat-bootstrap15
+          else
+            buildPackages.gnat15;
+        stdenv =
+          if
+            stdenv.hostPlatform == stdenv.targetPlatform
+            && stdenv.buildPlatform == stdenv.hostPlatform
+            && stdenv.buildPlatform.isDarwin
+          then
+            overrideCC gccStdenv gnat-bootstrap15
+          else
+            stdenv;
+      };
+    }
+    // lib.optionalAttrs stdenv.targetPlatform.isDarwin {
+      apple-sdk = apple-sdk_15;
     }
   );
 
-  gnat16 = wrapCC (
-    gcc16.cc.override {
-      name = "gnat";
-      langC = true;
-      langCC = false;
-      langAda = true;
-      profiledCompiler = false;
-      # As per upstream instructions building a cross compiler
-      # should be done with a (native) compiler of the same version.
-      # If we are cross-compiling GNAT, we may as well do the same.
-      gnat-bootstrap =
-        if stdenv.hostPlatform == stdenv.targetPlatform && stdenv.buildPlatform == stdenv.hostPlatform then
-          buildPackages.gnat-bootstrap16
-        else
-          buildPackages.gnat16;
-      stdenv =
-        if
-          stdenv.hostPlatform == stdenv.targetPlatform
-          && stdenv.buildPlatform == stdenv.hostPlatform
-          && stdenv.buildPlatform.isDarwin
-        then
-          overrideCC gccStdenv gnat-bootstrap16
-        else
-          stdenv;
+  gnat16 = wrapCCWith (
+    {
+      cc = gcc16.cc.override {
+        name = "gnat";
+        langC = true;
+        langCC = false;
+        langAda = true;
+        profiledCompiler = false;
+        # As per upstream instructions building a cross compiler
+        # should be done with a (native) compiler of the same version.
+        # If we are cross-compiling GNAT, we may as well do the same.
+        gnat-bootstrap =
+          if stdenv.hostPlatform == stdenv.targetPlatform && stdenv.buildPlatform == stdenv.hostPlatform then
+            buildPackages.gnat-bootstrap16
+          else
+            buildPackages.gnat16;
+        stdenv =
+          if
+            stdenv.hostPlatform == stdenv.targetPlatform
+            && stdenv.buildPlatform == stdenv.hostPlatform
+            && stdenv.buildPlatform.isDarwin
+          then
+            overrideCC gccStdenv gnat-bootstrap16
+          else
+            stdenv;
+      };
+    }
+    // lib.optionalAttrs stdenv.targetPlatform.isDarwin {
+      apple-sdk = apple-sdk_15;
     }
   );
 


### PR DESCRIPTION
Fix gnat and gnat packages build issues on Darwin.

- [x] Patch config.gcc so GNAT uses heap trampolines.
    - Darwin 20+ disallows executable stack memory, so GNAT must use heap trampolines instead.
- [x] Remove the gprbuild static linking patch, so executables don’t need to search for adalib at runtime and fail.
- [x] Patch the gprconfig knowledge base to support the arm64-apple-darwin target triple.
- [x]  Override `fallback_sdk` for gnat{14, 15, 16}, which are built against apple-sdk_15.
- [x] Use `stdenvNoCC` where appropriate to avoid SDK-related issues.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
