### PR TITLE
python3Packages.flufl-bounce: 4.0 -> 5.0.1

### DIFF
--- a/pkgs/development/python-modules/flufl/bounce.nix
+++ b/pkgs/development/python-modules/flufl/bounce.nix
@@ -1,41 +1,35 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
-  fetchpatch2,
-  setuptools,
+  fetchFromGitLab,
+  hatchling,
   atpublic,
-  zope-interface,
   pytestCheckHook,
+  sybil,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "flufl-bounce";
-  version = "4.0";
+  version = "5.0.1";
   pyproject = true;
 
-  src = fetchPypi {
-    pname = "flufl.bounce";
-    inherit version;
-    hash = "sha256-JVBK65duwP5aGc1sQTo0EMtRT9zb3Kn5tdjTQ6hgODE=";
+  src = fetchFromGitLab {
+    owner = "flufl";
+    repo = "flufl.bounce";
+    tag = finalAttrs.version;
+    hash = "sha256-NWDh8vqHCAjhQYyOUkURuFhDa2xdtEukppCBCjhxhfg=";
   };
 
-  patches = [
-    (fetchpatch2 {
-      # Replace deprecated failIf with assertFalse for Python 3.12 compatibility.
-      url = "https://gitlab.com/warsaw/flufl.bounce/-/commit/e0b9fd0f24572e024a8d0484a3c9fb4542337d18.patch";
-      hash = "sha256-HJHEbRVjiiP5Z7W0sQCj6elUMyaWOTqQw6UpYOYCVZM=";
-    })
-  ];
+  build-system = [ hatchling ];
 
-  nativeBuildInputs = [ setuptools ];
-
-  propagatedBuildInputs = [
+  dependencies = [
     atpublic
-    zope-interface
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    sybil
+  ];
 
   pythonImportsCheck = [ "flufl.bounce" ];
 
@@ -44,8 +38,8 @@ buildPythonPackage rec {
   meta = {
     description = "Email bounce detectors";
     homepage = "https://gitlab.com/warsaw/flufl.bounce";
-    changelog = "https://gitlab.com/warsaw/flufl.bounce/-/blob/${version}/flufl/bounce/NEWS.rst";
+    changelog = "https://gitlab.com/warsaw/flufl.bounce/-/blob/${finalAttrs.src.tag}/docs/NEWS.rst";
     maintainers = [ ];
     license = lib.licenses.asl20;
   };
-}
+})


### PR DESCRIPTION
Diff: https://gitlab.com/flufl/flufl.bounce/-/compare/4.0...5.0.1

Changelog: https://gitlab.com/warsaw/flufl.bounce/-/blob/5.0.1/docs/NEWS.rst


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
