### PR TITLE
perlPackages.CryptOpenSSLRSA: 0.35 -> 0.41

### DIFF
--- a/pkgs/development/perl-modules/MojoSAML-select-PKCS-1-padding.patch
+++ b/pkgs/development/perl-modules/MojoSAML-select-PKCS-1-padding.patch
@@ -1,0 +1,44 @@
+From 7dcb837f5f953206eead3d28144c3d0e2af85c2c Mon Sep 17 00:00:00 2001
+From: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
+Date: Mon, 20 Jul 2026 22:48:38 -0400
+Subject: [PATCH] Select PKCS#1 padding for XML signatures
+
+The rsa-sha* XML Signature algorithms require RSASSA-PKCS1-v1_5.
+Select that padding explicitly instead of relying on the RSA module's
+signing default, which is PSS in recent releases.
+
+Require Crypt::OpenSSL::RSA 0.38, the first release whose signing path
+honors the explicit padding choice.
+
+Assisted-by: Codex
+---
+ cpanfile           | 2 +-
+ lib/Mojo/XMLSig.pm | 1 +
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/cpanfile b/cpanfile
+index 6c56caf..149f4a6 100644
+--- a/cpanfile
++++ b/cpanfile
+@@ -1,5 +1,5 @@
+ requires 'Mojolicious', '7.78'; # tag_to_html
+-requires 'Crypt::OpenSSL::RSA';
++requires 'Crypt::OpenSSL::RSA', '0.38';
+ requires 'Crypt::OpenSSL::X509';
+ requires 'Data::GUID';
+ requires 'Digest::SHA';
+diff --git a/lib/Mojo/XMLSig.pm b/lib/Mojo/XMLSig.pm
+index 3ee9db3..2498bbe 100644
+--- a/lib/Mojo/XMLSig.pm
++++ b/lib/Mojo/XMLSig.pm
+@@ -91,6 +91,7 @@ my $set_algo = sub {
+     unless $key->$isa('Crypt::OpenSSL::RSA');
+   Carp::croak 'Unsupported RSA algorithm'
+     unless my $method = $key->can("use_${algo}_hash");
++  $key->use_pkcs1_padding;
+   $key->$method;
+   return $key;
+ };
+-- 
+2.54.0
+

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -7771,17 +7771,21 @@ with self;
 
   CryptOpenSSLRSA = buildPerlPackage {
     pname = "Crypt-OpenSSL-RSA";
-    version = "0.35";
+    version = "0.41";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TODDR/Crypt-OpenSSL-RSA-0.35.tar.gz";
-      hash = "sha256-XuvVWsBxY0yGSo549c+vuq9Dz4TAQyOgm3Hddr8CXMI=";
+      url = "mirror://cpan/authors/id/T/TI/TIMLEGGE/Crypt-OpenSSL-RSA-0.41.tar.gz";
+      hash = "sha256-gvqDmJe4jpwkW2Jl874m07yHnK5MeoFR+tSjB8M2aCI=";
     };
-    propagatedBuildInputs = [ CryptOpenSSLRandom ];
+    propagatedBuildInputs = [
+      CryptOpenSSLBignum
+      CryptOpenSSLRandom
+    ];
     env.NIX_CFLAGS_COMPILE = "-I${pkgs.openssl.dev}/include";
     env.NIX_CFLAGS_LINK = "-L${lib.getLib pkgs.openssl}/lib -lcrypto";
     env.OPENSSL_PREFIX = pkgs.openssl;
     buildInputs = [ CryptOpenSSLGuess ];
     meta = {
+      homepage = "https://github.com/cpan-authors/Crypt-OpenSSL-RSA";
       description = "RSA encoding and decoding, using the openSSL libraries";
       license = with lib.licenses; [
         artistic1

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -23090,6 +23090,9 @@ with self;
       url = "mirror://cpan/authors/id/J/JB/JBERGER/Mojo-SAML-0.07.tar.gz";
       hash = "sha256-csJMrNtvHXp14uqgBDfHFKv1eafSENSqTT8g8e/0cQ0=";
     };
+    patches = [
+      ../development/perl-modules/MojoSAML-select-PKCS-1-padding.patch
+    ];
     buildInputs = [ ModuleBuildTiny ];
     propagatedBuildInputs = [
       CryptOpenSSLRSA


### PR DESCRIPTION
Changelog: https://metacpan.org/dist/Crypt-OpenSSL-RSA/changes

Among other things, it restores PKCS#1 v1.5 padding for sign()/verify()
in 0.38 which broke proxmox api if deployed on NixOS [1].

[1] https://github.com/SaumonNet/proxmox-nixos/issues/217

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
