### PR TITLE
emacs: clean a few elisp pkgs

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-common-overrides.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-common-overrides.nix
@@ -323,8 +323,5 @@ in
       '';
   });
 
-  # native-ice https://github.com/mattiase/xr/issues/9
-  xr = ignoreCompilationError super.xr;
-
   # keep-sorted end
 }

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/color-theme-solarized/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/color-theme-solarized/package.nix
@@ -18,9 +18,6 @@ melpaBuild {
 
   files = ''(:defaults (:exclude "color-theme-solarized-pkg.el"))'';
 
-  # https://github.com/NixOS/nixpkgs/issues/335408
-  ignoreCompilationError = true;
-
   meta = {
     homepage = "http://ethanschoonover.com/solarized";
     description = "Precision colors for machines and people; Emacs implementation";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/session-management-for-emacs/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/session-management-for-emacs/package.nix
@@ -7,16 +7,13 @@
 melpaBuild (finalAttrs: {
   pname = "session-management-for-emacs";
   ename = "session";
-  version = "2.2a";
-  melpaVersion = "2.2"; # default value derived from version is not valid for Emacs
+  version = "2.4b";
+  melpaVersion = "2.4"; # default value derived from version is not valid for Emacs
 
   src = fetchzip {
     url = "mirror://sourceforge/emacs-session/session-${finalAttrs.version}.tar.gz";
-    hash = "sha256-lc6NIX+lx97qCs5JqG7x0iVE6ki09Gy7DEQuPW2c+7s=";
+    hash = "sha256-xF/hyUyerZPXgklOn2DElJtbyPZqSG/6S2PPxh971F0=";
   };
-
-  # https://github.com/NixOS/nixpkgs/issues/335421
-  ignoreCompilationError = true;
 
   meta = {
     /*


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

see commit messages for details

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
