### PR TITLE
roadrunner: 2025.1.14 -> 2025.1.15

### DIFF
--- a/pkgs/by-name/ro/roadrunner/package.nix
+++ b/pkgs/by-name/ro/roadrunner/package.nix
@@ -9,16 +9,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "roadrunner";
-  version = "2025.1.14";
+  version = "2025.1.15";
 
   src = fetchFromGitHub {
     owner = "roadrunner-server";
     repo = "roadrunner";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-0Mfu/De28tWCygJ5/QJnOzxk88aajx4Oq/Xm0TOXR0M=";
+    hash = "sha256-T7JWA/O25s7A/jSrWJJF4oJbQD0hQyCRt6vFiuz8kwE=";
   };
 
-  vendorHash = "sha256-KuATz7rVsDuGiyILvILaEpznI63sCHx0G+9D2vR+dx0=";
+  vendorHash = "sha256-OhfqfLYHCoBU8QyrpaHwKXtGZf5eK8ocfTyjtZxsgSg=";
   env.GOWORK = "off";
 
   subPackages = [ "cmd/rr" ];


### PR DESCRIPTION
Diff: https://github.com/roadrunner-server/roadrunner/compare/v2025.1.14...v2025.1.15

Changelog: https://github.com/roadrunner-server/roadrunner/blob/v2025.1.15/CHANGELOG.md

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
