### PR TITLE
jasp-desktop: 0.97.1 -> 0.98.1

### DIFF
--- a/pkgs/by-name/ja/jasp-desktop/disable-module-install-logic.patch
+++ b/pkgs/by-name/ja/jasp-desktop/disable-module-install-logic.patch
@@ -1,5 +1,5 @@
 diff --git a/Tools/CMake/Install.cmake b/Tools/CMake/Install.cmake
-index edd96b0..1fbdb3c 100644
+index a3ed1f3..a564046 100644
 --- a/Tools/CMake/Install.cmake
 +++ b/Tools/CMake/Install.cmake
 @@ -229,24 +229,10 @@ if(LINUX)
@@ -20,10 +20,10 @@ index edd96b0..1fbdb3c 100644
 -  #install(DIRECTORY ${MODULES_RENV_ROOT_PATH}/
 -  #        DESTINATION ${JASP_INSTALL_PREFIX}/lib64/renv-root)
 -
--if(NOT FLATPAK_USED) #because flatpak already puts renv-cache in /app/lib64 anyway
--  install(DIRECTORY ${MODULES_RENV_CACHE_PATH}/
+-  if(NOT FLATPAK_USED) #because flatpak already puts renv-cache in /app/lib64 anyway
+-    install(DIRECTORY ${MODULES_RENV_CACHE_PATH}/
 -          DESTINATION ${JASP_INSTALL_PREFIX}/lib64/renv-cache)
--endif()
+-  endif()
  
    #Flatpak wrapper that sets some environment variables that JASP needs
    install(PROGRAMS ${CMAKE_SOURCE_DIR}/Tools/flatpak/org.jaspstats.JASP

--- a/pkgs/by-name/ja/jasp-desktop/module-info.json
+++ b/pkgs/by-name/ja/jasp-desktop/module-info.json
@@ -97,9 +97,9 @@
   },
   "jaspLearnBayes": {
     "pname": "jaspLearnBayes",
-    "version": "0.95.5-release.12",
-    "tag": "0.95.5-release.12_R-4-5-2_Release",
-    "hash": "sha256-zqMcWFML/iexmegMtGWCe/OCGqwmWW98/XZfKVs6N8w="
+    "version": "0.96.5-release.0",
+    "tag": "0.96.5-release.0_R-4-5-2_Release",
+    "hash": "sha256-TdlwB2TV+YNj4Uwf4rNSIw/OtKQHEbrFKv1t2RioTmI="
   },
   "jaspLearnStats": {
     "pname": "jaspLearnStats",

--- a/pkgs/by-name/ja/jasp-desktop/package.nix
+++ b/pkgs/by-name/ja/jasp-desktop/package.nix
@@ -25,13 +25,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "jasp-desktop";
-  version = "0.97.1";
+  version = "0.98.1";
   src = fetchFromGitHub {
     owner = "jasp-stats";
     repo = "jasp-desktop";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-4K6ReOJJF8Pt/RdNSp2ZVH/d64ZMCFlX1RIXDAWWWBE=";
+    hash = "sha256-73RxbWVa03V6MdcW9k4Hv8EBsSNw0Feg91SioWLgC5U=";
   };
 
   patches = [
@@ -68,8 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
     qt6.qtbase
     qt6.qtdeclarative
     qt6.qtwebengine
-    qt6.qtsvg
-    qt6.qt5compat
+    qt6.qthttpserver
   ];
 
   # needed so that the linker can find libRInside.so

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -999,7 +999,7 @@ let
       rustc
     ];
     vdiffr = [ pkgs.libpng.dev ];
-    V8 = [ pkgs.nodejs-slim_22.libv8 ]; # when unpinning the version, don't forget about the other usages later
+    V8 = [ pkgs.pkg-config ];
     xactonomial = with pkgs; [
       cargo
       rustc
@@ -1150,6 +1150,10 @@ let
     svKomodo = [ pkgs.which ];
     transmogR = [ pkgs.zlib.dev ];
     ulid = [ pkgs.zlib.dev ];
+    V8 = with pkgs; [
+      nodejs-slim_22.libv8
+      icu78 # use same icu version as in pkgs/development/web/nodejs/nodejs.nix
+    ];
     unrtf = with pkgs; [
       bzip2.dev
       icu.dev
@@ -2643,18 +2647,9 @@ let
     });
 
     V8 = old.V8.overrideAttrs (attrs: {
-      postPatch = ''
-        substituteInPlace configure \
-          --replace-fail " -lv8_libplatform" ""
-        # Bypass the test checking if pointer compression is needed
-        substituteInPlace configure \
-          --replace-fail "./pctest1" "true"
-      '';
-
       preConfigure = ''
-        # when unpinning the version, don't forget about the other usage earlier
-        export INCLUDE_DIR=${pkgs.nodejs-slim_22.libv8}/include
-        export LIB_DIR=${pkgs.nodejs-slim_22.libv8}/lib
+        export V8_PKG_CFLAGS="$(pkg-config --cflags v8)";
+        export V8_PKG_LIBS="$(pkg-config --libs v8)";
         patchShebangs configure
       '';
 


### PR DESCRIPTION
Currently rebased on https://github.com/NixOS/nixpkgs/pull/539849

I had to use 16G RAM + 24G swap to build certain uncached R packages...
hopefully hydra will cache them once `r-updates` is merged.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
