### PR TITLE
ngrep: make use of lib.licenses

### DIFF
--- a/lib/licenses/licenses.nix
+++ b/lib/licenses/licenses.nix
@@ -1168,6 +1168,11 @@ lib.mapAttrs mkLicense (
       fullName = "Nethack General Public License";
     };
 
+    ngrep = {
+      spdxId = "ngrep";
+      fullName = "ngrep License";
+    };
+
     nistSoftware = {
       spdxId = "NIST-Software";
       fullName = "NIST Software License";

--- a/pkgs/by-name/ng/ngrep/package.nix
+++ b/pkgs/by-name/ng/ngrep/package.nix
@@ -47,12 +47,10 @@ stdenv.mkDerivation (finalAttrs: {
       more common packet sniffing tools, such as tcpdump and snoop.
     '';
     homepage = "https://github.com/jpr5/ngrep/";
-    license = {
-      shortName = "ngrep"; # BSD-style, see README.md and LICENSE
-      url = "https://github.com/jpr5/ngrep/blob/master/LICENSE";
-      free = true;
-      redistributable = true;
-    };
+    license = lib.licenses.AND [
+      lib.licenses.ngrep
+      lib.licenses.bsd3
+    ];
     platforms = with lib.platforms; linux ++ darwin;
     maintainers = [ lib.maintainers.bjornfor ];
     mainProgram = "ngrep";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
