### PR TITLE
chromium: remove broken `pulseSupport = false;` override

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -91,7 +91,6 @@
   cupsSupport ? true,
   cups ? null,
   proprietaryCodecs ? true,
-  pulseSupport ? false,
   libpulseaudio ? null,
   ungoogled ? false,
   ungoogled-chromium,
@@ -394,7 +393,9 @@ let
       libgcrypt
       cups
     ]
-    ++ lib.optional pulseSupport libpulseaudio;
+    ++ [
+      libpulseaudio
+    ];
 
     buildInputs = [
     ]
@@ -455,7 +456,9 @@ let
       libgcrypt
       cups
     ]
-    ++ lib.optional pulseSupport libpulseaudio;
+    ++ [
+      libpulseaudio
+    ];
 
     patches = [
       ./patches/cross-compile.patch
@@ -968,7 +971,7 @@ let
         use_vaapi = false;
         use_v4l2_codec = true;
       }
-      // lib.optionalAttrs pulseSupport {
+      // {
         use_pulseaudio = true;
         link_pulseaudio = true;
       }

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -32,7 +32,6 @@
   enableWideVine ? false,
   ungoogled ? false, # Whether to build chromium or ungoogled-chromium
   cupsSupport ? true,
-  pulseSupport ? config.pulseaudio or stdenv.hostPlatform.isLinux,
   commandLineArgs ? "",
   pkgsBuildBuild,
   pkgs,
@@ -76,7 +75,6 @@ let
       inherit
         proprietaryCodecs
         cupsSupport
-        pulseSupport
         ungoogled
         ;
       gnChromium = buildPackages.gn.override upstream-info.deps.gn;


### PR DESCRIPTION
As far as I can tell, this override broke almost 10 years ago in 8391241e0c90c8e5ee90d86d6cc1c9146e575768.

When trying to build the fixup commit that followed immediately after that (5f53fddf1ef784e2279bd4236c9f7566a038e89c) the build fails with the following error:

~~~
[11704/21910] CXX obj/media/media/vp9_compressed_header_parser.o
[11705/>
FAILED: obj/media/audio/audio/audio_manager_alsa.o
g++ -MMD -MF obj/media/audio/audio/audio_manager_alsa.o.d [...]
In file included from ../../media/audio/alsa/audio_manager_alsa.cc:28:0:
../../media/audio/pulse/audio_manager_pulse.h:8:30: fatal error: pulse/pulseaudio.h: No such file or directory
compilation terminated.
ninja: build stopped: subcommand failed.
~~~

And the same happens when trying to build chromium with `pulseSupport = false;` and picking random releases between 17.03 and now.

I don't think there is a good reason to keep this, especially since no one bothered to test this in almost a decade. The chromium derivation is a mess, so let's run with this rather small win and remove this broken, mostly useless, obscure and untested permutation.

Previously: #529290

## Things done

- Built on platform:
  - [x] x86_64-linux (no-op)
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
