### PR TITLE
vpxtool: init at 0.33.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20010,6 +20010,12 @@
     githubId = 4242897;
     name = "Nikolai Mishin";
   };
+  nmoya = {
+    email = "nikolasmoya@gmail.com";
+    github = "nmoya";
+    githubId = 1767648;
+    name = "Nikolas Moya";
+  };
   noaccos = {
     name = "Francesco Noacco";
     email = "francesco.noacco2000@gmail.com";

--- a/pkgs/by-name/vp/vpxtool/package.nix
+++ b/pkgs/by-name/vp/vpxtool/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  rustPlatform,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "vpxtool";
+  version = "0.33.4";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "francisdb";
+    repo = "vpxtool";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-bXKfXBm1y4cdGvNQA8InYdsxOo4GJzSX5w24QUkeHs8=";
+  };
+
+  cargoHash = "sha256-07Muapi8zILczLgCSP/+mEqynm8Abc6EclVX4eDVZmw=";
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Terminal based frontend and utilities for Visual Pinball";
+    homepage = "https://github.com/francisdb/vpxtool";
+    changelog = "https://github.com/francisdb/vpxtool/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nmoya ];
+    mainProgram = "vpxtool";
+  };
+})


### PR DESCRIPTION
Add vpxtool, a terminal-based frontend and utility suite for the Visual Pinball ecosystem.

This package builds vpxtool from source with rustPlatform.buildRustPackage and installs one public executable: vpxtool.

Tables, ROMs, and the Visual Pinball executable are not packaged. Users must provide their own .vpx tables, PinMAME ROMs, and vpinball executable where required by vpxtool commands. Runtime configuration remains managed by vpxtool through its normal config file under the user's platform-specific configuration directory.

The upstream source is pinned to release v0.33.4. Upstream Cargo metadata declares the package as MIT licensed, so the nixpkgs package uses lib.licenses.mit.

The package enables upstream cargo tests and a version install check.

It has been built and smoke-tested on x86_64-linux with:
  nix-build -A vpxtool
  ./result/bin/vpxtool --version


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests]
  - [x] Package build and upstream cargo tests: `nix-build -A vpxtool --no-out-link`
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality
- [ ] Ran `nixpkgs-review` on this PR
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`: `./result/bin/vpxtool --version`
- Nixpkgs Release Notes:
  - [ ] Package update: when the change is major or breaking
- NixOS Release Notes:
  - [ ] Module addition: when adding a new NixOS module
  - [ ] Module update: when the change is significant
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs
- [x] Follows the [automation/AI policy]

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
