### PR TITLE
nixos/dendrite: add package option

### DIFF
--- a/nixos/modules/services/matrix/dendrite.nix
+++ b/nixos/modules/services/matrix/dendrite.nix
@@ -13,6 +13,7 @@ in
 {
   options.services.dendrite = {
     enable = lib.mkEnableOption "matrix.org dendrite";
+    package = lib.mkPackageOption pkgs "dendrite" { };
     httpPort = lib.mkOption {
       type = lib.types.nullOr lib.types.port;
       default = 8008;
@@ -321,7 +322,7 @@ in
         ];
         ExecStart = lib.strings.concatStringsSep " " (
           [
-            "${pkgs.dendrite}/bin/dendrite"
+            (lib.getExe cfg.package)
             "--config /run/dendrite/dendrite.yaml"
           ]
           ++ lib.optionals (cfg.httpPort != null) [

--- a/pkgs/by-name/de/dendrite/package.nix
+++ b/pkgs/by-name/de/dendrite/package.nix
@@ -67,6 +67,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     homepage = "https://element-hq.github.io/dendrite";
+    mainProgram = "dendrite";
     description = "Second-generation Matrix homeserver written in Go";
     changelog = "https://github.com/element-hq/dendrite/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.agpl3Plus;


### PR DESCRIPTION
the "official" dendrite has been on maintenance mode for a while now,  but there are active forks out there  https://codefloe.com/pat-s/zendrite.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
