### PR TITLE
sacad: 2.8.3 -> 3.0.1

### DIFF
--- a/pkgs/by-name/sa/sacad/package.nix
+++ b/pkgs/by-name/sa/sacad/package.nix
@@ -1,46 +1,30 @@
 {
   lib,
-  python3Packages,
-  fetchPypi,
-  jpegoptim,
-  optipng,
+  rustPlatform,
+  fetchFromGitHub,
 }:
 
-python3Packages.buildPythonApplication (finalAttrs: {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sacad";
-  version = "2.8.3";
-  format = "setuptools";
+  version = "3.0.1";
 
-  src = fetchPypi {
-    inherit (finalAttrs) pname version;
-    hash = "sha256-6bKxFOP4hPbU5d1J/wro1BM/Bh9W//QzcZ4YbfaaqYY=";
+  src = fetchFromGitHub {
+    owner = "desbma";
+    repo = "sacad";
+    tag = finalAttrs.version;
+    hash = "sha256-dzVppb6Lg/yjLrPAwII/GMy+56jzaWn0WS7vRZOXkgU=";
   };
 
-  propagatedBuildInputs = with python3Packages; [
-    aiohttp
-    appdirs
-    bitarray
-    cssselect
-    fake-useragent
-    lxml
-    mutagen
-    pillow
-    tqdm
-    unidecode
-    web-cache
-    jpegoptim
-    optipng
-  ];
+  cargoHash = "sha256-tySgM7j26vztPOGkIq1kQeZn6YwDbk9mt3SEg94SW2o=";
 
-  # tests require internet connection
+  # Tests require internet connection.
   doCheck = false;
-
-  pythonImportsCheck = [ "sacad" ];
 
   meta = {
     description = "Smart Automatic Cover Art Downloader";
     homepage = "https://github.com/desbma/sacad";
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [ moni ];
+    mainProgram = "sacad";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Updates `sacad` to its new major release, where the package was fully rewritten in Rust.
Resolves #530385 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
