### PR TITLE
python3Packages.ical: 13.3.0 -> 14.0.1,  python3Packages.gcal-sync: 9.0.0 -> 9.1.0

### DIFF
--- a/pkgs/development/python-modules/gcal-sync/default.nix
+++ b/pkgs/development/python-modules/gcal-sync/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "gcal-sync";
-  version = "9.0.0";
+  version = "9.1.0";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "allenporter";
     repo = "gcal_sync";
     tag = version;
-    hash = "sha256-17w9ozdgMEZ9wpypWZtf3AqZDW/9XYb/oiO/7yO1MsM=";
+    hash = "sha256-9hSe2cHWG1biDQuYTVsvMz5LjUoyTkkwgay8OIlQeco=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/ical/default.nix
+++ b/pkgs/development/python-modules/ical/default.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   freezegun,
   tzdata,
+  pdoc,
   pydantic,
   pytest-benchmark,
   pytestCheckHook,
@@ -15,14 +16,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "ical";
-  version = "13.3.0";
+  version = "14.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "allenporter";
     repo = "ical";
     tag = finalAttrs.version;
-    hash = "sha256-tyPD0z2wWND6b6TKe/uXH2N5HcaJifhV4gQS9GEAQxs=";
+    hash = "sha256-y+YKHSVPd1Lkkjty2xA1O4YKmXvE4c0yIASEhjV82xo=";
   };
 
   build-system = [ setuptools ];
@@ -36,6 +37,7 @@ buildPythonPackage (finalAttrs: {
   nativeCheckInputs = [
     emoji
     freezegun
+    pdoc
     pytest-benchmark
     pytestCheckHook
     syrupy


### PR DESCRIPTION
Diff: https://github.com/allenporter/ical/compare/13.3.0...14.0.1

Changelog:
https://github.com/allenporter/ical/releases/tag/14.0.0
https://github.com/allenporter/ical/releases/tag/14.0.1
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
