### PR TITLE
bbrew: init at 2.3.1

### DIFF
--- a/pkgs/by-name/bb/bbrew/package.nix
+++ b/pkgs/by-name/bb/bbrew/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "bbrew";
+  version = "2.3.1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Valkyrie00";
+    repo = "bold-brew";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-g74rBvBlw/rlLmZdJtIeIp0sba0Q6kFyhlHTwegOA+0=";
+  };
+
+  vendorHash = "sha256-5gFyfyerRKfq0uGkyIJ1W4XLhyRR5qPyhc/f2Y2skrI=";
+
+  subPackages = [ "cmd/bbrew" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X bbrew/internal/services.AppVersion=${finalAttrs.version}"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "TUI for managing Homebrew, Flatpak, and Mac App Store packages";
+    homepage = "https://bold-brew.com";
+    changelog = "https://github.com/Valkyrie00/bold-brew/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tyceherrman ];
+    platforms = lib.platforms.unix;
+    mainProgram = "bbrew";
+  };
+})


### PR DESCRIPTION
Adds `bbrew`, the Bold Brew TUI for managing Homebrew, Flatpak, and Mac App Store packages.

Homepage: https://bold-brew.com

The package builds from source with `buildGoModule`, sets the upstream version via `ldflags`, and verifies the installed binary with `versionCheckHook`.

AI disclosure: this contribution was prepared with assistance from OpenAI Codex (GPT-5), then reviewed and verified before submission.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
