### PR TITLE
cmake: fix parenthesis in patch

### DIFF
--- a/pkgs/by-name/cm/cmake/remove-impure-search-paths.patch
+++ b/pkgs/by-name/cm/cmake/remove-impure-search-paths.patch
@@ -584,7 +584,7 @@ diff --git a/Modules/FindJNI.cmake b/Modules/FindJNI.cmake
 index a70b00f330..1962b55d4a 100644
 --- a/Modules/FindJNI.cmake
 +++ b/Modules/FindJNI.cmake
-@@ -367,57 +367,6 @@ if (WIN32)
+@@ -367,56 +367,6 @@ if (WIN32)
  endif()
  
  set(_JNI_JAVA_DIRECTORIES_BASE
@@ -638,10 +638,9 @@ index a70b00f330..1962b55d4a 100644
 -  # SuSE specific paths for default JVM
 -  /usr/lib64/jvm/java
 -  /usr/lib64/jvm/jre
--  )
+   )
  
  set(_JNI_JAVA_AWT_LIBRARY_TRIES)
- set(_JNI_JAVA_INCLUDE_TRIES)
 diff --git a/Modules/FindJava.cmake b/Modules/FindJava.cmake
 index 1587ce648b..e92213cba7 100644
 --- a/Modules/FindJava.cmake


### PR DESCRIPTION
This broke the build of `libjxl`

## Things done

- Built on platform:
  - [x] x86_64-linux: cmake (libjxl still ongoing)
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
