### PR TITLE
brioche: fix eval on unsupported systems

### DIFF
--- a/pkgs/by-name/br/brioche/package.nix
+++ b/pkgs/by-name/br/brioche/package.nix
@@ -64,5 +64,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ GaetanLepage ];
     mainProgram = "brioche";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
   };
 })


### PR DESCRIPTION
Fix :  

```
       … while calling the 'derivationStrict' builtin
         at «nix-internal»/derivation-internal.nix:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|
       … while evaluating derivation 'shell'
         whose name attribute is located at /nix/store/bn7w75m2q3i5snghm1n8mmx57awyjkr8-source/pkgs/stdenv/generic/make-derivation.nix:651:11
       … while evaluating attribute 'buildInputs' of derivation 'shell'
         at /nix/store/bn7w75m2q3i5snghm1n8mmx57awyjkr8-source/pkgs/stdenv/generic/make-derivation.nix:722:11:
          721|           depsHostHost = hostHostOutputs;
          722|           buildInputs = hostTargetOutputs;
             |           ^
          723|           depsTargetTarget = targetTargetOutputs;
       (stack trace truncated; use '--show-trace' to show the full, detailed trace)
       error: attribute 'riscv64-linux' missing
       at /nix/store/bn7w75m2q3i5snghm1n8mmx57awyjkr8-source/pkgs/by-name/br/brioche/fetchers.nix:14:16:
           13|       url = "https://github.com/denoland/rusty_v8/releases/download/v${args.version}/librusty_v8_release_${stdenv.hostPlatform.rust.rustcTarget}.a.gz";
           14|       sha256 = args.shas.${stdenv.hostPlatform.system};
             |                ^
           15|       meta = {
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] riscv64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
