### PR TITLE
nagstamon: Add missing dependencies

### DIFF
--- a/pkgs/by-name/na/nagstamon/package.nix
+++ b/pkgs/by-name/na/nagstamon/package.nix
@@ -41,8 +41,10 @@ python3Packages.buildPythonApplication (finalAttrs: {
     dbus-python
     keyring
     lxml
+    packaging
     psutil
     pyqt6
+    pyqt6-webengine
     pysocks
     python-dateutil
     requests


### PR DESCRIPTION
Adds the python deps

- packaging
- pyqt6-webengine

without which the application no longer launches.

The update in #537942 broke the package on my system.
In detail, the program aborts with `Qt is missing`. 

Concretely, it fails at https://github.com/HenriWahl/Nagstamon/blob/d4e08df335d74e749c3e7476c6d88e21393b3e0b/Nagstamon/qui/qt.py#L55.

I have tested that the component utilizing QTWebengine (Add Server with authentication type "Web" -> in the status page, there will be a button to open a QTWebengine window to authenticate with that server) and it works.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
