### PR TITLE
bentopdf: 1.11.2 -> 2.8.6

### DIFF
--- a/nixos/tests/bentopdf/caddy.nix
+++ b/nixos/tests/bentopdf/caddy.nix
@@ -22,7 +22,7 @@ import ../make-test-python.nix (
       machine.wait_for_unit("caddy.service")
       machine.wait_for_open_port(80)
       machine.succeed("curl -vvv --fail --show-error --silent --location --insecure http://localhost/")
-      assert "<title>BentoPDF - The Privacy First PDF Toolkit</title>" in machine.succeed("curl --fail --show-error --silent --location --insecure http://localhost/")
+      assert "<title>PDF Tools</title>" in machine.succeed("curl --fail --show-error --silent --location --insecure http://localhost/")
     '';
   }
 )

--- a/nixos/tests/bentopdf/nginx.nix
+++ b/nixos/tests/bentopdf/nginx.nix
@@ -18,7 +18,7 @@ import ../make-test-python.nix (
     testScript = ''
       machine.wait_for_unit("nginx.service")
       machine.wait_for_open_port(80)
-      assert "<title>BentoPDF - The Privacy First PDF Toolkit</title>" in machine.succeed("curl --fail --show-error --silent --location --insecure http://localhost:80/")
+      assert "<title>PDF Tools</title>" in machine.succeed("curl --fail --show-error --silent --location --insecure http://localhost:80/")
     '';
   }
 )

--- a/pkgs/by-name/be/bentopdf/package.nix
+++ b/pkgs/by-name/be/bentopdf/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
+  nix-update-script,
   nixosTests,
   simpleMode ? true,
 }:
@@ -35,8 +36,11 @@ buildNpmPackage (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.tests = {
-    inherit (nixosTests.bentopdf) caddy nginx;
+  passthru = {
+    tests = {
+      inherit (nixosTests.bentopdf) caddy nginx;
+    };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/by-name/be/bentopdf/package.nix
+++ b/pkgs/by-name/be/bentopdf/package.nix
@@ -7,18 +7,16 @@
 }:
 buildNpmPackage (finalAttrs: {
   pname = "bentopdf";
-  # We intentionally don't update the version, due to:
-  # https://github.com/NixOS/nixpkgs/issues/484067
-  # nixpkgs-update: no auto update
-  version = "1.11.2";
+  version = "2.8.6";
 
   src = fetchFromGitHub {
     owner = "alam00000";
     repo = "bentopdf";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-br4My0Q4zoA+ZIrXM4o4oQjZ7IpSdwg+iKiAUdc2B/s=";
+    hash = "sha256-rbThEonDXFGcudgdMtDrQHq84Wh4IvOZZBn4kXvrhoI=";
   };
-  npmDepsHash = "sha256-UNNNYO7e7qdumI0/ka2ieFZzKURPl1V3981vHCPcVfY=";
+  npmDepsHash = "sha256-RT6ifx24mNfNS8oO93vyW+zbKQGCx21RqBQrAXK8dAY=";
+  npmDepsFetcherVersion = 2;
 
   npmBuildFlags = [
     "--"


### PR DESCRIPTION
Too many releases to list them all... Updating this was blocked by https://github.com/NixOS/nixpkgs/issues/484067, but a fix reached master yesterday after being in staging for a while.

Fixes #518346

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
