### PR TITLE
astro-language-server: 2.6.10 -> 2.6.11

### DIFF
--- a/pkgs/by-name/as/astro-language-server/package.nix
+++ b/pkgs/by-name/as/astro-language-server/package.nix
@@ -2,12 +2,15 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  pnpm,
+  pnpm_11,
   fetchPnpmDeps,
   pnpmConfigHook,
   nodejs,
   nix-update-script,
 }:
+let
+  pnpm = pnpm_11;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "astro-language-server";
   version = "2.16.11";
@@ -29,6 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
       src
       pnpmWorkspaces
       ;
+    inherit pnpm;
 
     # pnpm 11 stores state in a SQLite binary, fetcherVersion = 4 dumps it to a deterministic SQL text file
     fetcherVersion = 4;
@@ -40,8 +44,6 @@ stdenv.mkDerivation (finalAttrs: {
     pnpmConfigHook
     pnpm
   ];
-
-  buildInputs = [ nodejs ];
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/by-name/as/astro-language-server/package.nix
+++ b/pkgs/by-name/as/astro-language-server/package.nix
@@ -20,10 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   # https://pnpm.io/filtering#--filter-package_name-1
-  pnpmWorkspaces = [
-    "@astrojs/language-server..."
-    "@astrojs/ts-plugin"
-  ];
+  pnpmWorkspaces = [ "@astrojs/language-server..." ];
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs)
@@ -35,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     # pnpm 11 stores state in a SQLite binary, fetcherVersion = 4 dumps it to a deterministic SQL text file
     fetcherVersion = 4;
-    hash = "sha256-/GpdKKvldm89LBr0f7zxSkuoawh2j/QL+FPozTlBRVA=";
+    hash = "sha256-U2K0uF0D3HyY1fLxpoPtMmNEFT7DKllRsFcgknVDt6Y=";
   };
 
   nativeBuildInputs = [
@@ -49,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildPhase = ''
     runHook preBuild
 
-    pnpm --filter "@astrojs/language-server..." --filter "@astrojs/ts-plugin" build
+    pnpm --filter "@astrojs/language-server..." build
 
     runHook postBuild
   '';
@@ -62,10 +59,11 @@ stdenv.mkDerivation (finalAttrs: {
     pnpm install --offline --prod --filter="@astrojs/language-server..."
     mkdir -p $out/{bin,lib/node_modules/astro-language-server/packages/language-tools}
     cp -r ./node_modules $out/lib/node_modules/astro-language-server
-    cp -r packages/language-tools/{language-server,yaml2ts,ts-plugin} $out/lib/node_modules/astro-language-server/packages/language-tools/
+    cp -r packages/language-tools/{language-server,yaml2ts} $out/lib/node_modules/astro-language-server/packages/language-tools/
     pushd $out/lib/node_modules/astro-language-server/node_modules
-    rm -rf {./,.pnpm/node_modules/}astro-{scripts,benchmark} .pnpm/node_modules/@astrojs/ts-plugin
+    rm -rf {./,.pnpm/node_modules/}astro-{scripts,benchmark}
     popd
+
     # pnpm creates symlinks for optional platform-specific packages (e.g. @biomejs/cli-darwin-arm64)
     # that are not installed by the --prod --filter install, leaving dangling symlinks
     find $out -xtype l -delete

--- a/pkgs/by-name/as/astro-language-server/package.nix
+++ b/pkgs/by-name/as/astro-language-server/package.nix
@@ -2,39 +2,22 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  pnpm_11,
-  nodejs-slim_22,
+  pnpm,
   fetchPnpmDeps,
   pnpmConfigHook,
   nodejs,
   nix-update-script,
-  fetchpatch2,
 }:
-let
-  # pnpm 11's bundled Node.js 24 has a libuv/kqueue bug on macOS, workaround copied from openclaw package
-  pnpm = pnpm_11.override { nodejs-slim = nodejs-slim_22; };
-
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "astro-language-server";
-  version = "2.16.10";
+  version = "2.16.11";
 
   src = fetchFromGitHub {
     owner = "withastro";
     repo = "astro";
     tag = "@astrojs/language-server@${finalAttrs.version}";
-    hash = "sha256-ZzLLGfbY6Rtjzqw+MMCHthvalo3B8lf/qxFJNJ/2LdQ=";
+    hash = "sha256-FbgxlXW87vMionLpN1IRztmq4iPoARsBZ8SO9axEbCc=";
   };
-
-  patches = [
-    # remove on next release
-    (fetchpatch2 {
-      name = "fix-supply-chain-verification-fail.patch";
-      url = "https://github.com/withastro/astro/commit/272ca6173b40cfa37299c27b513f495f386d4009.patch?full_index=1";
-      includes = [ "pnpm-workspace.yaml" ];
-      hash = "sha256-jPYFiyBlIoqpbIcT/hPa+VlF1IX+QCP8CVFQGarzlEs=";
-    })
-  ];
 
   # https://pnpm.io/filtering#--filter-package_name-1
   pnpmWorkspaces = [
@@ -48,12 +31,11 @@ stdenv.mkDerivation (finalAttrs: {
       version
       src
       pnpmWorkspaces
-      patches
       ;
-    inherit pnpm;
+
     # pnpm 11 stores state in a SQLite binary, fetcherVersion = 4 dumps it to a deterministic SQL text file
     fetcherVersion = 4;
-    hash = "sha256-dqqvN8FMLjEbTtgQRkkURD7clMJ/OL9Mbk6icc4KU60=";
+    hash = "sha256-/GpdKKvldm89LBr0f7zxSkuoawh2j/QL+FPozTlBRVA=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
