### PR TITLE
nixos/rpcbind: declare rpc user unconditionally to break recursion

### DIFF
--- a/nixos/modules/services/networking/rpcbind.nix
+++ b/nixos/modules/services/networking/rpcbind.nix
@@ -32,29 +32,34 @@ with lib;
 
   ###### implementation
 
-  config = mkIf config.services.rpcbind.enable {
-    environment.systemPackages = [ pkgs.rpcbind ];
+  config = mkMerge [
+    (mkIf config.services.rpcbind.enable {
+      environment.systemPackages = [ pkgs.rpcbind ];
 
-    systemd.packages = [ pkgs.rpcbind ];
+      systemd.packages = [ pkgs.rpcbind ];
 
-    systemd.services.rpcbind = {
-      wantedBy = [ "multi-user.target" ];
-      # rpcbind performs a check for /var/run/rpcbind.lock at startup
-      # and will crash if /var/run isn't present. In the stock NixOS
-      # var.conf tmpfiles configuration file, /var/run is symlinked to
-      # /run, so rpcbind can enter a race condition in which /var/run
-      # isn't symlinked yet but tries to interact with the path, so
-      # controlling the order explicitly here ensures that rpcbind can
-      # start successfully. The `wants` instead of `requires` should
-      # avoid creating a strict/brittle dependency.
-      wants = [ "systemd-tmpfiles-setup.service" ];
-      after = [ "systemd-tmpfiles-setup.service" ];
-    };
+      systemd.services.rpcbind = {
+        wantedBy = [ "multi-user.target" ];
+        # rpcbind performs a check for /var/run/rpcbind.lock at startup
+        # and will crash if /var/run isn't present. In the stock NixOS
+        # var.conf tmpfiles configuration file, /var/run is symlinked to
+        # /run, so rpcbind can enter a race condition in which /var/run
+        # isn't symlinked yet but tries to interact with the path, so
+        # controlling the order explicitly here ensures that rpcbind can
+        # start successfully. The `wants` instead of `requires` should
+        # avoid creating a strict/brittle dependency.
+        wants = [ "systemd-tmpfiles-setup.service" ];
+        after = [ "systemd-tmpfiles-setup.service" ];
+      };
+    })
 
-    users.users.rpc = {
-      group = "nogroup";
-      uid = config.ids.uids.rpc;
-    };
-  };
+    {
+      users.users.rpc = {
+        enable = config.services.rpcbind.enable;
+        group = "nogroup";
+        uid = config.ids.uids.rpc;
+      };
+    }
+  ];
 
 }


### PR DESCRIPTION
rpcbind defined its rpc user inside config = mkIf cfg.enable {...}, making the presence of the rpc key in config.users.users depend on services.rpcbind.enable. Since users.users is an attrsOf submodule, reading one user's attribute forces the whole key set, forcing that guard, which nfs.nix derives from boot.supportedFilesystems <- config.fileSystems. A fileSystems entry referencing a user (home/uid/gid) therefore closed an infinite-recursion loop, i.e. you couldn't write fileSystems."${config.users.users.me.home}/data".

Fixes #24570, #305643, and many a ticket in other repos such as home-manager.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].