### PR TITLE
Add regression test for services.xserver.xkb.layout

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1684,6 +1684,7 @@ in
   systemd-journal = runTest ./systemd-journal.nix;
   systemd-journal-gateway = runTest ./systemd-journal-gateway.nix;
   systemd-journal-upload = runTest ./systemd-journal-upload.nix;
+  systemd-localed = runTest ./systemd-localed.nix;
   systemd-lock-handler = runTestOn [ "aarch64-linux" "x86_64-linux" ] ./systemd-lock-handler.nix;
   systemd-machinectl = runTest ./systemd-machinectl.nix;
   systemd-misc = runTest ./systemd-misc.nix;

--- a/nixos/tests/systemd-localed.nix
+++ b/nixos/tests/systemd-localed.nix
@@ -1,0 +1,23 @@
+{ lib, ... }:
+{
+  name = "systemd-localed";
+  meta.maintainers = [ lib.maintainers.haansn08 ];
+
+  nodes.machine = { ... }: {
+    # we don't use services.xserver.enable because some window managers like
+    # niri rely on systemd-localed for the keyboard layout:
+    # https://niri-wm.github.io/niri/Configuration%3A-Input.html#layout
+    services.graphical-desktop.enable = true;
+
+    services.xserver.xkb.layout = "jp";
+  };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("default.target")
+    machine.wait_for_unit("dbus.socket")
+
+    status, stdout = machine.execute("localectl")
+    t.assertIn("X11 Layout: jp", stdout)
+  '';
+}


### PR DESCRIPTION
This test demonstrates the regression described in https://github.com/NixOS/nixpkgs/issues/540709 .
The test succeeds with nixpkgs d407951447dc, but fails with 0bb7ec54c848.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
