### PR TITLE
azure-cli: add ml (AzureML v2) extension

### DIFF
--- a/pkgs/by-name/az/azure-cli/extensions-manual.nix
+++ b/pkgs/by-name/az/azure-cli/extensions-manual.nix
@@ -271,6 +271,24 @@
     meta.maintainers = with lib.maintainers; [ techknowlogick ];
   };
 
+  ml = mkAzExtension rec {
+    pname = "ml";
+    version = "2.44.0";
+    url = "https://github.com/Azure/azure-cli-extensions/releases/download/ml-${version}/ml-${version}-py3-none-any.whl";
+    hash = "sha256-Aqr208ZKEx4dKFSyS8W0pnU9tI2iJNodIYyE7Y03PMk=";
+    description = "Microsoft Azure Machine Learning Command-Line Tools";
+    propagatedBuildInputs = with python3Packages; [
+      azure-ai-ml
+      azure-identity
+      cryptography
+      docker
+    ];
+    # azure-mgmt-resourcegraph only backs a niche subcommand and is not packaged.
+    pythonRemoveDeps = [ "azure-mgmt-resourcegraph" ];
+    pythonRelaxDeps = true;
+    meta.maintainers = with lib.maintainers; [ jfroche ];
+  };
+
   rdbms-connect = mkAzExtension rec {
     pname = "rdbms-connect";
     version = "1.0.7";

--- a/pkgs/development/python-modules/azure-ai-ml/default.nix
+++ b/pkgs/development/python-modules/azure-ai-ml/default.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  setuptools,
+  wheel,
+
+  # dependencies
+  azure-core,
+  azure-mgmt-core,
+  azure-storage-blob,
+  azure-storage-file-datalake,
+  azure-storage-file-share,
+  colorama,
+  isodate,
+  jsonschema,
+  marshmallow,
+  msrest,
+  opentelemetry-api,
+  pydash,
+  pyjwt,
+  pyyaml,
+  strictyaml,
+  tqdm,
+  typing-extensions,
+
+  azure-cli,
+}:
+
+buildPythonPackage rec {
+  pname = "azure-ai-ml";
+  version = "1.34.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "azure_ai_ml";
+    inherit version;
+    hash = "sha256-exHmaklNMoAihH6bk2fbNKdE/7ojohmMe1hwKLKWVyw=";
+  };
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  # Only imported lazily on the App Insights telemetry path.
+  pythonRemoveDeps = [ "azure-monitor-opentelemetry" ];
+
+  dependencies = [
+    azure-core
+    azure-mgmt-core
+    azure-storage-blob
+    azure-storage-file-datalake
+    azure-storage-file-share
+    colorama
+    isodate
+    jsonschema
+    marshmallow
+    msrest
+    opentelemetry-api
+    pydash
+    pyjwt
+    pyyaml
+    strictyaml
+    tqdm
+    typing-extensions
+  ];
+
+  # Tests require network access and additional azureml packages not in nixpkgs.
+  doCheck = false;
+
+  pythonImportsCheck = [ "azure.ai.ml" ];
+
+  meta = {
+    description = "Microsoft Azure Machine Learning Client Library for Python";
+    homepage = "https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/ml/azure-ai-ml";
+    changelog = "https://github.com/Azure/azure-sdk-for-python/blob/azure-ai-ml_${version}/sdk/ml/azure-ai-ml/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = azure-cli.meta.maintainers;
+  };
+}

--- a/pkgs/development/python-modules/marshmallow_3/default.nix
+++ b/pkgs/development/python-modules/marshmallow_3/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  flit-core,
+
+  # tests
+  pytestCheckHook,
+  pytz,
+  simplejson,
+}:
+
+buildPythonPackage rec {
+  pname = "marshmallow";
+  # nixpkgs-update: no auto update
+  version = "3.26.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-5tiv+2y2HTnSZAIJbcCu4S1aJtSQoSHxGNLoHcBxncY=";
+  };
+
+  build-system = [ flit-core ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytz
+    simplejson
+  ];
+
+  disabledTests = [
+    "test_from_timestamp_with_overflow_value"
+  ];
+
+  pythonImportsCheck = [ "marshmallow" ];
+
+  passthru.skipBulkUpdate = true;
+
+  meta = {
+    description = "Library for converting complex objects to and from simple Python datatypes";
+    homepage = "https://github.com/marshmallow-code/marshmallow";
+    changelog = "https://github.com/marshmallow-code/marshmallow/blob/${version}/CHANGELOG.rst";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jfroche ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1710,6 +1710,11 @@ self: super: with self; {
     callPackage ../development/python-modules/azure-ai-documentintelligence
       { };
 
+  azure-ai-ml = callPackage ../development/python-modules/azure-ai-ml {
+    # azure-ai-ml uses marshmallow 3.x only APIs that were removed in 4.x.
+    marshmallow = self.marshmallow_3;
+  };
+
   azure-ai-projects = callPackage ../development/python-modules/azure-ai-projects { };
 
   azure-ai-vision-imageanalysis =

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10110,6 +10110,8 @@ self: super: with self; {
 
   marshmallow-sqlalchemy = callPackage ../development/python-modules/marshmallow-sqlalchemy { };
 
+  marshmallow_3 = callPackage ../development/python-modules/marshmallow_3 { };
+
   mashumaro = callPackage ../development/python-modules/mashumaro { };
 
   masky = callPackage ../development/python-modules/masky { };


### PR DESCRIPTION
Adds the `ml` (AzureML v2) extension to `azure-cli`, so that `az ml ...` works via
`azure-cli.withExtensions [ azure-cli-extensions.ml ]`.

This required packaging the missing dependency substrate:

- **`python3Packages.marshmallow_3`** (3.26.1) — a private legacy pin. `azure-ai-ml` pins
  `marshmallow<4,>=3.5` and uses 3.x-only APIs (`FieldInstanceResolutionError`,
  `from_iso_datetime`) that were removed in 4.x, so relaxing the dep against nixpkgs'
  marshmallow 4.2.0 is not enough. Follows the existing `pyrate-limiter_2` idiom (top-level
  attribute, `skipBulkUpdate`, `nixpkgs-update: no auto update`).
- **`python3Packages.azure-ai-ml`** (1.34.0) — overrides `marshmallow = marshmallow_3`.
  `azure-monitor-opentelemetry` (lazy App-Insights import) is stripped via `pythonRemoveDeps`
  to avoid pulling the large `opentelemetry-instrumentation` closure. Two runtime deps the
  wheel metadata omits but the module imports at load time (`msrest`, `opentelemetry-api`)
  are added.
- **`azure-cli: add ml extension`** — `ml` 2.44.0 wheel; `azure-mgmt-resourcegraph` (niche
  subcommand, not packaged) stripped via `pythonRemoveDeps`, `pythonRelaxDeps` for the pinned
  `azure-identity==1.17.1`.

Version chain: `az` 2.88.0 → `ml` 2.44.0 → `azure-ai-ml` 1.34.0.

Changelogs:
- ml: https://github.com/Azure/azure-cli-extensions/releases/tag/ml-2.44.0
- azure-ai-ml: https://github.com/Azure/azure-sdk-for-python/blob/azure-ai-ml_1.34.0/sdk/ml/azure-ai-ml/CHANGELOG.md

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Verification performed:

- `nix build .#python3Packages.azure-ai-ml` — x86_64-linux and aarch64-linux
- `nix build .#azure-cli-extensions.ml` — x86_64-linux and aarch64-linux
- `azure-cli.withExtensions [ azure-cli-extensions.ml ]` — builds on both platforms,
  `catch-conflicts` and the CLI self-test pass.
- Smoke test: `az extension list` shows `ml 2.44.0`; `az ml --help`, `az ml job create --help`
  and `az ml model create --help` work with no dynamic-install override.
- Offline runtime check: `azure.ai.ml.load_job` deserializes a command-job YAML through the
  `marshmallow` 3.x schema path successfully (this is the API surface that marshmallow 4.x
  removed).
- Live read-only check against a real subscription: authenticated `az ml` list commands
  (workspace / compute / environment) execute end-to-end and return results, exercising the
  full extension → `azure-ai-ml` → ARM → marshmallow response-deserialization path. No
  resources were created or modified.

## Automation/AI disclosure

This contribution was produced with LLM-based AI assistance (Claude Code Opus 4.8), including
this PR summary. A responsible person (@jfroche) reviewed the changes before submission.
Confidence in the output was established via the automated verification above (builds on
x86_64-linux + aarch64-linux, `catch-conflicts`, `az ml` smoke tests, and read-only live
commands) in addition to manual review. Each commit carries an `Assisted-by:` trailer per
the policy.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
