### PR TITLE
ytdl-sub: disable test_directory_exists

### DIFF
--- a/pkgs/by-name/yt/ytdl-sub/package.nix
+++ b/pkgs/by-name/yt/ytdl-sub/package.nix
@@ -59,6 +59,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
     "test_no_config_works"
     "test_presets_run"
     "test_thumbnail"
+    # fails in bwrap nix-portable sandbox
+    "test_directory_exists"
   ];
 
   disabledTestPaths = [


### PR DESCRIPTION
`test_directory_exists` assumes the root directory is not writeable, which is host dependent.
In my case it fails with nix-portable in bwrap mode, despite me having removed the write-bit in the root directory bindmount.

discovered in https://github.com/NixOS/nixpkgs/pull/538090

Full error:

```
ytdl-sub> ____________________ TestFileHandler.test_directory_exists _____________________
ytdl-sub>
ytdl-sub> self = <tests.unit.utils.test_file_handler.TestFileHandler object at 0x7ffff2bc07d0>
ytdl-sub>
ytdl-sub> .    def test_directory_exists(self):
ytdl-sub>         if IS_WINDOWS:
ytdl-sub>             return
ytdl-sub>
ytdl-sub>         assert FileHandler.is_path_writable("/tmp")
ytdl-sub>         assert FileHandler.is_path_writable("/tmp/")
ytdl-sub>         assert FileHandler.is_path_writable("/tmp/non-existent")
ytdl-sub>         assert FileHandler.is_path_writable("/tmp/non-existent/")
ytdl-sub>         assert FileHandler.is_path_writable("/tmp/non-existent/nested")
ytdl-sub>
ytdl-sub> >       assert not FileHandler.is_path_writable("/lol-in-root")
ytdl-sub> E       AssertionError: assert not True
ytdl-sub> E        +  where True = is_path_writable('/lol-in-root')
ytdl-sub> E        +    where is_path_writable = FileHandler.is_path_writable
ytdl-sub>
ytdl-sub> tests/unit/utils/test_file_handler.py:16: AssertionError
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
