### PR TITLE
python3Packages.httpsig: Fix build with setuptools 82

### DIFF
--- a/pkgs/development/python-modules/httpsig/default.nix
+++ b/pkgs/development/python-modules/httpsig/default.nix
@@ -20,6 +20,11 @@ buildPythonPackage rec {
     hash = "sha256-cdbVAkYSnE98/sIPXlfjUdK4SS1jHMKqlnkUrPkfbOY=";
   };
 
+  patches = [
+    # pkg_resources is gone in setuptools 82
+    ./no-pkg-resources.patch
+  ];
+
   build-system = [
     setuptools
     setuptools-scm
@@ -29,7 +34,6 @@ buildPythonPackage rec {
     pycryptodome
     requests
     six
-    setuptools
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/httpsig/no-pkg-resources.patch
+++ b/pkgs/development/python-modules/httpsig/no-pkg-resources.patch
@@ -1,0 +1,17 @@
+--- a/httpsig/__init__.py
++++ b/httpsig/__init__.py
+@@ -1,11 +1,11 @@
+-from pkg_resources import get_distribution, DistributionNotFound
++from importlib.metadata import PackageNotFoundError, version
+ 
+ from .sign import Signer, HeaderSigner
+ from .verify import Verifier, HeaderVerifier
+ 
+ try:
+-    __version__ = get_distribution(__name__).version
+-except DistributionNotFound:
++    __version__ = version(__name__)
++except PackageNotFoundError:
+     # package is not installed
+     pass
+ 


### PR DESCRIPTION
Fixes build of `dpt-rp1-py`. I could pin to `setuptools_80` but the patch is trivial and [upstream](https://github.com/ahknight/httpsig) isn't going to shift under us anytime soon.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
