### PR TITLE
maintainers: remove diniamo

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7036,12 +7036,6 @@
     github = "DimitarNestorov";
     githubId = 8790386;
   };
-  diniamo = {
-    name = "diniamo";
-    email = "diniamo53@gmail.com";
-    github = "diniamo";
-    githubId = 55629891;
-  };
   diogomdp = {
     email = "me@diogodp.dev";
     github = "diogomdp";

--- a/nixos/modules/services/misc/shoko.nix
+++ b/nixos/modules/services/misc/shoko.nix
@@ -90,8 +90,5 @@ in
     };
   };
 
-  meta.maintainers = with lib.maintainers; [
-    diniamo
-    nanoyaki
-  ];
+  meta.maintainers = with lib.maintainers; [ nanoyaki ];
 }

--- a/nixos/tests/shoko.nix
+++ b/nixos/tests/shoko.nix
@@ -17,10 +17,7 @@
         machine.succeed("curl --fail http://localhost:8111")
       '';
 
-      meta.maintainers = with lib.maintainers; [
-        diniamo
-        nanoyaki
-      ];
+      meta.maintainers = with lib.maintainers; [ nanoyaki ];
     }
   );
 

--- a/pkgs/by-name/an/ananicy-cpp/package.nix
+++ b/pkgs/by-name/an/ananicy-cpp/package.nix
@@ -85,7 +85,6 @@ clangStdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       artturin
       johnrtitor
-      diniamo
     ];
     mainProgram = "ananicy-cpp";
   };

--- a/pkgs/by-name/an/ani-cli/package.nix
+++ b/pkgs/by-name/an/ani-cli/package.nix
@@ -66,10 +66,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://github.com/pystardust/ani-cli";
     description = "Cli tool to browse and play anime";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [
-      skykanin
-      diniamo
-    ];
+    maintainers = with lib.maintainers; [ skykanin ];
     platforms = lib.platforms.unix;
     mainProgram = "ani-cli";
     sourceProvenance = with lib.sourceTypes; [

--- a/pkgs/by-name/an/ani-skip/package.nix
+++ b/pkgs/by-name/an/ani-skip/package.nix
@@ -49,7 +49,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Automated solution to bypassing anime opening and ending sequences";
     mainProgram = "ani-skip";
     license = lib.licenses.gpl3;
-    maintainers = [ lib.maintainers.diniamo ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/od/odin/package.nix
+++ b/pkgs/by-name/od/odin/package.nix
@@ -97,7 +97,6 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       astavie
       atomicptr
-      diniamo
     ];
     platforms = lib.platforms.unix;
     broken = stdenv.hostPlatform.isMusl;

--- a/pkgs/by-name/ra/raylib/package.nix
+++ b/pkgs/by-name/ra/raylib/package.nix
@@ -88,7 +88,7 @@ lib.checkListOfEnum "raylib: platform"
         homepage = "https://www.raylib.com/";
         downloadPage = "https://github.com/raysan5/raylib";
         license = lib.licenses.zlib;
-        maintainers = [ lib.maintainers.diniamo ];
+        maintainers = [ ];
         teams = [ lib.teams.ngi ];
         platforms = lib.platforms.all;
         changelog = "https://github.com/raysan5/raylib/blob/${finalAttrs.src.rev}/CHANGELOG";

--- a/pkgs/by-name/sh/shoko-webui/package.nix
+++ b/pkgs/by-name/sh/shoko-webui/package.nix
@@ -64,10 +64,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ShokoAnime/Shoko-WebUI";
     changelog = "https://github.com/ShokoAnime/Shoko-WebUI/releases/tag/v${finalAttrs.version}";
     description = "Web-based frontend for the Shoko anime management system";
-    maintainers = with lib.maintainers; [
-      diniamo
-      nanoyaki
-    ];
+    maintainers = with lib.maintainers; [ nanoyaki ];
     inherit (shoko.meta) license platforms;
   };
 })

--- a/pkgs/by-name/sh/shoko/package.nix
+++ b/pkgs/by-name/sh/shoko/package.nix
@@ -55,10 +55,7 @@ buildDotnetModule (finalAttrs: {
     description = "Backend for the Shoko anime management system";
     license = lib.licenses.mit;
     mainProgram = "Shoko.CLI";
-    maintainers = with lib.maintainers; [
-      diniamo
-      nanoyaki
-    ];
+    maintainers = with lib.maintainers; [ nanoyaki ];
     inherit (dotnet-sdk_8.meta) platforms;
   };
 })

--- a/pkgs/by-name/um/umu-launcher-unwrapped/package.nix
+++ b/pkgs/by-name/um/umu-launcher-unwrapped/package.nix
@@ -99,7 +99,6 @@ python3Packages.buildPythonPackage rec {
     license = lib.licenses.gpl3;
     mainProgram = "umu-run";
     maintainers = with lib.maintainers; [
-      diniamo
       MattSturgeon
       fuzen
     ];


### PR DESCRIPTION
I left NixOS a while ago, and it seems like this choice was final, so I'm withdrawing my nixpkgs maintainer status as well. Thank you to all the maintainers who will take my place.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
