### PR TITLE
doc/style.css: use major second scale for headings

### DIFF
--- a/doc/style.css
+++ b/doc/style.css
@@ -184,59 +184,52 @@ hr {
   margin-bottom: 1rem;
 }
 
-h1 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   font-weight: 800;
-  line-height: 110%;
-  font-size: 200%;
-  margin-bottom: 1rem;
+  line-height: 1.1;
+  margin: 1.5rem 0 0.5rem;
+}
+
+/*
+  Major-second scale see: https://typescale.com/
+  rounded to .025rem (0.4px)
+*/
+h1 {
+  font-size: 2rem;
   color: var(--heading-color);
 }
 
 h2 {
-  font-weight: 800;
-  line-height: 110%;
-  font-size: 170%;
-  margin-bottom: 0.625rem;
+  font-size: 1.8rem;
   color: var(--heading-color);
-}
-
-h2:not(:first-child) {
-  margin-top: 1rem;
 }
 
 h3 {
-  font-weight: 800;
-  line-height: 110%;
-  margin-bottom: 1rem;
-  font-size: 150%;
+  font-size: 1.6rem;
   color: var(--heading-color);
 }
 
-:is(.note, .tip, .warning, .caution, .important) h3 {
-  font-size: 120%;
-}
-
 h4 {
-  font-weight: 800;
-  line-height: 110%;
-  margin-bottom: 1rem;
-  font-size: 140%;
+  font-size: 1.425rem;
   color: var(--heading-color);
 }
 
 h5 {
-  font-weight: 800;
-  line-height: 110%;
-  margin-bottom: 1rem;
-  font-size: 130%;
+  font-size: 1.275rem;
   color: var(--small-heading-color);
 }
 
 h6 {
-  font-weight: 800;
-  line-height: 110%;
-  margin-bottom: 1rem;
-  font-size: 120%;
+  font-size: 1.125rem;
+}
+
+:is(.note, .tip, .warning, .caution, .important) h3 {
+  font-size: 1.425rem;
 }
 
 strong {
@@ -328,11 +321,6 @@ div.appendix .programlisting {
 .caution {
   color: var(--caution-text-color);
   background: var(--caution-background);
-}
-
-div.book .section,
-div.appendix .section {
-  margin-top: 2em;
 }
 
 div.book div.example,


### PR DESCRIPTION
This PR removes `%` cruft and moves to a simple heading-owned margin model.

This is best practice among web developers: "cuddle-to-content" to emphasize where it belongs to.

See: https://typescale.com/ for the major-second-scale itself


<img width="1268" height="775" alt="image" src="https://github.com/user-attachments/assets/3cb39930-f39d-4ace-a9c6-fd4b12508395" />



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
