### PR TITLE
keycloak: 26.6.4 -> 26.7.0

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -90,6 +90,8 @@
 
 - `texlive.combine` is deprecated and scheduled for removal in 27.05. Please migrate to `texliveSmall.withPackages` (see [](#sec-language-texlive-user-guide)).
 
+- `keycloak` was updated to >= 26.7.0 and includes some breaking internal (API) changes. See the [upstream migration guide](https://www.keycloak.org/docs/latest/upgrading/#migrating-to-26-7-0) for more information.
+
 - `librest` providing 0.7 ABI was removed. `librest_1_0` providing 1.0 ABI was renamed to `librest` and `librest_1_0` was kept as an alias.
 
 - `pnpm_10` was upgraded to version 10.34.1+, which introduced stricter integrity checks. If you encounter `ERR_PNPM_MISSING_TARBALL_INTEGRITY`, you can fall back to the older `pnpm_10_34_0`.

--- a/pkgs/by-name/ke/keycloak/package.nix
+++ b/pkgs/by-name/ke/keycloak/package.nix
@@ -24,11 +24,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "keycloak";
-  version = "26.6.4";
+  version = "26.7.0";
 
   src = fetchzip {
     url = "https://github.com/keycloak/keycloak/releases/download/${finalAttrs.version}/keycloak-${finalAttrs.version}.zip";
-    hash = "sha256-rb3Wdzc3g8jMvUffOfMfJ4Uw9HJomznXzLtPOrHoWU8=";
+    hash = "sha256-QfPCgwUZYwiCWZgL8DVlVAYE3AoZnDHn99j+f/oo0Hs=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Release notes: https://github.com/keycloak/keycloak/releases/tag/26.7.0
Full changelog: https://github.com/keycloak/keycloak/compare/26.6.4...26.7.0
Breaking changes: https://www.keycloak.org/docs/latest/upgrading/#migrating-to-26-7-0 https://www.keycloak.org/docs/latest/upgrading/#migration-changes

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
