### PR TITLE
nixos/oo7: install oo7-cli and refactor module layout

### DIFF
--- a/nixos/modules/services/desktops/oo7.nix
+++ b/nixos/modules/services/desktops/oo7.nix
@@ -16,28 +16,26 @@ in
 
   config = lib.mkIf cfg.enable {
     environment.systemPackages = [ pkgs.oo7 ];
-
     services.dbus.packages = [ pkgs.oo7-server ];
 
-    systemd.packages = [ pkgs.oo7-server ];
+    systemd = {
+      packages = [ pkgs.oo7-server ];
+      user.services.oo7-daemon.wantedBy = [ "default.target" ];
+    };
 
-    systemd.user.services.oo7-daemon.wantedBy = [ "default.target" ];
+    security = {
+      pam.services.login.oo7.enable = true;
+
+      wrappers.oo7-daemon = {
+        owner = "root";
+        group = "root";
+        capabilities = "cap_ipc_lock=ep";
+        source = "${pkgs.oo7-server}/libexec/oo7-daemon";
+      };
+    };
 
     xdg.portal.extraPortals = [ pkgs.oo7-portal ];
-
-    security.pam.services.login.oo7.enable = true;
-
-    security.wrappers.oo7-daemon = {
-      owner = "root";
-      group = "root";
-      capabilities = "cap_ipc_lock=ep";
-      source = "${pkgs.oo7-server}/libexec/oo7-daemon";
-    };
   };
 
-  meta = {
-    inherit (pkgs.oo7.meta)
-      maintainers
-      ;
-  };
+  meta = { inherit (pkgs.oo7.meta) maintainers; };
 }

--- a/nixos/modules/services/desktops/oo7.nix
+++ b/nixos/modules/services/desktops/oo7.nix
@@ -15,6 +15,8 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.oo7 ];
+
     services.dbus.packages = [ pkgs.oo7-server ];
 
     systemd.packages = [ pkgs.oo7-server ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Follow-up to #526624, installs `oo7-cli` that was missing. I also refactored the module layout to make it easier to look at
cc: @salva09

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
