### PR TITLE
wtp: init at 2.10.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13757,6 +13757,12 @@
     name = "John Soo";
     githubId = 10039785;
   };
+  jsqu4re = {
+    email = "johannes.jeising@gmail.com";
+    github = "jsqu4re";
+    githubId = 35706792;
+    name = "Johannes Jeising";
+  };
   jsusk = {
     email = "joshua@suskalo.org";
     github = "IGJoshua";

--- a/pkgs/by-name/wt/wtp/package.nix
+++ b/pkgs/by-name/wt/wtp/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  gitMinimal,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "wtp";
+  version = "2.10.3";
+
+  src = fetchFromGitHub {
+    owner = "satococoa";
+    repo = "wtp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KgayKjH4iHi7LgWwk2Laba33bMVZdbiMQgSmqBSTfZ0=";
+  };
+
+  vendorHash = "sha256-zsSNo1MQgpvH3ZSd3kmvdIpOCVJgSu1/pYLltx/9dZg=";
+
+  subPackages = [ "cmd/wtp" ];
+  __structuredAttrs = true;
+
+  nativeCheckInputs = [ gitMinimal ];
+
+  preCheck = ''
+    git init .
+    git config user.name "nixpkgs"
+    git config user.email "nixpkgs@example.invalid"
+    touch .nixpkgs-wtp-test
+    git add .nixpkgs-wtp-test
+    git commit -m "Init test repo" >/dev/null
+  '';
+
+  meta = {
+    description = "Git worktree CLI with automated setup, branch tracking, and navigation";
+    homepage = "https://github.com/satococoa/wtp";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jsqu4re ];
+    mainProgram = "wtp";
+  };
+})


### PR DESCRIPTION
https://github.com/satococoa/wtp with 520 Stars at the time:

> A powerful Git worktree management tool that extends git's worktree functionality with automated setup, branch tracking, and project-specific hooks.



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
