### PR TITLE
python313Packages.okta_2: init at 2.9.13

### DIFF
--- a/pkgs/development/python-modules/okta/2.nix
+++ b/pkgs/development/python-modules/okta/2.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  aenum,
+  aiohttp,
+  buildPythonPackage,
+  fetchPypi,
+  flatdict,
+  jwcrypto,
+  pycryptodomex,
+  pydash,
+  pyfakefs,
+  pyjwt,
+  pytest-asyncio,
+  pytest-mock,
+  pytest-recording,
+  pytestCheckHook,
+  pyyaml,
+  setuptools,
+  xmltodict,
+  yarl,
+}:
+
+# gimme-aws-creds 2.8.2 requires okta < 3, but upstream nixpkgs `okta` has
+# already moved to the pydantic-based 3.x rewrite. This pins the last okta 2.x
+# release so gimme-aws-creds keeps building. Remove once gimme-aws-creds
+# releases a version compatible with okta 3.
+buildPythonPackage rec {
+  pname = "okta";
+  version = "2.9.13";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-jY6SZ1G3+NquF5TfLsGw6T9WO4smeBYT0gXLnRDoN+8=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    aenum
+    aiohttp
+    flatdict
+    jwcrypto
+    pycryptodomex
+    pydash
+    pyjwt
+    pyyaml
+    xmltodict
+    yarl
+  ];
+
+  nativeCheckInputs = [
+    pyfakefs
+    pytest-asyncio
+    pytest-mock
+    pytest-recording
+    pytestCheckHook
+  ];
+
+  enabledTestPaths = [ "tests/unit" ];
+
+  disabledTests = [
+    # network access / live-recording related, not replayable from bundled cassettes
+    "test_client_raise_exception"
+    "test_client_invalid_url"
+  ];
+
+  pythonImportsCheck = [
+    "okta"
+    "okta.cache"
+    "okta.client"
+    "okta.config"
+    "okta.errors"
+    "okta.exceptions"
+    "okta.http_client"
+    "okta.models"
+  ];
+
+  # okta must stay at 2.x for gimme-aws-creds, see
+  # https://github.com/NixOS/nixpkgs/pull/494062
+  passthru.skipBulkUpdate = true;
+
+  meta = {
+    description = "Python SDK for the Okta Management API";
+    homepage = "https://github.com/okta/okta-sdk-python";
+    changelog = "https://github.com/okta/okta-sdk-python/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jbgosselin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12031,6 +12031,8 @@ self: super: with self; {
 
   okta = callPackage ../development/python-modules/okta { };
 
+  okta_2 = callPackage ../development/python-modules/okta/2.nix { };
+
   oldest-supported-numpy = callPackage ../development/python-modules/oldest-supported-numpy { };
 
   oldmemo = callPackage ../development/python-modules/oldmemo { };


### PR DESCRIPTION
Adds `python313Packages.okta_2`, pinning the latest okta SDK 2.x release, as suggested in [#494062](https://github.com/NixOS/nixpkgs/pull/494062#issuecomment-4916017922). Motivation: `gimme-aws-creds` requires `okta < 3` (follow-up PR switches it to this attribute).

`passthru.skipBulkUpdate = true` keeps automated updates from bumping it past 2.x; the pin rationale is documented in the file.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test