### PR TITLE
nixos/music-assistant: add port for spotify_connect

### DIFF
--- a/nixos/modules/services/audio/music-assistant.nix
+++ b/nixos/modules/services/audio/music-assistant.nix
@@ -94,7 +94,9 @@ in
           5000 # AirPlay 1/RAOP
           7000 # AirPlay 2
         ]
+        # https://www.music-assistant.io/player-support/sendspin/#connecting-external-sendspin-clients
         ++ lib.optional (lib.elem "sendspin" cfg.providers) 8927
+        # https://www.music-assistant.io/player-support/snapcast/#known-issues--notes
         ++ lib.optional (lib.elem "snapcast" cfg.providers) 1780
         ++ lib.optional (lib.elem "spotify_connect" cfg.providers && cfg.spotifyConnectPort != 0) cfg.spotifyConnectPort
         ++ lib.optionals (lib.elem "squeezelite" cfg.providers) [

--- a/nixos/modules/services/audio/music-assistant.nix
+++ b/nixos/modules/services/audio/music-assistant.nix
@@ -19,6 +19,7 @@ let
     bool
     listOf
     enum
+    port
     str
     ;
 
@@ -75,6 +76,13 @@ in
         List of provider names for which dependencies will be installed.
       '';
     };
+
+    spotifyConnectPort = mkOption {
+      type = port;
+      default = 0;
+      example = 1234;
+      description = "If spotify_connect is used as a provider, this is the port it will listen on and that will be opened in the fireall if openFirewall is true.";
+    };
   };
 
   config = mkIf cfg.enable {
@@ -84,6 +92,7 @@ in
         ++ lib.optional (lib.elem "airplay" cfg.providers) 7000
         ++ lib.optional (lib.elem "sendspin" cfg.providers) 8927
         ++ lib.optional (lib.elem "snapcast" cfg.providers) 1780
+        ++ lib.optional (lib.elem "spotify_connect" cfg.providers && cfg.spotifyConnectPort != 0) cfg.spotifyConnectPort
         ++ lib.optionals (lib.elem "squeezelite" cfg.providers) [
           # https://lyrion.org/reference/slimproto-protocol/
           3483 # Slimproto control
@@ -167,6 +176,9 @@ in
           ]
           ++ cfg.extraOptions
         );
+        Environment = lib.mkIf (lib.elem "spotify_connect" cfg.providers) [
+          "MUSIC_ASSISTANT_SPOTIFY_CONNECT_ZEROCONF_PORT=${toString cfg.spotifyConnectPort}"
+        ];
         DynamicUser = true;
         StateDirectory = "music-assistant";
         AmbientCapabilities = "";

--- a/nixos/modules/services/audio/music-assistant.nix
+++ b/nixos/modules/services/audio/music-assistant.nix
@@ -89,7 +89,11 @@ in
     networking.firewall = lib.mkIf cfg.openFirewall {
       allowedTCPPorts =
         lib.optional cfg.enable 8097 # Music Assistant stream port
-        ++ lib.optional (lib.elem "airplay" cfg.providers) 7000
+        # https://github.com/music-assistant/server/blob/dev/music_assistant/providers/airplay/pairing.py#L191
+        ++ lib.optionals (lib.elem "airplay" cfg.providers) [
+          5000 # AirPlay 1/RAOP
+          7000 # AirPlay 2
+        ]
         ++ lib.optional (lib.elem "sendspin" cfg.providers) 8927
         ++ lib.optional (lib.elem "snapcast" cfg.providers) 1780
         ++ lib.optional (lib.elem "spotify_connect" cfg.providers && cfg.spotifyConnectPort != 0) cfg.spotifyConnectPort

--- a/pkgs/by-name/mu/music-assistant/allow-specifying-port-for-go-librespot.diff
+++ b/pkgs/by-name/mu/music-assistant/allow-specifying-port-for-go-librespot.diff
@@ -1,0 +1,12 @@
+diff --git a/music_assistant/providers/spotify_connect/__init__.py b/music_assistant/providers/spotify_connect/__init__.py
+index 85305a08c..3b2b960e2 100644
+--- a/music_assistant/providers/spotify_connect/__init__.py
++++ b/music_assistant/providers/spotify_connect/__init__.py
+@@ -680,6 +680,7 @@ def _write_config(self) -> None:
+             "volume_steps": VOLUME_STEPS,
+             "initial_volume": initial_volume,
+             "zeroconf_enabled": True,
++            "zeroconf_port": int(os.environ.get("MUSIC_ASSISTANT_SPOTIFY_CONNECT_ZEROCONF_PORT", "0")),
+             "credentials": {"type": "zeroconf", "zeroconf": {"persist_credentials": True}},
+             "server": {"enabled": True, "address": "127.0.0.1", "port": self._api_port},
+         }

--- a/pkgs/by-name/mu/music-assistant/package.nix
+++ b/pkgs/by-name/mu/music-assistant/package.nix
@@ -60,6 +60,10 @@ pythonPackages.buildPythonApplication (finalAttrs: {
     # Look up librespot from PATH at runtime
     ./librespot.patch
 
+    # Allow specifying a port via an env for the port go-librespot listens on instead of using a random one.
+    # If unset, defaults to random port.
+    ./allow-specifying-port-for-go-librespot.diff
+
     # Look up shairport-sync from PATH at runtime
     ./shairport-sync.patch
 


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
