### PR TITLE
nixos/hyprland: allow root wrapper to be disabled

### DIFF
--- a/nixos/modules/programs/wayland/hyprland.nix
+++ b/nixos/modules/programs/wayland/hyprland.nix
@@ -76,6 +76,16 @@ in
         Enabled by default for Hyprland versions older than 0.41.2.
       '';
     };
+
+    rootWrapper.enable = lib.mkEnableOption null // {
+      description = ''
+        Whether to wrap the `Hyprland` binary and make it owned by the `root` user, and grant CAP_SYS_NICE.
+
+        Disable this option if you need environment variables like `TZDIR` to be preserved as the musl
+        wrapper automatically strips some of these variables.
+      '';
+      default = true;
+    };
   };
 
   config = lib.mkIf cfg.enable (
@@ -91,6 +101,7 @@ in
         # Hyprland needs permissions to give itself SCHED_RR on startup:
         # https://github.com/hyprwm/Hyprland/blob/main/src/init/initHelpers.cpp
         security.wrappers.Hyprland = {
+          inherit (cfg.rootWrapper) enable;
           owner = "root";
           group = "root";
           capabilities = "cap_sys_nice+ep";


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/526193


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
