### PR TITLE
packetry: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/by-name/pa/packetry/package.nix
+++ b/pkgs/by-name/pa/packetry/package.nix
@@ -11,16 +11,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "packetry";
-  version = "0.4.0";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "greatscottgadgets";
     repo = "packetry";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-eDVom0kAL1QwO8BtrJS76VTvxtKs7CP6Ob5BWlE6wOM=";
+    hash = "sha256-mgQmorh/MSSufVyOspVtZhBn4nS1vITAiiDXv+/dc/o=";
   };
 
-  cargoHash = "sha256-he+Y2vBCw5lmYe5x6myIxMKRIohBCLDQ/B1EV+4pKGs=";
+  cargoHash = "sha256-qku45EAnsZetQ3Q0Y5Pr1OL/St0j6DGIjnlohA8+pDs=";
 
   nativeBuildInputs = [
     pkg-config
@@ -34,7 +34,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   # Disable test_replay tests as they need a gui
   preCheck = ''
-    sed -i 's:#\[test\]:#[test] #[ignore]:' src/test_replay.rs
+    substituteInPlace src/ui/test_replay.rs \
+      --replace-fail '#[test]' '#[test] #[ignore]'
   '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];


### PR DESCRIPTION
Changelog: https://github.com/greatscottgadgets/packetry/blob/v0.5.0/CHANGELOG.md
Compare: https://github.com/greatscottgadgets/packetry/compare/v0.4.0...v0.5.0

Darwin builds currently fails due to [gtk4 failing to build](https://hydra.nixos.org/build/336899371).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
