### PR TITLE
ncalayer: init at 1.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20212,6 +20212,12 @@
     githubId = 74260683;
     name = "Nuno David";
   };
+  ndenissov = {
+    email = "n.denissov@proton.me";
+    github = "ndenissov";
+    githubId = 70575593;
+    name = "Nikita Denissov";
+  };
   ndl = {
     email = "ndl@endl.ch";
     github = "ndl";

--- a/pkgs/by-name/nc/ncalayer/ncalayer-run.sh
+++ b/pkgs/by-name/nc/ncalayer/ncalayer-run.sh
@@ -1,0 +1,85 @@
+set -e
+
+export JAVA_HOME="$ncalayer_unwrapped/share/ncalayer/additions/jre8_ncalayer"
+export PATH="$JAVA_HOME/bin:$PATH"
+
+# Avoid rendering bugs and blank window glitches on Wayland
+export GDK_BACKEND=x11
+export _JAVA_AWT_WM_NONREPARENTING=1
+export _JAVA_OPTIONS="-Djdk.gtk.version=2 -Dawt.useSystemAAFontSettings=on -Dswing.aatext=true ${_JAVA_OPTIONS:-}"
+
+# pcsclite from targetPkgs will always be available in the standard path due to buildFHSEnv
+JAVA_ARGS="-Dsun.security.smartcardio.library=/usr/lib/libpcsclite.so.1"
+show_help() {
+  echo "Usage: ncalayer [OPTION]"
+  echo "NCALayer provides digital signature (EDS) capabilities for Kazakhstan government web portals."
+  echo ""
+  echo "Options:"
+  echo "  -h, --help       Show this help message"
+  echo "  --run            Run NCALayer in the background if not already running"
+  echo "  --settings       Open NCALayer configuration settings"
+  echo "  --bundle-manager Open NCALayer bundle manager"
+  echo "  --stop           Stop NCALayer execution"
+  echo "  --restart        Restart NCALayer"
+  echo ""
+  echo "Running without options will start NCALayer in the foreground."
+}
+
+wait_for_server() {
+  local timeout=60
+  while ! (echo > /dev/tcp/127.0.0.1/13579) >/dev/null 2>&1; do
+    sleep 0.5
+    timeout=$((timeout - 1))
+    if [ $timeout -le 0 ]; then
+      echo "Error: Timed out waiting for NCALayer socket (127.0.0.1:13579)." >&2
+      exit 1
+    fi
+  done
+}
+
+start_background() {
+  if ! pgrep -f "ncalayer.sh" > /dev/null; then
+    java $JAVA_ARGS -jar "$ncalayer_unwrapped/share/ncalayer/ncalayer.sh" >/dev/null 2>&1 &
+  fi
+}
+
+case "$1" in
+  -h|--help)
+    show_help
+    exit 0
+    ;;
+  --run)
+    if pgrep -f "ncalayer.sh" > /dev/null; then
+      echo "NCALayer is already running. You can use --stop or --restart."
+      exit 1
+    fi
+    java $JAVA_ARGS -jar "$ncalayer_unwrapped/share/ncalayer/ncalayer.sh" >/dev/null 2>&1 &
+    ;;
+  --settings)
+    start_background
+    wait_for_server
+    "$ncalayer_unwrapped/share/ncalayer/additions/showSettings"
+    ;;
+  --bundle-manager)
+    start_background
+    wait_for_server
+    "$ncalayer_unwrapped/share/ncalayer/additions/showBundleManager"
+    ;;
+  --stop)
+    pkill -f "ncalayer.sh" || true
+    exit 0
+    ;;
+  --restart)
+    pkill -f "ncalayer.sh" || true
+    while (echo > /dev/tcp/127.0.0.1/13579) >/dev/null 2>&1; do sleep 0.5; done
+    java $JAVA_ARGS -jar "$ncalayer_unwrapped/share/ncalayer/ncalayer.sh" >/dev/null 2>&1 &
+    ;;
+  "")
+    java $JAVA_ARGS -jar "$ncalayer_unwrapped/share/ncalayer/ncalayer.sh"
+    ;;
+  *)
+    echo "Unknown option: $1" >&2
+    show_help
+    exit 1
+    ;;
+esac

--- a/pkgs/by-name/nc/ncalayer/package.nix
+++ b/pkgs/by-name/nc/ncalayer/package.nix
@@ -1,0 +1,193 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  unzip,
+  buildFHSEnv,
+  copyDesktopItems,
+  makeDesktopItem,
+  writeShellScript,
+  alsa-lib,
+  atk,
+  cairo,
+  fontconfig,
+  freetype,
+  gdk-pixbuf,
+  glib,
+  gtk3,
+  libx11,
+  libxext,
+  libxi,
+  libxrender,
+  libxtst,
+  nspr,
+  nss,
+  pango,
+  pcsclite,
+  procps,
+  zlib,
+}:
+
+let
+  pname = "ncalayer";
+  version = "1.4";
+
+  src = fetchurl {
+    # Upstream updates the application by overwriting this static file
+    # without providing a versioned archive or changelog.
+    # A specific snapshot from Web Archive is pinned to guarantee reproducibility.
+    url = "https://web.archive.org/web/20260709073222/https://ncl.pki.gov.kz/images/NCALayer/ncalayer.zip";
+    hash = "sha256-MfR8Em/lYQfXbxHERhEN+gn8OX8DKlTvjuTXvK9kYcs=";
+  };
+
+  ncalayer-unwrapped = stdenv.mkDerivation {
+    pname = "${pname}-unwrapped";
+    inherit version src;
+
+    strictDeps = true;
+    __structuredAttrs = true;
+
+    nativeBuildInputs = [
+      unzip
+      copyDesktopItems
+    ];
+
+    sourceRoot = ".";
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/share/ncalayer
+      cp -r additions ncalayer.sh $out/share/ncalayer/
+
+      mkdir -p $out/share/pixmaps
+      cp additions/ncalayer.png $out/share/pixmaps/
+
+      chmod +x $out/share/ncalayer/additions/showSettings
+      chmod +x $out/share/ncalayer/additions/showBundleManager
+      chmod +x $out/share/ncalayer/additions/jre8_ncalayer/bin/*
+      chmod +x $out/share/ncalayer/ncalayer.sh
+
+      runHook postInstall
+    '';
+
+    desktopItems = [
+      (makeDesktopItem {
+        name = "ncalayer";
+        desktopName = "NCALayer";
+        genericName = "Digital Signature Client";
+        comment = "NCALayer digital signature application (Kazakhstan)";
+        icon = "ncalayer";
+        exec = "ncalayer --run";
+        terminal = false;
+        categories = [
+          "Network"
+          "RemoteAccess"
+        ];
+      })
+      (makeDesktopItem {
+        name = "ncalayer-settings";
+        desktopName = "NCALayer Settings";
+        genericName = "NCALayer Configuration";
+        comment = "Open NCALayer configuration window";
+        icon = "ncalayer";
+        exec = "ncalayer --settings";
+        terminal = false;
+        categories = [
+          "Settings"
+          "Network"
+        ];
+      })
+      (makeDesktopItem {
+        name = "ncalayer-bundle-manager";
+        desktopName = "NCALayer Bundle Manager";
+        genericName = "NCALayer Modules";
+        comment = "Manage NCALayer plugins and modules";
+        icon = "ncalayer";
+        exec = "ncalayer --bundle-manager";
+        terminal = false;
+        categories = [
+          "Settings"
+          "Network"
+        ];
+      })
+    ];
+  };
+
+  fhsEnv = buildFHSEnv {
+    name = pname;
+    inherit version;
+
+    targetPkgs = pkgs: [
+      alsa-lib
+      atk
+      cairo
+      fontconfig
+      freetype
+      gdk-pixbuf
+      glib
+      gtk3
+      libx11
+      libxext
+      libxi
+      libxrender
+      libxtst
+      nspr
+      nss
+      pango
+      pcsclite
+      procps
+      stdenv.cc.cc.lib
+      zlib
+    ];
+
+    runScript = writeShellScript "ncalayer-run" ''
+      ncalayer_unwrapped="${ncalayer-unwrapped}"
+      ${builtins.readFile ./ncalayer-run.sh}
+    '';
+  };
+
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    ln -s ${fhsEnv}/bin/${pname} $out/bin/${pname}
+
+    mkdir -p $out/share/applications $out/share/pixmaps
+    ln -s ${ncalayer-unwrapped}/share/applications/* $out/share/applications/
+    ln -s ${ncalayer-unwrapped}/share/pixmaps/* $out/share/pixmaps/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Digital signature client for Kazakhstan government portals";
+    longDescription = ''
+      NCALayer operates as a local HTTPS loopback server, allowing Kazakhstani
+      government and banking portals to interact with crypto-tokens and sign documents.
+
+      For the application to function properly, the National Certification Authority
+      (NCA / НУЦ РК) root certificates must be imported into your browser's or
+      system's trusted certificate store, otherwise web portals won't be able to
+      establish a secure connection with the local NCALayer service.
+
+      If you plan to use physical hardware tokens or smart-cards (like Kaztoken),
+      make sure to enable the PCSC-Lite daemon by adding `services.pcscd.enable = true;`
+      to your NixOS configuration.
+    '';
+    homepage = "https://ncl.pki.gov.kz/eng/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ ndenissov ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "ncalayer";
+  };
+}


### PR DESCRIPTION
This PR introduces `ncalayer`, a digital signature client for Kazakhstan's government and banking portals.

NCALayer operates as a local HTTP/WebSocket loopback server (on port `13579`), allowing web portals to interact with crypto-tokens and file keys to sign documents.

It is packaged using `buildFHSEnv` because the application is distributed as a pre-compiled bundle with its own JRE 8 and binary helpers, which rely on standard FHS dynamic libraries.

- **Homepage:** [https://ncl.pki.gov.kz/](https://ncl.pki.gov.kz/eng/)
- **License:** unfree

Tested the GUI launch and verified that the local server executes correctly.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test