### PR TITLE
tork: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17975,6 +17975,12 @@
     githubId = 101197249;
     name = "Tim";
   };
+  melqtx = {
+    email = "melqtx@proton.me";
+    github = "melqtx";
+    githubId = 105978905;
+    name = "melqtx";
+  };
   melsigl = {
     email = "melanie.bianca.sigl@gmail.com";
     github = "melsigl";

--- a/pkgs/by-name/to/tork/package.nix
+++ b/pkgs/by-name/to/tork/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "tork";
+  version = "0.2.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "melqtx";
+    repo = "tork";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Z6F9r/Hfi4zsi0VH9Z7dEn1nA8B+aVKYqiq72J4m5BU=";
+  };
+
+  vendorHash = "sha256-Vk3lmPUDvuhOzha8GlH0anRLgVhhyFjz9y328T2gycs=";
+
+  subPackages = [ "cmd/tork" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  # Nix builds with HOME=/homeless-shelter. A few integration-style tests create
+  # an isolated tork config, which derives its default download directory from
+  # HOME, so give the check phase a writable private home instead.
+  preCheck = ''
+    export HOME="$TMPDIR/home"
+    mkdir -p "$HOME"
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Terminal torrent search and download client";
+    homepage = "https://github.com/melqtx/tork";
+    changelog = "https://github.com/melqtx/tork/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ melqtx ];
+    mainProgram = "tork";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Adds [tork](https://github.com/melqtx/tork), a terminal torrent search and download client.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].