### PR TITLE
python3Packages.icalendar: fix build failure for python3.12

### DIFF
--- a/pkgs/development/python-modules/icalendar/default.nix
+++ b/pkgs/development/python-modules/icalendar/default.nix
@@ -3,9 +3,11 @@
   buildPythonPackage,
   fetchFromGitHub,
   replaceVars,
+  pythonOlder,
   hatch-vcs,
   hatchling,
   python-dateutil,
+  typing-extensions,
   tzdata,
   hypothesis,
   pyprojectVersionPatchHook,
@@ -36,6 +38,10 @@ buildPythonPackage rec {
   dependencies = [
     python-dateutil
     tzdata
+  ]
+  ++ lib.optionals (pythonOlder "3.13") [
+    # typing.TypeIs arrived in Python 3.13.
+    typing-extensions
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
Error message:

```
Executing pythonRuntimeDepsCheck
Checking runtime dependencies for icalendar-7.2.0-py3-none-any.whl
  - typing-extensions not installed
```

MWE flake.nix:

```
{
  inputs.nixpkgs.url = "github:NixOS/nixpkgs/0bb7ec54c8483066ec9d7720e780a5caa71f8612";

  outputs = { nixpkgs, ... }:
    let
      system = "x86_64-linux";
      pkgs = import nixpkgs { inherit system; };
    in {
      packages.${system} = {
        python312 = pkgs.python312Packages.icalendar;
        python312-fixed = pkgs.python312Packages.icalendar.overridePythonAttrs (old: {
          dependencies = old.dependencies ++ [ pkgs.python312Packages.typing-extensions ];
        });
        python313 = pkgs.python313Packages.icalendar;
        python314 = pkgs.python314Packages.icalendar;
      };
    };
}
```

Build it:

```
for package in python312 python312-fixed python313 python314; do
  if nix build --no-link ".#$package" >/dev/null 2>&1; then
    echo "$package: success"
  else
    echo "$package: failure"
  fi
done
```

Which prints:

```
python312: failure
python312-fixed: success
python313: success
python314: success
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
