### PR TITLE
yams: modern refactor + adopt by acidbong

### DIFF
--- a/pkgs/by-name/ya/yams/package.nix
+++ b/pkgs/by-name/ya/yams/package.nix
@@ -13,8 +13,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
   src = fetchFromGitHub {
     owner = "Berulacks";
     repo = "yams";
-    rev = finalAttrs.version;
-    sha256 = "1zkhcys9i0s6jkaz24an690rvnkv1r84jxpaa84sf46abi59ijh8";
+    tag = finalAttrs.version;
+    hash = "sha256-CMqYSlzKEKcJUup2SVAOe9qdQTJWEfHVlEaDmLRncP4=";
   };
 
   build-system = with python3Packages; [ setuptools ];

--- a/pkgs/by-name/ya/yams/package.nix
+++ b/pkgs/by-name/ya/yams/package.nix
@@ -33,6 +33,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
     description = "Last.FM scrobbler for MPD";
     mainProgram = "yams";
     license = lib.licenses.gpl3Only;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [
+      acidbong
+    ];
   };
 })

--- a/pkgs/by-name/ya/yams/package.nix
+++ b/pkgs/by-name/ya/yams/package.nix
@@ -4,7 +4,7 @@
   python3Packages,
 }:
 
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "yams";
   # nixpkgs-update: no auto update
   version = "0.7.3";
@@ -13,7 +13,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "Berulacks";
     repo = "yams";
-    rev = version;
+    rev = finalAttrs.version;
     sha256 = "1zkhcys9i0s6jkaz24an690rvnkv1r84jxpaa84sf46abi59ijh8";
   };
 
@@ -37,4 +37,4 @@ python3Packages.buildPythonApplication rec {
     license = lib.licenses.gpl3Only;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/by-name/ya/yams/package.nix
+++ b/pkgs/by-name/ya/yams/package.nix
@@ -26,8 +26,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
     requests
   ];
 
-  doCheck = false;
-
   pythonImportsCheck = [ "yams.scrobble" ];
 
   meta = {

--- a/pkgs/by-name/ya/yams/package.nix
+++ b/pkgs/by-name/ya/yams/package.nix
@@ -4,7 +4,7 @@
   python3Packages,
 }:
 
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonApplication rec {
   pname = "yams";
   # nixpkgs-update: no auto update
   version = "0.7.3";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
