### PR TITLE
 nixos/nginx: do not match pkgs.openresty as some modules like brotli add buildInputs

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -1617,7 +1617,7 @@ in
           MemoryDenyWriteExecute =
             !(
               (builtins.any (mod: (mod.allowMemoryWriteExecute or false)) cfg.package.modules)
-              || (cfg.package == pkgs.openresty)
+              || (lib.getName cfg.package == "openresty")
             );
           RestrictRealtime = true;
           RestrictSUIDSGID = true;

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -1617,7 +1617,6 @@ in
           MemoryDenyWriteExecute =
             !(
               (builtins.any (mod: (mod.allowMemoryWriteExecute or false)) cfg.package.modules)
-              || cfg.lua.enable
               || (cfg.package == pkgs.openresty)
             );
           RestrictRealtime = true;


### PR DESCRIPTION
```diff
--- /dev/fd/63	2026-07-12 01:29:24.447317728 +0200
+++ /dev/fd/62	2026-07-12 01:29:24.448317734 +0200
@@ -4,7 +4,7 @@
         [ ( "doc"
           , DerivationOutput
               { path =
-                  "/nix/store/r2jdcgwxp2a4pa1cxa6yvf9p0f7wi1ih-openresty-1.31.1.1-doc"
+                  "/nix/store/syrb1ccks4vqgg25ygrylahxglknrc5j-openresty-1.31.1.1-doc"
               , hashAlgo = ""
               , hash = ""
               }
@@ -12,7 +12,7 @@
         , ( "out"
           , DerivationOutput
               { path =
-                  "/nix/store/2saawkswxnxs4ffb98r7bidy4vj6259c-openresty-1.31.1.1"
+                  "/nix/store/n48gwmah2pxfc8vg7dc3ki0c4xmszr1d-openresty-1.31.1.1"
               , hashAlgo = ""
               , hash = ""
               }
@@ -62,12 +62,18 @@
         , ( "/nix/store/v2k6k32vbrfsl2cciclgl1k8v8c3jxv8-nginx-doc-unstable-0-unstable-2026-05-15.drv"
           , fromList [ "out" ]
           )
+        , ( "/nix/store/wkgfkcxnpk1dy9qdd7m22ifkhyxn1hd5-brotli-1.2.0.drv"
+          , fromList [ "dev" ]
+          )
         , ( "/nix/store/wx2j9jzk90dlsz9wvbrjdxlm4q1vf8aq-openresty-nix-etag-1.15.4.patch.drv"
           , fromList [ "out" ]
           )
         , ( "/nix/store/xk8m6ai5q00gr0h3vm8afc5dk1plpw9i-install-shell-files.drv"
           , fromList [ "out" ]
           )
+        , ( "/nix/store/xy1vwc4173xz5hz2yjv7z83gz3ss6h72-brotli.drv"
+          , fromList [ "out" ]
+          )
         , ( "/nix/store/zhhm8h70q64qgwg3bccc7ygwy48jn5c3-libxml2-2.15.3.drv"
           , fromList [ "dev" ]
           )
@@ -95,14 +101,14 @@
           )
         , ( "__structuredAttrs" , "" )
         , ( "buildInputs"
-          , "/nix/store/i0jqva96qfgc76g8w7jbyiv6h3si07b9-openssl-3.6.2-dev /nix/store/a9psmsc93llkravrd50rrv8k3dwdw60x-zlib-1.3.2-dev /nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev /nix/store/35wfzwiy77ab9dhzjblb4kmdnckss40i-libxml2-2.15.3-dev /nix/store/9vgz8w91lcw9f43glyqmfj50v1hvgkmp-libxslt-1.1.45-dev /nix/store/k7kxg101ikkm0cyf8jcqhg948vy542af-perl-5.42.0 /nix/store/hzdwjd2s60585lygfj81qdhm2825frsm-libpq-18.4-dev"
+          , "/nix/store/i0jqva96qfgc76g8w7jbyiv6h3si07b9-openssl-3.6.2-dev /nix/store/a9psmsc93llkravrd50rrv8k3dwdw60x-zlib-1.3.2-dev /nix/store/y5yv1kzvmppzdp0jkq3yf3apx563canv-pcre2-10.46-dev /nix/store/35wfzwiy77ab9dhzjblb4kmdnckss40i-libxml2-2.15.3-dev /nix/store/9vgz8w91lcw9f43glyqmfj50v1hvgkmp-libxslt-1.1.45-dev /nix/store/k7kxg101ikkm0cyf8jcqhg948vy542af-perl-5.42.0 /nix/store/hzdwjd2s60585lygfj81qdhm2825frsm-libpq-18.4-dev /nix/store/pcq77h5mhc5nfvf1rs92a5l5g0kaapdg-brotli-1.2.0-dev"
           )
         , ( "builder"
           , "/nix/store/zh1ijdhb6gng1509b1zrilb6xlzx60j6-bash-5.3p9/bin/bash"
           )
         , ( "cmakeFlags" , "" )
         , ( "configureFlags"
-          , "--sbin-path=bin/nginx --with-http_ssl_module --with-http_v2_module --with-http_v3_module --with-http_realip_module --with-http_addition_module --with-http_xslt_module --with-http_sub_module --with-http_dav_module --with-http_flv_module --with-http_mp4_module --with-http_gunzip_module --with-http_gzip_static_module --with-http_auth_request_module --with-http_random_index_module --with-http_secure_link_module --with-http_degradation_module --with-http_stub_status_module --with-threads --with-pcre-jit --http-log-path=/var/log/nginx/access.log --error-log-path=/var/log/nginx/error.log --pid-path=/var/log/nginx/nginx.pid --http-client-body-temp-path=/tmp/nginx_client_body --http-proxy-temp-path=/tmp/nginx_proxy --http-fastcgi-temp-path=/tmp/nginx_fastcgi --http-uwsgi-temp-path=/tmp/nginx_uwsgi --http-scgi-temp-path=/tmp/nginx_scgi --with-openssl-opt=enable-ktls --with-stream --with-stream_realip_module --with-stream_ssl_module --with-stream_ssl_preread_module --with-file-aio --with-http_postgres_module"
+          , "--sbin-path=bin/nginx --with-http_ssl_module --with-http_v2_module --with-http_v3_module --with-http_realip_module --with-http_addition_module --with-http_xslt_module --with-http_sub_module --with-http_dav_module --with-http_flv_module --with-http_mp4_module --with-http_gunzip_module --with-http_gzip_static_module --with-http_auth_request_module --with-http_random_index_module --with-http_secure_link_module --with-http_degradation_module --with-http_stub_status_module --with-threads --with-pcre-jit --http-log-path=/var/log/nginx/access.log --error-log-path=/var/log/nginx/error.log --pid-path=/var/log/nginx/nginx.pid --http-client-body-temp-path=/tmp/nginx_client_body --http-proxy-temp-path=/tmp/nginx_proxy --http-fastcgi-temp-path=/tmp/nginx_fastcgi --http-uwsgi-temp-path=/tmp/nginx_uwsgi --http-scgi-temp-path=/tmp/nginx_scgi --with-openssl-opt=enable-ktls --with-stream --with-stream_realip_module --with-stream_ssl_module --with-stream_ssl_preread_module --with-file-aio --with-http_postgres_module --add-module=/nix/store/sw63grm2cbi76pcq44izm8f8fdvzjafn-brotli"
           )
         , ( "configurePlatforms" , "" )
         , ( "depsBuildBuild" , "" )
@@ -113,11 +119,13 @@
         , ( "depsHostHostPropagated" , "" )
         , ( "depsTargetTarget" , "" )
         , ( "depsTargetTargetPropagated" , "" )
-        , ( "disallowedReferences" , "" )
+        , ( "disallowedReferences"
+          , "/nix/store/sw63grm2cbi76pcq44izm8f8fdvzjafn-brotli"
+          )
         , ( "doCheck" , "" )
         , ( "doInstallCheck" , "" )
         , ( "doc"
-          , "/nix/store/r2jdcgwxp2a4pa1cxa6yvf9p0f7wi1ih-openresty-1.31.1.1-doc"
+          , "/nix/store/syrb1ccks4vqgg25ygrylahxglknrc5j-openresty-1.31.1.1-doc"
           )
         , ( "enableParallelBuilding" , "1" )
         , ( "enableParallelChecking" , "1" )
@@ -129,7 +137,7 @@
           )
         , ( "nginxVersion" , "1.31.1" )
         , ( "out"
-          , "/nix/store/2saawkswxnxs4ffb98r7bidy4vj6259c-openresty-1.31.1.1"
+          , "/nix/store/n48gwmah2pxfc8vg7dc3ki0c4xmszr1d-openresty-1.31.1.1"
           )
         , ( "outputs" , "out doc" )
         , ( "patches"
@@ -137,7 +145,7 @@
           )
         , ( "pname" , "openresty" )
         , ( "postInstall"
-          , "ln -s $out/luajit/bin/luajit-2.1.ROLLING $out/bin/luajit-openresty\nln -sf $out/nginx/bin/nginx $out/bin/openresty\nln -s $out/nginx/bin/nginx $out/bin/nginx\nln -s $out/nginx/conf $out/conf\nln -s $out/nginx/html $out/html\n\nwrapProgram $out/bin/restydoc \\\n  --prefix PATH : /nix/store/i6jrv1f3mygdh2gv5r2yn1lm77d3qals-groff-1.24.1/bin\n\nsubstituteInPlace $out/bin/resty \\\n  --replace-fail \"'bin/nginx'\" \"'$out/bin/nginx'\"\n"
+          , "ln -s $out/luajit/bin/luajit-2.1.ROLLING $out/bin/luajit-openresty\nln -sf $out/nginx/bin/nginx $out/bin/openresty\nln -s $out/nginx/bin/nginx $out/bin/nginx\nln -s $out/nginx/conf $out/conf\nln -s $out/nginx/html $out/html\n\nwrapProgram $out/bin/restydoc \\\n  --prefix PATH : /nix/store/i6jrv1f3mygdh2gv5r2yn1lm77d3qals-groff-1.24.1/bin\n\nsubstituteInPlace $out/bin/resty \\\n  --replace-fail \"'bin/nginx'\" \"'$out/bin/nginx'\"\nremove-references-to -t /nix/store/sw63grm2cbi76pcq44izm8f8fdvzjafn-brotli $(readlink -fn $out/bin/nginx)\n"
           )
         , ( "postPatch"
           , "substituteInPlace bundle/nginx-1.31.1/src/http/ngx_http_core_module.c \\\n  --replace-fail '@nixStoreDir@' \"$NIX_STORE\" \\\n  --replace-fail '@nixStoreDirLen@' \"${#NIX_STORE}\"\n\npatchShebangs configure bundle/\n"

```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
