### PR TITLE
pdfding: 1.9.0 -> 1.10.0

### DIFF
--- a/nixos/tests/web-apps/pdfding/basic.nix
+++ b/nixos/tests/web-apps/pdfding/basic.nix
@@ -17,6 +17,11 @@
           secretKeyFile = pkgs.writeText "secretKeyFile" "test123";
         };
 
+        # NOTE: on aarch64-linux github actions runer due to lack of kvm, we need to delay pdfding start and give it more time to finish
+        systemd.services.pdfding.wantedBy = lib.mkIf pkgs.stdenv.hostPlatform.isAarch64 (lib.mkForce [ ]);
+        systemd.services.pdfding.serviceConfig.TimeoutStartSec =
+          lib.mkIf pkgs.stdenv.hostPlatform.isAarch64 "900";
+
         environment.systemPackages = with pkgs; [
           sqlite
         ];
@@ -60,6 +65,7 @@
 
       # create admin
       machine.wait_for_unit("multi-user.target")
+      machine.succeed("systemctl start pdfding.service")
       machine.wait_for_open_port(${toString port})
       machine.succeed("DJANGO_SUPERUSER_PASSWORD=admin pdfding-manage createsuperuser --no-input --username admin --email admin@localhost")
 

--- a/nixos/tests/web-apps/pdfding/postgres.nix
+++ b/nixos/tests/web-apps/pdfding/postgres.nix
@@ -22,6 +22,14 @@
           installTestHelpers = true;
         };
 
+        # NOTE: on aarch64-linux github actions runer due to lack of kvm, we need to delay pdfding start and give it more time to finish
+        systemd.services.pdfding.wantedBy = lib.mkIf pkgs.stdenv.hostPlatform.isAarch64 (lib.mkForce [ ]);
+        systemd.services.pdfding.serviceConfig.TimeoutStartSec =
+          lib.mkIf pkgs.stdenv.hostPlatform.isAarch64 "900";
+        systemd.services.pdfding-background.wantedBy = lib.mkIf pkgs.stdenv.hostPlatform.isAarch64 (
+          lib.mkForce [ ]
+        );
+
         environment.systemPackages = [
           config.services.postgresql.finalPackage
         ];
@@ -46,6 +54,8 @@
 
       # create admin
       machine.wait_for_unit("multi-user.target")
+      machine.succeed("systemctl start pdfding.service")
+      machine.succeed("systemctl start pdfding-background.service")
       machine.wait_for_open_port(${toString port})
 
       machine.succeed("DJANGO_SUPERUSER_PASSWORD=admin pdfding-manage createsuperuser --no-input --username admin --email admin@localhost")

--- a/nixos/tests/web-apps/pdfding/s3-backups.nix
+++ b/nixos/tests/web-apps/pdfding/s3-backups.nix
@@ -31,7 +31,7 @@ in
           backup.schedule = "*/1 * * * *";
           backup.endpoint = "[::]:3900";
           extraEnvironment.BACKUP_BUCKET_NAME = "pdfding-bucket";
-          extraEnvironment.BACKUP_REGION = "garage";
+          extraEnvironment.BACKUP_REGION = "us-east-1";
 
           envFiles = [ pdfding-s3-keys ];
           installTestHelpers = true;
@@ -48,7 +48,7 @@ in
             rpc_secret = "5c1915fa04d0b6739675c61bf5907eb0fe3d9c69850c83820f51b4d25d13868c";
 
             s3_api = {
-              s3_region = "garage";
+              s3_region = "us-east-1";
               api_bind_addr = "[::]:3900";
               root_domain = ".s3.garage";
             };
@@ -140,7 +140,7 @@ in
           -F "description=" \
           -F "collection=1" \
           -F "use_file_name=on" \
-          -F "name=test-upload" \
+          -F "name=dummy" \
           -F "file=@{test_pdf};type=application/pdf" \
           -F "csrfmiddlewaretoken=$csrf_token" \
           -H "Referer: {endpoint}/pdf/add" \

--- a/nixos/tests/web-apps/pdfding/s3-backups.nix
+++ b/nixos/tests/web-apps/pdfding/s3-backups.nix
@@ -37,6 +37,14 @@ in
           installTestHelpers = true;
         };
 
+        # NOTE: on aarch64-linux github actions runer due to lack of kvm, we need to delay pdfding start and give it more time to finish
+        systemd.services.pdfding.wantedBy = lib.mkIf pkgs.stdenv.hostPlatform.isAarch64 (lib.mkForce [ ]);
+        systemd.services.pdfding.serviceConfig.TimeoutStartSec =
+          lib.mkIf pkgs.stdenv.hostPlatform.isAarch64 "900";
+        systemd.services.pdfding-background.wantedBy = lib.mkIf pkgs.stdenv.hostPlatform.isAarch64 (
+          lib.mkForce [ ]
+        );
+
         # Setup a local garage service for the backup feature
         # taken from garage nixosTest
         services.garage = {
@@ -113,6 +121,8 @@ in
 
       # create admin
       machine.wait_for_unit("multi-user.target")
+      machine.succeed("systemctl start pdfding.service")
+      machine.succeed("systemctl start pdfding-background.service")
       machine.wait_for_open_port(${toString port})
       machine.succeed("DJANGO_SUPERUSER_PASSWORD=admin pdfding-manage createsuperuser --no-input --username admin --email admin@localhost")
 

--- a/pkgs/by-name/pd/pdfding/frontend.nix
+++ b/pkgs/by-name/pd/pdfding/frontend.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
   npmDeps = fetchNpmDeps {
     inherit (finalAttrs) src;
     name = "pdfding-${finalAttrs.version}-npm-deps";
-    hash = "sha256-fxhDP/kyDfL1uiZCUNr2Cd6vDnyb9V+gTSNPyjSIm18=";
+    hash = "sha256-TDX2xoHj07aUeuLPt/TlgkdRdTiv3fNbriChzEB4EXk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/pd/pdfding/package.nix
+++ b/pkgs/by-name/pd/pdfding/package.nix
@@ -12,12 +12,12 @@ let
 in
 python.pkgs.buildPythonPackage (finalAttrs: {
   pname = "pdfding";
-  version = "1.9.0";
+  version = "1.10.0";
   src = fetchFromGitHub {
     owner = "mrmn2";
     repo = "PdfDing";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-r3hO92iriQ/0KDl+D/0j5RoneTTCDmt8m4e7ugzyOPs=";
+    hash = "sha256-C1osj8V9+z3ahl4+zUtyI22GMtSgNLzfdGttL7gPDvY=";
   };
   pyproject = true;
 
@@ -132,11 +132,11 @@ python.pkgs.buildPythonPackage (finalAttrs: {
   '';
 
   pythonRelaxDeps = [
+    "django"
     "gunicorn"
     "huey"
     "nh3"
     "psycopg2-binary"
-    "pypdf"
     "pypdfium2"
   ];
 


### PR DESCRIPTION
Diff: https://github.com/mrmn2/PdfDing/compare/v1.9.0...v1.10.0
Changelog: https://github.com/mrmn2/PdfDing/releases/tag/v1.10.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
