### PR TITLE
jemalloc: skip extent test with profiling enabled

### DIFF
--- a/pkgs/by-name/je/jemalloc/package.nix
+++ b/pkgs/by-name/je/jemalloc/package.nix
@@ -51,6 +51,14 @@ stdenv.mkDerivation (finalAttrs: {
     # `rtree_read.constprop.0` shows up in some builds but
     # not others, so we fall back to O2:
     ./o3-to-o2.patch
+
+    # Active profiling may make xallocx decline to grow non-page-aligned
+    # allocations, so test/integration/extent can observe decommit without
+    # the matching commit on platforms with real decommit/commit.
+    #
+    # A (longer) patch addressing the failure posted upstream at:
+    # https://github.com/jemalloc/jemalloc/pull/2954
+    ./skip-extent-test-with-prof-active.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/je/jemalloc/skip-extent-test-with-prof-active.patch
+++ b/pkgs/by-name/je/jemalloc/skip-extent-test-with-prof-active.patch
@@ -1,0 +1,24 @@
+diff --git a/test/integration/extent.sh b/test/integration/extent.sh
+index 39fb0a73..ee9f3ed4 100644
+--- a/test/integration/extent.sh
++++ b/test/integration/extent.sh
+@@ -1,5 +1,19 @@
+ #!/bin/sh
+ 
++# With active profiling, xallocx may decline to grow non-page-aligned
++# allocations.  On platforms with real decommit/commit, this can make this
++# test observe a successful decommit without the matching commit.
++case ",${MALLOC_CONF_ALL}," in
++  *,prof:true,*)
++    case ",${MALLOC_CONF_ALL}," in
++      *,prof_active:false,*)
++        ;;
++      *)
++        return 1
++        ;;
++    esac
++esac
++
+ if [ "x${enable_fill}" = "x1" ] ; then
+   export MALLOC_CONF="junk:false"
+ fi


### PR DESCRIPTION
This fixes rust-jemalloc-sys build on darwin.

Linux builds pass only when overcommit is enabled in kernel, so it's
better to disable it for both platforms.

See: https://github.com/jemalloc/jemalloc/pull/2954

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
