### PR TITLE
darwin.xcode: add 26.6

### DIFF
--- a/pkgs/os-specific/darwin/xcode/default.nix
+++ b/pkgs/os-specific/darwin/xcode/default.nix
@@ -133,6 +133,8 @@ lib.makeExtensible (self: {
   xcode_26_4_1_Apple_silicon = requireXcode "26.4.1_Apple_silicon" "sha256-8MtGX97e/2+zvY2Et9Jm9eXqVmyr+U02UqsKmffh9hs=";
   xcode_26_5 = requireXcode "26.5_Universal" "sha256-hQ1I7CuVOmkCcVLo1AUV25PJGL33fT3MuWR+DJZ84aQ=";
   xcode_26_5_Apple_silicon = requireXcode "26.5_Apple_silicon" "sha256-lavdscO0z4Tyf22vV8QMooOt5yYFwnTi1oe3yA+wTdA=";
+  xcode_26_6 = requireXcode "26.6_Universal" "sha256-D2xuCXVhTLJLScQ1sxaVH8nANfgkm7/+9iYdi7/FCLI=";
+  xcode_26_6_Apple_silicon = requireXcode "26.6_Apple_silicon" "sha256-UOtZRrSPNhwCLGgpNJTPrdOrVKq+7UHnUJjlxakZmOA=";
   xcode =
     self."xcode_${
       lib.replaceStrings [ "." ] [ "_" ] (

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -140,6 +140,8 @@ makeScopeWithSplicing' {
         xcode_26_4_1_Apple_silicon
         xcode_26_5
         xcode_26_5_Apple_silicon
+        xcode_26_6
+        xcode_26_6_Apple_silicon
         xcode
         requireXcode
         ;


### PR DESCRIPTION
<table role="table">
<thead>
<tr>
<th><code>NIXPKGS_ALLOW_UNFREE=1 nix-build -A darwin.xcode_26_6</code></th>
<th><code>NIXPKGS_ALLOW_UNFREE=1 nix-build -A darwin.xcode_26_6_Apple_silicon</code></th>
</tr>
</thead>
<tbody>
<tr>
<td>
<pre>
<code>/nix/store/mg9sh5dpxj34ycicrrsvmgj9rcjl79pf-Xcode.app</code>
</pre>
</td>
<td>
<pre>
<code>/nix/store/znv0i1v3amg6xcnzikk1vb3nin24gjhk-Xcode.app</code>
</pre>
</td>
</tr>
<tr>
<td>
<img width="387" height="234" alt="image" src="https://github.com/user-attachments/assets/872107e4-0c4d-4c52-820a-16179bdd4ce2" />
</td>
<td>
<img width="388" height="239" alt="image" src="https://github.com/user-attachments/assets/90478f76-2ac3-4c02-ace6-936fa6267ee4" />
</td>
</tr>
</tbody>
</table>

<img width="642" height="331" alt="image" src="https://github.com/user-attachments/assets/2b13dff7-65ba-411c-ac12-d76b19f6aec4" />


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
