### PR TITLE
localsend: fix blank text rendering on aarch64-linux

### DIFF
--- a/pkgs/by-name/lo/localsend/package.nix
+++ b/pkgs/by-name/lo/localsend/package.nix
@@ -11,6 +11,7 @@
   undmg,
   makeBinaryWrapper,
   fetchpatch,
+  roboto,
 }:
 
 let
@@ -51,6 +52,38 @@ let
     postPatch = ''
       substituteInPlace lib/util/native/autostart_helper.dart \
         --replace-fail 'Exec=''${Platform.resolvedExecutable}' "Exec=localsend_app"
+    ''
+    # On aarch64-linux the Flutter engine fails to load the platform font, so
+    # all text renders blank while bundled font assets (e.g. the MaterialIcons
+    # glyphs) draw fine (https://github.com/localsend/localsend/issues/2873).
+    # Bundle Roboto as an app asset and use it as the default font family, so
+    # text is drawn from a bundled font exactly like the icons.
+    + lib.optionalString stdenv.hostPlatform.isAarch64 ''
+      mkdir -p fonts
+      cp ${roboto}/share/fonts/truetype/Roboto-Regular.ttf fonts/
+      cp ${roboto}/share/fonts/truetype/Roboto-Medium.ttf fonts/
+      cp ${roboto}/share/fonts/truetype/Roboto-Bold.ttf fonts/
+      cp ${roboto}/share/fonts/truetype/Roboto-Italic.ttf fonts/
+      cp ${roboto}/share/fonts/truetype/Roboto-BoldItalic.ttf fonts/
+
+      substituteInPlace pubspec.yaml \
+        --replace-fail '  uses-material-design: true' '  uses-material-design: true
+        fonts:
+          - family: Roboto
+            fonts:
+              - asset: fonts/Roboto-Regular.ttf
+              - asset: fonts/Roboto-Medium.ttf
+                weight: 500
+              - asset: fonts/Roboto-Bold.ttf
+                weight: 700
+              - asset: fonts/Roboto-Italic.ttf
+                style: italic
+              - asset: fonts/Roboto-BoldItalic.ttf
+                weight: 700
+                style: italic'
+
+      substituteInPlace lib/config/theme.dart \
+        --replace-fail 'fontFamily = null;' "fontFamily = 'Roboto';"
     '';
 
     nativeBuildInputs = [


### PR DESCRIPTION
On `aarch64-linux`, LocalSend renders all text blank/invisible while bundled
font assets (the MaterialIcons glyphs) draw fine. The Flutter engine on aarch64
fails to load the platform/system font, so every widget using the default font
family — which the app leaves `null` on Linux, deferring to the system font —
shows nothing. This affects both this from-source build and upstream's prebuilt
binaries; no fontconfig / software-GL workaround helps.

Upstream issue: https://github.com/localsend/localsend/issues/2873

### Fix

Bundle Roboto as an app asset and set it as the default `ThemeData.fontFamily`,
so text is drawn from a bundled font exactly like the icons already are. Scoped
to `aarch64-linux` via `lib.optionalString stdenv.hostPlatform.isAarch64`, so
**x86_64-linux builds are byte-identical to before** (verified: same `.drv` hash).

The Yaru color-mode theme is unaffected — it already uses Yaru's own bundled
Ubuntu font, which renders on aarch64 for the same reason the icons do.

## Things done

- Built on platform:
  - [ ] x86_64-linux — *unaffected; evaluates to the same derivation as before (no-op)*
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
- [ ] Ran `nixpkgs-review` on this PR
- [x] Tested basic functionality of all binary files — launched `localsend_app`; text now renders (was blank before)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking — *n/a, bugfix*
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs
- [x] Follows the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy) — *prepared with AI assistance, disclosed via an `Assisted-by:` commit trailer*
