### PR TITLE
python3Packages.blackjax: 1.5 -> 1.6

### DIFF
--- a/pkgs/development/python-modules/arviz-base/default.nix
+++ b/pkgs/development/python-modules/arviz-base/default.nix
@@ -67,6 +67,11 @@ buildPythonPackage (finalAttrs: {
     writableTmpDirAsHomeHook
   ];
 
+  pytestFlags = [
+    # DeprecationWarning: Setting the shape on a NumPy array has been deprecated in NumPy 2.5.
+    "-Wignore::DeprecationWarning"
+  ];
+
   meta = {
     description = "Base ArviZ features and converters";
     homepage = "https://github.com/arviz-devs/arviz-base";

--- a/pkgs/development/python-modules/blackjax/default.nix
+++ b/pkgs/development/python-modules/blackjax/default.nix
@@ -17,7 +17,8 @@
   typing-extensions,
 
   # optional-dependencies
-  fastprogress,
+  jax-tap,
+  tqdm,
 
   # checks
   chex,
@@ -27,14 +28,15 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "blackjax";
-  version = "1.5";
+  version = "1.6";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "blackjax-devs";
     repo = "blackjax";
     tag = finalAttrs.version;
-    hash = "sha256-tKJfukTqSiW2Xg3/8DakxtxlwGpJ14S/7qUE1OGM97I=";
+    hash = "sha256-qLOAmUQxr1xtlJB/TMnjFkvvHUwh0XKpPN+FVD8ju8Y=";
   };
 
   build-system = [
@@ -53,7 +55,8 @@ buildPythonPackage (finalAttrs: {
 
   optional-dependencies = {
     progress = [
-      fastprogress
+      jax-tap
+      tqdm
     ];
   };
 
@@ -77,6 +80,7 @@ buildPythonPackage (finalAttrs: {
 
     # AssertionError on numerical values
     "test_barker"
+    "test_imm_shrinkage_seed_influence_persists_diagonal"
     "test_laps"
     "test_mclmc"
     "test_mcse4"

--- a/pkgs/development/python-modules/corner/default.nix
+++ b/pkgs/development/python-modules/corner/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  writableTmpDirAsHomeHook,
 
   # build-system
   hatch-vcs,
@@ -13,6 +12,7 @@
 
   # optional-dependencies
   arviz,
+  arviz-base,
   ipython,
   myst-nb,
   pandoc,
@@ -23,27 +23,19 @@
 
   # tests
   pytestCheckHook,
-  corner,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "corner";
-  version = "2.2.3";
+  version = "2.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "dfm";
     repo = "corner.py";
-    tag = "v${version}";
-    hash = "sha256-gK2yylteI3VLVJ0p7NB7bR7cirCo2BvFKnYIH3kfyh4=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-H59IVXKPT4CLApn4kUuSuiYA9EWdOaH88Rd4YXf0VlQ=";
   };
-
-  nativeBuildInputs = [
-    # During `pythonImportsCheck`, `corner` imports `arviz` which wants to write a stamp file to the
-    # homedir. It then needs to be writable.
-    # https://github.com/arviz-devs/arviz/commit/4db612908f588d89bb5bfb6b83a08ada3d54fd02
-    writableTmpDirAsHomeHook
-  ];
 
   build-system = [
     hatch-vcs
@@ -53,9 +45,13 @@ buildPythonPackage rec {
   dependencies = [ matplotlib ];
 
   optional-dependencies = {
-    arviz = [ arviz ];
+    arviz = [
+      arviz
+      arviz-base
+    ];
     docs = [
       arviz
+      arviz-base
       ipython
       myst-nb
       pandoc
@@ -71,10 +67,14 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "corner" ];
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ corner.optional-dependencies.test;
+  nativeCheckInputs = [
+    arviz
+    pytestCheckHook
+    scipy
+  ];
 
-  # matplotlib.testing.exceptions.ImageComparisonFailure: images not close
   disabledTests = [
+    # matplotlib.testing.exceptions.ImageComparisonFailure: images not close
     "test_1d_fig_argument"
     "test_arviz"
     "test_basic"
@@ -110,8 +110,8 @@ buildPythonPackage rec {
   meta = {
     description = "Make some beautiful corner plots";
     homepage = "https://github.com/dfm/corner.py";
-    changelog = "https://github.com/dfm/corner.py/releases/tag/v${version}";
+    changelog = "https://github.com/dfm/corner.py/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ GaetanLepage ];
   };
-}
+})

--- a/pkgs/development/python-modules/jax-tap/default.nix
+++ b/pkgs/development/python-modules/jax-tap/default.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatch-vcs,
+  hatchling,
+
+  # dependencies
+  jax,
+
+  # optional-dependencies
+  pandas,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "jax-tap";
+  version = "0.3.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "arcueil";
+    repo = "jax-tap";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-B6Y8+9FXLhHZwQ9ayomffP3P7Uz7zuL52oxzJwCE2hM=";
+  };
+
+  build-system = [
+    hatch-vcs
+    hatchling
+  ];
+
+  dependencies = [
+    jax
+  ];
+
+  optional-dependencies = {
+    pandas = [
+      pandas
+    ];
+  };
+
+  pythonImportsCheck = [ "jaxtap" ];
+
+  nativeCheckInputs = [
+    pandas
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Make print-debugging great again";
+    homepage = "https://github.com/arcueil/jax-tap";
+    changelog = "https://github.com/arcueil/jax-tap/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/development/python-modules/minikanren/default.nix
+++ b/pkgs/development/python-modules/minikanren/default.nix
@@ -2,27 +2,35 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  toolz,
-  cons,
-  multipledispatch,
-  etuples,
-  logical-unification,
-  py,
-  pytestCheckHook,
-  pytest-html,
+
+  # build-system
   setuptools,
   setuptools-scm,
+
+  # dependencies
+  cons,
+  etuples,
+  logical-unification,
+  multipledispatch,
+  toolz,
+  typing-extensions,
+
+  # tests
+  py,
+  pytest-html,
+  pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "minikanren";
   version = "1.0.5";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "pythological";
     repo = "kanren";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-lCQ0mKT99zK5A74uoo/9bP+eFdm3MC43Fh8+P2krXrs=";
   };
 
@@ -32,17 +40,18 @@ buildPythonPackage rec {
   ];
 
   dependencies = [
-    toolz
     cons
-    multipledispatch
     etuples
     logical-unification
+    multipledispatch
+    toolz
+    typing-extensions
   ];
 
   nativeCheckInputs = [
     py
-    pytestCheckHook
     pytest-html
+    pytestCheckHook
   ];
 
   pytestFlags = [
@@ -55,8 +64,8 @@ buildPythonPackage rec {
   meta = {
     description = "Relational programming in Python";
     homepage = "https://github.com/pythological/kanren";
-    changelog = "https://github.com/pythological/kanren/releases/tag/${src.tag}";
+    changelog = "https://github.com/pythological/kanren/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ Etjean ];
   };
-}
+})

--- a/pkgs/development/python-modules/pytensor/default.nix
+++ b/pkgs/development/python-modules/pytensor/default.nix
@@ -33,7 +33,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pytensor";
-  version = "3.1.2";
+  version = "3.1.3";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -44,8 +44,15 @@ buildPythonPackage (finalAttrs: {
     postFetch = ''
       sed -i 's/git_refnames = "[^"]*"/git_refnames = " (tag: ${finalAttrs.src.tag})"/' $out/pytensor/_version.py
     '';
-    hash = "sha256-kKfbVSWsaA9ytii4GXeEmE+Oq8Qi7QNUOozgemqJI+k=";
+    hash = "sha256-9Apjyg+wmAWrK7hMSF54b1u/3TT0GGitDlyF6rQA4OY=";
   };
+
+  # DeprecationWarning: scipy.linalg: the `lwork` keyword is deprecated and no longer in use as of
+  # SciPy 1.18.0 and will be removed in SciPy 1.20.0
+  postPatch = ''
+    substituteInPlace pytensor/link/numba/dispatch/linalg/decomposition/qr.py \
+      --replace-fail "lwork=lwork," ""
+  '';
 
   build-system = [
     setuptools
@@ -85,7 +92,11 @@ buildPythonPackage (finalAttrs: {
     rm -rf pytensor
   '';
 
-  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+  disabledTests = [
+    # AssertionError: Not equal to tolerance rtol=0.0001, atol=0
+    "test_Searchsorted"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # Numerical assertion error
     # tests.unittest_tools.WrongValue: WrongValue
     "test_op_sd"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8369,6 +8369,8 @@ self: super: with self; {
 
   jax-jumpy = callPackage ../development/python-modules/jax-jumpy { };
 
+  jax-tap = callPackage ../development/python-modules/jax-tap { };
+
   jaxlib = jaxlib-bin;
 
   jaxlib-bin = callPackage ../development/python-modules/jaxlib/bin.nix { };


### PR DESCRIPTION

## Things done

- **python3Packages.jax-tap: init at 0.3.0**
- **python3Packages.blackjax: 1.5 -> 1.6**
  - Diff: https://github.com/blackjax-devs/blackjax/compare/1.5...1.6
  - Changelog: https://github.com/blackjax-devs/blackjax/releases/tag/1.6
- **python3Packages.minikanren: fix, cleanup**
- **python3Packages.arviz-base: ignore failing warning**
- **python3Packages.corner: 2.2.3 -> 2.3.0**
  - Diff: https://github.com/dfm/corner.py/compare/v2.2.3...v2.3.0
  - Changelog: https://github.com/dfm/corner.py/releases/tag/v2.3.0

cc @bcdarwin

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test