### PR TITLE
nixos/graphical-desktop: remove empty X11 keyboard options

### DIFF
--- a/nixos/modules/services/misc/graphical-desktop.nix
+++ b/nixos/modules/services/misc/graphical-desktop.nix
@@ -21,23 +21,32 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    environment = {
-      # localectl looks into 00-keyboard.conf
-      etc."X11/xorg.conf.d/00-keyboard.conf".text = ''
-        Section "InputClass"
-          Identifier "Keyboard catchall"
-          MatchIsKeyboard "on"
-          Option "XkbModel" "${xcfg.xkb.model}"
-          Option "XkbLayout" "${xcfg.xkb.layout}"
-          Option "XkbOptions" "${xcfg.xkb.options}"
-          Option "XkbVariant" "${xcfg.xkb.variant}"
-        EndSection
-      '';
-      systemPackages = with pkgs; [
-        nixos-icons # needed for gnome and pantheon about dialog, nixos-manual and maybe more
-        xdg-utils
-      ];
-    };
+    environment =
+      let
+        inherit (xcfg) xkb;
+        optionLines = lib.concatMapAttrsStringSep "\n" (key: val: ''Option "${key}" "${val}"'') (
+          lib.filterAttrs (_: val: val != "") {
+            XkbModel = xkb.model;
+            XkbLayout = xkb.layout;
+            XkbOptions = xkb.options;
+            XkbVariant = xkb.variant;
+          }
+        );
+      in
+      {
+        # localectl looks into 00-keyboard.conf
+        etc."X11/xorg.conf.d/00-keyboard.conf".text = ''
+          Section "InputClass"
+            Identifier "Keyboard catchall"
+            MatchIsKeyboard "on"
+            ${optionLines}
+          EndSection
+        '';
+        systemPackages = with pkgs; [
+          nixos-icons # needed for gnome and pantheon about dialog, nixos-manual and maybe more
+          xdg-utils
+        ];
+      };
 
     fonts.enableDefaultPackages = lib.mkDefault true;
 

--- a/nixos/tests/keymap.nix
+++ b/nixos/tests/keymap.nix
@@ -93,6 +93,10 @@ let
 
         machine.wait_for_x()
 
+        with subtest("X11 layout is reported by localectl"):
+            status, stdout = machine.execute("localectl")
+            t.assertIn("X11 Layout: ${extraConfig.services.xserver.xkb.layout}", stdout)
+
         for test_case_name, test_data in tests.items():
             for keymap_env_name, command in keymap_environments.items():
                 with subtest(f"{test_case_name} - {keymap_env_name}"):


### PR DESCRIPTION
systemd-loacled 261 string_is_safe fails "", rejecting nixos X11/00-keyboard.conf. this causes keyboard layouts to failover to defaults on KDE Plasma 6.7.

test validates that localed emits xkb information correctly in the presence of null variants in the keymap.qwertz test.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
