### PR TITLE
shoko-webui: 2.4.1 -> 2.5.9; shoko: 5.3.1 -> 5.3.3

### DIFF
--- a/pkgs/by-name/sh/shoko-webui/package.nix
+++ b/pkgs/by-name/sh/shoko-webui/package.nix
@@ -14,13 +14,13 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "shoko-webui";
-  version = "2.4.1";
+  version = "2.5.9";
 
   src = fetchFromGitHub {
     owner = "ShokoAnime";
     repo = "Shoko-WebUI";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-/frP6qI5xAmogb5a5AA83IJxgOhVUi6X0E4h3Qg5u6w=";
+    hash = "sha256-mHBflHehCnwCkh4K271vo30rfoQa+3xLos0d7P/kKvE=";
   };
 
   # Avoid requiring git as a build time dependency. It's used for version
@@ -32,7 +32,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     inherit (finalAttrs) pname version src;
     inherit pnpm;
     fetcherVersion = 3;
-    hash = "sha256-rTlem83dFptgvKUKUaHK8vi5B0FBehPFtkCUhOnUKd0=";
+    hash = "sha256-0ZXXfP6iHyd5zlUQruS3MZADkuucygXrUPRKNCNYA7k=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/sh/shoko/package.nix
+++ b/pkgs/by-name/sh/shoko/package.nix
@@ -12,13 +12,13 @@
 
 buildDotnetModule (finalAttrs: {
   pname = "shoko";
-  version = "5.3.1";
+  version = "5.3.3";
 
   src = fetchFromGitHub {
     owner = "ShokoAnime";
     repo = "ShokoServer";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-gZK0NUwPKhrrIjdnfwNI0s618qnTf1cYBgPkwajSTEw=";
+    hash = "sha256-PJtjG4YJBgUrjBt/S2uWyKrCj1pW4N9wrLqoh2gHKcg=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
My first PR to nixpkgs :)
Update to newest stable shoko-webui 2.5.9 and shoko server 5.3.3.
`This version requires a Shoko Server of at least version 5.3.3.0 to function.`

In the WebUI it will still say `Web UI Version 2.5.3-dev`, because
https://github.com/ShokoAnime/Shoko-WebUI/blob/v2.5.9/package.json#L3

 After updating, I had some UI bug with manual linking (range fill) of unrecognized files fixed  ✅

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
