### PR TITLE
iterm2: update to 3.6.11

### DIFF
--- a/pkgs/by-name/it/iterm2/package.nix
+++ b/pkgs/by-name/it/iterm2/package.nix
@@ -15,13 +15,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "iterm2";
-  version = "3.6.10";
+  version = "3.6.11";
 
   src = fetchzip {
     url = "https://iterm2.com/downloads/stable/iTerm2-${
       lib.replaceStrings [ "." ] [ "_" ] version
     }.zip";
-    hash = "sha256-igdExoh3d8EZBuKkqyNqF087jUISax07rSWG3eenUbw=";
+    hash = "sha256-01QKUiXtL4WCq174sT/A5+iqmXe8HZt/Vih02spVRRs=";
   };
 
   dontFixup = true;


### PR DESCRIPTION
Bump automático via GitHub Actions no fork (macos-latest runner) — workaround para nix-community/nixpkgs-update#513 (bot compartilhado não valida builds de pacotes Darwin-only em workers Linux).