### PR TITLE
nixos/matrix-authentication-service: use env var instead of %d

### DIFF
--- a/nixos/modules/services/matrix/matrix-authentication-service.nix
+++ b/nixos/modules/services/matrix/matrix-authentication-service.nix
@@ -45,7 +45,9 @@ let
       pruned;
   configFile = format.generate "config.yaml" finalSettings;
 
-  extraConfigFiles = lib.imap0 (i: _: "%d/config-${toString i}") cfg.extraConfigFiles;
+  extraConfigFiles = lib.imap0 (
+    i: _: "\${CREDENTIALS_DIRECTORY}/config-${toString i}"
+  ) cfg.extraConfigFiles;
   runtimeConfig = "/run/matrix-authentication-service/config.yaml";
 in
 {

--- a/nixos/tests/matrix/matrix-authentication-service.nix
+++ b/nixos/tests/matrix/matrix-authentication-service.nix
@@ -189,11 +189,26 @@ in
       { nodes, ... }:
       let
         bundle = mkBundle masDomain;
+
+        extraConfig = pkgs.writeText "masExtraConfig.yml" (
+          builtins.toJSON {
+            secrets = {
+              encryption_file = "/var/lib/matrix-authentication-service/encryption";
+              keys = [
+                {
+                  kid = "rsa-4096";
+                  key_file = "/var/lib/matrix-authentication-service/key_rsa_4096";
+                }
+              ];
+            };
+          }
+        );
       in
       {
         services.matrix-authentication-service = {
           enable = true;
           createDatabase = true;
+          extraConfigFiles = [ (toString extraConfig) ];
           settings = {
             http = {
               public_base = "https://${masDomain}:8080/";
@@ -223,15 +238,7 @@ in
               secret_file = "/var/lib/matrix-authentication-service/matrix_secret";
             };
             database.uri = "postgresql:///matrix-authentication-service?host=/run/postgresql&user=matrix-authentication-service";
-            secrets = {
-              encryption_file = "/var/lib/matrix-authentication-service/encryption";
-              keys = [
-                {
-                  kid = "rsa-4096";
-                  key_file = "/var/lib/matrix-authentication-service/key_rsa_4096";
-                }
-              ];
-            };
+            # secrets is defined in extraConfigFiles
             policy.data.client_registration.allow_insecure_uris = true;
             upstream_oauth2.providers = [
               {


### PR DESCRIPTION
Followup of #540397.

%d works in the context of the ExecStart command, since it's expanded by systemd.

However, extraConfigFiles is also used in the ExecStartPre *script*, and bash does not know what %d is, so it's not expanded and the MAS config check fails because it can't find "%d/config-0" (instead of the intended "/run/credentials/...")

This commit is currently running on my server (which uses extraConfigFiles!) and rebased on last night's nixos-unstable.

Note: despite looking like it, this isn't a revert; I added brackets around `CREDENTIALS_DIRECTORY` so that it only treats that as the variable name, and not `CREDENTIALS_DIRECTORY/config-0`

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
