### PR TITLE
wg-ddns: 1.3 -> 1.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9021,6 +9021,11 @@
     githubId = 5198058;
     name = "Udo Sauer";
   };
+  fernvenue = {
+    github = "fernvenue";
+    githubId = 84565547;
+    name = "fernvenue";
+  };
   feyorsh = {
     email = "george@feyor.sh";
     github = "Feyorsh";

--- a/pkgs/by-name/wg/wg-ddns/package.nix
+++ b/pkgs/by-name/wg/wg-ddns/package.nix
@@ -21,7 +21,10 @@ buildGoModule (finalAttrs: {
     description = "Lightweight tool that provides DDNS dynamic DNS support for WireGuard";
     homepage = "https://github.com/fernvenue/wg-ddns";
     license = lib.licenses.gpl3Only;
-    maintainers = [ lib.maintainers.bdim404 ];
+    maintainers = [
+      lib.maintainers.fernvenue
+      lib.maintainers.bdim404
+    ];
     platforms = lib.platforms.unix;
     mainProgram = "wg-ddns";
   };

--- a/pkgs/by-name/wg/wg-ddns/package.nix
+++ b/pkgs/by-name/wg/wg-ddns/package.nix
@@ -6,16 +6,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "wg-ddns";
-  version = "1.3";
+  version = "1.4";
 
   src = fetchFromGitHub {
     owner = "fernvenue";
     repo = "wg-ddns";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-BV57jidn6bPWU/IhhQvIeMF4xHtTm2WZKm4MQRSMM5Y=";
+    hash = "sha256-Djh/H/PlpwVeJ3T2V/xG8AAJNznYmStCQEMd5uh38us=";
   };
 
-  vendorHash = "sha256-VfSLrWuvJF4XwAW2BQGxh+3v9RiWmPdysw/nIdt2A9M=";
+  vendorHash = "sha256-oJOpf7PPQvb5z7nqpW0YjOhsF0UiWt/nlwBvF2SdzsY=";
 
   meta = {
     description = "Lightweight tool that provides DDNS dynamic DNS support for WireGuard";


### PR DESCRIPTION
Bump `wg-ddns` from 1.3 to 1.4 and add fernvenue, the upstream author of [fernvenue/wg-ddns](https://github.com/fernvenue/wg-ddns), as a co-maintainer alongside `bdim404`.

Upstream changes: [v1.3...v1.4](https://github.com/fernvenue/wg-ddns/compare/v1.3...v1.4). Mainly a dependency refresh (upstream `go.mod` bumped from `go 1.21` to `go 1.25.0`, gin 1.9 -> 1.12, and other transitive module bumps); no user-facing behavior change.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
