### PR TITLE
python3Packages.mistune_2: init at 2.0.5

### DIFF
--- a/pkgs/by-name/le/lektor/package.nix
+++ b/pkgs/by-name/le/lektor/package.nix
@@ -13,14 +13,7 @@ let
   python = python3.override {
     self = python;
     packageOverrides = self: super: {
-      mistune = super.mistune.overridePythonAttrs (old: rec {
-        version = "2.0.5";
-        src = fetchPypi {
-          inherit (old) pname;
-          inherit version;
-          hash = "sha256-AkYRPLJJLbh1xr5Wl0p8iTMzvybNkokchfYxUc7gnTQ=";
-        };
-      });
+      mistune = self.mistune_2;
     };
   };
 in

--- a/pkgs/by-name/pr/present/package.nix
+++ b/pkgs/by-name/pr/present/package.nix
@@ -8,14 +8,7 @@ let
   # https://github.com/NixOS/nixpkgs/issues/348788
   pythonPackages = python3Packages.overrideScope (
     self: super: {
-      mistune = super.mistune.overridePythonAttrs (oldAttrs: rec {
-        version = "2.0.5";
-        src = fetchPypi {
-          inherit (oldAttrs) pname;
-          inherit version;
-          hash = "sha256-AkYRPLJJLbh1xr5Wl0p8iTMzvybNkokchfYxUc7gnTQ=";
-        };
-      });
+      mistune = self.mistune_2;
     }
   );
 in

--- a/pkgs/development/python-modules/mistune/2.nix
+++ b/pkgs/development/python-modules/mistune/2.nix
@@ -1,0 +1,62 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  lib,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "mistune";
+  version = "2.0.5";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-AkYRPLJJLbh1xr5Wl0p8iTMzvybNkokchfYxUc7gnTQ=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "mistune" ];
+
+  meta = {
+    changelog = "https://github.com/lepture/mistune/blob/v${finalAttrs.version}/docs/changes.rst";
+    description = "Sane Markdown parser with useful plugins and renderers";
+    homepage = "https://github.com/lepture/mistune";
+    knownVulnerabilities = [
+      "GHSA-h7ww-273w-6cm8"
+      "CVE-2026-44896"
+      "CVE-2026-59926"
+      "CVE-2026-33441"
+      "CVE-2026-59924"
+      "CVE-2026-33079"
+      "CVE-2026-59923"
+      "GHSA-jhcm-5rpf-j3wv"
+      "CVE-2026-44708"
+      "CVE-2026-44897"
+      "CVE-2026-44898"
+      "CVE-2026-44899"
+      "GHSA-9jjx-3hq3-hx4j"
+      "GHSA-xrpv-r66x-8p7j"
+      "CVE-2026-59929"
+      "GHSA-xmwc-wjpr-q378"
+      "CVE-2026-59922"
+      "CVE-2026-59925"
+      "CVE-2026-59928"
+      "GHSA-96vr-jm8v-g22j"
+      "CVE-2026-59930"
+      "CVE-2026-59927"
+      "GHSA-3q64-rw38-243v"
+      "CVE-2026-49851"
+      "GHSA-x2gr-6qf2-fc9x"
+      "GHSA-f32h-38gf-rg5r"
+      "GHSA-jxhr-4j38-fpxg"
+      "GHSA-8ppg-4vv7-9p53"
+    ];
+    license = lib.licenses.bsd3;
+    maintainers = [ ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10502,6 +10502,8 @@ self: super: with self; {
 
   mistune = callPackage ../development/python-modules/mistune { };
 
+  mistune_2 = callPackage ../development/python-modules/mistune/2.nix { };
+
   mitmproxy = callPackage ../development/python-modules/mitmproxy { };
 
   mitmproxy-linux = callPackage ../development/python-modules/mitmproxy-linux { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
