### PR TITLE
croc: fix passthrough tests [10.4.6 -> 10.4.13]

### DIFF
--- a/nixos/tests/croc.nix
+++ b/nixos/tests/croc.nix
@@ -45,7 +45,7 @@ in
     sender.execute("echo Hello World > testfile01.txt")
     sender.execute("echo Hello Earth > testfile02.txt")
     sender.execute(
-        "env CROC_SECRET=topSecret croc --pass ${pass} --relay relay send --no-local testfile01.txt testfile02.txt >&2 &"
+        "env CROC_SECRET=topSecret croc --pass ${pass} --relay relay send testfile01.txt testfile02.txt >&2 &"
     )
 
     # receive the testfiles and check them

--- a/nixos/tests/croc.nix
+++ b/nixos/tests/croc.nix
@@ -12,8 +12,8 @@ in
   meta = with pkgs.lib.maintainers; {
     maintainers = [
       equirosa
-      SuperSandro2000
       ryan4yin
+      kaynetik
     ];
   };
 
@@ -45,7 +45,7 @@ in
     sender.execute("echo Hello World > testfile01.txt")
     sender.execute("echo Hello Earth > testfile02.txt")
     sender.execute(
-        "env CROC_SECRET=topSecret croc --pass ${pass} --relay relay send testfile01.txt testfile02.txt >&2 &"
+        "env CROC_SECRET=topSecret croc --pass ${pass} --relay relay send --no-local testfile01.txt testfile02.txt >&2 &"
     )
 
     # receive the testfiles and check them

--- a/pkgs/by-name/cr/croc/package.nix
+++ b/pkgs/by-name/cr/croc/package.nix
@@ -11,13 +11,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "croc";
-  version = "10.4.6";
+  version = "10.4.12";
 
   src = fetchFromGitHub {
     owner = "schollz";
     repo = "croc";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-+KG1PHUymeoAj92UAn/sitQF6xC1xwl+cdisxy2ZtPs=";
+    hash = "sha256-ThMwPbQcxRBVvL/jxTluBc4gKbEIl1Wm69c/3r976s0=";
   };
 
   vendorHash = "sha256-rwGunSDIgetBsk97LxQz0WHpzMDMMESHC1OhBWRuVjI=";

--- a/pkgs/by-name/cr/croc/package.nix
+++ b/pkgs/by-name/cr/croc/package.nix
@@ -11,13 +11,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "croc";
-  version = "10.4.12";
+  version = "10.4.13";
 
   src = fetchFromGitHub {
     owner = "schollz";
     repo = "croc";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-ThMwPbQcxRBVvL/jxTluBc4gKbEIl1Wm69c/3r976s0=";
+    hash = "sha256-XhudK0wFk2VFYmd1ihW4SjJ4nzwNxOp9pTNUWJUg+AU=";
   };
 
   vendorHash = "sha256-rwGunSDIgetBsk97LxQz0WHpzMDMMESHC1OhBWRuVjI=";

--- a/pkgs/by-name/cr/croc/test-local-relay.nix
+++ b/pkgs/by-name/cr/croc/test-local-relay.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
 
     # start sender in background
     MSG="See you later, alligator!"
-    croc --relay localhost:11111 send --no-local --code correct-horse-battery-staple --text "$MSG" &
+    croc --relay localhost:11111 send --code correct-horse-battery-staple --text "$MSG" &
 
     # wait for things to settle
     sleep 1

--- a/pkgs/by-name/cr/croc/test-local-relay.nix
+++ b/pkgs/by-name/cr/croc/test-local-relay.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
 
     # start sender in background
     MSG="See you later, alligator!"
-    croc --relay localhost:11111 send --code correct-horse-battery-staple --text "$MSG" &
+    croc --relay localhost:11111 send --no-local --code correct-horse-battery-staple --text "$MSG" &
 
     # wait for things to settle
     sleep 1


### PR DESCRIPTION
## croc: 10.4.6 -> 10.4.13

Version bump that also resolves the `passthru.tests` failure flagged by @r-ryantm on #539921.

### Background
Since 10.4.6, `croc send` starts an ephemeral local relay and LAN discovery alongside any explicit `--relay`. A race on the sender's relay route made it advertise/connect to the wrong relay, so a receiver using a dedicated relay failed with "could not secure channel".

Initially I worked around this by passing `--no-local` in both croc tests. Upstream has since fixed the root cause in 10.4.13, so the workaround is no longer needed and the tests are back to their original form.

Upstream refs:
- schollz/croc#1148 — bug report ("could not secure channel"), `--no-local` workaround
- schollz/croc#1150 — first partial fix for the local relay port race (10.4.8)
- schollz/croc#1162 — sender local/external relay route race fix (10.4.13)

### Changes
- `croc`: 10.4.6 -> 10.4.13 (`vendorHash` unchanged; `go.sum` identical)
- No test changes required beyond the maintainer-list sync in `nixos/tests/croc.nix`

### Upstream refs:
- schollz/croc#1148 ~ bug report, `--no-local` workaround
- schollz/croc#1150 ~ partial fix for the local relay port race (10.4.8)
- [recent fix] https://github.com/schollz/croc/pull/1162/changes

### Tested
- `nix-build -A croc` (darwin/linux, usual manual flow for croc)
- `nix-build -A croc.tests.local-relay` (Linux)
- `nix-build -A nixosTests.croc` (Linux)
- Manual repro of both test flows without `--no-local` on 10.4.13 — pass

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

---

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
