### PR TITLE
incus-spawn: 0.2.7 -> 0.2.14

### DIFF
--- a/pkgs/by-name/in/incus-spawn/package.nix
+++ b/pkgs/by-name/in/incus-spawn/package.nix
@@ -14,7 +14,7 @@
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
-  version = "0.2.7";
+  version = "0.2.14";
   pname = "incus-spawn";
 
   src =
@@ -66,15 +66,15 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     sources = {
       "x86_64-linux" = fetchurl {
         url = "https://github.com/Sanne/incus-spawn/releases/download/v${finalAttrs.version}/incus-spawn-linux-amd64";
-        hash = "sha256-jgdNuVfVshbg8piAGGpIy4cnJj5glbsGqOENDBoqpzI=";
+        hash = "sha256-eyz54Ej1NJaTgVJuOPJTZb7zUHpHf5/yJa9RUkEjozs=";
       };
       "aarch64-linux" = fetchurl {
         url = "https://github.com/Sanne/incus-spawn/releases/download/v${finalAttrs.version}/incus-spawn-linux-aarch64";
-        hash = "sha256-Y7OaNgQKAN/HVt75+tawrCtkyZdAHfAiUxx2a0eD5P8=";
+        hash = "sha256-9qDDWimLb/sDtEbJrV4LbtTiWmbRI2jws0lreECbWp8=";
       };
       "aarch64-darwin" = fetchurl {
         url = "https://github.com/Sanne/incus-spawn/releases/download/v${finalAttrs.version}/incus-spawn-macos-aarch64";
-        hash = "sha256-Uv0v7LxIcB0oNEnW1vK9Iy6MOwxoUeqtszGfsS5wt6k=";
+        hash = "sha256-ILGO6CGBWAeyVrkVVOnYZQOqoIYTzogfhk4NMkeY/a4=";
       };
     };
 


### PR DESCRIPTION
Update Incus Spawn from 0.2.7 to 0.2.14 version. Here are intermediate and final release changelogs:

* [0.2.8](https://github.com/Sanne/incus-spawn/releases#release-v0.2.8)
* [0.2.9](https://github.com/Sanne/incus-spawn/releases#release-v0.2.9)
* [0.2.10](https://github.com/Sanne/incus-spawn/releases#release-v0.2.10)
* [0.2.11](https://github.com/Sanne/incus-spawn/releases#release-v0.2.11)
* [0.2.12](https://github.com/Sanne/incus-spawn/releases#release-v0.2.12)
* [0.2.13](https://github.com/Sanne/incus-spawn/releases#release-v0.2.13)
* [0.2.14](https://github.com/Sanne/incus-spawn/releases#release-v0.2.14)

This PR also adds macOS Intel (x86_64) binary that was added in 0.2.13.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [n/a] [NixOS tests] in [nixos/tests]. (CLI tool, no NixOS module)
  - [x] [Package tests] at `passthru.tests`.
  - [n/a] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality. (CLI tool, no NixOS module)
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [n/a] Package update: when the change is major or breaking. (CLI tool, no NixOS module)
- NixOS Release Notes
  - [n/a] Module addition: when adding a new NixOS module. (CLI tool, no NixOS module)
  - [n/a] Module update: when the change is significant. (CLI tool, no NixOS module)
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test