### PR TITLE
buildPythonPackage: mark unsupported interpreter with `meta.problems.unsupportedPython`

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -163,8 +163,41 @@ following are specific to `buildPythonPackage`:
 
 * `catchConflicts ? true`: If `true`, abort package build if a package name
   appears more than once in dependency tree. Default is `true`.
-* `disabled ? false`: If `true`, package is not built for the particular Python
-  interpreter version.
+* `disabled ? false`:
+  If set to `true` for a particular Python interpreter version or implementation, the package is marked with `meta.problems.unsupportedPython`, and will throw an error message complaining the Python interpreter being unsupported during package instantiation.
+
+  ```nix
+  {
+    lib,
+    pythonAtLeast,
+    buildPythonPackage,
+    fetchFromGitHub,
+    setuptools,
+  }:
+  buildPythonPackage (finalAttrs: {
+    pname = "coconut";
+    version = "3.1.2";
+    pyproject = true;
+
+    src = fetchFromGitHub {
+      owner = "evhub";
+      repo = "coconut";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-Vd6ZY3PlbPOy63/0/0YJ1U2PpsVdctOoInyKftj//cM=";
+    };
+
+    disabled = pythonAtLeast "3.13";
+
+    build-system = [
+      setuptools
+    ];
+
+    meta = {
+      homepage = "http://coconut-lang.org/";
+    };
+  })
+  ```
+
 * `dontWrapPythonPrograms ? false`: Skip wrapping of Python programs.
 * `permitUserSite ? false`: Skip setting the `PYTHONNOUSERSITE` environment
   variable in wrapped programs.

--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -198,6 +198,50 @@ following are specific to `buildPythonPackage`:
   })
   ```
 
+  One can also choose to mark a package with `meta.problems.unsupportedPython` providing a custom `message` and optional `urls`:
+
+  ```nix
+  {
+    lib,
+    namePrefix,
+    pythonAtLeast,
+    buildPythonPackage,
+    fetchFromGitHub,
+    setuptools,
+  }:
+  buildPythonPackage (finalAttrs: {
+    pname = "coconut";
+    version = "3.1.2";
+    pyproject = true;
+
+    src = fetchFromGitHub {
+      owner = "evhub";
+      repo = "coconut";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-Vd6ZY3PlbPOy63/0/0YJ1U2PpsVdctOoInyKftj//cM=";
+    };
+
+    build-system = [
+      setuptools
+    ];
+
+    meta = {
+      homepage = "http://coconut-lang.org/";
+      problems.unsupportedPython = lib.optionalAttrs (pythonAtLeast "3.13") {
+        message = "${lib.removePrefix namePrefix} requires Python <3.13";
+        urls = [
+          "https://github.com/evhub/coconut/issues/873"
+        ];
+      };
+    };
+  })
+  ```
+
+  ::: {.note}
+  Referencing `<pkg>.disabled` or `finalAtts.disabled` for Python packages are deprecated.
+  Use `<pkg> ? meta.problems.unsupportedPython` instead (the same goes with `finalAttrs`).
+  :::
+
 * `dontWrapPythonPrograms ? false`: Skip wrapping of Python programs.
 * `permitUserSite ? false`: Skip setting the `PYTHONNOUSERSITE` environment
   variable in wrapped programs.

--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -107,6 +107,12 @@
 - `nim1` and respective aliases have been removed due to entering EOL; please migrate to `nim` or `nim-unwrapped` (nim 2).
 - `nim-2_0` & `nim-2_2` and respective aliases have been removed; please migrate to `nim` or `nim-unwrapped` (nim 2.2.10).
 
+- `buildPythonPackage` and `buildPythonApplication` now uses `meta.problems.unsupportedPython` to mark Python packages with unsupported Python interpreters.
+  - The `disabled` argument automatically converts to `meta.problems.unsupportedPython` with the default message.
+  - Overriding the `passthru.disabled` attribute no longer affects such marks.
+  - `<pkg> ? meta.problems.unsupportedPython` is now the canonical way to identify if the package uses an incompatible Python interpreter.
+    The `passthru.disabled` attribute is deprecated and will be removed in future releases.
+
 - `vimacs` has been removed, as it has not been maintained in 10 years and was built for an old version of vim (6.0).
 
 ## Other Notable Changes {#sec-nixpkgs-release-26.11-notable-changes}

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -411,12 +411,14 @@ lib.extendMkDerivation {
 
       passthru = {
         inherit
-          disabled
           pyproject
           build-system
           dependencies
           optional-dependencies
           ;
+
+        disabled = meta ? problems.unsupportedPython || disabled;
+
         updateScript = nix-update-script { };
         # __stdenvPythonCompat[Pos] attributes are here for overrideStdenvCompat in `python-packages-base.nix` to work.
         # They are internal and subject to changes.
@@ -432,7 +434,22 @@ lib.extendMkDerivation {
         platforms = python.meta.platforms;
         isBuildPythonPackage = python.meta.platforms;
       }
-      // meta;
+      // meta
+      // {
+        problems =
+          let
+            disabled' = meta ? problems.unsupportedPython || finalAttrs.disabled;
+          in
+          meta.problems or { }
+          // {
+            ${if disabled' then "unsupportedPython" else null} = meta.problems.unsupportedPython or { } // {
+              kind = "broken";
+              message =
+                meta.problems.unsupportedPython.message
+                  or "${removePrefix namePrefix finalAttrs.name} not supported for interpreter ${python.executable}";
+            };
+          };
+      };
     }
     // optionalAttrs (attrs ? checkPhase) {
       # If given use the specified checkPhase, otherwise use the setup hook.
@@ -468,20 +485,5 @@ lib.extendMkDerivation {
 
   # This derivation transformation function must be independent to `attrs`
   # for fixed-point arguments support in the future.
-  transformDrv =
-    let
-      # Workaround to make the `lib.extendDerivation`-based disabled functionality
-      # respect `<pkg>.overrideAttrs`
-      # It doesn't cover `<pkg>.<output>.overrideAttrs`.
-      disablePythonPackage =
-        drv:
-        extendDerivation (
-          drv.disabled
-          -> throw "${removePrefix namePrefix drv.name} not supported for interpreter ${python.executable}"
-        ) { } drv
-        // {
-          overrideAttrs = fdrv: disablePythonPackage (drv.overrideAttrs fdrv);
-        };
-    in
-    drv: disablePythonPackage (toPythonModule drv);
+  transformDrv = toPythonModule;
 }

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -417,7 +417,7 @@ lib.extendMkDerivation {
           optional-dependencies
           ;
 
-        disabled = meta ? problems.unsupportedPython || disabled;
+        disabled = finalAttrs ? meta.problems.unsupportedPython;
 
         updateScript = nix-update-script { };
         # __stdenvPythonCompat[Pos] attributes are here for overrideStdenvCompat in `python-packages-base.nix` to work.
@@ -438,7 +438,7 @@ lib.extendMkDerivation {
       // {
         problems =
           let
-            disabled' = meta ? problems.unsupportedPython || finalAttrs.disabled;
+            disabled' = meta ? problems.unsupportedPython || disabled;
           in
           meta.problems or { }
           // {


### PR DESCRIPTION
Implement the `disabled` functionality with `meta.problems.unsupportedPython` (whose `kind = "broken"`) instead of the ugly and buggy `lib.extendDerivation`.

For backward compatibility and smooth transition and backporting, this PR is implemented in two parts:
1. Implement the `disabled` functionality and preserve partial `passthru.derivation` overriding while prioritise user-set/overridden `meta.problems.unsupportedPython`:
   - Set the `passthru.disabled` attribute to true iff the argument `disabled` is true or the argument `meta` has `problems.unsupportedPython`.
   - Set `meta.problems.unsupportedPython` if `finalAttrs.passthru.disabled` is true or the argument `meta` has `problems.unsupportedPython`.

   Such design ensures that existing packages will evaluate the same way while also make backported packages with `meta.problems.unsupportedPython` set work as expected, and is suitable for backporting.
2. Make `meta.problems.unsupportedPython` the sole entry for unsupported-Python-interpreter mark's `<pkg>.overrrideAttrs` overriding, making `passthru.disabled` reference `finalAttrs ? meta.problems.unsupportedPython`.
   Even if we currently don't promise a stable `<pkg>.overrideAttrs` interface, it might still be used somewhere, making this part unsuitable for backporting.
   This part also include documentation changes and release note entry that deprecates `passthru.disabled`, making it backward incompatible.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform: (No rebuilds aside from documentation-related packages)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
