### PR TITLE
python3Packages.pandas-stubs: 2.3.3.260113 -> 3.0.3.260530

### DIFF
--- a/pkgs/development/python-modules/pandas-stubs/default.nix
+++ b/pkgs/development/python-modules/pandas-stubs/default.nix
@@ -35,14 +35,14 @@
 
 buildPythonPackage rec {
   pname = "pandas-stubs";
-  version = "2.3.3.260113";
+  version = "3.0.3.260530";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pandas-dev";
     repo = "pandas-stubs";
     tag = "v${version}";
-    hash = "sha256-DJS3aG79IZowiTqHeOEgDdlH9Z1SXrbZ7yplCrFTtzw=";
+    hash = "sha256-vPXz4ibNbFE2B14pkGPN5EDAwhA92VgFXzMLR9da6WQ=";
   };
 
   build-system = [ poetry-core ];
@@ -78,12 +78,19 @@ buildPythonPackage rec {
     # Missing dependencies, error and warning checks
     "test_all_read_without_lxml_dtype_backend" # pyarrow.orc
     "test_orc" # pyarrow.orc
+    "test_iceberg" # pyiceberg
     "test_plotting" # UserWarning: No artists with labels found to put in legend.
     "test_spss" # FutureWarning: ChainedAssignmentError: behaviour will change in pandas 3.0!
     "test_show_version"
     # FutureWarning: In the future `np.bool` will be defined as the corresponding...
     "test_timedelta_cmp"
     "test_timestamp_cmp"
+    # DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated
+    "test_timedelta_properties_methods"
+    "test_sparse_dtype"
+    "test_sparse_dtype_fill_value_subtype_compatibility"
+    "test_isna"
+    "test_timedelta_range"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     "test_clipboard" # FileNotFoundError: [Errno 2] No such file or directory: 'pbcopy'


### PR DESCRIPTION
Version bump to match current pandas. I had to disable some tests as well in order to get it to build.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
