### PR TITLE
git: fix darwin crashes when dealing with unicode filenames

### DIFF
--- a/pkgs/by-name/gi/git/package.nix
+++ b/pkgs/by-name/gi/git/package.nix
@@ -133,6 +133,12 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://lore.kernel.org/git/20260504101429.340123-1-joerg@thalheim.io/raw";
       hash = "sha256-44EPfEJ39LjPWjqjFb52EKNaJGzYxZzJaJOis8QnazU=";
     })
+    # Fix fortify darwin crashes when dealing with unicode filenames.
+    (fetchurl {
+      name = "darwin-unicode-filename-fix.patch";
+      url = "https://lore.kernel.org/git/20260704233724.16928-1-ihar.hrachyshka@gmail.com/raw";
+      hash = "sha256-lpGz3nFKQvFDtW2TtQLx/684ECJVBLGPGqip0XEtOdU=";
+    })
   ]
   ++ lib.optionals withSsh [
     # Hard-code the ssh executable to ${pkgs.openssh}/bin/ssh instead of


### PR DESCRIPTION
The backported patch is accepted in `next`.

Note: `aarch64-darwin` build was executed on `master`, not `staging` because currently `git` build is blocked by `jemalloc` test suite failures.

---

The gist is that we enabled additional FORTIFY rules recently, which triggered `git` crashes on Darwin because of array size enforcement on an array that is defined as `[NAME_MAX+1]`-sized in (darwin-specific) code but in reality is expanded further with `realloc` as needed by the implementation. The compiler still sees `[NAME_MAX+1]` as the threshold to enforce and makes `git` crash if an attempt to write beyond it is detected.

The specific scenario when `git` may crash is when it encounters a file name that is longer than `NAME_MAX+1` bytes (in NFD UTF-8 encoding) - a real and common scenario on MacOS. (On Linux, it's still possible but `git` code correctly deals with it for this platform. Hence the issue is Darwin specific.) (In case you wonder why NAME_MAX is not the real limit for a file name length... [here](https://lore.kernel.org/git/f35346ce-056f-4add-b071-2703c2455daa@gmail.com/))

The patch does not introduce runtime changes, only helps the compiler to know that it's dealing with a flexible array.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
