### PR TITLE
libressl: Actually utilize custom CA store

### DIFF
--- a/pkgs/by-name/li/libressl/default.nix
+++ b/pkgs/by-name/li/libressl/default.nix
@@ -100,6 +100,17 @@ let
         moveToOutput "share/man/man1/nc.1.gz" "$nc"
       '';
 
+      doInstallCheck = true;
+      installCheckPhase = ''
+        runHook preInstallCheck
+
+        # Check whether the build target actually contains our cacert.
+        # A simple binary match for the path is enough.
+        grep "${cacert}/etc/ssl/certs/ca-bundle.crt" $out/lib/*libtls*
+
+        runHook postInstallCheck
+      '';
+
       meta = {
         description = "Free TLS/SSL implementation";
         homepage = "https://www.libressl.org";

--- a/pkgs/by-name/li/libressl/default.nix
+++ b/pkgs/by-name/li/libressl/default.nix
@@ -139,6 +139,13 @@ let
     url = "https://github.com/libressl/portable/commit/a15ea0710398eaeed3be53cf643e80a1e80c981d.patch";
     hash = "sha256-Mlf4SrGCCqALQicbGtmVGdkdfcE8DEGYkOuVyG2CozM=";
   };
+
+  # https://github.com/libressl/portable/issues/1295
+  # https://github.com/libressl/portable/pull/1303
+  tls-default-ca-patch = fetchpatch {
+    url = "https://github.com/libressl/portable/commit/c85e07d0d68129fc1b1c9039b266099c8d735c3d.patch";
+    hash = "sha256-oNL3v8Ef1HrayXn+/3T4UhHLJos8eVMlqebVyaxnWVo=";
+  };
 in
 {
   # 4.2 was released October 2025 and will become unsupported on October 22,
@@ -148,6 +155,7 @@ in
     hash = "sha256-bVwvWFg1iOp5H0yGRQBAcdAN+lVKW/eIoAbKHrWr1ws=";
     patches = [
       common-cmake-install-full-dirs-patch
+      tls-default-ca-patch
     ];
   };
 
@@ -156,5 +164,8 @@ in
   libressl_4_3 = generic {
     version = "4.3.2";
     hash = "sha256-7fAa7iTGXWnmqe/LnUS82mgv+dTzu72V55Th36kIR7U=";
+    patches = [
+      tls-default-ca-patch
+    ];
   };
 }


### PR DESCRIPTION
This commit backports https://github.com/libressl/portable/pull/1303 to nixpkgs, which fixes a bug in the LibreSSL build systems which lead it to **not honor** our custom CA store.

Besides, it also adds an installCheckPhase test that greps the result to contain a binary match for the expected CA store path, which fails if this backported patch is not applied.

I think this patch is important because specifying the CA store is a core functionality for TLS libraries.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
