### PR TITLE
python3Packages.wokkel: fix build

### DIFF
--- a/pkgs/development/python-modules/wokkel/default.nix
+++ b/pkgs/development/python-modules/wokkel/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch2,
   setuptools,
   incremental,
   python-dateutil,
@@ -24,6 +25,14 @@ buildPythonPackage rec {
     # Fixes compat with current-day twisted
     # https://github.com/ralphm/wokkel/pull/32 with all the CI & doc changes excluded
     ./0001-Remove-py2-compat.patch
+
+    # Fix test failure with Twisted >= 26
+    # https://github.com/ralphm/wokkel/issues/33
+    (fetchpatch2 {
+      name = "fix-test-for-twisted-26.patch";
+      url = "https://salsa.debian.org/python-team/packages/wokkel/-/raw/f9425d127449a47a7578a01a1b802b7b26b0677f/debian/patches/fix-test-for-twisted-26.patch";
+      hash = "sha256-gyVKKqDCFFXyA5LG0q2p8SWIh9DJCUkdK6slOaYsAw0=";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
Fixes build of sylkserver.
- https://hydra.nixos.org/job/nixpkgs/unstable/python314Packages.wokkel.x86_64-linux
- https://hydra.nixos.org/build/337060888

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
