### PR TITLE
python3Packages.chefiq-ble: init at 1.0.1

### DIFF
--- a/pkgs/development/python-modules/chefiq-ble/default.nix
+++ b/pkgs/development/python-modules/chefiq-ble/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  bluetooth-data-tools,
+  bluetooth-sensor-state-data,
+  home-assistant-bluetooth,
+  sensor-state-data,
+  pytest-cov-stub,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "chefiq-ble";
+  version = "1.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Invader444";
+    repo = "chefiq-ble";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-aC0v3KtZEnEz90kJPxx0euUM/h6NzLnvI9WggImYQ5c=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    bluetooth-data-tools
+    bluetooth-sensor-state-data
+    home-assistant-bluetooth
+    sensor-state-data
+  ];
+
+  nativeCheckInputs = [
+    pytest-cov-stub
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "chefiq_ble" ];
+
+  meta = {
+    description = "Passive BLE advertisement parser for Chef iQ wireless probes (CQ50/CQ60)";
+    homepage = "https://github.com/Invader444/chefiq-ble";
+    changelog = "https://github.com/Invader444/chefiq-ble/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -1009,6 +1009,7 @@
         bluetooth-adapters
         bluetooth-auto-recovery
         bluetooth-data-tools
+        chefiq-ble
         dbus-fast
         esphome-dashboard-api
         ha-ffmpeg
@@ -1021,7 +1022,7 @@
         pyspeex-noise
         serialx
         zeroconf
-      ]; # missing inputs: chefiq-ble
+      ];
     "chess_com" =
       ps: with ps; [
         chess-com-api
@@ -7916,6 +7917,7 @@
     "centriconnect"
     "cert_expiry"
     "chacon_dio"
+    "chef_iq"
     "chess_com"
     "cielo_home"
     "citybikes"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3058,6 +3058,8 @@ self: super: with self; {
 
   cheetah3 = callPackage ../development/python-modules/cheetah3 { };
 
+  chefiq-ble = callPackage ../development/python-modules/chefiq-ble { };
+
   cheroot = callPackage ../development/python-modules/cheroot { };
 
   cherrypy = callPackage ../development/python-modules/cherrypy { };


### PR DESCRIPTION
- https://pypi.org/project/chefiq-ble/
- https://github.com/Invader444/chefiq-ble
- https://www.home-assistant.io/integrations/chef_iq/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
