### PR TITLE
evolvotron: init at 0.8.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12235,6 +12235,11 @@
     githubId = 45084216;
     keys = [ { fingerprint = "1BF9 8D10 E0D0 0B41 5723  5836 4C13 3A84 E646 9228"; } ];
   };
+  jacobwinters = {
+    name = "Jacob Winters";
+    github = "jacobwinters";
+    githubId = 28678931;
+  };
   JacoMalan1 = {
     name = "Jaco Malan";
     email = "jacom@codelog.co.za";

--- a/pkgs/by-name/ev/evolvotron/package.nix
+++ b/pkgs/by-name/ev/evolvotron/package.nix
@@ -1,0 +1,66 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  qt6,
+  boost,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "evolvotron";
+  version = "0.8.2";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "WickedSmoke";
+    repo = "evolvotron";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Kbo1YIdq2tEDsB8zQBZ/DCcJEaTZ6qpdBd3EtaMb9eU=";
+  };
+
+  buildInputs = [
+    qt6.qtbase
+    boost
+  ];
+
+  nativeBuildInputs = [
+    qt6.qmake
+    qt6.wrapQtAppsHook
+  ];
+
+  qmakeFlags = [
+    "VERSION_NUMBER=${finalAttrs.version}"
+    "main.pro"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/man/man1
+    install -m 755 evolvotron/evolvotron $out/bin
+    install -m 755 evolvotron_mutate/evolvotron_mutate $out/bin
+    install -m 755 evolvotron_render/evolvotron_render $out/bin
+    install -m 644 man/man1/evolvotron.1 $out/share/man/man1
+    install -m 644 man/man1/evolvotron_mutate.1 $out/share/man/man1
+    install -m 644 man/man1/evolvotron_render.1 $out/share/man/man1
+    install -D -m 644 dist/icon-48.png $out/share/icons/hicolor/48x48/apps/evolvotron.png
+    install -D -m 644 dist/icon-128.png $out/share/icons/hicolor/128x128/apps/evolvotron.png
+    install -D -m 644 dist/evolvotron.desktop $out/share/applications/evolvotron.desktop
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Interactive generative art program";
+    homepage = "https://www.timday.com/share/evolvotron/";
+    changelog = "https://github.com/WickedSmoke/evolvotron/blob/v${finalAttrs.version}/NEWS";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [
+      jacobwinters
+    ];
+    platforms = lib.platforms.linux;
+    mainProgram = "evolvotron";
+  };
+})


### PR DESCRIPTION
Evolvotron is an evolutionary texture generator app ([gallery of outputs](https://web.archive.org/web/20231207202423/https://www.timday.com/share/evolvotron/gallery.html)) with a history going back to ~2003. I remember installing it from the Debian repositories when I got my first Linux box back in grade school and it was by far the coolest app on the machine. It's still being maintained and it's not available here, so naturally I had to package it.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].