### PR TITLE
doc/style.css: add pill background to inline-code

### DIFF
--- a/doc/style.css
+++ b/doc/style.css
@@ -114,7 +114,7 @@ html {
 body {
   font-size: 1rem;
   font-family: "Roboto", sans-serif;
-  font-weight: 300;
+  font-weight: 400;
   color: var(--main-text-color);
   background-color: var(--background);
   min-height: 100vh;
@@ -264,13 +264,9 @@ code {
 }
 
 code {
-  color: #ff8657;
-  background: #f4f4f4;
-  display: inline-block;
-  padding: 0 0.5rem;
-  border: 1px solid #d8d8d8;
-  border-radius: 0.5rem;
-  line-height: 1.57777778;
+  padding: 0.2em 0.4em;
+  background: var(--inline-code-background);
+  border-radius: 0.375rem;
 }
 
 div.book .programlisting,
@@ -378,11 +374,6 @@ div.appendix dt {
 
 div.book code,
 div.appendix code {
-  padding: 0;
-  border: 0;
-  background-color: inherit;
-  color: inherit;
-  font-size: 100%;
   -webkit-hyphens: none;
   -moz-hyphens: none;
   hyphens: none;
@@ -441,6 +432,7 @@ div.appendix .variablelist .term {
   --caution-background: #ffebe8;
   --codeblock-background: #f2f8fd;
   --codeblock-text-color: #000;
+  --inline-code-background: #818b981f;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -466,6 +458,7 @@ div.appendix .variablelist .term {
     --caution-background: #422522;
     --codeblock-background: #393939;
     --codeblock-text-color: #fff;
+    --inline-code-background: #656c7633;
   }
 
   :is(.note, .tip, .warning, .caution, .important) {
@@ -476,7 +469,12 @@ div.appendix .variablelist .term {
 
 @font-face {
   font-family: Roboto;
-  src: url(Roboto.ttf);
+  src:
+    url(Roboto.ttf) format("truetype") tech(variations),
+    url(Roboto.ttf) format("truetype-variations");
+  font-weight: 100 900;
+  font-style: normal;
+  font-display: swap;
 }
 
 .chapter {


### PR DESCRIPTION
Inline code should fullfill the following two criterias:

- Pass WCAG AA readability.
- Emphasize copy/recall of technical names.

Before: inline-code looks like randomly bolded text.

After:

<img width="1312" height="116" alt="image" src="https://github.com/user-attachments/assets/fd1350b8-6663-4f48-aaa7-077b32cf0879" />

Note: I have also adjusted prose readability (default font-weight: 400 instead of 300)
For a text heavy site using a light font by default hurts accessibility.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
