### PR TITLE
ace-of-penguins: fix help triggering segfault

### DIFF
--- a/pkgs/by-name/ac/ace-of-penguins/fix-wayland-segfault.patch
+++ b/pkgs/by-name/ac/ace-of-penguins/fix-wayland-segfault.patch
@@ -1,0 +1,16 @@
+diff --git a/lib/help.c b/lib/help.c
+--- a/lib/help.c
++++ b/lib/help.c
+@@ -177,8 +177,12 @@
+   for (i=0; i<17; i++)
+   {
+     if (!fonts[i])
+       fonts[i] = XLoadQueryFont(display, i & STYLE_TT ? "fixed" : "variable");
++    if (!fonts[i])
++      fonts[i] = XLoadQueryFont(display, "fixed");
++    if (!fonts[i])
++      return;
+     thin_space[i] = XTextWidth(fonts[i], " ", 1);
+   }
+   for (i=0; i<NTAGS; i++)
+     tags[i].taglen = strlen(tags[i].tag);

--- a/pkgs/by-name/ac/ace-of-penguins/package.nix
+++ b/pkgs/by-name/ac/ace-of-penguins/package.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation (finalAttrs: {
     ./fix-gcc-14.patch
     # error: initialization of 'void (*)(int,  int,  int)' from incompatible pointer type 'void (*)(void)' [-Wincompatible-pointer-types]
     ./fix-gcc-15.patch
+    # fixes Wayland segfault from missing X11 fonts by providing a fallback
+    ./fix-wayland-segfault.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Games from `ace-of-penguins` would segfault when invoking their help menu due to `XLoadQueryFont` failing to return any 'variable' X11 fonts on Wayland, resulting in a segfault from de-referencing NULL later in code. This PR adds a fallback to explicitly use 'fixed' font which _is_ present on Wayland (tested in a KDE Plasma X11+Wayland VM) and deals with the problem.

Resolves #538503  

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
