### PR TITLE
python3Packages.{langchain,langgraph, langsmith}: Exclude alpha, beta, dev, etc. in updates

### DIFF
--- a/pkgs/development/python-modules/langchain-anthropic/default.nix
+++ b/pkgs/development/python-modules/langchain-anthropic/default.nix
@@ -74,6 +74,7 @@ buildPythonPackage (finalAttrs: {
     skipBulkUpdate = true;
     updateScript = gitUpdater {
       rev-prefix = "langchain-anthropic==";
+      ignoredVersions = "a|b|dev|rc";
     };
   };
 

--- a/pkgs/development/python-modules/langchain-aws/default.nix
+++ b/pkgs/development/python-modules/langchain-aws/default.nix
@@ -91,6 +91,7 @@ buildPythonPackage (finalAttrs: {
     skipBulkUpdate = true;
     updateScript = gitUpdater {
       rev-prefix = "langchain-aws==";
+      ignoredVersions = "a|b|dev|rc";
     };
   };
 

--- a/pkgs/development/python-modules/langchain-azure-dynamic-sessions/default.nix
+++ b/pkgs/development/python-modules/langchain-azure-dynamic-sessions/default.nix
@@ -79,6 +79,7 @@ buildPythonPackage rec {
     skipBulkUpdate = true;
     updateScript = gitUpdater {
       rev-prefix = "langchain-azure-dynamic-sessions==";
+      ignoredVersions = "a|b|dev|rc";
     };
   };
 

--- a/pkgs/development/python-modules/langchain-chroma/default.nix
+++ b/pkgs/development/python-modules/langchain-chroma/default.nix
@@ -62,6 +62,7 @@ buildPythonPackage rec {
     skipBulkUpdate = true;
     updateScript = gitUpdater {
       rev-prefix = "langchain-chroma==";
+      ignoredVersions = "a|b|dev|rc";
     };
   };
 

--- a/pkgs/development/python-modules/langchain-classic/default.nix
+++ b/pkgs/development/python-modules/langchain-classic/default.nix
@@ -106,6 +106,7 @@ buildPythonPackage (finalAttrs: {
     skipBulkUpdate = true;
     updateScript = gitUpdater {
       rev-prefix = "langchain-classic==";
+      ignoredVersions = "a|b|dev|rc";
     };
   };
 

--- a/pkgs/development/python-modules/langchain-community/default.nix
+++ b/pkgs/development/python-modules/langchain-community/default.nix
@@ -129,6 +129,7 @@ buildPythonPackage rec {
 
   passthru.updateScript = gitUpdater {
     rev-prefix = "libs/community/v";
+    ignoredVersions = "a|b|dev|rc";
   };
 
   meta = {

--- a/pkgs/development/python-modules/langchain-core/default.nix
+++ b/pkgs/development/python-modules/langchain-core/default.nix
@@ -92,6 +92,7 @@ buildPythonPackage (finalAttrs: {
     skipBulkUpdate = true;
     updateScript = gitUpdater {
       rev-prefix = "langchain-core==";
+      ignoredVersions = "a|b|dev|rc";
     };
   };
 

--- a/pkgs/development/python-modules/langchain-deepseek/default.nix
+++ b/pkgs/development/python-modules/langchain-deepseek/default.nix
@@ -65,6 +65,7 @@ buildPythonPackage rec {
     skipBulkUpdate = true;
     updateScript = gitUpdater {
       rev-prefix = "langchain-deepseek==";
+      ignoredVersions = "a|b|dev|rc";
     };
   };
 

--- a/pkgs/development/python-modules/langchain-fireworks/default.nix
+++ b/pkgs/development/python-modules/langchain-fireworks/default.nix
@@ -73,6 +73,7 @@ buildPythonPackage (finalAttrs: {
     skipBulkUpdate = true;
     updateScript = gitUpdater {
       rev-prefix = "langchain-fireworks==";
+      ignoredVersions = "a|b|dev|rc";
     };
   };
 

--- a/pkgs/development/python-modules/langchain-google-genai/default.nix
+++ b/pkgs/development/python-modules/langchain-google-genai/default.nix
@@ -87,6 +87,7 @@ buildPythonPackage (finalAttrs: {
     skipBulkUpdate = true;
     updateScript = gitUpdater {
       rev-prefix = "libs/genai/v";
+      ignoredVersions = "a|b|dev|rc";
     };
   };
 

--- a/pkgs/development/python-modules/langchain-groq/default.nix
+++ b/pkgs/development/python-modules/langchain-groq/default.nix
@@ -68,6 +68,7 @@ buildPythonPackage (finalAttrs: {
     skipBulkUpdate = true;
     updateScript = gitUpdater {
       rev-prefix = "langchain-groq==";
+      ignoredVersions = "a|b|dev|rc";
     };
   };
 

--- a/pkgs/development/python-modules/langchain-huggingface/default.nix
+++ b/pkgs/development/python-modules/langchain-huggingface/default.nix
@@ -87,6 +87,7 @@ buildPythonPackage (finalAttrs: {
     skipBulkUpdate = true;
     updateScript = gitUpdater {
       rev-prefix = "langchain-huggingface==";
+      ignoredVersions = "a|b|dev|rc";
     };
   };
 

--- a/pkgs/development/python-modules/langchain-mistralai/default.nix
+++ b/pkgs/development/python-modules/langchain-mistralai/default.nix
@@ -72,6 +72,7 @@ buildPythonPackage (finalAttrs: {
     skipBulkUpdate = true;
     updateScript = gitUpdater {
       rev-prefix = "langchain-mistralai==";
+      ignoredVersions = "a|b|dev|rc";
     };
   };
 

--- a/pkgs/development/python-modules/langchain-mongodb/default.nix
+++ b/pkgs/development/python-modules/langchain-mongodb/default.nix
@@ -100,6 +100,7 @@ buildPythonPackage (finalAttrs: {
     skipBulkUpdate = true;
     updateScript = gitUpdater {
       rev-prefix = "libs/langchain-mongodb/v";
+      ignoredVersions = "a|b|dev|rc";
     };
   };
 

--- a/pkgs/development/python-modules/langchain-ollama/default.nix
+++ b/pkgs/development/python-modules/langchain-ollama/default.nix
@@ -69,6 +69,7 @@ buildPythonPackage (finalAttrs: {
     skipBulkUpdate = true;
     updateScript = gitUpdater {
       rev-prefix = "langchain-ollama==";
+      ignoredVersions = "a|b|dev|rc";
     };
   };
 

--- a/pkgs/development/python-modules/langchain-openai/default.nix
+++ b/pkgs/development/python-modules/langchain-openai/default.nix
@@ -98,6 +98,7 @@ buildPythonPackage (finalAttrs: {
     skipBulkUpdate = true;
     updateScript = gitUpdater {
       rev-prefix = "langchain-openai==";
+      ignoredVersions = "a|b|dev|rc";
     };
   };
 

--- a/pkgs/development/python-modules/langchain-perplexity/default.nix
+++ b/pkgs/development/python-modules/langchain-perplexity/default.nix
@@ -68,6 +68,7 @@ buildPythonPackage (finalAttrs: {
     skipBulkUpdate = true;
     updateScript = gitUpdater {
       rev-prefix = "langchain-perplexity==";
+      ignoredVersions = "a|b|dev|rc";
     };
   };
 

--- a/pkgs/development/python-modules/langchain-tests/default.nix
+++ b/pkgs/development/python-modules/langchain-tests/default.nix
@@ -81,6 +81,7 @@ buildPythonPackage (finalAttrs: {
     skipBulkUpdate = true;
     updateScript = gitUpdater {
       rev-prefix = "langchain-tests==";
+      ignoredVersions = "a|b|dev|rc";
     };
   };
 

--- a/pkgs/development/python-modules/langchain-text-splitters/default.nix
+++ b/pkgs/development/python-modules/langchain-text-splitters/default.nix
@@ -53,6 +53,7 @@ buildPythonPackage (finalAttrs: {
     skipBulkUpdate = true;
     updateScript = gitUpdater {
       rev-prefix = "langchain-text-splitters==";
+      ignoredVersions = "a|b|dev|rc";
     };
   };
 

--- a/pkgs/development/python-modules/langchain-xai/default.nix
+++ b/pkgs/development/python-modules/langchain-xai/default.nix
@@ -67,6 +67,7 @@ buildPythonPackage (finalAttrs: {
     skipBulkUpdate = true;
     updateScript = gitUpdater {
       rev-prefix = "langchain-xai==";
+      ignoredVersions = "a|b|dev|rc";
     };
   };
 

--- a/pkgs/development/python-modules/langchain/default.nix
+++ b/pkgs/development/python-modules/langchain/default.nix
@@ -144,6 +144,7 @@ buildPythonPackage (finalAttrs: {
     skipBulkUpdate = true;
     updateScript = gitUpdater {
       rev-prefix = "langchain==";
+      ignoredVersions = "a|b|dev|rc";
     };
   };
 

--- a/pkgs/development/python-modules/langgraph-checkpoint-mongodb/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint-mongodb/default.nix
@@ -51,6 +51,7 @@ buildPythonPackage (finalAttrs: {
     skipBulkUpdate = true;
     updateScript = gitUpdater {
       rev-prefix = "libs/langgraph-checkpoint-mongodb/v";
+      ignoredVersions = "a|b|dev|rc";
     };
   };
 

--- a/pkgs/development/python-modules/langgraph-checkpoint-postgres/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint-postgres/default.nix
@@ -97,6 +97,7 @@ buildPythonPackage (finalAttrs: {
     skipBulkUpdate = true;
     updateScript = gitUpdater {
       rev-prefix = "checkpointpostgres==";
+      ignoredVersions = "a|b|dev|rc";
     };
   };
 

--- a/pkgs/development/python-modules/langgraph-checkpoint-sqlite/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint-sqlite/default.nix
@@ -80,6 +80,7 @@ buildPythonPackage (finalAttrs: {
     skipBulkUpdate = true;
     updateScript = gitUpdater {
       rev-prefix = "checkpointsqlite==";
+      ignoredVersions = "a|b|dev|rc";
     };
   };
 

--- a/pkgs/development/python-modules/langgraph-checkpoint/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint/default.nix
@@ -66,6 +66,7 @@ buildPythonPackage (finalAttrs: {
     skipBulkUpdate = true;
     updateScript = gitUpdater {
       rev-prefix = "checkpoint==";
+      ignoredVersions = "a|b|dev|rc";
     };
   };
 

--- a/pkgs/development/python-modules/langgraph-cli/default.nix
+++ b/pkgs/development/python-modules/langgraph-cli/default.nix
@@ -93,6 +93,7 @@ buildPythonPackage (finalAttrs: {
     skipBulkUpdate = true;
     updateScript = gitUpdater {
       rev-prefix = "cli==";
+      ignoredVersions = "a|b|dev|rc";
     };
   };
 

--- a/pkgs/development/python-modules/langgraph-prebuilt/default.nix
+++ b/pkgs/development/python-modules/langgraph-prebuilt/default.nix
@@ -97,6 +97,7 @@ buildPythonPackage (finalAttrs: {
     skipBulkUpdate = true;
     updateScript = gitUpdater {
       rev-prefix = "prebuilt==";
+      ignoredVersions = "a|b|dev|rc";
     };
   };
 

--- a/pkgs/development/python-modules/langgraph-sdk/default.nix
+++ b/pkgs/development/python-modules/langgraph-sdk/default.nix
@@ -57,6 +57,7 @@ buildPythonPackage (finalAttrs: {
     skipBulkUpdate = true;
     updateScript = gitUpdater {
       rev-prefix = "sdk==";
+      ignoredVersions = "a|b|dev|rc";
     };
   };
 


### PR DESCRIPTION
For those packages that use `gitUpdater` (due to `nix-update` not having a large enough window to catch all updates in a monorepo), exclude alpha, beta, dev, and rc updates from consideration.

Built each update individually to confirm there are no breakages.

(Determinate update done with a Perl script. All hail the Swiss Army Chainsaw!)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
