### PR TITLE
waytator: init at 1.2.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23888,6 +23888,14 @@
     githubId = 3302;
     name = "Renzo Carbonara";
   };
+  reo101 = {
+    name = "Pavel Atanasov";
+    email = "pavel.atanasov2001@gmail.com";
+    github = "reo101";
+    githubId = 37866329;
+    matrix = "@reo101:matrix.org";
+    keys = [ { fingerprint = "49B8 3918 36E2 4FEC BC68  7504 7DA9 78E6 383E 5885"; } ];
+  };
   replicapra = {
     name = "replicapra";
     github = "replicapra";

--- a/pkgs/by-name/wa/waytator/package.nix
+++ b/pkgs/by-name/wa/waytator/package.nix
@@ -48,7 +48,10 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Screenshot annotator and lightweight image editor";
     license = lib.licenses.gpl3Plus;
     mainProgram = "waytator";
-    maintainers = with lib.maintainers; [ _74k1 ];
+    maintainers = with lib.maintainers; [
+      _74k1
+      reo101
+    ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/wa/waytator/package.nix
+++ b/pkgs/by-name/wa/waytator/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  gtk4,
+  stdenv,
+  meson,
+  ninja,
+  tesseract,
+  pkg-config,
+  libadwaita,
+  makeWrapper,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "waytator";
+  version = "1.2.4";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "faetalize";
+    repo = "waytator";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/Tq4fVrgss/v/+ugAueWCx1mbQlsyQ0LE4jRtIhT4qU=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    gtk4
+    libadwaita
+  ];
+
+  postFixup = ''
+    wrapProgram $out/bin/waytator \
+      --prefix PATH : ${lib.makeBinPath [ tesseract ]}
+  '';
+
+  mesonBuildType = "release";
+
+  meta = {
+    homepage = "https://github.com/faetalize/waytator";
+    description = "Screenshot annotator and lightweight image editor";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "waytator";
+    maintainers = with lib.maintainers; [ _74k1 ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
https://github.com/faetalize/waytator

A screenshot annotation and lightweight image editing tool for Wayland, built with GTK4 and libadwaita.

Based on https://github.com/faetalize/waytator/pull/1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
