### PR TITLE
nixosTests.galene.stream: fix test

### DIFF
--- a/nixos/tests/galene.nix
+++ b/nixos/tests/galene.nix
@@ -302,7 +302,10 @@ in
                 + "-re -loop 1 -i /etc/${galeneStreamFeedImage} " # loop of feed image
                 + "-map 0:a -map 1:v " # arrange the output stream to have silent audio & looped video
                 + "-c:a mp2 " # stream audio codec
-                + "-c:v libx264 -pix_fmt yuv420p " # stream video codec
+                # note: Force baseline profile and level 3.1 because the GStreamer openh264dec
+                # plugin in galene-stream rejects higher profiles, and 800x600 resolution exceeds
+                # the macroblock limit for level 3.0, causing the test to drop all video frames.
+                + "-c:v libx264 -profile:v baseline -level 3.1 -pix_fmt yuv420p " # stream video codec
                 + "-f mpegts " # stream format
                 + "'srt://localhost:${toString galeneStreamSrtPort}' "
                 + ">/dev/null 2>&1 &"

--- a/pkgs/by-name/ga/galene-stream/package.nix
+++ b/pkgs/by-name/ga/galene-stream/package.nix
@@ -29,6 +29,10 @@ python3Packages.buildPythonApplication (finalAttrs: {
   postPatch = ''
     substituteInPlace galene_stream/galene.py \
       --replace-fail 'await websockets.connect(status["endpoint"], ssl=ssl_context)' 'await websockets.connect(status["endpoint"], ssl=None if self.insecure else ssl_context)'
+
+    # NOTE: python 3.14 disallows get_event_loop without an active loop, set one
+    substituteInPlace galene_stream/cli.py \
+      --replace-fail 'event_loop = asyncio.get_event_loop()' 'event_loop = asyncio.new_event_loop(); asyncio.set_event_loop(event_loop)'
   '';
 
   strictDeps = true;


### PR DESCRIPTION
It has been failing for a while https://hydra.nixos.org/job/nixos/unstable/nixos.tests.galene.stream.x86_64-linux

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core"
        functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in
      `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and
      other READMEs.
- [x] Follows the [automation/AI policy].
  - I've used google gemini via antigravity-cli (model Gemini 3.1 Pro (High)) to help debug the ffmpeg issue.
  - Added assisted by field in the commit messages.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
