### PR TITLE
balena-cli: fix docker compose support, balena-compose-parser: init at 0.2.6

### DIFF
--- a/pkgs/by-name/ba/balena-cli/package.nix
+++ b/pkgs/by-name/ba/balena-cli/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  balena-compose-parser,
   buildNpmPackage,
   fetchFromGitHub,
   nodejs_24,
@@ -45,6 +46,10 @@ buildNpmPackage' rec {
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     udev
   ];
+
+  postInstall = ''
+    cp ${lib.getExe balena-compose-parser} $out/lib/node_modules/balena-cli/node_modules/@balena/compose-parser/bin/
+  '';
 
   nativeInstallCheckInputs = [
     versionCheckHook

--- a/pkgs/by-name/ba/balena-compose-parser/package.nix
+++ b/pkgs/by-name/ba/balena-compose-parser/package.nix
@@ -1,0 +1,31 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+}:
+buildGoModule rec {
+  __structuredAttrs = true;
+  pname = "balena-compose-parser";
+  version = "0.2.6";
+
+  src = fetchFromGitHub {
+    owner = "balena-io-modules";
+    repo = "balena-compose-parser";
+    rev = "v${version}";
+    hash = "sha256-Bpcj3a689CjXmcjccyBzg30bj4+YT2FCvDvnpIy+EdY=";
+  };
+
+  modRoot = "lib";
+  vendorHash = "sha256-t3snmAQe+rbclrvNjmFl9O9KAc5OFU9zH3r+1+B+JI4=";
+
+  meta = {
+    description = "compose-go wrapper for parsing balena-compatible docker-compose.yml files ";
+    homepage = "https://github.com/balena-io-modules/balena-compose-parser";
+    changelog = "https://github.com/balena-io-modules/balena-compose-parser/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      kalebpace
+    ];
+    mainProgram = "balena-compose-parser";
+  };
+}


### PR DESCRIPTION
`balena push` (or `deploy`) would previously not work for docker compose files (multi-service releases) because the cli (or, well, a dependency) internally [calls an executable](https://github.com/balena-io-modules/balena-compose-parser/blob/v0.2.6/lib/compose.ts#L57-L62) to parse them. this was just missing alltogether, so I've added it as a new package to hack it into the right place inside balena-cli

note that I've deliberately made this a new package (instead of a let binding local to balena-cli) so we don't miss any updates. I don't expect anything else to use balena-compose-parser, though.

logs before:
```
➜ balena push blabla/blabla
Error parsing composition file "/home/willy/test/balena/docker-compose.yaml":
Unexpected end of JSON input

Additional information may be available with the `--debug` flag.

For further help or support, visit:
https://docs.balena.io/reference/balena-cli/latest#support-faq-and-troubleshooting


/ Uploading source package to https://builder.balena-cloud.com¶
```

after: deploy works (too lazy to redact everything lol)

@kalebpace I added you as a maintainer for the new package because you're already maintaining balena-cli, hope that's alright. balena-compose-parser is _tiny_ so I don't really expect much "maintenance" there besides the occasional update.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
