### PR TITLE
_1oom: 1.11.8 -> 1.11.9, update source

### DIFF
--- a/pkgs/by-name/_1/_1oom/package.nix
+++ b/pkgs/by-name/_1/_1oom/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitHub,
+  fetchgit,
   gitUpdater,
   autoreconfHook,
   allegro,
@@ -14,18 +14,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "1oom";
-  version = "1.11.8";
+  version = "1.11.9";
 
   outputs = [
     "out"
     "doc"
   ];
 
-  src = fetchFromGitHub {
-    owner = "1oom-fork";
-    repo = "1oom";
+  src = fetchgit {
+    url = "https://git@git.sourcecraft.dev/fork1oom/1oom.git";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Y29Xc8ylXhpQO7dDl7z7XC7+RB4UOIRksZ8RtfaCiEc=";
+    hash = "sha256-tU396z/7qpnhDEFqj/S55e/zeXa5jZFUi2VG3O6SJdY=";
   };
 
   nativeBuildInputs = [
@@ -42,19 +41,19 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   strictDeps = true;
+  __structuredAttrs = true;
   enableParallelBuilding = true;
 
   postInstall = ''
-    install -d $doc/share/doc/1oom
-    install -t $doc/share/doc/1oom \
+    install -Dm644 -t $doc/share/doc/1oom \
       HACKING NEWS PHILOSOPHY README.md doc/*.txt
   '';
 
   passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 
   meta = {
-    homepage = "https://github.com/1oom-fork/1oom";
-    changelog = "https://github.com/1oom-fork/1oom/releases/tag/v${finalAttrs.version}";
+    homepage = "https://fork1oom.sourcecraft.site/";
+    changelog = "https://sourcecraft.dev/fork1oom/1oom/releases/v${finalAttrs.version}";
     description = "Master of Orion (1993) game engine recreation; a more updated fork";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.linux;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
