### PR TITLE
minikube: fix darwin build; fix use of qemu driver; add withVfkit option, minor clean-up

### DIFF
--- a/pkgs/by-name/mi/minikube/package.nix
+++ b/pkgs/by-name/mi/minikube/package.nix
@@ -77,9 +77,9 @@ buildGoModule (finalAttrs: {
           lib.optionals withQemu [ qemu ] ++ lib.optionals stdenv.hostPlatform.isLinux [ libvirt ]
         )
       } \
-      --prefix LD_LIBRARY_PATH : ${
-        lib.makeLibraryPath (lib.optionals stdenv.hostPlatform.isLinux [ libvirt ])
-      }
+      ${lib.optionalString stdenv.hostPlatform.isLinux "--prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [ libvirt ]
+      }"}
     ln -sv $out/bin/minikube $out/bin/kubectl
 
     installShellCompletion --cmd minikube \

--- a/pkgs/by-name/mi/minikube/package.nix
+++ b/pkgs/by-name/mi/minikube/package.nix
@@ -38,14 +38,14 @@ buildGoModule (finalAttrs: {
   + (lib.optionalString (withQemu && stdenv.hostPlatform.isDarwin) ''
     substituteInPlace \
       pkg/minikube/registry/drvs/qemu2/qemu2.go \
-      --replace "/usr/local/opt/qemu/share/qemu" "${qemu}/share/qemu" \
-      --replace "/opt/homebrew/opt/qemu/share/qemu" "${qemu}/share/qemu"
+      --replace-fail "/usr/local/opt/qemu/share/qemu" "${lib.getLib qemu}/share/qemu" \
+      --replace-fail "/opt/homebrew/opt/qemu/share/qemu" "${lib.getLib qemu}/share/qemu"
   '')
   + (lib.optionalString (withQemu && stdenv.hostPlatform.isLinux) ''
     substituteInPlace \
       pkg/minikube/registry/drvs/qemu2/qemu2.go \
-      --replace "/usr/share/OVMF/OVMF_CODE.fd" "${OVMF.firmware}" \
-      --replace "/usr/share/AAVMF/AAVMF_CODE.fd" "${OVMF.firmware}"
+      --replace-fail "/usr/share/OVMF/OVMF_CODE.fd" "${OVMF.firmware}" \
+      --replace-fail "/usr/share/AAVMF/AAVMF_CODE.fd" "${OVMF.firmware}"
   '');
 
   nativeBuildInputs = [

--- a/pkgs/by-name/mi/minikube/package.nix
+++ b/pkgs/by-name/mi/minikube/package.nix
@@ -72,7 +72,11 @@ buildGoModule (finalAttrs: {
     installBin out/minikube
 
     wrapProgram $out/bin/minikube --set MINIKUBE_WANTUPDATENOTIFICATION false \
-      --prefix PATH : ${lib.makeBinPath (lib.optionals stdenv.hostPlatform.isLinux [ libvirt ])} \
+      --prefix PATH : ${
+        lib.makeBinPath (
+          lib.optionals withQemu [ qemu ] ++ lib.optionals stdenv.hostPlatform.isLinux [ libvirt ]
+        )
+      } \
       --prefix LD_LIBRARY_PATH : ${
         lib.makeLibraryPath (lib.optionals stdenv.hostPlatform.isLinux [ libvirt ])
       }

--- a/pkgs/by-name/mi/minikube/package.nix
+++ b/pkgs/by-name/mi/minikube/package.nix
@@ -9,6 +9,8 @@
   libvirt,
   withQemu ? false,
   qemu,
+  withVfkit ? false,
+  vfkit,
   makeWrapper,
   writableTmpDirAsHomeHook,
   OVMF,
@@ -74,7 +76,9 @@ buildGoModule (finalAttrs: {
     wrapProgram $out/bin/minikube --set MINIKUBE_WANTUPDATENOTIFICATION false \
       --prefix PATH : ${
         lib.makeBinPath (
-          lib.optionals withQemu [ qemu ] ++ lib.optionals stdenv.hostPlatform.isLinux [ libvirt ]
+          lib.optionals withQemu [ qemu ]
+          ++ lib.optionals stdenv.hostPlatform.isLinux [ libvirt ]
+          ++ lib.optionals (withVfkit && stdenv.hostPlatform.isDarwin) [ vfkit ]
         )
       } \
       ${lib.optionalString stdenv.hostPlatform.isLinux "--prefix LD_LIBRARY_PATH : ${

--- a/pkgs/by-name/mi/minikube/package.nix
+++ b/pkgs/by-name/mi/minikube/package.nix
@@ -78,10 +78,10 @@ buildGoModule (finalAttrs: {
       }
     ln -sv $out/bin/minikube $out/bin/kubectl
 
-    for shell in bash zsh fish; do
-      $out/bin/minikube completion $shell > minikube.$shell
-      installShellCompletion minikube.$shell
-    done
+    installShellCompletion --cmd minikube \
+      --bash <($out/bin/minikube completion bash) \
+      --fish <($out/bin/minikube completion fish) \
+      --zsh <($out/bin/minikube completion zsh)
 
     runHook postInstall
   '';


### PR DESCRIPTION
* Add qemu bin path to wrapped minikube when building `minikube` `withQemu = true` so that minikube finds the `qemu-*` programs to properly use the `qemu2` driver
* Use recommened `--replace-fail` option with `substituteInPlace`
* Simplify installation of shell completion

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
