### PR TITLE
python3Packages.catppuccin: fix build with matplotlib 3.11+

### DIFF
--- a/pkgs/by-name/ca/catppuccin-gtk/package.nix
+++ b/pkgs/by-name/ca/catppuccin-gtk/package.nix
@@ -75,7 +75,10 @@ lib.checkListOfEnum "${pname}: theme accent" validAccents accents lib.checkListO
       hash = "sha256-q5/VcFsm3vNEw55zq/vcM11eo456SYE5TQA3g2VQjGc=";
     };
 
-    patches = [ ./fix-inconsistent-theme-name.patch ];
+    patches = [
+      ./fix-inconsistent-theme-name.patch
+      ./python-3.14.patch # Fix build with python 3.14+
+    ];
 
     nativeBuildInputs = [
       gtk3

--- a/pkgs/by-name/ca/catppuccin-gtk/python-3.14.patch
+++ b/pkgs/by-name/ca/catppuccin-gtk/python-3.14.patch
@@ -1,0 +1,20 @@
+diff --git a/sources/build/args.py b/sources/build/args.py
+index 38a0a12..9221dec 100644
+--- a/sources/build/args.py
++++ b/sources/build/args.py
+@@ -84,7 +84,6 @@ def parse_args():
+     parser.add_argument(
+         "--zip",
+         help="Whether to bundle the theme into a zip",
+-        type=bool,
+         default=False,
+         action=argparse.BooleanOptionalAction,
+     )
+@@ -92,7 +91,6 @@ def parse_args():
+     parser.add_argument(
+         "--patch",
+         help="Whether to patch the colloid submodule",
+-        type=bool,
+         default=True,
+         action=argparse.BooleanOptionalAction,
+     )

--- a/pkgs/development/python-modules/catppuccin/default.nix
+++ b/pkgs/development/python-modules/catppuccin/default.nix
@@ -22,6 +22,11 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-wumJ8kpr+C2pdw8jYf+IqYTdSB6Iy37yZqPKycYmOSs=";
   };
 
+  patches = [
+    # https://github.com/catppuccin/python/pull/130
+    ./matplotlib-3.11.patch
+  ];
+
   build-system = [ hatchling ];
 
   optional-dependencies = {

--- a/pkgs/development/python-modules/catppuccin/matplotlib-3.11.patch
+++ b/pkgs/development/python-modules/catppuccin/matplotlib-3.11.patch
@@ -1,0 +1,37 @@
+From 11ab7be947064f11453f1063f63455b343b7253d Mon Sep 17 00:00:00 2001
+From: Raziman T V <razimantv@gmail.com>
+Date: Fri, 3 Jul 2026 13:36:29 +0100
+Subject: [PATCH] Fix #129 (caused by matplotlib 3.11 deprecating
+ mpl.style.core) by direct implementation
+
+---
+ catppuccin/extras/matplotlib.py | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/catppuccin/extras/matplotlib.py b/catppuccin/extras/matplotlib.py
+index 52934d1..f0ffafb 100644
+--- a/catppuccin/extras/matplotlib.py
++++ b/catppuccin/extras/matplotlib.py
+@@ -72,6 +72,7 @@
+ import matplotlib as mpl
+ import matplotlib.colors
+ import matplotlib.style
++from matplotlib import rc_params_from_file
+ 
+ from catppuccin.palette import PALETTE
+ 
+@@ -84,10 +85,10 @@
+ 
+ def _register_styles() -> None:
+     """Register the included stylesheets in the mpl style library."""
+-    catppuccin_stylesheets = mpl.style.core.read_style_directory(  # type: ignore [attr-defined]
+-        CATPPUCCIN_STYLE_DIRECTORY
+-    )
+-    mpl.style.core.update_nested_dict(mpl.style.library, catppuccin_stylesheets)  # type: ignore [attr-defined]
++    for path in Path(CATPPUCCIN_STYLE_DIRECTORY).glob(f"*.mplstyle"):
++        stylename = path.stem
++        style = rc_params_from_file(path, use_default_template=False)
++        mpl.style.library.setdefault(stylename, {}).update(style)
+ 
+ 
+ def _register_colormap_list() -> None:


### PR DESCRIPTION
The patch from https://github.com/catppuccin/python/pull/130 is vendored


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
