### PR TITLE
nixos/modular-services: split system-specific config out of `pkgs.<pkg>.services.<service>`

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -48,6 +48,7 @@
 /lib/options.nix            @infinisil @roberth @hsjobeki @llakala
 /lib/tests/modules.sh       @infinisil @roberth @hsjobeki
 /lib/tests/modules          @infinisil @roberth @hsjobeki
+/modules/generic            @nbp @roberth
 
 # Nixpkgs Internals
 /default.nix                                     @Ericson2314

--- a/modules/generic/meta-maintainers.nix
+++ b/modules/generic/meta-maintainers.nix
@@ -52,8 +52,11 @@ in
       };
     };
   };
-  meta.maintainers = with lib.maintainers; [
-    pierron
-    roberth
-  ];
+
+  # This module deliberately does not define `meta.maintainers` for itself.
+  # It is imported by every module system that offers the option - NixOS
+  # (`nixos/modules/misc/meta.nix`) and modular services
+  # (`lib/services/service.nix`) - so a definition here would attribute this
+  # file's maintainers to every module and every service that imports it.
+  # Ownership of this file is recorded in `ci/OWNERS` instead.
 }

--- a/modules/generic/meta-maintainers/test.nix
+++ b/modules/generic/meta-maintainers/test.nix
@@ -31,17 +31,21 @@ rec {
         _file = "ghost.nix";
         meta.maintainers = [ ghost ];
       }
+      {
+        _file = "poltergeist.nix";
+        meta.maintainers = [ lib.maintainers.roberth ];
+      }
     ];
   };
 
+  # Each defining file gets its own entry, and `../meta-maintainers.nix` gets
+  # none, because declaring the option does not make its author a maintainer of
+  # every module that imports it.
   test =
     assert
       example.config.meta.maintainers == {
-        ${toString ../meta-maintainers.nix} = [
-          lib.maintainers.pierron
-          lib.maintainers.roberth
-        ];
         "ghost.nix" = [ ghost ];
+        "poltergeist.nix" = [ lib.maintainers.roberth ];
       };
     { };
 

--- a/nixos/lib/default.nix
+++ b/nixos/lib/default.nix
@@ -39,4 +39,9 @@ in
     runTest
     ;
 
+  # Environment-specific variants of the modular services, keyed by
+  # `<pkg>.<service>.<environment>`. See
+  # nixos/modules/system/service/modular/default.nix.
+  modularServices = import ../modules/system/service/modular;
+
 }

--- a/nixos/lib/default.nix
+++ b/nixos/lib/default.nix
@@ -40,7 +40,7 @@ in
     ;
 
   # Environment-specific variants of the modular services, keyed by
-  # `<pkg>.<service>.<environment>`. See
+  # `<environment>.<pkg>.<service>`. See
   # nixos/modules/system/service/modular/default.nix.
   modularServices = import ../modules/system/service/modular;
 

--- a/nixos/modules/misc/documentation/modular-services.nix
+++ b/nixos/modules/misc/documentation/modular-services.nix
@@ -2,7 +2,12 @@
   Renders documentation for modular services.
   For inclusion into documentation.nixos.extraModules.
 */
-{ lib, pkgs, ... }:
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
 let
   /**
     Causes a modular service's docs to be rendered.
@@ -12,22 +17,38 @@ let
     module:
     lib.mkOption {
       type = lib.types.submoduleWith {
+        # The variants are ordinary service modules, so they expect the same
+        # arguments `system.services` provides. `pkgs` has to be a special
+        # argument: the variants reach the pure half through
+        # `imports = [ pkgs.<pkg>.services.<svc> ]`, and an argument that comes
+        # from `_module.args` is not available that early.
+        specialArgs = { inherit pkgs; };
         modules = [ module ];
       };
       description = "This is a [modular service](https://nixos.org/manual/nixos/unstable/#modular-services), which can be imported into a NixOS configuration using the [`system.services`](https://search.nixos.org/options?channel=unstable&show=system.services&query=modular+service) option.";
     };
 
+  # `python-http-server` is a fixture for nixos/tests/modular-service-etc rather
+  # than a service anyone would import, so it stays out of the manual.
+  undocumented = [ "python-http-server" ];
+
+  # Derived from the variant registry
+  # (nixos/modules/system/service/modular/default.nix) rather than listed by
+  # hand, so a newly registered service is documented without a second edit.
+  #
+  # Documenting the variants rather than the pure `pkgs.<pkg>.services.<svc>`
+  # modules also covers the NixOS-specific half of each service, which is the
+  # half a NixOS configuration gets.
   modularServicesModule = {
-    options = {
-      "<imports = [ pkgs.autopush-rs.services.autoconnect ]>" =
-        fakeSubmodule pkgs.autopush-rs.services.autoconnect;
-      "<imports = [ pkgs.autopush-rs.services.autoendpoint ]>" =
-        fakeSubmodule pkgs.autopush-rs.services.autoendpoint;
-      "<imports = [ pkgs.ghostunnel.services.default ]>" = fakeSubmodule pkgs.ghostunnel.services.default;
-      "<imports = [ pkgs.ktls-utils.services.default ]>" = fakeSubmodule pkgs.ktls-utils.services.default;
-      "<imports = [ pkgs.php.services.default ]>" = fakeSubmodule pkgs.php.services.default;
-      "<imports = [ pkgs.snid.services.default ]>" = fakeSubmodule pkgs.snid.services.default;
-    };
+    options = lib.concatMapAttrs (
+      package:
+      lib.mapAttrs' (
+        service: module:
+        lib.nameValuePair "<imports = [ config.modularServices.${package}.${service} ]>" (
+          fakeSubmodule module
+        )
+      )
+    ) (lib.removeAttrs config.modularServices undocumented);
   };
 in
 {

--- a/nixos/modules/system/service/modular/autopush-rs/autoconnect/default.nix
+++ b/nixos/modules/system/service/modular/autopush-rs/autoconnect/default.nix
@@ -1,0 +1,5 @@
+{ pkgs, ... }:
+{
+  _class = "service";
+  imports = [ pkgs.autopush-rs.services.autoconnect ];
+}

--- a/nixos/modules/system/service/modular/autopush-rs/autoconnect/system.nix
+++ b/nixos/modules/system/service/modular/autopush-rs/autoconnect/system.nix
@@ -1,0 +1,55 @@
+{ ... }:
+{
+  _class = "service";
+  imports = [ ./default.nix ];
+  config = {
+    systemd.service = {
+      after = [ "network.target" ];
+      wants = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Restart = "on-failure";
+
+        #hardening
+        MemoryDenyWriteExecute = true;
+        StateDirectoryMode = 0700;
+        UMask = 077;
+        DynamicUser = true;
+        PrivateUsers = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectSystem = "full";
+        ProtectHome = true;
+        NoNewPrivileges = true;
+        RuntimeDirectoryMode = 755;
+        ProtectHostname = true;
+        ProtectClock = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        ProtectControlGroups = true;
+        RestrictNamespaces = true;
+        LockPersonality = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        RemoveIPC = true;
+        SystemCallArchitectures = "native";
+
+        ProtectProc = "invisible";
+        ProcSubset = "pid";
+
+        SystemCallFilter = [
+          "~@clock"
+          "~@cpu-emulation"
+          "~@debug"
+          "~@module"
+          "~@mount"
+          "~@obsolete"
+          "~@raw-io"
+          "~@reboot"
+          "~@swap"
+        ];
+      };
+    };
+  };
+}

--- a/nixos/modules/system/service/modular/autopush-rs/autoendpoint/default.nix
+++ b/nixos/modules/system/service/modular/autopush-rs/autoendpoint/default.nix
@@ -1,0 +1,5 @@
+{ pkgs, ... }:
+{
+  _class = "service";
+  imports = [ pkgs.autopush-rs.services.autoendpoint ];
+}

--- a/nixos/modules/system/service/modular/autopush-rs/autoendpoint/system.nix
+++ b/nixos/modules/system/service/modular/autopush-rs/autoendpoint/system.nix
@@ -1,0 +1,55 @@
+{ ... }:
+{
+  _class = "service";
+  imports = [ ./default.nix ];
+  config = {
+    systemd.service = {
+      after = [ "network.target" ];
+      wants = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Restart = "on-failure";
+
+        #hardening
+        MemoryDenyWriteExecute = true;
+        StateDirectoryMode = 0700;
+        UMask = 077;
+        DynamicUser = true;
+        PrivateUsers = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectSystem = "full";
+        ProtectHome = true;
+        NoNewPrivileges = true;
+        RuntimeDirectoryMode = 755;
+        ProtectHostname = true;
+        ProtectClock = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        ProtectControlGroups = true;
+        RestrictNamespaces = true;
+        LockPersonality = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        RemoveIPC = true;
+        SystemCallArchitectures = "native";
+
+        ProtectProc = "invisible";
+        ProcSubset = "pid";
+
+        SystemCallFilter = [
+          "~@clock"
+          "~@cpu-emulation"
+          "~@debug"
+          "~@module"
+          "~@mount"
+          "~@obsolete"
+          "~@raw-io"
+          "~@reboot"
+          "~@swap"
+        ];
+      };
+    };
+  };
+}

--- a/nixos/modules/system/service/modular/default.nix
+++ b/nixos/modules/system/service/modular/default.nix
@@ -1,0 +1,24 @@
+# Aggregation registry for modular services, keyed by
+# `<pkg>.<service>.<environment>`.
+#
+# Each service instance (matching `passthru.services.<name>`) gets an entry per
+# supported environment. Today only the `system` (NixOS system) environment is
+# provided; a future `user` environment sits alongside it.
+#
+# Every modular service is enumerated here - including those with no
+# environment-specific configuration - so the directory advertises which
+# services are supported on the NixOS system environment.
+{
+  system = {
+    ghostunnel.default = import ./ghostunnel/default/system.nix;
+    snid.default = import ./snid/default/system.nix;
+    ktls-utils.default = import ./ktls-utils/default/system.nix;
+    autopush-rs = {
+      autoconnect = import ./autopush-rs/autoconnect/system.nix;
+      autoendpoint = import ./autopush-rs/autoendpoint/system.nix;
+    };
+    php.default = import ./php/default/system.nix;
+    holo-daemon.default = import ./holo-daemon/default/system.nix;
+    python-http-server.default = import ./python-http-server/default/system.nix;
+  };
+}

--- a/nixos/modules/system/service/modular/default.nix
+++ b/nixos/modules/system/service/modular/default.nix
@@ -1,5 +1,5 @@
 # Aggregation registry for modular services, keyed by
-# `<pkg>.<service>.<environment>`.
+# `<environment>.<pkg>.<service>`.
 #
 # Each service instance (matching `passthru.services.<name>`) gets an entry per
 # supported environment. Today only the `system` (NixOS system) environment is
@@ -8,17 +8,22 @@
 # Every modular service is enumerated here - including those with no
 # environment-specific configuration - so the directory advertises which
 # services are supported on the NixOS system environment.
+#
+# Entries are paths, not `import <path>`. A bare `import` yields a function,
+# which carries no `_file`, so the module system attributes the variant to
+# wherever the `deferredModule` was defined instead of to the variant's own
+# file. See ./test.nix.
 {
   system = {
-    ghostunnel.default = import ./ghostunnel/default/system.nix;
-    snid.default = import ./snid/default/system.nix;
-    ktls-utils.default = import ./ktls-utils/default/system.nix;
+    ghostunnel.default = ./ghostunnel/default/system.nix;
+    snid.default = ./snid/default/system.nix;
+    ktls-utils.default = ./ktls-utils/default/system.nix;
     autopush-rs = {
-      autoconnect = import ./autopush-rs/autoconnect/system.nix;
-      autoendpoint = import ./autopush-rs/autoendpoint/system.nix;
+      autoconnect = ./autopush-rs/autoconnect/system.nix;
+      autoendpoint = ./autopush-rs/autoendpoint/system.nix;
     };
-    php.default = import ./php/default/system.nix;
-    holo-daemon.default = import ./holo-daemon/default/system.nix;
-    python-http-server.default = import ./python-http-server/default/system.nix;
+    php.default = ./php/default/system.nix;
+    holo-daemon.default = ./holo-daemon/default/system.nix;
+    python-http-server.default = ./python-http-server/default/system.nix;
   };
 }

--- a/nixos/modules/system/service/modular/ghostunnel/default/default.nix
+++ b/nixos/modules/system/service/modular/ghostunnel/default/default.nix
@@ -1,0 +1,5 @@
+{ pkgs, ... }:
+{
+  _class = "service";
+  imports = [ pkgs.ghostunnel.services.default ];
+}

--- a/nixos/modules/system/service/modular/ghostunnel/default/system.nix
+++ b/nixos/modules/system/service/modular/ghostunnel/default/system.nix
@@ -1,0 +1,38 @@
+{ lib, config, ... }:
+let
+  inherit (lib) optional concatStringsSep;
+  cfg = config.ghostunnel;
+  # Build credential flags with systemd variable substitution
+  credentialFlags = concatStringsSep " " (
+    optional (cfg.keystore != null) "--keystore=\${CREDENTIALS_DIRECTORY}/keystore"
+    ++ optional (cfg.cert != null) "--cert=\${CREDENTIALS_DIRECTORY}/cert"
+    ++ optional (cfg.key != null) "--key=\${CREDENTIALS_DIRECTORY}/key"
+    ++ optional (cfg.cacert != null) "--cacert=\${CREDENTIALS_DIRECTORY}/cacert"
+  );
+in
+{
+  _class = "service";
+  imports = [ ./default.nix ];
+  config = {
+    # Use mainExecStart to add credential flags with systemd variable substitution
+    systemd.mainExecStart =
+      config.systemd.lib.escapeSystemdExecArgs config.process.argv
+      + lib.optionalString (credentialFlags != "") " ${credentialFlags}";
+
+    systemd.service = {
+      after = [ "network.target" ];
+      wants = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Restart = "always";
+        AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
+        DynamicUser = true;
+        LoadCredential =
+          optional (cfg.keystore != null) "keystore:${cfg.keystore}"
+          ++ optional (cfg.cert != null) "cert:${cfg.cert}"
+          ++ optional (cfg.key != null) "key:${cfg.key}"
+          ++ optional (cfg.cacert != null) "cacert:${cfg.cacert}";
+      };
+    };
+  };
+}

--- a/nixos/modules/system/service/modular/holo-daemon/default/default.nix
+++ b/nixos/modules/system/service/modular/holo-daemon/default/default.nix
@@ -1,0 +1,5 @@
+{ pkgs, ... }:
+{
+  _class = "service";
+  imports = [ pkgs.holo-daemon.services.default ];
+}

--- a/nixos/modules/system/service/modular/holo-daemon/default/system.nix
+++ b/nixos/modules/system/service/modular/holo-daemon/default/system.nix
@@ -1,0 +1,8 @@
+{ ... }:
+{
+  # holo-daemon has no system (NixOS) specific configuration; this variant
+  # exists so the service is advertised as supported on the NixOS system
+  # environment.
+  _class = "service";
+  imports = [ ./default.nix ];
+}

--- a/nixos/modules/system/service/modular/holo-daemon/default/system.nix
+++ b/nixos/modules/system/service/modular/holo-daemon/default/system.nix
@@ -1,8 +1,9 @@
-{ ... }:
+{ lib, ... }:
 {
   # holo-daemon has no system (NixOS) specific configuration; this variant
   # exists so the service is advertised as supported on the NixOS system
   # environment.
   _class = "service";
   imports = [ ./default.nix ];
+  meta.maintainers = with lib.maintainers; [ themadbit ];
 }

--- a/nixos/modules/system/service/modular/ktls-utils/default/default.nix
+++ b/nixos/modules/system/service/modular/ktls-utils/default/default.nix
@@ -1,0 +1,5 @@
+{ pkgs, ... }:
+{
+  _class = "service";
+  imports = [ pkgs.ktls-utils.services.default ];
+}

--- a/nixos/modules/system/service/modular/ktls-utils/default/system.nix
+++ b/nixos/modules/system/service/modular/ktls-utils/default/system.nix
@@ -1,0 +1,20 @@
+{ ... }:
+{
+  _class = "service";
+  imports = [ ./default.nix ];
+  config = {
+    systemd.service = {
+      description = "Handshake service for kernel TLS consumers";
+      documentation = [ "man:tlshd(8)" ];
+      unitConfig.DefaultDependencies = false;
+      before = [ "remote-fs-pre.target" ];
+      wantedBy = [ "remote-fs.target" ];
+      serviceConfig = {
+        Restart = "on-failure";
+        DynamicUser = true;
+        AmbientCapabilities = [ "CAP_NET_ADMIN" ];
+        CapabilityBoundingSet = [ "CAP_NET_ADMIN" ];
+      };
+    };
+  };
+}

--- a/nixos/modules/system/service/modular/php/default/default.nix
+++ b/nixos/modules/system/service/modular/php/default/default.nix
@@ -1,0 +1,5 @@
+{ pkgs, ... }:
+{
+  _class = "service";
+  imports = [ pkgs.php.services.default ];
+}

--- a/nixos/modules/system/service/modular/php/default/system.nix
+++ b/nixos/modules/system/service/modular/php/default/system.nix
@@ -1,7 +1,8 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 {
   _class = "service";
   imports = [ ./default.nix ];
+  meta.maintainers = with lib.maintainers; [ aanderse ];
   config = {
     # Reload signal for php-fpm; sets systemd's `ExecReload`.
     systemd.mainExecReload = "${pkgs.coreutils}/bin/kill -USR2 $MAINPID";

--- a/nixos/modules/system/service/modular/php/default/system.nix
+++ b/nixos/modules/system/service/modular/php/default/system.nix
@@ -1,0 +1,21 @@
+{ pkgs, ... }:
+{
+  _class = "service";
+  imports = [ ./default.nix ];
+  config = {
+    # Reload signal for php-fpm; sets systemd's `ExecReload`.
+    systemd.mainExecReload = "${pkgs.coreutils}/bin/kill -USR2 $MAINPID";
+
+    systemd.service = {
+      after = [ "network.target" ];
+      documentation = [ "man:php-fpm(8)" ];
+
+      serviceConfig = {
+        Type = "notify";
+        RuntimeDirectory = "php-fpm";
+        RuntimeDirectoryPreserve = true;
+        Restart = "always";
+      };
+    };
+  };
+}

--- a/nixos/modules/system/service/modular/python-http-server/default/default.nix
+++ b/nixos/modules/system/service/modular/python-http-server/default/default.nix
@@ -1,0 +1,7 @@
+{ ... }:
+{
+  # python-http-server is a test-only service with no package `services` attr,
+  # so the pure base is imported by path rather than via `pkgs.<name>.services`.
+  _class = "service";
+  imports = [ ../../../../../../tests/modular-service-etc/python-http-server.nix ];
+}

--- a/nixos/modules/system/service/modular/python-http-server/default/system.nix
+++ b/nixos/modules/system/service/modular/python-http-server/default/system.nix
@@ -1,0 +1,8 @@
+{ ... }:
+{
+  # python-http-server has no system (NixOS) specific configuration; this variant
+  # exists so the service is advertised as supported on the NixOS system
+  # environment.
+  _class = "service";
+  imports = [ ./default.nix ];
+}

--- a/nixos/modules/system/service/modular/snid/default/default.nix
+++ b/nixos/modules/system/service/modular/snid/default/default.nix
@@ -1,0 +1,5 @@
+{ pkgs, ... }:
+{
+  _class = "service";
+  imports = [ pkgs.snid.services.default ];
+}

--- a/nixos/modules/system/service/modular/snid/default/system.nix
+++ b/nixos/modules/system/service/modular/snid/default/system.nix
@@ -1,0 +1,17 @@
+{ ... }:
+{
+  _class = "service";
+  imports = [ ./default.nix ];
+  config = {
+    systemd.service = {
+      after = [ "network.target" ];
+      wants = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Restart = "on-failure";
+        DynamicUser = true;
+        AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
+      };
+    };
+  };
+}

--- a/nixos/modules/system/service/modular/test.nix
+++ b/nixos/modules/system/service/modular/test.nix
@@ -1,0 +1,99 @@
+# Run:
+#   nix-build -A nixosTests.modularServiceVariants
+#
+# Checks that the service variants registered in ./default.nix keep their file
+# attribution. Registering a variant as `import ./<pkg>/<svc>/system.nix`
+# instead of `./<pkg>/<svc>/system.nix` yields a bare function, which carries no
+# `_file`, so the module system falls back to the location where the
+# `deferredModule` was defined and the variant's own file is lost.
+#
+# `meta.maintainers` makes that observable: it merges to an attribute set that
+# maps defining file to maintainers, so its keys are exactly the files that
+# contributed to the service.
+
+{
+  evalSystem,
+  runCommand,
+  lib,
+  ...
+}:
+
+let
+  machine = evalSystem (
+    { config, ... }:
+    {
+      system.services.holod.imports = [ config.modularServices.holo-daemon.default ];
+      system.services.phpfpm.imports = [ config.modularServices.php.default ];
+
+      # irrelevant stuff
+      system.stateVersion = "25.05";
+      fileSystems."/" = {
+        device = "/test/dummy";
+        fsType = "auto";
+      };
+      boot.loader.grub.enable = false;
+    }
+  );
+
+  sourcesOf = name: lib.attrNames machine.config.system.services.${name}.meta.maintainers;
+
+  # Both halves of a modular service declare the maintainers of that service:
+  # the pure module under `pkgs/`, and the NixOS-specific variant under
+  # `nixos/modules/system/service/modular/`.
+  expected = {
+    holod = [
+      "/nixos/modules/system/service/modular/holo-daemon/default/system.nix"
+      "/pkgs/by-name/ho/holo-daemon/service.nix"
+    ];
+    phpfpm = [
+      "/nixos/modules/system/service/modular/php/default/system.nix"
+      "/pkgs/development/interpreters/php/service.nix"
+    ];
+  };
+
+  checkService =
+    name: suffixes:
+    let
+      sources = sourcesOf name;
+      missing = lib.filter (suffix: !(lib.any (lib.hasSuffix suffix) sources)) suffixes;
+      # The attribution `import` would produce instead of the variant's own file.
+      fallbacks = lib.filter (lib.hasInfix ", via option ") sources;
+    in
+    lib.optional (missing != [ ]) ''
+      service `${name}' is missing maintainer attribution for:
+        ${lib.concatStringsSep "\n    " missing}
+    ''
+    ++ lib.optional (fallbacks != [ ]) ''
+      service `${name}' has fallback attribution, so a variant lost its `_file':
+        ${lib.concatStringsSep "\n    " fallbacks}
+    '';
+
+  failures = lib.concatLists (lib.mapAttrsToList checkService expected);
+
+  report = lib.concatStringsSep "\n" (
+    lib.mapAttrsToList (name: _: "${name}:\n  ${lib.concatStringsSep "\n  " (sourcesOf name)}") expected
+  );
+in
+
+lib.throwIf (failures != [ ])
+  ''
+    Modular service maintainer attribution is wrong:
+
+    ${lib.concatStringsSep "\n" failures}
+    Attribution found:
+    ${report}
+  ''
+  runCommand
+  "test-modular-service-variants"
+  {
+    passthru = {
+      inherit machine;
+    };
+  }
+  ''
+    cat <<'EOF'
+    ${report}
+    EOF
+    echo 🐬👍
+    touch $out
+  ''

--- a/nixos/modules/system/service/systemd/defaults.nix
+++ b/nixos/modules/system/service/systemd/defaults.nix
@@ -22,5 +22,9 @@ in
       ```
     '';
     default = (import ../modular).system;
+    # The default is an attribute set of paths into the module tree. Rendering
+    # it would make the option documentation refer to the sandboxed copy of
+    # that tree, which `lazy-options.json` disallows.
+    defaultText = lib.literalExpression "(import ../modular).system";
   };
 }

--- a/nixos/modules/system/service/systemd/defaults.nix
+++ b/nixos/modules/system/service/systemd/defaults.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  ...
+}:
+let
+  inherit (lib) types;
+in
+{
+  _class = "nixos";
+
+  options.modularServices = lib.mkOption {
+    type = types.attrsOf (types.attrsOf types.deferredModule);
+    description = ''
+      Environment-specific variant of the [modular
+      services](https://nixos.org/manual/nixos/unstable/#modular-services),
+      keyed by `<pkg>.<service>`.
+
+      Import the variant matching the target environment, e.g.:
+
+      ```nix
+      imports = [ config.modularServices.ghostunnel.default ];
+      ```
+    '';
+    default = (import ../modular).system;
+  };
+}

--- a/nixos/modules/system/service/systemd/system.nix
+++ b/nixos/modules/system/service/systemd/system.nix
@@ -68,11 +68,19 @@ let
     ];
     extraRootSpecialArgs = {
       systemdPackage = config.systemd.package;
+      # Exposed so environment-specific service variants under
+      # `nixos/modules/system/service/modular/` can pull in their pure base from
+      # `pkgs.<name>.services.<svc>`.
+      inherit pkgs;
     };
   };
 in
 {
   _class = "nixos";
+
+  imports = [
+    ./defaults.nix
+  ];
 
   # First half of the magic: mix systemd logic into the otherwise abstract services
   options = {

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1054,6 +1054,9 @@ in
   modularService = pkgs.callPackage ../modules/system/service/systemd/test.nix {
     inherit evalSystem;
   };
+  modularServiceVariants = pkgs.callPackage ../modules/system/service/modular/test.nix {
+    inherit evalSystem;
+  };
   molly-brown = runTest ./molly-brown.nix;
   mollysocket = runTest ./mollysocket.nix;
   monado = runTest ./monado.nix;

--- a/nixos/tests/autopush-rs.nix
+++ b/nixos/tests/autopush-rs.nix
@@ -17,7 +17,7 @@
         };
         system.services.autopush-autoconnect = {
           imports = [
-            pkgs.autopush-rs.services.autoconnect
+            config.modularServices.autopush-rs.autoconnect
           ];
           autoconnect.settings = {
             #do not use this key in production!!!
@@ -28,7 +28,7 @@
         };
         system.services.autopush-autoendpoint = {
           imports = [
-            pkgs.autopush-rs.services.autoendpoint
+            config.modularServices.autopush-rs.autoendpoint
           ];
           autoendpoint.settings = {
             #do not use this key in production!!!

--- a/nixos/tests/ghostunnel-modular.nix
+++ b/nixos/tests/ghostunnel-modular.nix
@@ -14,10 +14,10 @@
         networking.firewall.allowedTCPPorts = [ 80 ];
       };
     service =
-      { pkgs, ... }:
+      { config, ... }:
       {
         system.services."ghostunnel-plain-old" = {
-          imports = [ pkgs.ghostunnel.services.default ];
+          imports = [ config.modularServices.ghostunnel.default ];
           ghostunnel = {
             listen = "0.0.0.0:443";
             cert = "/root/service-cert.pem";
@@ -28,7 +28,7 @@
           };
         };
         system.services."ghostunnel-client-cert" = {
-          imports = [ pkgs.ghostunnel.services.default ];
+          imports = [ config.modularServices.ghostunnel.default ];
           ghostunnel = {
             listen = "0.0.0.0:1443";
             cert = "/root/service-cert.pem";

--- a/nixos/tests/holo-daemon-modular.nix
+++ b/nixos/tests/holo-daemon-modular.nix
@@ -5,14 +5,14 @@
 
   nodes = {
     machine =
-      { pkgs, ... }:
+      { config, pkgs, ... }:
       {
         environment.systemPackages = [
           pkgs.holo-daemon
           pkgs.holo-cli
         ];
         system.services.holo-daemon = {
-          imports = [ pkgs.holo-daemon.services.default ];
+          imports = [ config.modularServices.holo-daemon.default ];
         };
         users.users.holo = {
           isSystemUser = true;

--- a/nixos/tests/modular-service-etc/test.nix
+++ b/nixos/tests/modular-service-etc/test.nix
@@ -4,7 +4,7 @@
 
 # This tests the NixOS modular service integration to make sure `etc` entries
 # are generated correctly for `configData` files.
-{ lib, ... }:
+{ config, lib, ... }:
 {
   _class = "nixosTest";
   name = "modular-service-etc";
@@ -16,7 +16,7 @@
         # Normally the package services.default attribute combines this, but we
         # don't have that, because this is not a production service. Should it be?
         python-http-server = {
-          imports = [ ./python-http-server.nix ];
+          imports = [ config.modularServices.python-http-server.default ];
           python-http-server.package = pkgs.python3;
         };
       in

--- a/nixos/tests/php/fpm-modular.nix
+++ b/nixos/tests/php/fpm-modular.nix
@@ -35,7 +35,7 @@
       };
 
       system.services.php-fpm = {
-        imports = [ php.services.default ];
+        imports = [ config.modularServices.php.default ];
         php-fpm = {
           package = php;
           settings = {

--- a/nixos/tests/snid.nix
+++ b/nixos/tests/snid.nix
@@ -5,10 +5,10 @@
 
   nodes = {
     machine =
-      { pkgs, ... }:
+      { config, ... }:
       {
         system.services.snid = {
-          imports = [ pkgs.snid.services.default ];
+          imports = [ config.modularServices.snid.default ];
           snid = {
             listen = [ "tcp:8443" ];
             mode = "tcp";

--- a/nixos/tests/tlshd.nix
+++ b/nixos/tests/tlshd.nix
@@ -31,10 +31,10 @@ in
 
   nodes = {
     server =
-      { pkgs, ... }:
+      { config, ... }:
       {
         system.services.tlshd = {
-          imports = [ pkgs.ktls-utils.services.default ];
+          imports = [ config.modularServices.ktls-utils.default ];
           tlshd.settings = {
             "authenticate.server" = {
               "x509.certificate" = toString serverCert;
@@ -56,10 +56,10 @@ in
       };
 
     client =
-      { pkgs, ... }:
+      { config, ... }:
       {
         system.services.tlshd = {
-          imports = [ pkgs.ktls-utils.services.default ];
+          imports = [ config.modularServices.ktls-utils.default ];
           tlshd.settings = {
             "authenticate.client" = {
               "x509.certificate" = toString clientCert;

--- a/pkgs/by-name/au/autopush-rs/service-autoconnect.nix
+++ b/pkgs/by-name/au/autopush-rs/service-autoconnect.nix
@@ -4,7 +4,6 @@
 # Service module
 {
   lib,
-  options,
   config,
   ...
 }:
@@ -42,55 +41,5 @@ in
         "-c"
         (toString configFile)
       ];
-    }
-    // lib.optionalAttrs (options ? systemd) {
-      systemd.service = {
-        after = [ "network.target" ];
-        wants = [ "network.target" ];
-        wantedBy = [ "multi-user.target" ];
-        serviceConfig = {
-          Restart = "on-failure";
-
-          #hardening
-          MemoryDenyWriteExecute = true;
-          StateDirectoryMode = 0700;
-          UMask = 077;
-          DynamicUser = true;
-          PrivateUsers = true;
-          PrivateTmp = true;
-          PrivateDevices = true;
-          ProtectSystem = "full";
-          ProtectHome = true;
-          NoNewPrivileges = true;
-          RuntimeDirectoryMode = 755;
-          ProtectHostname = true;
-          ProtectClock = true;
-          ProtectKernelTunables = true;
-          ProtectKernelModules = true;
-          ProtectKernelLogs = true;
-          ProtectControlGroups = true;
-          RestrictNamespaces = true;
-          LockPersonality = true;
-          RestrictRealtime = true;
-          RestrictSUIDSGID = true;
-          RemoveIPC = true;
-          SystemCallArchitectures = "native";
-
-          ProtectProc = "invisible";
-          ProcSubset = "pid";
-
-          SystemCallFilter = [
-            "~@clock"
-            "~@cpu-emulation"
-            "~@debug"
-            "~@module"
-            "~@mount"
-            "~@obsolete"
-            "~@raw-io"
-            "~@reboot"
-            "~@swap"
-          ];
-        };
-      };
     };
 }

--- a/pkgs/by-name/au/autopush-rs/service-autoendpoint.nix
+++ b/pkgs/by-name/au/autopush-rs/service-autoendpoint.nix
@@ -5,7 +5,6 @@
 {
   lib,
   config,
-  options,
   ...
 }:
 let
@@ -44,55 +43,5 @@ in
         "-c"
         (toString configFile)
       ];
-    }
-    // lib.optionalAttrs (options ? systemd) {
-      systemd.service = {
-        after = [ "network.target" ];
-        wants = [ "network.target" ];
-        wantedBy = [ "multi-user.target" ];
-        serviceConfig = {
-          Restart = "on-failure";
-
-          #hardening
-          MemoryDenyWriteExecute = true;
-          StateDirectoryMode = 0700;
-          UMask = 077;
-          DynamicUser = true;
-          PrivateUsers = true;
-          PrivateTmp = true;
-          PrivateDevices = true;
-          ProtectSystem = "full";
-          ProtectHome = true;
-          NoNewPrivileges = true;
-          RuntimeDirectoryMode = 755;
-          ProtectHostname = true;
-          ProtectClock = true;
-          ProtectKernelTunables = true;
-          ProtectKernelModules = true;
-          ProtectKernelLogs = true;
-          ProtectControlGroups = true;
-          RestrictNamespaces = true;
-          LockPersonality = true;
-          RestrictRealtime = true;
-          RestrictSUIDSGID = true;
-          RemoveIPC = true;
-          SystemCallArchitectures = "native";
-
-          ProtectProc = "invisible";
-          ProcSubset = "pid";
-
-          SystemCallFilter = [
-            "~@clock"
-            "~@cpu-emulation"
-            "~@debug"
-            "~@module"
-            "~@mount"
-            "~@obsolete"
-            "~@raw-io"
-            "~@reboot"
-            "~@swap"
-          ];
-        };
-      };
     };
 }

--- a/pkgs/by-name/gh/ghostunnel/service.nix
+++ b/pkgs/by-name/gh/ghostunnel/service.nix
@@ -10,7 +10,6 @@
 }:
 let
   inherit (lib)
-    concatStringsSep
     getExe
     mkDefault
     mkIf
@@ -205,39 +204,5 @@ in
       ++ optional cfg.unsafeTarget "--unsafe-target"
       ++ cfg.extraArguments;
     };
-  }
-  # Refine the service for systemd
-  // lib.optionalAttrs (options ? systemd) (
-    let
-      # Build credential flags with systemd variable substitution
-      credentialFlags = concatStringsSep " " (
-        optional (cfg.keystore != null) "--keystore=\${CREDENTIALS_DIRECTORY}/keystore"
-        ++ optional (cfg.cert != null) "--cert=\${CREDENTIALS_DIRECTORY}/cert"
-        ++ optional (cfg.key != null) "--key=\${CREDENTIALS_DIRECTORY}/key"
-        ++ optional (cfg.cacert != null) "--cacert=\${CREDENTIALS_DIRECTORY}/cacert"
-      );
-    in
-    {
-      # Use mainExecStart to add credential flags with systemd variable substitution
-      systemd.mainExecStart =
-        config.systemd.lib.escapeSystemdExecArgs config.process.argv
-        + lib.optionalString (credentialFlags != "") " ${credentialFlags}";
-
-      systemd.service = {
-        after = [ "network.target" ];
-        wants = [ "network.target" ];
-        wantedBy = [ "multi-user.target" ];
-        serviceConfig = {
-          Restart = "always";
-          AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
-          DynamicUser = true;
-          LoadCredential =
-            optional (cfg.keystore != null) "keystore:${cfg.keystore}"
-            ++ optional (cfg.cert != null) "cert:${cfg.cert}"
-            ++ optional (cfg.key != null) "key:${cfg.key}"
-            ++ optional (cfg.cacert != null) "cacert:${cfg.cacert}";
-        };
-      };
-    }
-  );
+  };
 }

--- a/pkgs/by-name/kt/ktls-utils/service.nix
+++ b/pkgs/by-name/kt/ktls-utils/service.nix
@@ -5,7 +5,6 @@
 {
   lib,
   config,
-  options,
   ...
 }:
 let
@@ -56,20 +55,5 @@ in
       "--config"
       configFile
     ];
-  }
-  // lib.optionalAttrs (options ? systemd) {
-    systemd.service = {
-      description = "Handshake service for kernel TLS consumers";
-      documentation = [ "man:tlshd(8)" ];
-      unitConfig.DefaultDependencies = false;
-      before = [ "remote-fs-pre.target" ];
-      wantedBy = [ "remote-fs.target" ];
-      serviceConfig = {
-        Restart = "on-failure";
-        DynamicUser = true;
-        AmbientCapabilities = [ "CAP_NET_ADMIN" ];
-        CapabilityBoundingSet = [ "CAP_NET_ADMIN" ];
-      };
-    };
   };
 }

--- a/pkgs/by-name/sn/snid/service.nix
+++ b/pkgs/by-name/sn/snid/service.nix
@@ -5,7 +5,6 @@
 {
   lib,
   config,
-  options,
   ...
 }:
 let
@@ -157,17 +156,5 @@ in
     ++ optional (cfg.backendPort != null) "-backend-port=${toString cfg.backendPort}"
     ++ optional (cfg.unixDirectory != null) "-unix-directory=${cfg.unixDirectory}"
     ++ optional cfg.proxyProto "-proxy-proto";
-  }
-  // lib.optionalAttrs (options ? systemd) {
-    systemd.service = {
-      after = [ "network.target" ];
-      wants = [ "network.target" ];
-      wantedBy = [ "multi-user.target" ];
-      serviceConfig = {
-        Restart = "on-failure";
-        DynamicUser = true;
-        AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
-      };
-    };
   };
 }

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -32,7 +32,6 @@ let
       common-updater-scripts,
       curl,
       jq,
-      coreutils,
       formats,
 
       version,
@@ -413,7 +412,7 @@ let
             services.default = {
               imports = [
                 (lib.modules.importApply ./service.nix {
-                  inherit formats coreutils;
+                  inherit formats;
                 })
               ];
               php-fpm.package = lib.mkDefault finalAttrs.finalPackage;

--- a/pkgs/development/interpreters/php/service.nix
+++ b/pkgs/development/interpreters/php/service.nix
@@ -1,11 +1,10 @@
 # Tests in: nixos/tests/php/fpm-modular.nix
 
 # Non-module dependencies (importApply)
-{ formats, coreutils }:
+{ formats }:
 
 # Service module
 {
-  options,
   config,
   lib,
   ...
@@ -162,30 +161,6 @@ in
       "-y"
       configFile
     ];
-  }
-  // lib.optionalAttrs (options ? systemd) {
-
-    systemd.service = {
-      after = [ "network.target" ];
-      documentation = [ "man:php-fpm(8)" ];
-
-      serviceConfig = {
-        Type = "notify";
-        ExecReload = "${coreutils}/bin/kill -USR2 $MAINPID";
-        RuntimeDirectory = "php-fpm";
-        RuntimeDirectoryPreserve = true;
-        Restart = "always";
-      };
-    };
-
-  }
-  // lib.optionalAttrs (options ? finit) {
-
-    finit.service = {
-      conditions = [ "service/syslogd/ready" ];
-      reload = "${coreutils}/bin/kill -USR2 $MAINPID";
-      notify = "systemd";
-    };
   };
 
   meta.maintainers = with lib.maintainers; [


### PR DESCRIPTION
Unprivileges system-specific snippets in current modular services, so as to show by example how other consuming systems might use them.
Makes explicit that current config is for system-level services - see #524517.

Disclaimer: I used a coding agent in the creation of this patch.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
