### PR TITLE
citrix-workspace: pin EGL/GTK to X11 to fix Wayland startup segfault

### DIFF
--- a/pkgs/by-name/ci/citrix-workspace/package.nix
+++ b/pkgs/by-name/ci/citrix-workspace/package.nix
@@ -280,6 +280,15 @@ stdenv.mkDerivation rec {
             ''--set LD_PRELOAD "${libredirect}/lib/libredirect.so ${lib.getLib pcsclite}/lib/libpcsclite.so"''
             ''--set NIX_REDIRECTS "/usr/share/zoneinfo=${tzdata}/share/zoneinfo:/etc/zoneinfo=${tzdata}/share/zoneinfo:/etc/timezone=$ICAInstDir/timezone"''
           ]
+          ++ lib.optionals (isWfica program) [
+            # wfica is an X11 client (it runs under XWayland). On a Wayland
+            # session Mesa's EGL loader otherwise auto-selects the Wayland
+            # platform for wfica's startup OpenGL probe and segfaults in
+            # wl_proxy_create_wrapper; pin the client to X11 (user-overridable).
+            # See https://github.com/NixOS/nixpkgs/issues/540102
+            "--set-default GDK_BACKEND x11"
+            "--set-default EGL_PLATFORM x11"
+          ]
         );
 
       wrap = program: ''


### PR DESCRIPTION
## Description of changes

Closes #540102.

On a Wayland session, `wfica` (the ICA session engine) segfaults **at startup, before any server connection**, so every published desktop/app launch dies at the loading screen (and Citrix's `lurdump` crash-reporter then loops on `SIGABRT`, presenting as a hung loading window).

`wfica` is an X11 application running under XWayland. At startup it probes the OpenGL profile via `eglInitialize`; because `WAYLAND_DISPLAY` is set, Mesa's EGL loader auto-selects the **Wayland** platform and is handed a display that isn't a valid `wl_display`, crashing in `wl_proxy_create_wrapper`:

```
#0 __pthread_mutex_lock                       (libc)
#1 wl_proxy_create_wrapper                     (libwayland-client)
#2 dri2_initialize_wayland                      (libEGL_mesa)
#3 eglInitialize
#4 EglWindow::load_egl() -> CtxGlContext::CheckOpenGLProfile()
#5 GetOpenGLFlagAndSendTelemetry -> OldMain -> main   (wfica)
```

Citrix's client-side OpenGL support was added upstream around 2408, so the crashing startup probe is present in all packaged versions since (not specific to 26.04). It does **not** reproduce on every Wayland/Mesa system — it depends on the GPU/driver and how Mesa resolves the default EGL platform — but where it does hit, there is currently no in-package mitigation.

This pins the client to the X11 path via the existing wrapper, using `--set-default` so users can still override:

```nix
"--set-default GDK_BACKEND x11"
"--set-default EGL_PLATFORM x11"
```

XWayland provides fully GPU-accelerated OpenGL, so HDX 3D is unaffected. This is the standard "run Citrix under X11" mitigation, applied at the package level so Wayland users are not exposed by default.

## Things done

- Verified the equivalent wrapper change on a live system (Hyprland / Mesa / AMD): before, every ICA launch `SIGSEGV`s in `wfica` with the backtrace above; after `--set EGL_PLATFORM x11` / `--set GDK_BACKEND x11`, the session connects normally with GPU-accelerated graphics.
- `nix-instantiate --parse` passes; file is `nixfmt`-clean.
- Change is limited to the wrapper args; no version/hash change.
- Note: I did not run a full `nix-build` of this exact recipe because `src` is `requireFile` (EULA-gated), so it cannot build in CI/sandbox without the vendor tarball. The change is a wrapper-arg addition only.

Built on platform(s):
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin

- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - the change on a live system (runtime behaviour of the wrapper), not a full package rebuild
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc maintainer @michaeladler
