### PR TITLE
nixos/btrfs: add crypto modules only for kernel < 7.0

### DIFF
--- a/nixos/modules/tasks/filesystems/btrfs.nix
+++ b/nixos/modules/tasks/filesystems/btrfs.nix
@@ -85,16 +85,20 @@ in
 
     (mkIf inInitrd {
       boot.initrd.kernelModules = [ "btrfs" ];
-      boot.initrd.availableKernelModules = [
-        "crc32c"
-      ]
-      ++ optionals (config.boot.kernelPackages.kernel.kernelAtLeast "5.5") [
-        # The canonical names of these modules are not very stable, so use the algorithm names that the btrfs module expects.
-        # See: https://github.com/torvalds/linux/blob/v6.19-rc1/fs/btrfs/super.c#L2705-L2708
-        "xxhash64"
-        "sha256" # Should be baked into our kernel, just to be sure
-        "blake2b-256"
-      ];
+      boot.initrd.availableKernelModules = (
+        mkIf (config.boot.kernelPackages.kernel.kernelOlder "7.0") (
+          [
+            "crc32c"
+          ]
+          ++ optionals (config.boot.kernelPackages.kernel.kernelAtLeast "5.5") [
+            # The canonical names of these modules are not very stable, so use the algorithm names that the btrfs module expects.
+            # See: https://github.com/torvalds/linux/blob/v6.19-rc1/fs/btrfs/super.c#L2705-L2708
+            "xxhash64"
+            "sha256" # Should be baked into our kernel, just to be sure
+            "blake2b-256"
+          ]
+        )
+      );
 
       boot.initrd.extraUtilsCommands = mkIf (!config.boot.initrd.systemd.enable) ''
         copy_bin_and_libs ${pkgs.btrfs-progs}/bin/btrfs


### PR DESCRIPTION
Since kernel 7.0 BTRFS uses the kernel crypto library API, and no longer depends on the traditional crypto API.

This PR makes adding the hashing kmods to the availableKernelModules only happen for older kernel versions.

Doing so enables using newer kernels that do not have those modules built/enabled.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
