### PR TITLE
mediaelch: backport TMDb duplicate include_adult search fix

### DIFF
--- a/pkgs/by-name/me/mediaelch/package.nix
+++ b/pkgs/by-name/me/mediaelch/package.nix
@@ -38,6 +38,15 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/Komet/MediaElch/commit/dbea12fbf2c1fe603819392aa2a181cffa168548.patch";
       hash = "sha256-Lv6rvjKbRNr5XrdZhPyw4S4RRCOnfAGhWgcSLo0gqS8=";
     })
+
+    # fix from: https://github.com/Komet/MediaElch/pull/1995
+    # TMDb rejects a duplicate include_adult query param with HTTP 400 (issue #1992).
+    # Remove once MediaElch > 2.12.0 is released.
+    (fetchpatch {
+      name = "fix-tmdb-duplicate-include-adult.patch";
+      url = "https://github.com/Komet/MediaElch/commit/f68419e746455d3c7eb6d95a4a1da7a6f7a5c505.patch";
+      hash = "sha256-u+ScJDFX2IIpjXV58MCp1uJGx9QU+7cbq+e1qZPMWns=";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
MediaElch 2.12.0 appends the `include_adult` query parameter **twice** to TMDb movie search URLs — once via `getMovieSearchUrl`'s third argument, once via the `UrlParameterMap` in `TmdbMovieSearchJob::doStart`. TMDb rejects the duplicate parameter with **HTTP 400**, surfacing in the UI as `Network Error: Could not load the requested resource` on every movie name search.

This backports the upstream fix ([Komet/MediaElch#1995](https://github.com/Komet/MediaElch/pull/1995), commit [`f68419e`](https://github.com/Komet/MediaElch/commit/f68419e746455d3c7eb6d95a4a1da7a6f7a5c505)), which removes the redundant `UrlParameterMap` entry. The fix is merged upstream but no release `> 2.12.0` has been tagged yet (current dev is `2.12.1-dev`), so a patch is the right shape until a release ships. Remove this patch once MediaElch `> 2.12.0` is released.

Upstream issue: https://github.com/Komet/MediaElch/issues/1992
Upstream PR:    https://github.com/Komet/MediaElch/pull/1995

The patch is fetched with `fetchpatch` (not `fetchpatch2`) because the commit's `.patch` carries short commit hashes in its `index` line; this matches the existing entry in the `patches` list. The URL points at a **merged** commit, so it is stable and will not be garbage-collected.

cc @stunkymonkey

---

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) — none exist for mediaelch
  - [x] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) — the package's `checkPhase` (`unit_test`) runs under the sandbox and passed
- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review rev HEAD`
- [x] Tested basic functionality of all binary files (launched `MediaElch` offscreen; initialized all TMDB/TV scrapers, loaded the media DB, no crash)
- Nixpkgs Release Notes
  - [ ] (Package updates) not a version update; patch fix only — no release-notes entry needed
- NixOS Release Notes
  - [ ] (Module updates) N/A — no module change
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)

## `nixpkgs-review` result

`nix run nixpkgs#nixpkgs-review -- rev HEAD` on `x86_64-linux`:

```
--------- Report for 'x86_64-linux' ---------
2 packages built:
mediaelch mediaelch-qt5
```

Both the qt6 default (`mediaelch`) and the qt5 variant build with the patch applied. No regressions.

## Disclosure

This contribution was prepared with the assistance of an LLM-based coding agent (pi, model `zai-org/glm-5.2`), disclosed via the `Assisted-by:` commit trailer per the nixpkgs AI policy. The change was reviewed and verified by the contributor: built under sandbox, `nixpkgs-review` run, and the binary executed.
