### PR TITLE
python3Packages.pyenvertechevt800: init at 0.2.4

### DIFF
--- a/pkgs/development/python-modules/pyenvertechevt800/default.nix
+++ b/pkgs/development/python-modules/pyenvertechevt800/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytest-asyncio,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pyenvertechevt800";
+  version = "0.2.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "daniel-bergmann-00";
+    repo = "pyenvertech-evt800";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JUXPyBnmwcKtGk2PjhKAaPZXnvl8Vkx9hrb7NurGvHo=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pyenvertechevt800" ];
+
+  meta = {
+    description = "Library to interface an Envertech EVT-800 device";
+    homepage = "https://github.com/daniel-bergmann-00/pyenvertech-evt800";
+    changelog = "https://github.com/daniel-bergmann-00/pyenvertech-evt800/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -1726,7 +1726,8 @@
       ];
     "envertech_evt800" =
       ps: with ps; [
-      ]; # missing inputs: pyenvertechevt800
+        pyenvertechevt800
+      ];
     "environment_canada" =
       ps: with ps; [
         env-canada
@@ -8030,6 +8031,7 @@
     "enigma2"
     "enocean"
     "enphase_envoy"
+    "envertech_evt800"
     "environment_canada"
     "envisalink"
     "epic_games_store"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14468,6 +14468,8 @@ self: super: with self; {
 
   pyenphase = callPackage ../development/python-modules/pyenphase { };
 
+  pyenvertechevt800 = callPackage ../development/python-modules/pyenvertechevt800 { };
+
   pyenvisalink = callPackage ../development/python-modules/pyenvisalink { };
 
   pyephember2 = callPackage ../development/python-modules/pyephember2 { };


### PR DESCRIPTION
- https://pypi.org/project/pyenvertechevt800/
- https://github.com/daniel-bergmann-00/pyenvertech-evt800
- https://www.home-assistant.io/integrations/envertech_evt800

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
