### PR TITLE
omp-bin: init at 18.1.10

### DIFF
--- a/pkgs/by-name/om/omp-bin/package.nix
+++ b/pkgs/by-name/om/omp-bin/package.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+  nix-update-script,
+  testers,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "omp-bin";
+  version = "18.1.10";
+
+  src =
+    let
+      sources = {
+        x86_64-linux = {
+          url = "https://github.com/can1357/oh-my-pi/releases/download/v${finalAttrs.version}/omp-linux-x64";
+          hash = "sha256-6R1VmO5H4dQJn9hobcn2HJt1Xy6gd9Xxd0q6EHIyH54=";
+        };
+        aarch64-linux = {
+          url = "https://github.com/can1357/oh-my-pi/releases/download/v${finalAttrs.version}/omp-linux-arm64";
+          hash = "sha256-s/Kzm7FWWeVaNAhxokQWNZCIAlF55MIOfKHCPlMNY20=";
+        };
+        x86_64-darwin = {
+          url = "https://github.com/can1357/oh-my-pi/releases/download/v${finalAttrs.version}/omp-darwin-x64";
+          hash = "sha256-87MB+qpAOKus/ALAH/Y+hnieV3v37sIBuSExUCg1s/U=";
+        };
+        aarch64-darwin = {
+          url = "https://github.com/can1357/oh-my-pi/releases/download/v${finalAttrs.version}/omp-darwin-arm64";
+          hash = "sha256-BFQaO6HyhhPrI6cH2TelsaTrgIY8gJVojbOwm4AjMF0=";
+        };
+      };
+      source =
+        sources.${stdenv.hostPlatform.system}
+          or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+    in
+    fetchurl source;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  dontUnpack = true;
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 $src $out/bin/omp
+
+    runHook postInstall
+  '';
+
+  # strip removes the embedded JS bundle from the bun-compiled binary
+  dontStrip = true;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+
+  doInstallCheck = true;
+
+  passthru = {
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+    };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Coding agent for the terminal with LSP, debugging, and multi-provider LLM support";
+    homepage = "https://omp.sh";
+    changelog = "https://github.com/can1357/oh-my-pi/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.gdifolco ];
+    mainProgram = "omp";
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
oh-my-pi (omp) is an AI coding agent

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
