### PR TITLE
fex: use packaging for aarch64_fit_native.py

### DIFF
--- a/pkgs/by-name/fe/fex/package.nix
+++ b/pkgs/by-name/fe/fex/package.nix
@@ -185,7 +185,7 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     llvmPackages.bintools
     (python3.withPackages (
       pythonPackages: with pythonPackages; [
-        setuptools
+        packaging
         libclang
       ]
     ))


### PR DESCRIPTION
`fex` fails to configure under recent nixpkgs (Python 3.14). The build-time
Python environment provides `setuptools`, because `Scripts/aarch64_fit_native.py`
imports `packaging.version` with a `pkg_resources` fallback:

```python
try:
    from packaging.version import Version as version_check
except ImportError:
    from pkg_resources import parse_version as version_check
```

Modern `setuptools` / Python 3.14 no longer provide `pkg_resources`, and
`packaging` was never in the environment, so both imports raise
`ModuleNotFoundError`. The script exits printing nothing to stdout, and CMake
then aborts on the empty output:

```
CMake Error at CMakeLists.txt:494 (string):
  string sub-command STRIP requires two arguments.
```

This replaces `setuptools` — present only for the now-defunct `pkg_resources`
path — with `packaging`, the module the script prefers. `libclang` (used by the
thunk generator) is unchanged.

I have no native aarch64 builder on hand, so the full `aarch64-linux` build is
left to ofborg; the change is otherwise verified by evaluation.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
