### PR TITLE
python3Packages.dbus-python: Re-enable tests

### DIFF
--- a/pkgs/development/python-modules/dbus-python/default.nix
+++ b/pkgs/development/python-modules/dbus-python/default.nix
@@ -16,83 +16,83 @@
   dbus-glib,
 }:
 
-lib.fix (
-  finalPackage:
-  buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
+  pname = "dbus-python";
+  version = "1.4.0";
+  pyproject = true;
+
+  disabled = isPyPy;
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchPypi {
     pname = "dbus-python";
-    version = "1.4.0";
-    pyproject = true;
+    inherit (finalAttrs) version;
+    hash = "sha256-mRZm5Jj2Db8+Sbi3Z49VWbimUDT99hquYs3s232Jx3A=";
+  };
 
-    disabled = isPyPy;
+  patches = [
+    # reduce required dependencies
+    # https://gitlab.freedesktop.org/dbus/dbus-python/-/merge_requests/23
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/dbus/dbus-python/-/commit/d5e19698a8d6e1485f05b67a5b2daa2392819aaf.patch";
+      hash = "sha256-Rmj/ByRLiLnIF3JsMBElJugxsG8IARcBdixLhoWgIYU=";
+    })
+  ];
 
-    outputs = [
-      "out"
-      "dev"
-    ];
+  postPatch = ''
+    # we provide patchelf natively, not through the python package
+    sed -i '/patchelf/d' pyproject.toml
 
-    src = fetchPypi {
-      inherit pname version;
-      hash = "sha256-mRZm5Jj2Db8+Sbi3Z49VWbimUDT99hquYs3s232Jx3A=";
-    };
+    patchShebangs test/*.sh
+  '';
 
-    patches = [
-      # reduce required dependencies
-      # https://gitlab.freedesktop.org/dbus/dbus-python/-/merge_requests/23
-      (fetchpatch {
-        url = "https://gitlab.freedesktop.org/dbus/dbus-python/-/commit/d5e19698a8d6e1485f05b67a5b2daa2392819aaf.patch";
-        hash = "sha256-Rmj/ByRLiLnIF3JsMBElJugxsG8IARcBdixLhoWgIYU=";
-      })
-    ];
+  nativeBuildInputs = [
+    dbus # build systems checks for `dbus-run-session` in PATH
+    meson
+    meson-python
+    pkg-config
+  ];
 
-    postPatch = ''
-      # we provide patchelf natively, not through the python package
-      sed -i '/patchelf/d' pyproject.toml
+  buildInputs = [
+    dbus
+    dbus-glib
+  ];
 
-      patchShebangs test/*.sh
-    '';
+  mesonFlags = [
+    (lib.mesonBool "tests" finalAttrs.finalPackage.doInstallCheck)
+  ];
 
-    nativeBuildInputs = [
-      dbus # build systems checks for `dbus-run-session` in PATH
-      meson
-      meson-python
-      pkg-config
-    ];
+  # workaround bug in meson-python
+  # https://github.com/mesonbuild/meson-python/issues/240
+  postInstall = ''
+    mkdir -p $dev/lib
+    mv $out/${python.sitePackages}/.dbus_python.mesonpy.libs/pkgconfig/ $dev/lib
+  '';
 
-    buildInputs = [
-      dbus
-      dbus-glib
-    ];
+  # make sure the Cflags in the pkgconfig file are correct and make the structure backwards compatible
+  postFixup = ''
+    ln -s $dev/include/*/dbus_python/dbus-1.0/ $dev/include/dbus-1.0
+  '';
 
-    mesonFlags = [ (lib.mesonBool "tests" finalPackage.doInstallCheck) ];
+  nativeCheckInputs = [ dbus.out ];
 
-    # workaround bug in meson-python
-    # https://github.com/mesonbuild/meson-python/issues/240
-    postInstall = ''
-      mkdir -p $dev/lib
-      mv $out/${python.sitePackages}/.dbus_python.mesonpy.libs/pkgconfig/ $dev/lib
-    '';
+  checkPhase = ''
+    runHook preCheck
 
-    # make sure the Cflags in the pkgconfig file are correct and make the structure backwards compatible
-    postFixup = ''
-      ln -s $dev/include/*/dbus_python/dbus-1.0/ $dev/include/dbus-1.0
-    '';
+    meson test -C build --no-rebuild --print-errorlogs --timeout-multiplier 0
 
-    nativeCheckInputs = [ dbus.out ];
+    runHook postCheck
+  '';
 
-    checkPhase = ''
-      runHook preCheck
-
-      meson test -C build --no-rebuild --print-errorlogs --timeout-multiplier 0
-
-      runHook postCheck
-    '';
-
-    meta = {
-      description = "Python DBus bindings";
-      homepage = "https://gitlab.freedesktop.org/dbus/dbus-python";
-      license = lib.licenses.mit;
-      platforms = dbus.meta.platforms;
-      maintainers = [ ];
-    };
-  }
-)
+  meta = {
+    description = "Python DBus bindings";
+    homepage = "https://gitlab.freedesktop.org/dbus/dbus-python";
+    license = lib.licenses.mit;
+    platforms = dbus.meta.platforms;
+    maintainers = [ ];
+  };
+})

--- a/pkgs/development/python-modules/dbus-python/default.nix
+++ b/pkgs/development/python-modules/dbus-python/default.nix
@@ -41,6 +41,14 @@ buildPythonPackage (finalAttrs: {
       url = "https://gitlab.freedesktop.org/dbus/dbus-python/-/commit/d5e19698a8d6e1485f05b67a5b2daa2392819aaf.patch";
       hash = "sha256-Rmj/ByRLiLnIF3JsMBElJugxsG8IARcBdixLhoWgIYU=";
     })
+
+    # Fix on Python 3.15, the patch did not achieve what it aimed for anyway.
+    # https://gitlab.freedesktop.org/dbus/dbus-python/-/work_items/59
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/dbus/dbus-python/-/commit/ebecd1747c382a57ad8e47d0e32112cdbd454b40.patch";
+      hash = "sha256-Hg4o+FPJvQ1/RW9fd8UJg/YEeVOvbJCov7SS7bT0vvs=";
+      revert = true;
+    })
   ];
 
   postPatch = ''

--- a/pkgs/development/python-modules/dbus-python/default.nix
+++ b/pkgs/development/python-modules/dbus-python/default.nix
@@ -14,6 +14,9 @@
   # native dependencies
   dbus,
   dbus-glib,
+
+  # test dependencies
+  pygobject3,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -70,8 +73,12 @@ buildPythonPackage (finalAttrs: {
     dbus-glib
   ];
 
+  checkInputs = [
+    pygobject3
+  ];
+
   mesonFlags = [
-    (lib.mesonBool "tests" finalAttrs.finalPackage.doInstallCheck)
+    (lib.mesonEnable "tests" finalAttrs.finalPackage.doInstallCheck)
   ];
 
   # workaround bug in meson-python


### PR DESCRIPTION
This was missed in f2355396eafb598a817bd8d86e45832fde18221e:

`tests` option switched to `feature` type, which mapped the old `true` value to `auto`:
  https://gitlab.freedesktop.org/dbus/dbus-python/-/commit/37c3f5a1f62bbaddbf49f28a3122bd406395d57a

Additionally, a `pygobject3` dependency has been introduced, which causes the `auto`-enabled tests to be disabled when missing: https://gitlab.freedesktop.org/dbus/dbus-python/-/commit/1614ee768ea45ba87d9dc7ad4db2254efe51d0fd


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
