### PR TITLE
ocamlPackages.ocsigen-toolkit: 4.2.0 → 4.3.0

### DIFF
--- a/pkgs/development/ocaml-modules/ocsigen-start/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-start/default.nix
@@ -12,6 +12,7 @@
   eliom,
   resource-pooling,
   ocsigen-ppx-rpc,
+  js_of_ocaml-ppx_deriving_json,
 }:
 
 stdenv.mkDerivation {
@@ -23,7 +24,10 @@ stdenv.mkDerivation {
     findlib
     eliom
   ];
-  buildInputs = [ ocsigen-ppx-rpc ];
+  buildInputs = [
+    ocsigen-ppx-rpc
+    js_of_ocaml-ppx_deriving_json
+  ];
   propagatedBuildInputs = [
     pgocaml_ppx
     safepass

--- a/pkgs/development/ocaml-modules/ocsigen-toolkit/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-toolkit/default.nix
@@ -1,57 +1,41 @@
 {
-  stdenv,
   lib,
+  buildDunePackage,
   fetchFromGitHub,
-  ocaml,
-  findlib,
-  opaline,
   calendar,
+  cmdliner,
   eliom,
   js_of_ocaml-ppx_deriving_json,
+  ocsigen-ppx-rpc,
 }:
 
-stdenv.mkDerivation rec {
+buildDunePackage (finalAttrs: {
   pname = "ocsigen-toolkit";
-  name = "ocaml${ocaml.version}-${pname}-${version}";
-  version = "4.2.0";
-
-  propagatedBuildInputs = [
-    calendar
-    js_of_ocaml-ppx_deriving_json
-    eliom
-  ];
-  nativeBuildInputs = [
-    ocaml
-    findlib
-    opaline
-    eliom
-  ];
-
-  strictDeps = true;
-
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $OCAMLFIND_DESTDIR
-    export OCAMLPATH=$out/lib/ocaml/${ocaml.version}/site-lib/:$OCAMLPATH
-    make install
-    opaline -prefix $out
-    runHook postInstall
-  '';
+  version = "4.3.0";
 
   src = fetchFromGitHub {
     owner = "ocsigen";
     repo = "ocsigen-toolkit";
-    tag = version;
-    hash = "sha256-wken+5hUewE0Nktl2PY1xMmVveSs8X0ihWD+MK4pzRQ=";
+    tag = finalAttrs.version;
+    hash = "sha256-q6e8pacQ/F2vJeI4IqgyWI68J8qKq1vk3yRpI09BjLU=";
   };
+
+  buildInputs = [
+    cmdliner
+    js_of_ocaml-ppx_deriving_json
+    ocsigen-ppx-rpc
+  ];
+
+  propagatedBuildInputs = [
+    calendar
+    eliom
+  ];
 
   meta = {
     homepage = "http://ocsigen.org/ocsigen-toolkit/";
     description = "User interface widgets for Ocsigen applications";
     license = lib.licenses.lgpl21;
     maintainers = [ lib.maintainers.gal_bolle ];
-    inherit (ocaml.meta) platforms;
-    broken = true;
   };
 
-}
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
