### PR TITLE
surrealdb: 2.6.1 -> 3.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1463,6 +1463,12 @@
     githubId = 60479013;
     name = "Alma Cemerlic";
   };
+  aln730 = {
+    email = "arnsg730@proton.me";
+    github = "aln730";
+    githubId = 94751172;
+    name = "AGawas";
+  };
   Alper-Celik = {
     email = "alper@alper-celik.dev";
     name = "Alper Çelik";

--- a/pkgs/by-name/su/surrealdb/package.nix
+++ b/pkgs/by-name/su/surrealdb/package.nix
@@ -18,7 +18,7 @@ assert lib.assertMsg (builtins.elem backend [
 ]) "surrealdb: backend must be one of [ \"rocksdb\" \"surrealkv\" ]";
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = if hasRocksDB then "surrealdb" else "surrealdb-surrealkv";
-  version = "2.6.1";
+  version = "3.0.0";
 
   __structuredAttrs = true;
 
@@ -26,15 +26,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "surrealdb";
     repo = "surrealdb";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Dd6tabpSTh7IN9PLE4Zt/s1G7mNUwYfy+nEZpPTy8a8=";
+    hash = "sha256-KDVc5BTkJ5OwxANeXOBnerJihnKU6y72Dw8h1ARcj3U=";
   };
 
-  cargoHash = "sha256-lebSQPGnxW+3a7vWw3R7QYtHx04/DsRK/n8c/UT3FZo=";
+  cargoHash = "sha256-yemnwhcC5CsQgO29Qiau39QAVbGnrNsOG1dNen987HM=";
 
   # Upstream hard-codes `aarch64-linux-gnu-gcc` in `.cargo/config.toml`.
   # Remove it so Cargo uses nixpkgs' wrapped C toolchain instead.
   postPatch = ''
     rm .cargo/config.toml
+    sed -i '1i #![recursion_limit = "256"]' surrealdb/server/src/lib.rs
   '';
 
   buildNoDefaultFeatures = true;
@@ -44,10 +45,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "http"
     "scripting"
     "storage-mem"
-    "storage-surrealcs"
-    # Keep this enabled for the default RocksDB build to preserve upstream's
-    # default storage feature set. It can be dropped if `pkgs.surrealdb` is
-    # intentionally slimmed to RocksDB-only in a later change.
     "storage-surrealkv"
   ]
   ++ lib.optional hasRocksDB "storage-rocksdb";
@@ -94,6 +91,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mainProgram = "surreal";
     license = lib.licenses.bsl11;
     maintainers = with lib.maintainers; [
+      aln730
       sikmir
       happysalada
       siriobalmelli


### PR DESCRIPTION
## surrealdb: 2.6.1 -> 3.0.0

Closes #540432.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
