### PR TITLE
python3Packages.energieleser: init at 0.1.5

### DIFF
--- a/pkgs/development/python-modules/energieleser/default.nix
+++ b/pkgs/development/python-modules/energieleser/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  aiohttp,
+  pytest-asyncio,
+  pytest-cov-stub,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "energieleser";
+  version = "0.1.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "nineti-GmbH";
+    repo = "energieleser.py";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-vJ4eJaf0ue4N9aXwsPR79sTVt3NM1GKNw5XomhQUUdU=";
+  };
+
+  build-system = [ poetry-core ];
+
+  dependencies = [ aiohttp ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-cov-stub
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "energieleser" ];
+
+  meta = {
+    description = "Async Python client for energieleser devices (stromleser, gasleser, wasserleser, wärmeleser)";
+    homepage = "https://github.com/nineti-GmbH/energieleser.py";
+    changelog = "https://github.com/nineti-GmbH/energieleser.py/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -1690,7 +1690,8 @@
       ];
     "energieleser" =
       ps: with ps; [
-      ]; # missing inputs: energieleser
+        energieleser
+      ];
     "energy" =
       ps: with ps; [
         fnv-hash-fast
@@ -8022,6 +8023,7 @@
     "emulated_kasa"
     "emulated_roku"
     "energenie_power_sockets"
+    "energieleser"
     "energy"
     "energyid"
     "energyzero"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5434,6 +5434,8 @@ self: super: with self; {
 
   encutils = callPackage ../development/python-modules/encutils { };
 
+  energieleser = callPackage ../development/python-modules/energieleser { };
+
   energyflip-client = callPackage ../development/python-modules/energyflip-client { };
 
   energyflow = callPackage ../development/python-modules/energyflow { };


### PR DESCRIPTION
- https://pypi.org/project/energieleser/
- https://github.com/nineti-GmbH/energieleser.py
- https://www.home-assistant.io/integrations/energieleser/ 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
