### PR TITLE
rcp: 0.35.0 -> 0.36.0

### DIFF
--- a/pkgs/by-name/rc/rcp/package.nix
+++ b/pkgs/by-name/rc/rcp/package.nix
@@ -6,16 +6,16 @@
 
 pkgsStatic.rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rcp";
-  version = "0.35.0";
+  version = "0.36.0";
 
   src = fetchFromGitHub {
     owner = "wykurz";
     repo = "rcp";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-toO+gVPHfc/drP9Xj0vJOJvOxsH/0VqXKSwfYvkZfnE=";
+    hash = "sha256-laGQWJbke+q0dAdqR8opXw4oQm6wdJJT0/t/A9c7d9s=";
   };
 
-  cargoHash = "sha256-lbS67Hiv0ay0DzzoZsFRxc9EKl9sw+pYJwn9FmXquos=";
+  cargoHash = "sha256-+T9aGsewRHdmKMtZisXv4st+9kBTNtEZnPraLz8S4e8=";
 
   env.RUSTFLAGS = "--cfg tokio_unstable";
 
@@ -33,6 +33,11 @@ pkgsStatic.rustPlatform.buildRustPackage (finalAttrs: {
     "--skip=test_preserve_settings_dir_7777_preserves_special_bits"
     "--skip=test_preserve_settings_file_7777_preserves_special_bits"
     "--skip=test_preserve_settings_none_strips_special_bits_on_directories"
+    "--skip=no_setid_clears_bits_for_unchanged_owner_rule"
+    "--skip=no_setid_clears_existing_bits_for_unrelated_mode"
+    "--skip=no_setid_dry_run_reports_but_does_not_clear_bits"
+    "--skip=no_setid_respects_filter_and_per_type_scope"
+    "--skip=no_setid_retains_sticky_and_clears_setgid_on_directory"
     # this test expects overwrite behavior that doesn't work in a sandbox
     "--skip=test_overwrite_behavior"
     # these tests require network access to determine local IP address


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
