### PR TITLE
displaycal: 3.9.17 → 3.9.18

### DIFF
--- a/pkgs/by-name/di/displaycal/package.nix
+++ b/pkgs/by-name/di/displaycal/package.nix
@@ -15,13 +15,13 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "displaycal";
-  version = "3.9.17";
+  version = "3.9.18";
   pyproject = true;
 
   src = fetchPypi {
-    pname = "DisplayCAL";
+    pname = "displaycal";
     inherit (finalAttrs) version;
-    hash = "sha256-cV8x1Hx+KQUhOOzqw/89QgoZ9+82vhwGrhG13KpE9Vw=";
+    hash = "sha256-mHUtO3vVIREzcIv6IFmPlo4nwuPPGDd9+UbIoXfvLYo=";
   };
 
   nativeBuildInputs = [
@@ -29,17 +29,30 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     gtk3
   ];
 
-  build-system = with python3.pkgs; [ setuptools ];
+  build-system = with python3.pkgs; [ setuptools_80 ];
+
+  postPatch = ''
+    # 2 conflicting copies of bin/displaycal end up from the installation
+    # process (one from pyproject.toml’s gui-scripts, one from setup.py). Keep
+    # only the setup.py version. Replace key with an invalide name to be
+    # skipped.
+    substituteInPlace pyproject.toml \
+      --replace-fail "[project.gui-scripts]" "[_project.gui-scripts]" \
+  '';
 
   dependencies = with python3.pkgs; [
     build
     certifi
+    defusedxml
     wxpython
     dbus-python
     distro
     numpy
     pillow
+    psutil
     pychromecast
+    pyglet
+    pyyaml
     send2trash
     zeroconf
   ];


### PR DESCRIPTION
LLM used to help with the `sed` script to delete the `gui-script` TOML section.

<!--
^ Please summarize the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.