### PR TITLE
tts-mod-vault: 2.0.0 -> 2.1.0

### DIFF
--- a/pkgs/by-name/tt/tts-mod-vault/package.nix
+++ b/pkgs/by-name/tt/tts-mod-vault/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  flutter341,
+  flutter344,
   makeDesktopItem,
   copyDesktopItems,
   fetchFromGitHub,
@@ -10,15 +10,15 @@
   _experimental-update-script-combinators,
 }:
 
-flutter341.buildFlutterApplication (finalAttrs: {
+flutter344.buildFlutterApplication (finalAttrs: {
   pname = "tts-mod-vault";
-  version = "2.0.0";
+  version = "2.1.0";
 
   src = fetchFromGitHub {
     owner = "markomijic";
     repo = "TTS-Mod-Vault";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-vreamzu+jzlgzjbEro5kE5bM1k6cL6XCG6Tsv+LEiyI=";
+    hash = "sha256-4DRDYRPHDuUrtGoZi+oEqkbv2LYn+qPkJI8Ep6IkUYo=";
   };
 
   pubspecLock = lib.importJSON ./pubspec.lock.json;

--- a/pkgs/by-name/tt/tts-mod-vault/pubspec.lock.json
+++ b/pkgs/by-name/tt/tts-mod-vault/pubspec.lock.json
@@ -1,75 +1,5 @@
 {
   "packages": {
-    "_fe_analyzer_shared": {
-      "dependency": "transitive",
-      "description": {
-        "name": "_fe_analyzer_shared",
-        "sha256": "3b19a47f6ea7c2632760777c78174f47f6aec1e05f0cd611380d4593b8af1dbc",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "96.0.0"
-    },
-    "adaptive_number": {
-      "dependency": "transitive",
-      "description": {
-        "name": "adaptive_number",
-        "sha256": "3a567544e9b5c9c803006f51140ad544aedc79604fd4f3f2c1380003f97c1d77",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "1.0.0"
-    },
-    "analyzer": {
-      "dependency": "transitive",
-      "description": {
-        "name": "analyzer",
-        "sha256": "0c516bc4ad36a1a75759e54d5047cb9d15cded4459df01aa35a0b5ec7db2c2a0",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "10.2.0"
-    },
-    "app_links": {
-      "dependency": "transitive",
-      "description": {
-        "name": "app_links",
-        "sha256": "5f88447519add627fe1cbcab4fd1da3d4fed15b9baf29f28b22535c95ecee3e8",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "6.4.1"
-    },
-    "app_links_linux": {
-      "dependency": "transitive",
-      "description": {
-        "name": "app_links_linux",
-        "sha256": "f5f7173a78609f3dfd4c2ff2c95bd559ab43c80a87dc6a095921d96c05688c81",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "1.0.3"
-    },
-    "app_links_platform_interface": {
-      "dependency": "transitive",
-      "description": {
-        "name": "app_links_platform_interface",
-        "sha256": "05f5379577c513b534a29ddea68176a4d4802c46180ee8e2e966257158772a3f",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.0.2"
-    },
-    "app_links_web": {
-      "dependency": "transitive",
-      "description": {
-        "name": "app_links_web",
-        "sha256": "af060ed76183f9e2b87510a9480e56a5352b6c249778d07bd2c95fc35632a555",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "1.0.4"
-    },
     "archive": {
       "dependency": "direct main",
       "description": {
@@ -94,11 +24,11 @@
       "dependency": "transitive",
       "description": {
         "name": "async",
-        "sha256": "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb",
+        "sha256": "e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.13.0"
+      "version": "2.13.1"
     },
     "boolean_selector": {
       "dependency": "transitive",
@@ -120,66 +50,6 @@
       "source": "hosted",
       "version": "5.0.8"
     },
-    "build": {
-      "dependency": "transitive",
-      "description": {
-        "name": "build",
-        "sha256": "275bf6bb2a00a9852c28d4e0b410da1d833a734d57d39d44f94bfc895a484ec3",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "4.0.4"
-    },
-    "build_config": {
-      "dependency": "transitive",
-      "description": {
-        "name": "build_config",
-        "sha256": "4f64382b97504dc2fcdf487d5aae33418e08b4703fc21249e4db6d804a4d0187",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "1.2.0"
-    },
-    "build_daemon": {
-      "dependency": "transitive",
-      "description": {
-        "name": "build_daemon",
-        "sha256": "bf05f6e12cfea92d3c09308d7bcdab1906cd8a179b023269eed00c071004b957",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "4.1.1"
-    },
-    "build_runner": {
-      "dependency": "direct dev",
-      "description": {
-        "name": "build_runner",
-        "sha256": "39ad4ca8a2876779737c60e4228b4bcd35d4352ef7e14e47514093edc012c734",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.11.1"
-    },
-    "built_collection": {
-      "dependency": "transitive",
-      "description": {
-        "name": "built_collection",
-        "sha256": "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "5.1.1"
-    },
-    "built_value": {
-      "dependency": "transitive",
-      "description": {
-        "name": "built_value",
-        "sha256": "6ae8a6435a8c6520c7077b107e77f1fb4ba7009633259a4d49a8afd8e7efc5e9",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "8.12.4"
-    },
     "characters": {
       "dependency": "transitive",
       "description": {
@@ -189,26 +59,6 @@
       },
       "source": "hosted",
       "version": "1.4.1"
-    },
-    "checked_yaml": {
-      "dependency": "transitive",
-      "description": {
-        "name": "checked_yaml",
-        "sha256": "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.0.4"
-    },
-    "cli_util": {
-      "dependency": "transitive",
-      "description": {
-        "name": "cli_util",
-        "sha256": "ff6785f7e9e3c38ac98b2fb035701789de90154024a75b6cb926445e83197d1c",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "0.4.2"
     },
     "clock": {
       "dependency": "transitive",
@@ -224,21 +74,11 @@
       "dependency": "transitive",
       "description": {
         "name": "code_assets",
-        "sha256": "83ccdaa064c980b5596c35dd64a8d3ecc68620174ab9b90b6343b753aa721687",
+        "sha256": "bf394f466ba9205f1812a0433b392d6af280f155f56651eda7c18cc32ed493b8",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.0.0"
-    },
-    "code_builder": {
-      "dependency": "transitive",
-      "description": {
-        "name": "code_builder",
-        "sha256": "6a6cab2ba4680d6423f34a9b972a4c9a94ebe1b62ecec4e1a1f2cba91fd1319d",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "4.11.1"
+      "version": "1.2.1"
     },
     "collection": {
       "dependency": "direct main",
@@ -249,16 +89,6 @@
       },
       "source": "hosted",
       "version": "1.19.1"
-    },
-    "convert": {
-      "dependency": "transitive",
-      "description": {
-        "name": "convert",
-        "sha256": "b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "3.1.2"
     },
     "cross_file": {
       "dependency": "transitive",
@@ -280,35 +110,15 @@
       "source": "hosted",
       "version": "3.0.7"
     },
-    "dart_jsonwebtoken": {
-      "dependency": "transitive",
-      "description": {
-        "name": "dart_jsonwebtoken",
-        "sha256": "0de65691c1d736e9459f22f654ddd6fd8368a271d4e41aa07e53e6301eff5075",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "3.3.1"
-    },
-    "dart_style": {
-      "dependency": "transitive",
-      "description": {
-        "name": "dart_style",
-        "sha256": "15a7db352c8fc6a4d2bc475ba901c25b39fe7157541da4c16eacce6f8be83e49",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "3.1.5"
-    },
     "dbus": {
       "dependency": "transitive",
       "description": {
         "name": "dbus",
-        "sha256": "d0c98dcd4f5169878b6cf8f6e0a52403a9dff371a3e2f019697accbf6f44a270",
+        "sha256": "792974a4007974fbc5c1b5433eb2330a9db3e368c3f906253af4c007d0f49a91",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.7.12"
+      "version": "0.7.13"
     },
     "decimal": {
       "dependency": "transitive",
@@ -324,31 +134,21 @@
       "dependency": "direct main",
       "description": {
         "name": "dio",
-        "sha256": "b9d46faecab38fc8cc286f80bc4d61a3bb5d4ac49e51ed877b4d6706efe57b25",
+        "sha256": "ea2bad3c89a27635ce2d85cce4d6b199da49a5a48ec77b03e45b65a3b90922b0",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "5.9.1"
+      "version": "5.10.0"
     },
     "dio_web_adapter": {
       "dependency": "transitive",
       "description": {
         "name": "dio_web_adapter",
-        "sha256": "7586e476d70caecaf1686d21eee7247ea43ef5c345eab9e0cc3583ff13378d78",
+        "sha256": "dd58dc3861eb36edb13b217efc006a1c21e5bbc341de8c229b85634fa5e362e4",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.1"
-    },
-    "ed25519_edwards": {
-      "dependency": "transitive",
-      "description": {
-        "name": "ed25519_edwards",
-        "sha256": "6ce0112d131327ec6d42beede1e5dfd526069b18ad45dcf654f15074ad9276cd",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "0.3.1"
+      "version": "2.2.0"
     },
     "fake_async": {
       "dependency": "transitive",
@@ -369,16 +169,6 @@
       },
       "source": "hosted",
       "version": "2.2.0"
-    },
-    "file": {
-      "dependency": "transitive",
-      "description": {
-        "name": "file",
-        "sha256": "a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "7.0.1"
     },
     "file_picker": {
       "dependency": "direct main",
@@ -406,26 +196,6 @@
       "source": "sdk",
       "version": "0.0.0"
     },
-    "flutter_archive": {
-      "dependency": "direct main",
-      "description": {
-        "name": "flutter_archive",
-        "sha256": "e433389fde0bdfc20af40784fdb6d91753794b40cf708a43f95244fcd5d6c298",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "6.0.4"
-    },
-    "flutter_dotenv": {
-      "dependency": "direct main",
-      "description": {
-        "name": "flutter_dotenv",
-        "sha256": "d4130c4a43e0b13fefc593bc3961f2cb46e30cb79e253d4a526b1b5d24ae1ce4",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "6.0.0"
-    },
     "flutter_hooks": {
       "dependency": "direct main",
       "description": {
@@ -435,16 +205,6 @@
       },
       "source": "hosted",
       "version": "0.21.3+1"
-    },
-    "flutter_launcher_icons": {
-      "dependency": "direct dev",
-      "description": {
-        "name": "flutter_launcher_icons",
-        "sha256": "10f13781741a2e3972126fae08393d3c4e01fa4cd7473326b94b72cf594195e7",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "0.14.4"
     },
     "flutter_lints": {
       "dependency": "direct dev",
@@ -466,11 +226,11 @@
       "dependency": "transitive",
       "description": {
         "name": "flutter_plugin_android_lifecycle",
-        "sha256": "ee8068e0e1cd16c4a82714119918efdeed33b3ba7772c54b5d094ab53f9b7fd1",
+        "sha256": "3854fe5e3bff0b113c658f260b90c95dea17c92db0f2addeac2e343dd9969785",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.0.33"
+      "version": "2.0.35"
     },
     "flutter_riverpod": {
       "dependency": "transitive",
@@ -494,58 +254,8 @@
       "source": "sdk",
       "version": "0.0.0"
     },
-    "functions_client": {
-      "dependency": "transitive",
-      "description": {
-        "name": "functions_client",
-        "sha256": "94074d62167ae634127ef6095f536835063a7dc80f2b1aa306d2346ff9023996",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.5.0"
-    },
-    "glob": {
-      "dependency": "transitive",
-      "description": {
-        "name": "glob",
-        "sha256": "c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.1.3"
-    },
-    "gotrue": {
-      "dependency": "transitive",
-      "description": {
-        "name": "gotrue",
-        "sha256": "f7b52008311941a7c3e99f9590c4ee32dfc102a5442e43abf1b287d9f8cc39b2",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.18.0"
-    },
-    "graphs": {
-      "dependency": "transitive",
-      "description": {
-        "name": "graphs",
-        "sha256": "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.3.2"
-    },
-    "gtk": {
-      "dependency": "transitive",
-      "description": {
-        "name": "gtk",
-        "sha256": "e8ce9ca4b1df106e4d72dad201d345ea1a036cc12c360f1a7d5a758f78ffa42c",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.1.0"
-    },
     "hive_ce": {
-      "dependency": "direct main",
+      "dependency": "transitive",
       "description": {
         "name": "hive_ce",
         "sha256": "8e9980e68643afb1e765d3af32b47996552a64e190d03faf622cea07c1294418",
@@ -564,25 +274,15 @@
       "source": "hosted",
       "version": "2.3.4"
     },
-    "hive_ce_generator": {
-      "dependency": "direct dev",
-      "description": {
-        "name": "hive_ce_generator",
-        "sha256": "c9a7cda57823ffec35846c051637ddcd105eafa253e7395d9c8c0ed5e87fbb72",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "1.11.1"
-    },
     "hooks": {
       "dependency": "transitive",
       "description": {
         "name": "hooks",
-        "sha256": "7a08a0d684cb3b8fb604b78455d5d352f502b68079f7b80b831c62220ab0a4f6",
+        "sha256": "9a62a50b50b769a737bc0a8ff381f333529df3ab746b2f6b02e83760231455ba",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.0.1"
+      "version": "2.0.2"
     },
     "hooks_riverpod": {
       "dependency": "direct main",
@@ -604,16 +304,6 @@
       "source": "hosted",
       "version": "1.6.0"
     },
-    "http_multi_server": {
-      "dependency": "transitive",
-      "description": {
-        "name": "http_multi_server",
-        "sha256": "aa6199f908078bb1c5efb8d8638d4ae191aac11b311132c3ef48ce352fb52ef8",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "3.2.2"
-    },
     "http_parser": {
       "dependency": "transitive",
       "description": {
@@ -624,15 +314,25 @@
       "source": "hosted",
       "version": "4.1.2"
     },
+    "icons_launcher": {
+      "dependency": "direct dev",
+      "description": {
+        "name": "icons_launcher",
+        "sha256": "b42b2f9b10e58d6a973f71293f00a1f0572595e5e50d676c53048e464f78cb7d",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.1.0"
+    },
     "image": {
       "dependency": "direct main",
       "description": {
         "name": "image",
-        "sha256": "f9881ff4998044947ec38d098bc7c8316ae1186fa786eddffdb867b9bc94dfce",
+        "sha256": "6300175e00616bbc832e2fc91bfa4d776af5402c81c7151bee6905bb08473c52",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.8.0"
+      "version": "4.9.1"
     },
     "intl": {
       "dependency": "direct main",
@@ -644,16 +344,6 @@
       "source": "hosted",
       "version": "0.20.2"
     },
-    "io": {
-      "dependency": "transitive",
-      "description": {
-        "name": "io",
-        "sha256": "dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "1.0.5"
-    },
     "isolate_channel": {
       "dependency": "transitive",
       "description": {
@@ -664,25 +354,35 @@
       "source": "hosted",
       "version": "0.6.1"
     },
+    "jni": {
+      "dependency": "transitive",
+      "description": {
+        "name": "jni",
+        "sha256": "c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.0"
+    },
+    "jni_flutter": {
+      "dependency": "transitive",
+      "description": {
+        "name": "jni_flutter",
+        "sha256": "8b59e590786050b1cd866677dddaf76b1ade5e7bc751abe04b86e84d379d3ba6",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.1"
+    },
     "json_annotation": {
       "dependency": "transitive",
       "description": {
         "name": "json_annotation",
-        "sha256": "cb09e7dac6210041fad964ed7fbee004f14258b4eca4040f72d1234062ace4c8",
+        "sha256": "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.11.0"
-    },
-    "jwt_decode": {
-      "dependency": "transitive",
-      "description": {
-        "name": "jwt_decode",
-        "sha256": "d2e9f68c052b2225130977429d30f187aa1981d789c76ad104a32243cfdebfbb",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "0.3.1"
+      "version": "4.12.0"
     },
     "leak_tracker": {
       "dependency": "transitive",
@@ -738,11 +438,11 @@
       "dependency": "transitive",
       "description": {
         "name": "matcher",
-        "sha256": "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6",
+        "sha256": "dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.12.18"
+      "version": "0.12.19"
     },
     "material_color_utilities": {
       "dependency": "transitive",
@@ -758,11 +458,11 @@
       "dependency": "transitive",
       "description": {
         "name": "meta",
-        "sha256": "9f29b9bcc8ee287b1a31e0d01be0eae99a930dbffdaecf04b3f3d82a969f296f",
+        "sha256": "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.18.1"
+      "version": "1.18.0"
     },
     "mime": {
       "dependency": "direct main",
@@ -774,25 +474,15 @@
       "source": "hosted",
       "version": "2.0.0"
     },
-    "native_toolchain_c": {
-      "dependency": "transitive",
-      "description": {
-        "name": "native_toolchain_c",
-        "sha256": "89e83885ba09da5fdf2cdacc8002a712ca238c28b7f717910b34bcd27b0d03ac",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "0.17.4"
-    },
     "objective_c": {
       "dependency": "transitive",
       "description": {
         "name": "objective_c",
-        "sha256": "100a1c87616ab6ed41ec263b083c0ef3261ee6cd1dc3b0f35f8ddfa4f996fe52",
+        "sha256": "6cb691c686fa2838c6deb34980d426145c2a5d537491cb83d463c33cdbc726ed",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "9.3.0"
+      "version": "9.4.1"
     },
     "open_filex": {
       "dependency": "direct main",
@@ -818,11 +508,11 @@
       "dependency": "direct main",
       "description": {
         "name": "package_info_plus",
-        "sha256": "f69da0d3189a4b4ceaeb1a3defb0f329b3b352517f52bed4290f83d4f06bc08d",
+        "sha256": "468c26b4254ab01979fa5e4a98cb343ea3631b9acee6f21028997419a80e1a20",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "9.0.0"
+      "version": "9.0.1"
     },
     "package_info_plus_platform_interface": {
       "dependency": "transitive",
@@ -855,24 +545,24 @@
       "version": "1.9.1"
     },
     "path_provider": {
-      "dependency": "direct main",
+      "dependency": "transitive",
       "description": {
         "name": "path_provider",
-        "sha256": "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd",
+        "sha256": "a7f4874f987173da295a61c181b8ee71dab59b332a486b391babf26a1b884825",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.5"
+      "version": "2.1.6"
     },
     "path_provider_android": {
       "dependency": "transitive",
       "description": {
         "name": "path_provider_android",
-        "sha256": "f2c65e21139ce2c3dad46922be8272bb5963516045659e71bb16e151c93b580e",
+        "sha256": "69cbd515a62b94d32a7944f086b2f82b4ac40a1d45bebfc00813a430ab2dabcd",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.2.22"
+      "version": "2.3.1"
     },
     "path_provider_foundation": {
       "dependency": "transitive",
@@ -888,21 +578,21 @@
       "dependency": "transitive",
       "description": {
         "name": "path_provider_linux",
-        "sha256": "f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279",
+        "sha256": "58c2005f147315b11e9b4a7bc889cd5203e250cba8e3f012dae259b4972b5c16",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.2.1"
+      "version": "2.2.2"
     },
     "path_provider_platform_interface": {
       "dependency": "transitive",
       "description": {
         "name": "path_provider_platform_interface",
-        "sha256": "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334",
+        "sha256": "484838772624c3a4b94f1e44a3e19897fee738f2d5c4ce448443b0417f7c9dda",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.2"
+      "version": "2.1.3"
     },
     "path_provider_windows": {
       "dependency": "transitive",
@@ -913,6 +603,26 @@
       },
       "source": "hosted",
       "version": "2.3.0"
+    },
+    "pdfium_dart": {
+      "dependency": "transitive",
+      "description": {
+        "name": "pdfium_dart",
+        "sha256": "86e95c66b09f3245b95c4924f2edce8d4f7c9786876e5c5ee8e36b104a94bbb0",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.2.5"
+    },
+    "pdfrx_engine": {
+      "dependency": "direct main",
+      "description": {
+        "name": "pdfrx_engine",
+        "sha256": "89865e158ced818690ab207a13a34a65803cd67ee1bec9f5f87838eb5a79600b",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.4.3"
     },
     "petitparser": {
       "dependency": "transitive",
@@ -944,26 +654,6 @@
       "source": "hosted",
       "version": "2.1.8"
     },
-    "pointycastle": {
-      "dependency": "transitive",
-      "description": {
-        "name": "pointycastle",
-        "sha256": "92aa3841d083cc4b0f4709b5c74fd6409a3e6ba833ffc7dc6a8fee096366acf5",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "4.0.0"
-    },
-    "pool": {
-      "dependency": "transitive",
-      "description": {
-        "name": "pool",
-        "sha256": "978783255c543aa3586a1b3c21f6e9d720eb315376a915872c61ef8b5c20177d",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "1.5.2"
-    },
     "posix": {
       "dependency": "transitive",
       "description": {
@@ -973,16 +663,6 @@
       },
       "source": "hosted",
       "version": "6.5.0"
-    },
-    "postgrest": {
-      "dependency": "transitive",
-      "description": {
-        "name": "postgrest",
-        "sha256": "f4b6bb24b465c47649243ef0140475de8a0ec311dc9c75ebe573b2dcabb10460",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.6.0"
     },
     "power_extensions": {
       "dependency": "transitive",
@@ -1004,16 +684,6 @@
       "source": "hosted",
       "version": "2.2.0"
     },
-    "pubspec_parse": {
-      "dependency": "transitive",
-      "description": {
-        "name": "pubspec_parse",
-        "sha256": "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "1.5.0"
-    },
     "rational": {
       "dependency": "transitive",
       "description": {
@@ -1024,25 +694,15 @@
       "source": "hosted",
       "version": "2.2.3"
     },
-    "realtime_client": {
+    "record_use": {
       "dependency": "transitive",
       "description": {
-        "name": "realtime_client",
-        "sha256": "5268afc208d02fb9109854d262c1ebf6ece224cd285199ae1d2f92d2ff49dbf1",
+        "name": "record_use",
+        "sha256": "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.7.0"
-    },
-    "retry": {
-      "dependency": "transitive",
-      "description": {
-        "name": "retry",
-        "sha256": "822e118d5b3aafed083109c72d5f484c6dc66707885e07c0fbcb8b986bba7efc",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "3.1.2"
+      "version": "0.6.0"
     },
     "riverpod": {
       "dependency": "transitive",
@@ -1068,167 +728,57 @@
       "dependency": "transitive",
       "description": {
         "name": "screen_retriever",
-        "sha256": "570dbc8e4f70bac451e0efc9c9bb19fa2d6799a11e6ef04f946d7886d2e23d0c",
+        "sha256": "42cc3b402a0f67d2455a0d067553d0f13453f6a008d98eababf8b63958d506bd",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.2.0"
+      "version": "0.2.1"
     },
     "screen_retriever_linux": {
       "dependency": "transitive",
       "description": {
         "name": "screen_retriever_linux",
-        "sha256": "f7f8120c92ef0784e58491ab664d01efda79a922b025ff286e29aa123ea3dd18",
+        "sha256": "2a476f1a5538065bc5badf376cfdc83d6ecf07d77eb2391b9c2bff5a76970048",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.2.0"
+      "version": "0.2.1"
     },
     "screen_retriever_macos": {
       "dependency": "transitive",
       "description": {
         "name": "screen_retriever_macos",
-        "sha256": "71f956e65c97315dd661d71f828708bd97b6d358e776f1a30d5aa7d22d78a149",
+        "sha256": "b5abb900fcb86614ff10b738b34e37b9e1d03b0447280668e2bc8a98bdc7bd59",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.2.0"
+      "version": "0.2.1"
     },
     "screen_retriever_platform_interface": {
       "dependency": "transitive",
       "description": {
         "name": "screen_retriever_platform_interface",
-        "sha256": "ee197f4581ff0d5608587819af40490748e1e39e648d7680ecf95c05197240c0",
+        "sha256": "3af22d926bedf20c2caa308eea376776451a3af125919ce072e56525fded8901",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.2.0"
+      "version": "0.2.1"
     },
     "screen_retriever_windows": {
       "dependency": "transitive",
       "description": {
         "name": "screen_retriever_windows",
-        "sha256": "449ee257f03ca98a57288ee526a301a430a344a161f9202b4fcc38576716fe13",
+        "sha256": "c44b38a4c4bab34af259180a70a4eee1e29384e7b82e627c9faa68afcdab2e73",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.2.0"
-    },
-    "shared_preferences": {
-      "dependency": "direct main",
-      "description": {
-        "name": "shared_preferences",
-        "sha256": "2939ae520c9024cb197fc20dee269cd8cdbf564c8b5746374ec6cacdc5169e64",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.5.4"
-    },
-    "shared_preferences_android": {
-      "dependency": "transitive",
-      "description": {
-        "name": "shared_preferences_android",
-        "sha256": "cbc40be9be1c5af4dab4d6e0de4d5d3729e6f3d65b89d21e1815d57705644a6f",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.4.20"
-    },
-    "shared_preferences_foundation": {
-      "dependency": "transitive",
-      "description": {
-        "name": "shared_preferences_foundation",
-        "sha256": "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.5.6"
-    },
-    "shared_preferences_linux": {
-      "dependency": "transitive",
-      "description": {
-        "name": "shared_preferences_linux",
-        "sha256": "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.4.1"
-    },
-    "shared_preferences_platform_interface": {
-      "dependency": "transitive",
-      "description": {
-        "name": "shared_preferences_platform_interface",
-        "sha256": "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.4.1"
-    },
-    "shared_preferences_web": {
-      "dependency": "transitive",
-      "description": {
-        "name": "shared_preferences_web",
-        "sha256": "c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.4.3"
-    },
-    "shared_preferences_windows": {
-      "dependency": "transitive",
-      "description": {
-        "name": "shared_preferences_windows",
-        "sha256": "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.4.1"
-    },
-    "shelf": {
-      "dependency": "transitive",
-      "description": {
-        "name": "shelf",
-        "sha256": "e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "1.4.2"
-    },
-    "shelf_web_socket": {
-      "dependency": "transitive",
-      "description": {
-        "name": "shelf_web_socket",
-        "sha256": "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "3.0.0"
+      "version": "0.2.1"
     },
     "sky_engine": {
       "dependency": "transitive",
       "description": "flutter",
       "source": "sdk",
       "version": "0.0.0"
-    },
-    "source_gen": {
-      "dependency": "transitive",
-      "description": {
-        "name": "source_gen",
-        "sha256": "1d562a3c1f713904ebbed50d2760217fd8a51ca170ac4b05b0db490699dbac17",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "4.2.0"
-    },
-    "source_helper": {
-      "dependency": "transitive",
-      "description": {
-        "name": "source_helper",
-        "sha256": "4a85e90b50694e652075cbe4575665539d253e6ec10e46e76b45368ab5e3caae",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "1.3.10"
     },
     "source_span": {
       "dependency": "transitive",
@@ -1260,16 +810,6 @@
       "source": "hosted",
       "version": "1.0.0"
     },
-    "storage_client": {
-      "dependency": "transitive",
-      "description": {
-        "name": "storage_client",
-        "sha256": "1c61b19ed9e78f37fdd1ca8b729ab8484e6c8fe82e15c87e070b861951183657",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.4.1"
-    },
     "stream_channel": {
       "dependency": "transitive",
       "description": {
@@ -1279,16 +819,6 @@
       },
       "source": "hosted",
       "version": "2.1.4"
-    },
-    "stream_transform": {
-      "dependency": "transitive",
-      "description": {
-        "name": "stream_transform",
-        "sha256": "ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.1.1"
     },
     "string_scanner": {
       "dependency": "transitive",
@@ -1300,25 +830,15 @@
       "source": "hosted",
       "version": "1.4.1"
     },
-    "supabase": {
+    "synchronized": {
       "dependency": "transitive",
       "description": {
-        "name": "supabase",
-        "sha256": "cc039f63a3168386b3a4f338f3bff342c860d415a3578f3fbe854024aee6f911",
+        "name": "synchronized",
+        "sha256": "93b153dcb6a26dcddee6ca087dd634b53e38c10b5aa163e8e49501a776456153",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.10.2"
-    },
-    "supabase_flutter": {
-      "dependency": "direct main",
-      "description": {
-        "name": "supabase_flutter",
-        "sha256": "92b2416ecb6a5c3ed34cf6e382b35ce6cc8921b64f2a9299d5d28968d42b09bb",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.12.0"
+      "version": "3.4.1"
     },
     "term_glyph": {
       "dependency": "transitive",
@@ -1334,11 +854,11 @@
       "dependency": "transitive",
       "description": {
         "name": "test_api",
-        "sha256": "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636",
+        "sha256": "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.7.9"
+      "version": "0.7.11"
     },
     "typed_data": {
       "dependency": "transitive",
@@ -1349,6 +869,16 @@
       },
       "source": "hosted",
       "version": "1.4.0"
+    },
+    "universal_io": {
+      "dependency": "transitive",
+      "description": {
+        "name": "universal_io",
+        "sha256": "f63cbc48103236abf48e345e07a03ce5757ea86285ed313a6a032596ed9301e2",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.3.1"
     },
     "url_launcher": {
       "dependency": "direct main",
@@ -1364,11 +894,11 @@
       "dependency": "transitive",
       "description": {
         "name": "url_launcher_android",
-        "sha256": "767344bf3063897b5cf0db830e94f904528e6dd50a6dfaf839f0abf509009611",
+        "sha256": "b413d49b73867ac08dd2f9890efd3cc11f2a0e577618d50843440a1fb3776c32",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.3.28"
+      "version": "6.3.32"
     },
     "url_launcher_ios": {
       "dependency": "transitive",
@@ -1414,11 +944,11 @@
       "dependency": "transitive",
       "description": {
         "name": "url_launcher_web",
-        "sha256": "d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f",
+        "sha256": "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.4.2"
+      "version": "2.4.3"
     },
     "url_launcher_windows": {
       "dependency": "transitive",
@@ -1454,21 +984,11 @@
       "dependency": "transitive",
       "description": {
         "name": "vm_service",
-        "sha256": "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60",
+        "sha256": "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "15.0.2"
-    },
-    "watcher": {
-      "dependency": "transitive",
-      "description": {
-        "name": "watcher",
-        "sha256": "1398c9f081a753f9226febe8900fce8f7d0a67163334e1c94a2438339d79d635",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "1.2.1"
+      "version": "15.2.0"
     },
     "web": {
       "dependency": "transitive",
@@ -1479,26 +999,6 @@
       },
       "source": "hosted",
       "version": "1.1.1"
-    },
-    "web_socket": {
-      "dependency": "transitive",
-      "description": {
-        "name": "web_socket",
-        "sha256": "34d64019aa8e36bf9842ac014bb5d2f5586ca73df5e4d9bf5c936975cae6982c",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "1.0.1"
-    },
-    "web_socket_channel": {
-      "dependency": "transitive",
-      "description": {
-        "name": "web_socket_channel",
-        "sha256": "d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "3.0.3"
     },
     "win32": {
       "dependency": "transitive",
@@ -1534,11 +1034,11 @@
       "dependency": "transitive",
       "description": {
         "name": "xml",
-        "sha256": "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025",
+        "sha256": "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.6.1"
+      "version": "7.0.1"
     },
     "yaml": {
       "dependency": "transitive",
@@ -1549,30 +1049,10 @@
       },
       "source": "hosted",
       "version": "3.1.3"
-    },
-    "yaml_writer": {
-      "dependency": "transitive",
-      "description": {
-        "name": "yaml_writer",
-        "sha256": "69651cd7238411179ac32079937d4aa9a2970150d6b2ae2c6fe6de09402a5dc5",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.1.0"
-    },
-    "yet_another_json_isolate": {
-      "dependency": "transitive",
-      "description": {
-        "name": "yet_another_json_isolate",
-        "sha256": "fe45897501fa156ccefbfb9359c9462ce5dec092f05e8a56109db30be864f01e",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.1.0"
     }
   },
   "sdks": {
-    "dart": ">=3.10.3 <4.0.0",
-    "flutter": ">=3.38.4"
+    "dart": ">=3.12.0 <4.0.0",
+    "flutter": ">=3.44.0"
   }
 }


### PR DESCRIPTION
Update to latest release

https://github.com/markomijic/TTS-Mod-Vault/compare/v2.0.0...v2.1.0


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
