### PR TITLE
bundlerApp: use `stdenvNoCC.mkDerivation` + `buildCommand` instead of `runCommand`

### DIFF
--- a/pkgs/development/ruby-modules/bundler-app/default.nix
+++ b/pkgs/development/ruby-modules/bundler-app/default.nix
@@ -83,33 +83,33 @@ stdenvNoCC.mkDerivation (
   // {
     inherit (basicEnv) name;
     buildCommand = ''
-  mkdir -p $out/bin
-  ${(lib.concatMapStrings (x: "ln -s '${basicEnv}/bin/${x}' $out/bin/${x};\n") exes)}
-  ${
-    (lib.concatMapStrings (
-      s:
-      "makeWrapper $out/bin/$(basename ${s}) $srcdir/${s} "
-      + "--set BUNDLE_GEMFILE ${basicEnv.confFiles}/Gemfile "
-      + "--unset BUNDLE_PATH "
-      + "--set BUNDLE_FROZEN 1 "
-      + "--set GEM_HOME ${basicEnv}/${ruby.gemPath} "
-      + "--set GEM_PATH ${basicEnv}/${ruby.gemPath} "
-      + "--chdir \"$srcdir\";\n"
-    ) scripts)
-  }
+      mkdir -p $out/bin
+      ${(lib.concatMapStrings (x: "ln -s '${basicEnv}/bin/${x}' $out/bin/${x};\n") exes)}
+      ${
+        (lib.concatMapStrings (
+          s:
+          "makeWrapper $out/bin/$(basename ${s}) $srcdir/${s} "
+          + "--set BUNDLE_GEMFILE ${basicEnv.confFiles}/Gemfile "
+          + "--unset BUNDLE_PATH "
+          + "--set BUNDLE_FROZEN 1 "
+          + "--set GEM_HOME ${basicEnv}/${ruby.gemPath} "
+          + "--set GEM_PATH ${basicEnv}/${ruby.gemPath} "
+          + "--chdir \"$srcdir\";\n"
+        ) scripts)
+      }
 
-  ${lib.optionalString installManpages ''
-    for section in {1..9}; do
-      mandir="$out/share/man/man$section"
+      ${lib.optionalString installManpages ''
+        for section in {1..9}; do
+          mandir="$out/share/man/man$section"
 
-      # See: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/ruby-modules/gem/default.nix#L184-L200
-      # See: https://github.com/rubygems/rubygems/blob/7a7b234721c375874b7e22b1c5b14925b943f04e/bundler/lib/bundler.rb#L285-L291
-      find -L ${basicEnv}/${ruby.gemPath}/${
-        lib.optionalString (basicEnv.gemType == "git" || basicEnv.gemType == "url") "bundler/"
-      }gems/${basicEnv.name} \( -wholename "*/man/*.$section" -o -wholename "*/man/man$section/*.$section" \) -print -execdir mkdir -p $mandir \; -execdir cp '{}' $mandir \;
-    done
-    compressManPages "''${!outputMan}"
-  ''}
+          # See: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/ruby-modules/gem/default.nix#L184-L200
+          # See: https://github.com/rubygems/rubygems/blob/7a7b234721c375874b7e22b1c5b14925b943f04e/bundler/lib/bundler.rb#L285-L291
+          find -L ${basicEnv}/${ruby.gemPath}/${
+            lib.optionalString (basicEnv.gemType == "git" || basicEnv.gemType == "url") "bundler/"
+          }gems/${basicEnv.name} \( -wholename "*/man/*.$section" -o -wholename "*/man/man$section/*.$section" \) -print -execdir mkdir -p $mandir \; -execdir cp '{}' $mandir \;
+        done
+        compressManPages "''${!outputMan}"
+      ''}
     '';
   }
 )

--- a/pkgs/development/ruby-modules/bundler-app/default.nix
+++ b/pkgs/development/ruby-modules/bundler-app/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
+  stdenvNoCC,
   callPackage,
-  runCommand,
   makeWrapper,
   ruby,
 }@defs:
@@ -77,7 +77,12 @@ let
         // passthru;
     };
 in
-runCommand basicEnv.name cmdArgs ''
+stdenvNoCC.mkDerivation (
+  finalAttrs:
+  cmdArgs
+  // {
+    inherit (basicEnv) name;
+    buildCommand = ''
   mkdir -p $out/bin
   ${(lib.concatMapStrings (x: "ln -s '${basicEnv}/bin/${x}' $out/bin/${x};\n") exes)}
   ${
@@ -105,4 +110,6 @@ runCommand basicEnv.name cmdArgs ''
     done
     compressManPages "''${!outputMan}"
   ''}
-''
+    '';
+  }
+)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Restructure `bundlerApp`'s implementation to use `stdenvNoCC.mkDerivation`'s `buildCommand` instead of `runCommand`.

Initial effort for #539137

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
