### PR TITLE
libuv: fix riscv64-linux build

### DIFF
--- a/pkgs/by-name/li/libuv/package.nix
+++ b/pkgs/by-name/li/libuv/package.nix
@@ -129,6 +129,10 @@ stdenv.mkDerivation (finalAttrs: {
         # https://github.com/libuv/libuv/issues/1871
         "shutdown_close_pipe"
       ]
+      ++ lib.optionals stdenv.hostPlatform.isRiscV64 [
+        # Aborts (SIGABRT, exit 134)
+        "poll_nested_epoll"
+      ]
       ++ lib.optionals stdenv.hostPlatform.isFreeBSD [
         # ENETUNREACH when performed in jailed build env
         "tcp_connect"


### PR DESCRIPTION
Fix : 

```
libuv> not ok 261 - poll_nested_epoll
libuv> # exit code 134
libuv> # Output from process `poll_nested_epoll`: (no output)
```

Validated on qemu & native hardware 5 times

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] riscv64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
