### PR TITLE
gnomeExtensions.appindicator: Hardcode gjs path

### DIFF
--- a/pkgs/desktops/gnome/extensions/extensionOverrides.nix
+++ b/pkgs/desktops/gnome/extensions/extensionOverrides.nix
@@ -52,6 +52,14 @@ in
 # the upstream repository's sources.
 super:
 lib.trivial.pipe super [
+  (patchExtension "appindicatorsupport@rgcjonas.gmail.com" (old: {
+    patches = [
+      (replaceVars ./extensionOverridesPatches/appindicatorsupport_at_rgcjonas.gmail.com.patch {
+        gjs = lib.getExe gjs;
+      })
+    ];
+  }))
+
   (patchExtension "apps-menu@gnome-shell-extensions.gcampax.github.com" (old: {
     patches = [
       (replaceVars

--- a/pkgs/desktops/gnome/extensions/extensionOverridesPatches/appindicatorsupport_at_rgcjonas.gmail.com.patch
+++ b/pkgs/desktops/gnome/extensions/extensionOverridesPatches/appindicatorsupport_at_rgcjonas.gmail.com.patch
@@ -1,0 +1,13 @@
+diff --git a/statusNotifierWatcher.js b/statusNotifierWatcher.js
+index c4c3486..67cf761 100644
+--- a/statusNotifierWatcher.js
++++ b/statusNotifierWatcher.js
+@@ -160,7 +160,7 @@ export class StatusNotifierWatcher {
+             extension.path, 'tools', 'busAnalyzer.js',
+         ]);
+ 
+-        const subProcess = Gio.Subprocess.new(['gjs', '-m', busAnalyzer],
++        const subProcess = Gio.Subprocess.new(['@gjs@', '-m', busAnalyzer],
+             Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE);
+ 
+         const stdOut = subProcess.get_stdout_pipe();


### PR DESCRIPTION
Fixes the following error:

    Looking for StatusNotifierItem's: GLib.SpawnError: Failed to execute child process “gjs” (No such file or directory)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
