### PR TITLE
 prometheus: 3.13.0 → 3.13.1

### DIFF
--- a/pkgs/by-name/pr/prometheus/source.nix
+++ b/pkgs/by-name/pr/prometheus/source.nix
@@ -1,6 +1,6 @@
 {
-  version = "3.13.0";
-  hash = "sha256-v6jk4MqoxcfK+yj+T31Ovqj1tyh3mc4aEr8BD0vjBOc=";
+  version = "3.13.1";
+  hash = "sha256-DtUdZp/o/tzLjiOZJ3duGqaLoNvkzulbL+wyLnY0dwA=";
   pnpmDepsHash = "sha256-Z1TYYZhELi+rIiuleN8xR/WiMn9TF4KotFMTOsR2e6Y=";
   vendorHash = "sha256-yvzQHfe7yd6Sjh1Vd2VxTp3jK8OWoKTmJ2uMyXX3+xs=";
 }

--- a/pkgs/by-name/pr/prometheus/update.sh
+++ b/pkgs/by-name/pr/prometheus/update.sh
@@ -49,8 +49,21 @@ cat > "$SOURCE_NIX" <<-EOF
 }
 EOF
 
-VENDOR_HASH=$(extractHash prometheus.goModules)
+# Resolve pnpm hash first: the Go integration pulls in the assets, so a fake
+# pnpmDepsHash makes that stage fail.
 PNPM_DEPS_HASH=$(extractHash prometheus.assets.pnpmDeps)
+
+cat > "$SOURCE_NIX" <<-EOF
+{
+  version = "$TARGET_VERSION";
+  hash = "$PREFETCH_HASH";
+  pnpmDepsHash = "$PNPM_DEPS_HASH";
+  vendorHash = "$FAKE_HASH";
+}
+EOF
+
+# Now do the Go module fetch.
+VENDOR_HASH=$(extractHash prometheus.goModules)
 
 cat > "$SOURCE_NIX" <<-EOF
 {


### PR DESCRIPTION
* https://github.com/prometheus/prometheus/releases/tag/v3.13.1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
