### PR TITLE
zepp-simulator: 2.0.2 -> 2.1.1

### DIFF
--- a/pkgs/by-name/ze/zepp-simulator/package.nix
+++ b/pkgs/by-name/ze/zepp-simulator/package.nix
@@ -6,8 +6,7 @@
   copyDesktopItems,
   autoPatchelfHook,
 
-  # Upstream is officially built with Electron 18
-  # (but it works with latest Electron with minor changes, see HACK below)
+  # Upstream is built with older Electron
   electron,
   asar,
   dpkg,
@@ -40,19 +39,14 @@
 }:
 
 let
-  # CDN links for 2.0.2:
-  # MacOS: https://upload-cdn.zepp.com/zepp-applet-and-wechat-applet/20240927/ecb6ca54f4dc97a2f91e53358bbb532d.dmg
-  # Windows: https://upload-cdn.zepp.com/zepp-applet-and-wechat-applet/20240927/9db7ae1c60c26836a447a71a6fb25b3b.exe
-  # Linux ARM64: https://upload-cdn.zepp.com/zepp-applet-and-wechat-applet/20240927/02ec69e6a2f3b744d964fd7ba4f40fc3.deb
-  # Linux AMD64: https://upload-cdn.zepp.com/zepp-applet-and-wechat-applet/20240927/3e688d423cd0cd31a8a589b8325a309e.deb
   srcs = {
     x86_64-linux = {
-      url = "https://upload-cdn.zepp.com/zepp-applet-and-wechat-applet/20240927/3e688d423cd0cd31a8a589b8325a309e.deb";
-      sha256 = "sha256-ZHqaEL8FoSnRtuqGWpTyJka7D0dHtRADZthq8DG2k24=";
+      url = "https://upload-cdn.zepp.com/zepp-applet-and-wechat-applet/20260410/simulator_2.1.1_linux_amd64.deb";
+      hash = "sha256-+cRt2jZexe3hI+jN2Lp58uM8GBDvEDqt/u3rp5F0wPo=";
     };
     aarch64-linux = {
-      url = "https://upload-cdn.zepp.com/zepp-applet-and-wechat-applet/20240927/02ec69e6a2f3b744d964fd7ba4f40fc3.deb";
-      sha256 = "sha256-J5Y4wLiFOM9D2MIMiRyUtHIZ19rt65ktVCOMZQQwBCI=";
+      url = "https://upload-cdn.zepp.com/zepp-applet-and-wechat-applet/20260509/simulator_2.1.1_arm64.deb";
+      hash = "sha256-JnMfiKmA3tyMYDtO2XoeGYOLE2wANKixcfz9wesXoLk=";
     };
   };
 
@@ -60,7 +54,7 @@ in
 
 stdenv.mkDerivation {
   pname = "zepp-simulator";
-  version = "2.0.2";
+  version = "2.1.1";
 
   src = fetchurl srcs.${stdenv.hostPlatform.system};
 


### PR DESCRIPTION


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
