### PR TITLE
immichframe: refactor into one derivation, 1.0.33.0 -> 1.0.35.0

### DIFF
--- a/pkgs/by-name/im/immichframe/package.nix
+++ b/pkgs/by-name/im/immichframe/package.nix
@@ -12,13 +12,13 @@
 
 buildDotnetModule (finalAttrs: {
   pname = "immichframe";
-  version = "1.0.33.0";
+  version = "1.0.35.0";
 
   src = fetchFromGitHub {
     owner = "immichFrame";
     repo = "immichFrame";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-b8hfzNZJz9XCRO4UfzwK5OsrgqV2F5wnZlRH7h3Eo9Q=";
+    hash = "sha256-VET0em+CyJzXPlCXjozj6SDhjD26lH94AETFKGG895I=";
   };
 
   projectFile = "ImmichFrame.WebApi/ImmichFrame.WebApi.csproj";
@@ -34,7 +34,7 @@ buildDotnetModule (finalAttrs: {
 
   npmDeps = fetchNpmDeps {
     src = "${finalAttrs.src}/${finalAttrs.npmRoot}";
-    hash = "sha256-PjbbBpYYUHH4oucJuk0FCdJa0LzTlkQnjkZ5MLziqTY=";
+    hash = "sha256-RyMY5ooC6Q+W+Y24ILv+WCcWLMDToZ52yefFuoAYubY=";
   };
 
   preBuild = ''
@@ -57,6 +57,7 @@ buildDotnetModule (finalAttrs: {
   };
 
   meta = {
+    changelog = "https://github.com/immichFrame/ImmichFrame/releases/tag/${finalAttrs.src.tag}";
     description = "Display your photos from Immich as a digital photo frame";
     homepage = "https://immichframe.dev";
     license = lib.licenses.gpl3Only;

--- a/pkgs/by-name/im/immichframe/package.nix
+++ b/pkgs/by-name/im/immichframe/package.nix
@@ -1,70 +1,58 @@
 {
   buildDotnetModule,
-  buildNpmPackage,
   dotnet-sdk,
   fetchFromGitHub,
+  fetchNpmDeps,
   lib,
   nixosTests,
-  writeShellApplication,
-  _experimental-update-script-combinators,
+  nodejs,
+  npmHooks,
   nix-update-script,
 }:
 
-let
+buildDotnetModule (finalAttrs: {
+  pname = "immichframe";
   version = "1.0.33.0";
+
   src = fetchFromGitHub {
     owner = "immichFrame";
     repo = "immichFrame";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-b8hfzNZJz9XCRO4UfzwK5OsrgqV2F5wnZlRH7h3Eo9Q=";
   };
 
-  api = buildDotnetModule {
-    pname = "immichframe";
-    inherit version src;
-    projectFile = "ImmichFrame.WebApi/ImmichFrame.WebApi.csproj";
-    nugetDeps = ./deps.json;
-    dotnet-runtime = dotnet-sdk.aspnetcore;
+  projectFile = "ImmichFrame.WebApi/ImmichFrame.WebApi.csproj";
+  nugetDeps = ./deps.json;
+  dotnet-runtime = dotnet-sdk.aspnetcore;
 
-    meta.mainProgram = "ImmichFrame.WebApi";
+  nativeBuildInputs = [
+    npmHooks.npmConfigHook
+    nodejs
+  ];
+
+  npmRoot = "immichFrame.Web";
+
+  npmDeps = fetchNpmDeps {
+    src = "${finalAttrs.src}/${finalAttrs.npmRoot}";
+    hash = "sha256-PjbbBpYYUHH4oucJuk0FCdJa0LzTlkQnjkZ5MLziqTY=";
   };
 
-  frontend = buildNpmPackage {
-    pname = "immichframe-frontend";
-    inherit version src;
-
-    sourceRoot = "${src.name}/immichFrame.Web";
-
-    npmBuildScript = "build";
-    npmDepsHash = "sha256-PjbbBpYYUHH4oucJuk0FCdJa0LzTlkQnjkZ5MLziqTY=";
-
-    installPhase = ''
-      runHook preInstall
-
-      mkdir $out
-      cp -r build/ $out/wwwroot
-
-      runHook postInstall
-    '';
-  };
-in
-writeShellApplication {
-  name = "ImmichFrame";
-
-  text = ''
-    cd ${frontend}
-    exec ${lib.getExe api} "$@"
+  preBuild = ''
+    pushd ${finalAttrs.npmRoot}
+    npm run build
+    popd
   '';
 
+  postInstall = ''
+    cp -r ${finalAttrs.npmRoot}/build/* $out/lib/immichframe/wwwroot/
+  '';
+
+  makeWrapperArgs = [
+    "--chdir ${placeholder "out"}/lib/immichframe"
+  ];
+
   passthru = {
-    inherit api frontend;
-    updateScript = _experimental-update-script-combinators.sequence [
-      (nix-update-script { attrPath = "immichframe.api"; })
-      (nix-update-script {
-        attrPath = "immichframe.frontend";
-        extraArgs = [ "--version=skip" ];
-      })
-    ];
+    updateScript = nix-update-script { };
     tests = { inherit (nixosTests) immichframe; };
   };
 
@@ -72,7 +60,8 @@ writeShellApplication {
     description = "Display your photos from Immich as a digital photo frame";
     homepage = "https://immichframe.dev";
     license = lib.licenses.gpl3Only;
+    mainProgram = "ImmichFrame.WebApi";
     maintainers = with lib.maintainers; [ jfly ];
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
Now `nix-update immichframe` works, no need for a special update script.

closes https://github.com/NixOS/nixpkgs/pull/540097

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
