### PR TITLE
arandr: fix build

### DIFF
--- a/pkgs/by-name/ar/arandr/gzip-timestamp-fix.patch
+++ b/pkgs/by-name/ar/arandr/gzip-timestamp-fix.patch
@@ -1,7 +1,8 @@
---- setup.py	2025-04-01 11:24:54.530984662 +0000
-+++ setup.py	2025-04-01 13:54:46.961341548 +0000
- 
-@@ -111,9 +111,11 @@
+diff --git a/setup.py b/setup.py
+index 6e295c8..048db19 100755
+--- a/setup.py
++++ b/setup.py
+@@ -111,9 +111,11 @@ class build_man(NoOptionCommand):
                  info('compressing man page to %s', gzfile)
  
                  if not self.dry_run:
@@ -13,3 +14,6 @@
 +                            compressed.write(manpage)
 +                            compressed.close()
 +                            file.close()
+ 
+ class update_translator_credits(NoOptionCommand):
+     description = 'Examine the git history to produce an updated metadata file.'

--- a/pkgs/by-name/ar/arandr/package.nix
+++ b/pkgs/by-name/ar/arandr/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitLab,
+  fetchpatch,
   python3Packages,
   gobject-introspection,
   gsettings-desktop-schemas,
@@ -30,9 +31,17 @@ buildPythonApplication (finalAttrs: {
     hash = "sha256-nQtfOKAnWKsy2DmvtRGJa4+Y9uGgX41BeHpd9m4d9YA=";
   };
 
-  # patch to set mtime=0 on setup.py
-  patches = [ ./gzip-timestamp-fix.patch ];
-  patchFlags = [ "-p0" ];
+  patches = [
+    # patch to set mtime=0 on setup.py
+    ./gzip-timestamp-fix.patch
+
+    # fixes build with setuptools 81+, while keeping it backwards compatible
+    (fetchpatch {
+      name = "arandr-0.1.11-setuptools-81.patch";
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/x11-misc/arandr/files/arandr-0.1.11-setuptools-81.patch";
+      hash = "sha256-b9U8b4rdkN5lWDVpv50szaVS0rAZVSy7q6IXNVLvq3A=";
+    })
+  ];
 
   nativeBuildInputs = [
     gobject-introspection


### PR DESCRIPTION
Fixes the build failure

```
this derivation will be built:
  /nix/store/ys3wv2li0jypd6n7d42wxd2gj453dvmm-arandr-0.1.11.drv
building '/nix/store/ys3wv2li0jypd6n7d42wxd2gj453dvmm-arandr-0.1.11.drv'...
Sourcing python-remove-tests-dir-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing python-remove-bin-bytecode-hook.sh
Sourcing pypa-build-hook
Using pypaBuildPhase
Sourcing python-runtime-deps-check-hook
Using pythonRuntimeDepsCheckHook
Sourcing pypa-install-hook
Using pypaInstallPhase
Sourcing python-imports-check-hook.sh
Using pythonImportsCheckPhase
Sourcing python-namespaces-hook
Sourcing python-catch-conflicts-hook.sh
Running phase: unpackPhase
unpacking source archive /nix/store/2adfp9g64j4gh9bdk76bkfnwd8c9agmz-source
source root is source
setting SOURCE_DATE_EPOCH to timestamp 315619200 of file "source/unxrandr"
Running phase: patchPhase
applying patch /nix/store/w5yl4ap9nk90y2y2brbsj0l9rf700ams-gzip-timestamp-fix.patch
patching file setup.py
Hunk #1 succeeded at 111 with fuzz 2.
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
no configure script, doing nothing
Running phase: buildPhase
Executing pypaBuildPhase
Creating a wheel...
pypa build flags: --no-isolation --outdir dist/ --wheel
* Getting build dependencies for wheel...
<string>:30: DeprecationWarning: dep_util is Deprecated. Use functions from setuptools instead.
* Building wheel...
<string>:30: DeprecationWarning: dep_util is Deprecated. Use functions from setuptools instead.
Traceback (most recent call last):
  File "/nix/store/48azs8q3m2gc3vgrjlb2i89c12klzsna-python3.14-pyproject-hooks-1.2.0/lib/python3.14/site-packages/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
    main()
    ~~~~^^
  File "/nix/store/48azs8q3m2gc3vgrjlb2i89c12klzsna-python3.14-pyproject-hooks-1.2.0/lib/python3.14/site-packages/pyproject_hooks/_in_process/_in_process.py", line 373, in main
    json_out["return_val"] = hook(**hook_input["kwargs"])
                             ~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/48azs8q3m2gc3vgrjlb2i89c12klzsna-python3.14-pyproject-hooks-1.2.0/lib/python3.14/site-packages/pyproject_hooks/_in_process/_in_process.py", line 280, in build_wheel
    return _build_backend().build_wheel(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        wheel_directory, config_settings, metadata_directory
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/nix/store/g13nfjvdbmszw808xyzvw35in1s30s68-python3.14-setuptools-82.0.1/lib/python3.14/site-packages/setuptools/build_meta.py", line 438, in build_wheel
    return _build(['bdist_wheel'])
  File "/nix/store/g13nfjvdbmszw808xyzvw35in1s30s68-python3.14-setuptools-82.0.1/lib/python3.14/site-packages/setuptools/build_meta.py", line 429, in _build
    return self._build_with_temp_dir(
           ~~~~~~~~~~~~~~~~~~~~~~~~~^
        cmd,
        ^^^^
    ...<3 lines>...
        self._arbitrary_args(config_settings),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/nix/store/g13nfjvdbmszw808xyzvw35in1s30s68-python3.14-setuptools-82.0.1/lib/python3.14/site-packages/setuptools/build_meta.py", line 410, in _build_with_temp_dir
    self.run_setup()
    ~~~~~~~~~~~~~~^^
  File "/nix/store/g13nfjvdbmszw808xyzvw35in1s30s68-python3.14-setuptools-82.0.1/lib/python3.14/site-packages/setuptools/build_meta.py", line 520, in run_setup
    super().run_setup(setup_script=setup_script)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/g13nfjvdbmszw808xyzvw35in1s30s68-python3.14-setuptools-82.0.1/lib/python3.14/site-packages/setuptools/build_meta.py", line 317, in run_setup
    exec(code, locals())
    ~~~~^^^^^^^^^^^^^^^^
  File "<string>", line 238, in <module>
  File "/nix/store/g13nfjvdbmszw808xyzvw35in1s30s68-python3.14-setuptools-82.0.1/lib/python3.14/site-packages/setuptools/_distutils/core.py", line 186, in setup
    return run_commands(dist)
  File "/nix/store/g13nfjvdbmszw808xyzvw35in1s30s68-python3.14-setuptools-82.0.1/lib/python3.14/site-packages/setuptools/_distutils/core.py", line 202, in run_commands
    dist.run_commands()
    ~~~~~~~~~~~~~~~~~^^
  File "/nix/store/g13nfjvdbmszw808xyzvw35in1s30s68-python3.14-setuptools-82.0.1/lib/python3.14/site-packages/setuptools/_distutils/dist.py", line 1000, in run_commands
    self.run_command(cmd)
    ~~~~~~~~~~~~~~~~^^^^^
  File "/nix/store/g13nfjvdbmszw808xyzvw35in1s30s68-python3.14-setuptools-82.0.1/lib/python3.14/site-packages/setuptools/dist.py", line 1107, in run_command
    super().run_command(command)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/nix/store/g13nfjvdbmszw808xyzvw35in1s30s68-python3.14-setuptools-82.0.1/lib/python3.14/site-packages/setuptools/_distutils/dist.py", line 1019, in run_command
    cmd_obj.run()
    ~~~~~~~~~~~^^
  File "/nix/store/g13nfjvdbmszw808xyzvw35in1s30s68-python3.14-setuptools-82.0.1/lib/python3.14/site-packages/setuptools/command/bdist_wheel.py", line 370, in run
    self.run_command("build")
    ~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/nix/store/g13nfjvdbmszw808xyzvw35in1s30s68-python3.14-setuptools-82.0.1/lib/python3.14/site-packages/setuptools/_distutils/cmd.py", line 341, in run_command
    self.distribution.run_command(command)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/nix/store/g13nfjvdbmszw808xyzvw35in1s30s68-python3.14-setuptools-82.0.1/lib/python3.14/site-packages/setuptools/dist.py", line 1107, in run_command
    super().run_command(command)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/nix/store/g13nfjvdbmszw808xyzvw35in1s30s68-python3.14-setuptools-82.0.1/lib/python3.14/site-packages/setuptools/_distutils/dist.py", line 1019, in run_command
    cmd_obj.run()
    ~~~~~~~~~~~^^
  File "<string>", line 203, in run
  File "/nix/store/g13nfjvdbmszw808xyzvw35in1s30s68-python3.14-setuptools-82.0.1/lib/python3.14/site-packages/setuptools/_distutils/command/build.py", line 135, in run
    self.run_command(cmd_name)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/nix/store/g13nfjvdbmszw808xyzvw35in1s30s68-python3.14-setuptools-82.0.1/lib/python3.14/site-packages/setuptools/_distutils/cmd.py", line 341, in run_command
    self.distribution.run_command(command)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/nix/store/g13nfjvdbmszw808xyzvw35in1s30s68-python3.14-setuptools-82.0.1/lib/python3.14/site-packages/setuptools/dist.py", line 1107, in run_command
    super().run_command(command)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/nix/store/g13nfjvdbmszw808xyzvw35in1s30s68-python3.14-setuptools-82.0.1/lib/python3.14/site-packages/setuptools/_distutils/dist.py", line 1019, in run_command
    cmd_obj.run()
    ~~~~~~~~~~~^^
  File "<string>", line 113, in run
AttributeError: 'build_man' object has no attribute 'dry_run'
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
