### PR TITLE
[Backport 26.05] maintainers: `FlameFlag` -> `_4evy`

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -502,7 +502,7 @@ pkgs/by-name/oc/octodns/ @anthonyroussel
 pkgs/by-name/te/teleport*     @arianvp @justinas @sigma @tomberek @techknowlogick @JuliusFreudenberger
 
 # Warp-terminal
-pkgs/by-name/wa/warp-terminal/  @emilytrau @imadnyc @FlameFlag @johnrtitor
+pkgs/by-name/wa/warp-terminal/  @emilytrau @imadnyc @4evy @johnrtitor
 
 # Nim
 /doc/languages-frameworks/nim.section.md  @NixOS/nim

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -262,7 +262,6 @@
     email = "git@evy.pink";
     github = "4evy";
     githubId = 57304299;
-    matrix = "@donteatoreo:matrix.org";
   };
   _4r7if3x = {
     email = "the.artifex@proton.me";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -259,7 +259,7 @@
   };
   _4evy = {
     name = "4evy";
-    email = "git@ps1.sh";
+    email = "git@evy.pink";
     github = "4evy";
     githubId = 57304299;
     matrix = "@donteatoreo:matrix.org";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -259,7 +259,7 @@
   };
   _4evy = {
     name = "_4evy";
-    email = "github@flameflag.dev";
+    email = "git@ps1.sh";
     github = "_4evy";
     githubId = 57304299;
     matrix = "@donteatoreo:matrix.org";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -258,9 +258,9 @@
     name = "Eske Nielsen";
   };
   _4evy = {
-    name = "_4evy";
+    name = "4evy";
     email = "git@ps1.sh";
-    github = "_4evy";
+    github = "4evy";
     githubId = 57304299;
     matrix = "@donteatoreo:matrix.org";
   };

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -257,6 +257,13 @@
     githubId = 3417013;
     name = "Eske Nielsen";
   };
+  _4evy = {
+    name = "_4evy";
+    email = "github@flameflag.dev";
+    github = "_4evy";
+    githubId = 57304299;
+    matrix = "@donteatoreo:matrix.org";
+  };
   _4r7if3x = {
     email = "the.artifex@proton.me";
     matrix = "@4r7if3x:matrix.org";
@@ -9034,13 +9041,6 @@
     githubId = 6499211;
     name = "Sebastian Neubauer";
     keys = [ { fingerprint = "2F93 661D AC17 EA98 A104  F780 ECC7 55EE 583C 1672"; } ];
-  };
-  FlameFlag = {
-    name = "FlameFlag";
-    email = "github@flameflag.dev";
-    github = "FlameFlag";
-    githubId = 57304299;
-    matrix = "@donteatoreo:matrix.org";
   };
   Flameopathic = {
     email = "flameopathic@gmail.com";

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -74,7 +74,7 @@ let
     mainProgram = "discord";
     maintainers = with lib.maintainers; [
       artturin
-      FlameFlag
+      _4evy
       infinidoge
       jopejoe1
       Scrumplex

--- a/pkgs/by-name/al/alt-tab-macos/package.nix
+++ b/pkgs/by-name/al/alt-tab-macos/package.nix
@@ -35,7 +35,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://alt-tab-macos.netlify.app";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
-      FlameFlag
+      _4evy
       emilytrau
     ];
     platforms = lib.platforms.darwin;

--- a/pkgs/by-name/cs/csharprepl/package.nix
+++ b/pkgs/by-name/cs/csharprepl/package.nix
@@ -21,7 +21,7 @@ buildDotnetGlobalTool {
     changelog = "https://github.com/waf/CSharpRepl/blob/main/CHANGELOG.md";
     license = lib.licenses.mpl20;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ FlameFlag ];
+    maintainers = with lib.maintainers; [ _4evy ];
     mainProgram = "csharprepl";
   };
 }

--- a/pkgs/by-name/ga/gallery-dl/package.nix
+++ b/pkgs/by-name/ga/gallery-dl/package.nix
@@ -54,7 +54,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     mainProgram = "gallery-dl";
     maintainers = with lib.maintainers; [
       dawidsowa
-      FlameFlag
+      _4evy
       lucasew
     ];
   };

--- a/pkgs/by-name/ge/gemini-cli/package.nix
+++ b/pkgs/by-name/ge/gemini-cli/package.nix
@@ -115,7 +115,7 @@ buildNpmPackage (finalAttrs: {
     maintainers = with lib.maintainers; [
       brantes
       xiaoxiangmoe
-      FlameFlag
+      _4evy
       taranarmo
       caverav
     ];

--- a/pkgs/by-name/hi/hidden-bar/package.nix
+++ b/pkgs/by-name/hi/hidden-bar/package.nix
@@ -31,7 +31,7 @@ stdenvNoCC.mkDerivation rec {
     description = "Ultra-light MacOS utility that helps hide menu bar icons";
     homepage = "https://github.com/dwarvesf/hidden";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ FlameFlag ];
+    maintainers = with lib.maintainers; [ _4evy ];
     platforms = lib.platforms.darwin;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };

--- a/pkgs/by-name/ic/ice-bar/package.nix
+++ b/pkgs/by-name/ic/ice-bar/package.nix
@@ -34,7 +34,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Powerful menu bar manager for macOS";
     homepage = "https://icemenubar.app/";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ FlameFlag ];
+    maintainers = with lib.maintainers; [ _4evy ];
     platforms = lib.platforms.darwin;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };

--- a/pkgs/by-name/ii/iina/package.nix
+++ b/pkgs/by-name/ii/iina/package.nix
@@ -34,7 +34,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [
       arkivm
-      FlameFlag
+      _4evy
       stepbrobd
     ];
     mainProgram = "iina";

--- a/pkgs/by-name/is/istat-menus/package.nix
+++ b/pkgs/by-name/is/istat-menus/package.nix
@@ -48,7 +48,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Set of nine separate and highly configurable menu items that let you know exactly what's going on inside your Mac";
     homepage = "https://bjango.com/mac/istatmenus/";
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ FlameFlag ];
+    maintainers = with lib.maintainers; [ _4evy ];
     platforms = lib.platforms.darwin;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };

--- a/pkgs/by-name/it/itsycal/package.nix
+++ b/pkgs/by-name/it/itsycal/package.nix
@@ -34,7 +34,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       eclairevoyant
-      FlameFlag
+      _4evy
     ];
     platforms = lib.platforms.darwin;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];

--- a/pkgs/by-name/ko/koboldcpp/package.nix
+++ b/pkgs/by-name/ko/koboldcpp/package.nix
@@ -131,7 +131,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     mainProgram = "koboldcpp";
     maintainers = with lib.maintainers; [
       maxstrid
-      FlameFlag
+      _4evy
     ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/me/mediamate/package.nix
+++ b/pkgs/by-name/me/mediamate/package.nix
@@ -36,7 +36,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "New, fresh visuals for changing your volume, brightness and now playing media";
     homepage = "https://wouter01.github.io/MediaMate/";
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ FlameFlag ];
+    maintainers = with lib.maintainers; [ _4evy ];
     platforms = lib.platforms.darwin;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };

--- a/pkgs/by-name/mo/moonlight/package.nix
+++ b/pkgs/by-name/mo/moonlight/package.nix
@@ -86,7 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.lgpl3;
     maintainers = with lib.maintainers; [
       ilys
-      FlameFlag
+      _4evy
       isabelroses
     ];
   };

--- a/pkgs/by-name/mo/mousecape/package.nix
+++ b/pkgs/by-name/mo/mousecape/package.nix
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Cursor manager for macOS built using private, nonintrusive CoreGraphics APIs";
     homepage = "https://github.com/alexzielenski/Mousecape";
     license = lib.licenses.free;
-    maintainers = with lib.maintainers; [ FlameFlag ];
+    maintainers = with lib.maintainers; [ _4evy ];
     platforms = lib.platforms.darwin;
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
   };

--- a/pkgs/by-name/nu/numi/package.nix
+++ b/pkgs/by-name/nu/numi/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Beautiful calculator app for macOS";
     homepage = "https://numi.app/";
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ FlameFlag ];
+    maintainers = with lib.maintainers; [ _4evy ];
     platforms = lib.platforms.darwin;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };

--- a/pkgs/by-name/ra/raycast-beta/package.nix
+++ b/pkgs/by-name/ra/raycast-beta/package.nix
@@ -71,7 +71,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://raycast.app/";
     license = lib.licenses.unfree;
     mainProgram = "raycast-beta";
-    maintainers = with lib.maintainers; [ FlameFlag ];
+    maintainers = with lib.maintainers; [ _4evy ];
     platforms = [ "aarch64-darwin" ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };

--- a/pkgs/by-name/ra/raycast/package.nix
+++ b/pkgs/by-name/ra/raycast/package.nix
@@ -80,7 +80,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       lovesegfault
       stepbrobd
-      FlameFlag
+      _4evy
       jakecleary
     ];
     platforms = [

--- a/pkgs/by-name/re/rectangle/package.nix
+++ b/pkgs/by-name/re/rectangle/package.nix
@@ -306,7 +306,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://rectangleapp.com/";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      FlameFlag
+      _4evy
       Intuinewin
       wegank
     ];

--- a/pkgs/by-name/sh/shottr/package.nix
+++ b/pkgs/by-name/sh/shottr/package.nix
@@ -58,7 +58,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://shottr.cc/";
     license = lib.licenses.unfree;
     mainProgram = "shottr";
-    maintainers = with lib.maintainers; [ FlameFlag ];
+    maintainers = with lib.maintainers; [ _4evy ];
     platforms = lib.platforms.darwin;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };

--- a/pkgs/by-name/so/soundsource/package.nix
+++ b/pkgs/by-name/so/soundsource/package.nix
@@ -33,7 +33,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     license = lib.licenses.unfree;
     maintainers = with lib.maintainers; [
       emilytrau
-      FlameFlag
+      _4evy
     ];
     platforms = lib.platforms.darwin;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];

--- a/pkgs/by-name/st/stats/package.nix
+++ b/pkgs/by-name/st/stats/package.nix
@@ -341,7 +341,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/exelban/stats";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      FlameFlag
+      _4evy
       emilytrau
     ];
     platforms = lib.platforms.darwin;

--- a/pkgs/by-name/ve/vencord/package.nix
+++ b/pkgs/by-name/ve/vencord/package.nix
@@ -109,7 +109,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/Vendicated/Vencord";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
-      FlameFlag
+      _4evy
       FlafyDev
       Gliczy
       NotAShelf

--- a/pkgs/by-name/wa/warp-terminal/package.nix
+++ b/pkgs/by-name/wa/warp-terminal/package.nix
@@ -126,7 +126,7 @@ let
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     maintainers = with lib.maintainers; [
       imadnyc
-      FlameFlag
+      _4evy
       johnrtitor
       logger
     ];

--- a/pkgs/by-name/wi/win-disk-writer/package.nix
+++ b/pkgs/by-name/wi/win-disk-writer/package.nix
@@ -29,7 +29,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Windows Bootable USB creator for macOS";
     homepage = "https://github.com/TechUnRestricted/WinDiskWriter";
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ FlameFlag ];
+    maintainers = with lib.maintainers; [ _4evy ];
     platforms = lib.platforms.darwin;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };

--- a/pkgs/by-name/yt/yt-dlp/package.nix
+++ b/pkgs/by-name/yt/yt-dlp/package.nix
@@ -171,7 +171,7 @@ python3Packages.buildPythonApplication rec {
     mainProgram = "yt-dlp";
     maintainers = with lib.maintainers; [
       SuperSandro2000
-      FlameFlag
+      _4evy
     ];
   };
 }

--- a/pkgs/development/python-modules/customtkinter/default.nix
+++ b/pkgs/development/python-modules/customtkinter/default.nix
@@ -53,6 +53,6 @@ buildPythonPackage {
       a consistent and modern look across all desktop platforms
       (Windows, macOS, Linux).
     '';
-    maintainers = with lib.maintainers; [ FlameFlag ];
+    maintainers = with lib.maintainers; [ _4evy ];
   };
 }

--- a/pkgs/development/python-modules/yt-dlp-ejs/default.nix
+++ b/pkgs/development/python-modules/yt-dlp-ejs/default.nix
@@ -59,7 +59,7 @@ buildPythonPackage rec {
     ];
     maintainers = with lib.maintainers; [
       SuperSandro2000
-      FlameFlag
+      _4evy
     ];
   };
 }


### PR DESCRIPTION
Backport of:
https://github.com/NixOS/nixpkgs/pull/538361
https://github.com/NixOS/nixpkgs/pull/540758

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
