### PR TITLE
nixos/testing: allow `meta.teams` in tests, fix maintainer pings for tests

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -2294,6 +2294,9 @@
   "test-opt-meta.hydraPlatforms": [
     "index.html#test-opt-meta.hydraPlatforms"
   ],
+  "test-opt-meta.teams": [
+    "index.html#test-opt-meta.teams"
+  ],
   "test-opt-meta.timeout": [
     "index.html#test-opt-meta.timeout"
   ],

--- a/nixos/lib/testing/meta.nix
+++ b/nixos/lib/testing/meta.nix
@@ -1,6 +1,20 @@
-{ lib, ... }:
+{ lib, options, ... }:
 let
   inherit (lib) types mkOption literalMD;
+
+  # Approximate position of meta.teams / meta.maintainers in nixos tests.
+  # Right now this assumes only one such position and ignores other definitions.
+  # FIXME allow having multiple `maintainersPosition` et al..
+  getPosition =
+    definitionsWithLocations:
+    if definitionsWithLocations == [ ] then
+      null
+    else
+      {
+        file = (lib.head definitionsWithLocations).file;
+        column = 0;
+        line = 1;
+      };
 in
 {
   options = {
@@ -12,7 +26,7 @@ in
       '';
       apply = lib.filterAttrs (k: v: v != null);
       type = types.submodule (
-        { config, ... }:
+        { options, config, ... }:
         {
           options = {
             maintainers = mkOption {
@@ -21,6 +35,25 @@ in
               description = ''
                 The [list of maintainers](https://nixos.org/manual/nixpkgs/stable/#var-meta-maintainers) for this test.
               '';
+            };
+            maintainersPosition = mkOption {
+              internal = true;
+              readOnly = true;
+              type = types.nullOr types.attrs;
+              default = getPosition options.maintainers.definitionsWithLocations;
+            };
+            teams = mkOption {
+              type = types.listOf types.raw;
+              default = [ ];
+              description = ''
+                The [list of maintainer-teams](https://nixos.org/manual/nixpkgs/stable/#var-meta-teams) for this test.
+              '';
+            };
+            teamsPosition = mkOption {
+              internal = true;
+              readOnly = true;
+              type = types.nullOr types.attrs;
+              default = getPosition options.teams.definitionsWithLocations;
             };
             timeout = mkOption {
               type = types.nullOr types.int;


### PR DESCRIPTION
With this patch I essentially get the expected list of maintainers for changes in nixos-tests.

The downside of this approach is that the CI facility assumes that there's at most a single definition of `meta.maintainers`, however it can be more in a module-system context.

For simplicity, just use the first definition location for the time being.

Verified with

    let
      lib = import ./lib;
      maintainers = import ./ci/eval/compare/maintainers.nix { inherit lib; };
    in
    maintainers {
      changedFiles = [
	"nixos/tests/matrix/matrix-authentication-service.nix"
      ];
      affectedAttrPaths = map (lib.splitString ".") [
	"nixosTests.matrix-authentication-service"
      ];
    }


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
