### PR TITLE
evdevremapkeys: 1.0.0 -> 1.0.3

### DIFF
--- a/pkgs/by-name/ev/evdevremapkeys/package.nix
+++ b/pkgs/by-name/ev/evdevremapkeys/package.nix
@@ -4,32 +4,35 @@
   python3Packages,
 }:
 
-python3Packages.buildPythonPackage {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "evdevremapkeys";
-  version = "1.0.0";
+  version = "1.0.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "philipl";
     repo = "evdevremapkeys";
-    rev = "9b6f372a9bdf8b27d39f7e655b74f6b9d1a8467f";
-    sha256 = "sha256-FwRbo0RTiiV2AB7z6XOalMnwMbj15jM4Dxs41TsIOQI=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Gtml52tHNtg/3Fy+QO9eIh90nim0p0Fs+oEyqJvsZKs=";
   };
 
   build-system = with python3Packages; [
-    setuptools
+    hatchling
+    hatch-vcs
   ];
+
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = finalAttrs.version;
 
   dependencies = with python3Packages; [
     pyyaml
     pyxdg
-    python-daemon
     evdev
     pyudev
   ];
 
-  # hase no tests
-  doCheck = false;
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+  ];
 
   pythonImportsCheck = [ "evdevremapkeys" ];
 
@@ -41,4 +44,4 @@ python3Packages.buildPythonPackage {
     maintainers = [ lib.maintainers.q3k ];
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Current `evdevremapkeys` is now broken (after latest staging-next):

```
File "/nix/store/jxyrvv4gbpnp3ap5iy7wxwl1sg4x2x88-python3-3.14.6/lib/python3.14/asyncio/events.py", line 718, in get_event_loop
    raise RuntimeError('There is no current event loop in thread %r.'
                       % threading.current_thread().name)
RuntimeError: There is no current event loop in thread 'MainThread'.
```

Fixed upstream in https://github.com/philipl/evdevremapkeys/commit/b889a5475f466a5ed4926b0b0fadae610684cf64.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
