### PR TITLE
python3Packages.parsnip: fix Numpy 2.5 error

### DIFF
--- a/pkgs/development/python-modules/parsnip/default.nix
+++ b/pkgs/development/python-modules/parsnip/default.nix
@@ -14,6 +14,7 @@
   # tests
   ase,
   gemmi,
+  gsd,
   pycifrw,
   pytest-doctestplus,
   pytestCheckHook,
@@ -22,7 +23,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "parsnip";
-  version = "0.6.0";
+  version = "1.0.0";
   pyproject = true;
 
   __structuredAttrs = true;
@@ -31,7 +32,7 @@ buildPythonPackage (finalAttrs: {
     owner = "glotzerlab";
     repo = "parsnip";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-A1YoTBRN3ukcueUso5P2zPZ/pxu25k9h6aI7+AQvr1Q=";
+    hash = "sha256-27FEp+Z+Q4a2RR01YVmN7eUClpto8uUysp5mZWeKz7M=";
   };
 
   patches = [
@@ -58,6 +59,7 @@ buildPythonPackage (finalAttrs: {
   nativeCheckInputs = [
     ase
     gemmi
+    gsd
     pycifrw
     pytest-doctestplus
     pytestCheckHook

--- a/pkgs/development/python-modules/parsnip/default.nix
+++ b/pkgs/development/python-modules/parsnip/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
 
   # build-system
   setuptools,
@@ -32,6 +33,18 @@ buildPythonPackage (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-A1YoTBRN3ukcueUso5P2zPZ/pxu25k9h6aI7+AQvr1Q=";
   };
+
+  patches = [
+    # Numpy 2.5 compatibility, see: https://github.com/glotzerlab/parsnip/pull/245
+    (fetchpatch {
+      url = "https://github.com/glotzerlab/parsnip/commit/41a6bd6e42ea212203d5ce5864c687927b834586.patch";
+      includes = [
+        # Other files are changelog & credits
+        "parsnip/parsnip.py"
+      ];
+      hash = "sha256-Y91fITsPkmcct2tDsaHtNB8ct41IMtw1A+QnRwChc7k=";
+    })
+  ];
 
   build-system = [
     setuptools

--- a/pkgs/development/python-modules/parsnip/default.nix
+++ b/pkgs/development/python-modules/parsnip/default.nix
@@ -2,9 +2,15 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
   setuptools,
+
+  # dependencies
   more-itertools,
   numpy,
+
+  # tests
   ase,
   gemmi,
   pycifrw,


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test