### PR TITLE
prowler: 5.31.1 -> 5.33.0

### DIFF
--- a/pkgs/by-name/pr/prowler/package.nix
+++ b/pkgs/by-name/pr/prowler/package.nix
@@ -1,12 +1,13 @@
 {
   lib,
   fetchFromGitHub,
+  kingfisher,
   python3Packages,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "prowler";
-  version = "5.31.1";
+  version = "5.33.0";
   pyproject = true;
 
   __structuredAttrs = true;
@@ -15,10 +16,12 @@ python3Packages.buildPythonApplication (finalAttrs: {
     owner = "prowler-cloud";
     repo = "prowler";
     tag = finalAttrs.version;
-    hash = "sha256-V3kPj3gtS8ZkeU/rBaTPaOdfWvYI70jAi52kCX0m/jg=";
+    hash = "sha256-dx4/AmV+K4YH9gqjznMNJcVv0MZ5Qt/Lelw6ErbHgt8=";
   };
 
   pythonRelaxDeps = true;
+
+  pythonRemoveDeps = [ "kingfisher-bin" ];
 
   build-system = with python3Packages; [ hatchling ];
 
@@ -106,6 +109,10 @@ python3Packages.buildPythonApplication (finalAttrs: {
     tzlocal
     uuid6
   ];
+
+  postFixup = ''
+    wrapProgram $out/bin/prowler --prefix PATH : "${lib.makeBinPath [ kingfisher ]}"
+  '';
 
   pythonImportsCheck = [ "prowler" ];
 


### PR DESCRIPTION
Diff: https://github.com/prowler-cloud/prowler/compare/5.31.1...5.33.0

Changelog: https://github.com/prowler-cloud/prowler/releases/tag/5.33.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
