### PR TITLE
nixos/headscale: deprecate `settings.ephemeral_node_inactivity_timeout`

### DIFF
--- a/nixos/modules/services/networking/headscale.nix
+++ b/nixos/modules/services/networking/headscale.nix
@@ -110,6 +110,15 @@ in
               example = "https://myheadscale.example.com:443";
             };
 
+            node.ephemeral.inactivity_timeout = lib.mkOption {
+              type = lib.types.str;
+              default = "30m";
+              description = ''
+                Time before an inactive ephemeral node is deleted.
+              '';
+              example = "5m";
+            };
+
             noise.private_key_path = lib.mkOption {
               type = lib.types.path;
               default = "${dataDir}/noise_private.key";
@@ -199,15 +208,6 @@ in
                   Path to derp private key file, generated automatically if it does not exist.
                 '';
               };
-            };
-
-            ephemeral_node_inactivity_timeout = lib.mkOption {
-              type = lib.types.str;
-              default = "30m";
-              description = ''
-                Time before an inactive ephemeral node is deleted.
-              '';
-              example = "5m";
             };
 
             database = {
@@ -609,10 +609,23 @@ in
       [ "services" "headscale" "derp" "urls" ]
       [ "services" "headscale" "settings" "derp" "urls" ]
     )
-    (mkRenamedOptionModule
-      [ "services" "headscale" "ephemeralNodeInactivityTimeout" ]
-      [ "services" "headscale" "settings" "ephemeral_node_inactivity_timeout" ]
-    )
+    (mkRenamedOptionModuleWith {
+      from = [
+        "services"
+        "headscale"
+        "settings"
+        "ephemeral_node_inactivity_timeout"
+      ];
+      to = [
+        "services"
+        "headscale"
+        "settings"
+        "node"
+        "ephemeral"
+        "inactivity_timeout"
+      ];
+      sinceRelease = 2611;
+    })
     (mkRenamedOptionModule
       [ "services" "headscale" "logLevel" ]
       [ "services" "headscale" "settings" "log" "level" ]


### PR DESCRIPTION
* settings.ephemeral_node_inactivity_timeout deprecated in upstream since `v0.29.0` (see: https://github.com/juanfont/headscale/blob/v0.29.0/CHANGELOG.md?plain=1#L299)
* `settings.ephemeral_node_inactivity_timeout` -> `settings.node.ephemeral.node_inactivity`

Resolves: #538040


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
