### PR TITLE
picocrypt{,-ng}: fix build on darwin

### DIFF
--- a/pkgs/by-name/pi/picocrypt-ng/package.nix
+++ b/pkgs/by-name/pi/picocrypt-ng/package.nix
@@ -12,6 +12,7 @@
   pkg-config,
   wrapGAppsHook3,
   writableTmpDirAsHomeHook,
+  llvmPackages,
 }:
 
 buildGoModule (finalAttrs: {
@@ -49,7 +50,9 @@ buildGoModule (finalAttrs: {
     pkg-config
     wrapGAppsHook3
     writableTmpDirAsHomeHook
-  ];
+  ]
+  # TODO: Remove once #536365 reaches this branch
+  ++ lib.optional stdenv.hostPlatform.isDarwin llvmPackages.lld;
 
   # git ls-files doesn't work as source is not a git repo
   checkFlags =
@@ -61,7 +64,13 @@ buildGoModule (finalAttrs: {
     in
     [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
-  env.CGO_ENABLED = 1;
+  env = {
+    CGO_ENABLED = 1;
+  }
+  // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    # TODO: Remove once #536365 reaches this branch
+    NIX_CFLAGS_LINK = "-fuse-ld=lld";
+  };
 
   postInstall = ''
     mv $out/bin/picocrypt $out/bin/picocrypt-ng-gui

--- a/pkgs/by-name/pi/picocrypt/package.nix
+++ b/pkgs/by-name/pi/picocrypt/package.nix
@@ -11,6 +11,7 @@
   gtk3,
   pkg-config,
   wrapGAppsHook3,
+  llvmPackages,
 }:
 
 buildGoModule (finalAttrs: {
@@ -46,9 +47,17 @@ buildGoModule (finalAttrs: {
     copyDesktopItems
     pkg-config
     wrapGAppsHook3
-  ];
+  ]
+  # TODO: Remove once #536365 reaches this branch
+  ++ lib.optional stdenv.hostPlatform.isDarwin llvmPackages.lld;
 
-  env.CGO_ENABLED = 1;
+  env = {
+    CGO_ENABLED = 1;
+  }
+  // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    # TODO: Remove once #536365 reaches this branch
+    NIX_CFLAGS_LINK = "-fuse-ld=lld";
+  };
 
   postInstall = ''
     mv $out/bin/Picocrypt $out/bin/picocrypt-gui


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
