### PR TITLE
opentrack: 2026.1.0-unstable-2026-06-18 -> 2026.1.0-unstable-2026-07-09, add macOS support

### DIFF
--- a/pkgs/by-name/op/opentrack/package.nix
+++ b/pkgs/by-name/op/opentrack/package.nix
@@ -23,13 +23,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "opentrack";
-  version = "2026.1.0-unstable-2026-06-18";
+  version = "2026.1.0-unstable-2026-07-09";
 
   src = fetchFromGitHub {
     owner = "opentrack";
     repo = "opentrack";
-    rev = "3661aa28bb9489a798d9c42eb1c0ccf30876c848";
-    hash = "sha256-CClUz8g/fSL+NZzikKZuZx4pZsGhIdH70ax6clSG2xk=";
+    rev = "5ce3de85301c9cdb0e2c2e024f03d94cb42bfd62";
+    hash = "sha256-k4uAdsEIVYgHPrfl5m2CezQwi4ZGlItgq/e0cHd1TzY=";
   };
 
   aruco = callPackage ./aruco.nix { };

--- a/pkgs/by-name/op/opentrack/package.nix
+++ b/pkgs/by-name/op/opentrack/package.nix
@@ -12,8 +12,11 @@
   opencv4,
   procps,
   eigen,
+  imagemagick,
   libxdmcp,
   libevdev,
+  libicns,
+  llvmPackages,
   makeDesktopItem,
   wineWow64Packages,
   onnxruntime,
@@ -21,6 +24,9 @@
   v4l-utils,
   withWine ? stdenv.targetPlatform.isx86_64,
 }:
+let
+  inherit (stdenv.hostPlatform) isLinux isDarwin;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "opentrack";
   version = "2026.1.0-unstable-2026-07-09";
@@ -51,6 +57,8 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # calls `app.setDesktopFileName("opentrack");` - distros that don't wrap the binary apparently don't need this.
     ./desktop-filename.patch
+    # disables the upstream macOS .app artifact script
+    ./remove_app_bundle_script.patch
   ];
 
   strictDeps = true;
@@ -62,40 +70,89 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     qt6.wrapQtAppsHook
   ]
+  ++ lib.optionals isDarwin [
+    libicns
+    imagemagick
+  ]
   ++ lib.optionals withWine [ wineWow64Packages.stable ];
 
   buildInputs = [
-    finalAttrs.aruco
     eigen
     libxdmcp
-    libevdev
     onnxruntime
     opencv4
     procps
     qt6.qtbase
     qt6.qttools
-  ];
+  ]
+  ++ lib.optionals isLinux [
+    finalAttrs.aruco
+    libevdev
+  ]
+  ++ lib.optionals isDarwin [
+    qt6.qtmultimedia
+  ]
+  # <omp.h> is available-by-default on gcc
+  ++ lib.optionals stdenv.cc.isClang [ llvmPackages.openmp ];
 
   cmakeFlags = [
     (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_AHRSFUSION" "${finalAttrs.fusion}")
     (lib.cmakeFeature "OPENTRACK_COMMIT" "opentrack-${finalAttrs.version}")
     (lib.cmakeBool "SDK_WINE" withWine)
-    (lib.cmakeFeature "SDK_ARUCO_LIBPATH" "${finalAttrs.aruco}/lib/libaruco.a")
     (lib.cmakeFeature "SDK_XPLANE" finalAttrs.xplaneSdk.outPath)
+  ]
+  ++ lib.optionals isLinux [
+    (lib.cmakeFeature "SDK_ARUCO_LIBPATH" "${finalAttrs.aruco}/lib/libaruco.a")
   ];
 
-  postInstall = ''
-    install -Dt $out/share/icons/hicolor/256x256/apps ../gui/images/opentrack.png
-  '';
+  postInstall =
+    lib.optionalString isLinux ''
+      install -Dt $out/share/icons/hicolor/256x256/apps ../gui/images/opentrack.png
+    ''
+    + lib.optionalString isDarwin ''
+      mkdir -p $out/Applications
+      mv $out/opentrack.app $out/Applications/
+
+      chmod -R +w "$out/Applications/opentrack.app"
+
+      # use upstream Info.plist for correct permissions etc.
+      cp "../macosx/Info.plist" "$out/Applications/opentrack.app/Contents/"
+      substituteInPlace "$out/Applications/opentrack.app/Contents/Info.plist" \
+        --subst-var-by "OPENTRACK-VERSION" "${finalAttrs.version}"
+
+      cp "../macosx/PkgInfo" "$out/Applications/opentrack.app/Contents/"
+      mv "$out/Plugins" "$out/Applications/opentrack.app/Contents/MacOS/Plugins"
+
+      # create the macOS iconset
+      tmp="$(mktemp -d)"
+      files=""
+      for size in 16 32 64 128 256 512; do
+          outfile="$tmp/opentrack_''${size}x''${size}.png"
+          magick "../gui/images/opentrack.png" -filter triangle -resize "''${size}x''${size}" "$outfile"
+          files="$files $outfile"
+      done
+      png2icns "$out/Applications/opentrack.app/Contents/Resources/opentrack.icns" $files
+      rm -rf "$tmp"
+    '';
 
   # manually wrap just the main binary
   dontWrapQtApps = true;
-  preFixup = ''
-    wrapQtApp $out/bin/opentrack \
-      --prefix PATH : ${lib.makeBinPath [ v4l-utils ]}
-  '';
+  qtWrapperArgs =
+    lib.optionals isLinux [
+      "--prefix PATH : ${lib.makeBinPath [ v4l-utils ]}"
+    ]
+    ++ lib.optionals isDarwin [
+      "--set DYLD_LIBRARY_PATH ${placeholder "out"}/Library"
+    ];
+  preFixup =
+    lib.optionalString isLinux ''
+      wrapQtApp $out/bin/opentrack
+    ''
+    + lib.optionalString isDarwin ''
+      wrapQtApp $out/Applications/opentrack.app/Contents/MacOS/opentrack
+    '';
 
-  desktopItems = [
+  desktopItems = lib.optionals isLinux [
     (makeDesktopItem {
       name = "opentrack";
       exec = "opentrack";
@@ -124,6 +181,6 @@ stdenv.mkDerivation (finalAttrs: {
       lib.maintainers.nekowinston
       lib.maintainers.zaninime
     ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/op/opentrack/remove_app_bundle_script.patch
+++ b/pkgs/by-name/op/opentrack/remove_app_bundle_script.patch
@@ -1,0 +1,15 @@
+diff --git a/macosx/CMakeLists.txt b/macosx/CMakeLists.txt
+index 8520e9e9..6428e91e 100644
+--- a/macosx/CMakeLists.txt
++++ b/macosx/CMakeLists.txt
+@@ -2,10 +2,4 @@ if(APPLE)
+     otr_escape_string(srcdir "${CMAKE_SOURCE_DIR}")
+     otr_escape_string(instdir "${CMAKE_INSTALL_PREFIX}")
+     otr_escape_string(commit "${OPENTRACK_COMMIT}")
+-    install(CODE "
+-       execute_process(COMMAND /bin/sh \"${srcdir}/macosx/make-app-bundle.sh\"
+-                                        \"${srcdir}/macosx\"
+-                                        \"${instdir}\"
+-                                       \"${commit}\")
+-    ")
+ endif()


### PR DESCRIPTION
Recent changes fixed building on macOS, so this enables that in nixpkgs.

Changes: https://github.com/opentrack/opentrack/compare/3661aa28bb9489a798d9c42eb1c0ccf30876c848...5ce3de85301c9cdb0e2c2e024f03d94cb42bfd62

Supersedes the auto-update #539499.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
