### PR TITLE
Revert "hdrhistogram_c: 0.11.9 -> 0.11.10"

### DIFF
--- a/pkgs/by-name/hd/hdrhistogram_c/package.nix
+++ b/pkgs/by-name/hd/hdrhistogram_c/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hdrhistogram_c";
-  version = "0.11.10";
+  version = "0.11.9";
 
   src = fetchFromGitHub {
     owner = "HdrHistogram";
     repo = "HdrHistogram_c";
     tag = finalAttrs.version;
-    hash = "sha256-LMZj7vuxOA1bgU/J10IKnyNe3R0dk2AA1ydLTHun4vg=";
+    hash = "sha256-9Xp+gPqJpB7xZr5dzyc9Via9gxG9q/EriCx3cm++0kU=";
   };
 
   buildInputs = [ zlib ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#538019. See https://github.com/NixOS/nixpkgs/pull/538019#issuecomment-4928744686 for why, this was an accidental mass rebuild shipped straight to master. If I'm right, this should complain about many rebuilds.