### PR TITLE
matrix-continuwuity: 0.5.10 -> 26.6.1

### DIFF
--- a/nixos/tests/matrix/continuwuity.nix
+++ b/nixos/tests/matrix/continuwuity.nix
@@ -20,61 +20,66 @@ in
       };
       networking.firewall.allowedTCPPorts = [ 6167 ];
     };
+
     client =
       { pkgs, ... }:
       {
         environment.systemPackages = [
-          (pkgs.writers.writePython3Bin "do_test" { libraries = [ pkgs.python3Packages.matrix-nio ]; } ''
+          (pkgs.writers.writePython3Bin "do_test" { libraries = [ pkgs.python3Packages.mautrix ]; } ''
             import asyncio
-            import nio
+
+            from mautrix.client import Client
+            from mautrix.types import EventType, RoomFilter
 
 
             async def main() -> None:
                 # Connect to continuwuity
-                client = nio.AsyncClient("http://continuwuity:6167", "${user}")
+                client = Client(
+                    mxid="@${user}:${name}",
+                    base_url="http://continuwuity:6167",
+                )
 
                 # Log in as user alice
-                response = await client.login("${pass}")
+                await client.login(password="${pass}")
 
                 # Create a new room
-                response = await client.room_create(federate=False)
-                print("Matrix room create response:", response)
-                assert isinstance(response, nio.RoomCreateResponse)
-                room_id = response.room_id
+                room_id = await client.create_room()
+                print("Created room:", room_id)
 
                 # Join the room
-                response = await client.join(room_id)
-                print("Matrix join response:", response)
-                assert isinstance(response, nio.JoinResponse)
+                await client.join_room_by_id(room_id)
+                print("Joined room")
 
                 # Send a message to the room
-                response = await client.room_send(
-                    room_id=room_id,
-                    message_type="m.room.message",
-                    content={
-                        "msgtype": "m.text",
-                        "body": "Hello continuwuity!"
-                    }
-                )
-                print("Matrix room send response:", response)
-                assert isinstance(response, nio.RoomSendResponse)
+                received = asyncio.Event()
+                msg = "Hello continuwuity!"
 
-                # Sync responses
-                response = await client.sync(timeout=30000)
-                print("Matrix sync response:", response)
-                assert isinstance(response, nio.SyncResponse)
+                async def on_message(evt):
+                    if (
+                        evt.room_id != room_id
+                        or evt.sender != client.mxid
+                        or evt.type != EventType.ROOM_MESSAGE
+                    ):
+                        return
 
-                # Check the message was received by continuwuity
-                last_message = response.rooms.join[room_id].timeline.events[-1].body
-                assert last_message == "Hello continuwuity!"
+                    assert evt.content.body == msg
+                    received.set()
+
+                client.add_event_handler(EventType.ROOM_MESSAGE, on_message)
+                sync_task = client.start(RoomFilter(rooms=[room_id]))
+
+                await client.send_text(room_id, msg)
+
+                # Sync until message is received
+                await asyncio.wait_for(received.wait(), timeout=30)
 
                 # Leave the room
-                response = await client.room_leave(room_id)
-                print("Matrix room leave response:", response)
-                assert isinstance(response, nio.RoomLeaveResponse)
+                await client.leave_room(room_id)
+                print("Left room")
 
                 # Close the client
-                await client.close()
+                client.stop()
+                await sync_task
 
 
             if __name__ == "__main__":

--- a/nixos/tests/matrix/continuwuity.nix
+++ b/nixos/tests/matrix/continuwuity.nix
@@ -101,6 +101,7 @@ in
   '';
 
   meta.maintainers = with lib.maintainers; [
+    bartoostveen
     nyabinary
     snaki
   ];

--- a/pkgs/by-name/ma/matrix-continuwuity/package.nix
+++ b/pkgs/by-name/ma/matrix-continuwuity/package.nix
@@ -23,13 +23,13 @@ let
     }).overrideAttrs
       (
         final: old: {
-          version = "10.10.1";
+          version = "11.1.1";
           src = fetchFromGitea {
             domain = "forgejo.ellis.link";
             owner = "continuwuation";
             repo = "rocksdb";
-            rev = "10.10.fb";
-            hash = "sha256-1ef75IDMs5Hba4VWEyXPJb02JyShy5k4gJfzGDhopRk=";
+            rev = "3756b2b905e13216d8b56bcc783d814e7b073aff";
+            hash = "sha256-rSv4fr2bf9JJwdodgeuPCuceeh7k97KVxrAOC0wyPQY=";
           };
 
           patches = [ ];
@@ -38,17 +38,17 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "matrix-continuwuity";
-  version = "0.5.10";
+  version = "26.6.1";
 
   src = fetchFromGitea {
     domain = "forgejo.ellis.link";
     owner = "continuwuation";
     repo = "continuwuity";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-oevEGYlAK/rMJhm200CkwerT5oVak8sJj0Fa6r6+J/Q=";
+    hash = "sha256-sfUxhBPf0P46Xf0lcZFDj23cuZ9apJDyTQPa97jlcSY=";
   };
 
-  cargoHash = "sha256-uvMiFURXxkLbbbwq4pG5hevsLZHQ1wVfTNvzQRTQWxE=";
+  cargoHash = "sha256-Qmw9Xum+Osu/4kbVqJP79gbtimpV2P7SkCMuQWyBYxg=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
- **matrix-continuwuity: 0.5.10 -> 26.6.1**
- **nixos/tests/matrix-continuwuity: refactor to mautrix library**
- **nixos/tests/matrix-continuwuity: add bartoostveen as a maintainer**

Release notes: https://forgejo.ellis.link/continuwuation/continuwuity/releases/tag/v26.6.1 and https://forgejo.ellis.link/continuwuation/continuwuity/releases/tag/v26.6.0
Changelog: https://forgejo.ellis.link/continuwuation/continuwuity/src/commit/v26.6.1/CHANGELOG.md
Diff: https://forgejo.ellis.link/continuwuation/continuwuity/compare/v0.5.10...v26.6.1

Tested new tests against release candidate, will keep drafted until release notes are available and build is verified on my system.

cc @Henry-Hiles

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
