### PR TITLE
remark42: 1.15.0 -> 1.16.4

### DIFF
--- a/pkgs/by-name/re/remark42/package.nix
+++ b/pkgs/by-name/re/remark42/package.nix
@@ -4,21 +4,21 @@
   fetchFromGitHub,
   buildGoModule,
   nodejs-slim_22,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   testers,
 }:
 
 let
-  pnpm = pnpm_9.override { nodejs-slim = nodejs-slim_22; };
-  version = "1.15.0";
+  pnpm = pnpm_10.override { nodejs-slim = nodejs-slim_22; };
+  version = "1.16.4";
 
   src = fetchFromGitHub {
     owner = "umputun";
     repo = "remark42";
     tag = "v${version}";
-    hash = "sha256-yd/qTRSZj0nZpgK77xP+XHyHcVXlNpyMzdfj6EbVcXQ=";
+    hash = "sha256-VCFpN/8GRziD7sKVw7jK33llo0AGqygW4ghHZxrluJc=";
   };
 
   remark42-web = stdenv.mkDerivation (finalAttrs: {
@@ -41,20 +41,11 @@ let
         version
         src
         sourceRoot
-        postPatch
         ;
       inherit pnpm;
       fetcherVersion = 4;
-      hash = "sha256-wFrMoSeD87H1yfMD0jBcw60DKDeh4yjka5aWyHuQssA=";
+      hash = "sha256-PInNiI8hcXzQoYWtHUy6BTQKgII7rHzlbSGFc+ixz7k=";
     };
-
-    postPatch = ''
-      substituteInPlace "package.json" "apps/remark42/package.json" \
-        --replace-fail "pnpm@8.15.9" "pnpm@${pnpm.version}"
-
-      substituteInPlace "apps/remark42/package.json" \
-        --replace-fail '"pnpm": "8.*"' '"pnpm": "9.*"'
-    '';
 
     buildPhase = ''
       runHook preBuild


### PR DESCRIPTION
Tracking: ~~#529286~~ #529285

Changelog: https://github.com/umputun/remark42/releases/tag/v1.16.4

pnpm is updated from 9 to 10, and the `fetcherVersion` is also bumped to 4.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
