### PR TITLE
T0yv0/fix sage darwin aarch64

### DIFF
--- a/pkgs/by-name/sa/sage/package.nix
+++ b/pkgs/by-name/sa/sage/package.nix
@@ -12,12 +12,22 @@
 let
   inherit (pkgs) symlinkJoin callPackage mathjax;
 
+  isDarwinAarch64 = pkgs.stdenv.hostPlatform.isDarwin && pkgs.stdenv.hostPlatform.isAarch64;
+
+  ntl = if (!isDarwinAarch64) then pkgs.ntl else pkgs.ntl.overrideAttrs (old: {
+    configureFlags = (old.configureFlags or [ ]) ++ [
+      "NTL_THREADS=off"
+      "NTL_THREAD_BOOST=off"
+    ];
+  });
+
   python3 = pkgs.python3 // {
     pkgs = pkgs.python3.pkgs.overrideScope (
       self: super: {
         # `sagelib`, i.e. all of sage except some wrappers and runtime dependencies
         sagelib = self.callPackage ./sagelib.nix {
           inherit flint;
+          inherit ntl;
           inherit sage-src env-locations singular;
           inherit (maxima) lisp-compiler;
           linbox = pkgs.linbox;
@@ -80,6 +90,7 @@ let
       singular
       palp
       flint
+      ntl
       pythonEnv
       maxima
       ;
@@ -94,6 +105,7 @@ let
   # sagelib with added wrappers and a dependency on sage-tests to make sure thet tests were run.
   sage-with-env = callPackage ./sage-with-env.nix {
     inherit python3 pythonEnv;
+    inherit ntl;
     inherit sage-env;
     inherit singular maxima;
     inherit three;

--- a/pkgs/by-name/sa/sage/sage-env.nix
+++ b/pkgs/by-name/sa/sage/sage-env.nix
@@ -100,6 +100,8 @@ let
       less # needed to prevent transient test errors until https://github.com/ipython/ipython/pull/11864 is resolved
     ]
   );
+
+  isDarwinAarch64 = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64;
 in
 writeTextFile rec {
   name = "sage-env";
@@ -179,12 +181,14 @@ writeTextFile rec {
 
     # for find_library
     export DYLD_LIBRARY_PATH="${
-      lib.makeLibraryPath [
+      lib.makeLibraryPath ([
         stdenv.cc.libc
         singular
         giac
         gap
-      ]
+      ] ++ lib.optionals isDarwinAarch64 [
+        maxima.lisp-compiler
+      ])
     }''${DYLD_LIBRARY_PATH:+:}$DYLD_LIBRARY_PATH"
   '';
 }

--- a/pkgs/by-name/sa/sage/sagelib.nix
+++ b/pkgs/by-name/sa/sage/sagelib.nix
@@ -19,6 +19,7 @@
   brial,
   cliquer,
   eclib,
+  eclibEnabled ? !(stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64),
   ecm,
   fflas-ffpack,
   flint,
@@ -115,7 +116,10 @@ buildPythonPackage rec {
     libpng
   ];
 
-  mesonFlags = [ "-Dbuild-docs=false" ];
+  mesonFlags = [ "-Dbuild-docs=false" ]
+               ++ lib.optional (!eclibEnabled) [
+                 "-Declib=disabled"
+               ];
 
   env = lib.optionalAttrs stdenv.cc.isClang {
     # code tries to assign a unsigned long to an int in an initialized list
@@ -130,7 +134,6 @@ buildPythonPackage rec {
     boost
     brial
     cliquer
-    eclib
     ecm
     fflas-ffpack
     flint
@@ -195,6 +198,8 @@ buildPythonPackage rec {
     sphinx
     sympy
     typing-extensions
+  ] ++ lib.optional eclibEnabled [
+    eclib
   ];
 
   preBuild = ''

--- a/pkgs/by-name/si/singular/package.nix
+++ b/pkgs/by-name/si/singular/package.nix
@@ -72,7 +72,15 @@ stdenv.mkDerivation rec {
     # ld: file not found: @rpath/libquadmath.0.dylib
     substituteInPlace m4/p-procs.m4 \
       --replace-fail "-flat_namespace" ""
-
+  ''
+  + lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) ''
+    # In xalloc fallback mode libSingular must record a real dependency on
+    # libomalloc instead of relying on unresolved flat-namespace lookups.
+    substituteInPlace Singular/Makefile.am \
+      --replace-fail 'libSingular_la_LDFLAGS    =$(SINGULAR_LDFLAGS) ''${USEPPROCSDYNAMICLDFLAGS} ''${USEPPROCSDYNAMICLD} -release ''${PACKAGE_VERSION} $(CCLUSTER_LIBS) ''${PTHREAD_LDFLAGS}' 'libSingular_la_LDFLAGS    =$(SINGULAR_LDFLAGS) -release ''${PACKAGE_VERSION} $(CCLUSTER_LIBS) ''${PTHREAD_LDFLAGS}' \
+      --replace-fail 'libSingular_la_LIBADD     =''${USEPPROCSDYNAMICLDFLAGS} ''${USEPPROCSDYNAMICLD} ''${BUILTIN_FLAGS} ''${top_builddir}/kernel/libkernel.la ''${PTHREAD_LIBS}' 'libSingular_la_LIBADD     =''${BUILTIN_FLAGS} ''${top_builddir}/kernel/libkernel.la ''${OMALLOC_LIBS} ''${PTHREAD_LIBS}'
+  ''
+  + ''
     patchShebangs .
   '';
 
@@ -141,7 +149,7 @@ stdenv.mkDerivation rec {
     make install
   ''
   + lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) ''
-    install -Dm644 ${src}/omalloc/xalloc.h $out/include/omalloc/xalloc.h
+    install -Dm644 omalloc/xalloc.h $out/include/omalloc/xalloc.h
   ''
   + lib.optionalString enableDocs ''
     # Sage uses singular.info, which is not installed by default

--- a/pkgs/by-name/si/singular/package.nix
+++ b/pkgs/by-name/si/singular/package.nix
@@ -140,6 +140,9 @@ stdenv.mkDerivation rec {
     rm /tmp/conic.log /tmp/conic.tex /tmp/tropicalcurve*.tex || true
     make install
   ''
+  + lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) ''
+    install -Dm644 ${src}/omalloc/xalloc.h $out/include/omalloc/xalloc.h
+  ''
   + lib.optionalString enableDocs ''
     # Sage uses singular.info, which is not installed by default
     mkdir -p $out/share/info


### PR DESCRIPTION
These changes make `sage` usable on Apple M-series silicon (darwin+aarch64).

- patches for the `singular` dependency that has issues with omalloc on this platform; omalloc was already disabled before the change but was not correctly propagating headers and linking dependent libraries.  

- ntl does not build correctly with threading; threading disabled specifically for ntl used as a sage dependency

- libecl added to DYLD_LIBRARY_PATH so sage can start and find when solving simple equations

- eclib disabled for now; it would be better to investigate why it fails to build

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
