### PR TITLE
vivaldi-ffmpeg-codecs: update from vivaldi 8.1.4087.48 update-ffmpeg

### DIFF
--- a/pkgs/by-name/vi/vivaldi-ffmpeg-codecs/package.nix
+++ b/pkgs/by-name/vi/vivaldi-ffmpeg-codecs/package.nix
@@ -11,19 +11,19 @@
 let
   sources = {
     x86_64-linux = fetchurl {
-      url = "https://api.snapcraft.io/api/v1/snaps/download/XXzVIXswXKHqlUATPqGCj2w2l7BxosS8_82.snap";
-      hash = "sha256-G9RcOuFjkLDJUNlw2G8GiONpWHYvyTnv3Nr0JSdW0As=";
+      url = "https://api.snapcraft.io/api/v1/snaps/download/XXzVIXswXKHqlUATPqGCj2w2l7BxosS8_117.snap";
+      hash = "sha256-YEE7oF8NLGDCQ3gpY5z6B+7xDxcOumjOzwUztJUM+/s=";
     };
     aarch64-linux = fetchurl {
-      url = "https://api.snapcraft.io/api/v1/snaps/download/XXzVIXswXKHqlUATPqGCj2w2l7BxosS8_83.snap";
-      hash = "sha256-6XMdH4dnvYB1FaJLMi/MFnTzkelmOHMedVcIg/Fh7h4=";
+      url = "https://api.snapcraft.io/api/v1/snaps/download/XXzVIXswXKHqlUATPqGCj2w2l7BxosS8_116.snap";
+      hash = "sha256-4RmVOQ9emlRyzAGxeiSLwvkGv+7R/mKLVYm5IWXqLpo=";
     };
   };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "chromium-codecs-ffmpeg-extra";
 
-  version = "120726";
+  version = "2026-05-18";
 
   src = sources."${stdenv.hostPlatform.system}";
 
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   installPhase = ''
-    install -vD chromium-ffmpeg-${finalAttrs.version}/chromium-ffmpeg/libffmpeg.so $out/lib/libffmpeg.so
+    install -vD chromium-ffmpeg-git-${finalAttrs.version}/chromium-ffmpeg/libffmpeg.so $out/lib/libffmpeg.so
   '';
 
   passthru = {


### PR DESCRIPTION
Updated the snap URLs with the ones from the update-ffmpeg script in the latest Vivaldi release. 8.1.4087.48 won't launch with the old one (`undefined symbol: av_dynamic_hdr_smpte2094_app5_to_t35`).

The version string format has changed as well since the last time the package was updated. Is the new version string fine like this?
```
❯ unsquashfs -l -max 1 XXzVIXswXKHqlUATPqGCj2w2l7BxosS8_117.snap
squashfs-root
squashfs-root/chromium-ffmpeg-120726
squashfs-root/chromium-ffmpeg-121586
squashfs-root/chromium-ffmpeg-122056
squashfs-root/chromium-ffmpeg-123075
squashfs-root/chromium-ffmpeg-git-2026-01-05
squashfs-root/chromium-ffmpeg-git-2026-01-28
squashfs-root/chromium-ffmpeg-git-2026-02-09
squashfs-root/chromium-ffmpeg-git-2026-03-16
squashfs-root/chromium-ffmpeg-git-2026-05-18
squashfs-root/meta
squashfs-root/snap
```

Should be merged after/with #540169

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
