### PR TITLE
ov: 0.51.1 -> 0.54.0, adopt

### DIFF
--- a/pkgs/by-name/ov/ov/package.nix
+++ b/pkgs/by-name/ov/ov/package.nix
@@ -6,26 +6,27 @@
   installShellFiles,
   pandoc,
   makeWrapper,
-  testers,
-  ov,
+  nix-update-script,
+  versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "ov";
-  version = "0.51.1";
+  version = "0.54.0";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "noborus";
     repo = "ov";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Wt7XF1/l5WwdlrnFLyJPYoXyaWhE+uF1RAN68iol3qM=";
+    hash = "sha256-cIjtu4T9It+u/ZVC+XoUacvnYw51QSnbTNge1QaHr0s=";
   };
 
-  vendorHash = "sha256-rfUE38Wfo29s9GRsg/F/FCIto9yikE4b9QwLxYjvSg8=";
+  vendorHash = "sha256-eQh/S2isNvT9l+A4uK+/APcw+krsFL54OD5E6yEduxU=";
 
   ldflags = [
     "-s"
-    "-w"
     "-X=main.Version=v${finalAttrs.version}"
     "-X=main.Revision=${finalAttrs.src.rev}"
   ];
@@ -61,11 +62,13 @@ buildGoModule (finalAttrs: {
       cp $src/ov.yaml $doc/share/$name/sample-config.yaml
     '';
 
-  passthru.tests = {
-    version = testers.testVersion {
-      package = ov;
-      version = "v${finalAttrs.version}";
-    };
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/by-name/ov/ov/package.nix
+++ b/pkgs/by-name/ov/ov/package.nix
@@ -76,7 +76,7 @@ buildGoModule (finalAttrs: {
     homepage = "https://noborus.github.io/ov";
     changelog = "https://github.com/noborus/ov/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ Holiu618 ];
     mainProgram = "ov";
   };
 })


### PR DESCRIPTION
ov: 0.51.1 -> 0.54.0, adopt
Diff: https://github.com/noborus/ov/compare/v0.51.0...v0.54.0
Changelog: https://github.com/noborus/ov/releases/tag/v0.54.0


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
