### PR TITLE
legit-web: make package easier to customize

### DIFF
--- a/nixos/modules/services/networking/legit.nix
+++ b/nixos/modules/services/networking/legit.nix
@@ -52,6 +52,7 @@ in
         for possible values.
       '';
       type = types.submodule {
+        freeformType = yaml.type;
         options.repo = {
           scanPath = mkOption {
             type = types.path;
@@ -60,7 +61,12 @@ in
           };
           readme = mkOption {
             type = types.listOf types.str;
-            default = [ ];
+            default = [
+              "readme"
+              "README"
+              "readme.md"
+              "README.md"
+            ];
             description = "Readme files to look for.";
           };
           mainBranch = mkOption {
@@ -80,14 +86,14 @@ in
         options.dirs = {
           templates = mkOption {
             type = types.path;
-            default = "${pkgs.legit-web}/lib/legit/templates";
-            defaultText = literalExpression ''"''${pkgs.legit-web}/lib/legit/templates"'';
+            default = "${cfg.package}/lib/legit/templates";
+            defaultText = literalExpression ''"''${config.services.legit.package}/lib/legit/templates"'';
             description = "Directories where template files are located.";
           };
           static = mkOption {
             type = types.path;
-            default = "${pkgs.legit-web}/lib/legit/static";
-            defaultText = literalExpression ''"''${pkgs.legit-web}/lib/legit/static"'';
+            default = "${cfg.package}/lib/legit/static";
+            defaultText = literalExpression ''"''${config.services.legit.package}/lib/legit/static"'';
             description = "Directories where static files are located.";
           };
         };

--- a/pkgs/by-name/le/legit-web/package.nix
+++ b/pkgs/by-name/le/legit-web/package.nix
@@ -22,8 +22,8 @@ buildGoModule (finalAttrs: {
     mkdir -p $out/lib/legit/templates
     mkdir -p $out/lib/legit/static
 
-    cp -r $src/templates/* $out/lib/legit/templates
-    cp -r $src/static/* $out/lib/legit/static
+    cp -r templates/* $out/lib/legit/templates
+    cp -r static/* $out/lib/legit/static
   '';
 
   passthru.tests = { inherit (nixosTests) legit; };


### PR DESCRIPTION
I made `services.legit.settings` accept settings other than the ones listed (useful if you're using a legit fork), added the same default for the `readme` setting that upstream recommends, and fixed a few mistakes in the package


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
