### PR TITLE
calibre-web: fix build

### DIFF
--- a/pkgs/by-name/ca/calibre-web/package.nix
+++ b/pkgs/by-name/ca/calibre-web/package.nix
@@ -127,6 +127,8 @@ python3Packages.buildPythonApplication rec {
   pythonRelaxDeps = [
     "apscheduler"
     "bleach"
+    "certifi"
+    "chardet"
     "cryptography"
     "flask"
     "flask-limiter"

--- a/pkgs/development/python-modules/pip-chill/default.nix
+++ b/pkgs/development/python-modules/pip-chill/default.nix
@@ -1,28 +1,24 @@
 {
   lib,
-  fetchFromGitHub,
+  fetchPypi,
   buildPythonPackage,
   setuptools,
   pip,
-  pythonAtLeast,
   pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "pip-chill";
-  version = "1.0.3";
+  version = "1.0.5";
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "rbanffy";
-    repo = "pip-chill";
-    tag = "v${version}";
-    hash = "sha256-oWq3UWBL5nsCBUkaElashZKvm7pN3StJNubgU++8YFs=";
+  src = fetchPypi {
+    pname = "pip_chill";
+    inherit version;
+    hash = "sha256-55vFFKv+FE8u9SKQ9ZZ30nnLBbQIT6n4FLvlzA6gTBw=";
   };
 
   build-system = [ setuptools ];
-
-  dependencies = lib.optionals (pythonAtLeast "3.12") [ setuptools ];
 
   nativeCheckInputs = [
     pip
@@ -39,7 +35,6 @@ buildPythonPackage rec {
   meta = {
     description = "More relaxed `pip freeze`";
     homepage = "https://github.com/rbanffy/pip-chill";
-    changelog = "https://github.com/rbanffy/pip-chill/releases/tag/v${version}";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ tochiaha ];
     mainProgram = "pip-chill";


### PR DESCRIPTION
`pip-chill` is in dependency chain of `calibre-web`. Version 1.0.3 fails to build due to missing `pkg_resources`. Version 1.0.5 drops `pkg_resources` and switches to `importlib.metadata`. This version is released to PyPI and pushed to GitHub, however it lacks a tag or release on GH, hence the switch to `fetchPypi`.

After fixing `pip-chill`, `calibre-web` still fails to build due to upper bounds on `certifi` and `chardet` packages so I relaxed those deps.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
