### PR TITLE
python3Packages.aiomelcloudhome: init at 0.1.9

### DIFF
--- a/pkgs/development/python-modules/aiomelcloudhome/default.nix
+++ b/pkgs/development/python-modules/aiomelcloudhome/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  aiohttp,
+  pydantic,
+  tenacity,
+  yarl,
+  aresponses,
+  pytest-cov-stub,
+  pytestCheckHook,
+  syrupy,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "aiomelcloudhome";
+  version = "0.1.9";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "erwindouna";
+    repo = "aiomelcloudhome";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-aYaV7+Lj7LShO0HqoUjSFAMTOHY5piMdSACOVizGgco=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    aiohttp
+    pydantic
+    tenacity
+    yarl
+  ];
+
+  nativeCheckInputs = [
+    aresponses
+    pytest-cov-stub
+    pytestCheckHook
+    syrupy
+  ];
+
+  pythonImportsCheck = [ "aiomelcloudhome" ];
+
+  meta = {
+    description = "Asynchronous Python client for the Melcloud Home API";
+    homepage = "https://github.com/erwindouna/aiomelcloudhome";
+    changelog = "https://github.com/erwindouna/aiomelcloudhome/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -3980,7 +3980,8 @@
       ];
     "melcloud_home" =
       ps: with ps; [
-      ]; # missing inputs: aiomelcloudhome
+        aiomelcloudhome
+      ];
     "melissa" =
       ps: with ps; [
         py-melissa-climate
@@ -8351,6 +8352,7 @@
     "media_player"
     "media_source"
     "melcloud"
+    "melcloud_home"
     "melissa"
     "melnor"
     "meraki"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -422,6 +422,8 @@ self: super: with self; {
 
   aiomealie = callPackage ../development/python-modules/aiomealie { };
 
+  aiomelcloudhome = callPackage ../development/python-modules/aiomelcloudhome { };
+
   aiomisc = callPackage ../development/python-modules/aiomisc { };
 
   aiomisc-pytest = callPackage ../development/python-modules/aiomisc-pytest { };


### PR DESCRIPTION
- https://pypi.org/project/aiomelcloudhome/
- https://github.com/erwindouna/aiomelcloudhome
- https://www.home-assistant.io/integrations/melcloud_home/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
