### PR TITLE
folly: fix building with musl

### DIFF
--- a/pkgs/by-name/fo/folly/Modify-LocalLifetime-destructor-to-clear-local-cache.patch
+++ b/pkgs/by-name/fo/folly/Modify-LocalLifetime-destructor-to-clear-local-cache.patch
@@ -1,0 +1,32 @@
+From f09ac09e7f5e097e4bbc1d8af3c17d581ef0ee4c Mon Sep 17 00:00:00 2001
+From: Henri Menke <henri@henrimenke.de>
+Date: Fri, 10 Jul 2026 14:57:15 +0200
+Subject: [PATCH] Modify LocalLifetime destructor to clear local cache
+
+`destroy(getWrapper())` re-enters `ThreadLocalPtr::get()` while TLS destructors
+are already running. This crashes sometimes, see e.g. #2002. Instead avoid
+re-entering `ThreadLocal` in the TLS destructor and only clears the local
+fast-path cache `getLocalCache().object = nullptr`, which is sufficient to
+prevent stale reuse.
+
+Signed-off-by: Henri Menke <henri@henrimenke.de>
+---
+ folly/SingletonThreadLocal.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/folly/SingletonThreadLocal.h b/folly/SingletonThreadLocal.h
+index c71f87c3b..5249812ad 100644
+--- a/folly/SingletonThreadLocal.h
++++ b/folly/SingletonThreadLocal.h
+@@ -126,7 +126,7 @@ class SingletonThreadLocal {
+   using WrapperTL = ThreadLocal<Wrapper, TLTag>;
+ 
+   struct LocalLifetime : State::LocalLifetime {
+-    ~LocalLifetime() { destroy(getWrapper()); }
++    ~LocalLifetime() { getLocalCache().object = nullptr; }
+   };
+ 
+   SingletonThreadLocal() = delete;
+-- 
+2.55.0
+

--- a/pkgs/by-name/fo/folly/elf-native-class.patch
+++ b/pkgs/by-name/fo/folly/elf-native-class.patch
@@ -1,0 +1,23 @@
+--- a/folly/debugging/symbolizer/Elf.cpp
++++ b/folly/debugging/symbolizer/Elf.cpp
+@@ -18,6 +18,7 @@
+ 
+ #include <fcntl.h>
+ #include <sys/stat.h>
++#include <cstdint>
+ #include <cstring>
+ 
+ #include <glog/logging.h>
+@@ -46,6 +47,12 @@
+ #endif
+ #elif defined(__ANDROID__)
+ #define FOLLY_ELF_NATIVE_CLASS __WORDSIZE
++#else
++  #if INTPTR_MAX == INT64_MAX
++    #define FOLLY_ELF_NATIVE_CLASS 64
++  #elif INTPTR_MAX == INT32_MAX
++    #define FOLLY_ELF_NATIVE_CLASS 32
++  #endif
+ #endif // __ELF_NATIVE_CLASS
+ 
+ namespace folly {

--- a/pkgs/by-name/fo/folly/lzma-dependency.patch
+++ b/pkgs/by-name/fo/folly/lzma-dependency.patch
@@ -1,0 +1,22 @@
+--- a/build/fbcode_builder/CMake/FindLibUnwind.cmake
++++ b/build/fbcode_builder/CMake/FindLibUnwind.cmake
+@@ -18,12 +18,18 @@ mark_as_advanced(LIBUNWIND_INCLUDE_DIR)
+ find_library(LIBUNWIND_LIBRARY NAMES unwind)
+ mark_as_advanced(LIBUNWIND_LIBRARY)
+ 
++# Awkward hack to attach liblzma dependency to libunwind
++if (NOT LIBLZMA_LIBRARIES)
++  find_library(LIBLZMA_LIBRARIES NAMES lzma)
++  mark_as_advanced(LIBLZMA_LIBRARIES)
++endif ()
++
+ include(FindPackageHandleStandardArgs)
+ FIND_PACKAGE_HANDLE_STANDARD_ARGS(
+   LIBUNWIND
+   REQUIRED_VARS LIBUNWIND_LIBRARY LIBUNWIND_INCLUDE_DIR)
+ 
+ if(LIBUNWIND_FOUND)
+-  set(LIBUNWIND_LIBRARIES ${LIBUNWIND_LIBRARY})
++  set(LIBUNWIND_LIBRARIES ${LIBUNWIND_LIBRARY} ${LIBLZMA_LIBRARIES})
+   set(LIBUNWIND_INCLUDE_DIRS ${LIBUNWIND_INCLUDE_DIR})
+ endif()

--- a/pkgs/by-name/fo/folly/package.nix
+++ b/pkgs/by-name/fo/folly/package.nix
@@ -98,6 +98,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeBool "BOOST_LINK_STATIC" stdenv.hostPlatform.isStatic)
+    (lib.cmakeBool "FOLLY_NO_EXCEPTION_TRACER" stdenv.hostPlatform.isStatic)
 
     (lib.cmakeBool "BUILD_TESTS" finalAttrs.finalPackage.doCheck)
 
@@ -115,6 +117,11 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals (stdenv.cc.isGNU && stdenv.hostPlatform.isAarch64) [
       # /build/source/folly/algorithm/simd/Movemask.h:156:32: error: cannot convert '__Uint64x1_t' to '__Uint8x8_t'
       "-flax-vector-conversions"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isMusl [
+      # To support off64_t
+      "-D_LARGEFILE_SOURCE"
+      "-D_LARGEFILE64_SOURCE"
     ]
   );
 
@@ -156,6 +163,21 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/facebook/folly/commit/fdde9bc360d525a1b2889b9ba89d671c3a13e72e.patch?full_index=1";
       hash = "sha256-+1XJRAl4o9YubjqdIgQZpyrMmcb2imBfQUmiHNmFMRE=";
     })
+
+    # On musl compilation fails with `error: 'ELFCLASSFOLLY_ELF_NATIVE_CLASS'
+    # was not declared in this scope`, because musl doesn't define
+    # `__ELF_NATIVE_CLASS`.  Work around by setting
+    # `ELFCLASSFOLLY_ELF_NATIVE_CLASS` to `__WORDSIZE`.
+    # https://github.com/facebook/folly/issues/1478
+    ./elf-native-class.patch
+
+    # libunwind depends on liblzma (from xz) but when linking statically Folly's
+    # CMake does not detect that dependency, because it doesn't use libunwind's
+    # pkg-config files.
+    ./lzma-dependency.patch
+
+    # https://github.com/facebook/folly/pull/2670
+    ./Modify-LocalLifetime-destructor-to-clear-local-cache.patch
   ];
 
   # https://github.com/NixOS/nixpkgs/issues/144170
@@ -221,6 +243,25 @@ stdenv.mkDerivation (finalAttrs: {
     # No idea why these fail.
     "logging_xlog_test.XlogTest.perFileCategoryHandling"
     "futures_future_test.Future.makeFutureFromMoveOnlyException"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isMusl [
+    # assertion failure: expected thread name [foo], got [Unknown]
+    "logging_glog_formatter_test.GlogFormatter.logThreadNameChanged"
+
+    # assertion failure: expected EINVAL (22), got ENOTTY (25)
+    "memory_test.alignedMalloc.examples"
+
+    # terminate called after throwing an instance of 'folly::OptionalEmptyException'
+    "system_thread_name_test.ThreadName.getCurrentThreadName"
+  ] ++ lib.optionals stdenv.hostPlatform.isStatic [
+    # FileUtilTest.cpp uses dlsym
+    "file_util_test.WriteFileAtomic.writeNew"
+    "file_util_test.WriteFileAtomic.withSync"
+    "file_util_test.WriteFileAtomic.overwrite"
+    "file_util_test.WriteFileAtomic.directoryPermissions"
+    "file_util_test.WriteFileAtomic.multipleFiles"
+    "file_util_test.WriteFileAtomic.WriteWithCustomTempPath"
+    "file_util_test.WriteFileAtomic.chmodFailure"
   ];
 
   passthru = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
