### PR TITLE
python3Packages.pytest-ticket: init at 0-unstable-2025-05-15

### DIFF
--- a/pkgs/development/python-modules/pytest-ticket/default.nix
+++ b/pkgs/development/python-modules/pytest-ticket/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  hatch-vcs,
+  hatch-requirements-txt,
+  pytest,
+  unstableGitUpdater,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pytest-ticket";
+  version = "0-unstable-2025-05-15";
+  pyproject = true;
+
+  # hatch-vcs validates this against PEP 440 and 0-unstable-* is not a valid PEP 440 version string
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = builtins.elemAt (builtins.split "-" finalAttrs.version) 0;
+
+  src = fetchFromGitHub {
+    owner = "next-actions";
+    repo = "pytest-ticket";
+    rev = "9f77e77d99ee25a65cad2ab07815884bf7271552";
+    hash = "sha256-oR0kwrr8nnrVpWc27pOtM+6K00llTQGRTpvKmOyCIYY=";
+  };
+
+  build-system = [
+    hatchling
+    hatch-vcs
+    hatch-requirements-txt
+  ];
+
+  dependencies = [
+    pytest
+  ];
+
+  # Patch requirements.txt out of the package
+  postInstall = ''
+    rm -f $out/lib/python*/site-packages/requirements.txt
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "pytest plugin that adds the ability to filter test cases by an associated ticket of a tracker of your choice";
+    homepage = "https://github.com/next-actions/pytest-ticket";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ joaosreis ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16249,6 +16249,8 @@ self: super: with self; {
 
   pytest-textual-snapshot = callPackage ../development/python-modules/pytest-textual-snapshot { };
 
+  pytest-ticket = callPackage ../development/python-modules/pytest-ticket { };
+
   pytest-timeout = callPackage ../development/python-modules/pytest-timeout { };
 
   pytest-tornado = callPackage ../development/python-modules/pytest-tornado { };


### PR DESCRIPTION
Add `pytest-ticket` Python package - "a pytest plugin that adds the ability to filter test cases by an associated ticket of a tracker of your choice".

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
