### PR TITLE
python3Packages.pytest-mh: init at 1.0.29

### DIFF
--- a/pkgs/development/python-modules/pytest-mh/default.nix
+++ b/pkgs/development/python-modules/pytest-mh/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  hatch-vcs,
+  hatch-requirements-txt,
+  ansible-pylibssh,
+  colorama,
+  pytest,
+  pyyaml,
+  gitUpdater,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pytest-mh";
+  version = "1.0.29";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "next-actions";
+    repo = "pytest-mh";
+    tag = finalAttrs.version;
+    hash = "sha256-1QaqHDS+eU1O2aLWtdd6XWxErwqONAPngKe8FqYAmJY=";
+  };
+
+  build-system = [
+    hatchling
+    hatch-vcs
+    hatch-requirements-txt
+  ];
+
+  dependencies = [
+    ansible-pylibssh
+    colorama
+    pytest
+    pyyaml
+  ];
+
+  # Patch requirements.txt out of the package
+  postInstall = ''
+    rm -f $out/lib/python*/site-packages/requirements.txt
+  '';
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = {
+    description = "pytest plugin that allows you to run shell commands and scripts over SSH on remote Linux or Windows hosts";
+    homepage = "https://github.com/next-actions/pytest-mh";
+    changelog = "https://github.com/next-actions/pytest-mh/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ joaosreis ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15823,6 +15823,8 @@ self: super: with self; {
 
   pytest-metadata = callPackage ../development/python-modules/pytest-metadata { };
 
+  pytest-mh = callPackage ../development/python-modules/pytest-mh { };
+
   pytest-mock = callPackage ../development/python-modules/pytest-mock { };
 
   pytest-mockito = callPackage ../development/python-modules/pytest-mockito { };


### PR DESCRIPTION
Add `pytest-mh` Python package - "a pytest plugin that allows you to run shell commands and scripts over SSH on remote Linux or Windows hosts".

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
