### PR TITLE
{,ungoogled-}chromium,chromedriver: 150.0.7871.100 -> 150.0.7871.114

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -838,7 +838,7 @@
     }
   },
   "ungoogled-chromium": {
-    "version": "150.0.7871.100",
+    "version": "150.0.7871.114",
     "deps": {
       "depot_tools": {
         "rev": "f4fadaf6a5ba1bced9d3d9021060667b563bf583",
@@ -850,16 +850,16 @@
         "hash": "sha256-/1A+DkzAQj2zGPe/A/G0Z3VrYJXUxq4Hd/+d/o5p3G8="
       },
       "ungoogled-patches": {
-        "rev": "150.0.7871.100-1",
-        "hash": "sha256-a+bGt3sROlE9edUBN2/VGn/grN6BqxWX/bsUlAVoAxY="
+        "rev": "150.0.7871.114-1",
+        "hash": "sha256-qvAtrj013U44vU+U3JLuItAPbgtHwm9Kq7hU2NLYDaE="
       },
       "npmHash": "sha256-pF0JtwFpPC4/fodbhSJnQKkczA9WlDg4VqEAy9aDVLg="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "b5a9b587b83512ef1fab99cb7510c58a06d22089",
-        "hash": "sha256-bylGmZC9NhUjcU6amK3mwuZ1it7uTm2hsC60DaKINr4=",
+        "rev": "f405107495a07cb1bfcf687d4af8d91117098db6",
+        "hash": "sha256-VdDnFbE+/leFzR/PqR3ColKKqwkvuY/LsFje0nrwiXU=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -929,8 +929,8 @@
       },
       "src/third_party/angle": {
         "url": "https://chromium.googlesource.com/angle/angle.git",
-        "rev": "bbf3d8a4755268f016087be2f56099fa5a5f3f6e",
-        "hash": "sha256-8iuHtNgHumlMXeXj2k0ZPcvnTeJ00di298+789OjScs="
+        "rev": "8d3c5a8caebd836b99fa32062951a401910eba33",
+        "hash": "sha256-7X8FSWCA+BpAXbUPvjPyiGagmVXsadRGAY5haAEzRL8="
       },
       "src/third_party/angle/third_party/glmark2/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glmark2/glmark2",
@@ -1099,8 +1099,8 @@
       },
       "src/third_party/devtools-frontend/src": {
         "url": "https://chromium.googlesource.com/devtools/devtools-frontend",
-        "rev": "1d67dc0dafa344bbd6ca75c124e2d6d9d53074d8",
-        "hash": "sha256-VBXch2YwnKm+lMcZ5L0SlW+vAYeaSwgZvcOhg1TE5/A="
+        "rev": "ec97cf3bbeea2cb623fbf97c4e3f22f5acb4d568",
+        "hash": "sha256-kbGcNwpdmqFTIAe/OU3Y1C13ZEHz5OP+QDAExg6tw2g="
       },
       "src/third_party/dom_distiller_js/dist": {
         "url": "https://chromium.googlesource.com/chromium/dom-distiller/dist.git",
@@ -1664,8 +1664,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "968f19a8970f8d91702d86f0ec1522f3909781b7",
-        "hash": "sha256-x3rCWvC3hEjyJq6PNThhZEp4oRF9Y1JJEPnZTqVNVrY="
+        "rev": "ce0af5c0d181678bcda077c68d4beaec2854ad16",
+        "hash": "sha256-gjuH2HQAC0poQileS8JLusocBDoShuaQ9pbaAXmFj4g="
       },
       "src/agents/shared": {
         "url": "https://chromium.googlesource.com/chromium/agents.git",

--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,10 +1,10 @@
 {
   "chromium": {
-    "version": "150.0.7871.100",
+    "version": "150.0.7871.114",
     "chromedriver": {
-      "version": "150.0.7871.101",
-      "hash_darwin": "sha256-LJPfzeJjVcEHenRNqKNOGcEZLL/rHRH55yBefLFTlEs=",
-      "hash_darwin_aarch64": "sha256-+WZw22dgaDsDMOQUJTjTuCGyUZT1t1RBjutyqmumX/A="
+      "version": "150.0.7871.115",
+      "hash_darwin": "sha256-3QytnwfqPqpYL2TMTMykvT+yAfZqWiRHMbMEK+whe0Q=",
+      "hash_darwin_aarch64": "sha256-jJ1URVS4led/1rTODm3t8wewJ8oIOzKIrq1utn5JJ3s="
     },
     "deps": {
       "depot_tools": {
@@ -21,8 +21,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "b5a9b587b83512ef1fab99cb7510c58a06d22089",
-        "hash": "sha256-bylGmZC9NhUjcU6amK3mwuZ1it7uTm2hsC60DaKINr4=",
+        "rev": "f405107495a07cb1bfcf687d4af8d91117098db6",
+        "hash": "sha256-VdDnFbE+/leFzR/PqR3ColKKqwkvuY/LsFje0nrwiXU=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -92,8 +92,8 @@
       },
       "src/third_party/angle": {
         "url": "https://chromium.googlesource.com/angle/angle.git",
-        "rev": "bbf3d8a4755268f016087be2f56099fa5a5f3f6e",
-        "hash": "sha256-8iuHtNgHumlMXeXj2k0ZPcvnTeJ00di298+789OjScs="
+        "rev": "8d3c5a8caebd836b99fa32062951a401910eba33",
+        "hash": "sha256-7X8FSWCA+BpAXbUPvjPyiGagmVXsadRGAY5haAEzRL8="
       },
       "src/third_party/angle/third_party/glmark2/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glmark2/glmark2",
@@ -262,8 +262,8 @@
       },
       "src/third_party/devtools-frontend/src": {
         "url": "https://chromium.googlesource.com/devtools/devtools-frontend",
-        "rev": "1d67dc0dafa344bbd6ca75c124e2d6d9d53074d8",
-        "hash": "sha256-VBXch2YwnKm+lMcZ5L0SlW+vAYeaSwgZvcOhg1TE5/A="
+        "rev": "ec97cf3bbeea2cb623fbf97c4e3f22f5acb4d568",
+        "hash": "sha256-kbGcNwpdmqFTIAe/OU3Y1C13ZEHz5OP+QDAExg6tw2g="
       },
       "src/third_party/dom_distiller_js/dist": {
         "url": "https://chromium.googlesource.com/chromium/dom-distiller/dist.git",
@@ -827,8 +827,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "968f19a8970f8d91702d86f0ec1522f3909781b7",
-        "hash": "sha256-x3rCWvC3hEjyJq6PNThhZEp4oRF9Y1JJEPnZTqVNVrY="
+        "rev": "ce0af5c0d181678bcda077c68d4beaec2854ad16",
+        "hash": "sha256-gjuH2HQAC0poQileS8JLusocBDoShuaQ9pbaAXmFj4g="
       },
       "src/agents/shared": {
         "url": "https://chromium.googlesource.com/chromium/agents.git",


### PR DESCRIPTION
https://chromereleases.googleblog.com/2026/07/stable-channel-update-for-desktop_01162222768.html

This update includes 27 security fixes.

CVEs:
CVE-2026-15112 CVE-2026-15129 CVE-2026-15132 CVE-2026-15133 CVE-2026-15108 CVE-2026-15109 CVE-2026-15110 CVE-2026-15111 CVE-2026-15113 CVE-2026-15114 CVE-2026-15115 CVE-2026-15116 CVE-2026-15117 CVE-2026-15118 CVE-2026-15119 CVE-2026-15120 CVE-2026-15121 CVE-2026-15122 CVE-2026-15123 CVE-2026-15124 CVE-2026-15125 CVE-2026-15126 CVE-2026-15127 CVE-2026-15128 CVE-2026-15130 CVE-2026-15107 CVE-2026-15131

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests] (`nix-build -A stable -A ungoogled nixos/tests/chromium.nix`).
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
