### PR TITLE
various: pin setuptools_80 to fix jenkins-job-builder

### DIFF
--- a/pkgs/development/python-modules/pbr/default.nix
+++ b/pkgs/development/python-modules/pbr/default.nix
@@ -4,7 +4,7 @@
   callPackage,
   distutils,
   fetchPypi,
-  setuptools,
+  setuptools_80,
 }:
 
 buildPythonPackage rec {
@@ -17,11 +17,11 @@ buildPythonPackage rec {
     hash = "sha256-tGAE7DClMkZyaD7ISK7Z6PxQCw0mHUCjIpwtK7/O3Ck=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [ setuptools_80 ];
 
   dependencies = [
     distutils # for distutils.command in pbr/packaging.py
-    setuptools # for pkg_resources
+    setuptools_80 # for pkg_resources
   ];
 
   # check in passthru.tests.pytest to escape infinite recursion with fixtures

--- a/pkgs/development/python-modules/python-jenkins/default.nix
+++ b/pkgs/development/python-modules/python-jenkins/default.nix
@@ -6,7 +6,7 @@
   mock,
   pbr,
   pyyaml,
-  setuptools,
+  setuptools_80,
   six,
   multi-key-dict,
   testscenarios,
@@ -40,7 +40,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     pbr
     pyyaml
-    setuptools
+    setuptools_80
     six
     multi-key-dict
     requests

--- a/pkgs/development/python-modules/testscenarios/default.nix
+++ b/pkgs/development/python-modules/testscenarios/default.nix
@@ -5,7 +5,7 @@
 
   # build-system
   pbr,
-  setuptools,
+  setuptools_80,
 
   # dependencies
   testtools,
@@ -32,7 +32,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     pbr
-    setuptools
+    setuptools_80
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/testtools/default.nix
+++ b/pkgs/development/python-modules/testtools/default.nix
@@ -9,7 +9,7 @@
   hatch-vcs,
 
   # dependencies
-  setuptools,
+  setuptools_80,
 }:
 
 buildPythonPackage rec {
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   pythonRemoveDeps = [ "fixtures" ];
 
-  propagatedBuildInputs = lib.optionals (pythonAtLeast "3.12") [ setuptools ];
+  propagatedBuildInputs = lib.optionals (pythonAtLeast "3.12") [ setuptools_80 ];
 
   # testscenarios has a circular dependency on testtools
   doCheck = false;


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Pin setuptools_80 in some deps of jenkins-job-builder, to fix build/runtime issue:

- **python3Packages.python-jenkins: use setuptools_80**
- **python3Packages.pbr: use setuptools_80**
- **python3Packages.testscenarios: use setuptools_80**
- **python3Packages.testtools: use setuptools_80**

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
