### PR TITLE
nixos/matrix-authentication-service: fix loading of extraConfigFiles

### DIFF
--- a/nixos/modules/services/matrix/matrix-authentication-service.nix
+++ b/nixos/modules/services/matrix/matrix-authentication-service.nix
@@ -45,9 +45,7 @@ let
       pruned;
   configFile = format.generate "config.yaml" finalSettings;
 
-  extraConfigFiles = lib.imap0 (
-    i: _: "$CREDENTIALS_DIRECTORY/config-${toString i}"
-  ) cfg.extraConfigFiles;
+  extraConfigFiles = lib.imap0 (i: _: "%d/config-${toString i}") cfg.extraConfigFiles;
   runtimeConfig = "/run/matrix-authentication-service/config.yaml";
 in
 {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
I've made a simple patch to fix the issue with escaping `CREDENTIALS_DIRECTORY` environment variable. After #537261 has been merged, we were using `$CREDENTIALS_DIRECTORY/config-0` and this was wrong because systemd wasn't terminating the variable name with `/` like we should expect. Now the module is using `%d`, which - in case of the service files - is a native placeholder for the credentials directory.

Until this PR will reach relevant branches, users can use this hack to get MAS to work again:
```nix
systemd.services.matrix-authentication-service.serviceConfig.ExecStart = lib.mkForce ''
  ${lib.getExe config.services.matrix-authentication-service.package} server \
    --config /run/matrix-authentication-service/config.yaml \
    --config %d/config-0
'';
```

...and so on for additional `extraConfigFiles`: `--config %d/config-1 --config %d/config-2 ...`.

I've tested this fix on my server, after rebuilding MAS is working fine again without any issues.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
