### PR TITLE
Janet: Prototype setup hooks and bundles

### DIFF
--- a/pkgs/development/interpreters/janet/bundle.nix
+++ b/pkgs/development/interpreters/janet/bundle.nix
@@ -1,0 +1,34 @@
+{
+  stdenv,
+  lib,
+  janet,
+  janetHooks,
+}:
+lib.extendMkDerivation {
+  constructDrv = stdenv.mkDerivation;
+
+  extendDrvArgs =
+    finalAttrs:
+    {
+      shimJPM ? false,
+
+      nativeBuildInputs ? [ ],
+      buildInputs ? [ ],
+
+      ...
+    }@attrs:
+    {
+      buildInputs = buildInputs ++ [ janet ];
+      nativeBuildInputs =
+        nativeBuildInputs
+        ++ [
+          janet
+          janetHooks.bundleInstallHook
+        ]
+        ++ lib.optionals shimJPM [ janetHooks.bundleShimJpmHook ];
+
+      meta = (attrs.meta or { }) // {
+        broken = stdenv.hostPlatform != stdenv.buildPlatform;
+      };
+    };
+}

--- a/pkgs/development/interpreters/janet/default.nix
+++ b/pkgs/development/interpreters/janet/default.nix
@@ -1,78 +1,14 @@
 {
   lib,
-  stdenv,
-  fetchFromGitHub,
-  meson,
-  ninja,
-  nix-update-script,
-  pkgsBuildBuild,
-  runCommand,
+  newScope,
 }:
+lib.makeScope newScope (self: {
+  janet = self.callPackage ./janet.nix { };
 
-stdenv.mkDerivation (finalAttrs: {
-  pname = "janet";
-  version = "1.41.2";
+  janetHooks = self.callPackage ./hooks { };
 
-  src = fetchFromGitHub {
-    owner = "janet-lang";
-    repo = "janet";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-sNRhcGG8JysmPHHXeRkYCt7qA75U6flptUEWWun+rDs=";
-  };
+  buildJanetBundle = self.callPackage ./bundle.nix { };
 
-  postPatch = ''
-    substituteInPlace janet.1 \
-      --replace /usr/local/ $out/
-  ''
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    # error: Socket is not connected
-    substituteInPlace meson.build \
-      --replace "'test/suite-ev.janet'," ""
-  '';
-
-  depsBuildBuild = [ pkgsBuildBuild.stdenv.cc ];
-  nativeBuildInputs = [
-    meson
-    ninja
-  ];
-
-  mesonBuildType = "release";
-  mesonFlags = [ "-Dgit_hash=release" ];
-
-  doCheck = true;
-
-  doInstallCheck = true;
-
-  installCheckPhase = ''
-    $out/bin/janet -e '(+ 1 2 3)'
-  '';
-
-  passthru = {
-    tests.run =
-      runCommand "janet-test-run"
-        {
-          nativeBuildInputs = [ finalAttrs.finalPackage ];
-        }
-        ''
-          echo "(+ 1 2 3)" | janet | tail -n 1 > arithmeticTest.txt;
-          diff -U3 --color=auto <(cat arithmeticTest.txt) <(echo "6");
-
-          echo "(print \"Hello, World!\")" | janet | tail -n 2 > ioTest.txt;
-          diff -U3 --color=auto <(cat ioTest.txt) <(echo -e "Hello, World!\nnil");
-
-          touch $out;
-        '';
-    updateScript = nix-update-script { };
-  };
-
-  meta = {
-    description = "Janet programming language";
-    mainProgram = "janet";
-    homepage = "https://janet-lang.org/";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [
-      peterhoeg
-    ];
-    platforms = lib.platforms.all;
-  };
+  jpm = self.callPackage ./jpm.nix { };
+  spork = self.callPackage ./spork.nix { };
 })

--- a/pkgs/development/interpreters/janet/hooks/bundle-install-hook.sh
+++ b/pkgs/development/interpreters/janet/hooks/bundle-install-hook.sh
@@ -1,0 +1,38 @@
+# shellcheck shell=bash
+
+janetBundleInstallHook() {
+    echo "Executing janetBundleInstallHook"
+
+    runHook preInstall
+
+    target=$out/lib/janet
+
+    # Janet expects the last element in JANET_PATH to be the *syspath*
+    # But we want to preserve the original ordering, so the old syspath needs to be moved to the front
+    if [[ -z "${JANET_PATH-}" ]]; then
+        export JANET_PATH=$target
+    elif [[ "$JANET_PATH" == *:* ]]; then
+        export JANET_PATH="${JANET_PATH##*:}:${JANET_PATH%:*}:$target"
+    else
+        export JANET_PATH="$JANET_PATH:$target"
+    fi
+
+    mkdir -p $target
+    janet --install .
+
+    if [ -d "$target/bin" ]; then
+        ln -s $target/bin $out
+    fi
+
+    if [ -d "$target/man" ]; then
+        ln -s $target/man $out
+    fi
+
+    runHook postInstall
+
+    echo "Finished janetBundleInstallHook"
+}
+
+if [ -z "${installPhase-}" ]; then
+    installPhase=janetBundleInstallHook
+fi

--- a/pkgs/development/interpreters/janet/hooks/bundle-shim-jpm-hook.sh
+++ b/pkgs/development/interpreters/janet/hooks/bundle-shim-jpm-hook.sh
@@ -1,0 +1,20 @@
+# shellcheck shell=bash
+
+janetBundleShimJpmHook() {
+    echo "Executing janetBundleShimJpmHook"
+
+    mkdir bundle
+
+    cat << EOF > bundle/info.jdn
+{:name "$pname"}
+EOF
+
+    cat << EOF > bundle/init.janet
+(use @@spork@/lib/janet/spork/declare-cc)
+(dofile "project.janet" :env (jpm-shim-env))
+EOF
+
+    echo "Finished janetBundleShimJpmHook"
+}
+
+postPatchHooks+=(janetBundleShimJpmHook)

--- a/pkgs/development/interpreters/janet/hooks/default.nix
+++ b/pkgs/development/interpreters/janet/hooks/default.nix
@@ -1,0 +1,14 @@
+{
+  makeSetupHook,
+  spork,
+}:
+{
+  bundleShimJpmHook = makeSetupHook {
+    name = "janet-bundle-shim-jpm-hook";
+    substitutions = { inherit spork; };
+  } ./bundle-shim-jpm-hook.sh;
+
+  bundleInstallHook = makeSetupHook {
+    name = "janet-bundle-install-hook";
+  } ./bundle-install-hook.sh;
+}

--- a/pkgs/development/interpreters/janet/janet.nix
+++ b/pkgs/development/interpreters/janet/janet.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  nix-update-script,
+  pkgsBuildBuild,
+  runCommand,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "janet";
+  version = "1.41.2";
+
+  src = fetchFromGitHub {
+    owner = "janet-lang";
+    repo = "janet";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-sNRhcGG8JysmPHHXeRkYCt7qA75U6flptUEWWun+rDs=";
+  };
+
+  postPatch = ''
+    substituteInPlace janet.1 \
+      --replace /usr/local/ $out/
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # error: Socket is not connected
+    substituteInPlace meson.build \
+      --replace "'test/suite-ev.janet'," ""
+  '';
+
+  depsBuildBuild = [ pkgsBuildBuild.stdenv.cc ];
+  nativeBuildInputs = [
+    meson
+    ninja
+  ];
+
+  mesonBuildType = "release";
+  mesonFlags = [ "-Dgit_hash=release" ];
+
+  doCheck = true;
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    $out/bin/janet -e '(+ 1 2 3)'
+  '';
+
+  passthru = {
+    tests.run =
+      runCommand "janet-test-run"
+        {
+          nativeBuildInputs = [ finalAttrs.finalPackage ];
+        }
+        ''
+          echo "(+ 1 2 3)" | janet | tail -n 1 > arithmeticTest.txt;
+          diff -U3 --color=auto <(cat arithmeticTest.txt) <(echo "6");
+
+          echo "(print \"Hello, World!\")" | janet | tail -n 2 > ioTest.txt;
+          diff -U3 --color=auto <(cat ioTest.txt) <(echo -e "Hello, World!\nnil");
+
+          touch $out;
+        '';
+    updateScript = nix-update-script { };
+  };
+
+  setupHook = ./setup-hook.sh;
+
+  meta = {
+    description = "Janet programming language";
+    mainProgram = "janet";
+    homepage = "https://janet-lang.org/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      peterhoeg
+    ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/development/interpreters/janet/setup-hook.sh
+++ b/pkgs/development/interpreters/janet/setup-hook.sh
@@ -1,0 +1,15 @@
+addJanetBundlePath() {
+    # Janet expects the last element in JANET_PATH to be the *syspath*
+
+    export JANET_PATH="${JANET_PATH:-@out@/lib/janet}"
+
+    if [[ -d "$1/lib/janet" && "${JANET_PATH:+:${JANET_PATH}:}" != *":$1/lib/janet:"* ]]; then
+        if [[ "$JANET_PATH" == *:* ]]; then
+            export JANET_PATH="${JANET_PATH%:*}:$1/lib/janet:${JANET_PATH##*:}"
+        else
+            export JANET_PATH="$1/lib/janet:$JANET_PATH"
+        fi
+    fi
+}
+
+addEnvHooks "$targetOffset" addJanetBundlePath

--- a/pkgs/development/interpreters/janet/spork.nix
+++ b/pkgs/development/interpreters/janet/spork.nix
@@ -1,0 +1,23 @@
+{
+  fetchFromGitHub,
+  buildJanetBundle,
+  lib,
+}:
+buildJanetBundle (finalAttrs: {
+  pname = "spork";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "janet-lang";
+    repo = "spork";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-aAM9USwh3ZifupHVPqu/aFyaLrTGlYnzV/88RDkpLjE=";
+  };
+
+  meta = {
+    description = "Various Janet utility modules - the official \"Contrib\" library.";
+    homepage = "https://github.com/janet-lang/spork";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4460,9 +4460,11 @@ with pkgs;
 
   jacinda = haskell.lib.compose.justStaticExecutables haskellPackages.jacinda;
 
-  janet = callPackage ../development/interpreters/janet { };
-
-  jpm = callPackage ../development/interpreters/janet/jpm.nix { };
+  janetPackages = recurseIntoAttrs (callPackage ../development/interpreters/janet { });
+  inherit (janetPackages)
+    janet
+    jpm
+    ;
 
   lambda-lisp-blc = lambda-lisp;
 


### PR DESCRIPTION
I noticed that Janet support in Nixpkgs was very barebones. Notably, I do not believe that there currently is a convenient way to manage Janet packages from Nix. I believe that a key part of this is that Janet used to relegate package management to an external tool, `jpm`, which came with quite a few caveats. Since then, Janet has standardized into a new system called "bundles", which have been part of its standard library for [over two years now](https://github.com/janet-lang/janet/commit/9c437796d3665cf8bf0754100eece2c372ac5ab9). This PR is a prototype for expanding Janet support in Nixpkgs based on this new system.

@peterhoeg, I believe that you are the current Janet maintainer for Nixpkgs. I would love to have your opinion on this.

## Things done

+ Refactor Janet and JPM into a new scope, `janetPackages`.
+ introduce hooks for installing a Janet bundle, and for shimming a JPM-style project for bundles.
+ Introduce `buildJanetBundle`, a `mkDerivation`-style function based on the above hooks.
+ Add Spork, the official "Contrib" library. 
+ Introduce a setup hook so that Janet packages are added to the `JANET_PATH`.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
