### PR TITLE
nixos/redmine: Add option for pandoc support allowing document preview

### DIFF
--- a/nixos/modules/services/misc/redmine.nix
+++ b/nixos/modules/services/misc/redmine.nix
@@ -265,6 +265,8 @@ in
           description = "MiniMagick font path";
           example = "/run/current-system/sw/share/X11/fonts/LiberationSans-Regular.ttf";
         };
+
+        pandoc = lib.mkEnableOption "pandoc integration for previewing LibreOffice and Microsoft Office documents";
       };
     };
   };
@@ -310,6 +312,7 @@ in
         imagemagick_convert_command = lib.optionalString cfg.components.imagemagick "${pkgs.imagemagick}/bin/convert";
         gs_command = lib.optionalString cfg.components.ghostscript "${pkgs.ghostscript}/bin/gs";
         minimagick_font_path = "${cfg.components.minimagick_font_path}";
+        pandoc_command = lib.optionalString cfg.components.pandoc "${pkgs.pandoc}/bin/pandoc";
       };
     };
 

--- a/nixos/modules/services/misc/redmine.nix
+++ b/nixos/modules/services/misc/redmine.nix
@@ -245,19 +245,19 @@ in
       };
 
       components = {
-        subversion = lib.mkEnableOption "Subversion integration.";
+        subversion = lib.mkEnableOption "Subversion integration";
 
-        mercurial = lib.mkEnableOption "Mercurial integration.";
+        mercurial = lib.mkEnableOption "Mercurial integration";
 
-        git = lib.mkEnableOption "git integration.";
+        git = lib.mkEnableOption "git integration";
 
-        cvs = lib.mkEnableOption "cvs integration.";
+        cvs = lib.mkEnableOption "cvs integration";
 
-        breezy = lib.mkEnableOption "bazaar integration.";
+        breezy = lib.mkEnableOption "bazaar integration";
 
-        imagemagick = lib.mkEnableOption "exporting Gant diagrams as PNG.";
+        imagemagick = lib.mkEnableOption "exporting Gant diagrams as PNG";
 
-        ghostscript = lib.mkEnableOption "exporting Gant diagrams as PDF.";
+        ghostscript = lib.mkEnableOption "exporting Gant diagrams as PDF";
 
         minimagick_font_path = lib.mkOption {
           type = lib.types.str;


### PR DESCRIPTION
Tested the pandoc support. Redmine reports pandoc as found and LibreOffice documents are previewed as expected.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
