### PR TITLE
code-cursor: 3.9.16 -> 3.11.13

### DIFF
--- a/pkgs/by-name/co/code-cursor/package.nix
+++ b/pkgs/by-name/co/code-cursor/package.nix
@@ -24,7 +24,14 @@ let
 in
 (buildVscode rec {
   inherit commandLineArgs useVSCodeRipgrep;
-  inherit (sourcesJson) version vscodeVersion;
+  inherit (sourcesJson) version;
+  # Cursor reports vscode >= 1.122 but still ships @vscode/ripgrep.
+  # Capping the build-time vscodeVersion avoids modifying the notarized app bundle on Darwin.
+  vscodeVersion =
+    if lib.versionAtLeast sourcesJson.vscodeVersion "1.122.0" then
+      "1.121.0"
+    else
+      sourcesJson.vscodeVersion;
 
   pname = "cursor";
 

--- a/pkgs/by-name/co/code-cursor/sources.json
+++ b/pkgs/by-name/co/code-cursor/sources.json
@@ -1,22 +1,22 @@
 {
-  "version": "3.9.16",
-  "vscodeVersion": "1.105.1",
+  "version": "3.11.13",
+  "vscodeVersion": "1.125.0",
   "sources": {
     "x86_64-linux": {
-      "url": "https://downloads.cursor.com/production/042b3c1a4c53f2c3808067f519fbfc67b72cad8b/linux/x64/Cursor-3.9.16-x86_64.AppImage",
-      "hash": "sha256-dG61VYGMHPip57ldzNICEi1yPc4s1dON+MlDGiKadKc="
+      "url": "https://downloads.cursor.com/production/3f21b08f0b436a07be29fbfe00b304fa15553353/linux/x64/Cursor-3.11.13-x86_64.AppImage",
+      "hash": "sha256-MXBXgGe7HXiL3kAMKxBSRTZxWMbh15D5dfXw6iemG9g="
     },
     "aarch64-linux": {
-      "url": "https://downloads.cursor.com/production/042b3c1a4c53f2c3808067f519fbfc67b72cad8b/linux/arm64/Cursor-3.9.16-aarch64.AppImage",
-      "hash": "sha256-7tkupyy8EFeOpzQqoHQsYxWQlFoW6VBpXkuCJsRIhRw="
+      "url": "https://downloads.cursor.com/production/3f21b08f0b436a07be29fbfe00b304fa15553353/linux/arm64/Cursor-3.11.13-aarch64.AppImage",
+      "hash": "sha256-UCjZFxXjzeovYrZWp6xrZGp+eH4uGo41Tl9Uj9q16W4="
     },
     "x86_64-darwin": {
-      "url": "https://downloads.cursor.com/production/042b3c1a4c53f2c3808067f519fbfc67b72cad8b/darwin/x64/Cursor-darwin-x64.dmg",
-      "hash": "sha256-5sAj/FiPAs1facGmNKgXiNzs1Kc1ht9eXYU1aZ1VoUA="
+      "url": "https://downloads.cursor.com/production/3f21b08f0b436a07be29fbfe00b304fa15553353/darwin/x64/Cursor-darwin-x64.dmg",
+      "hash": "sha256-FbSBuRaWKjTD7vdg0GvFsizmbpNvnNyzB6yAljMAtSs="
     },
     "aarch64-darwin": {
-      "url": "https://downloads.cursor.com/production/042b3c1a4c53f2c3808067f519fbfc67b72cad8b/darwin/arm64/Cursor-darwin-arm64.dmg",
-      "hash": "sha256-pnSsOvyFiBKJsPUPkfnSY1l+LEzz3g5kbepIco7dDIM="
+      "url": "https://downloads.cursor.com/production/3f21b08f0b436a07be29fbfe00b304fa15553353/darwin/arm64/Cursor-darwin-arm64.dmg",
+      "hash": "sha256-j1k40mFZDWnNTl/IwCB39JZ+Zc4/JwEthNh8SPCXAZE="
     }
   }
 }


### PR DESCRIPTION
## Summary
- Update code-cursor from 3.9.16 to 3.11.13

https://cursor.com/changelog

Cap build-time `vscodeVersion` for ripgrep path selection so the notarized macOS app bundle is not modified during the build.

## Things done

- Built on platform:
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests
  - [ ] Package tests at `passthru.tests`
- [x] Ran `nixpkgs-review` on this PR
- [x] Tested basic functionality of all binary files (verified app bundle version and notarized signature via `spctl`)
- [x] Fits CONTRIBUTING.md, pkgs/README.md
- [x] Follows the automation/AI policy

## Test plan
- [x] `nix build .#code-cursor --impure` on aarch64-darwin
- [x] `spctl -a -vv ./result/Applications/Cursor.app` reports accepted / Notarized Developer ID
- [x] `nixpkgs-review rev HEAD` — 1 package built (code-cursor)