### PR TITLE
system.systemBuilderArgs: Use lazyAttrsOf

### DIFF
--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -191,7 +191,13 @@ in
     };
 
     system.systemBuilderArgs = mkOption {
-      type = types.attrsOf types.unspecified;
+      # The laziness of this type is required to keep the WHNF of
+      # `system.build.toplevel` (e.g. its `name` attribute) from forcing
+      # the attribute values, which typically reference store paths.
+      # Attributes whose definitions are disabled by `mkIf` evaluate to
+      # `null` (via the `emptyValue` of `nullOr`) instead of being
+      # removed from the attribute set as `attrsOf` would do.
+      type = types.lazyAttrsOf (types.nullOr types.unspecified);
       internal = true;
       default = { };
       description = ''


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This is to make `baseSystem` (i.e. config.system.build.toplevel) more lazy: evaluating the `name` attribute (e.g. by `nix flake show`) shouldn't cause thousands of derivations to be instantiated.

Unset value from disabled modules are now passed as null attributes, but those are filtered out by `mkDerivation` (due to `__ignoreNulls`) anyway, so this shouldn't change evaluation results.

Assisted-by: Claude Fable 5 <noreply@anthropic.com>



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
