### PR TITLE
maintainers: drop ccellado

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4719,12 +4719,6 @@
     githubId = 52760912;
     name = "Cameron Brown";
   };
-  ccellado = {
-    email = "annplague@gmail.com";
-    github = "ccellado";
-    githubId = 44584960;
-    name = "Denis Khalmatov";
-  };
   ccicnce113424 = {
     email = "ccicnce113424@gmail.com";
     matrix = "@ccicnce113424:matrix.org";

--- a/pkgs/by-name/gl/glpaper/package.nix
+++ b/pkgs/by-name/gl/glpaper/package.nix
@@ -42,6 +42,6 @@ stdenv.mkDerivation {
     homepage = "https://hg.sr.ht/~scoopta/glpaper";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ ccellado ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ya/yams/package.nix
+++ b/pkgs/by-name/ya/yams/package.nix
@@ -35,6 +35,6 @@ python3Packages.buildPythonPackage rec {
     description = "Last.FM scrobbler for MPD";
     mainProgram = "yams";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ ccellado ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pyvips/default.nix
+++ b/pkgs/development/python-modules/pyvips/default.nix
@@ -72,7 +72,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/libvips/pyvips/blob/v${version}/CHANGELOG.rst";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      ccellado
       anthonyroussel
     ];
   };


### PR DESCRIPTION

- Hasn't commented since [late 2023](https://github.com/NixOS/nixpkgs/issues?q=commenter:ccellado),
- hasn't opened any tickets themselves since [early 2024](https://github.com/NixOS/nixpkgs/issues?q=author:ccellado)
- was requested a lot [without reaction](https://github.com/NixOS/nixpkgs/issues?q=is:pr+involves:ccellado+-commenter:ccellado+-author:ccellado+-reviewed-by:ccellado),

all of which are longer than the 3 months, specified in the [maintainer README](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status), which makes them eligible for removal from Nixpkgs.

Colby, you have a week (until 6:00 UTC, Jul 19) to object and show us your intent to continue maintenance. Even if you don't make it, you're still welcome back.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
