### PR TITLE
nixos/immichframe: harden and fix tests

### DIFF
--- a/nixos/modules/services/web-apps/immichframe.nix
+++ b/nixos/modules/services/web-apps/immichframe.nix
@@ -134,6 +134,40 @@ in
           Type = "simple";
           Restart = "on-failure";
           RestartSec = 3;
+
+          # systemd hardening, based on jellyfin (also .NET) but stricter
+          CapabilityBoundingSet = [ "" ];
+          DevicePolicy = "closed";
+          LockPersonality = true;
+          NoNewPrivileges = true;
+          PrivateDevices = true;
+          PrivateUsers = true;
+          ProcSubset = "pid";
+          ProtectClock = true;
+          ProtectControlGroups = !config.boot.isContainer;
+          ProtectHome = true;
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = !config.boot.isContainer;
+          ProtectKernelTunables = !config.boot.isContainer;
+          ProtectProc = "invisible";
+          ProtectSystem = "strict";
+          # no AF_NETLINK here since there's no network connection monitoring
+          RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+            "AF_UNIX"
+          ];
+          RestrictNamespaces = !config.boot.isContainer;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          SystemCallArchitectures = "native";
+          SystemCallErrorNumber = "EPERM";
+          SystemCallFilter = [
+            "@system-service"
+            "~@privileged"
+          ];
+          UMask = "0077";
         };
       };
   };

--- a/nixos/tests/web-apps/immichframe.nix
+++ b/nixos/tests/web-apps/immichframe.nix
@@ -11,7 +11,10 @@ in
 {
   name = "immichframe";
 
-  meta.maintainers = with lib.maintainers; [ numinit ];
+  meta.maintainers = with lib.maintainers; [
+    numinit
+    jfly
+  ];
 
   enableOCR = true;
 

--- a/nixos/tests/web-apps/immichframe.nix
+++ b/nixos/tests/web-apps/immichframe.nix
@@ -1,9 +1,17 @@
+{
+  lib,
+  ...
+}:
+
 let
   apiKeyFile = "/tmp/immich-api.key";
   customInterval = 5;
+  user = "alice";
 in
 {
   name = "immichframe";
+
+  meta.maintainers = with lib.maintainers; [ numinit ];
 
   enableOCR = true;
 
@@ -15,11 +23,17 @@ in
       ...
     }:
     {
-      imports = [ ../common/x11.nix ];
+      imports = [
+        ../common/user-account.nix
+        ../common/x11.nix
+      ];
 
       # When setting this to 2500 I got "Kernel panic - not syncing: Out of
       # memory: compulsory panic_on_oom is enabled".
       virtualisation.memorySize = 3000;
+      hardware.graphics.enable = true;
+      environment.variables.XAUTHORITY = "/home/${user}/.Xauthority";
+      test-support.displayManager.auto.user = user;
 
       environment.systemPackages = with pkgs; [
         imagemagick
@@ -69,6 +83,7 @@ in
 
     custom_interval = ${toString customInterval}
 
+    machine.wait_for_x()
     machine.wait_for_unit("immich-server.service")
     machine.wait_for_open_port(2283)
 
@@ -133,11 +148,7 @@ in
     assert len(assets) == 2, assets
 
     # Wait for a photo to be displayed.
-    machine.wait_for_x()
-    machine.execute("xterm -e 'firefox --kiosk http://localhost:8002' >&2 &")
-    machine.wait_for_window("immichFrame")
-    _, active_window = machine.execute("xdotool getactivewindow")
-    machine.succeed(f"xdotool windowsize {quote(active_window.strip())} 100% 100%")
+    machine.execute("su - ${user} -c 'firefox --kiosk http://localhost:8002' >&2 & disown")
     machine.wait_for_text('reproduce this moment')
     machine.wait_for_text('with NixOS tests')
     machine.screenshot("screen")


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add systemd hardening options based on jellyfin and fix tests. Will need #540204 first, this was tested on top of it.

closes https://github.com/NixOS/nixpkgs/pull/540174

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
