### PR TITLE
python3Packages.aiohttp: do not drag isa-l into derivation closure by default

### DIFF
--- a/pkgs/development/python-modules/aiohttp/default.nix
+++ b/pkgs/development/python-modules/aiohttp/default.nix
@@ -34,7 +34,6 @@
   blockbuster,
   freezegun,
   gunicorn,
-  isal,
   proxy-py,
   pytest-codspeed,
   pytest-cov-stub,
@@ -44,6 +43,12 @@
   re-assert,
   trustme,
   zlib-ng,
+
+  # Tests with ISA-L.
+  # Excluded by default to avoided making thousands of python packages dependant on ISA-L.
+  withIsalTests ? false,
+  isal,
+  aiohttp,
 }:
 
 buildPythonPackage rec {
@@ -109,7 +114,6 @@ buildPythonPackage rec {
     blockbuster
     freezegun
     gunicorn
-    isal
     proxy-py
     pytest-codspeed
     pytest-cov-stub
@@ -119,6 +123,9 @@ buildPythonPackage rec {
     re-assert
     trustme
     zlib-ng
+  ]
+  ++ lib.optionals withIsalTests [
+    isal
   ];
 
   disabledTests = [
@@ -158,6 +165,12 @@ buildPythonPackage rec {
     # Work around "OSError: AF_UNIX path too long"
     export TMPDIR="/tmp"
   '';
+
+  passthru.tests = {
+    with-isal = aiohttp.override {
+      withIsalTests = true;
+    };
+  };
 
   meta = {
     changelog = "https://docs.aiohttp.org/en/${src.tag}/changes.html";

--- a/pkgs/development/python-modules/aiohttp/default.nix
+++ b/pkgs/development/python-modules/aiohttp/default.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   isPyPy,
   pythonOlder,
+  writableTmpDirAsHomeHook,
 
   # build-system
   cython,
@@ -103,6 +104,8 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+
     blockbuster
     freezegun
     gunicorn
@@ -150,8 +153,6 @@ buildPythonPackage rec {
     # aiohttp in current folder shadows installed version
     rm -r aiohttp
     touch tests/data.unknown_mime_type # has to be modified after 1 Jan 1990
-
-    export HOME=$(mktemp -d)
   ''
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
     # Work around "OSError: AF_UNIX path too long"


### PR DESCRIPTION
Problem: touching `isa-l` causes `python3Packages.isal` to change, which causes `python3Packages.aiohttp` to change, which, in turn, causes thousands of rebuilds, despite isa-l being a pretty niche library, which (in aiohttp) is only ever used for a few tests and isn't included into the output closure.

This would not be an issue if `contentAddressedByDefault` was a thing, but, sadly, it's still quite a distance away.

See:
- https://github.com/NixOS/nixpkgs/pull/536654#issuecomment-4837781131
- https://github.com/NixOS/nixpkgs/pull/537327#pullrequestreview-4607367001

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

___

Probably warrants a comment explaining why isa-l is not included by default.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
