### PR TITLE
python3Packages.kivy-garden: unbreak

### DIFF
--- a/pkgs/development/python-modules/kivy-garden/default.nix
+++ b/pkgs/development/python-modules/kivy-garden/default.nix
@@ -2,22 +2,31 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
   requests,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "kivy-garden";
   version = "0.1.5";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "kivy-garden";
     repo = "garden";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-xOMBPFKV7mTa51Q0VKja7b0E509IaWjwlJVlSRVdct8=";
   };
 
-  propagatedBuildInputs = [ requests ];
+  patches = [
+    # See https://github.com/kivy-garden/garden/commit/6257325da4b91c8cd288bfb107c366703f9f17c2
+    ./fix-name.diff
+    ./remove-import-pkg-resources.diff
+  ];
+
+  build-system = [ setuptools ];
+
+  dependencies = [ requests ];
 
   pythonImportsCheck = [ "garden" ];
 
@@ -30,4 +39,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ risson ];
   };
-}
+})

--- a/pkgs/development/python-modules/kivy-garden/fix-name.diff
+++ b/pkgs/development/python-modules/kivy-garden/fix-name.diff
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index ca8791b81f..a78fb9bfc2 100644
+--- a/setup.py
++++ b/setup.py
+@@ -4,7 +4,7 @@
+ from setuptools import setup
+ 
+ setup(
+-        name='Kivy Garden',
++        name='Kivy-Garden',
+         version='0.1.5',
+         license='MIT',
+         packages=['garden'],

--- a/pkgs/development/python-modules/kivy-garden/remove-import-pkg-resources.diff
+++ b/pkgs/development/python-modules/kivy-garden/remove-import-pkg-resources.diff
@@ -1,0 +1,37 @@
+diff --git a/ez_setup.py b/ez_setup.py
+index b02f3f17b0..de90a8e805 100644
+--- a/ez_setup.py
++++ b/ez_setup.py
+@@ -124,32 +124,6 @@
+                    to_dir=os.curdir, download_delay=15):
+     # making sure we use the absolute path
+     to_dir = os.path.abspath(to_dir)
+-    was_imported = 'pkg_resources' in sys.modules or \
+-        'setuptools' in sys.modules
+-    try:
+-        import pkg_resources
+-    except ImportError:
+-        return _do_download(version, download_base, to_dir, download_delay)
+-    try:
+-        pkg_resources.require("setuptools>=" + version)
+-        return
+-    except pkg_resources.VersionConflict:
+-        e = sys.exc_info()[1]
+-        if was_imported:
+-            sys.stderr.write(
+-            "The required version of setuptools (>=%s) is not available,\n"
+-            "and can't be installed while this script is running. Please\n"
+-            "install a more recent version first, using\n"
+-            "'easy_install -U setuptools'."
+-            "\n\n(Currently using %r)\n" % (version, e.args[0]))
+-            sys.exit(2)
+-        else:
+-            del pkg_resources, sys.modules['pkg_resources']    # reload ok
+-            return _do_download(version, download_base, to_dir,
+-                                download_delay)
+-    except pkg_resources.DistributionNotFound:
+-        return _do_download(version, download_base, to_dir,
+-                            download_delay)
+ 
+ def download_file_powershell(url, target):
+     """


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
