### PR TITLE
python3Packages.timm: 1.0.27 -> 1.0.28

### DIFF
--- a/pkgs/development/python-modules/pandantic/default.nix
+++ b/pkgs/development/python-modules/pandantic/default.nix
@@ -2,28 +2,45 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  multiprocess,
-  pandas-stubs,
-  pandas,
+  pyprojectVersionPatchHook,
+
+  # build-system
   poetry-core,
+
+  # dependencies
+  multiprocess,
+  pandas,
+  pandas-stubs,
   pydantic,
+
+  # tests
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pandantic";
   version = "1.0.1";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "wesselhuising";
     repo = "pandantic";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-lqd4aQiBMbATFMdftKQeTlqQ3MGrxm2shb7qil+84iA=";
   };
 
+  # Upstream forgot to bump the version in `pyproject.toml` for the 1.0.1 release
+  nativeBuildInputs = [
+    pyprojectVersionPatchHook
+  ];
+
   build-system = [ poetry-core ];
 
+  pythonRelaxDeps = [
+    "pandas"
+    "pandas-stubs"
+  ];
   dependencies = [
     multiprocess
     pandas
@@ -31,15 +48,15 @@ buildPythonPackage rec {
     pydantic
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
-
   pythonImportsCheck = [ "pandantic" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
 
   meta = {
     description = "Module to enriche the Pydantic BaseModel class";
     homepage = "https://github.com/wesselhuising/pandantic";
-    changelog = "https://github.com/wesselhuising/pandantic/releases/tag/${src.tag}";
+    changelog = "https://github.com/wesselhuising/pandantic/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/development/python-modules/pandas-stubs/default.nix
+++ b/pkgs/development/python-modules/pandas-stubs/default.nix
@@ -9,11 +9,8 @@
 
   # dependencies
   numpy,
-  types-pytz,
 
   # tests
-  # pytestCheckHook,
-  pytest9_0CheckHook,
   beautifulsoup4,
   html5lib,
   jinja2,
@@ -23,7 +20,9 @@
   openpyxl,
   pandas,
   pyarrow,
+  pyiceberg,
   pyreadstat,
+  pytestCheckHook,
   python-calamine,
   scipy,
   sqlalchemy,
@@ -33,23 +32,17 @@
   xarray,
   xlsxwriter,
 }:
-let
-  # pytest 9.1 turns non-list/tuple argvalues in @parametrize into
-  # PytestRemovedIn10Warning, which pandas-stubs' warning filter treats
-  # as a fatal error during test collection.
-  # Pin to 9.0 until upstream converts the affected
-  # generators to lists/tuples
-  pytestCheckHook = pytest9_0CheckHook;
-in
-buildPythonPackage rec {
+
+buildPythonPackage (finalAttrs: {
   pname = "pandas-stubs";
   version = "3.0.3.260530";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "pandas-dev";
     repo = "pandas-stubs";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-vPXz4ibNbFE2B14pkGPN5EDAwhA92VgFXzMLR9da6WQ=";
   };
 
@@ -57,11 +50,9 @@ buildPythonPackage rec {
 
   dependencies = [
     numpy
-    types-pytz
   ];
 
   nativeCheckInputs = [
-    pytestCheckHook
     beautifulsoup4
     html5lib
     jinja2
@@ -71,7 +62,10 @@ buildPythonPackage rec {
     openpyxl
     pandas
     pyarrow
+    pyiceberg
     pyreadstat
+    pytestCheckHook
+    python-calamine
     scipy
     sqlalchemy
     tables
@@ -79,7 +73,12 @@ buildPythonPackage rec {
     typing-extensions
     xarray
     xlsxwriter
-    python-calamine
+  ];
+
+  pytestFlags = [
+    # DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future.
+    # This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.
+    "-Wignore::DeprecationWarning"
   ];
 
   disabledTests = [
@@ -117,4 +116,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ malo ];
   };
-}
+})

--- a/pkgs/development/python-modules/pandera/default.nix
+++ b/pkgs/development/python-modules/pandera/default.nix
@@ -19,7 +19,6 @@
   # optional-dependencies
   black,
   dask,
-  duckdb,
   fastapi,
   frictionless,
   geopandas,
@@ -35,6 +34,7 @@
   xarray,
 
   # tests
+  duckdb,
   joblib,
   pyarrow-hotfix,
   pyarrow,
@@ -48,6 +48,7 @@ buildPythonPackage (finalAttrs: {
   pname = "pandera";
   version = "0.32.1";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "unionai-oss";
@@ -103,7 +104,7 @@ buildPythonPackage (finalAttrs: {
         ];
         ibis = [
           ibis-framework
-          duckdb
+          pyarrow-hotfix
         ];
         narwhals = [ narwhals ];
         pandas = [
@@ -112,14 +113,15 @@ buildPythonPackage (finalAttrs: {
         ];
         polars = [ polars ];
         xarray = [
-          xarray
           numpy
+          xarray
         ];
       };
     in
     extras // { all = lib.concatLists (lib.attrValues extras); };
 
   nativeCheckInputs = [
+    duckdb
     joblib
     pyarrow
     pyarrow-hotfix
@@ -150,6 +152,9 @@ buildPythonPackage (finalAttrs: {
   ];
 
   disabledTests = [
+    # AssertionError: assert failure_cases.equals(expected_failure_cases)
+    "test_ibis_custom_check"
+
     # TypeError: __class__ assignment: 'GeoDataFrame' object...
     "test_schema_model"
     "test_schema_from_dataframe"

--- a/pkgs/development/python-modules/timm/default.nix
+++ b/pkgs/development/python-modules/timm/default.nix
@@ -23,7 +23,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "timm";
-  version = "1.0.27";
+  version = "1.0.28";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -31,7 +31,7 @@ buildPythonPackage (finalAttrs: {
     owner = "huggingface";
     repo = "pytorch-image-models";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Tur4niy89MyMJ8TD7+zBY6x/tmvtYDkruksf65KdTkE=";
+    hash = "sha256-axPiPmqn/ZAtr4BgKFYA/ZUPcmMxIkUbY+dKZdpzrgk=";
   };
 
   # Fix torch 2.11.0 compatibility


### PR DESCRIPTION
## Things done

- **python3Packages.pandas-stubs: cleanup**
- **python3Packages.timm: 1.0.27 -> 1.0.28** ([Diff](https://github.com/huggingface/pytorch-image-models/compare/v1.0.27...v1.0.28), [Changelog](https://github.com/huggingface/pytorch-image-models/blob/v1.0.28/README.md#whats-new))
- **python3Packages.pandera: 0.30.1 -> 0.32.1** ([Diff](https://github.com/unionai-oss/pandera/compare/v0.30.1...v0.32.1), [Changelog](https://github.com/unionai-oss/pandera/releases/tag/v0.32.1))
- **python3Packages.pandantic: cleanup, relax deps**

cc @bcdarwin

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
