### PR TITLE
vulkan-validation-layers: fix build by disabling UPDATE_DEPS

### DIFF
--- a/pkgs/by-name/vu/vulkan-validation-layers/package.nix
+++ b/pkgs/by-name/vu/vulkan-validation-layers/package.nix
@@ -66,6 +66,8 @@ stdenv.mkDerivation (finalAttrs: {
     "-DBUILD_LAYER_SUPPORT_FILES=ON"
     # Hide dev warnings that are useless for packaging
     "-Wno-dev"
+    # Don't run update_deps.py which tries to git clone dependencies
+    "-DUPDATE_DEPS=OFF"
   ];
 
   # Tests require access to vulkan-compatible GPU, which isn't


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fix build fail by disabling cmake flag `UPDATE_DEPS` which tries to download dependencies with git.

Upstream make the `UPDATE_DEPS` CMake option default enable in [commit 19935a1](https://github.com/KhronosGroup/Vulkan-ValidationLayers/commit/19935a123d0028f254ed34d4748fc6f0e5d5be4a) but Nix already provides all dependencies through `buildInputs`.

Fail log:

```
FileNotFoundError: [Errno 2] No such file or directory: 'git'
> CMake Error at scripts/CMakeLists.txt:133 (message):
>   Could not run update_deps.py which is necessary to download dependencies.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
