### PR TITLE
[26.05] mate-power-manager: Fix backlight-helper polkit popup

### DIFF
--- a/pkgs/by-name/ma/mate-power-manager/package.nix
+++ b/pkgs/by-name/ma/mate-power-manager/package.nix
@@ -56,7 +56,16 @@ stdenv.mkDerivation (finalAttrs: {
     mate-panel
   ];
 
-  configureFlags = [ "--enable-applets" ];
+  configureFlags = [
+    "--enable-applets"
+    "--sbindir=$(out)/bin"
+  ];
+
+  postPatch = ''
+    # Fixes polkit popup after `nixos-rebuild switch`.
+    substituteInPlace src/gpm-brightness.c \
+      --replace-fail 'SBINDIR "/mate-power-backlight-helper' '"/run/current-system/sw/bin/mate-power-backlight-helper'
+  '';
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
Same as 4d9714d7c9e07f5f.

(cherry picked from commit b27618bc1e638e418d19317111a54a2bef0fbbc8)

- #540734

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
