### PR TITLE
 python3Packages.bandcamp-async-api: init at 0.2.2 

### DIFF
--- a/pkgs/by-name/mu/music-assistant/providers.nix
+++ b/pkgs/by-name/mu/music-assistant/providers.nix
@@ -48,8 +48,10 @@
       ps: with ps; [
         aioaudiobookshelf
       ];
-    bandcamp = ps: [
-    ]; # missing bandcamp-async-api
+    bandcamp =
+      ps: with ps; [
+        bandcamp-async-api
+      ];
     bbc_sounds =
       ps: with ps; [
         pytz

--- a/pkgs/development/python-modules/bandcamp-async-api/default.nix
+++ b/pkgs/development/python-modules/bandcamp-async-api/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  aiohttp,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytest-asyncio,
+  python-dotenv,
+  pytestCheckHook,
+  uv-build,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "bandcamp-async-api";
+  version = "0.2.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ALERTua";
+    repo = "bandcamp_async_api";
+    tag = finalAttrs.version;
+    hash = "sha256-pL1V3xAcI48cgddf0tmE+djGI7sagGAI3w0Qu7/O8pI=";
+  };
+
+  build-system = [
+    uv-build
+  ];
+
+  dependencies = [
+    aiohttp
+  ];
+
+  pythonImportsCheck = [ "bandcamp_async_api" ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    python-dotenv
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Modern, asynchronous Python client for the Bandcamp API";
+    homepage = "https://github.com/ALERTua/bandcamp_async_api";
+    # https://github.com/ALERTua/bandcamp_async_api/issues/34
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2155,6 +2155,8 @@ self: super: with self; {
 
   bandcamp-api = callPackage ../development/python-modules/bandcamp-api { };
 
+  bandcamp-async-api = callPackage ../development/python-modules/bandcamp-async-api { };
+
   bandit = callPackage ../development/python-modules/bandit { };
 
   bangla = callPackage ../development/python-modules/bangla { };


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
