### PR TITLE
opentestability: init at 0.0.1

### DIFF
--- a/pkgs/by-name/op/opentestability/package.nix
+++ b/pkgs/by-name/op/opentestability/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "opentestability";
+  version = "0.0.1";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ranaumarnadeem";
+    repo = "OpenTestability";
+    tag = "v${version}";
+    hash = "sha256-ehfH5kaRhMh73vsSKEUqMa5RwW+DMhkPcxIwg0sYFTI=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+    wheel
+    cython
+    numpy
+  ];
+
+  dependencies = with python3Packages; [
+    numpy
+    networkx
+    matplotlib
+    pyyaml
+  ];
+
+  nativeCheckInputs = with python3Packages; [ pytestCheckHook ];
+
+  pythonImportsCheck = [
+    "opentestability"
+    "opentestability.core.scoap._kernels"
+  ];
+
+  # tests/conftest.py prepends the uncompiled src/ onto sys.path, which would
+  # shadow the installed compiled package; neutralise it so the checks run
+  # against the real installed artifact.
+  preCheck = ''
+    substituteInPlace tests/conftest.py \
+      --replace-fail 'sys.path.insert(0, str(PROJECT_ROOT / "src"))' 'pass'
+  '';
+
+  # unit exercises the compiled SCOAP kernel; integration exercises the bundled
+  # s27 netlist. System tests are skipped -- they write to a project-relative
+  # output dir. The "not slow" marker is applied via the project's
+  # tests/pytest.ini, discovered from these paths.
+  pytestFlagsArray = [
+    "tests/unit"
+    "tests/integration"
+  ];
+
+  meta = {
+    description = "SCOAP/COP testability analysis and test-point insertion for gate-level netlists";
+    homepage = "https://github.com/ranaumarnadeem/OpenTestability";
+    changelog = "https://github.com/ranaumarnadeem/OpenTestability/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    mainProgram = "opentest";
+    maintainers = [ ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds `opentestability` at 0.0.1 — a gate-level DFT toolkit: SCOAP/COP testability analysis, reconvergence-aware scoring, and automated test-point insertion over Yosys JSON netlists, built around a compiled Cython SCOAP kernel.

Upstream: https://github.com/ranaumarnadeem/OpenTestability (Apache-2.0). The project also ships its own flake; this packages a tagged release (`v0.0.1`) for nixpkgs.

Packaged as `buildPythonApplication` (the primary artifact is the `opentest` CLI; `meta.mainProgram` is set). `pythonImportsCheck` forces the compiled `_kernels` extension to load, and the check phase runs the unit + integration suites (the unit tests bit-exactly verify the Cython kernel against a pure-Python reference).

## Things done

- Built on platform(s):
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Built the package via `callPackage` against a pinned nixpkgs (24.11) on x86_64-linux — build + `checkPhase` pass (1211 passed / 2 skipped). Upstream flake CI (the same test suite) is green on Linux and macOS. I do **not** have a local nixpkgs checkout, so I have **not** run `nixpkgs-review`; happy for a committer to run it.
- [x] `nix-build` equivalent (callPackage) succeeds.
- [x] Nixpkgs formatting (`nixfmt-rfc-style`) applied.
- [x] `meta` complete: description, homepage, changelog, license (asl20), mainProgram, platforms (linux + darwin).
- `maintainers` is empty for now — I (the upstream author, GitHub `ranaumarnadeem`) am glad to add myself to `maintainers/maintainer-list.nix` if that's preferred before merge.

## Notes for reviewers

- macOS is advertised in `meta.platforms` and CI-tested upstream, but I built only on x86_64-linux here.
- System-level tests are intentionally excluded from `checkPhase` (they write to a project-relative output dir); the compiled kernel and end-to-end SCOAP/COP/TPI paths are covered by the unit + integration suites that do run.