### PR TITLE
unityhub: add unzip as dependency

### DIFF
--- a/pkgs/by-name/un/unityhub/package.nix
+++ b/pkgs/by-name/un/unityhub/package.nix
@@ -36,6 +36,7 @@ stdenv.mkDerivation rec {
         libxrandr
         xdg-utils
         p7zip
+        unzip
 
         # GTK filepicker
         gsettings-desktop-schemas


### PR DESCRIPTION
Makes `unzip` available to Unity Hub, similar to #500431.

It is required when installing module "Android SDK & NDK Tools" for [Unity 2022.3 LTS (2022.3.22f1)](https://unity.com/releases/editor/whats-new/2022.3.22f1). This Unity version is the latest one [supported by VRChat](https://creators.vrchat.com/sdk/upgrade/current-unity-version/).

<details>

<summary>
Unity Hub logs ($HOME/.config/unityhub/logs/info-log.json)
</summary>

```json
{"level":"info","time":"2026-07-05T16:49:33.052Z","pid":130492,"moduleName":"hubFS","msg":"Command unzip not found in known locations, checking system PATH..."}
{"level":"warn","time":"2026-07-05T16:49:33.062Z","pid":130492,"moduleName":"hubFS","msg":"which/where command failed for unzip Error: Command failed: which unzip\nwhich: no unzip in (/run/wrappers/bin:/usr/bin:/usr/sbin:/run/wrappers/bin:/home/sandro/.nix-profile/bin:/home/sandro/.local/state/nix/profile/bin:/etc/profiles/per-user/sandro/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin)\n\n    at genericNodeError (node:internal/errors:985:15)\n    at wrappedFn (node:internal/errors:539:14)\n    at ChildProcess.exithandler (node:child_process:417:12)\n    at ChildProcess.emit (node:events:509:28)\n    at maybeClose (node:internal/child_process:1124:16)\n    at Socket.<anonymous> (node:internal/child_process:481:11)\n    at Socket.emit (node:events:509:28)\n    at Pipe.<anonymous> (node:net:350:12) {\n  code: 1,\n  killed: false,\n  signal: null,\n  cmd: 'which unzip',\n  stdout: '',\n  stderr: 'which: no unzip in (/run/wrappers/bin:/usr/bin:/usr/sbin:/run/wrappers/bin:/home/sandro/.nix-profile/bin:/home/sandro/.local/state/nix/profile/bin:/etc/profiles/per-user/sandro/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin)\\n'\n}"}
{"level":"warn","time":"2026-07-05T16:49:33.062Z","pid":130492,"moduleName":"UnityInstallerLinux","msg":"Error in deployZip: Error: Command 'unzip' not found in PATH or known locations: /usr/bin/unzip, /bin/unzip\n    at Object.which (file:///nix/store/l7zvjzhbfmzxz1iqgpzlgm4dc9plcq7m-unityhub-3.18.3/opt/unityhub/resources/app.asar/build/main/hub-fs-DjZtN9TX.js:111:8)\n    at async extractZipToDestination (file:///nix/store/l7zvjzhbfmzxz1iqgpzlgm4dc9plcq7m-unityhub-3.18.3/opt/unityhub/resources/app.asar/build/main/unityInstaller_linux-B4Y6QTq9.js:182:20)\n    at async Object.installModule (file:///nix/store/l7zvjzhbfmzxz1iqgpzlgm4dc9plcq7m-unityhub-3.18.3/opt/unityhub/resources/app.asar/build/main/unityInstaller_linux-B4Y6QTq9.js:95:4)\n    at async ModuleInstallerWorkflow.start (file:///nix/store/l7zvjzhbfmzxz1iqgpzlgm4dc9plcq7m-unityhub-3.18.3/opt/unityhub/resources/app.asar/build/main/app-CKFRRJa6.js:35056:4)\n    at async InstallerItem.onInstallation (file:///nix/store/l7zvjzhbfmzxz1iqgpzlgm4dc9plcq7m-unityhub-3.18.3/opt/unityhub/resources/app.asar/build/main/app-CKFRRJa6.js:35224:4)"}
{"level":"error","time":"2026-07-05T16:49:33.062Z","pid":130492,"moduleName":"Installer: android-sdk-ndk-tools","msg":"Installation failed. Reason: Error: Command 'unzip' not found in PATH or known locations: /usr/bin/unzip, /bin/unzip\n    at Object.which (file:///nix/store/l7zvjzhbfmzxz1iqgpzlgm4dc9plcq7m-unityhub-3.18.3/opt/unityhub/resources/app.asar/build/main/hub-fs-DjZtN9TX.js:111:8)\n    at async extractZipToDestination (file:///nix/store/l7zvjzhbfmzxz1iqgpzlgm4dc9plcq7m-unityhub-3.18.3/opt/unityhub/resources/app.asar/build/main/unityInstaller_linux-B4Y6QTq9.js:182:20)\n    at async Object.installModule (file:///nix/store/l7zvjzhbfmzxz1iqgpzlgm4dc9plcq7m-unityhub-3.18.3/opt/unityhub/resources/app.asar/build/main/unityInstaller_linux-B4Y6QTq9.js:95:4)\n    at async ModuleInstallerWorkflow.start (file:///nix/store/l7zvjzhbfmzxz1iqgpzlgm4dc9plcq7m-unityhub-3.18.3/opt/unityhub/resources/app.asar/build/main/app-CKFRRJa6.js:35056:4)\n    at async InstallerItem.onInstallation (file:///nix/store/l7zvjzhbfmzxz1iqgpzlgm4dc9plcq7m-unityhub-3.18.3/opt/unityhub/resources/app.asar/build/main/app-CKFRRJa6.js:35224:4)"}
{"level":"info","time":"2026-07-05T16:49:33.063Z","pid":130492,"moduleName":"Installer: android-sdk-ndk-tools","msg":"Exiting from State: Installation. Event: ERROR"}
{"level":"info","time":"2026-07-05T16:49:33.063Z","pid":130492,"moduleName":"Installer: android-sdk-ndk-tools","msg":"Transition to state \"install_failed\" on event \"ERROR\""}
{"level":"info","time":"2026-07-05T16:49:33.063Z","pid":130492,"moduleName":"Installation Manager","msg":"Update: install_failed"}
```

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
