### PR TITLE
python314Packages.samplerate-ledfx: fix Python 3.14 support

### DIFF
--- a/pkgs/development/python-modules/samplerate-ledfx/default.nix
+++ b/pkgs/development/python-modules/samplerate-ledfx/default.nix
@@ -56,6 +56,11 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
   ];
 
+  disabledTestPaths = [
+    # timing sensitive: AssertionError: Expected speedup > 1.0, got 0.68x
+    "tests/test_threading_performance.py::test_conditional_gil_release_large_data_threading"
+  ];
+
   pythonImportsCheck = [ "samplerate" ];
 
   meta = {

--- a/pkgs/development/python-modules/samplerate-ledfx/default.nix
+++ b/pkgs/development/python-modules/samplerate-ledfx/default.nix
@@ -3,12 +3,12 @@
   buildPythonPackage,
   cmake,
   fetchFromGitHub,
+  fetchpatch,
   libsamplerate,
   numpy,
   pybind11,
   pytest-asyncio,
   pytestCheckHook,
-  pythonAtLeast,
   setuptools,
   setuptools-scm,
 }:
@@ -18,14 +18,18 @@ buildPythonPackage (finalAttrs: {
   version = "0.2.6";
   pyproject = true;
 
-  disabled = pythonAtLeast "3.14";
-
   src = fetchFromGitHub {
     owner = "LedFx";
     repo = "python-samplerate-ledfx";
     tag = "v${finalAttrs.version}";
     hash = "sha256-SLmaWSq/Ou23BfdWKlzE9gIfORgF9skUVEw1Tzpd5b4=";
   };
+
+  patches = [
+    # Fix Python 3.14 support based on https://github.com/tuxu/python-samplerate/commit/06e88d1a869db30ce9037498f4dec2f74601d127
+    # but with fixes that it applies
+    ./fix-python3.14-support.diff
+  ];
 
   # unvendor pybind11, libsamplerate
   postPatch = ''

--- a/pkgs/development/python-modules/samplerate-ledfx/fix-python3.14-support.diff
+++ b/pkgs/development/python-modules/samplerate-ledfx/fix-python3.14-support.diff
@@ -1,0 +1,38 @@
+diff --git a/src/samplerate.cpp b/src/samplerate.cpp
+index f0eba25..04f16fd 100644
+--- a/src/samplerate.cpp
++++ b/src/samplerate.cpp
+@@ -268,7 +268,9 @@ class Resampler {
+     // create a shorter view of the array
+     if ((size_t)output_frames_gen < new_size) {
+       out_shape[0] = output_frames_gen;
+-      output.resize(out_shape);
++      return py::array_t<float, py::array::c_style>(
++        out_shape, outbuf.strides, static_cast<float *>(outbuf.ptr),
++        output);
+     } else if ((size_t)output_frames_gen >= new_size) {
+       // This means our fudge factor is too small.
+       throw std::runtime_error("Generated more output samples than expected!");
+@@ -434,7 +436,10 @@ class CallbackResampler {
+     // create a shorter view of the array
+     if (output_frames_gen < frames) {
+       out_shape[0] = output_frames_gen;
+-      output.resize(out_shape);
++      auto strides = std::vector<py::ssize_t>(output.strides(),
++                                              output.strides() + output.ndim());
++      return py::array_t<float, py::array::c_style>(
++        out_shape, strides, static_cast<float *>(outbuf.ptr), output);
+     }
+ 
+     return output;
+@@ -561,7 +566,9 @@ py::array_t<float, py::array::c_style> resample(
+   // create a shorter view of the array
+   if ((size_t)output_frames_gen < new_size) {
+     out_shape[0] = output_frames_gen;
+-    output.resize(out_shape);
++    auto base = output;
++    output = py::array_t<float, py::array::c_style>(
++      out_shape, outbuf.strides, static_cast<float *>(outbuf.ptr), base);
+   } else if ((size_t)output_frames_gen >= new_size) {
+     // This means our fudge factor is too small.
+     throw std::runtime_error("Generated more output samples than expected!");


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
