### PR TITLE
recyclarr: fix dotnetBuild and dotnetInstall race conditions by building single output

### DIFF
--- a/pkgs/by-name/re/recyclarr/package.nix
+++ b/pkgs/by-name/re/recyclarr/package.nix
@@ -42,6 +42,10 @@ buildDotnetModule (finalAttrs: {
     "/m:1"
   ];
 
+  dotnetInstallFlags = [
+    "/m:1"
+  ];
+
   dotnet-sdk = dotnetCorePackages.sdk_10_0;
   dotnet-runtime = dotnetCorePackages.runtime_10_0;
 

--- a/pkgs/by-name/re/recyclarr/package.nix
+++ b/pkgs/by-name/re/recyclarr/package.nix
@@ -18,7 +18,7 @@ buildDotnetModule (finalAttrs: {
     hash = "sha256-Uu6fBKODzKGYA6vSJPw0OV/+bi3y2F/SHfrdd5pdyzs=";
   };
 
-  projectFile = "Recyclarr.slnx";
+  projectFile = "src/Recyclarr.Cli/Recyclarr.Cli.csproj";
   nugetDeps = ./deps.json;
 
   postPatch = ''
@@ -39,12 +39,8 @@ buildDotnetModule (finalAttrs: {
 
   dotnetBuildFlags = [
     "-p:DisableGitVersionTask=true"
-    "/m:1"
   ];
 
-  dotnetInstallFlags = [
-    "/m:1"
-  ];
 
   dotnet-sdk = dotnetCorePackages.sdk_10_0;
   dotnet-runtime = dotnetCorePackages.runtime_10_0;
@@ -61,7 +57,11 @@ buildDotnetModule (finalAttrs: {
 
   passthru = {
     updateScript = ./update.sh;
-    tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      command = ''RECYCLARR_CONFIG_DIR="$TMPDIR/recyclarr" recyclarr --version'';
+      version = "v${finalAttrs.version}";
+    };
   };
 
   meta = {

--- a/pkgs/by-name/re/recyclarr/package.nix
+++ b/pkgs/by-name/re/recyclarr/package.nix
@@ -41,7 +41,6 @@ buildDotnetModule (finalAttrs: {
     "-p:DisableGitVersionTask=true"
   ];
 
-
   dotnet-sdk = dotnetCorePackages.sdk_10_0;
   dotnet-runtime = dotnetCorePackages.runtime_10_0;
 


### PR DESCRIPTION
## Description of changes
`recyclarr` builds a solution (`Recyclarr.slnx`) with `buildDotnetModule`.  
While `dotnetBuildFlags` already contains `/m:1`, `dotnetInstallFlags` does not.  
During `dotnet publish` (the install phase), multiple projects in the solution
publish in parallel to the same output directory. They race to copy shared
NuGet DLLs (e.g. `Microsoft.Extensions.Options.dll`, `Mono.Cecil.dll`), causing:
    error MSB3021: Unable to copy file "...". Access to the path '...' is denied.
Adding `/m:1` (`-maxcpucount:1`) to `dotnetInstallFlags` forces single-node
publish, eliminating the race.
Fixes the build failure on current `nixos-unstable`.

## AI use
Used AI to evaluate the stack trace and come up with a fix.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

##### Error stack trace (before fix):
`error: Cannot build '/nix/store/5rnis294dn3dbigj1chiq9xiawvmr7b1-recyclarr-8.6.0.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/37i4gc4shvz3r2yl5h5dz3d2b0p5ckc0-recyclarr-8.6.0
       Last 25 log lines:
       > Finished dotnetBuildHook
       > Running phase: installPhase
       > Executing dotnetInstallHook
       > Project(s)
       > ----------
       > src/Recyclarr.Api.Radarr/Recyclarr.Api.Radarr.csproj
       > src/Recyclarr.Api.Sonarr/Recyclarr.Api.Sonarr.csproj
       > src/Recyclarr.Cli/Recyclarr.Cli.csproj
       > src/Recyclarr.Core/Recyclarr.Core.csproj
       > tests/Recyclarr.Cli.Tests/Recyclarr.Cli.Tests.csproj
       > tests/Recyclarr.Core.TestLibrary/Recyclarr.Core.TestLibrary.csproj
       > tests/Recyclarr.Core.Tests/Recyclarr.Core.Tests.csproj
       > tests/Recyclarr.EndToEndTests/Recyclarr.EndToEndTests.csproj
       > tests/Recyclarr.TestLibrary/Recyclarr.TestLibrary.csproj
       > /nix/store/9n3h8ijylhcph4s043by0fi2x7x8wvcs-dotnet-sdk-10.0.300/share/dotnet/sdk/10.0.300/Current/SolutionFile/ImportAfter/Microsoft.NET.Sdk.Solution.targets(36,5): warning NETSDK1194: The "--output" option isn't supported when building a solution. Specifying a solution-level output path results in all projects copying outputs to the same directory, which can lead to inconsistent builds. [/build/source/Recyclarr.slnx]
       >   Recyclarr.TestLibrary -> /nix/store/37i4gc4shvz3r2yl5h5dz3d2b0p5ckc0-recyclarr-8.6.0/lib/recyclarr/
       >   Recyclarr.Api.Sonarr -> /nix/store/37i4gc4shvz3r2yl5h5dz3d2b0p5ckc0-recyclarr-8.6.0/lib/recyclarr/
       > /nix/store/9n3h8ijylhcph4s043by0fi2x7x8wvcs-dotnet-sdk-10.0.300/share/dotnet/sdk/10.0.300/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Publish.targets(372,5): error MSB3021: Unable to copy file "/build/nuget.xELKO5/fallback/microsoft.extensions.options/10.0.6/lib/net10.0/Microsoft.Extensions.Options.dll" to "/nix/store/37i4gc4shvz3r2yl5h5dz3d2b0p5ckc0-recyclarr-8.6.0/lib/recyclarr/Microsoft.Extensions.Options.dll". Access to the path '/nix/store/37i4gc4shvz3r2yl5h5dz3d2b0p5ckc0-recyclarr-8.6.0/lib/recyclarr/Microsoft.Extensions.Options.dll' is denied. [/build/source/src/Recyclarr.Api.Radarr/Recyclarr.Api.Radarr.csproj]
       >   Recyclarr.Core -> /nix/store/37i4gc4shvz3r2yl5h5dz3d2b0p5ckc0-recyclarr-8.6.0/lib/recyclarr/
       >   Recyclarr.Cli -> /nix/store/37i4gc4shvz3r2yl5h5dz3d2b0p5ckc0-recyclarr-8.6.0/lib/recyclarr/
       >   Recyclarr.EndToEndTests -> /nix/store/37i4gc4shvz3r2yl5h5dz3d2b0p5ckc0-recyclarr-8.6.0/lib/recyclarr/
       >   Recyclarr.Core.TestLibrary -> /nix/store/37i4gc4shvz3r2yl5h5dz3d2b0p5ckc0-recyclarr-8.6.0/lib/recyclarr/
       > /build/nuget.xELKO5/fallback/coverlet.collector/10.0.0/build/net10.0/coverlet.collector.targets(18,5): error MSB3021: Unable to copy file "/build/nuget.xELKO5/fallback/coverlet.collector/10.0.0/build/net10.0/Mono.Cecil.Pdb.dll" to "/nix/store/37i4gc4shvz3r2yl5h5dz3d2b0p5ckc0-recyclarr-8.6.0/lib/recyclarr/Mono.Cecil.Pdb.dll". Access to the path '/nix/store/37i4gc4shvz3r2yl5h5dz3d2b0p5ckc0-recyclarr-8.6.0/lib/recyclarr/Mono.Cecil.Pdb.dll' is denied. [/build/source/tests/Recyclarr.Core.Tests/Recyclarr.Core.Tests.csproj]
       > /build/nuget.xELKO5/fallback/coverlet.collector/10.0.0/build/net10.0/coverlet.collector.targets(18,5): error MSB3021: Unable to copy file "/build/nuget.xELKO5/fallback/coverlet.collector/10.0.0/build/net10.0/Mono.Cecil.dll" to "/nix/store/37i4gc4shvz3r2yl5h5dz3d2b0p5ckc0-recyclarr-8.6.0/lib/recyclarr/Mono.Cecil.dll". Access to the path '/nix/store/37i4gc4shvz3r2yl5h5dz3d2b0p5ckc0-recyclarr-8.6.0/lib/recyclarr/Mono.Cecil.dll' is denied. [/build/source/tests/Recyclarr.Core.Tests/Recyclarr.Core.Tests.csproj]
       >   Recyclarr.Cli.Tests -> /nix/store/37i4gc4shvz3r2yl5h5dz3d2b0p5ckc0-recyclarr-8.6.0/lib/recyclarr/`
