### PR TITLE
python3Packages.autobean-refactor: init at 0.3.1

### DIFF
--- a/pkgs/development/python-modules/autobean-refactor/default.nix
+++ b/pkgs/development/python-modules/autobean-refactor/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchpatch,
+  lark,
+  mako,
+  nix-update-script,
+  pdm-backend,
+  pytest-benchmark,
+  pytest-cov-stub,
+  pytestCheckHook,
+  stringcase,
+  typing-extensions,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "autobean-refactor";
+  version = "0.3.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "SEIAROTg";
+    repo = "autobean-refactor";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-VNqyr46yqOs5ynEfpD/FJKRljEpb9emqyNlL+w8jGmo=";
+  };
+
+  build-system = [
+    pdm-backend
+  ];
+
+  dependencies = [
+    lark
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [
+    mako
+    pytest-benchmark
+    pytest-cov-stub
+    pytestCheckHook
+    stringcase
+  ];
+
+  pythonImportsCheck = [ "autobean_refactor" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://autobean-refactor.readthedocs.io";
+    description = "Ergonomic and losess beancount manipulation library";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ambroisie ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1603,6 +1603,8 @@ self: super: with self; {
 
   autobean = callPackage ../development/python-modules/autobean { };
 
+  autobean-refactor = callPackage ../development/python-modules/autobean-refactor { };
+
   autocommand = callPackage ../development/python-modules/autocommand { };
 
   autodocsumm = callPackage ../development/python-modules/autodocsumm { };


### PR DESCRIPTION
Based on #540917, as they would otherwise immediately conflict with each other when merged.

Please only review the top commit.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
