### PR TITLE
nixos/openlinkhub: add NixOS module

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -352,6 +352,24 @@
   "module-services-opencloud-basic-usage": [
     "index.html#module-services-opencloud-basic-usage"
   ],
+  "module-services-openlinkhub": [
+    "index.html#module-services-openlinkhub"
+  ],
+  "module-services-openlinkhub-web-ui": [
+    "index.html#module-services-openlinkhub-web-ui"
+  ],
+  "module-services-openlinkhub-state": [
+    "index.html#module-services-openlinkhub-state"
+  ],
+  "module-services-openlinkhub-uinput": [
+    "index.html#module-services-openlinkhub-uinput"
+  ],
+  "module-services-openlinkhub-group": [
+    "index.html#module-services-openlinkhub-group"
+  ],
+  "module-services-openlinkhub-limitations": [
+    "index.html#module-services-openlinkhub-limitations"
+  ],
   "module-services-networking-pihole-ftl-configuration-inherit-dnsmasq": [
     "index.html#module-services-networking-pihole-ftl-configuration-inherit-dnsmasq"
   ],

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -22,6 +22,8 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- [OpenLinkHub](https://github.com/jurkovic-nikola/OpenLinkHub), an open-source controller daemon for Corsair iCUE LINK hubs, AIOs and supported HID/USB peripherals, exposing a local web UI for device configuration. Available as [services.hardware.openlinkhub](#opt-services.hardware.openlinkhub.enable).
+
 - [tranquil](https://tangled.org/tranquil.farm/tranquil-pds) is an ATProto PDS (personal data server) implementation in Rust. A featureful, spec conscious and community driven alternative to the Bluesky reference implementation PDS. Available as [services.tranquil-pds](#opt-services.tranquil-pds.enable).
 
 - [scx_loader](https://github.com/sched-ext/scx-loader), a system daemon and DBus-based loader for sched_ext schedulers. `scxctl` is the command-line client for interacting with the loader, allowing users to switch schedulers, modes, and arguments dynamically. Available as [services.scx-loader](#opt-services.scx-loader.enable)

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -695,6 +695,7 @@
   ./services/hardware/monado.nix
   ./services/hardware/nvidia-container-toolkit
   ./services/hardware/nvidia-optimus.nix
+  ./services/hardware/openlinkhub.nix
   ./services/hardware/openrgb.nix
   ./services/hardware/pcscd.nix
   ./services/hardware/pdudaemon.nix

--- a/nixos/modules/services/hardware/openlinkhub.md
+++ b/nixos/modules/services/hardware/openlinkhub.md
@@ -1,0 +1,67 @@
+# OpenLinkHub {#module-services-openlinkhub}
+
+[OpenLinkHub](https://github.com/jurkovic-nikola/OpenLinkHub) is an open-source
+controller daemon for Corsair iCUE LINK hubs, AIOs and other supported HID/USB
+peripherals. It exposes a local web UI for device configuration and control.
+
+To enable OpenLinkHub, add the following to your {file}`configuration.nix`:
+
+```nix
+{
+  services.hardware.openlinkhub.enable = true;
+}
+```
+
+This starts the daemon as a system service under an unprivileged
+`openlinkhub` user, installs the shipped udev rules and grants the daemon
+access to matched Corsair devices via the `openlinkhub` group.
+
+## Web UI {#module-services-openlinkhub-web-ui}
+
+The web UI is served on `http://127.0.0.1:27003` by default. Both listen
+address and port are stored in {file}`/var/lib/openlinkhub/config.json` and
+must be changed through the UI (or by editing the file while the service is
+stopped). If you expose the UI on a non-loopback address, open the
+corresponding port in {option}`networking.firewall.allowedTCPPorts`
+yourself.
+
+## State and data {#module-services-openlinkhub-state}
+
+All runtime state lives in {file}`/var/lib/openlinkhub`:
+
+- {file}`config.json` — daemon settings, rewritten by the UI.
+- {file}`database/` — device presets, LCD images and language files.
+  Seeded from the package on first start and preserved across rebuilds and
+  restarts (the seed uses `cp -n`, so user changes are never overwritten).
+
+## SCUF gamepad emulation {#module-services-openlinkhub-uinput}
+
+SCUF gamepad emulation requires the `uinput` kernel module. It is normally
+autoloaded on access via the shipped udev rule. If it is not, set:
+
+```nix
+{
+  boot.kernelModules = [ "uinput" ];
+}
+```
+
+## Direct device access {#module-services-openlinkhub-group}
+
+Users who need direct access to Corsair devices outside the daemon (for
+example for debugging) can be added to the `openlinkhub` group:
+
+```nix
+{
+  users.users.alice.extraGroups = [ "openlinkhub" ];
+}
+```
+
+## Limitations {#module-services-openlinkhub-limitations}
+
+- **No declarative configuration.** The daemon owns and rewrites
+  {file}`config.json` at runtime, so no NixOS options are provided beyond
+  enabling the service. Configure through the web UI.
+- **No Home Manager module.** OpenLinkHub's user-space installation still
+  requires system-level udev rules, a system group and adding the user to
+  it — all root operations. A pure Home Manager module cannot provide a
+  working setup on its own.

--- a/nixos/modules/services/hardware/openlinkhub.nix
+++ b/nixos/modules/services/hardware/openlinkhub.nix
@@ -1,7 +1,15 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   cfg = config.services.hardware.openlinkhub;
 
+  # Upstream sets OWNER="openlinkhub" in the udev rule, which requires the daemon
+  # to run as root to take ownership of device nodes. We replace it with
+  # GROUP="openlinkhub" so the daemon can run as an unprivileged system user.
   udevRulesPkg = pkgs.runCommand "openlinkhub-udev-rules" { } ''
     install -Dm 644 \
       ${cfg.package}/etc/udev/rules.d/99-openlinkhub.rules \
@@ -12,33 +20,7 @@ let
 in
 {
   options.services.hardware.openlinkhub = {
-    enable = lib.mkEnableOption ''
-      OpenLinkHub, an open-source controller daemon for Corsair iCUE LINK
-      hubs, AIOs and other supported HID/USB peripherals.
-
-      The daemon exposes a local web UI on `http://127.0.0.1:27003` by
-      default. Both `listenAddress` and `listenPort` are configurable in
-      `/var/lib/openlinkhub/config.json` via the web UI; if you expose the
-      UI on a non-loopback address, open the corresponding port in
-      `networking.firewall.allowedTCPPorts` yourself.
-
-      All runtime configuration is owned by the daemon and persisted in
-      `/var/lib/openlinkhub/config.json`, which is rewritten whenever
-      settings change in the web UI. No declarative configuration options
-      are provided; edit settings through the UI or by stopping the service
-      and editing the JSON file directly.
-
-      Device presets, LCD images and language files are seeded from the
-      package into `/var/lib/openlinkhub/database/` on first start and are
-      preserved across rebuilds.
-
-      SCUF gamepad emulation requires the `uinput` kernel module, which is
-      normally autoloaded on access via the shipped udev rule. If not, set
-      `boot.kernelModules = [ "uinput" ]`.
-
-      Users who need direct device access outside the daemon (e.g. for
-      debugging) can be added to the `openlinkhub` group
-    '';
+    enable = lib.mkEnableOption "OpenLinkHub, a controller daemon for Corsair iCUE LINK devices, AIOs and hubs";
 
     package = lib.mkPackageOption pkgs "openlinkhub" { };
   };
@@ -54,15 +36,19 @@ in
     services.udev.packages = [ udevRulesPkg ];
 
     systemd.services.openlinkhub = {
-      description = "OpenLinkHub — Corsair iCUE LINK / AIO / Hub controller";
+      description = "OpenLinkHub - Corsair iCUE LINK / AIO / Hub controller";
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
       wants = [ "dev-usb.device" ];
 
       preStart = ''
+        # web/ and static/ live in the read-only store; symlink them into the
+        # writable StateDirectory so the daemon can serve them at runtime.
         ln -sfnT ${cfg.package}/opt/OpenLinkHub/web web
         ln -sfnT ${cfg.package}/opt/OpenLinkHub/static static
         mkdir -p database
+        # Seed the database on first start. -n (no-clobber) preserves user data
+        # (device profiles, settings) on subsequent restarts and rebuilds.
         cp -rn --no-preserve=mode,ownership \
           ${cfg.package}/opt/OpenLinkHub/database/. database/
         chmod -R u+w database
@@ -76,6 +62,9 @@ in
         User = "openlinkhub";
         Group = "openlinkhub";
         SupplementaryGroups = [ "input" ];
+        # Restart=always handles the residual race between udev rule application
+        # and first device open: if the daemon starts before GROUP="openlinkhub"
+        # is applied to a device node, it fails and retries after RestartSec.
         Restart = "always";
         RestartSec = "5s";
 
@@ -114,5 +103,8 @@ in
     };
   };
 
-  meta.maintainers = [ ];
+  meta = {
+    maintainers = [ ];
+    doc = ./openlinkhub.md;
+  };
 }

--- a/nixos/modules/services/hardware/openlinkhub.nix
+++ b/nixos/modules/services/hardware/openlinkhub.nix
@@ -1,0 +1,118 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.services.hardware.openlinkhub;
+
+  udevRulesPkg = pkgs.runCommand "openlinkhub-udev-rules" { } ''
+    install -Dm 644 \
+      ${cfg.package}/etc/udev/rules.d/99-openlinkhub.rules \
+      $out/lib/udev/rules.d/99-openlinkhub.rules
+    substituteInPlace $out/lib/udev/rules.d/99-openlinkhub.rules \
+      --replace-fail 'OWNER="openlinkhub"' 'GROUP="openlinkhub"'
+  '';
+in
+{
+  options.services.hardware.openlinkhub = {
+    enable = lib.mkEnableOption ''
+      OpenLinkHub, an open-source controller daemon for Corsair iCUE LINK
+      hubs, AIOs and other supported HID/USB peripherals.
+
+      The daemon exposes a local web UI on `http://127.0.0.1:27003` by
+      default. Both `listenAddress` and `listenPort` are configurable in
+      `/var/lib/openlinkhub/config.json` via the web UI; if you expose the
+      UI on a non-loopback address, open the corresponding port in
+      `networking.firewall.allowedTCPPorts` yourself.
+
+      All runtime configuration is owned by the daemon and persisted in
+      `/var/lib/openlinkhub/config.json`, which is rewritten whenever
+      settings change in the web UI. No declarative configuration options
+      are provided; edit settings through the UI or by stopping the service
+      and editing the JSON file directly.
+
+      Device presets, LCD images and language files are seeded from the
+      package into `/var/lib/openlinkhub/database/` on first start and are
+      preserved across rebuilds.
+
+      SCUF gamepad emulation requires the `uinput` kernel module, which is
+      normally autoloaded on access via the shipped udev rule. If not, set
+      `boot.kernelModules = [ "uinput" ]`.
+
+      Users who need direct device access outside the daemon (e.g. for
+      debugging) can be added to the `openlinkhub` group
+    '';
+
+    package = lib.mkPackageOption pkgs "openlinkhub" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.users.openlinkhub = {
+      isSystemUser = true;
+      group = "openlinkhub";
+      description = "OpenLinkHub daemon user";
+    };
+    users.groups.openlinkhub = { };
+
+    services.udev.packages = [ udevRulesPkg ];
+
+    systemd.services.openlinkhub = {
+      description = "OpenLinkHub — Corsair iCUE LINK / AIO / Hub controller";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      wants = [ "dev-usb.device" ];
+
+      preStart = ''
+        ln -sfnT ${cfg.package}/opt/OpenLinkHub/web web
+        ln -sfnT ${cfg.package}/opt/OpenLinkHub/static static
+        mkdir -p database
+        cp -rn --no-preserve=mode,ownership \
+          ${cfg.package}/opt/OpenLinkHub/database/. database/
+        chmod -R u+w database
+      '';
+
+      serviceConfig = {
+        ExecStart = lib.getExe cfg.package;
+        WorkingDirectory = "/var/lib/openlinkhub";
+        StateDirectory = "openlinkhub";
+        StateDirectoryMode = "0750";
+        User = "openlinkhub";
+        Group = "openlinkhub";
+        SupplementaryGroups = [ "input" ];
+        Restart = "always";
+        RestartSec = "5s";
+
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        ProtectClock = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectControlGroups = true;
+        ProtectHostname = true;
+        ProtectProc = "invisible";
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        LockPersonality = true;
+        SystemCallArchitectures = "native";
+        MemoryDenyWriteExecute = true;
+        RestrictAddressFamilies = [
+          "AF_UNIX"
+          "AF_INET"
+          "AF_INET6"
+        ];
+        CapabilityBoundingSet = [ "" ];
+        AmbientCapabilities = [ "" ];
+        DevicePolicy = "closed";
+        DeviceAllow = [
+          "char-hidraw rw"
+          "char-usb_device rw"
+          "/dev/uinput rw"
+        ];
+        UMask = "0027";
+      };
+    };
+  };
+
+  meta.maintainers = [ ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1270,6 +1270,7 @@ in
   openbao = runTest ./openbao.nix;
   opencloud = runTest ./opencloud.nix;
   openldap = runTest ./openldap.nix;
+  openlinkhub = runTest ./openlinkhub.nix;
   openresty-lua = runTest ./openresty-lua.nix;
   opensearch = discoverTests (import ./opensearch.nix);
   opensmtpd = handleTest ./opensmtpd.nix { };

--- a/nixos/tests/openlinkhub.nix
+++ b/nixos/tests/openlinkhub.nix
@@ -1,0 +1,21 @@
+{ pkgs, ... }:
+{
+  name = "openlinkhub";
+  meta.maintainers = [ ];
+
+  nodes.machine =
+    { ... }:
+    {
+      services.hardware.openlinkhub.enable = true;
+    };
+
+  testScript = ''
+    machine.wait_for_unit("openlinkhub.service")
+    machine.wait_for_open_port(27003)
+    machine.succeed("curl -sfL http://127.0.0.1:27003/ >/dev/null")
+    machine.succeed("test -d /var/lib/openlinkhub/database")
+    machine.succeed(
+        "systemctl show -p User --value openlinkhub.service | grep -x openlinkhub"
+    )
+  '';
+}


### PR DESCRIPTION
Add a NixOS module `services.hardware.openlinkhub` for [OpenLinkHub](https://github.com/jurkovic-nikola/OpenLinkHub), an open-source controller daemon for Corsair iCUE LINK hubs, AIOs and supported HID/USB peripherals.

The package is already in nixpkgs but the binary alone is not usable: it requires a systemd service, udev rules, and hardware group permissions.

## What this adds

- `nixos/modules/services/hardware/openlinkhub.nix` — NixOS module
  - `services.hardware.openlinkhub.enable` / `.package`
  - Dedicated `openlinkhub` system user and group
  - Patched udev rules: upstream uses `OWNER="openlinkhub"` (requires root); we replace it with `GROUP="openlinkhub"` so the daemon runs unprivileged
  - `StateDirectory` at `/var/lib/openlinkhub`; `preStart` seeds `database/` from the store on first run (no-clobber, preserves user data)
  - `WorkingDirectory` pointing at the state dir so the daemon finds `web/`, `static/` and `database/` via symlinks
  - Tight systemd sandboxing (`NoNewPrivileges`, `ProtectSystem=strict`, `DevicePolicy=closed`, `DeviceAllow` for hidraw/usb/uinput, etc.)
  - `Restart=always` with 5 s delay to handle the udev-race on first boot
- `nixos/modules/services/hardware/openlinkhub.md` — module documentation
- `nixos/tests/openlinkhub.nix` — NixOS integration test (service starts, port 27003 open, HTTP 200, database seeded, correct user)

## Why no Home Manager module

OpenLinkHub's user-space installation still requires system-level udev rules and a system group — both root operations. A pure Home Manager module cannot provide a working setup on its own; this is documented in the Limitations section.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

> **AI disclosure**: This module was developed with AI assistance (Claude Code). The implementation, logic, and NixOS conventions were reviewed and validated manually, including a VM boot test confirming the service starts, the web UI is reachable on port 27003, and hardware access works.


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
