### PR TITLE
python3Packages.deltachat2: 0.10.0 -> 1.0.3

### DIFF
--- a/pkgs/development/python-modules/deltachat2/default.nix
+++ b/pkgs/development/python-modules/deltachat2/default.nix
@@ -2,6 +2,7 @@
   lib,
   fetchFromGitHub,
   buildPythonPackage,
+  dacite,
   deltachat-rpc-server,
   setuptools-scm,
   replaceVars,
@@ -9,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "deltachat2";
-  version = "0.10.0";
+  version = "1.0.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "adbenitez";
     repo = "deltachat2";
     tag = version;
-    hash = "sha256-04MXh1p2xRRnvyu5GrPqMuaraP08WQbFzXYhkXRznA4=";
+    hash = "sha256-L2T1dUv7OCkAg6R5W1ukT/jEcSIkoLUVZmBhYxuPDCE=";
   };
 
   patches = [
@@ -27,6 +28,10 @@ buildPythonPackage rec {
 
   build-system = [
     setuptools-scm
+  ];
+
+  dependencies = [
+    dacite
   ];
 
   pythonImportsCheck = [ "deltachat2" ];

--- a/pkgs/development/python-modules/deltachat2/paths.patch
+++ b/pkgs/development/python-modules/deltachat2/paths.patch
@@ -1,13 +1,13 @@
 diff --git a/deltachat2/transport.py b/deltachat2/transport.py
-index c48827e..bfbc390 100644
+index c8b4a9c..a89994c 100644
 --- a/deltachat2/transport.py
 +++ b/deltachat2/transport.py
-@@ -71,7 +71,7 @@ class IOTransport:
-             # `process_group` is not supported before Python 3.11.
-             kwargs = {"preexec_fn": os.setpgrp, **self._kwargs}  # noqa: PLW1509
-         self.process = subprocess.Popen(  # pylint:disable=consider-using-with
--            "deltachat-rpc-server",
-+            "@deltachatrpcserver@",
-             stdin=subprocess.PIPE,
-             stdout=subprocess.PIPE,
-             **kwargs,
+@@ -44,7 +44,7 @@ class IOTransport:
+     def __init__(
+         self,
+         accounts_dir: Optional[str] = None,
+-        rpc_executable: str = "deltachat-rpc-server",
++        rpc_executable: str = "@deltachatrpcserver@",
+         **kwargs,
+     ):
+         """The given arguments will be passed to subprocess.Popen()"""


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
