### PR TITLE
libvmi: drop fuse dependency

### DIFF
--- a/pkgs/by-name/li/libvmi/package.nix
+++ b/pkgs/by-name/li/libvmi/package.nix
@@ -13,9 +13,6 @@
   json_c,
   libvirt,
 
-  withVMIFS ? true,
-  fuse,
-
   legacyKVM ? false,
   libkvmi,
 
@@ -67,13 +64,11 @@ stdenv.mkDerivation {
     libvirt
   ]
   ++ lib.optionals xenSupport [ xen ]
-  ++ lib.optionals (!legacyKVM) [ libkvmi ]
-  ++ lib.optionals withVMIFS [ fuse ];
+  ++ lib.optionals (!legacyKVM) [ libkvmi ];
 
   configureFlags =
     lib.optionals (!xenSupport) [ "--disable-xen" ]
-    ++ lib.optionals legacyKVM [ "--enable-kvm-legacy" ]
-    ++ lib.optionals withVMIFS [ "--enable-vmifs" ];
+    ++ lib.optionals legacyKVM [ "--enable-kvm-legacy" ];
 
   # libvmi uses dlopen() for the xen libraries, however autoPatchelfHook doesn't work here
   postFixup = lib.optionalString xenSupport ''


### PR DESCRIPTION
libvmi has an optional feature that depends on FUSE 2. We can just disable it here, given that FUSE 2 is now deprecated.

Tracked by: #526161

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
