### PR TITLE
autopush-rs.services.{autoconnect,authoendpoint}: rename package attribute

### DIFF
--- a/pkgs/by-name/au/autopush-rs/package.nix
+++ b/pkgs/by-name/au/autopush-rs/package.nix
@@ -106,13 +106,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
       imports = [
         (lib.modules.importApply ./service-autoconnect.nix { inherit pkgs; })
       ];
-      package = finalAttrs.finalPackage.out;
+      autoconnect.package = finalAttrs.finalPackage;
     };
     services.autoendpoint = {
       imports = [
         (lib.modules.importApply ./service-autoendpoint.nix { inherit pkgs; })
       ];
-      package = finalAttrs.finalPackage.out;
+      autoendpoint.package = finalAttrs.finalPackage;
     };
 
     updateScript = nix-update-script { };

--- a/pkgs/by-name/au/autopush-rs/service-autoconnect.nix
+++ b/pkgs/by-name/au/autopush-rs/service-autoconnect.nix
@@ -15,21 +15,23 @@ in
 {
   _class = "service";
   options = {
-    package = lib.mkPackageOption pkgs "autopush-rs.out" { };
-    autoconnect.settings = lib.mkOption {
-      type = lib.types.submodule {
-        freeformType = tomlFmt.type;
-        options = {
-          db_dsn = lib.mkOption {
-            description = "Endpoint of the database server.";
-            type = lib.types.str;
-            default = "";
-            example = lib.literalExpression "redis+socket://\${config.services.redis.servers.autopush-rs.port}";
+    autoconnect = {
+      package = lib.mkPackageOption pkgs "autopush-rs" { };
+      settings = lib.mkOption {
+        type = lib.types.submodule {
+          freeformType = tomlFmt.type;
+          options = {
+            db_dsn = lib.mkOption {
+              description = "Endpoint of the database server.";
+              type = lib.types.str;
+              default = "";
+              example = lib.literalExpression "redis+socket://\${config.services.redis.servers.autopush-rs.port}";
+            };
           };
         };
+        default = { };
+        description = "";
       };
-      default = { };
-      description = "";
     };
   };
   config =
@@ -38,7 +40,7 @@ in
     in
     {
       process.argv = [
-        "${config.package}/bin/autoconnect"
+        "${cfg.package}/bin/autoconnect"
         "-c"
         (toString configFile)
       ];

--- a/pkgs/by-name/au/autopush-rs/service-autoendpoint.nix
+++ b/pkgs/by-name/au/autopush-rs/service-autoendpoint.nix
@@ -15,8 +15,8 @@ in
 {
   _class = "service";
   options = {
-    package = lib.mkPackageOption pkgs "autopush-rs.out" { };
     autoendpoint = {
+      package = lib.mkPackageOption pkgs "autopush-rs" { };
       settings = lib.mkOption {
         type = lib.types.submodule {
           freeformType = tomlFmt.type;
@@ -40,7 +40,7 @@ in
     in
     {
       process.argv = [
-        "${config.package}/bin/autoendpoint"
+        "${cfg.package}/bin/autoendpoint"
         "-c"
         (toString configFile)
       ];


### PR DESCRIPTION
Context in https://github.com/NixOS/nixpkgs/pull/520214#discussion_r3551632870

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
