### PR TITLE
python3Packages.sqlalchemy_1_3: create new event loop if not exists

### DIFF
--- a/pkgs/development/python-modules/sqlalchemy/1.3-0001-fix-create-new-event-loop-if-not-exists.patch
+++ b/pkgs/development/python-modules/sqlalchemy/1.3-0001-fix-create-new-event-loop-if-not-exists.patch
@@ -1,0 +1,26 @@
+From 98fd6e87243c6d5992429a9b90426af73dbcc3ff Mon Sep 17 00:00:00 2001
+From: Bart Oostveen <bart@bartoostveen.nl>
+Date: Fri, 10 Jul 2026 13:59:21 +0200
+Subject: [PATCH] fix: create new event loop if not exists
+
+---
+ lib/sqlalchemy/util/_concurrency_py3k.py | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/lib/sqlalchemy/util/_concurrency_py3k.py b/lib/sqlalchemy/util/_concurrency_py3k.py
+index 1e4ffef..5aaf12c 100644
+--- a/lib/sqlalchemy/util/_concurrency_py3k.py
++++ b/lib/sqlalchemy/util/_concurrency_py3k.py
+@@ -190,6 +190,8 @@ def get_event_loop():
+         try:
+             return asyncio.get_running_loop()
+         except RuntimeError:
+-            return asyncio.get_event_loop_policy().get_event_loop()
++            loop = asyncio.new_event_loop()
++            asyncio.set_event_loop(loop)
++            return loop
+     else:
+         return asyncio.get_event_loop()
+-- 
+2.54.0
+

--- a/pkgs/development/python-modules/sqlalchemy/1_3.nix
+++ b/pkgs/development/python-modules/sqlalchemy/1_3.nix
@@ -37,6 +37,8 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-6qAjyqMVrugABHssAQuql3z1YHTAOSm5hARJuJXJJvo=";
   };
 
+  patches = [ ./1.3-0001-fix-create-new-event-loop-if-not-exists.patch ];
+
   postPatch = ''
     sed -i '/tag_build = dev/d' setup.cfg
   '';


### PR DESCRIPTION
This fixes the broken build: https://hydra.nixos.org/build/336830567
See also: https://github.com/NixOS/nixpkgs/pull/528120#issuecomment-4934908836


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
