### PR TITLE
xvcd: init at 2026.07.09.e24745d

### DIFF
--- a/pkgs/by-name/xv/xvcd/package.nix
+++ b/pkgs/by-name/xv/xvcd/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  libusb1,
+  libftdi1,
+}:
+
+stdenv.mkDerivation {
+  pname = "xvcd";
+  version = "2026.07.09.e24745d";
+
+  src = fetchFromGitHub {
+    owner = "tmbinc";
+    repo = "xvcd";
+    rev = "e24745d5fe29b52d30e5c08cda4f2ecdf4909abb";
+    hash = "sha256-/O1Oal3RBqCNTgTzvFkq6DkUJH8rHWQyuoCu3e97tro=";
+  };
+
+  buildInputs = [
+    libusb1
+    libftdi1
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv bin/xvcd $out/bin/
+  '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Xilinx Virtual Cable server";
+    homepage = "https://github.com/tmbinc/xvcd";
+    license = lib.licenses.cc0;
+    mainProgram = "xvcd";
+    maintainers = with lib.maintainers; [ feyorsh ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
xvcd is a server that implements the Xilinx Virtual Cable protocol, which lets the server "share" its JTAG connection (to a device plugged in over USB) with a remote Vivado/Vitis process which can be used for flashing bitstreams and the like.

I've never encountered a package that has no version information whatsoever, so I'm unsure if the YYY.MM.DD.SHA format is correct.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

<!-- Message of single commit: -->