### PR TITLE
python3Packages.signalslot: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/signalslot/default.nix
+++ b/pkgs/development/python-modules/signalslot/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   contexter,
   eventlet,
   mock,
@@ -13,7 +14,7 @@
 buildPythonPackage rec {
   pname = "signalslot";
   version = "0.2.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
@@ -26,7 +27,9 @@ buildPythonPackage rec {
       --replace "--cov-report html" ""
   '';
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     contexter
     six
   ];

--- a/pkgs/development/python-modules/signalslot/default.nix
+++ b/pkgs/development/python-modules/signalslot/default.nix
@@ -11,20 +11,23 @@
   six,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "signalslot";
   version = "0.2.0";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
-    inherit pname version;
+    pname = "signalslot";
+    inherit (finalAttrs) version;
     hash = "sha256-ZNodibNGfCOa8xd3myN+cRa28rY3/ynNUia1kwjTIOU=";
   };
 
   postPatch = ''
     substituteInPlace setup.cfg \
-      --replace "--pep8 --cov" "" \
-      --replace "--cov-report html" ""
+      --replace-fail "--pep8 --cov" "" \
+      --replace-fail "--cov-report html" ""
   '';
 
   build-system = [ setuptools ];
@@ -53,4 +56,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ myaats ];
   };
-}
+})

--- a/pkgs/development/python-modules/signalslot/default.nix
+++ b/pkgs/development/python-modules/signalslot/default.nix
@@ -37,10 +37,6 @@ buildPythonPackage (finalAttrs: {
     six
   ];
 
-  pythonRemoveDeps = [
-    "weakrefmethod" # needed until https://github.com/Numergy/signalslot/pull/17
-  ];
-
   nativeCheckInputs = [
     eventlet
     mock


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
