### PR TITLE
equibop: fix missing pipewire, libpulseaudio and glib libraries at runtime

### DIFF
--- a/pkgs/by-name/eq/equibop/package.nix
+++ b/pkgs/by-name/eq/equibop/package.nix
@@ -14,6 +14,7 @@
   autoPatchelfHook,
   bun,
   nodejs,
+  glib,
   withTTS ? true,
   withMiddleClickScroll ? false,
 }:
@@ -130,6 +131,14 @@ stdenv.mkDerivation (finalAttrs: {
   postFixup = ''
     makeWrapper ${electron}/bin/electron $out/bin/equibop \
       --add-flags $out/opt/Equibop/resources/app.asar \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          (lib.getLib stdenv.cc.cc)
+          pipewire
+          libpulseaudio
+          glib
+        ]
+      } \
       ${lib.optionalString withTTS ''
         --run 'if [[ "''${NIXOS_SPEECH:-default}" != "False" ]]; then NIXOS_SPEECH=True; else unset NIXOS_SPEECH; fi' \
         --add-flags "\''${NIXOS_SPEECH:+--enable-speech-dispatcher}" \


### PR DESCRIPTION
I noticed that context menu on tray icon doesn't work on Equibop. In logs i noticed that it spams:
```
[Tray] Failed to load native StatusNotifierItem, falling back to Electron Tray: Error: libstdc++.so.6: cannot open shared object file: No such file or directory
    at process.func [as dlopen] (node:electron/js2c/node_init:2:2630)
    at Module._extensions..node (node:internal/modules/cjs/loader:2022:18)
    at Object.func [as .node] (node:electron/js2c/node_init:2:2857)
    at Module.load (node:internal/modules/cjs/loader:1584:32)
    at Module._load (node:internal/modules/cjs/loader:1386:12)
    at c._load (node:electron/js2c/node_init:2:18060)
    at wrapModuleLoad (node:internal/modules/cjs/loader:262:19)
    at Module.require (node:internal/modules/cjs/loader:1607:12)
    at require (node:internal/modules/helpers:153:16)
    at VesktopMain:104:4398 {
  code: 'ERR_DLOPEN_FAILED'
}
```

So i decided to make this pr to fix those issues. I did test it on machine and it fixed all those issues what i had.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
