### PR TITLE
nixos/btrfs: add autoBalance option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -123,6 +123,8 @@
 
 - `security.polkit.settings` added for RFC42 style configuration of the polkitd daemon.
 
+- `services.btrfs.autoBalance` has been added, to periodically balance btrfs filesystems, reclaiming space from partially empty block groups and preventing metadata space from filling up.
+
 - `boot.supportedFilesystems.ntfs` installs `ntfsprogs-plus` instead of `ntfs3g` on kernel version 7.1 and later, unless `boot.supportedFilesystems.ntfs-3g` is explicitly enabled.
 
 - The `programs.fuse` module, which provides the `fusermount3` executable and the `/etc/fuse.conf` config file, is now opt-in. The obligation to enable it has been shifted to its various consumers (e.g. gvfs, flatpak, appimage, sshfs). This can break fuse consumers at runtime, that don't explicitly declare that dependency with a module, e.g the mounting functionality in various backup tools (borg, restic, rclone, ...).

--- a/nixos/modules/tasks/filesystems/btrfs.nix
+++ b/nixos/modules/tasks/filesystems/btrfs.nix
@@ -26,16 +26,65 @@ let
   inSystem = config.boot.supportedFilesystems.btrfs or false;
 
   cfgScrub = config.services.btrfs.autoScrub;
+  cfgBalance = config.services.btrfs.autoBalance;
 
   enableAutoScrub = cfgScrub.enable;
+  enableAutoBalance = cfgBalance.enable;
   enableBtrfs = inInitrd || inSystem || enableAutoScrub;
 
 in
 
 {
   options = {
-    # One could also do regular btrfs balances, but that shouldn't be necessary
-    # during normal usage and as long as the filesystems aren't filled near capacity
+
+    services.btrfs.autoBalance = {
+      enable = mkEnableOption "regular btrfs balance";
+
+      fileSystems = mkOption {
+        type = types.listOf types.path;
+        example = [ "/" ];
+        description = ''
+          List of paths to btrfs filesystems to regularly call {command}`btrfs balance` on.
+          Defaults to all mount points with btrfs filesystems.
+          Note that if you have filesystems that span multiple devices (e.g. RAID), you should
+          take care to use the same device for any given mount point and let btrfs take care
+          of automatically mounting the rest, in order to avoid balancing the same data multiple times.
+        '';
+      };
+
+      interval = mkOption {
+        default = "monthly";
+        type = types.str;
+        example = "weekly";
+        description = ''
+          Systemd calendar expression for when to balance btrfs filesystems.
+          The recommended period is a month but could be less
+          ({manpage}`btrfs-balance(8)`).
+          See
+          {manpage}`systemd.time(7)`
+          for more information on the syntax.
+        '';
+      };
+
+      dusage = mkOption {
+        default = 20;
+        type = types.ints.between 0 100;
+        description = ''
+          Relocate data block groups with usage under this percentage.
+          Lower values mean cheaper, faster balances that only touch
+          near-empty chunks; higher values reclaim more space but take longer.
+        '';
+      };
+
+      musage = mkOption {
+        default = 20;
+        type = types.ints.between 0 100;
+        description = ''
+          Relocate metadata block groups with usage under this percentage.
+        '';
+      };
+    };
+
     services.btrfs.autoScrub = {
       enable = mkEnableOption "regular btrfs scrub";
 
@@ -111,6 +160,102 @@ in
       '';
 
       boot.initrd.systemd.initrdBin = [ pkgs.btrfs-progs ];
+    })
+
+    (mkIf enableAutoBalance {
+      assertions = [
+        {
+          assertion = cfgBalance.enable -> (cfgBalance.fileSystems != [ ]);
+          message = ''
+            If 'services.btrfs.autoBalance' is enabled, you need to have at least one
+            btrfs file system mounted via 'fileSystems' or specify a list manually
+            in 'services.btrfs.autoBalance.fileSystems'.
+          '';
+        }
+      ];
+
+      # This will remove duplicated units from either having a filesystem mounted multiple
+      # time, or additionally mounted subvolumes, as well as having a filesystem span
+      # multiple devices (provided the same device is used to mount said filesystem).
+      services.btrfs.autoBalance.fileSystems =
+        let
+          isDeviceInList = list: device: builtins.filter (e: e.device == device) list != [ ];
+
+          uniqueDeviceList = foldl' (acc: e: if isDeviceInList acc e.device then acc else acc ++ [ e ]) [ ];
+        in
+        mkDefault (
+          map (e: e.mountPoint) (
+            uniqueDeviceList (
+              mapAttrsToList (name: fs: {
+                mountPoint = fs.mountPoint;
+                device = fs.device;
+              }) (filterAttrs (name: fs: fs.fsType == "btrfs") config.fileSystems)
+            )
+          )
+        );
+
+      # TODO: Did not manage to do it via the usual btrfs-balance@.timer/.service
+      # template units due to problems enabling the parameterized units,
+      # so settled with many units and templating via nix for now.
+      # https://github.com/NixOS/nixpkgs/pull/32496#discussion_r156527544
+      systemd.timers =
+        let
+          balanceTimer =
+            fs:
+            let
+              fs' = utils.escapeSystemdPath fs;
+            in
+            nameValuePair "btrfs-balance-${fs'}" {
+              description = "regular btrfs balance timer on ${fs}";
+
+              wantedBy = [ "timers.target" ];
+              timerConfig = {
+                OnCalendar = cfgBalance.interval;
+                AccuracySec = "1d";
+                Persistent = true;
+              };
+            };
+        in
+        listToAttrs (map balanceTimer cfgBalance.fileSystems);
+
+      systemd.services =
+        let
+          balanceService =
+            fs:
+            let
+              fs' = utils.escapeSystemdPath fs;
+            in
+            nameValuePair "btrfs-balance-${fs'}" {
+              description = "btrfs balance on ${fs}";
+              documentation = [ "man:btrfs-balance(8)" ];
+              # balance prevents suspend2ram or proper shutdown
+              conflicts = [
+                "shutdown.target"
+                "sleep.target"
+              ];
+              before = [
+                "shutdown.target"
+                "sleep.target"
+              ];
+              # avoid contending with scrub for I/O if both are enabled
+              after = [ "btrfs-scrub-${fs'}.service" ];
+
+              serviceConfig = {
+                # simple and not oneshot, otherwise ExecStop is not used
+                Type = "simple";
+                Nice = 19;
+                IOSchedulingClass = "idle";
+                ExecStart = "${pkgs.btrfs-progs}/bin/btrfs balance start
+                  -musage=${toString cfgBalance.musage}
+                  -dusage=${toString cfgBalance.dusage} ${fs}";
+                # if the service is stopped before balance end, cancel it
+                ExecStop = pkgs.writeShellScript "btrfs-balance-maybe-cancel" ''
+                  (${pkgs.btrfs-progs}/bin/btrfs balance status ${fs} | ${pkgs.gnugrep}/bin/grep "No balance found") || ${pkgs.btrfs-progs}/bin/btrfs balance cancel ${fs}
+                '';
+              };
+            };
+        in
+        listToAttrs (map balanceService cfgBalance.fileSystems);
     })
 
     (mkIf enableAutoScrub {


### PR DESCRIPTION
`services.btrfs.autoBalance` has been added, to periodically balance btrfs filesystems, reclaiming space from partially empty block groups and preventing metadata space from filling up.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
