### PR TITLE
 python314Packages.pyopengl-accelerate: inherit from pyopengl;  python314Packages.pyopengl: fetch from github, cleanup 

### DIFF
--- a/pkgs/development/python-modules/pyopengl-accelerate/default.nix
+++ b/pkgs/development/python-modules/pyopengl-accelerate/default.nix
@@ -1,35 +1,28 @@
 {
-  lib,
   buildPythonPackage,
-  fetchPypi,
   cython,
   numpy,
+  pyopengl,
   setuptools,
-  wheel,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "pyopengl-accelerate";
-  version = "3.1.10";
   pyproject = true;
 
-  src = fetchPypi {
-    pname = "pyopengl_accelerate";
-    inherit version;
-    hash = "sha256-gnUcg/Cm9zK4tZI5kO3CRB04F2qYdWsXGOjWxDefWnE=";
-  };
+  inherit (pyopengl) version src;
+
+  sourceRoot = "${pyopengl.src.name}/accelerate";
 
   build-system = [
     cython
     numpy
     setuptools
-    wheel
   ];
 
   meta = {
     description = "This set of C (Cython) extensions provides acceleration of common operations for slow points in PyOpenGL 3.x";
-    homepage = "https://pyopengl.sourceforge.net/";
-    maintainers = with lib.maintainers; [ laikq ];
-    license = lib.licenses.bsd3;
+    homepage = "https://github.com/mcfletch/pyopengl/tree/master/accelerate#readme";
+    inherit (pyopengl.meta) maintainers license;
   };
 }

--- a/pkgs/development/python-modules/pyopengl/default.nix
+++ b/pkgs/development/python-modules/pyopengl/default.nix
@@ -1,13 +1,12 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
-  replaceVars,
-  fetchPypi,
-  setuptools,
-  pkgs,
-  pillow,
+  fetchFromGitHub,
   mesa,
+  pkgs,
+  replaceVars,
+  setuptools,
+  stdenv,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -15,22 +14,12 @@ buildPythonPackage (finalAttrs: {
   version = "3.1.10";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit (finalAttrs) pname version;
-    hash = "sha256-xKAtaGa1TrEZyOmz+wT6g1qVq4At2WYHq0zbABLfgzU=";
+  src = fetchFromGitHub {
+    owner = "mcfletch";
+    repo = "pyopengl";
+    tag = finalAttrs.version;
+    hash = "sha256-U/7J3EoxKHp/dR2LAzTiwR5wcjZbUBuT5Dt3c76xxj4=";
   };
-
-  build-system = [ setuptools ];
-
-  dependencies = [ pillow ];
-
-  passthru.runtimeLibs = lib.optionals (!stdenv.hostPlatform.isDarwin) [
-    "/run/opengl-driver/lib"
-    pkgs.libglvnd
-    pkgs.libGLU
-    pkgs.libglut
-    pkgs.gle
-  ];
 
   patches = lib.optionals (finalAttrs.passthru.runtimeLibs != [ ]) [
     # patch OpenGL.platform.ctypesloader::_loadLibraryPosix with extra search paths
@@ -39,11 +28,11 @@ buildPythonPackage (finalAttrs: {
     })
   ];
 
-  # Need to fix test runner
-  # Tests have many dependencies
-  # Extension types could not be found.
-  # Should run test suite from $out/${python.sitePackages}
-  doCheck = false; # does not affect pythonImportsCheck
+  build-system = [ setuptools ];
+
+  # mosts tests fail in the nix sandbox with:
+  #  GLX is not supported
+  doCheck = false;
 
   # PyOpenGL looks for libraries during import, making this a somewhat decent test of our patching
   # (these are impure deps on darwin)
@@ -61,14 +50,19 @@ buildPythonPackage (finalAttrs: {
     "OpenGL.GLX"
   ];
 
+  passthru.runtimeLibs = lib.optionals (!stdenv.hostPlatform.isDarwin) [
+    "/run/opengl-driver/lib"
+    pkgs.libglvnd
+    pkgs.libGLU
+    pkgs.libglut
+    pkgs.gle
+  ];
+
   meta = {
     homepage = "https://mcfletch.github.io/pyopengl/";
     description = "PyOpenGL, the Python OpenGL bindings";
     longDescription = ''
-      PyOpenGL is the cross platform Python binding to OpenGL and
-      related APIs.  The binding is created using the standard (in
-      Python 2.5) ctypes library, and is provided under an extremely
-      liberal BSD-style Open-Source license.
+      PyOpenGL is the cross platform Python binding to OpenGL and related APIs.
     '';
     license = lib.licenses.bsd3;
     inherit (mesa.meta) platforms;


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
