### PR TITLE
python3Packages.fastapi: remove strictDeps already set by default

### DIFF
--- a/pkgs/development/python-modules/fastapi/default.nix
+++ b/pkgs/development/python-modules/fastapi/default.nix
@@ -43,7 +43,6 @@ buildPythonPackage (finalAttrs: {
   version = "0.139.0";
   pyproject = true;
   __structuredAttrs = true;
-  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "tiangolo";

--- a/pkgs/development/python-modules/fastapi/default.nix
+++ b/pkgs/development/python-modules/fastapi/default.nix
@@ -18,6 +18,7 @@
   a2wsgi,
   dirty-equals,
   flask,
+  httpx2,
   inline-snapshot,
   pwdlib,
   pyjwt,
@@ -27,7 +28,7 @@
 
   # optional-dependencies
   fastapi-cli,
-  httpx2,
+  httpx,
   jinja2,
   itsdangerous,
   python-multipart,
@@ -64,7 +65,7 @@ buildPythonPackage (finalAttrs: {
   optional-dependencies = {
     all = [
       fastapi-cli
-      httpx2
+      httpx
       jinja2
       python-multipart
       itsdangerous
@@ -79,7 +80,7 @@ buildPythonPackage (finalAttrs: {
     standard = [
       fastapi-cli
       # FIXME package fastar
-      httpx2
+      httpx
       jinja2
       python-multipart
       email-validator
@@ -91,7 +92,7 @@ buildPythonPackage (finalAttrs: {
     ++ uvicorn.optional-dependencies.standard;
     standard-no-fastapi-cloud-cli = [
       fastapi-cli
-      httpx2
+      httpx
       jinja2
       python-multipart
       email-validator
@@ -109,6 +110,7 @@ buildPythonPackage (finalAttrs: {
     a2wsgi
     dirty-equals
     flask
+    httpx2
     inline-snapshot
     pwdlib
     pyjwt


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test