### PR TITLE
emacsPackages.majutsu: init at 0.6.0-unstable-2026-07-09

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/majutsu/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/majutsu/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  melpaBuild,
+  fetchFromGitHub,
+  nix-update-script,
+  magit,
+  transient,
+  with-editor,
+}:
+melpaBuild {
+  pname = "majutsu";
+  version = "0.6.0-unstable-2026-07-09";
+
+  src = fetchFromGitHub {
+    owner = "0WD0";
+    repo = "majutsu";
+    rev = "59aff9b93eac575fbccc1f4ab2d48d048e0ead9b";
+    hash = "sha256-GJ62hsHgLEFIY0ghij0VPFt1jMUGRKhI2eCroBjkxtc=";
+  };
+
+  packageRequires = [
+    magit
+    transient
+    with-editor
+  ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch=main" ]; };
+
+  meta = {
+    description = "Magit for jujutsu";
+    homepage = "https://github.com/0WD0/majutsu";
+    maintainers = [ lib.maintainers.shunueda ];
+    license = lib.licenses.gpl3Plus;
+  };
+}


### PR DESCRIPTION
Adding [majutsu](https://github.com/0WD0/majutsu) at 0.6.0-unstable-2026-07-09, magit for jujutsu.

Opened [an issue upstream](https://github.com/0WD0/majutsu/issues/43) asking whether they're open to publishing on ELPA, but haven't heard back in a few months. Listing myself as maintainer for now; if they do publish on ELPA, I'll action on it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
