### PR TITLE
rPackages: fix dependencies for several when using strictDeps

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -457,10 +457,7 @@ let
       ncurses
       gsl
     ];
-    bioacoustics = [
-      pkgs.fftw.dev
-      pkgs.cmake
-    ];
+    bioacoustics = [ pkgs.cmake ];
     bigGP = [ pkgs.mpi ];
     bigrquerystorage = with pkgs; [
       grpc
@@ -1095,6 +1092,7 @@ let
       zlib.dev
       zstd.dev
     ];
+    bioacoustics = [ pkgs.fftw ];
     blosc = [ pkgs.c-blosc ];
     curl = [ pkgs.curl ];
     EHRmuse = [ pkgs.gsl.dev ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -494,7 +494,6 @@ let
     ];
     interpolation = [ pkgs.pkg-config ];
     clarabel = [ pkgs.cargo ];
-    curl = [ pkgs.curl.dev ];
     CytoML = [ pkgs.libxml2.dev ];
     data_table =
       with pkgs;
@@ -1134,6 +1133,7 @@ let
       zstd.dev
     ];
     blosc = [ pkgs.c-blosc ];
+    curl = [ pkgs.curl ];
     EHRmuse = [ pkgs.gsl.dev ];
     island = [ pkgs.gsl.dev ];
     knowYourCG = with pkgs; [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -412,11 +412,7 @@ let
   packagesWithNativeBuildInputs = {
     adimpro = [ pkgs.imagemagick ];
     animation = [ pkgs.which ];
-    Apollonius = with pkgs; [
-      pkg-config
-      gmp.dev
-      mpfr.dev
-    ];
+    Apollonius = [ pkgs.pkg-config ];
     arrow =
       with pkgs;
       [
@@ -1083,6 +1079,10 @@ let
       libkrb5.dev
       openpam
       libpq
+    ];
+    Apollonius = with pkgs; [
+      gmp
+      mpfr
     ];
     asciicast = with pkgs; [
       bzip2.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -843,7 +843,7 @@ let
       pkg-config
     ];
     httpuv = [ pkgs.zlib.dev ];
-    clustermq = [ pkgs.zeromq ];
+    clustermq = [ pkgs.pkg-config ];
     SAVE = with pkgs; [
       zlib
       bzip2
@@ -1155,7 +1155,7 @@ let
     pqsfinder = [ pkgs.boost ];
     bigmemory = lib.optionals stdenv.hostPlatform.isLinux [ pkgs.libuuid.dev ];
     bayesWatch = [ pkgs.boost.dev ];
-    clustermq = [ pkgs.pkg-config ];
+    clustermq = [ pkgs.zeromq ];
     coga = [ pkgs.gsl.dev ];
     mBvs = [ pkgs.gsl.dev ];
     milorGWAS = [ pkgs.zlib.dev ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -659,6 +659,7 @@ let
     ];
     rsbml = [ pkgs.pkg-config ];
     rvg = [ pkgs.libpng.dev ];
+    SuperGauss = [ pkgs.pkg-config ];
     MAGEE = [
       pkgs.zlib.dev
       pkgs.bzip2.dev
@@ -1231,10 +1232,7 @@ let
       netcdf
     ];
     rsbml = [ pkgs.libsbml ];
-    SuperGauss = [
-      pkgs.pkg-config
-      pkgs.fftw.dev
-    ];
+    SuperGauss = [ pkgs.fftw ];
     ravetools = with pkgs; [
       pkg-config
       fftw.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -811,7 +811,7 @@ let
     ];
     RODBC = [ pkgs.libiodbc ];
     rpanel = [ pkgs.tclPackages.bwidget ];
-    Rpoppler = [ pkgs.poppler ];
+    Rpoppler = [ pkgs.pkg-config ];
     RPostgreSQL = with pkgs; [ libpq.pg_config ];
     RProtoBuf = [ pkgs.pkg-config ];
     rsamplr = with pkgs; [
@@ -1208,7 +1208,7 @@ let
       protobuf
       abseil-cpp
     ];
-    Rpoppler = [ pkgs.pkg-config ];
+    Rpoppler = [ pkgs.poppler ];
     RPostgres = with pkgs; [ libpq ];
     XML = [ pkgs.pkg-config ];
     apsimx = [ pkgs.which ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -707,7 +707,7 @@ let
       pkgs.pkg-config
       pkgs.clp
     ];
-    pdftools = [ pkgs.poppler.dev ];
+    pdftools = [ pkgs.pkg-config ];
     PEPBVS = [ pkgs.gsl ];
     phytools = [ pkgs.which ];
     PKI = [ pkgs.openssl.dev ];
@@ -1294,7 +1294,7 @@ let
       protobuf
       zlib.dev
     ];
-    pdftools = [ pkgs.pkg-config ];
+    pdftools = [ pkgs.poppler ];
     qckitfastq = [ pkgs.zlib.dev ];
     raer = with pkgs; [
       zlib.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -1069,7 +1069,10 @@ let
     ];
     symbolicQspray = [ pkgs.pkg-config ];
     sphereTessellation = [ pkgs.pkg-config ];
-    vapour = [ pkgs.pkg-config ];
+    vapour = with pkgs; [
+      pkg-config
+      gdal # for gdal-config
+    ];
     xdvir = [ pkgs.freetype.dev ];
   };
 
@@ -1624,10 +1627,7 @@ let
       gmp.dev
       mpfr.dev
     ];
-    vapour = with pkgs; [
-      proj.dev
-      gdal
-    ];
+    vapour = [ pkgs.proj ];
     MedianaDesigner = [ pkgs.zlib.dev ];
     ChemmineOB = with pkgs; [
       eigen
@@ -2165,12 +2165,6 @@ let
 
     unsum = old.unsum.overrideAttrs (attrs: {
       postPatch = "patchShebangs configure";
-    });
-
-    vapour = old.vapour.overrideAttrs (attrs: {
-      configureFlags = [
-        "--with-proj-lib=${pkgs.lib.getLib pkgs.proj}/lib"
-      ];
     });
 
     rzmq = old.rzmq.overrideAttrs (attrs: {

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -479,7 +479,7 @@ let
     cairoDevice = [ pkgs.pkg-config ];
     Cairo = [ pkgs.pkg-config ];
     Cardinal = [ pkgs.which ];
-    chebpol = [ pkgs.fftw.dev ];
+    chebpol = [ pkgs.pkg-config ];
     ChemmineOB = [ pkgs.pkg-config ];
     ciflyr = with pkgs; [
       cargo
@@ -1194,7 +1194,10 @@ let
     apsimx = [ pkgs.which ];
     cairoDevice = [ pkgs.gtk2 ];
     CBN2Path = [ pkgs.gsl ];
-    chebpol = [ pkgs.pkg-config ];
+    chebpol = with pkgs; [
+      fftw
+      gsl
+    ];
     baseline = [ pkgs.lapack ];
     eds = [ pkgs.zlib.dev ];
     iscream = with pkgs; [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -872,11 +872,9 @@ let
       bzip2
     ];
     sf = with pkgs; [
-      gdal
-      proj
-      geos
-      libtiff
-      curl
+      pkg-config
+      gdal # for gdal-config
+      geos # for geos-config
     ];
     fio = with pkgs; [
       cargo
@@ -1279,9 +1277,8 @@ let
     ];
     saeMSPE = [ pkgs.gsl.dev ];
     sf = with pkgs; [
-      pkg-config
-      sqlite.dev
-      proj.dev
+      proj
+      sqlite
     ];
     terra = with pkgs; [
       pkg-config
@@ -2166,12 +2163,6 @@ let
         --replace-fail "Calloc" "R_Calloc" \
         --replace-fail "Free" "R_Free"
       '';
-    });
-
-    sf = old.sf.overrideAttrs (attrs: {
-      configureFlags = [
-        "--with-proj-lib=${pkgs.lib.getLib pkgs.proj}/lib"
-      ];
     });
 
     terra = old.terra.overrideAttrs (attrs: {

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -528,7 +528,7 @@ let
       cargo
       rustc
     ];
-    fftw = [ pkgs.fftw.dev ];
+    fftw = [ pkgs.pkg-config ];
     fftwtools = with pkgs; [
       fftw.dev
       pkg-config
@@ -1227,7 +1227,7 @@ let
     ];
     fs = [ pkgs.libuv ];
     pgenlibr = [ pkgs.zlib.dev ];
-    fftw = [ pkgs.pkg-config ];
+    fftw = [ pkgs.fftw ];
     gdtools = [ pkgs.pkg-config ];
     archive = [ pkgs.libarchive ];
     lpsymphony = with pkgs; [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -1043,6 +1043,7 @@ let
       pkgs.pkg-config
       pkgs.gmp.dev
     ];
+    multibridge = [ pkgs.pkg-config ];
     RcppCWB = [
       pkgs.pkg-config
       pkgs.pcre2
@@ -1541,10 +1542,7 @@ let
     LCMCR = [ pkgs.gsl ];
     BNSP = [ pkgs.gsl ];
     scModels = [ pkgs.mpfr.dev ];
-    multibridge = with pkgs; [
-      pkg-config
-      mpfr.dev
-    ];
+    multibridge = [ pkgs.mpfr ];
     RcppCWB = with pkgs; [
       pcre.dev
       glib.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -813,10 +813,7 @@ let
     rpanel = [ pkgs.tclPackages.bwidget ];
     Rpoppler = [ pkgs.poppler ];
     RPostgreSQL = with pkgs; [ libpq.pg_config ];
-    RProtoBuf = with pkgs; [
-      protobuf
-      abseil-cpp.dev
-    ];
+    RProtoBuf = [ pkgs.pkg-config ];
     rsamplr = with pkgs; [
       cargo
       rustc
@@ -1207,7 +1204,10 @@ let
       libpng.dev
     ];
     RGtk2 = [ pkgs.pkg-config ];
-    RProtoBuf = [ pkgs.pkg-config ];
+    RProtoBuf = with pkgs; [
+      protobuf
+      abseil-cpp
+    ];
     Rpoppler = [ pkgs.pkg-config ];
     RPostgres = with pkgs; [ libpq ];
     XML = [ pkgs.pkg-config ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -548,17 +548,7 @@ let
     ];
     gamstransfer = [ pkgs.zlib ];
     gdalraster = [ pkgs.pkg-config ];
-    gdtools =
-      with pkgs;
-      [
-        cairo.dev
-        fontconfig.lib
-        freetype.dev
-      ]
-      ++ lib.optionals stdenv.hostPlatform.isDarwin [
-        expat
-        libxdmcp
-      ];
+    gdtools = [ pkgs.pkg-config ];
     GeneralizedWendland = [ pkgs.gsl ];
     ggiraph = [ pkgs.libpng.dev ];
     git2r = with pkgs; [
@@ -1217,7 +1207,17 @@ let
     fs = [ pkgs.libuv ];
     pgenlibr = [ pkgs.zlib.dev ];
     fftw = [ pkgs.fftw ];
-    gdtools = [ pkgs.pkg-config ];
+    gdtools =
+      with pkgs;
+      [
+        cairo
+        fontconfig.lib
+        freetype
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [
+        expat
+        libxdmcp
+      ];
     archive = [ pkgs.libarchive ];
     lpsymphony = with pkgs; [
       symphony

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -1011,7 +1011,6 @@ let
     gmapR = [ pkgs.zlib.dev ];
     Rsubread = [ pkgs.zlib.dev ];
     Rsubbotools = [ pkgs.gsl ];
-    XVector = [ pkgs.zlib.dev ];
     Rsamtools = with pkgs; [
       zlib.dev
       curl.dev
@@ -1656,6 +1655,7 @@ let
       pkgs.lapack
       pkgs.blas
     ];
+    XVector = [ pkgs.zlib ];
   };
 
   packagesRequiringX = [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -946,7 +946,7 @@ let
     spate = [ pkgs.fftw.dev ];
     ssanv = [ pkgs.proj ];
     stsm = [ pkgs.gsl ];
-    stringi = [ pkgs.icu.dev ];
+    stringi = [ pkgs.pkg-config ];
     parseLatex = [ pkgs.icu.dev ];
     survSNP = [ pkgs.gsl ];
     svglite = [ pkgs.libpng.dev ];
@@ -1306,7 +1306,7 @@ let
     ];
     showtext = [ pkgs.pkg-config ];
     spate = [ pkgs.pkg-config ];
-    stringi = [ pkgs.pkg-config ];
+    stringi = [ pkgs.icu74 ];
     SynExtend = [ pkgs.zlib.dev ];
     sysfonts = with pkgs; [
       zlib

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -1262,7 +1262,6 @@ let
     mwaved = [ pkgs.pkg-config ];
     nloptr = [ pkgs.nlopt ];
     odbc = [ pkgs.unixodbc ];
-    openssl = [ pkgs.pkg-config ];
     otelsdk = with pkgs; [
       protobuf
       zlib.dev
@@ -2581,9 +2580,6 @@ let
     });
 
     openssl = old.openssl.overrideAttrs (attrs: {
-      preConfigure = ''
-        patchShebangs configure
-      '';
       env = (attrs.env or { }) // {
         PKGCONFIG_CFLAGS = "-I${pkgs.openssl.dev}/include";
         PKGCONFIG_LIBS = "-Wl,-rpath,${lib.getLib pkgs.openssl}/lib -L${lib.getLib pkgs.openssl}/lib -lssl -lcrypto";

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -642,9 +642,8 @@ let
       gettext
     ];
     lwgeom = with pkgs; [
-      proj
-      geos
-      gdal
+      pkg-config
+      geos # for geos-config
     ];
     otelsdk = with pkgs; [
       cmake
@@ -1258,11 +1257,7 @@ let
       pkg-config
       opencv
     ];
-    lwgeom = with pkgs; [
-      pkg-config
-      proj.dev
-      sqlite.dev
-    ];
+    lwgeom = [ pkgs.proj ];
     magick = [ pkgs.pkg-config ];
     mwaved = [ pkgs.pkg-config ];
     nloptr = [ pkgs.nlopt ];
@@ -2172,12 +2167,6 @@ let
         --replace-fail "Calloc" "R_Calloc" \
         --replace-fail "Free" "R_Free"
       '';
-    });
-
-    lwgeom = old.lwgeom.overrideAttrs (attrs: {
-      configureFlags = [
-        "--with-proj-lib=${pkgs.lib.getLib pkgs.proj}/lib"
-      ];
     });
 
     sf = old.sf.overrideAttrs (attrs: {

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -697,11 +697,7 @@ let
       cargo
       rustc
     ];
-    R2SWF = with pkgs; [
-      zlib
-      libpng
-      freetype.dev
-    ];
+    R2SWF = [ pkgs.pkg-config ];
     RAppArmor = [ pkgs.libapparmor ];
     rapportools = [ pkgs.which ];
     rapport = [ pkgs.which ];
@@ -1168,7 +1164,11 @@ let
       zstd.dev
     ];
     RCurl = [ pkgs.curl.dev ];
-    R2SWF = [ pkgs.pkg-config ];
+    R2SWF = with pkgs; [
+      zlib
+      libpng
+      freetype
+    ];
     rDEA = [ pkgs.glpk ];
     rgl = with pkgs; [
       libGLU

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -688,10 +688,7 @@ let
     ];
     ncdf4 = [ pkgs.netcdf ];
     neojags = [ pkgs.jags ];
-    nloptr = with pkgs; [
-      nlopt
-      pkg-config
-    ];
+    nloptr = [ pkgs.pkg-config ];
     n1qn1 = [ pkgs.gfortran ];
     odbc = [ pkgs.unixodbc ];
     opencv = [ pkgs.pkg-config ];
@@ -1283,6 +1280,7 @@ let
     ];
     magick = [ pkgs.pkg-config ];
     mwaved = [ pkgs.pkg-config ];
+    nloptr = [ pkgs.nlopt ];
     odbc = [ pkgs.pkg-config ];
     openssl = [ pkgs.pkg-config ];
     otelsdk = with pkgs; [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -486,6 +486,7 @@ let
       rustc
     ];
     interpolation = [ pkgs.pkg-config ];
+    image_textlinedetector = [ pkgs.pkg-config ];
     clarabel = [ pkgs.cargo ];
     CytoML = [ pkgs.libxml2.dev ];
     data_table =
@@ -1254,10 +1255,7 @@ let
       gmp
       mpfr
     ];
-    image_textlinedetector = with pkgs; [
-      pkg-config
-      opencv
-    ];
+    image_textlinedetector = [ pkgs.opencv ];
     lwgeom = [ pkgs.proj ];
     magick = [ pkgs.imagemagick ];
     mwaved = [ pkgs.pkg-config ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -476,7 +476,7 @@ let
       cargo
       rustc
     ];
-    cairoDevice = [ pkgs.gtk2.dev ];
+    cairoDevice = [ pkgs.pkg-config ];
     Cairo = [ pkgs.pkg-config ];
     Cardinal = [ pkgs.which ];
     chebpol = [ pkgs.fftw.dev ];
@@ -1192,7 +1192,7 @@ let
       libxslt
     ];
     apsimx = [ pkgs.which ];
-    cairoDevice = [ pkgs.pkg-config ];
+    cairoDevice = [ pkgs.gtk2 ];
     CBN2Path = [ pkgs.gsl ];
     chebpol = [ pkgs.pkg-config ];
     baseline = [ pkgs.lapack ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -484,13 +484,7 @@ let
       rustc
     ];
     cairoDevice = [ pkgs.gtk2.dev ];
-    Cairo = with pkgs; [
-      libtiff
-      libjpeg
-      cairo.dev
-      libxt.dev
-      fontconfig.lib
-    ];
+    Cairo = [ pkgs.pkg-config ];
     Cardinal = [ pkgs.which ];
     chebpol = [ pkgs.fftw.dev ];
     ChemmineOB = [ pkgs.pkg-config ];
@@ -1329,7 +1323,7 @@ let
     sysfonts = [ pkgs.pkg-config ];
     systemfonts = [ pkgs.pkg-config ];
     tesseract = [ pkgs.pkg-config ];
-    Cairo = [ pkgs.pkg-config ];
+    Cairo = [ pkgs.cairo ];
     CLVTools = [ pkgs.gsl ];
     excursions = [ pkgs.gsl ];
     OpenCL = with pkgs; [
@@ -2234,12 +2228,6 @@ let
 
     clustermq = old.clustermq.overrideAttrs (attrs: {
       preConfigure = "patchShebangs configure";
-    });
-
-    Cairo = old.Cairo.overrideAttrs (attrs: {
-      env = (attrs.env or { }) // {
-        NIX_LDFLAGS = "-lfontconfig";
-      };
     });
 
     curl = old.curl.overrideAttrs (attrs: {

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -971,10 +971,7 @@ let
     rlas = [ pkgs.pkg-config ];
     TAQMNGR = [ pkgs.zlib.dev ];
     TDA = [ pkgs.gmp ];
-    tesseract = with pkgs; [
-      tesseract
-      leptonica
-    ];
+    tesseract = [ pkgs.pkg-config ];
     tiff = [ pkgs.libtiff.dev ];
     tkrplot = with pkgs; [
       libx11
@@ -1322,7 +1319,10 @@ let
     SynExtend = [ pkgs.zlib.dev ];
     sysfonts = [ pkgs.pkg-config ];
     systemfonts = [ pkgs.pkg-config ];
-    tesseract = [ pkgs.pkg-config ];
+    tesseract = with pkgs; [
+      tesseract
+      leptonica
+    ];
     Cairo = [ pkgs.cairo ];
     CLVTools = [ pkgs.gsl ];
     excursions = [ pkgs.gsl ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -661,7 +661,7 @@ let
     ModelMetrics = lib.optional stdenv.hostPlatform.isDarwin pkgs.llvmPackages.openmp;
     mvabund = [ pkgs.gsl ];
     mcrPioda = [ pkgs.gsl ];
-    mwaved = [ pkgs.fftw.dev ];
+    mwaved = [ pkgs.pkg-config ];
     mzR = with pkgs; [
       zlib
       netcdf
@@ -1258,7 +1258,7 @@ let
     image_textlinedetector = [ pkgs.opencv ];
     lwgeom = [ pkgs.proj ];
     magick = [ pkgs.imagemagick ];
-    mwaved = [ pkgs.pkg-config ];
+    mwaved = [ pkgs.fftw ];
     nloptr = [ pkgs.nlopt ];
     odbc = [ pkgs.unixodbc ];
     otelsdk = with pkgs; [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -584,8 +584,6 @@ let
     ];
     HiCParser = [ pkgs.zlib ];
     yyjsonr = with pkgs; [ zlib.dev ];
-    RNifti = with pkgs; [ zlib.dev ];
-    RNiftyReg = with pkgs; [ zlib.dev ];
     highs = [
       pkgs.which
       pkgs.cmake
@@ -1232,6 +1230,8 @@ let
       netcdf
     ];
     rsbml = [ pkgs.libsbml ];
+    RNifti = [ pkgs.zlib ];
+    RNiftyReg = [ pkgs.zlib ];
     SuperGauss = [ pkgs.fftw ];
     ravetools = with pkgs; [
       pkg-config

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -991,10 +991,8 @@ let
     ];
     xml2 = [ pkgs.libxml2.dev ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ pkgs.perl ];
     XML = with pkgs; [
-      libtool
-      libxml2.dev
-      xmlsec
-      libxslt
+      pkg-config
+      libxml2 # for xml2-config
     ];
     affyPLM = [ pkgs.zlib.dev ];
     BitSeq = [ pkgs.zlib.dev ];
@@ -1210,7 +1208,12 @@ let
     ];
     Rpoppler = [ pkgs.poppler ];
     RPostgres = with pkgs; [ libpq ];
-    XML = [ pkgs.pkg-config ];
+    XML = with pkgs; [
+      libtool
+      libxml2
+      xmlsec
+      libxslt
+    ];
     apsimx = [ pkgs.which ];
     cairoDevice = [ pkgs.pkg-config ];
     CBN2Path = [ pkgs.gsl ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -680,7 +680,7 @@ let
     neojags = [ pkgs.jags ];
     nloptr = [ pkgs.pkg-config ];
     n1qn1 = [ pkgs.gfortran ];
-    odbc = [ pkgs.unixodbc ];
+    odbc = [ pkgs.pkg-config ];
     opencv = [ pkgs.pkg-config ];
     pak = [ pkgs.curl.dev ];
     pander = with pkgs; [
@@ -1261,7 +1261,7 @@ let
     magick = [ pkgs.imagemagick ];
     mwaved = [ pkgs.pkg-config ];
     nloptr = [ pkgs.nlopt ];
-    odbc = [ pkgs.pkg-config ];
+    odbc = [ pkgs.unixodbc ];
     openssl = [ pkgs.pkg-config ];
     otelsdk = with pkgs; [
       protobuf

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -955,10 +955,7 @@ let
       libpng
       freetype.dev
     ];
-    systemfonts = with pkgs; [
-      fontconfig.dev
-      freetype.dev
-    ];
+    systemfonts = [ pkgs.pkg-config ];
     rlas = [ pkgs.pkg-config ];
     TAQMNGR = [ pkgs.zlib.dev ];
     TDA = [ pkgs.gmp ];
@@ -1316,7 +1313,10 @@ let
     stringi = [ pkgs.pkg-config ];
     SynExtend = [ pkgs.zlib.dev ];
     sysfonts = [ pkgs.pkg-config ];
-    systemfonts = [ pkgs.pkg-config ];
+    systemfonts = with pkgs; [
+      fontconfig
+      freetype
+    ];
     tesseract = with pkgs; [
       tesseract
       leptonica

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -936,12 +936,7 @@ let
     ];
     apcf = with pkgs; [ geos ];
     SemiCompRisks = [ pkgs.gsl ];
-    showtext = with pkgs; [
-      zlib
-      libpng
-      icu
-      freetype.dev
-    ];
+    showtext = [ pkgs.pkg-config ];
     simplexreg = [ pkgs.gsl ];
     spate = [ pkgs.pkg-config ];
     ssanv = [ pkgs.proj ];
@@ -1304,7 +1299,11 @@ let
       sqlite.dev
       proj.dev
     ];
-    showtext = [ pkgs.pkg-config ];
+    showtext = with pkgs; [
+      zlib
+      libpng
+      freetype
+    ];
     spate = [ pkgs.fftw ];
     stringi = [ pkgs.icu74 ];
     SynExtend = [ pkgs.zlib.dev ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -891,10 +891,9 @@ let
     strawr = with pkgs; [ curl.dev ];
     string2path = [ pkgs.cargo ];
     terra = with pkgs; [
-      gdal
-      proj
-      geos
-      netcdf
+      pkg-config
+      gdal # for gdal-config
+      geos # for geos-config
     ];
     tok = with pkgs; [
       cargo
@@ -1281,9 +1280,8 @@ let
       sqlite
     ];
     terra = with pkgs; [
-      pkg-config
-      sqlite.dev
-      proj.dev
+      proj
+      sqlite
     ];
     showtext = with pkgs; [
       zlib
@@ -2163,12 +2161,6 @@ let
         --replace-fail "Calloc" "R_Calloc" \
         --replace-fail "Free" "R_Free"
       '';
-    });
-
-    terra = old.terra.overrideAttrs (attrs: {
-      configureFlags = [
-        "--with-proj-lib=${pkgs.lib.getLib pkgs.proj}/lib"
-      ];
     });
 
     unsum = old.unsum.overrideAttrs (attrs: {

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -943,7 +943,7 @@ let
       freetype.dev
     ];
     simplexreg = [ pkgs.gsl ];
-    spate = [ pkgs.fftw.dev ];
+    spate = [ pkgs.pkg-config ];
     ssanv = [ pkgs.proj ];
     stsm = [ pkgs.gsl ];
     stringi = [ pkgs.pkg-config ];
@@ -1305,7 +1305,7 @@ let
       proj.dev
     ];
     showtext = [ pkgs.pkg-config ];
-    spate = [ pkgs.pkg-config ];
+    spate = [ pkgs.fftw ];
     stringi = [ pkgs.icu74 ];
     SynExtend = [ pkgs.zlib.dev ];
     sysfonts = with pkgs; [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -658,6 +658,7 @@ let
     rsbml = [ pkgs.pkg-config ];
     rvg = [ pkgs.libpng.dev ];
     SuperGauss = [ pkgs.pkg-config ];
+    ravetools = [ pkgs.pkg-config ];
     MAGEE = [
       pkgs.zlib.dev
       pkgs.bzip2.dev
@@ -1233,10 +1234,7 @@ let
     RNifti = [ pkgs.zlib ];
     RNiftyReg = [ pkgs.zlib ];
     SuperGauss = [ pkgs.fftw ];
-    ravetools = with pkgs; [
-      pkg-config
-      fftw.dev
-    ];
+    ravetools = [ pkgs.fftw ];
     specklestar = [ pkgs.fftw.dev ];
     cartogramR = with pkgs; [
       fftw.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -635,6 +635,7 @@ let
       gfortran
       gettext
     ];
+    sodium = [ pkgs.pkg-config ];
     lwgeom = with pkgs; [
       pkg-config
       geos # for geos-config
@@ -1226,6 +1227,7 @@ let
       cgl
       clp
     ];
+    sodium = [ pkgs.libsodium ];
     gdalcubes = with pkgs; [
       proj.dev
       gdal
@@ -2937,15 +2939,11 @@ let
       '';
     });
 
-    sodium = old.sodium.overrideAttrs (
-      attrs: with pkgs; {
-        preConfigure = ''
-          patchShebangs configure
-        '';
-        nativeBuildInputs = [ pkg-config ] ++ attrs.nativeBuildInputs;
-        buildInputs = [ libsodium.dev ] ++ attrs.buildInputs;
-      }
-    );
+    sodium = old.sodium.overrideAttrs (attrs: {
+      preConfigure = ''
+        patchShebangs configure
+      '';
+    });
 
     keyring = old.keyring.overrideAttrs (attrs: {
       preConfigure = ''

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -838,10 +838,7 @@ let
       zlib.dev
       boost
     ];
-    rzmq = with pkgs; [
-      zeromq
-      pkg-config
-    ];
+    rzmq = [ pkgs.pkg-config ];
     httpuv = [ pkgs.zlib.dev ];
     clustermq = [ pkgs.pkg-config ];
     SAVE = with pkgs; [
@@ -1155,6 +1152,7 @@ let
     pqsfinder = [ pkgs.boost ];
     bigmemory = lib.optionals stdenv.hostPlatform.isLinux [ pkgs.libuuid.dev ];
     bayesWatch = [ pkgs.boost.dev ];
+    rzmq = [ pkgs.zeromq ];
     clustermq = [ pkgs.zeromq ];
     coga = [ pkgs.gsl.dev ];
     mBvs = [ pkgs.gsl.dev ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -950,11 +950,7 @@ let
     parseLatex = [ pkgs.icu.dev ];
     survSNP = [ pkgs.gsl ];
     svglite = [ pkgs.libpng.dev ];
-    sysfonts = with pkgs; [
-      zlib
-      libpng
-      freetype.dev
-    ];
+    sysfonts = [ pkgs.pkg-config ];
     systemfonts = [ pkgs.pkg-config ];
     rlas = [ pkgs.pkg-config ];
     TAQMNGR = [ pkgs.zlib.dev ];
@@ -1312,7 +1308,11 @@ let
     spate = [ pkgs.pkg-config ];
     stringi = [ pkgs.pkg-config ];
     SynExtend = [ pkgs.zlib.dev ];
-    sysfonts = [ pkgs.pkg-config ];
+    sysfonts = with pkgs; [
+      zlib
+      libpng
+      freetype
+    ];
     systemfonts = with pkgs; [
       fontconfig
       freetype

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -951,7 +951,6 @@ let
       udunits
       expat
     ];
-    units = [ pkgs.udunits ];
     unigd = [ pkgs.pkg-config ];
     unsum = with pkgs; [
       cargo
@@ -1187,6 +1186,7 @@ let
     ];
     Rpoppler = [ pkgs.poppler ];
     RPostgres = with pkgs; [ libpq ];
+    units = [ pkgs.udunits ];
     XML = with pkgs; [
       libtool
       libxml2

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -663,7 +663,7 @@ let
       pkgs.zlib.dev
       pkgs.bzip2.dev
     ];
-    magick = [ pkgs.imagemagick.dev ];
+    magick = [ pkgs.pkg-config ];
     ModelMetrics = lib.optional stdenv.hostPlatform.isDarwin pkgs.llvmPackages.openmp;
     mvabund = [ pkgs.gsl ];
     mcrPioda = [ pkgs.gsl ];
@@ -1258,7 +1258,7 @@ let
       opencv
     ];
     lwgeom = [ pkgs.proj ];
-    magick = [ pkgs.pkg-config ];
+    magick = [ pkgs.imagemagick ];
     mwaved = [ pkgs.pkg-config ];
     nloptr = [ pkgs.nlopt ];
     odbc = [ pkgs.pkg-config ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -732,7 +732,7 @@ let
       cmake
       pkg-config
     ];
-    RGtk2 = [ pkgs.gtk2.dev ];
+    RGtk2 = [ pkgs.pkg-config ];
     rhdf5 = [ pkgs.zlib ];
     Rhdf5lib = with pkgs; [
       cmake
@@ -1177,7 +1177,7 @@ let
       freetype.dev
       libpng.dev
     ];
-    RGtk2 = [ pkgs.pkg-config ];
+    RGtk2 = [ pkgs.gtk2 ];
     RProtoBuf = with pkgs; [
       protobuf
       abseil-cpp

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -659,6 +659,7 @@ let
     rvg = [ pkgs.libpng.dev ];
     SuperGauss = [ pkgs.pkg-config ];
     ravetools = [ pkgs.pkg-config ];
+    cartogramR = [ pkgs.pkg-config ];
     MAGEE = [
       pkgs.zlib.dev
       pkgs.bzip2.dev
@@ -1236,10 +1237,7 @@ let
     SuperGauss = [ pkgs.fftw ];
     ravetools = [ pkgs.fftw ];
     specklestar = [ pkgs.fftw.dev ];
-    cartogramR = with pkgs; [
-      fftw.dev
-      pkg-config
-    ];
+    cartogramR = [ pkgs.fftw ];
     Rhdf5lib = with pkgs; [
       curl
       zlib.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -625,7 +625,7 @@ let
     jqr = [ pkgs.jq.dev ];
     KFKSDS = [ pkgs.gsl ];
     KSgeneral = with pkgs; [ pkg-config ];
-    kza = [ pkgs.fftw.dev ];
+    kza = [ pkgs.pkg-config ];
     leidenAlg = [ pkgs.gmp.dev ];
     Libra = [ pkgs.gsl ];
     libstable4u = [ pkgs.gsl ];
@@ -1244,7 +1244,7 @@ let
     ];
     GRAB = [ pkgs.zlib.dev ];
     jqr = [ pkgs.jq.out ];
-    kza = [ pkgs.pkg-config ];
+    kza = [ pkgs.fftw ];
     igraph = with pkgs; [
       gmp
       libxml2.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -813,7 +813,6 @@ let
       boost
     ];
     rzmq = [ pkgs.pkg-config ];
-    httpuv = [ pkgs.zlib.dev ];
     clustermq = [ pkgs.pkg-config ];
     SAVE = with pkgs; [
       zlib
@@ -1117,6 +1116,7 @@ let
     bigmemory = lib.optionals stdenv.hostPlatform.isLinux [ pkgs.libuuid.dev ];
     bayesWatch = [ pkgs.boost.dev ];
     rzmq = [ pkgs.zeromq ];
+    httpuv = [ pkgs.zlib ];
     clustermq = [ pkgs.zeromq ];
     coga = [ pkgs.gsl.dev ];
     mBvs = [ pkgs.gsl.dev ];


### PR DESCRIPTION
Related: https://github.com/NixOS/nixpkgs/pull/539315

A LOT of packages specify dependencies in the wrong place. e.g. `nativeBuildInputs` and `buildInputs` are swapped for some reason.
This breaks the packages when building with `strictDeps = true`

This is just a small portion of the packages that need fixing. These are mostly `pkg-config` related fixes, but there are some miscellaneous fixes as well.

To test this I have edited the `generic-builder.nix` (`buildRPPackage`) to have `strictDeps = true` and moved everything necessary into `nativeBuildInputs` inside it.

For `rPackages.stringi` I pinned the icu version, as it was using the vendored `icu` because our default `icu` version was too high.

Also: just FYI, you don't need to specify `.dev`, because `stdenv.mkDerivation` automatically uses `lib.getDev` on the dependencies, if possible. Weird, I know.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
