### PR TITLE
wayvr: 26.2.1 -> 26.7.1

### DIFF
--- a/pkgs/by-name/wa/wayvr/package.nix
+++ b/pkgs/by-name/wa/wayvr/package.nix
@@ -1,5 +1,6 @@
 {
   alsa-lib,
+  dav1d,
   dbus,
   fetchFromGitHub,
   lib,
@@ -25,16 +26,16 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "wayvr";
-  version = "26.2.1";
+  version = "26.7.1";
 
   src = fetchFromGitHub {
     owner = "wlx-team";
     repo = "wayvr";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-v1Wkelru825KV+ciXD9esLq39oTyMm/Z4rRbN+jjviY=";
+    hash = "sha256-SdHN3jDe2QJaRORy452RP7kTMxPOZOB/yjpApUOLhRU=";
   };
 
-  cargoHash = "sha256-d6iRaOHq+4j90L76bx7+EwCLOY4MxPeqm3ELJ5H9O+8=";
+  cargoHash = "sha256-eGmlFtlorKG7uygLer3UW6ERLQzdugoYyXVSC2sFh+k=";
 
   nativeBuildInputs = [
     pkg-config
@@ -43,6 +44,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   buildInputs = [
     alsa-lib
+    dav1d
     dbus
     libx11
     libxext
@@ -78,6 +80,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   postInstall = ''
     install -D wayvr/wayvr.desktop -t $out/share/applications
     install -D wayvr/wayvr.svg -t $out/share/icons/hicolor/scalable/apps
+
+    rm $out/bin/prost_build
   '';
 
   passthru = {


### PR DESCRIPTION
https://github.com/wayvr-org/wayvr/releases/tag/v26.7.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
