### PR TITLE
python3Packages.dfdiskcache: relax pandas<3 upper bound

### DIFF
--- a/pkgs/development/python-modules/dfdiskcache/default.nix
+++ b/pkgs/development/python-modules/dfdiskcache/default.nix
@@ -23,6 +23,12 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools ];
 
+  # Upstream pins pandas<3 (still true as of the v0.1.0 tag), but the
+  # package works fine against pandas 3.x; relax the constraint rather
+  # than staying behind on pandas.
+  # https://github.com/thombashi/df-diskcache/blob/v0.1.0/requirements/requirements.txt
+  pythonRelaxDeps = [ "pandas" ];
+
   propagatedBuildInputs = [
     pandas
     simplesqlite


### PR DESCRIPTION
nixpkgs bumped pandas to 3.0.4, which trips df-diskcache's pinned 'pandas<3,>=1' runtime dependency check. Upstream still pins pandas<3 as of the v0.1.0 tag.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
