### PR TITLE
nixos-rebuild-ng: refactor tempdir context manager in test_tmpdir.py

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_tmpdir.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_tmpdir.py
@@ -8,23 +8,15 @@ from nixos_rebuild.tmpdir import MAX_TMPDIR_LENGTH, make_tmpdir
 
 
 @contextlib.contextmanager
-def system_tempdir(path: Path) -> typing.Generator[None]:
-    path.mkdir(exist_ok=True)
-
-    # `tempfile` caches the tempdir, you must clear it for it to recompute.
-    tempfile.tempdir = None
-
-    og_tmpdir = os.environ.get("TMPDIR")
-
+def tempfile_tempdir(path: str) -> typing.Generator[None]:
+    Path(path).mkdir(exist_ok=True)
     try:
-        os.environ["TMPDIR"] = str(path)
-        assert Path(tempfile.gettempdir()) == path
+        og_tmpdir = tempfile.tempdir
+        tempfile.tempdir = path
+        assert tempfile.gettempdir() == path
         yield
     finally:
-        if og_tmpdir is None:
-            del os.environ["TMPDIR"]
-        else:
-            os.environ["TMPDIR"] = og_tmpdir
+        tempfile.tempdir = og_tmpdir
 
 
 def test_make_tmpdir() -> None:
@@ -36,7 +28,7 @@ def test_make_tmpdir() -> None:
     assert len(os.fsencode(str(tmp))) <= MAX_TMPDIR_LENGTH
 
     # Test with a short system temp dir. We should use it unmodified.
-    with system_tempdir(Path("/tmp/not-too-long")):
+    with tempfile_tempdir("/tmp/not-too-long"):
         tmpdir = make_tmpdir()
         tmp = Path(tmpdir.name)
 
@@ -47,7 +39,7 @@ def test_make_tmpdir() -> None:
     # Test with a long system temp dir. We should ignore
     # it and fall back to something short enough for OpenSSH to
     # create sockets in.
-    with system_tempdir(Path("/tmp/long" + ("g" * MAX_TMPDIR_LENGTH))):
+    with tempfile_tempdir("/tmp/long" + ("g" * MAX_TMPDIR_LENGTH)):
         tmpdir = make_tmpdir()
         tmp = Path(tmpdir.name)
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_tmpdir.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_tmpdir.py
@@ -10,8 +10,8 @@ from nixos_rebuild.tmpdir import MAX_TMPDIR_LENGTH, make_tmpdir
 @contextlib.contextmanager
 def tempfile_tempdir(path: str) -> typing.Generator[None]:
     Path(path).mkdir(exist_ok=True)
+    og_tmpdir = tempfile.tempdir
     try:
-        og_tmpdir = tempfile.tempdir
         tempfile.tempdir = path
         assert tempfile.gettempdir() == path
         yield
@@ -20,21 +20,25 @@ def tempfile_tempdir(path: str) -> typing.Generator[None]:
 
 
 def test_make_tmpdir() -> None:
-    # Basic test: whatever the default system temp dir happens to be.
-    tmpdir = make_tmpdir()
-    tmp = Path(tmpdir.name)
-    assert tmp.exists()
-    assert tmp.is_dir()
-    assert len(os.fsencode(str(tmp))) <= MAX_TMPDIR_LENGTH
-
-    # Test with a short system temp dir. We should use it unmodified.
-    with tempfile_tempdir("/tmp/not-too-long"):
-        tmpdir = make_tmpdir()
-        tmp = Path(tmpdir.name)
-
+    def assert_tmpdir(tmp: Path) -> None:
         assert tmp.exists()
         assert tmp.is_dir()
         assert len(os.fsencode(str(tmp))) <= MAX_TMPDIR_LENGTH
+
+    # Basic test: whatever the default system temp dir happens to be.
+    tmpdir = make_tmpdir()
+    tmp = Path(tmpdir.name)
+
+    assert_tmpdir(tmp)
+
+    # Test with a short system temp dir. We should use it unmodified.
+    short_tempdir = "/tmp/not-too-long"
+    with tempfile_tempdir(short_tempdir):
+        tmpdir = make_tmpdir()
+        tmp = Path(tmpdir.name)
+
+        assert tmp.parent == Path(short_tempdir)
+        assert_tmpdir(tmp)
 
     # Test with a long system temp dir. We should ignore
     # it and fall back to something short enough for OpenSSH to
@@ -43,6 +47,4 @@ def test_make_tmpdir() -> None:
         tmpdir = make_tmpdir()
         tmp = Path(tmpdir.name)
 
-        assert tmp.exists()
-        assert tmp.is_dir()
-        assert len(os.fsencode(str(tmp))) <= MAX_TMPDIR_LENGTH
+        assert_tmpdir(tmp)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Maybe fix this issue? https://github.com/NixOS/nixpkgs/issues/539644.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
