### PR TITLE
python3Packages.simanneal: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/simanneal/default.nix
+++ b/pkgs/development/python-modules/simanneal/default.nix
@@ -6,15 +6,17 @@
   pytest,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "simanneal";
   version = "0.5.0";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "perrygeo";
     repo = "simanneal";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-yKZHkrf6fM0WsHczIEK5Kxusz5dSBgydK3fLu1nDyvk=";
   };
 
@@ -23,10 +25,12 @@ buildPythonPackage rec {
   nativeCheckInputs = [ pytest ];
   checkPhase = "pytest tests";
 
+  pythonImportsCheck = [ "simanneal" ];
+
   meta = {
     description = "Python implementation of the simulated annealing optimization technique";
     homepage = "https://github.com/perrygeo/simanneal";
     license = lib.licenses.isc;
     maintainers = with lib.maintainers; [ veprbl ];
   };
-}
+})

--- a/pkgs/development/python-modules/simanneal/default.nix
+++ b/pkgs/development/python-modules/simanneal/default.nix
@@ -2,13 +2,14 @@
   lib,
   fetchFromGitHub,
   buildPythonPackage,
+  setuptools,
   pytest,
 }:
 
 buildPythonPackage rec {
   pname = "simanneal";
   version = "0.5.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "perrygeo";
@@ -16,6 +17,8 @@ buildPythonPackage rec {
     rev = version;
     hash = "sha256-yKZHkrf6fM0WsHczIEK5Kxusz5dSBgydK3fLu1nDyvk=";
   };
+
+  build-system = [ setuptools ];
 
   nativeCheckInputs = [ pytest ];
   checkPhase = "pytest tests";

--- a/pkgs/development/python-modules/simanneal/default.nix
+++ b/pkgs/development/python-modules/simanneal/default.nix
@@ -3,7 +3,7 @@
   fetchFromGitHub,
   buildPythonPackage,
   setuptools,
-  pytest,
+  pytestCheckHook,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -22,8 +22,7 @@ buildPythonPackage (finalAttrs: {
 
   build-system = [ setuptools ];
 
-  nativeCheckInputs = [ pytest ];
-  checkPhase = "pytest tests";
+  nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "simanneal" ];
 


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
