### PR TITLE
python3Packages.pamqp: 4.0.0 -> 4.0.1

### DIFF
--- a/pkgs/development/python-modules/pamqp/default.nix
+++ b/pkgs/development/python-modules/pamqp/default.nix
@@ -7,7 +7,7 @@
 }:
 
 buildPythonPackage rec {
-  version = "4.0.0";
+  version = "4.0.1";
   pname = "pamqp";
 
   pyproject = true;
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     owner = "gmr";
     repo = "pamqp";
     tag = version;
-    hash = "sha256-0rRVbzC5G+lH6Okvw8PtoPZKD8LlobAGYvDEIDw0aFo=";
+    hash = "sha256-WKkiwisCfGRkNbw8WtXqNe4OqUiRgVfVL7o0oMdeFJw=";
   };
 
   build-system = [ hatchling ];
@@ -37,7 +37,7 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    changelog = "https://github.com/gmr/pamqp/blob/${src.tag}/docs/changelog.rst";
+    changelog = "https://github.com/gmr/pamqp/blob/${src.tag}/docs/changelog.md";
     description = "RabbitMQ Focused AMQP low-level library";
     homepage = "https://github.com/gmr/pamqp";
     license = lib.licenses.bsd3;

--- a/pkgs/development/python-modules/pamqp/default.nix
+++ b/pkgs/development/python-modules/pamqp/default.nix
@@ -6,7 +6,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   version = "4.0.1";
   pname = "pamqp";
 
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "gmr";
     repo = "pamqp";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-WKkiwisCfGRkNbw8WtXqNe4OqUiRgVfVL7o0oMdeFJw=";
   };
 
@@ -37,10 +37,10 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    changelog = "https://github.com/gmr/pamqp/blob/${src.tag}/docs/changelog.md";
+    changelog = "https://github.com/gmr/pamqp/blob/${finalAttrs.src.tag}/docs/changelog.md";
     description = "RabbitMQ Focused AMQP low-level library";
     homepage = "https://github.com/gmr/pamqp";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ dotlambda ];
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/gmr/pamqp/compare/4.0.0...4.0.1

Changelog: https://github.com/gmr/pamqp/releases/tag/4.0.1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
