### PR TITLE
jenkins: 2.555.3 -> 2.568.1

### DIFF
--- a/pkgs/by-name/je/jenkins/package.nix
+++ b/pkgs/by-name/je/jenkins/package.nix
@@ -18,11 +18,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "jenkins";
-  version = "2.555.3";
+  version = "2.568.1";
 
   src = fetchurl {
     url = "https://get.jenkins.io/war-stable/${finalAttrs.version}/jenkins.war";
-    hash = "sha256-XRmQXmwPI6/4n/AH3lVkuW4KBcE/TRqS0P3LabAzu5o=";
+    hash = "sha256-WPJPOWX773cIYp++FY1RvxOP/Vd8rbyGtGNn6K0L64M=";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
Changelog: https://www.jenkins.io/changelog-stable/#v2.568.1

Fixed security advisories:

* [CVE-2026-41838](https://spring.io/security/cve-2026-41838) "Spring Framework Predictable Session ID in WebSocket Module"
* [CVE-2026-41839](https://spring.io/security/cve-2026-41839) "Spring Framework Escalation via Session Fixation in WebFlux"
* [CVE-2026-41840](https://spring.io/security/cve-2026-41840) "Spring Framework Denial of Service via Multipart Requests in WebFlux"
* [CVE-2026-41841](https://spring.io/security/cve-2026-41841) "Spring Framework Information Disclosure via Static Resource Cache in Spring MVC and WebFlux"
* [CVE-2026-41842](https://spring.io/security/cve-2026-41842) "Spring Framework Denial of Service via Versioned Resources in Spring MVC and WebFlux"
* [CVE-2026-41843](https://spring.io/security/cve-2026-41843) "Spring Framework Path Traversal via Versioned Static Resources in Spring MVC and WebFlux"
* [CVE-2026-41844](https://spring.io/security/cve-2026-41844) "Spring Framework Open Redirect in Spring MVC and WebFlux"
* [CVE-2026-41845](https://spring.io/security/cve-2026-41845) "Spring Framework Cross-site Scripting via JavaScriptUtils"
* [CVE-2026-41846](https://spring.io/security/cve-2026-41846) "Spring Framework Cross-site Scripting via JSP Form Tags"
* [CVE-2026-41848](https://spring.io/security/cve-2026-41848) "Spring Framework Denial of Service via AntPathMatcher"
* [CVE-2026-41850](https://spring.io/security/cve-2026-41850) "Spring Framework Algorithmic Denial of Service via SpEL Expressions"
* [CVE-2026-41851](https://spring.io/security/cve-2026-41851) "Spring Framework Denial of Service via Unbounded Cache in SpEL"
* [CVE-2026-41852](https://spring.io/security/cve-2026-41852) "Spring Framework Arbitrary Method Invocation in SpEL Expressions"
* [CVE-2026-41853](https://spring.io/security/cve-2026-41853) "Spring Framework Multipart Request Smuggling in Spring MVC and WebFlux"
* [CVE-2026-41854](https://spring.io/security/cve-2026-41854) "Spring Framework Server-Side Request Forgery via UriComponentsBuilder"
* [CVE-2026-41855](https://spring.io/security/cve-2026-41855) "Spring Framework Unsafe Deserialization via Jackson JMS Converters"
* [CVE-2026-57280](https://www.jenkins.io/security/advisory/2026-06-24/#SECURITY-3792) "Sandbox bypass vulnerability in Script Security Plugin"
* [CVE-2026-57281](https://www.jenkins.io/security/advisory/2026-06-24/#SECURITY-3793) "Script security bypass vulnerability in Script Security Plugin"

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
