### PR TITLE
config.system.build.toplevel: Make assertions lazier

### DIFF
--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -60,7 +60,8 @@ let
       name = "nixos-system-${config.system.name}-${config.system.nixos.label}";
       preferLocalBuild = true;
       allowSubstitutes = false;
-      buildCommand = systemBuilder;
+      # We handle assertions here so that merely evaluating the name attribute (e.g. in `nix flake show`) doesn't trigger heavy instantiations.
+      buildCommand = lib.asserts.checkAssertWarn config.assertions config.warnings systemBuilder;
 
       systemd = config.systemd.package;
 
@@ -74,9 +75,6 @@ let
     }
   );
 
-  # Handle assertions and warnings
-  baseSystemAssertWarn = lib.asserts.checkAssertWarn config.assertions config.warnings baseSystem;
-
   # Replace runtime dependencies
   system =
     let
@@ -84,7 +82,7 @@ let
     in
     if replacements == [ ] then
       # Avoid IFD if possible, by sidestepping replaceDependencies if no replacements are specified.
-      baseSystemAssertWarn
+      baseSystem
     else
       (pkgs.replaceDependencies.override {
         replaceDirectDependencies = pkgs.replaceDirectDependencies.override {
@@ -92,7 +90,7 @@ let
         };
       })
         {
-          drv = baseSystemAssertWarn;
+          drv = baseSystem;
           inherit replacements cutoffPackages;
         };
 


### PR DESCRIPTION


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Evaluating the name attribute of a NixOS system derivation (e.g. in `nix flake show`) shouldn't trigger the instantiation of thousands of derivations, but checking the module system assertions as a dependency of the WHNF of `toplevel` causes that to happen. So move those assertions under an arbitrary non-name, non-meta attribute (obviously they will still be checked when actually instantiating the system).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
