### PR TITLE
python3Packages.gradio: 6.19.0 -> 6.20.0

### DIFF
--- a/pkgs/development/python-modules/gradio/client.nix
+++ b/pkgs/development/python-modules/gradio/client.nix
@@ -120,6 +120,22 @@ buildPythonPackage (finalAttrs: {
   __darwinAllowLocalNetworking = true;
 
   passthru = {
+    # Cyclic dependencies are fun!
+    # overridePythonAttrs is not available in finalAttrs.finalPackage
+    sans-reverse-dependencies = finalAttrs.finalPackage.overrideAttrs (old: {
+      pname = old.pname + "-sans-reverse-dependencies";
+      # we aggressively remove all checkPhase related attrs
+      # to save on rebuilds during bumps
+      doInstallCheck = false;
+      doCheck = false;
+      preCheck = "";
+      enabledTestPaths = [ ];
+      disabledTestMarks = [ ];
+      disabledTests = [ ];
+      pythonImportsCheck = null;
+      dontCheckRuntimeDeps = true;
+    });
+
     inherit (gradio) updateScript;
   };
 

--- a/pkgs/development/python-modules/gradio/default.nix
+++ b/pkgs/development/python-modules/gradio/default.nix
@@ -81,7 +81,7 @@ let
 in
 buildPythonPackage (finalAttrs: {
   pname = "gradio";
-  version = "6.19.0";
+  version = "6.20.0"; # please always backport gradio changes
   pyproject = true;
   __structuredAttrs = true;
 
@@ -89,7 +89,7 @@ buildPythonPackage (finalAttrs: {
     owner = "gradio-app";
     repo = "gradio";
     tag = "gradio@${finalAttrs.version}";
-    hash = "sha256-9vO+cuxpXERD/rH8wMuNWBNSH6Mu+yZLQMxLoiUTKtk=";
+    hash = "sha256-q5OoMguG/f0A3c6X+zotafc3kRRuebxMBPUIlrlcNFI=";
   };
 
   patches = [
@@ -102,17 +102,16 @@ buildPythonPackage (finalAttrs: {
   ];
 
   pnpmDeps = fetchPnpmDeps {
-    inherit (finalAttrs)
-      pname
-      version
-      src
-      ;
+    pname = "gradio"; # to avoid a "sans-reverse-dependencies" duplicate
+    inherit (finalAttrs) version src;
     inherit pnpm;
     fetcherVersion = 4;
     hash = "sha256-xCxr/jnp9emeB6THGt4cumvApw6fSZQwG2NGOcvR0yQ=";
   };
 
   env = {
+    # test/test_utils.py
+    # @settings(derandomize=os.getenv("CI") is not None)
     CI = "true";
   };
 
@@ -431,6 +430,7 @@ buildPythonPackage (finalAttrs: {
           disabledTestPaths = [ ];
           disabledTestMarks = [ ];
           pytestFlags = [ ];
+          preBuild = ":"; # skip pnpm build, for speed
           postInstall = ''
             shopt -s globstar
             for f in $out/**/*.py; do

--- a/pkgs/development/python-modules/gradio/default.nix
+++ b/pkgs/development/python-modules/gradio/default.nix
@@ -414,14 +414,14 @@ buildPythonPackage (finalAttrs: {
         # gradio.sans-reverse-dependencies, which would create a build cycle.
         # Break it by giving hf-gradio a checkless gradio-client.
         hf-gradio = hf-gradio.override {
-          gradio-client = gradio-client.overridePythonAttrs {
-            doCheck = false;
-          };
+          gradio-client = gradio-client.sans-reverse-dependencies;
         };
       }).overridePythonAttrs
         (old: {
           pname = old.pname + "-sans-reverse-dependencies";
           pythonRemoveDeps = (old.pythonRemoveDeps or [ ]) ++ [ "gradio-client" ];
+          # we aggressively remove all checkPhase related attrs
+          # to save on rebuilds during bumps
           doInstallCheck = false;
           doCheck = false;
           postPatch = "";


### PR DESCRIPTION
- **python3Packages.gradio: 6.19.0 -> 6.20.0**
- **python3Packages.gradio-client: add sans-reverse-dependencies passthru**

part of https://github.com/NixOS/nixpkgs/issues/539892

will likely require a manual backport

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
