### PR TITLE
smux: 0.3.1 -> 0.4.0

### DIFF
--- a/pkgs/by-name/sm/smux/package.nix
+++ b/pkgs/by-name/sm/smux/package.nix
@@ -12,16 +12,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "smux";
-  version = "0.3.1";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "Aietes";
     repo = "smux";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-mc7sspGN4Wf8Jn995S/jsZ0v1s5kgJ0ASn9iGbzH13U=";
+    hash = "sha256-oEnlxIRk41hqkoIqcJAIqm5VcGvXJ29M1pfz2tj+S48=";
   };
 
-  cargoHash = "sha256-nUJwIOdVmZR+inDz4kYpPTFXREyZyf891ATed6UFIJo=";
+  cargoHash = "sha256-P4uzdP4eOlL6TDOSzVf8s6U9DyO0HbAdGIcObDC06fU=";
 
   __structuredAttrs = true;
   strictDeps = true;


### PR DESCRIPTION
Version bump for smux, following its 0.4.0 release.

Release notes: https://github.com/Aietes/smux/releases/tag/v0.4.0

Highlights: per-template/project session environment variables (`tmux new-session -e`), an `on_create` lifecycle hook, `smux kill` and `smux clone` commands (including a GitHub repo browser via the optional `gh` CLI), a window-level picker mode, `--json`/`--quiet` scripting flags, and several tmux-targeting correctness fixes.

The new man pages (`smux-kill.1`, `smux-clone.1`) and the updated zsh completion are generated by the existing `postInstall`, no packaging changes needed beyond version and hashes. The optional `gh` dependency is intentionally not added to the PATH wrapper to keep the closure small; smux falls back gracefully without it.

## Things done

- Built on platform(s)
  - [x] aarch64-darwin
- [x] Ran the binary from the build result (`smux --version`, man pages incl. new `smux-kill.1`/`smux-clone.1`, zsh completion, PATH wrapper verified)
- [x] `nixfmt` passes on the changed file
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)