### PR TITLE
throttled: add dbus-next as a dependency to throttled.py

### DIFF
--- a/pkgs/by-name/th/throttled/package.nix
+++ b/pkgs/by-name/th/throttled/package.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   pythonPath = with python3Packages; [
     configparser
+    dbus-next
     dbus-python
     pygobject3
   ];


### PR DESCRIPTION
Hey everyone,
while trying to update my flake today, I've bumped into this:

```
warning: the following units failed: throttled.service
× throttled.service - Stop Intel throttling
     Loaded: loaded (/etc/systemd/system/throttled.service; enabled; preset: ignored)
    Drop-In: /nix/store/dk26sna6n0gxrq7dnhsivz08nqqinmmm-system-units/throttled.service.d
             └─overrides.conf
     Active: failed (Result: exit-code) since Thu 2026-07-09 15:06:09 -03; 1s ago
   Duration: 302ms
 Invocation: a02ff7d22fa94d9985916733684e2f81
    Process: 791339 ExecStart=/nix/store/migg9ar07gg52kpkwvfwcy7g5r5c4shf-throttled-0.12/bin/throttled.py (code=exited, status=1/FAILURE)
   Main PID: 791339 (code=exited, status=1/FAILURE)
         IP: 0B in, 0B out
         IO: 0B read, 0B written
   Mem peak: 16.3M
        CPU: 296ms

Jul 09 15:06:09 hydrus throttled.py[791339]:     context = await setup_dbus_signal_handlers(config_or_state)
Jul 09 15:06:09 hydrus throttled.py[791339]:               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jul 09 15:06:09 hydrus throttled.py[791339]:   File "/nix/store/migg9ar07gg52kpkwvfwcy7g5r5c4shf-throttled-0.12/bin/.throttled.py-wrapped", line 427, in setup_dbus_signal_handlers
Jul 09 15:06:09 hydrus throttled.py[791339]:     MessageBus, BusType = get_dbus_next()
Jul 09 15:06:09 hydrus throttled.py[791339]:                           ~~~~~~~~~~~~~^^
Jul 09 15:06:09 hydrus throttled.py[791339]:   File "/nix/store/migg9ar07gg52kpkwvfwcy7g5r5c4shf-throttled-0.12/bin/.throttled.py-wrapped", line 355, in get_dbus_next
Jul 09 15:06:09 hydrus throttled.py[791339]:     from dbus_next.aio import MessageBus
Jul 09 15:06:09 hydrus throttled.py[791339]: ModuleNotFoundError: No module named 'dbus_next'
Jul 09 15:06:09 hydrus systemd[1]: throttled.service: Main process exited, code=exited, status=1/FAILURE
Jul 09 15:06:09 hydrus systemd[1]: throttled.service: Failed with result 'exit-code'.
Command 'systemd-run -E LOCALE_ARCHIVE -E NIXOS_INSTALL_BOOTLOADER -E NIXOS_NO_CHECK --collect --no-ask-password --pipe --quiet --service-type=exec --unit=nixos-rebuild-switch-to-configuration /nix/store/65yb7ix8z3hcz75ifh8f3msb27vxfi13-nixos-system-hydrus-26.11.20260705.d407951/bin/switch-to-configuration switch' returned non-zero exit status 4.
```

I added `dbus-next` as a dependency for throttled:

```nix
  pythonPath = with python3Packages; [
    configparser
    dbus-next
    dbus-python
    pygobject3
  ];
```

Now the package works properly. I didn't check if `dbus-python` is still necessary; I could check if that's the case.
Thanks!


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
