### PR TITLE
picolibc: 1.8.9-2 → 1.8.12-1; add maintainer

### DIFF
--- a/pkgs/by-name/pi/picolibc/package.nix
+++ b/pkgs/by-name/pi/picolibc/package.nix
@@ -19,7 +19,7 @@ let
 in
 stdenvNoLibc.mkDerivation (finalAttrs: {
   pname = "picolibc";
-  version = "1.8.12";
+  version = "1.8.12-1";
   strictDeps = true;
 
   outputs = [
@@ -31,7 +31,7 @@ stdenvNoLibc.mkDerivation (finalAttrs: {
     owner = "picolibc";
     repo = "picolibc";
     tag = finalAttrs.version;
-    hash = "sha256-a2XLUN2U49Lpsyizzb2cQpMbww0cmOUUKdgIj6OHhpQ=";
+    hash = "sha256-FhTNgffsnHbzIXOOwCMe6O1FGkEtqWfw+e30RW+Y4K4=";
   };
 
   depsBuildBuild = lib.optionals canExecute [

--- a/pkgs/by-name/pi/picolibc/package.nix
+++ b/pkgs/by-name/pi/picolibc/package.nix
@@ -18,7 +18,7 @@ let
 in
 stdenvNoLibc.mkDerivation (finalAttrs: {
   pname = "picolibc";
-  version = "1.8.11";
+  version = "1.8.12";
   strictDeps = true;
 
   outputs = [
@@ -30,7 +30,7 @@ stdenvNoLibc.mkDerivation (finalAttrs: {
     owner = "picolibc";
     repo = "picolibc";
     tag = finalAttrs.version;
-    hash = "sha256-9xFkUZJJ2ikyi4/m5B+oDa5Zznm/1aPa8El2JLEZBE8=";
+    hash = "sha256-a2XLUN2U49Lpsyizzb2cQpMbww0cmOUUKdgIj6OHhpQ=";
   };
 
   depsBuildBuild = lib.optionals canExecute [

--- a/pkgs/by-name/pi/picolibc/package.nix
+++ b/pkgs/by-name/pi/picolibc/package.nix
@@ -9,30 +9,35 @@
   pkgsCross,
 
   # General Build Options
-  # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/meson_options.txt#L40-L57
+  # https://github.com/picolibc/picolibc/blob/95869670fb165e7c43e85c3d384a1e5682505244/meson_options.txt#L40
   multilib ? true,
+  multilib-list ? [ ],
+  multilib-exclude ? [ ],
   sanitize-bounds ? false,
+  sanitize-undefined ? false,
   sanitize-trap-on-error ? false,
+  sanitize-allow-missing ? false,
   profile ? false,
   analyzer ? false,
   assert-verbose ? true,
   fast-strcmp ? true,
+  sanitize ? "none",
 
   # Testing options
-  # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/meson_options.txt#L75
+  # https://github.com/picolibc/picolibc/blob/95869670fb165e7c43e85c3d384a1e5682505244/meson_options.txt#L87
   picolib ? stdenvNoLibc.hostPlatform.isNone,
   semihost ? stdenvNoLibc.hostPlatform.isNone,
+  fake-semihost ? true,
 
   # Stdio Options
-  # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/meson_options.txt#L114
-  tinystdio ? true,
+  # https://github.com/picolibc/picolibc/blob/95869670fb165e7c43e85c3d384a1e5682505244/meson_options.txt#L125
   io-c99-formats ? true,
   io-long-long ? false,
   io-pos-args ? false,
   io-long-double ? false,
 
   # Tinystdio options
-  # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/meson_options.txt#L129
+  # https://github.com/picolibc/picolibc/blob/95869670fb165e7c43e85c3d384a1e5682505244/meson_options.txt#L129
   io-float-exact ? true,
   atomic-ungetc ? true,
   posix-console ? !stdenvNoLibc.hostPlatform.isNone,
@@ -44,9 +49,12 @@
   minimal-io-long-long ? false,
   fast-bufio ? false,
   io-wchar ? false,
+  stdio-locking ? false,
+  have-fcntl ? false,
+  fstat-bufsiz ? false,
 
   # Internationalization options
-  # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/meson_options.txt#L181
+  # https://github.com/picolibc/picolibc/blob/95869670fb165e7c43e85c3d384a1e5682505244/meson_options.txt#L166
   mb-capable ? false,
   mb-extended-charsets ? false,
   mb-ucs-charsets ? "auto",
@@ -55,39 +63,41 @@
   mb-windows-charsets ? "auto",
 
   # Startup/shutdown options
-  # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/meson_options.txt#L198
+  # https://github.com/picolibc/picolibc/blob/95869670fb165e7c43e85c3d384a1e5682505244/meson_options.txt#L180
   picocrt ? stdenvNoLibc.hostPlatform.isNone,
   picocrt-enable-mmu ? true,
   picocrt-lib ? true,
-  picoexit ? true,
   initfini-array ? true,
+  initfini ? false,
   crt-runtime-size ? false,
 
   # Legacy (non-picoexit) startup/shutdown options
-  # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/meson_options.txt#L217
-  newlib-atexit-dynamic-alloc ? false,
-  newlib-global-atexit ? !stdenvNoLibc.hostPlatform.isNone,
-  newlib-register-fini ? false,
 
   # Malloc options
-  # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/meson_options.txt#L228
-  newlib-nano-malloc ? true,
-  nano-malloc-clear-freed ? false,
+  # https://github.com/picolibc/picolibc/blob/95869670fb165e7c43e85c3d384a1e5682505244/meson_options.txt#L194
+  enable-malloc ? true,
+  malloc-clear-freed ? false,
+  internal-heap ? 0,
 
   # Locking options
-  # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/meson_options.txt#L237
+  # https://github.com/picolibc/picolibc/blob/95869670fb165e7c43e85c3d384a1e5682505244/meson_options.txt#L206
   single-thread ? false,
 
   # TLS storage options
-  # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/meson_options.txt#L244
+  # https://github.com/picolibc/picolibc/blob/95869670fb165e7c43e85c3d384a1e5682505244/meson_options.txt#L209
   thread-local-storage ? "picolibc",
+  thread-local-storage-api ? true,
   tls-model ? if stdenvNoLibc.hostPlatform.isNone then "local-exec" else "global-dynamic",
   newlib-global-errno ? false,
   errno-function ? if stdenvNoLibc.hostPlatform.isNone then "false" else "auto",
   tls-rp2040 ? false,
+  stack-protector-guard ? "auto",
 
   # Math options
-  # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/meson_options.txt#L261
+  # https://github.com/picolibc/picolibc/blob/95869670fb165e7c43e85c3d384a1e5682505244/meson_options.txt#L225
+  newlib-obsolete-math ? "auto",
+  newlib-obsolete-math-float ? "auto",
+  newlib-obsolete-math-double ? "auto",
   want-math-errno ? false,
 }:
 let
@@ -97,7 +107,7 @@ let
 in
 stdenvNoLibc.mkDerivation (finalAttrs: {
   pname = "picolibc";
-  version = "1.8.9-2";
+  version = "1.8.11";
   strictDeps = true;
 
   outputs = [
@@ -109,10 +119,10 @@ stdenvNoLibc.mkDerivation (finalAttrs: {
     owner = "picolibc";
     repo = "picolibc";
     tag = finalAttrs.version;
-    hash = "sha256-djOZKkinsaaYD4tUEA6mKdo+5em0GP1/+rI0mIm7Vs8=";
+    hash = "sha256-9xFkUZJJ2ikyi4/m5B+oDa5Zznm/1aPa8El2JLEZBE8=";
   };
 
-  depsBuildBuild = lib.optionals canExecute [
+  depsBuildBuild = lib.optionals (stdenvNoLibc.buildPlatform.canExecute stdenvNoLibc.hostPlatform) [
     buildPackages.stdenv.cc
   ];
 
@@ -123,25 +133,30 @@ stdenvNoLibc.mkDerivation (finalAttrs: {
 
   # Default values taken from
   # Build fails without using them.
-  # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/doc/os.md?plain=1#L183
+  # https://github.com/picolibc/picolibc/blob/95869670fb165e7c43e85c3d384a1e5682505244/doc/os.md?plain=1#L183
   mesonFlags = [
     (mesonBool "multilib" multilib)
+    (mesonOption "multilib-list" (lib.concatStringsSep "," multilib-list))
+    (mesonOption "multilib-exclude" (lib.concatStringsSep "," multilib-exclude))
     (mesonBool "sanitize-bounds" sanitize-bounds)
+    (mesonBool "sanitize-undefined" sanitize-undefined)
     (mesonBool "sanitize-trap-on-error" sanitize-trap-on-error)
+    (mesonBool "sanitize-allow-missing" sanitize-allow-missing)
     (mesonBool "profile" profile)
     (mesonBool "analyzer" analyzer)
     (mesonBool "assert-verbose" assert-verbose)
     (mesonBool "fast-strcmp" fast-strcmp)
+    (mesonOption "sanitize" sanitize)
 
     # Testing options
     (mesonBool "picolib" picolib)
     (mesonBool "semihost" semihost)
+    (mesonBool "fake-semihost" fake-semihost)
     (mesonBool "use-stdlib" true)
 
     # Install options
     (mesonOption "specsdir" "${placeholder "dev"}/lib")
 
-    (mesonBool "tinystdio" tinystdio)
     (mesonBool "io-c99-formats" io-c99-formats)
     (mesonBool "io-long-long" io-long-long)
     (mesonBool "io-pos-args" io-pos-args)
@@ -158,6 +173,9 @@ stdenvNoLibc.mkDerivation (finalAttrs: {
     (mesonBool "minimal-io-long-long" minimal-io-long-long)
     (mesonBool "fast-bufio" fast-bufio)
     (mesonBool "io-wchar" io-wchar)
+    (mesonBool "stdio-locking" stdio-locking)
+    (mesonBool "have-fcntl" have-fcntl)
+    (mesonBool "fstat-bufsiz" fstat-bufsiz)
 
     (mesonBool "mb-capable" mb-capable)
     (mesonBool "mb-extended-charsets" mb-extended-charsets)
@@ -169,25 +187,27 @@ stdenvNoLibc.mkDerivation (finalAttrs: {
     (mesonBool "picocrt" picocrt)
     (mesonBool "picocrt-enable-mmu" picocrt-enable-mmu)
     (mesonBool "picocrt-lib" picocrt-lib)
-    (mesonBool "picoexit" picoexit)
-    (mesonBool "newlib-initfini-array" initfini-array)
+    (mesonBool "initfini-array" initfini-array)
+    (mesonBool "initfini" initfini)
     (mesonBool "crt-runtime-size" crt-runtime-size)
 
-    (mesonBool "newlib-atexit-dynamic-alloc" newlib-atexit-dynamic-alloc)
-    (mesonBool "newlib-global-atexit" newlib-global-atexit)
-    (mesonBool "newlib-register-fini" newlib-register-fini)
+    (mesonBool "enable-malloc" enable-malloc)
+    (mesonBool "malloc-clear-freed" malloc-clear-freed)
+    (mesonOption "internal-heap" (toString internal-heap))
 
-    (mesonBool "newlib-nano-malloc" newlib-nano-malloc)
-    (mesonBool "nano-malloc-clear-freed" nano-malloc-clear-freed)
-
-    (mesonBool "newlib-multithread" (!single-thread))
+    (mesonBool "single-thread" single-thread)
 
     (mesonOption "thread-local-storage" thread-local-storage)
+    (mesonBool "thread-local-storage-api" thread-local-storage-api)
     (mesonOption "tls-model" tls-model)
     (mesonBool "newlib-global-errno" newlib-global-errno)
     (mesonOption "errno-function" errno-function)
     (mesonBool "tls-rp2040" tls-rp2040)
+    (mesonOption "stack-protector-guard" stack-protector-guard)
 
+    (mesonOption "newlib-obsolete-math" newlib-obsolete-math)
+    (mesonOption "newlib-obsolete-math-float" newlib-obsolete-math-float)
+    (mesonOption "newlib-obsolete-math-double" newlib-obsolete-math-double)
     (mesonBool "want-math-errno" want-math-errno)
   ]
   ++ lib.optionals finalAttrs.finalPackage.doCheck [

--- a/pkgs/by-name/pi/picolibc/package.nix
+++ b/pkgs/by-name/pi/picolibc/package.nix
@@ -82,26 +82,22 @@ stdenvNoLibc.mkDerivation (finalAttrs: {
     };
   };
 
-  meta =
-    let
-      inherit (lib) licenses maintainers;
-    in
-    {
-      description = "C library designed for embedded 32- and 64- bit systems";
-      longDescription = ''
-        Picolibc is library offering standard C library APIs that targets
-        small embedded systems with limited RAM. Picolibc was formed by blending
-        code from [Newlib](http://sourceware.org/newlib/) and
-        [AVR Libc](https://www.nongnu.org/avr-libc/).
-      '';
-      homepage = "https://keithp.com/picolibc/";
-      changelog = "https://github.com/picolibc/picolibc/releases/tag/${finalAttrs.version}";
-      license = [
-        licenses.bsd2
-        licenses.bsd3
-      ];
-      maintainers = [ ];
-      # https://github.com/picolibc/picolibc/tree/db4d0fe5952d5ecd714781e3212d4086d970735a?tab=readme-ov-file#supported-architectures
-      platforms = lib.platforms.all;
-    };
+  meta = {
+    description = "C library designed for embedded 32- and 64-bit systems";
+    longDescription = ''
+      Picolibc is library offering standard C library APIs that targets small
+      embedded systems with limited RAM. Picolibc was formed by blending code
+      from [Newlib](http://sourceware.org/newlib/) and [AVR
+      Libc](https://www.nongnu.org/avr-libc/).
+    '';
+    homepage = "https://keithp.com/picolibc/";
+    changelog = "https://github.com/picolibc/picolibc/releases/tag/${finalAttrs.version}";
+    license = with lib.licenses; [
+      bsd2
+      bsd3
+    ];
+    maintainers = [ ];
+    # https://github.com/picolibc/picolibc/tree/${finalAttrs.version}?tab=readme-ov-file#supported-architectures
+    platforms = lib.platforms.all;
+  };
 })

--- a/pkgs/by-name/pi/picolibc/package.nix
+++ b/pkgs/by-name/pi/picolibc/package.nix
@@ -15,6 +15,7 @@
 
 let
   canExecute = stdenvNoLibc.buildPlatform.canExecute stdenvNoLibc.hostPlatform;
+  isHosted = !stdenvNoLibc.hostPlatform.isNone;
 in
 stdenvNoLibc.mkDerivation (finalAttrs: {
   pname = "picolibc";
@@ -43,8 +44,14 @@ stdenvNoLibc.mkDerivation (finalAttrs: {
   ];
 
   mesonFlags = [
-    # Always non-default from upstream
-    (lib.mesonBool "use-stdlib" true)
+    # use-stdlib builds against a system C library, requiring a Linux-ABI libc
+    # whose headers we can compile against (libc/native needs statx() & 64-bit
+    # off_t/time_t)… so native glibc/musl only.
+    (lib.mesonBool "use-stdlib" (
+      isHosted
+      && stdenvNoLibc.hostPlatform == stdenvNoLibc.buildPlatform
+      && (stdenvNoLibc.hostPlatform.libc == "glibc" || stdenvNoLibc.hostPlatform.libc == "musl")
+    ))
     (lib.mesonOption "specsdir" "${placeholder "dev"}/lib")
 
     # Multi-lib (cross-compilation)
@@ -53,17 +60,23 @@ stdenvNoLibc.mkDerivation (finalAttrs: {
     (lib.mesonOption "multilib-exclude" (lib.concatStringsSep "," multilib-exclude))
 
     # Platform-dependent: picolibc defaults are for bare-metal; adjust for
-    # hosted (non-none) platforms.
-    (lib.mesonBool "picolib" stdenvNoLibc.hostPlatform.isNone)
-    (lib.mesonBool "semihost" stdenvNoLibc.hostPlatform.isNone)
-    (lib.mesonBool "picocrt" stdenvNoLibc.hostPlatform.isNone)
-    (lib.mesonBool "posix-console" (!stdenvNoLibc.hostPlatform.isNone))
-    (lib.mesonOption "tls-model" (
-      if stdenvNoLibc.hostPlatform.isNone then "local-exec" else "global-dynamic"
-    ))
-    (lib.mesonOption "errno-function" (
-      if stdenvNoLibc.hostPlatform.isNone then "false" else "auto"
-    ))
+    # hosted platforms.
+    (lib.mesonBool "semihost" (!isHosted))
+    (lib.mesonBool "picocrt" (!isHosted))
+    (lib.mesonBool "posix-console" isHosted)
+    (lib.mesonBool "initfini-array" (!isHosted))
+    (lib.mesonOption "tls-model" (if isHosted then "global-dynamic" else "local-exec"))
+    (lib.mesonOption "errno-function" (if isHosted then "auto" else "false"))
+
+    # For hosted builds, disable os-fallback since sbrk.c in the fallback
+    # library references __heap_start/__heap_end which are only defined for
+    # bare-metal targets with an internal heap.
+    (lib.mesonOption "os-fallback" (if isHosted then "false" else "auto"))
+  ]
+  ++ lib.optionals (stdenvNoLibc.hostPlatform.libc == "fblibc") [
+    # Linkless cross toolchain: meson’s TLS auto-detect enables TLS then
+    # rejects -ftls-model; fall back to non-thread-local errno.
+    (lib.mesonBool "thread-local-storage" false)
   ]
   ++ lib.optionals finalAttrs.doCheck [
     (lib.mesonBool "tests" true)
@@ -73,12 +86,17 @@ stdenvNoLibc.mkDerivation (finalAttrs: {
     (lib.mesonOption "tests-cdefs" "false")
   ];
 
-  doCheck = stdenvNoLibc.buildPlatform.canExecute stdenvNoLibc.hostPlatform;
+  # The cross no-libc toolchains cannot link (no crt files), so meson’s
+  # link-based probes (meaning the --defsym alias check that enables the printf
+  # tests) all fail. Keep tests on the native build only.
+  doCheck = canExecute && stdenvNoLibc.hostPlatform == stdenvNoLibc.buildPlatform;
 
   passthru = {
     updateScript = nix-update-script { };
     tests = {
       arm = pkgsCross.arm-embedded.picolibc;
+      musl64 = pkgsCross.musl64.picolibc;
+      riscv64 = pkgsCross.riscv64-embedded.picolibc;
     };
   };
 
@@ -97,6 +115,7 @@ stdenvNoLibc.mkDerivation (finalAttrs: {
       bsd3
     ];
     maintainers = with lib.maintainers; [ toastal ];
+    badPlatforms = [ lib.systems.inspect.patterns.isMinGW ];
     # https://github.com/picolibc/picolibc/tree/${finalAttrs.version}?tab=readme-ov-file#supported-architectures
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/pi/picolibc/package.nix
+++ b/pkgs/by-name/pi/picolibc/package.nix
@@ -96,7 +96,7 @@ stdenvNoLibc.mkDerivation (finalAttrs: {
       bsd2
       bsd3
     ];
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ toastal ];
     # https://github.com/picolibc/picolibc/tree/${finalAttrs.version}?tab=readme-ov-file#supported-architectures
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/pi/picolibc/package.nix
+++ b/pkgs/by-name/pi/picolibc/package.nix
@@ -8,101 +8,12 @@
   nix-update-script,
   pkgsCross,
 
-  # General Build Options
-  # https://github.com/picolibc/picolibc/blob/95869670fb165e7c43e85c3d384a1e5682505244/meson_options.txt#L40
   multilib ? true,
   multilib-list ? [ ],
   multilib-exclude ? [ ],
-  sanitize-bounds ? false,
-  sanitize-undefined ? false,
-  sanitize-trap-on-error ? false,
-  sanitize-allow-missing ? false,
-  profile ? false,
-  analyzer ? false,
-  assert-verbose ? true,
-  fast-strcmp ? true,
-  sanitize ? "none",
-
-  # Testing options
-  # https://github.com/picolibc/picolibc/blob/95869670fb165e7c43e85c3d384a1e5682505244/meson_options.txt#L87
-  picolib ? stdenvNoLibc.hostPlatform.isNone,
-  semihost ? stdenvNoLibc.hostPlatform.isNone,
-  fake-semihost ? true,
-
-  # Stdio Options
-  # https://github.com/picolibc/picolibc/blob/95869670fb165e7c43e85c3d384a1e5682505244/meson_options.txt#L125
-  io-c99-formats ? true,
-  io-long-long ? false,
-  io-pos-args ? false,
-  io-long-double ? false,
-
-  # Tinystdio options
-  # https://github.com/picolibc/picolibc/blob/95869670fb165e7c43e85c3d384a1e5682505244/meson_options.txt#L129
-  io-float-exact ? true,
-  atomic-ungetc ? true,
-  posix-console ? !stdenvNoLibc.hostPlatform.isNone,
-  format-default ? "double",
-  printf-aliases ? true,
-  io-percent-b ? false,
-  printf-small-ultoa ? true,
-  printf-percent-n ? false,
-  minimal-io-long-long ? false,
-  fast-bufio ? false,
-  io-wchar ? false,
-  stdio-locking ? false,
-  have-fcntl ? false,
-  fstat-bufsiz ? false,
-
-  # Internationalization options
-  # https://github.com/picolibc/picolibc/blob/95869670fb165e7c43e85c3d384a1e5682505244/meson_options.txt#L166
-  mb-capable ? false,
-  mb-extended-charsets ? false,
-  mb-ucs-charsets ? "auto",
-  mb-iso-charsets ? "auto",
-  mb-jis-charsets ? "auto",
-  mb-windows-charsets ? "auto",
-
-  # Startup/shutdown options
-  # https://github.com/picolibc/picolibc/blob/95869670fb165e7c43e85c3d384a1e5682505244/meson_options.txt#L180
-  picocrt ? stdenvNoLibc.hostPlatform.isNone,
-  picocrt-enable-mmu ? true,
-  picocrt-lib ? true,
-  initfini-array ? true,
-  initfini ? false,
-  crt-runtime-size ? false,
-
-  # Legacy (non-picoexit) startup/shutdown options
-
-  # Malloc options
-  # https://github.com/picolibc/picolibc/blob/95869670fb165e7c43e85c3d384a1e5682505244/meson_options.txt#L194
-  enable-malloc ? true,
-  malloc-clear-freed ? false,
-  internal-heap ? 0,
-
-  # Locking options
-  # https://github.com/picolibc/picolibc/blob/95869670fb165e7c43e85c3d384a1e5682505244/meson_options.txt#L206
-  single-thread ? false,
-
-  # TLS storage options
-  # https://github.com/picolibc/picolibc/blob/95869670fb165e7c43e85c3d384a1e5682505244/meson_options.txt#L209
-  thread-local-storage ? "picolibc",
-  thread-local-storage-api ? true,
-  tls-model ? if stdenvNoLibc.hostPlatform.isNone then "local-exec" else "global-dynamic",
-  newlib-global-errno ? false,
-  errno-function ? if stdenvNoLibc.hostPlatform.isNone then "false" else "auto",
-  tls-rp2040 ? false,
-  stack-protector-guard ? "auto",
-
-  # Math options
-  # https://github.com/picolibc/picolibc/blob/95869670fb165e7c43e85c3d384a1e5682505244/meson_options.txt#L225
-  newlib-obsolete-math ? "auto",
-  newlib-obsolete-math-float ? "auto",
-  newlib-obsolete-math-double ? "auto",
-  want-math-errno ? false,
 }:
-let
-  inherit (lib.strings) mesonBool mesonOption;
 
+let
   canExecute = stdenvNoLibc.buildPlatform.canExecute stdenvNoLibc.hostPlatform;
 in
 stdenvNoLibc.mkDerivation (finalAttrs: {
@@ -122,7 +33,7 @@ stdenvNoLibc.mkDerivation (finalAttrs: {
     hash = "sha256-9xFkUZJJ2ikyi4/m5B+oDa5Zznm/1aPa8El2JLEZBE8=";
   };
 
-  depsBuildBuild = lib.optionals (stdenvNoLibc.buildPlatform.canExecute stdenvNoLibc.hostPlatform) [
+  depsBuildBuild = lib.optionals canExecute [
     buildPackages.stdenv.cc
   ];
 
@@ -131,94 +42,38 @@ stdenvNoLibc.mkDerivation (finalAttrs: {
     ninja
   ];
 
-  # Default values taken from
-  # Build fails without using them.
-  # https://github.com/picolibc/picolibc/blob/95869670fb165e7c43e85c3d384a1e5682505244/doc/os.md?plain=1#L183
   mesonFlags = [
-    (mesonBool "multilib" multilib)
-    (mesonOption "multilib-list" (lib.concatStringsSep "," multilib-list))
-    (mesonOption "multilib-exclude" (lib.concatStringsSep "," multilib-exclude))
-    (mesonBool "sanitize-bounds" sanitize-bounds)
-    (mesonBool "sanitize-undefined" sanitize-undefined)
-    (mesonBool "sanitize-trap-on-error" sanitize-trap-on-error)
-    (mesonBool "sanitize-allow-missing" sanitize-allow-missing)
-    (mesonBool "profile" profile)
-    (mesonBool "analyzer" analyzer)
-    (mesonBool "assert-verbose" assert-verbose)
-    (mesonBool "fast-strcmp" fast-strcmp)
-    (mesonOption "sanitize" sanitize)
+    # Always non-default from upstream
+    (lib.mesonBool "use-stdlib" true)
+    (lib.mesonOption "specsdir" "${placeholder "dev"}/lib")
 
-    # Testing options
-    (mesonBool "picolib" picolib)
-    (mesonBool "semihost" semihost)
-    (mesonBool "fake-semihost" fake-semihost)
-    (mesonBool "use-stdlib" true)
+    # Multi-lib (cross-compilation)
+    (lib.mesonBool "multilib" multilib)
+    (lib.mesonOption "multilib-list" (lib.concatStringsSep "," multilib-list))
+    (lib.mesonOption "multilib-exclude" (lib.concatStringsSep "," multilib-exclude))
 
-    # Install options
-    (mesonOption "specsdir" "${placeholder "dev"}/lib")
-
-    (mesonBool "io-c99-formats" io-c99-formats)
-    (mesonBool "io-long-long" io-long-long)
-    (mesonBool "io-pos-args" io-pos-args)
-    (mesonBool "io-long-double" io-long-double)
-
-    (mesonBool "io-float-exact" io-float-exact)
-    (mesonBool "atomic-ungetc" atomic-ungetc)
-    (mesonBool "posix-console" posix-console)
-    (mesonOption "format-default" format-default)
-    (mesonBool "printf-aliases" printf-aliases)
-    (mesonBool "io-percent-b" io-percent-b)
-    (mesonBool "printf-small-ultoa" printf-small-ultoa)
-    (mesonBool "printf-percent-n" printf-percent-n)
-    (mesonBool "minimal-io-long-long" minimal-io-long-long)
-    (mesonBool "fast-bufio" fast-bufio)
-    (mesonBool "io-wchar" io-wchar)
-    (mesonBool "stdio-locking" stdio-locking)
-    (mesonBool "have-fcntl" have-fcntl)
-    (mesonBool "fstat-bufsiz" fstat-bufsiz)
-
-    (mesonBool "mb-capable" mb-capable)
-    (mesonBool "mb-extended-charsets" mb-extended-charsets)
-    (mesonOption "mb-ucs-charsets" mb-ucs-charsets)
-    (mesonOption "mb-iso-charsets" mb-iso-charsets)
-    (mesonOption "mb-jis-charsets" mb-jis-charsets)
-    (mesonOption "mb-windows-charsets" mb-windows-charsets)
-
-    (mesonBool "picocrt" picocrt)
-    (mesonBool "picocrt-enable-mmu" picocrt-enable-mmu)
-    (mesonBool "picocrt-lib" picocrt-lib)
-    (mesonBool "initfini-array" initfini-array)
-    (mesonBool "initfini" initfini)
-    (mesonBool "crt-runtime-size" crt-runtime-size)
-
-    (mesonBool "enable-malloc" enable-malloc)
-    (mesonBool "malloc-clear-freed" malloc-clear-freed)
-    (mesonOption "internal-heap" (toString internal-heap))
-
-    (mesonBool "single-thread" single-thread)
-
-    (mesonOption "thread-local-storage" thread-local-storage)
-    (mesonBool "thread-local-storage-api" thread-local-storage-api)
-    (mesonOption "tls-model" tls-model)
-    (mesonBool "newlib-global-errno" newlib-global-errno)
-    (mesonOption "errno-function" errno-function)
-    (mesonBool "tls-rp2040" tls-rp2040)
-    (mesonOption "stack-protector-guard" stack-protector-guard)
-
-    (mesonOption "newlib-obsolete-math" newlib-obsolete-math)
-    (mesonOption "newlib-obsolete-math-float" newlib-obsolete-math-float)
-    (mesonOption "newlib-obsolete-math-double" newlib-obsolete-math-double)
-    (mesonBool "want-math-errno" want-math-errno)
+    # Platform-dependent: picolibc defaults are for bare-metal; adjust for
+    # hosted (non-none) platforms.
+    (lib.mesonBool "picolib" stdenvNoLibc.hostPlatform.isNone)
+    (lib.mesonBool "semihost" stdenvNoLibc.hostPlatform.isNone)
+    (lib.mesonBool "picocrt" stdenvNoLibc.hostPlatform.isNone)
+    (lib.mesonBool "posix-console" (!stdenvNoLibc.hostPlatform.isNone))
+    (lib.mesonOption "tls-model" (
+      if stdenvNoLibc.hostPlatform.isNone then "local-exec" else "global-dynamic"
+    ))
+    (lib.mesonOption "errno-function" (
+      if stdenvNoLibc.hostPlatform.isNone then "false" else "auto"
+    ))
   ]
-  ++ lib.optionals finalAttrs.finalPackage.doCheck [
-    (mesonBool "tests" true)
-    (mesonBool "native-tests" canExecute)
-    (mesonBool "native-math-tests" canExecute)
+  ++ lib.optionals finalAttrs.doCheck [
+    (lib.mesonBool "tests" true)
+    (lib.mesonBool "native-tests" canExecute)
+    (lib.mesonBool "native-math-tests" canExecute)
     # Something is broken with this and I'm not sure what.
-    (mesonOption "tests-cdefs" "false")
+    (lib.mesonOption "tests-cdefs" "false")
   ];
 
-  doCheck = canExecute;
+  doCheck = stdenvNoLibc.buildPlatform.canExecute stdenvNoLibc.hostPlatform;
 
   passthru = {
     updateScript = nix-update-script { };


### PR DESCRIPTION
This is an extension of #537028 which needs review/merge first. Used an LLM to check all of the new `meson_options.txt` & that they are in order following the existing pattern since it was just so hairy & easy to miss an option. …But, then I took a step back after to see that this is mostly a faff when `overrideAttrs` is better suited for this task of modifying flags, so dropping most flags is  better.

While here, I tried out a ton of cross-compiler targets exposing some bugs/missing flags/broken platforms.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.