### PR TITLE
bazarr: package from source

### DIFF
--- a/pkgs/by-name/ba/bazarr/package.nix
+++ b/pkgs/by-name/ba/bazarr/package.nix
@@ -68,7 +68,10 @@ stdenv.mkDerivation rec {
     homepage = "https://www.bazarr.media/";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ diogotcorreia ];
+    maintainers = with lib.maintainers; [
+      connor-grady
+      diogotcorreia
+    ];
     mainProgram = "bazarr";
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/ba/bazarr/package.nix
+++ b/pkgs/by-name/ba/bazarr/package.nix
@@ -1,78 +1,112 @@
 {
-  stdenv,
   lib,
-  fetchzip,
-  makeWrapper,
-  python3,
-  unar,
+  stdenv,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  nodejs,
+  npmHooks,
+  dart-sass,
+  makeBinaryWrapper,
+  python313,
   ffmpeg,
+  unar,
   nixosTests,
+  nix-update-script,
 }:
-
 let
-  runtimeProgDeps = [
-    ffmpeg
-    unar
-  ];
+  python = python313.withPackages (ps: [
+    ps.lxml
+    ps.numpy
+    ps.pillow
+    ps.psycopg2
+    ps.setuptools
+    ps.webrtcvad
+  ]);
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "bazarr";
   version = "1.6.0";
 
-  src = fetchzip {
-    url = "https://github.com/morpheus65535/bazarr/releases/download/v${version}/bazarr.zip";
-    hash = "sha256-LRcc2wg5u260yl3A7rRwBfldl6WOyvF2T9NKGTKabfw=";
-    stripRoot = false;
+  src = fetchFromGitHub {
+    owner = "morpheus65535";
+    repo = "bazarr";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-r3H0JEcGYzQOTHVR/zONmtOIF+LnJd+qn2pcAj8vdOA=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  npmRoot = "frontend";
+  npmDeps = fetchNpmDeps {
+    name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
+    inherit (finalAttrs) src;
+    sourceRoot = "${finalAttrs.src.name}/frontend";
+    hash = "sha256-cb++eqVtKZer9B1rwJ9WR4mZImnASeFU2MojgXAPWf4=";
+  };
 
-  buildInputs = [
-    (python3.withPackages (ps: [
-      ps.lxml
-      ps.numpy
-      ps.gevent
-      ps.gevent-websocket
-      ps.pillow
-      ps.setuptools
-      ps.psycopg2
-      ps.webrtcvad
-    ]))
-  ]
-  ++ runtimeProgDeps;
+  nativeBuildInputs = [
+    nodejs
+    npmHooks.npmConfigHook
+    dart-sass
+    makeBinaryWrapper
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    pushd frontend
+    # sass-embedded's bundled Dart compiler won't run in the sandbox; use nixpkgs' dart-sass.
+    # https://github.com/sass/embedded-host-node/issues/334
+    substituteInPlace node_modules/sass-embedded/dist/lib/src/compiler-path.js \
+      --replace-fail 'compilerCommand = (() => {' 'compilerCommand = (() => { return ["dart-sass"];'
+    npm run build
+    popd
+    runHook postBuild
+  '';
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p "$out"/{bin,share/${pname}}
-    cp -r * "$out/share/${pname}"
+    mkdir -p $out/share/bazarr/frontend
+    cp -r bazarr bazarr.py custom_libs libs migrations $out/share/bazarr/
+    cp -r frontend/build $out/share/bazarr/frontend/build
 
-    # Add missing shebang and execute perms so that patchShebangs can do its
-    # thing.
-    sed -i "1i #!/usr/bin/env python3" "$out/share/${pname}/bazarr.py"
-    chmod +x "$out/share/${pname}/bazarr.py"
+    printf '%s' "${finalAttrs.version}" > $out/share/bazarr/VERSION
 
-    makeWrapper "$out/share/${pname}/bazarr.py" \
-        "$out/bin/bazarr" \
-        --suffix PATH : ${lib.makeBinPath runtimeProgDeps}
+    printf '%s' "${
+      lib.generators.toKeyValue { } {
+        updatemethod = "External";
+        updatemethodmessage = "Bazarr is managed by Nix. Update it through your system configuration.";
+        packageversion = finalAttrs.version;
+        packageauthor = "nixpkgs";
+      }
+    }" > $out/share/bazarr/package_info
+
+    makeWrapper ${lib.getExe python} $out/bin/bazarr \
+      --add-flags $out/share/bazarr/bazarr.py \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          ffmpeg
+          unar
+        ]
+      }
 
     runHook postInstall
   '';
 
-  passthru.tests = {
-    smoke-test = nixosTests.bazarr;
+  passthru = {
+    tests.smoke-test = nixosTests.bazarr;
+    updateScript = nix-update-script { };
   };
 
   meta = {
     description = "Subtitle manager for Sonarr and Radarr";
     homepage = "https://www.bazarr.media/";
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    changelog = "https://github.com/morpheus65535/bazarr/releases/tag/v${finalAttrs.version}";
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
       connor-grady
       diogotcorreia
     ];
     mainProgram = "bazarr";
-    platforms = lib.platforms.all;
+    platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
Builds Bazarr from source with `fetchFromGitHub` instead of repackaging the prebuilt `bazarr.zip` release asset. The web UI is compiled from the Vite/React sources via `npmConfigHook`, and the Python backend (with its vendored `libs/`) is assembled and wrapped around the interpreter. `sourceProvenance` moves from `binaryNativeCode` to `fromSource`.

A few things worth flagging:

- The `sass-embedded` dep bundles a prebuilt Dart binary that fails to run in the build sandbox, so the build patches `compiler-path.js` to point at nixpkgs' `dart-sass`.
- The python version is pinned to `python313` because upstream marks versions newer than 3.13 as unsupported.
- `VERSION` and `package_info` files are generated at install time because the git checkout lacks both, and they are needed to report the correct version and to disable the in-app updater, respectively.
- Adds a `passthru.updateScript` to automate updates in the future.

Requested by @diogotcorreia in #538399.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test