### PR TITLE
tests/problems: adjust test code for oldestSupportedRelease=26.05 & fix `maintainerless` kind error in the same domain

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -142,10 +142,11 @@
 
 ### Deprecations {#sec-nixpkgs-release-26.11-lib-deprecations}
 
-- Create the first release note entry in this section!
+- Setting `config.allowBrokenPredicate` is deprecated in favor of
+  using `config.problems.handlers.PackageName.broken = "warn"` (or `=
+  "ignore"`). For more information see [](#sec-allow-broken).
 
 
 ### Additions and Improvements {#sec-nixpkgs-release-26.11-lib-additions-improvements}
 
 - Create the first release note entry in this section!
-

--- a/pkgs/test/problems/cases/allow-broken-predicate-match/default.nix
+++ b/pkgs/test/problems/cases/allow-broken-predicate-match/default.nix
@@ -5,7 +5,7 @@ let
     system = "x86_64-linux";
     overlays = [ ];
     config = {
-      allowBrokenPredicate = attrs: lib.getName attrs == "a";
+      problems.handlers.a.broken = "ignore";
     };
   };
 in

--- a/pkgs/test/problems/cases/invalid-kind-error/expected-stderr
+++ b/pkgs/test/problems/cases/invalid-kind-error/expected-stderr
@@ -1,4 +1,4 @@
 (stack trace truncated; use '--show-trace' to show the full, detailed trace)
 
 error: Refusing to evaluate package 'a-0' in /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-default.nix:11 because it has an invalid meta attrset:
-  - a.meta.problems.invalid: Problem kind invalid, inferred from the problem name, is invalid; expected enum<broken,deprecated,removal>. You can specify an explicit problem kind with `a.meta.problems.invalid.kind`
+  - a.meta.problems.invalid: Problem kind invalid, inferred from the problem name, is invalid; expected enum<broken,deprecated,maintainerless,removal>. You can specify an explicit problem kind with `a.meta.problems.invalid.kind`


### PR DESCRIPTION
In 53cd6f2 the oldestSupportedRelease version was bumped to 26.05 which caused the meta/problems tests to fail because the `config.allowBrokenPredicate` is now deprecated and the code is warning about it.  The same is true for the invalid kind test which was missing the new `maintainerless` kind.

While at it, I also added a changelog entry to document the behaviour.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Tested, as applicable:
  -  [x] `nix build -A tests.problems`
- Nixpkgs Release Notes
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
