### PR TITLE
orca: Add missing dependency and enable tests

### DIFF
--- a/pkgs/by-name/or/orca/fix-mock-typing.patch
+++ b/pkgs/by-name/or/orca/fix-mock-typing.patch
@@ -1,0 +1,64 @@
+diff --git a/tests/unit_tests/test_dbus_service.py b/tests/unit_tests/test_dbus_service.py
+index bf8cab8a7..0db3afd60 100644
+--- a/tests/unit_tests/test_dbus_service.py
++++ b/tests/unit_tests/test_dbus_service.py
+@@ -59,6 +59,7 @@ class TestDBusService:
+         external_modules = [
+             "gi",
+             "gi.repository",
++            "gi.repository.Atspi",
+             "dasbus",
+             "dasbus.connection",
+             "dasbus.error",
+@@ -96,8 +97,16 @@ class TestDBusService:
+                 """Unpack the variant value."""
+                 return self._value
+ 
+-        essential_modules["gi.repository"].GLib = test_context.Mock()
+-        essential_modules["gi.repository"].GLib.Variant = MockGLibVariant
++        gi_repository_mock = essential_modules["gi.repository"]
++        gi_repository_mock.GLib = test_context.Mock()
++        gi_repository_mock.GLib.Variant = MockGLibVariant
++
++        class Fake():
++            pass
++
++        atspi_mock = essential_modules["gi.repository.Atspi"]
++        atspi_mock.Accessible = Fake
++        gi_repository_mock.Atspi = atspi_mock
+ 
+         class MockPublishable:
+             """Mock Publishable base class for inheritance."""
+
+
+Taken from https://gitlab.gnome.org/GNOME/orca/-/commit/20340d2075a34721aa6af46507d02525f3eac5f5
+
+diff --git a/src/orca/ax_utilities_application.py b/src/orca/ax_utilities_application.py
+index 2edcabf11..d59b8ae9e 100644
+--- a/src/orca/ax_utilities_application.py
++++ b/src/orca/ax_utilities_application.py
+@@ -21,6 +21,7 @@
+ 
+ """Utilities for accessible applications."""
+ 
++from __future__ import annotations
+ import gi
+ 
+ gi.require_version("Atspi", "2.0")
+
+
+Taken from https://gitlab.gnome.org/GNOME/orca/-/commit/6c18ba002c6fac3fb80a10791b0daab6ea85f072
+
+diff --git a/src/orca/ax_event_synthesizer.py b/src/orca/ax_event_synthesizer.py
+index 4b999ef75..cb0f0e31a 100644
+--- a/src/orca/ax_event_synthesizer.py
++++ b/src/orca/ax_event_synthesizer.py
+@@ -22,6 +22,8 @@
+ 
+ """Provides support for synthesizing accessible input events."""
+ 
++from __future__ import annotations
++
+ import gi
+ 
+ gi.require_version("Atspi", "2.0")

--- a/pkgs/by-name/or/orca/fix-paths.patch
+++ b/pkgs/by-name/or/orca/fix-paths.patch
@@ -1,70 +1,75 @@
-diff --git a/src/orca/ax_utilities_application.py b/src/orca/ax_utilities_application.py
-index 218c7bf22..4474f26cd 100644
---- a/src/orca/ax_utilities_application.py
-+++ b/src/orca/ax_utilities_application.py
-@@ -180,7 +180,7 @@ class AXUtilitiesApplication:
- 
-         pid = AXUtilitiesApplication.get_process_id(app)
-         try:
--            state = subprocess.getoutput(f"cat /proc/{pid}/status | grep State")
-+            state = subprocess.getoutput(f"@cat@ /proc/{pid}/status | @grep@ State")
-             state = state.split()[1]
-         except (GLib.GError, IndexError) as error:
-             tokens = [f"AXUtilitiesApplication: Exception checking state of pid {pid}: {error}"]
-diff --git a/src/orca/debugging_tools_manager.py b/src/orca/debugging_tools_manager.py
-index 5c607f3cd..18ddcd920 100644
---- a/src/orca/debugging_tools_manager.py
-+++ b/src/orca/debugging_tools_manager.py
-@@ -169,7 +169,7 @@ class DebuggingToolsManager:
-             else:
-                 name = AXObject.get_name(app) or "[DEAD]"
-             try:
--                cmdline = subprocess.getoutput(f"cat /proc/{pid}/cmdline")
-+                cmdline = subprocess.getoutput(f"@cat@ /proc/{pid}/cmdline")
-             except subprocess.SubprocessError as error:
-                 cmdline = f"EXCEPTION: {error}"
-             else:
 diff --git a/src/orca/orca_bin.py.in b/src/orca/orca_bin.py.in
-index 86a1413ca..f272c431d 100755
+index be3d4ebdd..1f83d6d6c 100755
 --- a/src/orca/orca_bin.py.in
 +++ b/src/orca/orca_bin.py.in
-@@ -211,7 +211,7 @@ def in_graphical_desktop() -> bool:
- def other_orcas() -> list[int]:
+@@ -209,7 +209,7 @@ def other_orcas() -> list[int]:
      """Returns the pid of any other instances of Orca owned by this user."""
  
--    with subprocess.Popen(f"pgrep -u {os.getuid()} -x orca",
-+    with subprocess.Popen(f"@pgrep@ -u {os.getuid()} -x orca",
-                           shell=True,
-                           stdout=subprocess.PIPE) as proc:
+     with subprocess.Popen(
+-        ["pgrep", "-u", str(os.getuid()), "-x", "orca"],
++        ["@pgrep@", "-u", str(os.getuid()), "-x", "orca"],
+         stdout=subprocess.PIPE,
+     ) as proc:
          pids = proc.stdout.read() if proc.stdout else b""
 diff --git a/src/orca/orca_modifier_manager.py b/src/orca/orca_modifier_manager.py
-index d1d95f5b9..e57993521 100644
+index eec1edc5f..e4ceee004 100644
 --- a/src/orca/orca_modifier_manager.py
 +++ b/src/orca/orca_modifier_manager.py
 @@ -289,7 +289,7 @@ class OrcaModifierManager:
  
          self._restore_original_xkbcomp()
-         with subprocess.Popen(
--            ["xkbcomp", display, "-"],
-+            ["@xkbcomp@", display, "-"],
+         with subprocess.Popen(  # noqa: S603 - xkbcomp is a system dependency, not untrusted input
+-            ["xkbcomp", display, "-"],  # noqa: S607 - full path would break across distros
++            ["@xkbcomp@", display, "-"],  # noqa: S607 - full path would break across distros
              stdout=subprocess.PIPE,
              stderr=subprocess.DEVNULL,
          ) as p:
 @@ -338,7 +338,7 @@ class OrcaModifierManager:
  
          self._caps_lock_cleared = False
-         with subprocess.Popen(
--            ["xkbcomp", "-w0", "-", display],
-+            ["@xkbcomp@", "-w0", "-", display],
+         with subprocess.Popen(  # noqa: S603 - xkbcomp is a system dependency, not untrusted input
+-            ["xkbcomp", "-w0", "-", display],  # noqa: S607 - full path would break across distros
++            ["@xkbcomp@", "-w0", "-", display],  # noqa: S607 - full path would break across distros
              stdin=subprocess.PIPE,
              stdout=None,
              stderr=None,
 @@ -449,7 +449,7 @@ class OrcaModifierManager:
          debug.print_message(debug.LEVEL_INFO, msg, True)
  
-         with subprocess.Popen(
--            ["xkbcomp", "-w0", "-", display],
-+            ["@xkbcomp@", "-w0", "-", display],
+         with subprocess.Popen(  # noqa: S603 - xkbcomp is a system dependency, not untrusted input
+-            ["xkbcomp", "-w0", "-", display],  # noqa: S607 - full path would break across distros
++            ["@xkbcomp@", "-w0", "-", display],  # noqa: S607 - full path would break across distros
              stdin=subprocess.PIPE,
              stdout=None,
              stderr=None,
+diff --git a/tests/unit_tests/test_orca_modifier_manager.py b/tests/unit_tests/test_orca_modifier_manager.py
+index 3c6c917cb..5d714f2a5 100644
+--- a/tests/unit_tests/test_orca_modifier_manager.py
++++ b/tests/unit_tests/test_orca_modifier_manager.py
+@@ -700,7 +700,7 @@ class TestOrcaModifierManager:
+         manager.refresh_orca_modifiers("test reason")
+         mock_restore.assert_called_once()
+         mock_popen.assert_called_once_with(
+-            ["xkbcomp", ":0", "-"],
++            ["@xkbcomp@", ":0", "-"],
+             stdout=subprocess.PIPE,
+             stderr=subprocess.DEVNULL,
+         )
+@@ -808,7 +808,7 @@ class TestOrcaModifierManager:
+         mock_unmap.assert_called_once()
+         if expects_popen_call:
+             mock_popen.assert_called_once_with(
+-                ["xkbcomp", "-w0", "-", ":0"],
++                ["@xkbcomp@", "-w0", "-", ":0"],
+                 stdin=subprocess.PIPE,
+                 stdout=None,
+                 stderr=None,
+@@ -880,7 +880,7 @@ class TestOrcaModifierManager:
+ 
+         if expects_popen_call:
+             mock_popen.assert_called_once_with(
+-                ["xkbcomp", "-w0", "-", ":0"],
++                ["@xkbcomp@", "-w0", "-", ":0"],
+                 stdin=subprocess.PIPE,
+                 stdout=None,
+                 stderr=None,

--- a/pkgs/by-name/or/orca/package.nix
+++ b/pkgs/by-name/or/orca/package.nix
@@ -55,6 +55,30 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
       ];
     })
 
+    # Fix tests on Python < 3.15
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/orca/-/commit/6c18ba002c6fac3fb80a10791b0daab6ea85f072.patch";
+      hash = "sha256-jTwVN0hPkead7PiVo/KEUrP04XU/05LXnXutvVmyecc=";
+      excludes = [
+        # These do not apply, fixed in fix-mock-typing.patch
+        "src/orca/ax_event_synthesizer.py"
+        "tests/unit_tests/test_flat_review_presenter.py"
+      ];
+    })
+
+    # Fix more tests on Python < 3.15
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/orca/-/commit/0a1271f0d6ed6f6d73d41b227a9f6d84d994c154.patch";
+      hash = "sha256-ry8fmzUjtHR8/0UpB/zXuv6RYDS8z6fWRdb9eci6nLY=";
+      includes = [
+        "src/orca/sound.py"
+      ];
+    })
+
+    # Fix more tests on Python < 3.15
+    # https://gitlab.gnome.org/GNOME/orca/-/work_items/729
+    ./fix-mock-typing.patch
+
     (replaceVars ./fix-paths.patch {
       pgrep = "${procps}/bin/pgrep";
       xkbcomp = "${xkbcomp}/bin/xkbcomp";
@@ -107,10 +131,31 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     gst_all_1.gst-plugins-good
   ];
 
+  nativeCheckInputs = with python3.pkgs; [
+    pytest
+  ];
+
+  checkInputs = with python3.pkgs; [
+    pytest-mock
+  ];
+
+  postPatch = ''
+    # Disable broken tests
+    substituteInPlace tests/meson.build \
+      --replace-fail "  'unit_tests/test_preferences_grid_base.py'," "" \
+      --replace-fail "  'unit_tests/test_braille_presenter.py'," "" \
+      --replace-fail "  'unit_tests/test_profile_manager.py'," ""
+  '';
+
   # Help GI find typelibs during Meson's configure step in cross builds
   preConfigure = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
     export GI_TYPELIB_PATH=${buildPackages.gtk3}/lib/girepository-1.0''${GI_TYPELIB_PATH:+:$GI_TYPELIB_PATH}
   '';
+
+  # `buildPythonPackage` uses `installCheckPhase` and leaves `checkPhase`
+  # empty. It renames `doCheck` from its arguments, but not `checkPhase`.
+  # See: https://github.com/NixOS/nixpkgs/issues/47390
+  installCheckPhase = "mesonCheckPhase";
 
   dontWrapGApps = true; # Prevent double wrapping
 

--- a/pkgs/by-name/or/orca/package.nix
+++ b/pkgs/by-name/or/orca/package.nix
@@ -71,7 +71,6 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   pythonPath = with python3.pkgs; [
     dasbus
     pygobject3
-    dbus-python
     pyxdg
     brltty
     liblouis

--- a/pkgs/by-name/or/orca/package.nix
+++ b/pkgs/by-name/or/orca/package.nix
@@ -46,7 +46,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
       hash = "sha256-ts/ZCgEaTrnmMM1cUFJB2rDW9icMoi4jV34psD0IDCc=";
     })
 
-    # Required for next patch to apply.
+    # Required for fix-paths.patch to apply.
     (fetchpatch {
       url = "https://gitlab.gnome.org/GNOME/orca/-/commit/a7b10302b9ff9145a98cb3626f2488d15c558d3e.patch";
       hash = "sha256-lacy9vIyM3n84s+tbYvAUBKWCT+4nlI9uPVl7UPVS74=";
@@ -90,6 +90,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     speechd-minimal
     gst-python
     setproctitle
+    at-spi2-core
   ];
 
   strictDeps = false;

--- a/pkgs/by-name/or/orca/package.nix
+++ b/pkgs/by-name/or/orca/package.nix
@@ -4,6 +4,7 @@
   buildPackages,
   pkg-config,
   fetchurl,
+  fetchpatch,
   meson,
   ninja,
   wrapGAppsHook3,
@@ -20,8 +21,6 @@
   dbus,
   xkbcomp,
   procps,
-  gnugrep,
-  coreutils,
   gsettings-desktop-schemas,
   speechd-minimal,
   brltty,
@@ -41,9 +40,22 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   };
 
   patches = [
+    # Avoid running `cat` and `grep` subshells.
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/orca/-/commit/8f47283da2da7a7d34e769d9c129152decf632cb.patch";
+      hash = "sha256-ts/ZCgEaTrnmMM1cUFJB2rDW9icMoi4jV34psD0IDCc=";
+    })
+
+    # Required for next patch to apply.
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/orca/-/commit/a7b10302b9ff9145a98cb3626f2488d15c558d3e.patch";
+      hash = "sha256-lacy9vIyM3n84s+tbYvAUBKWCT+4nlI9uPVl7UPVS74=";
+      includes = [
+        "src/orca/orca_modifier_manager.py"
+      ];
+    })
+
     (replaceVars ./fix-paths.patch {
-      cat = "${coreutils}/bin/cat";
-      grep = "${gnugrep}/bin/grep";
       pgrep = "${procps}/bin/pgrep";
       xkbcomp = "${xkbcomp}/bin/xkbcomp";
     })


### PR DESCRIPTION
Specifically, the `__hash__` method in `Atspi.Accessible` is required for proper state management. See https://gitlab.gnome.org/GNOME/orca/-/merge_requests/283 for details.

Fixes: https://github.com/NixOS/nixpkgs/issues/540352

I am also enabling tests. Initially, I wanted to verify that the required runtime dependencies are present but the test environment will gladly pick them up from `buildInputs` without them actually being recorded in the derivation for runtime. The tests are still useful as a sanity check, though.

The three disabled tests will segfault in `_gtk_settings_get_screen`. While that can be fixed by running the tests using `xvfb-run`, it them fails on missing accessibility bus. Since it will be resolved in next orca version, I am not bothering to replicate the integration test environment here.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
