### PR TITLE
rPackages: fix more dependencies when using strictDeps

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -521,6 +521,7 @@ let
     ];
     animation = [ pkgs.which ];
     apcf = [ pkgs.geos ]; # for geos-config
+    apsimx = [ pkgs.which ];
     arcgisgeocode = with pkgs; [
       cargo
       rustc
@@ -1104,7 +1105,6 @@ let
     ];
     affyPLM = [ pkgs.zlib ];
     affyio = [ pkgs.zlib ];
-    apsimx = [ pkgs.which ];
     arcgisplaces = [ pkgs.openssl ];
     archive = [ pkgs.libarchive ];
     arrangements = with pkgs; [ gmp.dev ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -778,7 +778,6 @@ let
     ];
     jSDM = [ pkgs.gsl ];
     jack = [ pkgs.pkg-config ];
-    jpeg = [ pkgs.libjpeg.dev ];
     jqr = [ pkgs.jq.dev ];
     kza = [ pkgs.pkg-config ];
     leidenAlg = [ pkgs.gmp.dev ];
@@ -1365,6 +1364,7 @@ let
       xz.dev
       bzip2.dev
     ];
+    jpeg = [ pkgs.libjpeg ];
     jqr = [ pkgs.jq.out ];
     knowYourCG = with pkgs; [
       zlib.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -596,8 +596,8 @@ let
     ];
     diseq = [ pkgs.gsl ]; # for gsl-config
     diversitree = [ pkgs.gsl ]; # for gsl-config
-    dynr = [ pkgs.gsl ];
-    eaf = [ pkgs.gsl ];
+    dynr = [ pkgs.gsl ]; # for gsl-config
+    eaf = [ pkgs.gsl ]; # for gsl-config
     exactextractr = [ pkgs.geos ];
     fRLR = [ pkgs.gsl ];
     fangs = with pkgs; [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -825,7 +825,6 @@ let
       cargo
       rustc
     ];
-    trackViewer = [ pkgs.zlib.dev ];
     udunits2 = with pkgs; [
       udunits
       expat

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -709,6 +709,7 @@ let
     ];
     magick = [ pkgs.pkg-config ];
     markets = [ pkgs.gsl ]; # for gsl-config
+    mashr = [ pkgs.gsl ]; # for gsl-config via RcppGSL
     mcrPioda = [ pkgs.gsl ]; # for gsl-config
     mixlink = [ pkgs.gsl ]; # for gsl-config
     mixture = [ pkgs.gsl ]; # for gsl-config
@@ -1320,7 +1321,6 @@ let
     magick = [ pkgs.imagemagick ];
     mappoly = [ pkgs.zlib.dev ];
     markets = [ pkgs.gsl ];
-    mashr = [ pkgs.gsl ];
     matchingMarkets = [ pkgs.zlib.dev ];
     methylKit = with pkgs; [
       zlib.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -595,10 +595,7 @@ let
       rustc
     ];
     diseq = [ pkgs.gsl ]; # for gsl-config
-    diversitree = with pkgs; [
-      gsl
-      fftw
-    ];
+    diversitree = [ pkgs.gsl ]; # for gsl-config
     dynr = [ pkgs.gsl ];
     eaf = [ pkgs.gsl ];
     exactextractr = [ pkgs.geos ];
@@ -1267,6 +1264,7 @@ let
       xz.dev
       bzip2.dev
     ];
+    diversitree = [ pkgs.fftw ];
     divest = [ pkgs.zlib.dev ];
     econetwork = [ pkgs.gsl ];
     eds = [ pkgs.zlib.dev ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -795,7 +795,6 @@ let
     sodium = [ pkgs.pkg-config ];
     spate = [ pkgs.pkg-config ];
     sphereTessellation = [ pkgs.pkg-config ];
-    ssanv = [ pkgs.proj ];
     strawr = with pkgs; [ curl.dev ];
     string2path = [ pkgs.cargo ];
     stringi = [ pkgs.pkg-config ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -660,10 +660,6 @@ let
     ];
     hypergeo2 = [ pkgs.pkg-config ];
     iBMQ = [ pkgs.gsl ]; # for gsl-config
-    image_CannyEdges = with pkgs; [
-      fftw.dev
-      libpng.dev
-    ];
     image_textlinedetector = [ pkgs.pkg-config ];
     imager = [ pkgs.libx11.dev ];
     imbibe = [ pkgs.zlib.dev ];
@@ -1316,6 +1312,10 @@ let
       libtiff
       libjpeg
       zlib
+    ];
+    image_CannyEdges = with pkgs; [
+      fftw
+      libpng
     ];
     image_textlinedetector = [ pkgs.opencv ];
     interpolation = with pkgs; [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -594,7 +594,6 @@ let
       cargo
       rustc
     ];
-    devEMF = with pkgs; [ libxft.dev ];
     diseq = [ pkgs.gsl ];
     diversitree = with pkgs; [
       gsl
@@ -1263,6 +1262,7 @@ let
       bzip2.dev
       zlib.dev
     ];
+    devEMF = [ pkgs.zlib ];
     diffHic = with pkgs; [
       xz.dev
       bzip2.dev
@@ -2394,13 +2394,6 @@ let
     });
 
     dbarts = old.dbarts.override { platforms = lib.platforms.x86_64 ++ lib.platforms.x86; };
-
-    devEMF = old.devEMF.overrideAttrs (attrs: {
-      env = (attrs.env or { }) // {
-        NIX_CFLAGS_LINK = "-L${pkgs.libxft.out}/lib -lXft";
-        NIX_LDFLAGS = "-lX11";
-      };
-    });
 
     enderecobr = old.enderecobr.overrideAttrs (attrs: {
       postPatch = "patchShebangs configure";

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -848,7 +848,7 @@ let
       cargo
       rustc
     ];
-    xml2 = [ pkgs.libxml2.dev ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ pkgs.perl ];
+    xml2 = [ pkgs.pkg-config ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ pkgs.perl ];
     xslt = [ pkgs.pkg-config ];
     ymd = with pkgs; [
       cargo
@@ -1629,6 +1629,7 @@ let
     webp = [ pkgs.libwebp ];
     writexl = with pkgs; [ zlib.dev ];
     xdvir = [ pkgs.freetype ];
+    xml2 = [ pkgs.libxml2 ];
     xslt =
       with pkgs;
       [
@@ -3145,7 +3146,6 @@ let
 
     xml2 = old.xml2.overrideAttrs (attrs: {
       preConfigure = ''
-        export LIBXML_INCDIR=${pkgs.libxml2.dev}/include/libxml2
         patchShebangs configure
       '';
     });

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -433,7 +433,7 @@ let
     ModelMetrics = lib.optional stdenv.hostPlatform.isDarwin pkgs.llvmPackages.openmp;
     PEPBVS = [ pkgs.gsl ]; # for gsl-config
     PICS = [ pkgs.gsl ];
-    QF = [ pkgs.gsl ];
+    QF = [ pkgs.gsl ]; # for gsl-config
     R2SWF = [ pkgs.pkg-config ];
     RAppArmor = [ pkgs.libapparmor ];
     RCurl = [ pkgs.curl ]; # for curl-config

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -514,7 +514,7 @@ let
       which
     ];
     animation = [ pkgs.which ];
-    apcf = with pkgs; [ geos ];
+    apcf = [ pkgs.geos ]; # for geos-config
     arcgisgeocode = with pkgs; [
       cargo
       rustc

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -608,7 +608,6 @@ let
       cargo
       rustc
     ];
-    fastpng = [ pkgs.zlib.dev ];
     fcl = with pkgs; [
       cargo
       rustc
@@ -1273,6 +1272,7 @@ let
       zlib.dev
     ];
     excursions = [ pkgs.gsl ];
+    fastpng = [ pkgs.zlib ];
     fftw = [ pkgs.fftw ];
     fftwtools = [ pkgs.fftw ];
     flan = [ pkgs.gsl ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -740,10 +740,7 @@ let
     redux = [ pkgs.pkg-config ];
     reprex = [ pkgs.which ];
     resultant = [ pkgs.pkg-config ];
-    rgdal = with pkgs; [
-      proj.dev
-      gdal
-    ];
+    rgdal = [ pkgs.gdal ]; # for gdal-config
     rgeos = [ pkgs.geos ];
     rhdf5 = [ pkgs.zlib ];
     ridge = [ pkgs.gsl ];
@@ -1479,6 +1476,7 @@ let
       gmp
       mpfr
     ];
+    rgdal = [ pkgs.proj ];
     rgl = with pkgs; [
       libGLU
       libGL

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -799,7 +799,6 @@ let
     stringi = [ pkgs.pkg-config ];
     survSNP = [ pkgs.gsl ]; # for gsl-config
     surveyvoi = [ pkgs.pkg-config ];
-    svglite = [ pkgs.libpng.dev ];
     symbolicQspray = [ pkgs.pkg-config ];
     sysfonts = [ pkgs.pkg-config ];
     systemfonts = [ pkgs.pkg-config ];
@@ -1560,6 +1559,7 @@ let
       mpfr.dev
     ];
     svKomodo = [ pkgs.which ];
+    svglite = [ pkgs.libpng ];
     symbolicQspray = with pkgs; [
       gmp.dev
       mpfr.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -448,10 +448,6 @@ let
     ];
     RPostgreSQL = with pkgs; [ libpq.pg_config ];
     RProtoBuf = [ pkgs.pkg-config ];
-    RVowpalWabbit = with pkgs; [
-      zlib.dev
-      boost
-    ];
     RationalMatrix = [
       pkgs.pkg-config
       pkgs.gmp.dev
@@ -1122,6 +1118,10 @@ let
       boost.dev
     ];
     RSclient = [ pkgs.openssl ];
+    RVowpalWabbit = with pkgs; [
+      boost
+      zlib
+    ];
     Rarr = [ pkgs.zlib.dev ];
     Rbowtie = with pkgs; [ zlib.dev ];
     Rbowtie2 = [ pkgs.zlib.dev ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -711,10 +711,7 @@ let
     pbdMPI = [ pkgs.mpi ];
     pbdPROF = [ pkgs.mpi ];
     pbdZMQ = [ pkgs.pkg-config ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ pkgs.which ];
-    pcaL1 = [
-      pkgs.pkg-config
-      pkgs.clp
-    ];
+    pcaL1 = [ pkgs.pkg-config ];
     pdftools = [ pkgs.pkg-config ];
     phytools = [ pkgs.which ];
     png = [ pkgs.libpng ]; # for libpng-config
@@ -1404,6 +1401,7 @@ let
     pak = [ pkgs.curl ];
     parseLatex = [ pkgs.icu ];
     pbdZMQ = [ pkgs.zeromq ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ pkgs.darwin.binutils ];
+    pcaL1 = [ pkgs.clp ];
     pdftools = [ pkgs.poppler ];
     pexm = [ pkgs.jags ];
     pgenlibr = [ pkgs.zlib.dev ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -659,7 +659,7 @@ let
       pkgs.cmake
     ];
     hypergeo2 = [ pkgs.pkg-config ];
-    iBMQ = [ pkgs.gsl ];
+    iBMQ = [ pkgs.gsl ]; # for gsl-config
     image_CannyEdges = with pkgs; [
       fftw.dev
       libpng.dev
@@ -1306,6 +1306,7 @@ let
       gmp
       mpfr
     ];
+    iBMQ = [ pkgs.gsl ];
     igraph = with pkgs; [
       gmp
       libxml2.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -557,7 +557,6 @@ let
       protobuf
       which
     ];
-    bio3d = [ pkgs.zlib ];
     bioacoustics = [ pkgs.cmake ];
     blosc = [ pkgs.pkg-config ];
     bnpmr = [ pkgs.gsl ];
@@ -1237,7 +1236,7 @@ let
       protobuf
     ];
     bigsnpr = [ pkgs.zlib.dev ];
-    bio3d = with pkgs; [ zlib.dev ];
+    bio3d = [ pkgs.zlib ];
     bioacoustics = [ pkgs.fftw ];
     blosc = [ pkgs.c-blosc ];
     cairoDevice = [ pkgs.gtk2 ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -684,6 +684,7 @@ let
       pkg-config
       which
     ];
+    island = [ pkgs.gsl ]; # for gsl-config
     jSDM = [ pkgs.gsl ]; # for gsl-config
     jack = [ pkgs.pkg-config ];
     kza = [ pkgs.pkg-config ];
@@ -1268,7 +1269,6 @@ let
       xz.dev
       zlib.dev
     ];
-    island = [ pkgs.gsl.dev ];
     jack = with pkgs; [
       gmp.dev
       mpfr.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -671,7 +671,10 @@ let
     jSDM = [ pkgs.gsl ]; # for gsl-config
     jack = [ pkgs.pkg-config ];
     kza = [ pkgs.pkg-config ];
-    libdeflate = [ pkgs.cmake ];
+    libdeflate = with pkgs; [
+      cmake
+      pkg-config
+    ];
     lpsymphony = with pkgs; [
       pkg-config
       gfortran
@@ -1349,6 +1352,7 @@ let
     landsepi = [ pkgs.gsl ];
     largeList = [ pkgs.zlib.dev ];
     leidenAlg = [ pkgs.gmp ];
+    libdeflate = [ pkgs.libdeflate ];
     libstable4u = [ pkgs.gsl ];
     libstableR = [ pkgs.gsl ];
     littler = with pkgs; [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -952,7 +952,6 @@ let
     tesseract = [ pkgs.pkg-config ];
     textshaping = [ pkgs.pkg-config ];
     themetagenomics = [ pkgs.zlib.dev ];
-    tiff = [ pkgs.libtiff.dev ];
     tinyimg = with pkgs; [
       cargo
       rustc
@@ -1599,6 +1598,7 @@ let
     ];
     tfevents = [ pkgs.protobuf ];
     tidypopgen = [ pkgs.zlib.dev ];
+    tiff = [ pkgs.libtiff ];
     tikzDevice = with pkgs; [
       which
       texliveMedium

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -448,7 +448,6 @@ let
     ];
     RPostgreSQL = with pkgs; [ libpq.pg_config ];
     RProtoBuf = [ pkgs.pkg-config ];
-    RSclient = [ pkgs.openssl.dev ];
     RVowpalWabbit = with pkgs; [
       zlib.dev
       boost
@@ -1122,6 +1121,7 @@ let
       quantlib.dev
       boost.dev
     ];
+    RSclient = [ pkgs.openssl ];
     Rarr = [ pkgs.zlib.dev ];
     Rbowtie = with pkgs; [ zlib.dev ];
     Rbowtie2 = [ pkgs.zlib.dev ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -433,7 +433,6 @@ let
     ModelMetrics = lib.optional stdenv.hostPlatform.isDarwin pkgs.llvmPackages.openmp;
     PEPBVS = [ pkgs.gsl ];
     PICS = [ pkgs.gsl ];
-    PKI = [ pkgs.openssl.dev ];
     QF = [ pkgs.gsl ];
     R2SWF = [ pkgs.pkg-config ];
     RAppArmor = [ pkgs.libapparmor ];
@@ -1092,6 +1091,7 @@ let
       ocl-icd
     ];
     PING = [ pkgs.gsl ];
+    PKI = [ pkgs.openssl ];
     PROJ = [ pkgs.proj.dev ];
     PoissonBinomial = [ pkgs.fftw.dev ];
     PoissonMultinomial = [ pkgs.fftw.dev ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -742,7 +742,7 @@ let
     resultant = [ pkgs.pkg-config ];
     rgdal = [ pkgs.gdal ]; # for gdal-config
     rgeos = [ pkgs.geos ]; # for geos-config
-    ridge = [ pkgs.gsl ];
+    ridge = [ pkgs.gsl ]; # for gsl-config
     rjags = [ pkgs.pkg-config ];
     rlas = [ pkgs.pkg-config ];
     rmatio = [
@@ -1487,6 +1487,7 @@ let
       zlib.dev
       bzip2.dev
     ];
+    ridge = [ pkgs.gsl ];
     rjags = [ pkgs.jags ];
     rlas = with pkgs; [
       boost

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -742,7 +742,6 @@ let
     resultant = [ pkgs.pkg-config ];
     rgdal = [ pkgs.gdal ]; # for gdal-config
     rgeos = [ pkgs.geos ]; # for geos-config
-    rhdf5 = [ pkgs.zlib ];
     ridge = [ pkgs.gsl ];
     rjags = [ pkgs.pkg-config ];
     rlas = [ pkgs.pkg-config ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -614,7 +614,7 @@ let
     ];
     fftw = [ pkgs.pkg-config ];
     fftwtools = [ pkgs.pkg-config ];
-    fingerPro = [ pkgs.gsl ];
+    fingerPro = [ pkgs.gsl ]; # for gsl-config via RcppGSL
     fio = with pkgs; [
       cargo
       rustc
@@ -1275,6 +1275,7 @@ let
     fastpng = [ pkgs.zlib ];
     fftw = [ pkgs.fftw ];
     fftwtools = [ pkgs.fftw ];
+    fingerPro = [ pkgs.gsl ];
     flan = [ pkgs.gsl ];
     flowWorkspace = [ pkgs.zlib.dev ];
     fs = [ pkgs.libuv ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -462,7 +462,6 @@ let
       pkg-config
     ];
     RcppZiggurat = [ pkgs.gsl ]; # for gsl-config
-    Rglpk = [ pkgs.glpk ];
     Rhdf5lib = with pkgs; [
       cmake
     ];
@@ -1139,6 +1138,7 @@ let
       bzip2.dev
       zlib.dev
     ];
+    Rglpk = [ pkgs.glpk ];
     Rhdf5lib = with pkgs; [
       curl
       zlib.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -630,7 +630,11 @@ let
       cargo
       rustc
     ];
-    gdalcubes = [ pkgs.pkg-config ];
+    gdalcubes = with pkgs; [
+      pkg-config
+      gdal # for gdal-config
+      netcdf # for nc-config
+    ];
     gdalraster = [ pkgs.pkg-config ];
     gdtools = [ pkgs.pkg-config ];
     gert = [ pkgs.pkg-config ];
@@ -1191,9 +1195,7 @@ let
     gaston = with pkgs; [ zlib.dev ];
     gdalcubes = with pkgs; [
       proj.dev
-      gdal
       sqlite.dev
-      netcdf
     ];
     gdalraster = with pkgs; [
       gdal

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -737,7 +737,6 @@ let
       cargo
       rustc
     ];
-    rcdd = [ pkgs.gmp.dev ];
     redux = [ pkgs.pkg-config ];
     reprex = [ pkgs.which ];
     resultant = with pkgs; [
@@ -1469,6 +1468,7 @@ let
     ravetools = [ pkgs.fftw ];
     rawrr = [ pkgs.mono ];
     rbedrock = [ pkgs.zlib ];
+    rcdd = [ pkgs.gmp ];
     rcontroll = [ pkgs.gsl.dev ];
     redux = [ pkgs.hiredis ];
     registr = with pkgs; [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -2544,6 +2544,7 @@ let
     });
 
     hdf5r = old.hdf5r.overrideAttrs (attrs: {
+      nativeBuildInputs = attrs.nativeBuildInputs ++ [ new.Rhdf5lib.hdf5 ];
       buildInputs = attrs.buildInputs ++ [ new.Rhdf5lib.hdf5 ];
     });
 

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -620,7 +620,7 @@ let
       rustc
     ];
     flint = [ pkgs.pkg-config ];
-    flowPeaks = [ pkgs.gsl ];
+    flowPeaks = [ pkgs.gsl ]; # for gsl-config
     frailtyMMpen = [ pkgs.gsl ];
     fru = with pkgs; [
       cargo

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -423,8 +423,6 @@ let
     Cardinal = [ pkgs.which ];
     ChemmineOB = [ pkgs.pkg-config ];
     CytoML = [ pkgs.libxml2 ]; # for xml2-config
-    DEploid = [ pkgs.zlib.dev ];
-    DEploid_utils = [ pkgs.zlib.dev ];
     DiffBind = with pkgs; [
       zlib.dev
       xz.dev
@@ -1073,6 +1071,8 @@ let
       openbabel
       zlib.dev
     ];
+    DEploid = [ pkgs.zlib ];
+    DEploid_utils = [ pkgs.zlib ];
     DGP4LCF = [
       pkgs.lapack
       pkgs.blas

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -452,6 +452,7 @@ let
     ];
     RPostgreSQL = with pkgs; [ libpq.pg_config ];
     RProtoBuf = [ pkgs.pkg-config ];
+    RQuantLib = [ pkgs.quantlib ]; # for quantlib-config
     RationalMatrix = [ pkgs.pkg-config ];
     RcppCWB = with pkgs; [
       pkg-config
@@ -984,8 +985,8 @@ let
     ];
     RPushbullet = [ pkgs.which ];
     RQuantLib = with pkgs; [
-      quantlib.dev
-      boost.dev
+      boost
+      quantlib
     ];
     RSclient = [ pkgs.openssl ];
     RVowpalWabbit = with pkgs; [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -619,12 +619,7 @@ let
       cargo
       rustc
     ];
-    flint = with pkgs; [
-      pkg-config
-      gmp.dev
-      mpfr.dev
-      flint
-    ];
+    flint = [ pkgs.pkg-config ];
     flowPeaks = [ pkgs.gsl ];
     frailtyMMpen = [ pkgs.gsl ];
     fru = with pkgs; [
@@ -1277,6 +1272,11 @@ let
     fftwtools = [ pkgs.fftw ];
     fingerPro = [ pkgs.gsl ];
     flan = [ pkgs.gsl ];
+    flint = with pkgs; [
+      gmp
+      mpfr
+      flint
+    ];
     flowWorkspace = [ pkgs.zlib.dev ];
     fs = [ pkgs.libuv ];
     gaston = with pkgs; [ zlib.dev ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -694,10 +694,6 @@ let
     mvabund = [ pkgs.gsl ]; # for gsl-config via RcppGSL
     mvst = [ pkgs.gsl ]; # for gsl-config
     mwaved = [ pkgs.pkg-config ];
-    mzR = with pkgs; [
-      zlib
-      netcdf
-    ];
     n1qn1 = [ pkgs.gfortran ];
     nanonext = with pkgs; [
       mbedtls

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -497,7 +497,6 @@ let
     SimInf = [ pkgs.gsl ]; # for gsl-config
     SuperGauss = [ pkgs.pkg-config ];
     SymTS = [ pkgs.gsl ]; # for gsl-config
-    TAQMNGR = [ pkgs.zlib.dev ];
     TDA = [ pkgs.gmp ];
     V8 = [ pkgs.pkg-config ];
     VBLPCM = [ pkgs.gsl ];
@@ -1177,6 +1176,7 @@ let
     Signac = [ pkgs.zlib.dev ];
     SuperGauss = [ pkgs.fftw ];
     SynExtend = [ pkgs.zlib.dev ];
+    TAQMNGR = [ pkgs.zlib ];
     TransView = with pkgs; [
       xz.dev
       bzip2.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -494,7 +494,6 @@ let
       cargo
       rustc
     ];
-    SemiCompRisks = [ pkgs.gsl ];
     SimInf = [ pkgs.gsl ];
     SuperGauss = [ pkgs.pkg-config ];
     SymTS = [ pkgs.gsl ];
@@ -1173,6 +1172,7 @@ let
     ];
     SLmetrics = [ pkgs.zlib.dev ];
     SPARSEMODr = [ pkgs.gsl ];
+    SemiCompRisks = [ pkgs.gsl ];
     ShortRead = [ pkgs.zlib ];
     Signac = [ pkgs.zlib.dev ];
     SuperGauss = [ pkgs.fftw ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -797,7 +797,6 @@ let
     sphereTessellation = [ pkgs.pkg-config ];
     string2path = [ pkgs.cargo ];
     stringi = [ pkgs.pkg-config ];
-    stsm = [ pkgs.gsl ];
     survSNP = [ pkgs.gsl ];
     surveyvoi = [ pkgs.pkg-config ];
     svglite = [ pkgs.libpng.dev ];
@@ -1555,6 +1554,7 @@ let
     stpphawkes = [ pkgs.gsl ];
     strawr = [ pkgs.curl ];
     stringi = [ pkgs.icu74 ];
+    stsm = [ pkgs.gsl ];
     surveyvoi = with pkgs; [
       gmp.dev
       mpfr.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -739,11 +739,7 @@ let
     ];
     redux = [ pkgs.pkg-config ];
     reprex = [ pkgs.which ];
-    resultant = with pkgs; [
-      gmp.dev
-      mpfr.dev
-      pkg-config
-    ];
+    resultant = [ pkgs.pkg-config ];
     rgdal = with pkgs; [
       proj.dev
       gdal
@@ -1478,6 +1474,10 @@ let
       xz.dev
       libdeflate
       zstd.dev
+    ];
+    resultant = with pkgs; [
+      gmp
+      mpfr
     ];
     rgl = with pkgs; [
       libGLU

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -936,7 +936,6 @@ let
       fftw.dev
       libsndfile.dev
     ];
-    seqinr = [ pkgs.zlib.dev ];
     seqminer = with pkgs; [
       zlib.dev
       bzip2
@@ -1540,6 +1539,7 @@ let
       bzip2.dev
       xz.dev
     ];
+    seqinr = [ pkgs.zlib ];
     sf = with pkgs; [
       proj
       sqlite

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -559,7 +559,6 @@ let
     ];
     bioacoustics = [ pkgs.cmake ];
     blosc = [ pkgs.pkg-config ];
-    bnpmr = [ pkgs.gsl ];
     cairoDevice = [ pkgs.pkg-config ];
     cartogramR = [ pkgs.pkg-config ];
     caugi = with pkgs; [
@@ -1239,6 +1238,7 @@ let
     bio3d = [ pkgs.zlib ];
     bioacoustics = [ pkgs.fftw ];
     blosc = [ pkgs.c-blosc ];
+    bnpmr = [ pkgs.gsl ];
     cairoDevice = [ pkgs.gtk2 ];
     cartogramR = [ pkgs.fftw ];
     catSurv = [ pkgs.gsl ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -661,7 +661,7 @@ let
     hypergeo2 = [ pkgs.pkg-config ];
     iBMQ = [ pkgs.gsl ]; # for gsl-config
     image_textlinedetector = [ pkgs.pkg-config ];
-    imager = [ pkgs.libx11.dev ];
+    imager = [ pkgs.pkg-config ];
     imbibe = [ pkgs.zlib.dev ];
     immunoClust = [ pkgs.gsl ];
     interpolation = [ pkgs.pkg-config ];
@@ -1318,6 +1318,11 @@ let
       libpng
     ];
     image_textlinedetector = [ pkgs.opencv ];
+    imager = with pkgs; [
+      fftw
+      libtiff
+      libx11
+    ];
     interpolation = with pkgs; [
       gmp
       mpfr

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -430,7 +430,6 @@ let
       which
     ];
     KSgeneral = with pkgs; [ pkg-config ];
-    Libra = [ pkgs.gsl ];
     MAGEE = [
       pkgs.zlib.dev
       pkgs.bzip2.dev
@@ -1082,6 +1081,7 @@ let
     KSgeneral = [ pkgs.fftw.dev ];
     LCMCR = [ pkgs.gsl ];
     LOMAR = [ pkgs.gmp ];
+    Libra = [ pkgs.gsl ];
     MedianaDesigner = [ pkgs.zlib.dev ];
     MethScope = with pkgs; [
       ncurses

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -825,7 +825,6 @@ let
       cargo
       rustc
     ];
-    topicmodels = [ pkgs.gsl ];
     trackViewer = [ pkgs.zlib.dev ];
     udunits2 = with pkgs; [
       udunits
@@ -1603,6 +1602,7 @@ let
       libx11
       tk
     ];
+    topicmodels = [ pkgs.gsl ];
     transmogR = [ pkgs.zlib.dev ];
     ulid = [ pkgs.zlib.dev ];
     unigd =

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -421,7 +421,6 @@ let
     BiocCheck = [ pkgs.which ];
     Cairo = [ pkgs.pkg-config ];
     Cardinal = [ pkgs.which ];
-    CellBarcode = [ pkgs.zlib ];
     ChemmineOB = [ pkgs.pkg-config ];
     CytoML = [ pkgs.libxml2.dev ];
     DEploid = [ pkgs.zlib.dev ];
@@ -1068,6 +1067,7 @@ let
     CLVTools = [ pkgs.gsl ];
     CNEr = with pkgs; [ zlib ];
     Cairo = [ pkgs.cairo ];
+    CellBarcode = [ pkgs.zlib ];
     ChemmineOB = with pkgs; [
       eigen
       openbabel

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -481,8 +481,7 @@ let
     Rlibeemd = [ pkgs.gsl ]; # for gsl-config
     Rmpi = [ pkgs.prrte ];
     Rpoppler = [ pkgs.pkg-config ];
-    Rsubbotools = [ pkgs.gsl ];
-    Rsubread = [ pkgs.zlib.dev ];
+    Rsubbotools = [ pkgs.gsl ]; # for gsl-config
     Rsymphony = [ pkgs.pkg-config ];
     SAVE = with pkgs; [
       zlib
@@ -1158,6 +1157,7 @@ let
     ];
     Rserve = [ pkgs.openssl ];
     Rssa = [ pkgs.fftw ];
+    Rsubread = [ pkgs.zlib ];
     Rsymphony = with pkgs; [
       symphony
       doxygen

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -423,7 +423,6 @@ let
     Cardinal = [ pkgs.which ];
     ChemmineOB = [ pkgs.pkg-config ];
     CytoML = [ pkgs.libxml2 ]; # for xml2-config
-    Formula = [ pkgs.gmp ];
     GLAD = [ pkgs.gsl ];
     GPBayes = [ pkgs.gsl ];
     GeneralizedWendland = [ pkgs.gsl ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -685,9 +685,9 @@ let
       geos # for geos-config
     ];
     magick = [ pkgs.pkg-config ];
-    mcrPioda = [ pkgs.gsl ];
-    mixlink = [ pkgs.gsl ];
-    mixture = [ pkgs.gsl ];
+    mcrPioda = [ pkgs.gsl ]; # for gsl-config
+    mixlink = [ pkgs.gsl ]; # for gsl-config
+    mixture = [ pkgs.gsl ]; # for gsl-config
     mmpca = [ pkgs.gsl ];
     monoreg = [ pkgs.gsl ];
     multibridge = [ pkgs.pkg-config ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -430,10 +430,6 @@ let
       which
     ];
     KSgeneral = with pkgs; [ pkg-config ];
-    MAGEE = [
-      pkgs.zlib.dev
-      pkgs.bzip2.dev
-    ];
     ModelMetrics = lib.optional stdenv.hostPlatform.isDarwin pkgs.llvmPackages.openmp;
     NanoMethViz = [ pkgs.zlib.dev ];
     PEPBVS = [ pkgs.gsl ];
@@ -1082,6 +1078,10 @@ let
     LCMCR = [ pkgs.gsl ];
     LOMAR = [ pkgs.gmp ];
     Libra = [ pkgs.gsl ];
+    MAGEE = with pkgs; [
+      zlib
+      bzip2
+    ];
     MedianaDesigner = [ pkgs.zlib.dev ];
     MethScope = with pkgs; [
       ncurses

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -834,18 +834,7 @@ let
     qqconf = [ pkgs.pkg-config ];
     qspray = [ pkgs.pkg-config ];
     rGEDI = [ pkgs.gsl ];
-    rJava = with pkgs; [
-      stripJavaArchivesHook
-      zlib
-      bzip2.dev
-      icu
-      xz.dev
-      zstd.dev
-      pcre.dev
-      jdk
-      libzip
-      libdeflate
-    ];
+    rJava = [ pkgs.stripJavaArchivesHook ];
     ragg = [ pkgs.pkg-config ];
     rapport = [ pkgs.which ];
     rapportools = [ pkgs.which ];
@@ -1449,6 +1438,13 @@ let
       hdf5.dev
     ];
     rJPSGCS = [ pkgs.zlib.dev ];
+    rJava = with pkgs; [
+      zlib
+      bzip2
+      xz
+      zstd
+      icu
+    ];
     raer = with pkgs; [
       zlib.dev
       xz.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -431,6 +431,7 @@ let
       which
     ];
     KSgeneral = with pkgs; [ pkg-config ];
+    LCMCR = [ pkgs.gsl ]; # for gsl-config
     ModelMetrics = lib.optional stdenv.hostPlatform.isDarwin pkgs.llvmPackages.openmp;
     PEPBVS = [ pkgs.gsl ]; # for gsl-config
     PICS = [ pkgs.gsl ];
@@ -931,7 +932,6 @@ let
     JMcmprsk = [ pkgs.gsl ];
     KFKSDS = [ pkgs.gsl ];
     KSgeneral = [ pkgs.fftw.dev ];
-    LCMCR = [ pkgs.gsl ];
     LOMAR = [ pkgs.gmp ];
     Libra = [ pkgs.gsl ];
     MAGEE = with pkgs; [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -729,10 +729,9 @@ let
     rapportools = [ pkgs.which ];
     ratioOfQsprays = [ pkgs.pkg-config ];
     ravetools = [ pkgs.pkg-config ];
-    rbedrock = [
-      pkgs.zlib.dev
-      pkgs.which
-      pkgs.cmake
+    rbedrock = with pkgs; [
+      which
+      cmake
     ];
     rbm25 = with pkgs; [
       cargo
@@ -1469,6 +1468,7 @@ let
     ];
     ravetools = [ pkgs.fftw ];
     rawrr = [ pkgs.mono ];
+    rbedrock = [ pkgs.zlib ];
     rcontroll = [ pkgs.gsl.dev ];
     redux = [ pkgs.hiredis ];
     registr = with pkgs; [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -722,7 +722,7 @@ let
     ];
     qqconf = [ pkgs.pkg-config ];
     qspray = [ pkgs.pkg-config ];
-    rGEDI = [ pkgs.gsl ];
+    rGEDI = [ pkgs.gsl ]; # for gsl-config
     rJava = [ pkgs.stripJavaArchivesHook ];
     ragg = [ pkgs.pkg-config ];
     rapport = [ pkgs.which ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -733,6 +733,7 @@ let
     pbdZMQ = [ pkgs.pkg-config ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ pkgs.which ];
     pcaL1 = [ pkgs.pkg-config ];
     pdftools = [ pkgs.pkg-config ];
+    pexm = [ pkgs.jags ];
     phytools = [ pkgs.which ];
     png = [ pkgs.libpng ]; # for libpng-config
     protolite = [ pkgs.protobuf ];
@@ -1357,7 +1358,6 @@ let
     pbdZMQ = [ pkgs.zeromq ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ pkgs.darwin.binutils ];
     pcaL1 = [ pkgs.clp ];
     pdftools = [ pkgs.poppler ];
-    pexm = [ pkgs.jags ];
     pgenlibr = [ pkgs.zlib.dev ];
     pliman = with pkgs; [
       fftw.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -703,7 +703,6 @@ let
     otelsdk = with pkgs; [
       cmake
       which
-      curl.dev
     ];
     pak = [ pkgs.curl.dev ];
     pander = with pkgs; [
@@ -1400,8 +1399,9 @@ let
     odbc = [ pkgs.unixodbc ];
     oligo = [ pkgs.zlib ];
     otelsdk = with pkgs; [
+      curl
       protobuf
-      zlib.dev
+      zlib
     ];
     pbdZMQ = [ pkgs.zeromq ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ pkgs.darwin.binutils ];
     pdftools = [ pkgs.poppler ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -429,7 +429,6 @@ let
       pkg-config
       which
     ];
-    JavaGD = [ pkgs.jdk ];
     KFKSDS = [ pkgs.gsl ];
     KSgeneral = with pkgs; [ pkg-config ];
     LOMAR = [ pkgs.gmp.dev ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -815,7 +815,7 @@ let
     rgeos = [ pkgs.geos ];
     rhdf5 = [ pkgs.zlib ];
     ridge = [ pkgs.gsl ];
-    rjags = [ pkgs.jags ];
+    rjags = [ pkgs.pkg-config ];
     rlas = [ pkgs.pkg-config ];
     rmatio = [
       pkgs.zlib.dev
@@ -1479,6 +1479,7 @@ let
       zlib.dev
       bzip2.dev
     ];
+    rjags = [ pkgs.jags ];
     rlas = with pkgs; [
       boost
       gdal

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -579,10 +579,6 @@ let
     cld3 = [ pkgs.protobuf ];
     clustermq = [ pkgs.pkg-config ];
     cpp11bigwig = [ pkgs.curl ]; # for curl-config
-    cpp11qpdf = with pkgs; [
-      zlib.dev
-      libjpeg
-    ];
     crc32c = [
       pkgs.which
       pkgs.cmake
@@ -1249,6 +1245,10 @@ let
     clustermq = [ pkgs.zeromq ];
     coga = [ pkgs.gsl.dev ];
     cpp11bigwig = [ pkgs.zlib ];
+    cpp11qpdf = with pkgs; [
+      libjpeg
+      zlib
+    ];
     crandep = [ pkgs.gsl ];
     csaw = with pkgs; [
       zlib.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -598,8 +598,8 @@ let
     diversitree = [ pkgs.gsl ]; # for gsl-config
     dynr = [ pkgs.gsl ]; # for gsl-config
     eaf = [ pkgs.gsl ]; # for gsl-config
-    exactextractr = [ pkgs.geos ];
-    fRLR = [ pkgs.gsl ];
+    exactextractr = [ pkgs.geos ]; # for geos-config
+    fRLR = [ pkgs.gsl ]; # for gsl-config
     fangs = with pkgs; [
       cargo
       rustc

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -440,11 +440,7 @@ let
     RDieHarder = [ pkgs.gsl ]; # for gsl-config
     RGtk2 = [ pkgs.pkg-config ];
     RJMCMCNucleosomes = [ pkgs.gsl ]; # for gsl-config
-    RMySQL = with pkgs; [
-      zlib
-      libmysqlclient
-      openssl.dev
-    ];
+    RMySQL = [ pkgs.libmysqlclient ]; # for mysql_config
     RNetCDF = with pkgs; [
       netcdf
       udunits
@@ -2027,17 +2023,6 @@ let
            echo "bftools provides: $bf_version"
            exit 1
         fi
-      '';
-    });
-
-    RMySQL = old.RMySQL.overrideAttrs (attrs: {
-      env = (attrs.env or { }) // {
-        MYSQL_DIR = "${pkgs.libmysqlclient}";
-        PKGCONFIG_CFLAGS = "-I${pkgs.libmysqlclient.dev}/include/mysql";
-        NIX_CFLAGS_LINK = "-L${pkgs.libmysqlclient}/lib/mysql -lmysqlclient";
-      };
-      preConfigure = ''
-        patchShebangs configure
       '';
     });
 

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -788,7 +788,6 @@ let
       rustc
       which
     ];
-    snpStats = [ pkgs.zlib.dev ];
     socratadata = with pkgs; [
       cargo
       rustc
@@ -1542,6 +1541,7 @@ let
     ];
     shrinkTVP = [ pkgs.gsl ];
     simplexreg = [ pkgs.gsl ];
+    snpStats = [ pkgs.zlib ];
     sodium = [ pkgs.libsodium ];
     spFW = [ pkgs.fftw.dev ];
     spaMM = [ pkgs.gsl ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -912,10 +912,7 @@ let
       cmake
       pkg-config
     ];
-    rtracklayer = with pkgs; [
-      zlib.dev
-      curl.dev
-    ];
+    rtracklayer = [ pkgs.pkg-config ];
     runjags = [ pkgs.jags ];
     rvg = [ pkgs.libpng.dev ];
     rzmq = [ pkgs.pkg-config ];
@@ -1516,6 +1513,10 @@ let
     ];
     rtk = [ pkgs.zlib.dev ];
     rtmpt = [ pkgs.gsl ];
+    rtracklayer = with pkgs; [
+      zlib
+      curl
+    ];
     rzmq = [ pkgs.zeromq ];
     s2 = with pkgs; [
       abseil-cpp

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -745,10 +745,7 @@ let
     ridge = [ pkgs.gsl ]; # for gsl-config
     rjags = [ pkgs.pkg-config ];
     rlas = [ pkgs.pkg-config ];
-    rmatio = [
-      pkgs.zlib.dev
-      pkgs.pkg-config
-    ];
+    rmatio = [ pkgs.pkg-config ];
     rnetcarto = [ pkgs.gsl ];
     roxigraph = with pkgs; [
       cargo
@@ -1496,6 +1493,7 @@ let
       sqlite
       geos
     ];
+    rmatio = [ pkgs.zlib ];
     rmumps = with pkgs; [ zlib.dev ];
     rrd = [ pkgs.rrdtool ];
     rsbml = [ pkgs.libsbml ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -481,7 +481,6 @@ let
     Rlibeemd = [ pkgs.gsl ]; # for gsl-config
     Rmpi = [ pkgs.prrte ];
     Rpoppler = [ pkgs.pkg-config ];
-    Rserve = [ pkgs.openssl ];
     Rssa = [ pkgs.fftw.dev ];
     Rsubbotools = [ pkgs.gsl ];
     Rsubread = [ pkgs.zlib.dev ];
@@ -1158,6 +1157,7 @@ let
       xz
       zlib
     ];
+    Rserve = [ pkgs.openssl ];
     Rsymphony = with pkgs; [
       symphony
       doxygen

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -437,9 +437,9 @@ let
     R2SWF = [ pkgs.pkg-config ];
     RAppArmor = [ pkgs.pkg-config ];
     RCurl = [ pkgs.curl ]; # for curl-config
-    RDieHarder = [ pkgs.gsl ];
+    RDieHarder = [ pkgs.gsl ]; # for gsl-config
     RGtk2 = [ pkgs.pkg-config ];
-    RJMCMCNucleosomes = [ pkgs.gsl ];
+    RJMCMCNucleosomes = [ pkgs.gsl ]; # for gsl-config
     RMySQL = with pkgs; [
       zlib
       libmysqlclient

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -419,6 +419,7 @@ let
     BayesXsrc = [ pkgs.gsl ]; # for gsl-config
     BigDataStatMeth = [ pkgs.pkg-config ];
     BiocCheck = [ pkgs.which ];
+    CLVTools = [ pkgs.gsl ]; # for gsl-config via RcppGSL
     Cairo = [ pkgs.pkg-config ];
     Cardinal = [ pkgs.which ];
     ChemmineOB = [ pkgs.pkg-config ];
@@ -885,7 +886,6 @@ let
     BigDataStatMeth = [ pkgs.zlib ];
     BitSeq = [ pkgs.zlib ];
     CBN2Path = [ pkgs.gsl ];
-    CLVTools = [ pkgs.gsl ];
     CNEr = with pkgs; [ zlib ];
     Cairo = [ pkgs.cairo ];
     CellBarcode = [ pkgs.zlib ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -671,10 +671,7 @@ let
       rustc
     ];
     fftw = [ pkgs.pkg-config ];
-    fftwtools = with pkgs; [
-      fftw.dev
-      pkg-config
-    ];
+    fftwtools = [ pkgs.pkg-config ];
     fingerPro = [ pkgs.gsl ];
     fio = with pkgs; [
       cargo
@@ -1284,6 +1281,7 @@ let
     ];
     excursions = [ pkgs.gsl ];
     fftw = [ pkgs.fftw ];
+    fftwtools = [ pkgs.fftw ];
     flan = [ pkgs.gsl ];
     flowWorkspace = [ pkgs.zlib.dev ];
     fs = [ pkgs.libuv ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -776,10 +776,6 @@ let
       rustc
     ];
     scorematchingad = [ pkgs.cmake ];
-    seqminer = with pkgs; [
-      zlib.dev
-      bzip2
-    ];
     sf = with pkgs; [
       pkg-config
       gdal # for gdal-config
@@ -1530,6 +1526,12 @@ let
       xz.dev
     ];
     seqinr = [ pkgs.zlib ];
+    seqminer = with pkgs; [
+      bzip2
+      sqlite
+      zlib
+      zstd
+    ];
     sf = with pkgs; [
       proj
       sqlite

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -696,7 +696,7 @@ let
     mwaved = [ pkgs.pkg-config ];
     n1qn1 = [ pkgs.gfortran ];
     ncdf4 = [ pkgs.netcdf ]; # for nc-config
-    neojags = [ pkgs.jags ];
+    neojags = [ pkgs.pkg-config ];
     nloptr = [ pkgs.pkg-config ];
     odbc = [ pkgs.pkg-config ];
     oligo = [ pkgs.zlib.dev ];
@@ -1396,6 +1396,7 @@ let
     nat_templatebrains = [ pkgs.which ];
     ncdfFlow = [ pkgs.zlib.dev ];
     ndjson = [ pkgs.zlib.dev ];
+    neojags = [ pkgs.jags ];
     nloptr = [ pkgs.nlopt ];
     odbc = [ pkgs.unixodbc ];
     otelsdk = with pkgs; [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -630,7 +630,6 @@ let
       cargo
       rustc
     ];
-    gamstransfer = [ pkgs.zlib ];
     gdalcubes = [ pkgs.pkg-config ];
     gdalraster = [ pkgs.pkg-config ];
     gdtools = [ pkgs.pkg-config ];
@@ -1280,6 +1279,7 @@ let
     flowWorkspace = [ pkgs.zlib.dev ];
     frailtyMMpen = [ pkgs.gsl ];
     fs = [ pkgs.libuv ];
+    gamstransfer = [ pkgs.zlib ];
     gaston = with pkgs; [ zlib.dev ];
     gdalcubes = with pkgs; [
       proj.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -416,9 +416,6 @@ let
   packagesWithNativeBuildInputs = {
     # keep-sorted start block=yes
     Apollonius = [ pkgs.pkg-config ];
-    BayesChange = [ pkgs.gsl ];
-    BayesSAE = [ pkgs.gsl ];
-    BayesVarSel = [ pkgs.gsl ];
     BayesXsrc = with pkgs; [
       readline.dev
       ncurses
@@ -1085,6 +1082,9 @@ let
       which
     ];
     BNSP = [ pkgs.gsl ];
+    BayesChange = [ pkgs.gsl ];
+    BayesSAE = [ pkgs.gsl ];
+    BayesVarSel = [ pkgs.gsl ];
     BigDataStatMeth = [ pkgs.zlib ];
     CBN2Path = [ pkgs.gsl ];
     CLVTools = [ pkgs.gsl ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -419,6 +419,7 @@ let
     BayesXsrc = [ pkgs.gsl ]; # for gsl-config
     BigDataStatMeth = [ pkgs.pkg-config ];
     BiocCheck = [ pkgs.which ];
+    CBN2Path = [ pkgs.gsl ]; # for gsl-config
     CLVTools = [ pkgs.gsl ]; # for gsl-config via RcppGSL
     Cairo = [ pkgs.pkg-config ];
     Cardinal = [ pkgs.which ];
@@ -900,7 +901,6 @@ let
     BayesVarSel = [ pkgs.gsl ];
     BigDataStatMeth = [ pkgs.zlib ];
     BitSeq = [ pkgs.zlib ];
-    CBN2Path = [ pkgs.gsl ];
     CNEr = with pkgs; [ zlib ];
     Cairo = [ pkgs.cairo ];
     CellBarcode = [ pkgs.zlib ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -813,7 +813,6 @@ let
     ];
     tesseract = [ pkgs.pkg-config ];
     textshaping = [ pkgs.pkg-config ];
-    themetagenomics = [ pkgs.zlib.dev ];
     tinyimg = with pkgs; [
       cargo
       rustc
@@ -1597,6 +1596,7 @@ let
       libpng
     ];
     tfevents = [ pkgs.protobuf ];
+    themetagenomics = [ pkgs.zlib ];
     tidypopgen = [ pkgs.zlib.dev ];
     tiff = [ pkgs.libtiff ];
     tikzDevice = with pkgs; [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -635,7 +635,10 @@ let
       gdal # for gdal-config
       netcdf # for nc-config
     ];
-    gdalraster = [ pkgs.pkg-config ];
+    gdalraster = with pkgs; [
+      pkg-config
+      gdal # for gdal-config
+    ];
     gdtools = [ pkgs.pkg-config ];
     gert = [ pkgs.pkg-config ];
     gglinedensity = [ pkgs.cargo ];
@@ -1197,11 +1200,7 @@ let
       proj.dev
       sqlite.dev
     ];
-    gdalraster = with pkgs; [
-      gdal
-      proj.dev
-      sqlite.dev
-    ];
+    gdalraster = [ pkgs.proj ];
     gdtools =
       with pkgs;
       [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -798,6 +798,7 @@ let
       cargo
       rustc
     ];
+    sbrl = [ pkgs.gsl ]; # for gsl-config
     scorematchingad = [ pkgs.cmake ];
     sf = with pkgs; [
       pkg-config
@@ -1485,10 +1486,7 @@ let
       openssl.dev
     ];
     saeMSPE = [ pkgs.gsl.dev ];
-    sbrl = with pkgs; [
-      gsl
-      gmp.dev
-    ];
+    sbrl = [ pkgs.gmp ];
     scModels = [ pkgs.mpfr.dev ];
     scPipe = with pkgs; [
       bzip2.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -835,12 +835,6 @@ let
       pkg-config
       gdal # for gdal-config
     ];
-    vcfppR = [
-      pkgs.curl.dev
-      pkgs.bzip2
-      pkgs.zlib.dev
-      pkgs.xz
-    ];
     vdiffr = [ pkgs.libpng.dev ];
     watcher = with pkgs; [
       cmake
@@ -1626,6 +1620,13 @@ let
     ];
     vapour = [ pkgs.proj ];
     vcfR = with pkgs; [ zlib.dev ];
+    vcfppR = with pkgs; [
+      bzip2
+      curl
+      libdeflate
+      xz
+      zlib
+    ];
     webp = [ pkgs.libwebp ];
     writexl = with pkgs; [ zlib.dev ];
     xslt =

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -691,7 +691,6 @@ let
       glpk
     ];
     gmapR = [ pkgs.zlib.dev ];
-    gmp = [ pkgs.gmp.dev ];
     graphscan = [ pkgs.gsl ];
     gsl = [ pkgs.gsl ];
     gslnls = [ pkgs.gsl ];
@@ -1307,6 +1306,7 @@ let
         libxdmcp
       ];
     gfilogisreg = [ pkgs.gmp.dev ];
+    gmp = [ pkgs.gmp ];
     gpg = [ pkgs.gpgme ];
     gpuMagic = [ pkgs.ocl-icd ];
     gridGraphics = [ pkgs.which ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -497,7 +497,6 @@ let
     SimInf = [ pkgs.gsl ]; # for gsl-config
     SuperGauss = [ pkgs.pkg-config ];
     SymTS = [ pkgs.gsl ]; # for gsl-config
-    TDA = [ pkgs.gmp ];
     V8 = [ pkgs.pkg-config ];
     VBLPCM = [ pkgs.gsl ];
     XBRL = with pkgs; [
@@ -1177,6 +1176,7 @@ let
     SuperGauss = [ pkgs.fftw ];
     SynExtend = [ pkgs.zlib.dev ];
     TAQMNGR = [ pkgs.zlib ];
+    TDA = [ pkgs.gmp ];
     TransView = with pkgs; [
       xz.dev
       bzip2.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -423,11 +423,6 @@ let
     Cardinal = [ pkgs.which ];
     ChemmineOB = [ pkgs.pkg-config ];
     CytoML = [ pkgs.libxml2 ]; # for xml2-config
-    DiffBind = with pkgs; [
-      zlib.dev
-      xz.dev
-      bzip2.dev
-    ];
     EMCluster = [ pkgs.lapack ];
     Formula = [ pkgs.gmp ];
     GLAD = [ pkgs.gsl ];
@@ -1075,7 +1070,11 @@ let
       pkgs.lapack
       pkgs.blas
     ];
-    DiffBind = with pkgs; [ zlib.dev ];
+    DiffBind = with pkgs; [
+      zlib
+      xz
+      bzip2
+    ];
     DirichletMultinomial = with pkgs; [ gsl ];
     DropletUtils = [ pkgs.zlib.dev ];
     EHRmuse = [ pkgs.gsl.dev ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -570,6 +570,7 @@ let
     blosc = [ pkgs.pkg-config ];
     cairoDevice = [ pkgs.pkg-config ];
     cartogramR = [ pkgs.pkg-config ];
+    catSurv = [ pkgs.gsl ]; # for gsl-config via RcppGSL
     caugi = with pkgs; [
       cargo
       rustc

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -431,7 +431,6 @@ let
     ];
     KSgeneral = with pkgs; [ pkg-config ];
     ModelMetrics = lib.optional stdenv.hostPlatform.isDarwin pkgs.llvmPackages.openmp;
-    NanoMethViz = [ pkgs.zlib.dev ];
     PEPBVS = [ pkgs.gsl ];
     PICS = [ pkgs.gsl ];
     PKI = [ pkgs.openssl.dev ];
@@ -1087,6 +1086,7 @@ let
       ncurses
       zlib.dev
     ];
+    NanoMethViz = [ pkgs.zlib ];
     OpenCL = with pkgs; [
       opencl-clhpp
       ocl-icd

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -479,10 +479,6 @@ let
     ];
     Rigraphlib = [ pkgs.cmake ];
     Rlibeemd = [ pkgs.gsl ]; # for gsl-config
-    Rmpfr = with pkgs; [
-      gmp
-      mpfr.dev
-    ];
     Rmpi = with pkgs; [
       mpi.dev
       prrte.dev
@@ -1152,6 +1148,10 @@ let
     Rlibeemd = [ pkgs.gsl ];
     RmecabKo = [ pkgs.mecab ];
     Rmmquant = [ pkgs.zlib.dev ];
+    Rmpfr = with pkgs; [
+      gmp
+      mpfr
+    ];
     RoBMA = [ pkgs.jags ];
     RoBSA = [ pkgs.jags ];
     Rpoppler = [ pkgs.poppler ];
@@ -2113,12 +2113,6 @@ let
       preConfigure = ''
         substituteInPlace R/zzz.R --replace-fail "-lcurl" "-L${pkgs.curl.out}/lib -lcurl"
       '';
-    });
-
-    Rmpfr = old.Rmpfr.overrideAttrs (attrs: {
-      configureFlags = [
-        "--with-mpfr-include=${pkgs.mpfr.dev}/include"
-      ];
     });
 
     Rmpi = old.Rmpi.overrideAttrs (attrs: {

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -1232,6 +1232,10 @@ let
     bbl = with pkgs; [ gsl ];
     bgx = [ pkgs.boost ];
     bigmemory = lib.optionals stdenv.hostPlatform.isLinux [ pkgs.libuuid.dev ];
+    bigrquerystorage = with pkgs; [
+      grpc
+      protobuf
+    ];
     bigsnpr = [ pkgs.zlib.dev ];
     bio3d = with pkgs; [ zlib.dev ];
     bioacoustics = [ pkgs.fftw ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -546,7 +546,6 @@ let
       rustc
     ];
     SemiCompRisks = [ pkgs.gsl ];
-    ShortRead = [ pkgs.zlib.dev ];
     SimInf = [ pkgs.gsl ];
     SuperGauss = [ pkgs.pkg-config ];
     SymTS = [ pkgs.gsl ];
@@ -1199,6 +1198,7 @@ let
     ];
     SLmetrics = [ pkgs.zlib.dev ];
     SPARSEMODr = [ pkgs.gsl ];
+    ShortRead = [ pkgs.zlib ];
     Signac = [ pkgs.zlib.dev ];
     SuperGauss = [ pkgs.fftw ];
     SynExtend = [ pkgs.zlib.dev ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -449,9 +449,9 @@ let
     RPostgreSQL = with pkgs; [ libpq.pg_config ];
     RProtoBuf = [ pkgs.pkg-config ];
     RationalMatrix = [ pkgs.pkg-config ];
-    RcppCWB = [
-      pkgs.pkg-config
-      pkgs.pcre2
+    RcppCWB = with pkgs; [
+      pkg-config
+      pcre2 # for pcre2-config
     ];
     RcppDPR = [ pkgs.gsl ];
     RcppGSL = [ pkgs.gsl ];
@@ -1125,8 +1125,8 @@ let
     RcppBigIntAlgos = [ pkgs.gmp.dev ];
     RcppCNPy = [ pkgs.zlib ];
     RcppCWB = with pkgs; [
-      pcre.dev
-      glib.dev
+      pcre2
+      glib
     ];
     RcppMeCab = [ pkgs.mecab ];
     RcppPlanc = with pkgs; [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -817,10 +817,6 @@ let
       cargo
       rustc
     ];
-    tkrplot = with pkgs; [
-      libx11
-      tk.dev
-    ];
     tok = with pkgs; [
       cargo
       rustc
@@ -1602,6 +1598,10 @@ let
     tikzDevice = with pkgs; [
       which
       texliveMedium
+    ];
+    tkrplot = with pkgs; [
+      libx11
+      tk
     ];
     transmogR = [ pkgs.zlib.dev ];
     ulid = [ pkgs.zlib.dev ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -627,6 +627,7 @@ let
       cargo
       rustc
     ];
+    flan = [ pkgs.gsl ]; # for gsl-config
     flint = [ pkgs.pkg-config ];
     flowPeaks = [ pkgs.gsl ]; # for gsl-config
     frailtyMMpen = [ pkgs.gsl ]; # for gsl-config

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -519,14 +519,6 @@ let
       mpi
       pcre.dev
     ];
-    Rhtslib = with pkgs; [
-      zlib.dev
-      automake
-      autoconf
-      bzip2.dev
-      xz.dev
-      curl.dev
-    ];
     Rigraphlib = [ pkgs.cmake ];
     Rlibeemd = [ pkgs.gsl ];
     Rmpfr = with pkgs; [
@@ -1183,6 +1175,12 @@ let
     Rhdf5lib = with pkgs; [
       curl
       zlib.dev
+    ];
+    Rhtslib = with pkgs; [
+      bzip2
+      curl
+      xz
+      zlib
     ];
     RmecabKo = [ pkgs.mecab ];
     Rmmquant = [ pkgs.zlib.dev ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -425,7 +425,6 @@ let
     CytoML = [ pkgs.libxml2 ]; # for xml2-config
     GLAD = [ pkgs.gsl ]; # for gsl-config
     GPBayes = [ pkgs.gsl ]; # for gsl-config
-    GeneralizedWendland = [ pkgs.gsl ];
     HiCParser = [ pkgs.zlib ];
     HiCseg = [ pkgs.gsl ];
     HilbertVisGUI = with pkgs; [
@@ -1087,6 +1086,7 @@ let
       bzip2.dev
     ];
     GRAB = [ pkgs.zlib.dev ];
+    GeneralizedWendland = [ pkgs.gsl ];
     GeoFIS = with pkgs; [
       mpfr.dev
       gmp.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -430,7 +430,6 @@ let
       which
     ];
     KSgeneral = with pkgs; [ pkg-config ];
-    LOMAR = [ pkgs.gmp.dev ];
     Libra = [ pkgs.gsl ];
     MAGEE = [
       pkgs.zlib.dev
@@ -1082,6 +1081,7 @@ let
     KFKSDS = [ pkgs.gsl ];
     KSgeneral = [ pkgs.fftw.dev ];
     LCMCR = [ pkgs.gsl ];
+    LOMAR = [ pkgs.gmp ];
     MedianaDesigner = [ pkgs.zlib.dev ];
     MethScope = with pkgs; [
       ncurses

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -585,6 +585,7 @@ let
     clarabel = [ pkgs.cargo ];
     cld3 = [ pkgs.protobuf ];
     clustermq = [ pkgs.pkg-config ];
+    coga = [ pkgs.gsl ]; # for gsl-config
     cpp11bigwig = [ pkgs.curl ]; # for curl-config
     crc32c = [
       pkgs.which
@@ -1147,7 +1148,6 @@ let
     cit = [ pkgs.gsl ];
     cld3 = [ pkgs.protobuf ];
     clustermq = [ pkgs.zeromq ];
-    coga = [ pkgs.gsl.dev ];
     cpp11bigwig = [ pkgs.zlib ];
     cpp11qpdf = with pkgs; [
       libjpeg

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -441,10 +441,7 @@ let
     RGtk2 = [ pkgs.pkg-config ];
     RJMCMCNucleosomes = [ pkgs.gsl ]; # for gsl-config
     RMySQL = [ pkgs.libmysqlclient ]; # for mysql_config
-    RNetCDF = with pkgs; [
-      netcdf
-      udunits
-    ];
+    RNetCDF = [ pkgs.pkg-config ];
     RODBC = [ pkgs.libiodbc ];
     RPesto = with pkgs; [
       cargo
@@ -1109,6 +1106,10 @@ let
     RKHSMetaMod = [ pkgs.gsl ];
     RMariaDB = [ pkgs.libmysqlclient.dev ];
     RMark = [ pkgs.which ];
+    RNetCDF = with pkgs; [
+      netcdf
+      udunits
+    ];
     RNifti = [ pkgs.zlib ];
     RNiftyReg = [ pkgs.zlib ];
     RPostgres = with pkgs; [ libpq ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -838,7 +838,7 @@ let
     ];
     pdftools = [ pkgs.pkg-config ];
     phytools = [ pkgs.which ];
-    png = [ pkgs.libpng.dev ];
+    png = [ pkgs.libpng ]; # for libpng-config
     protolite = [ pkgs.protobuf ];
     prqlr = with pkgs; [
       cargo
@@ -1425,6 +1425,7 @@ let
       fftw.dev
       libpng.dev
     ];
+    png = [ pkgs.libpng ];
     podkat = with pkgs; [
       zlib.dev
       xz.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -694,6 +694,7 @@ let
       cmake
       pkg-config
     ];
+    lnmixsurv = [ pkgs.gsl ]; # for gsl-config
     lpsymphony = with pkgs; [
       pkg-config
       gfortran
@@ -1302,7 +1303,6 @@ let
       zstd
       icu
     ];
-    lnmixsurv = [ pkgs.gsl.dev ];
     lpsymphony = with pkgs; [
       symphony
       cgl

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -651,13 +651,13 @@ let
       pkgs.which
       pkgs.cmake
     ];
-    data_table =
-      with pkgs;
+    data_table = (
+      # added extra parentheses so that `keep-sorted` doesn't get tripped up
       [
-        pkg-config
-        zlib.dev
+        pkgs.pkg-config
       ]
-      ++ lib.optional stdenv.hostPlatform.isDarwin pkgs.llvmPackages.openmp;
+      ++ lib.optional stdenv.hostPlatform.isDarwin pkgs.llvmPackages.openmp
+    );
     datefixR = with pkgs; [
       cargo
       rustc
@@ -1282,6 +1282,7 @@ let
       curl
     ];
     curl = [ pkgs.curl ];
+    data_table = [ pkgs.zlib ];
     deepSNV = with pkgs; [
       xz.dev
       bzip2.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -640,8 +640,8 @@ let
       gmp
       glpk
     ];
-    gsl = [ pkgs.gsl ];
-    gslnls = [ pkgs.gsl ];
+    gsl = [ pkgs.gsl ]; # for gsl-config
+    gslnls = [ pkgs.gsl ]; # for gsl-config
     h3o = with pkgs; [
       cargo
       rustc

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -1418,6 +1418,7 @@ let
     poisbinom = [ pkgs.fftw.dev ];
     pqsfinder = [ pkgs.boost ];
     proj4 = [ pkgs.proj.dev ];
+    protolite = [ pkgs.protobuf ];
     psbcGroup = [ pkgs.gsl.dev ];
     qckitfastq = [ pkgs.zlib.dev ];
     qpdf = with pkgs; [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -422,7 +422,7 @@ let
     Cairo = [ pkgs.pkg-config ];
     Cardinal = [ pkgs.which ];
     ChemmineOB = [ pkgs.pkg-config ];
-    CytoML = [ pkgs.libxml2.dev ];
+    CytoML = [ pkgs.libxml2 ]; # for xml2-config
     DEploid = [ pkgs.zlib.dev ];
     DEploid_utils = [ pkgs.zlib.dev ];
     DiffBind = with pkgs; [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -809,6 +809,7 @@ let
       geos # for geos-config
     ];
     showtext = [ pkgs.pkg-config ];
+    shrinkTVP = [ pkgs.gsl ]; # for gsl-config via RcppGSL
     smam = [ pkgs.gsl ]; # for gsl-config
     smcryptoR = with pkgs; [
       cargo
@@ -1520,7 +1521,6 @@ let
       libpng
       freetype
     ];
-    shrinkTVP = [ pkgs.gsl ];
     simplexreg = [ pkgs.gsl ];
     snpStats = [ pkgs.zlib ];
     sodium = [ pkgs.libsodium ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -668,7 +668,7 @@ let
       pkg-config
       which
     ];
-    jSDM = [ pkgs.gsl ];
+    jSDM = [ pkgs.gsl ]; # for gsl-config
     jack = [ pkgs.pkg-config ];
     jqr = [ pkgs.jq.dev ];
     kza = [ pkgs.pkg-config ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -504,7 +504,10 @@ let
       pkg-config
       libxml2 # for xml2-config
     ];
-    abn = [ pkgs.gsl ];
+    abn = with pkgs; [
+      gsl # for gsl-config
+      jags
+    ];
     adimpro = [ pkgs.imagemagick ];
     affyPLM = [ pkgs.zlib.dev ];
     affyio = [ pkgs.zlib.dev ];
@@ -1197,7 +1200,6 @@ let
     ];
     XVector = [ pkgs.zlib ];
     XYomics = [ pkgs.boost ];
-    abn = [ pkgs.jags ];
     adbcpostgresql = with pkgs; [
       readline.dev
       zlib.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -737,6 +737,10 @@ let
     nloptr = [ pkgs.pkg-config ];
     odbc = [ pkgs.pkg-config ];
     opencv = [ pkgs.pkg-config ];
+    orbweaver = with pkgs; [
+      cargo
+      rustc
+    ];
     otelsdk = with pkgs; [
       cmake
       which
@@ -796,6 +800,10 @@ let
       rustc
     ];
     rsbml = [ pkgs.pkg-config ];
+    rsgeo = with pkgs; [
+      cargo
+      rustc
+    ];
     rshift = with pkgs; [
       cargo
       rustc
@@ -804,6 +812,10 @@ let
     rswipl = with pkgs; [
       cmake
       pkg-config
+    ];
+    rtiktoken = with pkgs; [
+      cargo
+      rustc
     ];
     rtracklayer = [ pkgs.pkg-config ];
     runjags = [ pkgs.pkg-config ];
@@ -2741,10 +2753,6 @@ let
 
     orbweaver = old.orbweaver.overrideAttrs (attrs: {
       postPatch = "patchShebangs configure";
-      nativeBuildInputs = attrs.nativeBuildInputs ++ [
-        pkgs.cargo
-        pkgs.rustc
-      ];
     });
 
     otelsdk = old.otelsdk.overrideAttrs (attrs: {
@@ -2936,7 +2944,6 @@ let
     });
 
     rsgeo = old.rsgeo.overrideAttrs (attrs: {
-      nativeBuildInputs = [ pkgs.cargo ] ++ attrs.nativeBuildInputs;
       postPatch = "patchShebangs configure";
     });
 
@@ -2952,10 +2959,6 @@ let
 
     rtiktoken = old.rtiktoken.overrideAttrs (attrs: {
       postPatch = "patchShebangs configure";
-      nativeBuildInputs = attrs.nativeBuildInputs ++ [
-        pkgs.cargo
-        pkgs.rustc
-      ];
     });
 
     rvisidata = old.rvisidata.overrideAttrs (attrs: {

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -520,10 +520,9 @@ let
       rustc
     ];
     arcgisplaces = with pkgs; [
-      pkg-config
-      openssl.dev
       cargo
       rustc
+      pkg-config
     ];
     arcgisutils = with pkgs; [
       cargo
@@ -968,7 +967,6 @@ let
       cargo
       rustc
     ];
-    yyjsonr = with pkgs; [ zlib.dev ];
     # keep-sorted end
   };
 
@@ -1213,6 +1211,7 @@ let
     affyPLM = [ pkgs.zlib ];
     affyio = [ pkgs.zlib ];
     apsimx = [ pkgs.which ];
+    arcgisplaces = [ pkgs.openssl ];
     archive = [ pkgs.libarchive ];
     arrangements = with pkgs; [ gmp.dev ];
     asciicast = with pkgs; [
@@ -1633,6 +1632,7 @@ let
         libxml2
       ]
       ++ lib.optionals stdenv.hostPlatform.isDarwin [ xz ];
+    yyjsonr = [ pkgs.zlib ];
     zlib = [ pkgs.zlib.dev ];
     # keep-sorted end
   };

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -478,7 +478,7 @@ let
       pcre.dev
     ];
     Rigraphlib = [ pkgs.cmake ];
-    Rlibeemd = [ pkgs.gsl ];
+    Rlibeemd = [ pkgs.gsl ]; # for gsl-config
     Rmpfr = with pkgs; [
       gmp
       mpfr.dev
@@ -1149,6 +1149,7 @@ let
       xz
       zlib
     ];
+    Rlibeemd = [ pkgs.gsl ];
     RmecabKo = [ pkgs.mecab ];
     Rmmquant = [ pkgs.zlib.dev ];
     RoBMA = [ pkgs.jags ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -1248,6 +1248,7 @@ let
       gsl
     ];
     cit = [ pkgs.gsl ];
+    cld3 = [ pkgs.protobuf ];
     clustermq = [ pkgs.zeromq ];
     coga = [ pkgs.gsl.dev ];
     crandep = [ pkgs.gsl ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -672,7 +672,6 @@ let
     jack = [ pkgs.pkg-config ];
     kza = [ pkgs.pkg-config ];
     libdeflate = [ pkgs.cmake ];
-    littler = [ pkgs.libdeflate ];
     lpsymphony = with pkgs; [
       pkg-config
       gfortran
@@ -1352,6 +1351,13 @@ let
     leidenAlg = [ pkgs.gmp ];
     libstable4u = [ pkgs.gsl ];
     libstableR = [ pkgs.gsl ];
+    littler = with pkgs; [
+      xz
+      zlib
+      bzip2
+      zstd
+      icu
+    ];
     lnmixsurv = [ pkgs.gsl.dev ];
     lpsymphony = with pkgs; [
       symphony
@@ -2634,28 +2640,16 @@ let
       '';
     });
 
-    littler = old.littler.overrideAttrs (
-      attrs: with pkgs; {
-        buildInputs = [
-          pcre
-          xz
-          zlib
-          bzip2
-          icu
-          which
-          zstd.dev
-        ]
-        ++ attrs.buildInputs;
-        postInstall = ''
-          install -d $out/bin $out/share/man/man1
-          ln -s ../library/littler/bin/r $out/bin/r
-          ln -s ../library/littler/bin/r $out/bin/lr
-          ln -s ../../../library/littler/man-page/r.1 $out/share/man/man1
-          # these won't run without special provisions, so better remove them
-          rm -r $out/library/littler/script-tests
-        '';
-      }
-    );
+    littler = old.littler.overrideAttrs (attrs: {
+      postInstall = ''
+        install -d $out/bin $out/share/man/man1
+        ln -s ../library/littler/bin/r $out/bin/r
+        ln -s ../library/littler/bin/r $out/bin/lr
+        ln -s ../../../library/littler/man-page/r.1 $out/share/man/man1
+        # these won't run without special provisions, so better remove them
+        rm -r $out/library/littler/script-tests
+      '';
+    });
 
     lpsymphony = old.lpsymphony.overrideAttrs (attrs: {
       postPatch = ''

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -578,10 +578,7 @@ let
     clarabel = [ pkgs.cargo ];
     cld3 = [ pkgs.protobuf ];
     clustermq = [ pkgs.pkg-config ];
-    cpp11bigwig = with pkgs; [
-      zlib.dev
-      curl.dev
-    ];
+    cpp11bigwig = [ pkgs.curl ]; # for curl-config
     cpp11qpdf = with pkgs; [
       zlib.dev
       libjpeg
@@ -1251,6 +1248,7 @@ let
     cld3 = [ pkgs.protobuf ];
     clustermq = [ pkgs.zeromq ];
     coga = [ pkgs.gsl.dev ];
+    cpp11bigwig = [ pkgs.zlib ];
     crandep = [ pkgs.gsl ];
     csaw = with pkgs; [
       zlib.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -671,7 +671,6 @@ let
     jSDM = [ pkgs.gsl ]; # for gsl-config
     jack = [ pkgs.pkg-config ];
     kza = [ pkgs.pkg-config ];
-    leidenAlg = [ pkgs.gmp.dev ];
     libdeflate = [ pkgs.cmake ];
     libstable4u = [ pkgs.gsl ];
     littler = [ pkgs.libdeflate ];
@@ -1351,6 +1350,7 @@ let
     kza = [ pkgs.fftw ];
     landsepi = [ pkgs.gsl ];
     largeList = [ pkgs.zlib.dev ];
+    leidenAlg = [ pkgs.gmp ];
     libstableR = [ pkgs.gsl ];
     lnmixsurv = [ pkgs.gsl.dev ];
     lpsymphony = with pkgs; [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -449,7 +449,6 @@ let
     RPostgreSQL = with pkgs; [ libpq.pg_config ];
     RProtoBuf = [ pkgs.pkg-config ];
     RationalMatrix = [ pkgs.pkg-config ];
-    Rbwa = [ pkgs.zlib.dev ];
     RcppCNPy = [ pkgs.zlib.dev ];
     RcppCWB = [
       pkgs.pkg-config
@@ -1122,6 +1121,7 @@ let
     RationalMatrix = [ pkgs.gmp ];
     Rbowtie = with pkgs; [ zlib.dev ];
     Rbowtie2 = [ pkgs.zlib.dev ];
+    Rbwa = [ pkgs.zlib ];
     RcppAlgos = [ pkgs.gmp.dev ];
     RcppBigIntAlgos = [ pkgs.gmp.dev ];
     RcppCWB = with pkgs; [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -746,7 +746,7 @@ let
     rjags = [ pkgs.pkg-config ];
     rlas = [ pkgs.pkg-config ];
     rmatio = [ pkgs.pkg-config ];
-    rnetcarto = [ pkgs.gsl ];
+    rnetcarto = [ pkgs.gsl ]; # for gsl-config
     roxigraph = with pkgs; [
       cargo
       rustc

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -708,7 +708,6 @@ let
       pandoc
       which
     ];
-    parseLatex = [ pkgs.icu.dev ];
     pbdMPI = [ pkgs.mpi ];
     pbdPROF = [ pkgs.mpi ];
     pbdZMQ = [ pkgs.pkg-config ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ pkgs.which ];
@@ -1403,6 +1402,7 @@ let
       zlib
     ];
     pak = [ pkgs.curl ];
+    parseLatex = [ pkgs.icu ];
     pbdZMQ = [ pkgs.zeromq ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ pkgs.darwin.binutils ];
     pdftools = [ pkgs.poppler ];
     pexm = [ pkgs.jags ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -703,7 +703,7 @@ let
       mbedtls
       nng
     ];
-    ncdf4 = [ pkgs.netcdf ];
+    ncdf4 = [ pkgs.netcdf ]; # for nc-config
     neojags = [ pkgs.jags ];
     nloptr = [ pkgs.pkg-config ];
     odbc = [ pkgs.pkg-config ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -776,10 +776,6 @@ let
       rustc
     ];
     scorematchingad = [ pkgs.cmake ];
-    sdcTable = with pkgs; [
-      gmp
-      glpk
-    ];
     seewave = with pkgs; [
       fftw.dev
       libsndfile.dev
@@ -1527,6 +1523,10 @@ let
       zlib.dev
     ];
     screenCounter = [ pkgs.zlib.dev ];
+    sdcTable = with pkgs; [
+      gmp
+      glpk
+    ];
     seqTools = [ pkgs.zlib.dev ];
     seqbias = with pkgs; [
       zlib.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -797,7 +797,7 @@ let
     sphereTessellation = [ pkgs.pkg-config ];
     string2path = [ pkgs.cargo ];
     stringi = [ pkgs.pkg-config ];
-    survSNP = [ pkgs.gsl ];
+    survSNP = [ pkgs.gsl ]; # for gsl-config
     surveyvoi = [ pkgs.pkg-config ];
     svglite = [ pkgs.libpng.dev ];
     symbolicQspray = [ pkgs.pkg-config ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -640,7 +640,6 @@ let
       gmp
       glpk
     ];
-    graphscan = [ pkgs.gsl ];
     gsl = [ pkgs.gsl ];
     gslnls = [ pkgs.gsl ];
     h3o = with pkgs; [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -662,7 +662,6 @@ let
     iBMQ = [ pkgs.gsl ]; # for gsl-config
     image_textlinedetector = [ pkgs.pkg-config ];
     imager = [ pkgs.pkg-config ];
-    imbibe = [ pkgs.zlib.dev ];
     immunoClust = [ pkgs.gsl ];
     interpolation = [ pkgs.pkg-config ];
     iscream = with pkgs; [
@@ -1323,6 +1322,7 @@ let
       libtiff
       libx11
     ];
+    imbibe = [ pkgs.zlib ];
     interpolation = with pkgs; [
       gmp
       mpfr

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -499,10 +499,7 @@ let
     SymTS = [ pkgs.gsl ]; # for gsl-config
     V8 = [ pkgs.pkg-config ];
     VBLPCM = [ pkgs.gsl ]; # for gsl-config
-    XBRL = with pkgs; [
-      zlib
-      libxml2.dev
-    ];
+    XBRL = [ pkgs.libxml2 ]; # for xml2-config
     XML = with pkgs; [
       pkg-config
       libxml2 # for xml2-config

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -634,7 +634,6 @@ let
     gdalraster = [ pkgs.pkg-config ];
     gdtools = [ pkgs.pkg-config ];
     gert = [ pkgs.pkg-config ];
-    ggiraph = [ pkgs.libpng.dev ];
     gglinedensity = [ pkgs.cargo ];
     git2r = with pkgs; [
       zlib.dev
@@ -1305,6 +1304,7 @@ let
       ];
     gert = [ pkgs.libgit2 ];
     gfilogisreg = [ pkgs.gmp.dev ];
+    ggiraph = [ pkgs.libpng ];
     gmp = [ pkgs.gmp ];
     gpg = [ pkgs.gpgme ];
     gpuMagic = [ pkgs.ocl-icd ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -782,7 +782,7 @@ let
       geos # for geos-config
     ];
     showtext = [ pkgs.pkg-config ];
-    smam = [ pkgs.gsl ];
+    smam = [ pkgs.gsl ]; # for gsl-config
     smcryptoR = with pkgs; [
       cargo
       rustc

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -425,7 +425,6 @@ let
     CytoML = [ pkgs.libxml2 ]; # for xml2-config
     GLAD = [ pkgs.gsl ]; # for gsl-config
     GPBayes = [ pkgs.gsl ]; # for gsl-config
-    HiCseg = [ pkgs.gsl ];
     HilbertVisGUI = with pkgs; [
       pkg-config
       which
@@ -1094,6 +1093,7 @@ let
     HDF5Array = [ pkgs.zlib.dev ];
     HiCDCPlus = [ pkgs.zlib.dev ];
     HiCParser = [ pkgs.zlib ];
+    HiCseg = [ pkgs.gsl ];
     HilbertVisGUI = [ pkgs.gtkmm2.dev ];
     JMcmprsk = [ pkgs.gsl ];
     KSgeneral = [ pkgs.fftw.dev ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -461,7 +461,7 @@ let
       cmake
       pkg-config
     ];
-    RcppZiggurat = [ pkgs.gsl ];
+    RcppZiggurat = [ pkgs.gsl ]; # for gsl-config
     Rglpk = [ pkgs.glpk ];
     Rhdf5lib = with pkgs; [
       cmake
@@ -1133,6 +1133,7 @@ let
       hwloc
       hdf5.dev
     ];
+    RcppZiggurat = [ pkgs.gsl ];
     Rfastp = with pkgs; [
       xz.dev
       bzip2.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -699,7 +699,6 @@ let
     neojags = [ pkgs.pkg-config ];
     nloptr = [ pkgs.pkg-config ];
     odbc = [ pkgs.pkg-config ];
-    oligo = [ pkgs.zlib.dev ];
     opencv = [ pkgs.pkg-config ];
     otelsdk = with pkgs; [
       cmake
@@ -1399,6 +1398,7 @@ let
     neojags = [ pkgs.jags ];
     nloptr = [ pkgs.nlopt ];
     odbc = [ pkgs.unixodbc ];
+    oligo = [ pkgs.zlib ];
     otelsdk = with pkgs; [
       protobuf
       zlib.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -904,7 +904,15 @@ let
     ];
     xml2 = [ pkgs.pkg-config ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ pkgs.perl ];
     xslt = [ pkgs.pkg-config ];
+    yaml12 = with pkgs; [
+      cargo
+      rustc
+    ];
     ymd = with pkgs; [
+      cargo
+      rustc
+    ];
+    zoomerjoin = with pkgs; [
       cargo
       rustc
     ];
@@ -3151,10 +3159,6 @@ let
 
     yaml12 = old.yaml12.overrideAttrs (attrs: {
       postPatch = "patchShebangs configure";
-      nativeBuildInputs = attrs.nativeBuildInputs ++ [
-        pkgs.cargo
-        pkgs.rustc
-      ];
     });
 
     ymd = old.ymd.overrideAttrs (attrs: {
@@ -3162,11 +3166,6 @@ let
     });
 
     zoomerjoin = old.zoomerjoin.overrideAttrs (attrs: {
-      nativeBuildInputs = [
-        pkgs.cargo
-        pkgs.rustc
-      ]
-      ++ attrs.nativeBuildInputs;
       postPatch = "patchShebangs configure";
     });
     # keep-sorted end

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -704,6 +704,7 @@ let
       geos # for geos-config
     ];
     magick = [ pkgs.pkg-config ];
+    markets = [ pkgs.gsl ]; # for gsl-config
     mcrPioda = [ pkgs.gsl ]; # for gsl-config
     mixlink = [ pkgs.gsl ]; # for gsl-config
     mixture = [ pkgs.gsl ]; # for gsl-config

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -442,7 +442,6 @@ let
     RJMCMCNucleosomes = [ pkgs.gsl ]; # for gsl-config
     RMySQL = [ pkgs.libmysqlclient ]; # for mysql_config
     RNetCDF = [ pkgs.pkg-config ];
-    RODBC = [ pkgs.libiodbc ];
     RPesto = with pkgs; [
       cargo
       rustc
@@ -1112,6 +1111,7 @@ let
     ];
     RNifti = [ pkgs.zlib ];
     RNiftyReg = [ pkgs.zlib ];
+    RODBC = [ pkgs.libiodbc ];
     RPostgres = with pkgs; [ libpq ];
     RProtoBuf = with pkgs; [
       protobuf

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -669,7 +669,6 @@ let
     ];
     hSDM = [ pkgs.gsl ];
     harbinger = [ pkgs.glibcLocales ];
-    haven = with pkgs; [ zlib.dev ];
     heck = with pkgs; [
       cargo
       rustc
@@ -1308,6 +1307,7 @@ let
     gpuMagic = [ pkgs.ocl-icd ];
     gridGraphics = [ pkgs.which ];
     hadron = [ pkgs.gsl ];
+    haven = [ pkgs.zlib ];
     hipread = [ pkgs.zlib.dev ];
     httpuv = [ pkgs.zlib ];
     igraph = with pkgs; [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -416,11 +416,7 @@ let
   packagesWithNativeBuildInputs = {
     # keep-sorted start block=yes
     Apollonius = [ pkgs.pkg-config ];
-    BayesXsrc = with pkgs; [
-      readline.dev
-      ncurses
-      gsl
-    ];
+    BayesXsrc = [ pkgs.gsl ]; # for gsl-config
     BigDataStatMeth = [ pkgs.pkg-config ];
     BiocCheck = [ pkgs.which ];
     Biostrings = [ pkgs.zlib ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -848,7 +848,6 @@ let
       cargo
       rustc
     ];
-    xdvir = [ pkgs.freetype.dev ];
     xml2 = [ pkgs.libxml2.dev ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ pkgs.perl ];
     xslt = [ pkgs.pkg-config ];
     ymd = with pkgs; [
@@ -1629,6 +1628,7 @@ let
     vdiffr = [ pkgs.libpng ];
     webp = [ pkgs.libwebp ];
     writexl = with pkgs; [ zlib.dev ];
+    xdvir = [ pkgs.freetype ];
     xslt =
       with pkgs;
       [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -456,6 +456,7 @@ let
     QF = [ pkgs.gsl ];
     R2SWF = [ pkgs.pkg-config ];
     RAppArmor = [ pkgs.libapparmor ];
+    RCurl = [ pkgs.curl ]; # for curl-config
     RDieHarder = [ pkgs.gsl ];
     RGtk2 = [ pkgs.pkg-config ];
     RJMCMCNucleosomes = [ pkgs.gsl ];
@@ -1126,7 +1127,6 @@ let
       libpng
       freetype
     ];
-    RCurl = [ pkgs.curl.dev ];
     RGtk2 = [ pkgs.gtk2 ];
     RITCH = [ pkgs.zlib.dev ];
     RKHSMetaMod = [ pkgs.gsl ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -633,7 +633,7 @@ let
     gdalcubes = [ pkgs.pkg-config ];
     gdalraster = [ pkgs.pkg-config ];
     gdtools = [ pkgs.pkg-config ];
-    gert = [ pkgs.libgit2 ];
+    gert = [ pkgs.pkg-config ];
     ggiraph = [ pkgs.libpng.dev ];
     gglinedensity = [ pkgs.cargo ];
     git2r = with pkgs; [
@@ -1303,6 +1303,7 @@ let
         expat
         libxdmcp
       ];
+    gert = [ pkgs.libgit2 ];
     gfilogisreg = [ pkgs.gmp.dev ];
     gmp = [ pkgs.gmp ];
     gpg = [ pkgs.gpgme ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -594,7 +594,7 @@ let
       cargo
       rustc
     ];
-    diseq = [ pkgs.gsl ];
+    diseq = [ pkgs.gsl ]; # for gsl-config
     diversitree = with pkgs; [
       gsl
       fftw

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -688,8 +688,8 @@ let
     mcrPioda = [ pkgs.gsl ]; # for gsl-config
     mixlink = [ pkgs.gsl ]; # for gsl-config
     mixture = [ pkgs.gsl ]; # for gsl-config
-    mmpca = [ pkgs.gsl ];
-    monoreg = [ pkgs.gsl ];
+    mmpca = [ pkgs.gsl ]; # for gsl-config via RcppGSL
+    monoreg = [ pkgs.gsl ]; # for gsl-config
     multibridge = [ pkgs.pkg-config ];
     mvabund = [ pkgs.gsl ];
     mvst = [ pkgs.gsl ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -424,7 +424,7 @@ let
     ChemmineOB = [ pkgs.pkg-config ];
     CytoML = [ pkgs.libxml2 ]; # for xml2-config
     GLAD = [ pkgs.gsl ]; # for gsl-config
-    GPBayes = [ pkgs.gsl ];
+    GPBayes = [ pkgs.gsl ]; # for gsl-config
     GeneralizedWendland = [ pkgs.gsl ];
     HiCParser = [ pkgs.zlib ];
     HiCseg = [ pkgs.gsl ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -795,7 +795,6 @@ let
     sodium = [ pkgs.pkg-config ];
     spate = [ pkgs.pkg-config ];
     sphereTessellation = [ pkgs.pkg-config ];
-    strawr = with pkgs; [ curl.dev ];
     string2path = [ pkgs.cargo ];
     stringi = [ pkgs.pkg-config ];
     stsm = [ pkgs.gsl ];
@@ -1554,6 +1553,7 @@ let
     spp = with pkgs; [ zlib.dev ];
     ssh = with pkgs; [ libssh ];
     stpphawkes = [ pkgs.gsl ];
+    strawr = [ pkgs.curl ];
     stringi = [ pkgs.icu74 ];
     surveyvoi = with pkgs; [
       gmp.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -435,7 +435,7 @@ let
     PICS = [ pkgs.gsl ];
     QF = [ pkgs.gsl ]; # for gsl-config
     R2SWF = [ pkgs.pkg-config ];
-    RAppArmor = [ pkgs.libapparmor ];
+    RAppArmor = [ pkgs.pkg-config ];
     RCurl = [ pkgs.curl ]; # for curl-config
     RDieHarder = [ pkgs.gsl ];
     RGtk2 = [ pkgs.pkg-config ];
@@ -967,6 +967,7 @@ let
       expat
     ];
     unigd = [ pkgs.pkg-config ];
+    unix = [ pkgs.pkg-config ];
     unsum = with pkgs; [
       cargo
       rustc
@@ -1106,6 +1107,7 @@ let
       libpng
       freetype
     ];
+    RAppArmor = lib.optionals stdenv.hostPlatform.isLinux [ pkgs.libapparmor ];
     RGtk2 = [ pkgs.gtk2 ];
     RITCH = [ pkgs.zlib.dev ];
     RKHSMetaMod = [ pkgs.gsl ];
@@ -1616,6 +1618,7 @@ let
         libxdmcp
       ];
     units = [ pkgs.udunits ];
+    unix = lib.optionals stdenv.hostPlatform.isLinux [ pkgs.libapparmor ];
     unrtf = with pkgs; [
       bzip2.dev
       icu.dev
@@ -1992,9 +1995,11 @@ let
     });
 
     RAppArmor = old.RAppArmor.overrideAttrs (attrs: {
-      env = (attrs.env or { }) // {
-        LIBAPPARMOR_HOME = pkgs.libapparmor;
-      };
+      postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''
+        # ignore apparmor detection logic
+        substituteInPlace configure \
+          --replace-fail '[ ! -e "/sys/module/apparmor" ]' 'false'
+      '';
     });
 
     RBioFormats = old.RBioFormats.overrideAttrs (attrs: {
@@ -3129,6 +3134,14 @@ let
 
     universalmotif = old.universalmotif.overrideAttrs (attrs: {
       patches = [ ./patches/universalmotif.patch ];
+    });
+
+    unix = old.unix.overrideAttrs (attrs: {
+      postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''
+        # ignore apparmor detection logic
+        substituteInPlace configure \
+          --replace-fail '[ ! -d "/sys/module/apparmor" ]' 'false'
+      '';
     });
 
     unsum = old.unsum.overrideAttrs (attrs: {

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -431,7 +431,7 @@ let
     ];
     KSgeneral = with pkgs; [ pkg-config ];
     ModelMetrics = lib.optional stdenv.hostPlatform.isDarwin pkgs.llvmPackages.openmp;
-    PEPBVS = [ pkgs.gsl ];
+    PEPBVS = [ pkgs.gsl ]; # for gsl-config
     PICS = [ pkgs.gsl ];
     QF = [ pkgs.gsl ];
     R2SWF = [ pkgs.pkg-config ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -782,7 +782,6 @@ let
       geos # for geos-config
     ];
     showtext = [ pkgs.pkg-config ];
-    simplexreg = [ pkgs.gsl ];
     smam = [ pkgs.gsl ];
     smcryptoR = with pkgs; [
       cargo
@@ -1542,6 +1541,7 @@ let
       freetype
     ];
     shrinkTVP = [ pkgs.gsl ];
+    simplexreg = [ pkgs.gsl ];
     sodium = [ pkgs.libsodium ];
     spFW = [ pkgs.fftw.dev ];
     spaMM = [ pkgs.gsl ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -691,7 +691,7 @@ let
     mmpca = [ pkgs.gsl ]; # for gsl-config via RcppGSL
     monoreg = [ pkgs.gsl ]; # for gsl-config
     multibridge = [ pkgs.pkg-config ];
-    mvabund = [ pkgs.gsl ];
+    mvabund = [ pkgs.gsl ]; # for gsl-config via RcppGSL
     mvst = [ pkgs.gsl ];
     mwaved = [ pkgs.pkg-config ];
     mzR = with pkgs; [
@@ -1394,6 +1394,7 @@ let
     mixcat = [ pkgs.gsl ];
     multibridge = [ pkgs.mpfr ];
     mutscan = [ pkgs.zlib.dev ];
+    mvabund = [ pkgs.gsl ];
     mwaved = [ pkgs.fftw ];
     nat = [ pkgs.which ];
     nat_templatebrains = [ pkgs.which ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -455,7 +455,7 @@ let
     ];
     RcppDPR = [ pkgs.gsl ]; # for gsl-config via RcppGSL
     RcppGSL = [ pkgs.gsl ]; # for gsl-config
-    RcppMeCab = [ pkgs.pkg-config ];
+    RcppMeCab = [ pkgs.mecab ]; # for mecab-config
     RcppPlanc = with pkgs; [
       which
       cmake
@@ -997,7 +997,6 @@ let
       pcre2
       glib
     ];
-    RcppMeCab = [ pkgs.mecab ];
     RcppPlanc = with pkgs; [
       hwloc
       hdf5.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -443,6 +443,7 @@ let
     RDieHarder = [ pkgs.gsl ]; # for gsl-config
     RGtk2 = [ pkgs.pkg-config ];
     RJMCMCNucleosomes = [ pkgs.gsl ]; # for gsl-config
+    RMariaDB = [ pkgs.libmysqlclient ]; # for mysql_config
     RMySQL = [ pkgs.libmysqlclient ]; # for mysql_config
     RNetCDF = [ pkgs.pkg-config ];
     RPesto = with pkgs; [
@@ -968,7 +969,6 @@ let
     RGtk2 = [ pkgs.gtk2 ];
     RITCH = [ pkgs.zlib.dev ];
     RKHSMetaMod = [ pkgs.gsl ];
-    RMariaDB = [ pkgs.libmysqlclient.dev ];
     RMark = [ pkgs.which ];
     RNetCDF = with pkgs; [
       netcdf

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -662,7 +662,7 @@ let
     iBMQ = [ pkgs.gsl ]; # for gsl-config
     image_textlinedetector = [ pkgs.pkg-config ];
     imager = [ pkgs.pkg-config ];
-    immunoClust = [ pkgs.gsl ];
+    immunoClust = [ pkgs.gsl ]; # for gsl-config
     interpolation = [ pkgs.pkg-config ];
     iscream = with pkgs; [
       pkg-config
@@ -1323,6 +1323,7 @@ let
       libx11
     ];
     imbibe = [ pkgs.zlib ];
+    immunoClust = [ pkgs.gsl ];
     interpolation = with pkgs; [
       gmp
       mpfr

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -741,7 +741,7 @@ let
     reprex = [ pkgs.which ];
     resultant = [ pkgs.pkg-config ];
     rgdal = [ pkgs.gdal ]; # for gdal-config
-    rgeos = [ pkgs.geos ];
+    rgeos = [ pkgs.geos ]; # for geos-config
     rhdf5 = [ pkgs.zlib ];
     ridge = [ pkgs.gsl ];
     rjags = [ pkgs.pkg-config ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -494,9 +494,9 @@ let
       cargo
       rustc
     ];
-    SimInf = [ pkgs.gsl ];
+    SimInf = [ pkgs.gsl ]; # for gsl-config
     SuperGauss = [ pkgs.pkg-config ];
-    SymTS = [ pkgs.gsl ];
+    SymTS = [ pkgs.gsl ]; # for gsl-config
     TAQMNGR = [ pkgs.zlib.dev ];
     TDA = [ pkgs.gmp ];
     V8 = [ pkgs.pkg-config ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -423,6 +423,7 @@ let
     Cardinal = [ pkgs.which ];
     ChemmineOB = [ pkgs.pkg-config ];
     CytoML = [ pkgs.libxml2 ]; # for xml2-config
+    DirichletMultinomial = [ pkgs.gsl ]; # for gsl-config
     GLAD = [ pkgs.gsl ]; # for gsl-config
     GPBayes = [ pkgs.gsl ]; # for gsl-config
     HilbertVisGUI = with pkgs; [
@@ -903,7 +904,6 @@ let
       xz
       bzip2
     ];
-    DirichletMultinomial = with pkgs; [ gsl ];
     DropletUtils = [ pkgs.zlib.dev ];
     EHRmuse = [ pkgs.gsl.dev ];
     FLAMES = with pkgs; [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -835,7 +835,6 @@ let
       pkg-config
       gdal # for gdal-config
     ];
-    vdiffr = [ pkgs.libpng.dev ];
     watcher = with pkgs; [
       cmake
       which
@@ -1627,6 +1626,7 @@ let
       xz
       zlib
     ];
+    vdiffr = [ pkgs.libpng ];
     webp = [ pkgs.libwebp ];
     writexl = with pkgs; [ zlib.dev ];
     xslt =

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -670,7 +670,6 @@ let
     ];
     jSDM = [ pkgs.gsl ]; # for gsl-config
     jack = [ pkgs.pkg-config ];
-    jqr = [ pkgs.jq.dev ];
     kza = [ pkgs.pkg-config ];
     leidenAlg = [ pkgs.gmp.dev ];
     libdeflate = [ pkgs.cmake ];
@@ -1344,7 +1343,7 @@ let
       bzip2.dev
     ];
     jpeg = [ pkgs.libjpeg ];
-    jqr = [ pkgs.jq.out ];
+    jqr = [ pkgs.jq ];
     knowYourCG = with pkgs; [
       zlib.dev
       ncurses.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -658,11 +658,7 @@ let
       pkgs.which
       pkgs.cmake
     ];
-    hypergeo2 = with pkgs; [
-      gmp.dev
-      mpfr.dev
-      pkg-config
-    ];
+    hypergeo2 = [ pkgs.pkg-config ];
     iBMQ = [ pkgs.gsl ];
     image_CannyEdges = with pkgs; [
       fftw.dev
@@ -1306,6 +1302,10 @@ let
     haven = [ pkgs.zlib ];
     hipread = [ pkgs.zlib.dev ];
     httpuv = [ pkgs.zlib ];
+    hypergeo2 = with pkgs; [
+      gmp
+      mpfr
+    ];
     igraph = with pkgs; [
       gmp
       libxml2.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -423,7 +423,6 @@ let
     Cardinal = [ pkgs.which ];
     ChemmineOB = [ pkgs.pkg-config ];
     CytoML = [ pkgs.libxml2 ]; # for xml2-config
-    EMCluster = [ pkgs.lapack ];
     Formula = [ pkgs.gmp ];
     GLAD = [ pkgs.gsl ];
     GPBayes = [ pkgs.gsl ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -448,10 +448,7 @@ let
     ];
     RPostgreSQL = with pkgs; [ libpq.pg_config ];
     RProtoBuf = [ pkgs.pkg-config ];
-    RationalMatrix = [
-      pkgs.pkg-config
-      pkgs.gmp.dev
-    ];
+    RationalMatrix = [ pkgs.pkg-config ];
     Rbwa = [ pkgs.zlib.dev ];
     RcppCNPy = [ pkgs.zlib.dev ];
     RcppCWB = [
@@ -1122,6 +1119,7 @@ let
       zlib
     ];
     Rarr = [ pkgs.zlib.dev ];
+    RationalMatrix = [ pkgs.gmp ];
     Rbowtie = with pkgs; [ zlib.dev ];
     Rbowtie2 = [ pkgs.zlib.dev ];
     RcppAlgos = [ pkgs.gmp.dev ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -621,7 +621,7 @@ let
     ];
     flint = [ pkgs.pkg-config ];
     flowPeaks = [ pkgs.gsl ]; # for gsl-config
-    frailtyMMpen = [ pkgs.gsl ];
+    frailtyMMpen = [ pkgs.gsl ]; # for gsl-config
     fru = with pkgs; [
       cargo
       rustc
@@ -1278,6 +1278,7 @@ let
       flint
     ];
     flowWorkspace = [ pkgs.zlib.dev ];
+    frailtyMMpen = [ pkgs.gsl ];
     fs = [ pkgs.libuv ];
     gaston = with pkgs; [ zlib.dev ];
     gdalcubes = with pkgs; [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -769,7 +769,6 @@ let
     ];
     rtracklayer = [ pkgs.pkg-config ];
     runjags = [ pkgs.pkg-config ];
-    rvg = [ pkgs.libpng.dev ];
     rzmq = [ pkgs.pkg-config ];
     s2 = [ pkgs.pkg-config ];
     salso = with pkgs; [
@@ -1510,6 +1509,7 @@ let
       curl
     ];
     runjags = [ pkgs.jags ];
+    rvg = [ pkgs.libpng ];
     rzmq = [ pkgs.zeromq ];
     s2 = with pkgs; [
       abseil-cpp

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -561,6 +561,10 @@ let
       cargo
       rustc
     ];
+    b64 = with pkgs; [
+      cargo
+      rustc
+    ];
     bigGP = [ pkgs.mpi ];
     bigrquerystorage = with pkgs; [
       grpc
@@ -610,6 +614,10 @@ let
     diversitree = [ pkgs.gsl ]; # for gsl-config
     dynr = [ pkgs.gsl ]; # for gsl-config
     eaf = [ pkgs.gsl ]; # for gsl-config
+    enderecobr = with pkgs; [
+      cargo
+      rustc
+    ];
     exactextractr = [ pkgs.geos ]; # for geos-config
     excursions = [ pkgs.gsl ]; # for gsl-config
     fRLR = [ pkgs.gsl ]; # for gsl-config
@@ -656,6 +664,10 @@ let
     gdtools = [ pkgs.pkg-config ];
     gert = [ pkgs.pkg-config ];
     gglinedensity = [ pkgs.cargo ];
+    gifski = with pkgs; [
+      cargo
+      rustc
+    ];
     git2r = [ pkgs.pkg-config ];
     glpkAPI = with pkgs; [
       gmp
@@ -2328,13 +2340,6 @@ let
     });
 
     b64 = old.b64.overrideAttrs (attrs: {
-      nativeBuildInputs =
-        with pkgs;
-        [
-          cargo
-          rustc
-        ]
-        ++ attrs.nativeBuildInputs;
       postPatch = "patchShebangs configure";
     });
 
@@ -2404,10 +2409,6 @@ let
 
     enderecobr = old.enderecobr.overrideAttrs (attrs: {
       postPatch = "patchShebangs configure";
-      nativeBuildInputs = attrs.nativeBuildInputs ++ [
-        pkgs.cargo
-        pkgs.rustc
-      ];
     });
 
     exifr = old.exifr.overrideAttrs (attrs: {
@@ -2482,22 +2483,6 @@ let
       env = (attrs.env or { }) // {
         RGL_USE_NULL = "true";
       };
-    });
-
-    gifski = old.gifski.overrideAttrs (attrs: {
-      cargoDeps = pkgs.rustPlatform.fetchCargoVendor {
-        src = attrs.src;
-        sourceRoot = "gifski/src/myrustlib";
-        hash = "sha256-yz6M3qDQPfT0HJHyK2wgzgl5sBh7EmdJ5zW8SJkk+wY=";
-      };
-
-      cargoRoot = "src/myrustlib";
-
-      nativeBuildInputs = attrs.nativeBuildInputs ++ [
-        pkgs.rustPlatform.cargoSetupHook
-        pkgs.cargo
-        pkgs.rustc
-      ];
     });
 
     gmailr = old.gmailr.overrideAttrs (attrs: {

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -429,7 +429,6 @@ let
       pkg-config
       which
     ];
-    KFKSDS = [ pkgs.gsl ];
     KSgeneral = with pkgs; [ pkg-config ];
     LOMAR = [ pkgs.gmp.dev ];
     Libra = [ pkgs.gsl ];
@@ -1084,6 +1083,7 @@ let
     HiCseg = [ pkgs.gsl ];
     HilbertVisGUI = [ pkgs.gtkmm2.dev ];
     JMcmprsk = [ pkgs.gsl ];
+    KFKSDS = [ pkgs.gsl ];
     KSgeneral = [ pkgs.fftw.dev ];
     LCMCR = [ pkgs.gsl ];
     MedianaDesigner = [ pkgs.zlib.dev ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -498,7 +498,7 @@ let
     SuperGauss = [ pkgs.pkg-config ];
     SymTS = [ pkgs.gsl ]; # for gsl-config
     V8 = [ pkgs.pkg-config ];
-    VBLPCM = [ pkgs.gsl ];
+    VBLPCM = [ pkgs.gsl ]; # for gsl-config
     XBRL = with pkgs; [
       zlib
       libxml2.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -658,7 +658,6 @@ let
       pkgs.which
       pkgs.cmake
     ];
-    httpgd = with pkgs; [ cairo.dev ];
     hypergeo2 = with pkgs; [
       gmp.dev
       mpfr.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -481,7 +481,6 @@ let
     Rlibeemd = [ pkgs.gsl ]; # for gsl-config
     Rmpi = [ pkgs.prrte ];
     Rpoppler = [ pkgs.pkg-config ];
-    Rssa = [ pkgs.fftw.dev ];
     Rsubbotools = [ pkgs.gsl ];
     Rsubread = [ pkgs.zlib.dev ];
     Rsymphony = [ pkgs.pkg-config ];
@@ -1158,6 +1157,7 @@ let
       zlib
     ];
     Rserve = [ pkgs.openssl ];
+    Rssa = [ pkgs.fftw ];
     Rsymphony = with pkgs; [
       symphony
       doxygen

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -425,7 +425,6 @@ let
     CytoML = [ pkgs.libxml2 ]; # for xml2-config
     GLAD = [ pkgs.gsl ]; # for gsl-config
     GPBayes = [ pkgs.gsl ]; # for gsl-config
-    HiCParser = [ pkgs.zlib ];
     HiCseg = [ pkgs.gsl ];
     HilbertVisGUI = with pkgs; [
       pkg-config
@@ -1094,6 +1093,7 @@ let
     GrafGen = [ pkgs.zlib ];
     HDF5Array = [ pkgs.zlib.dev ];
     HiCDCPlus = [ pkgs.zlib.dev ];
+    HiCParser = [ pkgs.zlib ];
     HilbertVisGUI = [ pkgs.gtkmm2.dev ];
     JMcmprsk = [ pkgs.gsl ];
     KSgeneral = [ pkgs.fftw.dev ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -423,7 +423,7 @@ let
     Cardinal = [ pkgs.which ];
     ChemmineOB = [ pkgs.pkg-config ];
     CytoML = [ pkgs.libxml2 ]; # for xml2-config
-    GLAD = [ pkgs.gsl ];
+    GLAD = [ pkgs.gsl ]; # for gsl-config
     GPBayes = [ pkgs.gsl ];
     GeneralizedWendland = [ pkgs.gsl ];
     HiCParser = [ pkgs.zlib ];
@@ -1081,6 +1081,7 @@ let
       bzip2.dev
       xz.dev
     ];
+    GLAD = [ pkgs.gsl ];
     GMMAT = with pkgs; [
       zlib.dev
       bzip2.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -530,12 +530,6 @@ let
       prrte.dev
     ];
     Rpoppler = [ pkgs.pkg-config ];
-    Rsamtools = with pkgs; [
-      zlib.dev
-      curl.dev
-      bzip2
-      xz
-    ];
     Rserve = [ pkgs.openssl ];
     Rssa = [ pkgs.fftw.dev ];
     Rsubbotools = [ pkgs.gsl ];
@@ -1187,6 +1181,11 @@ let
     RoBMA = [ pkgs.jags ];
     RoBSA = [ pkgs.jags ];
     Rpoppler = [ pkgs.poppler ];
+    Rsamtools = with pkgs; [
+      bzip2
+      xz
+      zlib
+    ];
     Rsymphony = with pkgs; [
       symphony
       doxygen

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -484,6 +484,7 @@ let
     ];
     Rigraphlib = [ pkgs.cmake ];
     Rlibeemd = [ pkgs.gsl ]; # for gsl-config
+    RmecabKo = [ pkgs.mecab ]; # for mecab-config
     Rmpi = [ pkgs.prrte ];
     Rpoppler = [ pkgs.pkg-config ];
     Rsubbotools = [ pkgs.gsl ]; # for gsl-config
@@ -1027,7 +1028,6 @@ let
       zlib
     ];
     Rlibeemd = [ pkgs.gsl ];
-    RmecabKo = [ pkgs.mecab ];
     Rmmquant = [ pkgs.zlib.dev ];
     Rmpfr = with pkgs; [
       gmp

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -776,10 +776,6 @@ let
       rustc
     ];
     scorematchingad = [ pkgs.cmake ];
-    seewave = with pkgs; [
-      fftw.dev
-      libsndfile.dev
-    ];
     seqminer = with pkgs; [
       zlib.dev
       bzip2

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -419,7 +419,6 @@ let
     BayesXsrc = [ pkgs.gsl ]; # for gsl-config
     BigDataStatMeth = [ pkgs.pkg-config ];
     BiocCheck = [ pkgs.which ];
-    BitSeq = [ pkgs.zlib.dev ];
     Cairo = [ pkgs.pkg-config ];
     Cardinal = [ pkgs.which ];
     CellBarcode = [ pkgs.zlib ];
@@ -1067,6 +1066,7 @@ let
     BayesSAE = [ pkgs.gsl ];
     BayesVarSel = [ pkgs.gsl ];
     BigDataStatMeth = [ pkgs.zlib ];
+    BitSeq = [ pkgs.zlib ];
     CBN2Path = [ pkgs.gsl ];
     CLVTools = [ pkgs.gsl ];
     CNEr = with pkgs; [ zlib ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -646,14 +646,14 @@ let
       cargo
       rustc
     ];
-    hSDM = [ pkgs.gsl ];
+    hSDM = [ pkgs.gsl ]; # for gsl-config
     harbinger = [ pkgs.glibcLocales ];
     heck = with pkgs; [
       cargo
       rustc
     ];
     hellorust = [ pkgs.cargo ];
-    hgwrr = [ pkgs.gsl ];
+    hgwrr = [ pkgs.gsl ]; # for gsl-config
     highs = [
       pkgs.which
       pkgs.cmake

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -635,13 +635,7 @@ let
     gdtools = [ pkgs.pkg-config ];
     gert = [ pkgs.pkg-config ];
     gglinedensity = [ pkgs.cargo ];
-    git2r = with pkgs; [
-      zlib.dev
-      openssl.dev
-      libssh2.dev
-      libgit2
-      pkg-config
-    ];
+    git2r = [ pkgs.pkg-config ];
     glpkAPI = with pkgs; [
       gmp
       glpk
@@ -1305,6 +1299,7 @@ let
     gert = [ pkgs.libgit2 ];
     gfilogisreg = [ pkgs.gmp.dev ];
     ggiraph = [ pkgs.libpng ];
+    git2r = [ pkgs.libgit2 ];
     gmp = [ pkgs.gmp ];
     gpg = [ pkgs.gpgme ];
     gpuMagic = [ pkgs.ocl-icd ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -842,6 +842,7 @@ let
     ];
     tesseract = [ pkgs.pkg-config ];
     textshaping = [ pkgs.pkg-config ];
+    tfevents = [ pkgs.protobuf ];
     tinyimg = with pkgs; [
       cargo
       rustc

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -486,6 +486,8 @@ let
     Rlibeemd = [ pkgs.gsl ]; # for gsl-config
     RmecabKo = [ pkgs.mecab ]; # for mecab-config
     Rmpi = [ pkgs.prrte ];
+    RoBMA = [ pkgs.pkg-config ];
+    RoBSA = [ pkgs.pkg-config ];
     Rpoppler = [ pkgs.pkg-config ];
     Rsubbotools = [ pkgs.gsl ]; # for gsl-config
     Rsymphony = [ pkgs.pkg-config ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -640,7 +640,6 @@ let
       gmp
       glpk
     ];
-    gmapR = [ pkgs.zlib.dev ];
     graphscan = [ pkgs.gsl ];
     gsl = [ pkgs.gsl ];
     gslnls = [ pkgs.gsl ];
@@ -1300,6 +1299,7 @@ let
     gfilogisreg = [ pkgs.gmp.dev ];
     ggiraph = [ pkgs.libpng ];
     git2r = [ pkgs.libgit2 ];
+    gmapR = [ pkgs.zlib ];
     gmp = [ pkgs.gmp ];
     gpg = [ pkgs.gpgme ];
     gpuMagic = [ pkgs.ocl-icd ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -574,7 +574,7 @@ let
       cargo
       rustc
     ];
-    cit = [ pkgs.gsl ];
+    cit = [ pkgs.gsl ]; # for gsl-config
     clarabel = [ pkgs.cargo ];
     cld3 = [ pkgs.protobuf ];
     clustermq = [ pkgs.pkg-config ];
@@ -1247,6 +1247,7 @@ let
       fftw
       gsl
     ];
+    cit = [ pkgs.gsl ];
     clustermq = [ pkgs.zeromq ];
     coga = [ pkgs.gsl.dev ];
     crandep = [ pkgs.gsl ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -610,6 +610,7 @@ let
     dynr = [ pkgs.gsl ]; # for gsl-config
     eaf = [ pkgs.gsl ]; # for gsl-config
     exactextractr = [ pkgs.geos ]; # for geos-config
+    excursions = [ pkgs.gsl ]; # for gsl-config
     fRLR = [ pkgs.gsl ]; # for gsl-config
     fangs = with pkgs; [
       cargo
@@ -1190,7 +1191,6 @@ let
       bzip2.dev
       zlib.dev
     ];
-    excursions = [ pkgs.gsl ];
     fastpng = [ pkgs.zlib ];
     fftw = [ pkgs.fftw ];
     fftwtools = [ pkgs.fftw ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -788,7 +788,7 @@ let
       pkg-config
     ];
     rtracklayer = [ pkgs.pkg-config ];
-    runjags = [ pkgs.jags ];
+    runjags = [ pkgs.pkg-config ];
     rvg = [ pkgs.libpng.dev ];
     rzmq = [ pkgs.pkg-config ];
     s2 = [ pkgs.pkg-config ];
@@ -1513,6 +1513,7 @@ let
       zlib
       curl
     ];
+    runjags = [ pkgs.jags ];
     rzmq = [ pkgs.zeromq ];
     s2 = with pkgs; [
       abseil-cpp

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -646,11 +646,6 @@ let
       cargo
       rustc
     ];
-    h5vc = with pkgs; [
-      zlib.dev
-      bzip2.dev
-      xz.dev
-    ];
     hSDM = [ pkgs.gsl ];
     harbinger = [ pkgs.glibcLocales ];
     heck = with pkgs; [
@@ -1303,6 +1298,11 @@ let
     gpg = [ pkgs.gpgme ];
     gpuMagic = [ pkgs.ocl-icd ];
     gridGraphics = [ pkgs.which ];
+    h5vc = with pkgs; [
+      zlib
+      bzip2
+      xz
+    ];
     hadron = [ pkgs.gsl ];
     haven = [ pkgs.zlib ];
     hipread = [ pkgs.zlib.dev ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -453,8 +453,8 @@ let
       pkg-config
       pcre2 # for pcre2-config
     ];
-    RcppDPR = [ pkgs.gsl ];
-    RcppGSL = [ pkgs.gsl ];
+    RcppDPR = [ pkgs.gsl ]; # for gsl-config via RcppGSL
+    RcppGSL = [ pkgs.gsl ]; # for gsl-config
     RcppMeCab = [ pkgs.pkg-config ];
     RcppPlanc = with pkgs; [
       which

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -695,10 +695,6 @@ let
     mvst = [ pkgs.gsl ]; # for gsl-config
     mwaved = [ pkgs.pkg-config ];
     n1qn1 = [ pkgs.gfortran ];
-    nanonext = with pkgs; [
-      mbedtls
-      nng
-    ];
     ncdf4 = [ pkgs.netcdf ]; # for nc-config
     neojags = [ pkgs.jags ];
     nloptr = [ pkgs.pkg-config ];
@@ -1392,6 +1388,10 @@ let
     mutscan = [ pkgs.zlib.dev ];
     mvabund = [ pkgs.gsl ];
     mwaved = [ pkgs.fftw ];
+    nanonext = with pkgs; [
+      mbedtls
+      nng
+    ];
     nat = [ pkgs.which ];
     nat_templatebrains = [ pkgs.which ];
     ncdfFlow = [ pkgs.zlib.dev ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -692,7 +692,7 @@ let
     monoreg = [ pkgs.gsl ]; # for gsl-config
     multibridge = [ pkgs.pkg-config ];
     mvabund = [ pkgs.gsl ]; # for gsl-config via RcppGSL
-    mvst = [ pkgs.gsl ];
+    mvst = [ pkgs.gsl ]; # for gsl-config
     mwaved = [ pkgs.pkg-config ];
     mzR = with pkgs; [
       zlib

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -823,6 +823,7 @@ let
     sodium = [ pkgs.pkg-config ];
     spate = [ pkgs.pkg-config ];
     sphereTessellation = [ pkgs.pkg-config ];
+    stpphawkes = [ pkgs.gsl ]; # for gsl-config via RcppGSL
     string2path = [ pkgs.cargo ];
     stringi = [ pkgs.pkg-config ];
     survSNP = [ pkgs.gsl ]; # for gsl-config
@@ -1535,7 +1536,6 @@ let
     ];
     spp = with pkgs; [ zlib.dev ];
     ssh = with pkgs; [ libssh ];
-    stpphawkes = [ pkgs.gsl ];
     strawr = [ pkgs.curl ];
     stringi = [ pkgs.icu74 ];
     stsm = [ pkgs.gsl ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -419,7 +419,6 @@ let
     BayesXsrc = [ pkgs.gsl ]; # for gsl-config
     BigDataStatMeth = [ pkgs.pkg-config ];
     BiocCheck = [ pkgs.which ];
-    Biostrings = [ pkgs.zlib ];
     BitSeq = [ pkgs.zlib.dev ];
     Cairo = [ pkgs.pkg-config ];
     Cardinal = [ pkgs.which ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -672,7 +672,6 @@ let
     jack = [ pkgs.pkg-config ];
     kza = [ pkgs.pkg-config ];
     libdeflate = [ pkgs.cmake ];
-    libstable4u = [ pkgs.gsl ];
     littler = [ pkgs.libdeflate ];
     lpsymphony = with pkgs; [
       pkg-config
@@ -1351,6 +1350,7 @@ let
     landsepi = [ pkgs.gsl ];
     largeList = [ pkgs.zlib.dev ];
     leidenAlg = [ pkgs.gmp ];
+    libstable4u = [ pkgs.gsl ];
     libstableR = [ pkgs.gsl ];
     lnmixsurv = [ pkgs.gsl.dev ];
     lpsymphony = with pkgs; [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -704,7 +704,6 @@ let
       cmake
       which
     ];
-    pak = [ pkgs.curl.dev ];
     pander = with pkgs; [
       pandoc
       which
@@ -1403,6 +1402,7 @@ let
       protobuf
       zlib
     ];
+    pak = [ pkgs.curl ];
     pbdZMQ = [ pkgs.zeromq ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ pkgs.darwin.binutils ];
     pdftools = [ pkgs.poppler ];
     pexm = [ pkgs.jags ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -449,7 +449,6 @@ let
     RPostgreSQL = with pkgs; [ libpq.pg_config ];
     RProtoBuf = [ pkgs.pkg-config ];
     RationalMatrix = [ pkgs.pkg-config ];
-    RcppCNPy = [ pkgs.zlib.dev ];
     RcppCWB = [
       pkgs.pkg-config
       pkgs.pcre2
@@ -1124,6 +1123,7 @@ let
     Rbwa = [ pkgs.zlib ];
     RcppAlgos = [ pkgs.gmp.dev ];
     RcppBigIntAlgos = [ pkgs.gmp.dev ];
+    RcppCNPy = [ pkgs.zlib ];
     RcppCWB = with pkgs; [
       pcre.dev
       glib.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -509,8 +509,6 @@ let
       jags
     ];
     adimpro = [ pkgs.imagemagick ];
-    affyPLM = [ pkgs.zlib.dev ];
-    affyio = [ pkgs.zlib.dev ];
     alcyon = with pkgs; [
       cmake
       which
@@ -1212,6 +1210,8 @@ let
       which
       xdpyinfo
     ];
+    affyPLM = [ pkgs.zlib ];
+    affyio = [ pkgs.zlib ];
     apsimx = [ pkgs.which ];
     archive = [ pkgs.libarchive ];
     arrangements = with pkgs; [ gmp.dev ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -825,10 +825,6 @@ let
       cargo
       rustc
     ];
-    udunits2 = with pkgs; [
-      udunits
-      expat
-    ];
     unigd = [ pkgs.pkg-config ];
     unix = [ pkgs.pkg-config ];
     unsum = with pkgs; [
@@ -1603,6 +1599,10 @@ let
     ];
     topicmodels = [ pkgs.gsl ];
     transmogR = [ pkgs.zlib.dev ];
+    udunits2 = with pkgs; [
+      udunits
+      expat
+    ];
     ulid = [ pkgs.zlib.dev ];
     unigd =
       with pkgs;

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -543,7 +543,6 @@ let
       cargo
       rustc
     ];
-    audio = [ pkgs.portaudio ];
     awdb = with pkgs; [
       cargo
       rustc
@@ -1222,6 +1221,7 @@ let
       zlib.dev
       zstd.dev
     ];
+    audio = [ pkgs.portaudio ];
     bamsignals = with pkgs; [
       zlib.dev
       xz.dev

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -479,10 +479,7 @@ let
     ];
     Rigraphlib = [ pkgs.cmake ];
     Rlibeemd = [ pkgs.gsl ]; # for gsl-config
-    Rmpi = with pkgs; [
-      mpi.dev
-      prrte.dev
-    ];
+    Rmpi = [ pkgs.prrte ];
     Rpoppler = [ pkgs.pkg-config ];
     Rserve = [ pkgs.openssl ];
     Rssa = [ pkgs.fftw.dev ];
@@ -1152,6 +1149,7 @@ let
       gmp
       mpfr
     ];
+    Rmpi = [ pkgs.mpi ];
     RoBMA = [ pkgs.jags ];
     RoBSA = [ pkgs.jags ];
     Rpoppler = [ pkgs.poppler ];


### PR DESCRIPTION
Targeting https://github.com/NixOS/nixpkgs/pull/539315

This takes care of almost all packages that have any overrides.

Changing the last line of `r-modules/default.nix` to the following:
```nix
self
// {
  _debug = lib.filter (pkg: pkg != null) (
    lib.map
      (
        name:
        if
          lib.elem name [
            "redatamx" # "Andromeda" tries to download data?
            "bigGP" # $out/library/Rmpi/libs/Rmpi.so: undefined symbol: mpi_universe_size
            "arrow"
            "prqlr" # $out/library/00LOCK-prqlr/00new/prqlr/libs/prqlr.so: cannot enable executable stack as shared object requires: Invalid argument
            "cn_farms" # sparse_farms.c:111:31: error: implicit declaration of function 'R_R_Calloc'; did you mean 'R_Calloc'?

            "ROracle" # unfree

            # long builds:
            "opencv"
            "FlexReg"
            "networkscaleup"

            # needs to be fixed:
            "iscream" # Rhtslib patch for strictDeps?
          ]
          || (self.${name}.meta.broken or false)
        then
          null
        else
          self.${name}
      )
      (
        lib.attrNames packagesWithNativeBuildInputs
        ++ lib.attrNames packagesWithBuildInputs
        ++ lib.attrNames (otherOverrides self self)
      )
  );
}
```

and then running `nix-build -A rPackages._debug` (maybe with `--max-jobs 1`) I was able to build everything listed inside `packagesWithNativeBuildInputs`, `packagesWithBuildInputs` and `otherOverrides`, except the packages listed in the ignorelist.

I did this both with and without my strictDeps patch.

Btw this is my strictDeps version of `generic-builder.nix`
```nix
{
  stdenv,
  lib,
  R,
  xvfb-run,
  util-linux,
  gettext,
  gfortran,
  libiconv,
}:

args:

stdenv.mkDerivation (
  {
    name = "r-${args.name or "${args.pname}-${args.version}"}";

    strictDeps = true;

    nativeBuildInputs =
      (args.nativeBuildInputs or [ ])
      ++ [
        R
        gettext
      ]
      ++ lib.optionals (args.requireX or false) [
        util-linux
        xvfb-run
      ]
      ++ lib.optionals stdenv.hostPlatform.isDarwin [
        gfortran
      ];

    buildInputs =
      (args.buildInputs or [ ])
      ++ [
        R
        gettext
      ]
      ++ lib.optionals stdenv.hostPlatform.isDarwin [
        gfortran
        libiconv
      ];

    enableParallelBuilding = true;

    env = (args.env or { }) // {
      NIX_CFLAGS_COMPILE =
        (args.env.NIX_CFLAGS_COMPILE or "")
        + lib.optionalString stdenv.hostPlatform.isDarwin " -I${lib.getInclude stdenv.cc.libcxx}/include/c++/v1";
    };

    configurePhase = ''
      runHook preConfigure

      export MAKEFLAGS+="''${enableParallelBuilding:+-j$NIX_BUILD_CORES}"
      export R_LIBS_SITE="$R_LIBS_SITE''${R_LIBS_SITE:+:}$out/library"

      if [ -f ./configure ] && [ -z "''${dontPatchShebangsInConfigure:-}" ]; then
        patchShebangs --build ./configure
      fi

      runHook postConfigure
    '';

    buildPhase = ''
      runHook preBuild
      runHook postBuild
    '';

    installFlags =
      (args.installFlags or [ ]) ++ (if (args.doCheck or true) then [ ] else [ "--no-test-load" ]);

    rCommand =
      if (args.requireX or false) then
        # Unfortunately, xvfb-run has a race condition even with -a option, so that
        # we acquire a lock explicitly.
        "flock ${xvfb-run} xvfb-run -a -e xvfb-error R"
      else
        "R";

    checkPhase = ''
      # noop since R CMD INSTALL tests packages
    '';

    installPhase = ''
      runHook preInstall
      mkdir -p $out/library
      $rCommand CMD INSTALL --built-timestamp='1970-01-01 00:00:00 UTC' $installFlags --configure-args="$configureFlags" -l $out/library .
      runHook postInstall
    '';

    postFixup = ''
      if test -e $out/nix-support/propagated-build-inputs; then
        ln -s $out/nix-support/propagated-build-inputs $out/nix-support/propagated-user-env-packages
      fi
    ''
    + (args.postFixup or "");
  }
  // (lib.removeAttrs args [
    "name"
    "nativeBuildInputs"
    "buildInputs"
    "env"
    "installFlags"
    "postFixup"
  ])
)
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
