### PR TITLE
lib.modules: Add deep options merging to deferredModule

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -854,7 +854,7 @@ let
       );
 
       # Convert an option tree decl to a submodule option decl
-      optionTreeToOption =
+      optionTreeToSubmoduleOption =
         decl:
         if isOption decl.options then
           decl
@@ -868,6 +868,21 @@ let
                 # value that means "whatever the user has declared elsewhere".
                 # This might become obsolete with https://github.com/NixOS/nixpkgs/issues/162398
                 shorthandOnlyDefinesConfig = null;
+              };
+            };
+          };
+
+      # Convert an option tree decl to a deferred module option decl
+      optionTreeToDeferredModuleOption =
+        decl:
+        if isOption decl.options then
+          decl
+        else
+          decl
+          // {
+            options = mkOption {
+              type = types.deferredModuleWith {
+                staticModules = [ { options = decl.options; } ];
               };
             };
           };
@@ -894,8 +909,6 @@ let
             unmatchedDefns = [ ];
           }
         else if optionDecls != [ ] then
-          if
-            all (x: x.options.type.name or null == "submodule") optionDecls
           # Raw options can only be merged into submodules. Merging into
           # attrsets might be nice, but ambiguous. Suppose we have
           # attrset as a `attrsOf submodule`. User declares option
@@ -905,9 +918,17 @@ let
           #  c. reject and require "<name>" as a reminder that it behaves like (b).
           #  d. magically combine (a) and (c).
           # All of the above are merely syntax sugar though.
-          then
+          if all (x: x.options.type.name or null == "submodule") optionDecls then
             let
-              opt = fixupOptionType loc (mergeOptionDecls loc (map optionTreeToOption decls));
+              opt = fixupOptionType loc (mergeOptionDecls loc (map optionTreeToSubmoduleOption decls));
+            in
+            {
+              matchedOptions = evalOptionValue loc opt defns';
+              unmatchedDefns = [ ];
+            }
+          else if all (x: x.options.type.name or null == "deferredModule") optionDecls then
+            let
+              opt = fixupOptionType loc (mergeOptionDecls loc (map optionTreeToDeferredModuleOption decls));
             in
             {
               matchedOptions = evalOptionValue loc opt defns';

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -282,6 +282,7 @@ checkConfigOutput '^true$' config.value.trueFalse ./boolByOr.nix
 checkConfigOutput '^true$' config.value.falseTrue ./boolByOr.nix
 checkConfigOutput '^true$' config.value.trueTrue ./boolByOr.nix
 
+# Submodule deep options
 checkConfigOutput '^1$' config.bare-submodule.nested ./declare-bare-submodule.nix ./declare-bare-submodule-nested-option.nix
 checkConfigOutput '^2$' config.bare-submodule.deep ./declare-bare-submodule.nix ./declare-bare-submodule-deep-option.nix
 checkConfigOutput '^42$' config.bare-submodule.nested ./declare-bare-submodule.nix ./declare-bare-submodule-nested-option.nix ./declare-bare-submodule-deep-option.nix ./define-bare-submodule-values.nix
@@ -475,6 +476,14 @@ checkConfigOutput '"beta"' config.nodes.foo.settingsDict.c ./deferred-module.nix
 # errors from the default module are reported with accurate location
 checkConfigError 'In `the-file-that-contains-the-bad-config.nix, via option default'\'': "bogus"' config.nodes.foo.bottom ./deferred-module.nix
 checkConfigError '.*lib/tests/modules/deferred-module-error.nix, via option deferred [(]:anon-1:anon-1:anon-1[)] does not look like a module.' config.result ./deferred-module-error.nix
+# deep options
+checkConfigOutput '^"merged-default"$' config.final.merged ./declare-deferred-module.nix ./declare-deferred-module-merged-option.nix
+checkConfigOutput '^"nested-default"$' config.final.nested ./declare-deferred-module.nix ./declare-deferred-module-nested-option.nix
+checkConfigOutput '^"deep-default"$' config.final.deep ./declare-deferred-module.nix ./declare-deferred-module-deep-option.nix
+checkConfigOutput '^"merged"$' config.final.merged ./declare-deferred-module.nix ./declare-deferred-module-merged-option.nix ./declare-deferred-module-nested-option.nix ./declare-deferred-module-deep-option.nix ./define-deferred-module-values.nix
+checkConfigOutput '^"nested"$' config.final.nested ./declare-deferred-module.nix ./declare-deferred-module-merged-option.nix ./declare-deferred-module-nested-option.nix ./declare-deferred-module-deep-option.nix ./define-deferred-module-values.nix
+checkConfigOutput '^"deep"$' config.final.deep ./declare-deferred-module.nix ./declare-deferred-module-merged-option.nix ./declare-deferred-module-nested-option.nix ./declare-deferred-module-deep-option.nix ./define-deferred-module-values.nix
+checkConfigError 'The option .deep. in .*/declare-deferred-module-deep-option.nix. is already declared in .*/declare-deferred-module-deep-option-duplicate.nix' config.final.deep ./declare-deferred-module.nix ./declare-deferred-module-deep-option.nix  ./declare-deferred-module-deep-option-duplicate.nix
 
 # Check the file location information is propagated into submodules
 checkConfigOutput the-file.nix config.submodule.internalFiles.0 ./submoduleFiles.nix

--- a/lib/tests/modules/declare-deferred-module-deep-option-duplicate.nix
+++ b/lib/tests/modules/declare-deferred-module-deep-option-duplicate.nix
@@ -1,0 +1,10 @@
+{ lib, ... }:
+let
+  inherit (lib) mkOption types;
+in
+{
+  options.deferred-module.deep = mkOption {
+    type = types.str;
+    default = "deep-default";
+  };
+}

--- a/lib/tests/modules/declare-deferred-module-deep-option.nix
+++ b/lib/tests/modules/declare-deferred-module-deep-option.nix
@@ -1,0 +1,10 @@
+{ lib, ... }:
+let
+  inherit (lib) mkOption types;
+in
+{
+  options.deferred-module.deep = mkOption {
+    type = types.str;
+    default = "deep-default";
+  };
+}

--- a/lib/tests/modules/declare-deferred-module-merged-option.nix
+++ b/lib/tests/modules/declare-deferred-module-merged-option.nix
@@ -1,0 +1,18 @@
+{ lib, ... }:
+let
+  inherit (lib) mkOption types;
+in
+{
+  options.deferred-module = mkOption {
+    type = types.deferredModuleWith {
+      staticModules = [
+        {
+          options.merged = mkOption {
+            type = types.str;
+            default = "merged-default";
+          };
+        }
+      ];
+    };
+  };
+}

--- a/lib/tests/modules/declare-deferred-module-nested-option.nix
+++ b/lib/tests/modules/declare-deferred-module-nested-option.nix
@@ -1,0 +1,12 @@
+{ lib, ... }:
+let
+  inherit (lib) mkOption types;
+in
+{
+  config.deferred-module = {
+    options.nested = mkOption {
+      type = types.str;
+      default = "nested-default";
+    };
+  };
+}

--- a/lib/tests/modules/declare-deferred-module.nix
+++ b/lib/tests/modules/declare-deferred-module.nix
@@ -1,0 +1,16 @@
+{ config, lib, ... }:
+let
+  inherit (lib) mkOption types;
+in
+{
+  options.final = mkOption {
+    type = types.submoduleWith {
+      modules = [ config.deferred-module ];
+    };
+  };
+
+  options.deferred-module = mkOption {
+    type = types.deferredModule;
+    default = { };
+  };
+}

--- a/lib/tests/modules/define-deferred-module-values.nix
+++ b/lib/tests/modules/define-deferred-module-values.nix
@@ -1,0 +1,5 @@
+{
+  deferred-module.merged = "merged";
+  deferred-module.nested = "nested";
+  deferred-module.deep = "deep";
+}


### PR DESCRIPTION
Resolves #540291

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
