### PR TITLE
streamlink: fix build

### DIFF
--- a/pkgs/by-name/st/streamlink/package.nix
+++ b/pkgs/by-name/st/streamlink/package.nix
@@ -7,6 +7,7 @@
   extras ? [
     "decompress"
   ],
+  fetchpatch2,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -22,6 +23,12 @@ python3Packages.buildPythonApplication rec {
   patches = [
     (replaceVars ./ffmpeg-path.patch {
       ffmpeg = lib.getExe ffmpeg;
+    })
+    # remove when bumping to >8.4.0
+    (fetchpatch2 {
+      name = "fix-read-timeout-test.patch";
+      url = "https://github.com/streamlink/streamlink/commit/a1875a2c85cef47ddf6b1375c3651d52c8e799a1.patch?full_index=1";
+      hash = "sha256-9C4NedVyuk0ed3JvpKtvxei3Wo+r4SPlQXbBpoRXZ4k=";
     })
   ];
 


### PR DESCRIPTION
Updating requests to 2.34 caused test failure.

Pull upstream patch to fix it. See https://github.com/streamlink/streamlink/pull/6923

Resolves #540335

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
