### PR TITLE
tuist: 4.144.0 -> 4.202.1

### DIFF
--- a/pkgs/by-name/tu/tuist/package.nix
+++ b/pkgs/by-name/tu/tuist/package.nix
@@ -8,11 +8,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "tuist";
-  version = "4.144.0";
+  version = "4.202.1";
 
   src = fetchurl {
     url = "https://github.com/tuist/tuist/releases/download/${finalAttrs.version}/tuist.zip";
-    hash = "sha256-t6nqGnrIwZQFfji7r1I2MvV0e8MFtUTlpOmOi8i8aYM=";
+    hash = "sha256-J/xlwRRW3zLr03jA6Xpa5frlRQGHa/nmzzlj35/30tw=";
   };
 
   dontUnpack = true;

--- a/pkgs/by-name/tu/tuist/package.nix
+++ b/pkgs/by-name/tu/tuist/package.nix
@@ -4,6 +4,7 @@
   fetchurl,
   unzip,
   nix-update-script,
+  versionCheckHook,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -33,6 +34,24 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     ln -s $out/opt/tuist/tuist $out/bin/tuist
 
     runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "version";
+  versionCheckKeepEnvironment = [
+    "HOME"
+    "XDG_CACHE_HOME"
+    "XDG_CONFIG_HOME"
+    "XDG_STATE_HOME"
+  ];
+  preVersionCheck = ''
+    export HOME=$(mktemp -d)
+    export XDG_CACHE_HOME=$HOME/.cache
+    export XDG_CONFIG_HOME=$HOME/.config
+    export XDG_STATE_HOME=$HOME/.local/state
   '';
 
   passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=^([0-9.]+)$" ]; };


### PR DESCRIPTION
## Things done

Manually tested on `aarch64-darwin`:
```console
$ nix-build -A tuist
/nix/store/51ckd0sm5knm0yl0gfbcpqs8cka3mnbb-tuist-4.202.1
$ cd /tmp
$ mkdir TuistTest
$ cat >TuistTest/Project.swift <<EOF
import ProjectDescription
let project = Project(name: "Test", targets: [])
EOF
$ cd TuistTest/
$ git init
Initialized empty Git repository in /private/tmp/TuistTest/.git/
$ /nix/store/51ckd0sm5knm0yl0gfbcpqs8cka3mnbb-tuist-4.202.1/bin/tuist generate --no-open
Loading and constructing the graph
It might take a while if the cache is empty
Generating workspace Test.xcworkspace
Generating project Test
Total time taken: 1.566s
✔ Success 
  Project generated. 
$ ls -1a
.git
Project.swift
Test.xcodeproj
Test.xcworkspace
```

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
