### PR TITLE
 timbreid: move to by-name/, replace explicit phases with nix flags

### DIFF
--- a/pkgs/by-name/ti/timbreid/package.nix
+++ b/pkgs/by-name/ti/timbreid/package.nix
@@ -4,7 +4,7 @@
   fetchurl,
   unzip,
   puredata,
-  fftw,
+  fftwSinglePrec,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ unzip ];
   buildInputs = [
     puredata
-    fftw
+    fftwSinglePrec
   ];
 
   unpackPhase = ''

--- a/pkgs/by-name/ti/timbreid/package.nix
+++ b/pkgs/by-name/ti/timbreid/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Collection of audio feature analysis externals for puredata";
     homepage = "http://williambrent.conflations.com/pages/research.html";
-    license = lib.licenses.gpl3;
+    license = lib.licenses.gpl3Plus;
     maintainers = [ lib.maintainers.magnetophon ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/ti/timbreid/package.nix
+++ b/pkgs/by-name/ti/timbreid/package.nix
@@ -29,6 +29,8 @@ stdenv.mkDerivation (finalAttrs: {
     "all"
   ];
 
+  enableParallelBuilding = true;
+
   installPhase = ''
     runHook preInstall
     mkdir -p $out/

--- a/pkgs/by-name/ti/timbreid/package.nix
+++ b/pkgs/by-name/ti/timbreid/package.nix
@@ -16,29 +16,28 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "14k2xk5zrzrw1zprdbwx45hrlc7ck8vq4drpd3l455i5r8yk4y6b";
   };
 
+  sourceRoot = ".";
+
   nativeBuildInputs = [ unzip ];
   buildInputs = [
     puredata
     fftwSinglePrec
   ];
 
-  unpackPhase = ''
-    mkdir source
-    cd source
-    unzip $src
-  '';
-
-  buildPhase = ''
-    make tIDLib.o all
-  '';
+  makeFlags = [
+    "tIDLib.o"
+    "all"
+  ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/
     cp -r *.pd $out/
     cp -r *.pd_linux $out/
     cp -r audio/ $out/
     cp -r data/ $out/
     cp -r doc/ $out/
+    runHook postInstall
   '';
 
   postFixup = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9586,10 +9586,6 @@ with pkgs;
     versionSuffix = "esr";
   };
 
-  timbreid = callPackage ../applications/audio/pd-plugins/timbreid {
-    fftw = fftwSinglePrec;
-  };
-
   inherit
     ({
       timeshift-unwrapped = callPackage ../applications/backup/timeshift/unwrapped.nix { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
