### PR TITLE
gittuf: 0.12.0 -> 0.15.0

### DIFF
--- a/pkgs/by-name/gi/gittuf/package.nix
+++ b/pkgs/by-name/gi/gittuf/package.nix
@@ -50,6 +50,9 @@ buildGoModule (finalAttrs: {
     homepage = "https://gittuf.dev";
     license = lib.licenses.asl20;
     mainProgram = "gittuf";
-    maintainers = with lib.maintainers; [ flandweber ];
+    maintainers = with lib.maintainers; [
+      flandweber
+      anish
+    ];
   };
 })

--- a/pkgs/by-name/gi/gittuf/package.nix
+++ b/pkgs/by-name/gi/gittuf/package.nix
@@ -6,6 +6,8 @@
   gnupg,
   less,
   openssh,
+  versionCheckHook,
+  nix-update-script,
 }:
 
 buildGoModule (finalAttrs: {
@@ -35,6 +37,12 @@ buildGoModule (finalAttrs: {
   checkFlags = [ "-skip=TestLoadRepository|TestSSH" ];
 
   postInstall = "rm $out/bin/cli $out/bin/sandbox"; # remove gendoc helper binaries
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     changelog = "https://github.com/gittuf/gittuf/blob/${finalAttrs.src.tag}/CHANGELOG.md";

--- a/pkgs/by-name/gi/gittuf/package.nix
+++ b/pkgs/by-name/gi/gittuf/package.nix
@@ -3,26 +3,30 @@
   fetchFromGitHub,
   buildGoModule,
   git,
+  gnupg,
+  less,
   openssh,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "gittuf";
-  version = "0.12.0";
+  version = "0.15.0";
 
   src = fetchFromGitHub {
     owner = "gittuf";
     repo = "gittuf";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-/PKbo8LPvU6ZTav9n82mrj2h6z6AyJ225mCH7EfazVU=";
+    hash = "sha256-VWbM7y9XCs/pANJtPa3MDbDhuEtVQ97X5Cyo6yY0Rd8=";
   };
 
-  vendorHash = "sha256-unj9PpRkfNHWQzeCmcjppMFGAlHNcP0/j9EiGvpRzRc=";
+  vendorHash = "sha256-VTfS0bLq7B037qmFABO5JDrV98zik5ycR4s6NZr3H4s=";
 
   ldflags = [ "-X github.com/gittuf/gittuf/internal/version.gitVersion=${finalAttrs.version}" ];
 
   nativeCheckInputs = [
     git
+    gnupg
+    less
     openssh
   ];
   checkFlags = [

--- a/pkgs/by-name/gi/gittuf/package.nix
+++ b/pkgs/by-name/gi/gittuf/package.nix
@@ -15,7 +15,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "gittuf";
     repo = "gittuf";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-VWbM7y9XCs/pANJtPa3MDbDhuEtVQ97X5Cyo6yY0Rd8=";
   };
 
@@ -23,21 +23,21 @@ buildGoModule (finalAttrs: {
 
   ldflags = [ "-X github.com/gittuf/gittuf/internal/version.gitVersion=${finalAttrs.version}" ];
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   nativeCheckInputs = [
     git
     gnupg
     less
     openssh
   ];
-  checkFlags = [
-    "-skip=TestLoadRepository"
-    "-skip=TestSSH"
-  ];
+  checkFlags = [ "-skip=TestLoadRepository|TestSSH" ];
 
   postInstall = "rm $out/bin/cli $out/bin/sandbox"; # remove gendoc helper binaries
 
   meta = {
-    changelog = "https://github.com/gittuf/gittuf/blob/v${finalAttrs.version}/CHANGELOG.md";
+    changelog = "https://github.com/gittuf/gittuf/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     description = "Security layer for Git repositories";
     homepage = "https://gittuf.dev";
     license = lib.licenses.asl20;

--- a/pkgs/by-name/gi/gittuf/package.nix
+++ b/pkgs/by-name/gi/gittuf/package.nix
@@ -30,7 +30,7 @@ buildGoModule (finalAttrs: {
     "-skip=TestSSH"
   ];
 
-  postInstall = "rm $out/bin/cli"; # remove gendoc cli binary
+  postInstall = "rm $out/bin/cli $out/bin/sandbox"; # remove gendoc helper binaries
 
   meta = {
     changelog = "https://github.com/gittuf/gittuf/blob/v${finalAttrs.version}/CHANGELOG.md";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
