### PR TITLE
python3Packages.pyimouapi: init at 1.3.0

### DIFF
--- a/pkgs/development/python-modules/pyimouapi/default.nix
+++ b/pkgs/development/python-modules/pyimouapi/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  aiohttp,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytest-asyncio,
+  pytest-timeout,
+  pytestCheckHook,
+  setuptools,
+  simpleeval,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pyimouapi";
+  version = "1.3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Imou-OpenPlatform";
+    repo = "Py-Imou-Open-Api";
+    tag = finalAttrs.version;
+    hash = "sha256-/ZGaJubdeEe5d4wnzrS/e6hPC5i/IRccgYc34su2iw4=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    aiohttp
+    simpleeval
+  ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-timeout
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pyimouapi" ];
+
+  meta = {
+    description = "Async Python client for the Imou Open Platform cloud APIs";
+    homepage = "https://github.com/Imou-OpenPlatform/Py-Imou-Open-Api";
+    changelog = "https://github.com/Imou-OpenPlatform/Py-Imou-Open-Api/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -3002,7 +3002,8 @@
       ];
     "imou" =
       ps: with ps; [
-      ]; # missing inputs: pyimouapi
+        pyimouapi
+      ];
     "improv_ble" =
       ps: with ps; [
         aioesphomeapi
@@ -8222,6 +8223,7 @@
     "imeon_inverter"
     "imgw_pib"
     "immich"
+    "imou"
     "improv_ble"
     "incomfort"
     "indevolt"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14736,6 +14736,8 @@ self: super: with self; {
 
   pyimgbox = callPackage ../development/python-modules/pyimgbox { };
 
+  pyimouapi = callPackage ../development/python-modules/pyimouapi { };
+
   pyimpfuzzy = callPackage ../development/python-modules/pyimpfuzzy { inherit (pkgs) ssdeep; };
 
   pyindego = callPackage ../development/python-modules/pyindego { };


### PR DESCRIPTION
- https://pypi.org/project/pyimouapi/
- https://github.com/Imou-OpenPlatform/Py-Imou-Open-Api
- https://www.home-assistant.io/integrations/imou

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
