### PR TITLE
frame-media-converter: init at 0.30.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -284,6 +284,11 @@
     name = "6543";
     keys = [ { fingerprint = "8722 B61D 7234 1082 553B  201C B8BE 6D61 0E61 C862"; } ];
   };
+  _66HEX = {
+    github = "66HEX";
+    githubId = 168720167;
+    name = "Marek Jóźwiak";
+  };
   _6AA4FD = {
     email = "f6442954@gmail.com";
     github = "6AA4FD";

--- a/pkgs/by-name/fr/frame-media-converter/package.nix
+++ b/pkgs/by-name/fr/frame-media-converter/package.nix
@@ -1,0 +1,95 @@
+{
+  alsa-lib,
+  fetchFromGitHub,
+  ffmpeg,
+  fontconfig,
+  freetype,
+  lib,
+  libdrm,
+  libGL,
+  libx11,
+  libxcb,
+  libxkbcommon,
+  makeWrapper,
+  pkg-config,
+  rustPlatform,
+  wayland,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "frame-media-converter";
+  version = "0.30.0";
+
+  src = fetchFromGitHub {
+    owner = "66HEX";
+    repo = "frame";
+    tag = finalAttrs.version;
+    hash = "sha256-2BT4+7C1f2laflMvUMC35/F0mYF/j/0PO8XjaLDTjqY=";
+  };
+
+  cargoHash = "sha256-7cmLjjkaVraLtcI0JmMEbiH9gMUUe+zA+6HMQ2AHd7w=";
+
+  cargoBuildFlags = [
+    "--package"
+    "frame-app"
+  ];
+
+  cargoTestFlags = [
+    "--package"
+    "frame-app"
+  ];
+
+  nativeBuildInputs = [
+    makeWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    alsa-lib
+    fontconfig
+    freetype
+    libdrm
+    libGL
+    libx11
+    libxcb
+    libxkbcommon
+    wayland
+  ];
+
+  postInstall = ''
+    install -Dm444 frame-app/resources/frame.desktop.in "$out/share/applications/frame.desktop"
+    substituteInPlace "$out/share/applications/frame.desktop" \
+      --replace-fail '$APP_NAME' Frame \
+      --replace-fail '$APP_CLI' frame \
+      --replace-fail '$APP_ICON' frame
+
+    install -Dm444 frame-app/resources/app-icons/32x32.png \
+      "$out/share/icons/hicolor/32x32/apps/frame.png"
+    install -Dm444 frame-app/resources/app-icons/64x64.png \
+      "$out/share/icons/hicolor/64x64/apps/frame.png"
+    install -Dm444 frame-app/resources/app-icons/128x128.png \
+      "$out/share/icons/hicolor/128x128/apps/frame.png"
+    install -Dm444 frame-app/resources/app-icons/128x128@2x.png \
+      "$out/share/icons/hicolor/256x256/apps/frame.png"
+    install -Dm444 frame-app/resources/app-icons/icon.png \
+      "$out/share/icons/hicolor/512x512/apps/frame.png"
+  '';
+
+  postFixup = ''
+    wrapProgram "$out/bin/frame" \
+      --prefix PATH : ${lib.makeBinPath [ ffmpeg ]} \
+      --set FRAME_USE_SYSTEM_MEDIA_TOOLS 1 \
+      --set FRAME_UPDATE_EXPLANATION \
+        'This Nixpkgs build is managed by Nix. Install updates through your Nix profile, flake, or NixOS configuration.'
+  '';
+
+  meta = {
+    description = "Native desktop interface for FFmpeg media conversion";
+    homepage = "https://github.com/66HEX/frame";
+    changelog = "https://github.com/66HEX/frame/blob/${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers._66HEX ];
+    mainProgram = "frame";
+    platforms = [ "x86_64-linux" ];
+  };
+})


### PR DESCRIPTION
## Summary

- Add Frame 0.30.0 as frame-media-converter; pkgs.frame is already occupied.
- Build the frame-app workspace package from source and install the desktop entry plus five hicolor icons.
- Wrap only frame with nixpkgs FFmpeg, system-media-tools mode, and the Nix-managed update explanation.

## Validation

Base commit: 58ac14d00e963f59c5a3f301d3c276341fb0884b

- Linux Docker build with Nix sandbox enabled passed. The container is aarch64-linux and uses NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM only for validation; package metadata remains x86_64-linux.
- Default check phase passed: 634 tests passed, 0 failed, 6 upstream-ignored.
- Maintainer validation passed.
- nixfmt check passed.
- nixpkgs-review rev passed and built frame-media-converter.
- nixpkgs-vet passed against the upstream master base.
- Output verification found the binary, desktop entry, five icons, no bundled resources/binaries, wrapper FFmpeg path and both environment variables, and no missing ELF dependency in ldd. Recursive closure: 1.1 GiB.

## Remaining before ready

Manual smoke tests are not run: this environment has no native x86_64 Linux desktop, X11, or Wayland session. The draft needs independent x86_64 Linux X11 and Wayland smoke tests covering launch and icon, ffprobe analysis, H.264 preview, MP4 to WebM and WAV to MP3 conversion, and the Check now Nix-managed update message.