### PR TITLE
nixos/sing-box: support immutable /etc

### DIFF
--- a/nixos/modules/services/networking/sing-box.nix
+++ b/nixos/modules/services/networking/sing-box.nix
@@ -7,6 +7,7 @@
 }:
 let
   cfg = config.services.sing-box;
+  immutableEtc = config.system.etc.overlay.enable && !config.system.etc.overlay.mutable;
   settingsFormat = pkgs.formats.json { };
 in
 {
@@ -50,7 +51,7 @@ in
       serviceConfig = {
         User = "sing-box";
         Group = "sing-box";
-        ConfigurationDirectory = "sing-box";
+        ConfigurationDirectory = lib.mkIf (!immutableEtc) "sing-box";
         StateDirectory = "sing-box";
         StateDirectoryMode = "0700";
         RuntimeDirectory = "sing-box";
@@ -66,11 +67,11 @@ in
           lib.mkIf (cfg.settings != { }) "+${script}";
         ExecStart =
           let
-            configDir = if cfg.settings != { } then "RUNTIME_DIRECTORY" else "CONFIGURATION_DIRECTORY";
+            configDir = if cfg.settings != { } then "\${RUNTIME_DIRECTORY}" else "/etc/sing-box";
           in
           [
             ""
-            "${lib.getExe cfg.package} -D \${STATE_DIRECTORY} -C \${${configDir}} run"
+            "${lib.getExe cfg.package} -D \${STATE_DIRECTORY} -C ${configDir} run"
           ];
       };
       # After= is specified by upstream


### PR DESCRIPTION
Follow up of https://github.com/NixOS/nixpkgs/pull/506939#issuecomment-4849943231.

Avoid setting `ConfigurationDirectory` when `/etc` is provided by an immutable overlay. Use the explicit `/etc/sing-box` path so the service does not depend on `CONFIGURATION_DIRECTORY` being set.

This enables use cases like setting `/etc/sing-box` with `environment.etc`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
