### PR TITLE
types.path.check: Avoid derivation instantiation

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -742,6 +742,9 @@ checkConfigOutput '^38|27$' options.submoduleLine38.declarationPositions.1.line 
 # nested options work
 checkConfigOutput '^34$' options.nested.nestedLine34.declarationPositions.0.line ./declaration-positions.nix
 
+# types.pathWith in-module assertions
+checkConfigOutput '"ok"' config.assertionsResult ./pathWith.nix
+
 # types.pathWith { inStore = true; }
 checkConfigOutput '".*/store/0lz9p8xhf89kb1c1kk6jxrzskaiygnlh-bash-5.2-p15.drv"' config.pathInStore.ok1 ./pathWith.nix
 checkConfigOutput '".*/store/0fb3ykw9r5hpayd05sr0cizwadzq1d8q-bash-5.2-p15"' config.pathInStore.ok2 ./pathWith.nix

--- a/lib/tests/modules/pathWith.nix
+++ b/lib/tests/modules/pathWith.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ config, lib, ... }:
 let
   inherit (builtins)
     storeDir
@@ -12,6 +12,8 @@ in
   imports = [
     {
       options = {
+        assertionsResult = mkOption { };
+
         pathInStore = mkOption { type = types.lazyAttrsOf (types.pathWith { inStore = true; }); };
         pathNotInStore = mkOption { type = types.lazyAttrsOf (types.pathWith { inStore = false; }); };
         anyPath = mkOption { type = types.lazyAttrsOf (types.pathWith { }); };
@@ -19,6 +21,13 @@ in
           type = types.lazyAttrsOf (
             types.pathWith {
               inStore = false;
+              absolute = true;
+            }
+          );
+        };
+        absolutePath = mkOption {
+          type = types.lazyAttrsOf (
+            types.pathWith {
               absolute = true;
             }
           );
@@ -85,7 +94,21 @@ in
   absolutePathNotInStore.bad1 = "./this/is/relative";
   absolutePathNotInStore.bad2 = "${storeDir}/0fb3ykw9r5hpayd05sr0cizwadzq1d8q-bash-5.2-p15";
 
+  absolutePath.ok1 = "/var/lib/postgresql";
+  absolutePath.ok2 = {
+    type = "derivation";
+    outPath = abort "do not instantiate (via outPath)";
+    drvPath = abort "do not instantiate (via drvPath)";
+    meta.description = "just a test fixture";
+  };
+
   conflictingPathOptionType = "/foo/bar";
 
   impossiblePathOptionType = "/foo/bar";
+
+  assertionsResult =
+    assert config.absolutePath.ok1 == "/var/lib/postgresql";
+    assert config.absolutePath.ok2.type == "derivation";
+    assert config.absolutePath.ok2.meta.description == "just a test fixture";
+    "ok";
 }

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -691,7 +691,7 @@ rec {
               else
                 /. + builtins.unsafeDiscardStringContext x
             );
-            isAbsolute = substring 0 1 (toString x) == "/";
+            isAbsolute = x.type or null == "derivation" || substring 0 1 (toString x) == "/";
             isExpectedType = (
               if inStore == null || inStore then isStringLike x else isString x # Do not allow a true path, which could be copied to the store later on.
             );


### PR DESCRIPTION



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

If the argument is a derivation, applying `toString` forces it to be instantiated to the Nix store, which is expensive when doing an operation that shouldn't instantiate (e.g. `nix flake show` or tab completion on attribute names).

We can avoid that by checking that the argument is a derivation, since then it always represents an absolute path when coerced to a string.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
