### PR TITLE
spectral-mic: init at 0.8.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18941,6 +18941,12 @@
     githubId = 104795;
     name = "Marek Mahut";
   };
+  mmclinton = {
+    email = "nixpkg.concur071@simplelogin.com";
+    github = "mmclinton";
+    githubId = 96266047;
+    name = "Miller Clinton";
+  };
   mmesch = {
     github = "MMesch";
     githubId = 2597803;

--- a/pkgs/by-name/sp/spectral-mic/package.nix
+++ b/pkgs/by-name/sp/spectral-mic/package.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitea,
+  pkg-config,
+  makeWrapper,
+  libxkbcommon,
+  wayland,
+  libx11,
+  libxcursor,
+  libxi,
+  libxrandr,
+  fontconfig,
+  pipewire,
+  versionCheckHook,
+}:
+let
+  # Loaded via dlopen at runtime by winit (x11-dl, xkbcommon-dl) and
+  # wayland-sys; everything linked at build time (fontconfig, pipewire)
+  # resolves through the binary's RUNPATH instead.
+  dlopenLibs = [
+    libxkbcommon
+    wayland
+    libx11
+    libxcursor
+    libxi
+    libxrandr
+  ];
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "spectral-mic";
+  version = "0.8.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "mmc";
+    repo = "spectral";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2HaTOLhHVLYKnEsWjvLf1GqPvtBdrjotG1kZj9mbwkk=";
+  };
+
+  cargoHash = "sha256-OMrYfPQim9H178LnRUg2Ues9Nf2txz4u+tEddrllKME=";
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    fontconfig
+    pipewire
+  ];
+
+  postInstall = ''
+    install -Dm644 assets/page.codeberg.mmc.Spectral.desktop $out/share/applications/page.codeberg.mmc.Spectral.desktop
+    install -Dm644 assets/page.codeberg.mmc.Spectral.metainfo.xml $out/share/metainfo/page.codeberg.mmc.Spectral.metainfo.xml
+    install -Dm644 assets/spectral.png $out/share/icons/hicolor/512x512/apps/page.codeberg.mmc.Spectral.png
+    install -Dm644 THIRD-PARTY.md $out/share/licenses/spectral-mic/THIRD-PARTY.md
+
+    wrapProgram $out/bin/spectral \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath dlopenLibs}"
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Real-time audio noise suppression application";
+    longDescription = ''
+      Spectral is a real-time audio noise suppression application powered by
+      RNNoise, a hybrid DSP and neural-network-based noise suppression system.
+      It creates a virtual microphone that can be used with any application,
+      filtering out background noise in real-time.
+    '';
+    homepage = "https://codeberg.org/mmc/spectral";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.mmclinton ];
+    mainProgram = "spectral";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
New package: Spectral — a Linux-only, real-time noise-suppression app that exposes the cleaned input as a virtual PipeWire microphone any application can select.

Homepage: https://codeberg.org/mmc/spectral
Changelog: https://codeberg.org/mmc/spectral/src/tag/v0.8.0/CHANGELOG.md

Rebased on current master and retargeted at 0.8.0, a GUI release: the control panel was rebuilt as a resizable layout, so the minimum window size drops to 720x680 and the screenshot in the AppStream metainfo was retaken. The packaging expression is unchanged from the previous revision apart from `version` and the two hashes.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
