### PR TITLE
hunk: init at v0.17.0

### DIFF
--- a/pkgs/by-name/hu/hunk/package.nix
+++ b/pkgs/by-name/hu/hunk/package.nix
@@ -1,0 +1,152 @@
+{
+  lib,
+  stdenv,
+  bun,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+
+let
+  pname = "hunk";
+  version = "0.17.0";
+
+  src = fetchFromGitHub {
+    owner = "modem-dev";
+    repo = "hunk";
+    tag = "v${version}";
+    hash = "sha256-FlwCtcu2JRECyKC1balItY/DmQyb+obh+97wo7+06DU=";
+  };
+
+  node_modules = stdenv.mkDerivation {
+    pname = "${pname}-node_modules";
+    inherit version src;
+
+    nativeBuildInputs = [
+      bun
+      writableTmpDirAsHomeHook
+    ];
+
+    dontConfigure = true;
+
+    buildPhase = ''
+      runHook preBuild
+
+      export BUN_INSTALL_CACHE_DIR=$(mktemp -d)
+      bun install \
+        --cpu="*" \
+        --frozen-lockfile \
+        --ignore-scripts \
+        --no-progress \
+        --os="*"
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      cp -R node_modules $out
+      find packages -type d -name node_modules -exec cp -R --parents {} $out \;
+
+      runHook postInstall
+    '';
+
+    dontFixup = true;
+
+    outputHash = "sha256-LkOAWScuNPx9/KOcG110ngLz0QmB4/S3VxIAb3EIH7I=";
+    outputHashMode = "recursive";
+  };
+in
+stdenv.mkDerivation {
+  inherit pname version src;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    bun
+    writableTmpDirAsHomeHook
+  ];
+
+  configurePhase = ''
+    runHook preConfigure
+
+    cp -R ${node_modules}/. .
+    chmod -R u+w node_modules
+    find packages -type d -name node_modules -exec chmod -R u+w {} \;
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    mkdir -p .bun-tmp .bun-install
+    BUN_TMPDIR=$PWD/.bun-tmp \
+    BUN_INSTALL=$PWD/.bun-install \
+      bun build --compile \
+        --no-compile-autoload-bunfig \
+        --no-compile-autoload-dotenv \
+        src/main.tsx \
+        --outfile hunk
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 hunk $out/bin/hunk
+    mkdir -p $out/share/hunk
+    cp -R skills $out/share/hunk/skills
+    ln -s share/hunk/skills $out/skills
+
+    runHook postInstall
+  '';
+
+  dontFixup = true;
+  dontStrip = true;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  versionCheckProgramArg = "--version";
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    $out/bin/hunk --version | grep -F ${version}
+    test -f "$($out/bin/hunk skill path)"
+
+    runHook postInstallCheck
+  '';
+
+  passthru = {
+    inherit node_modules;
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--subpackage"
+        "node_modules"
+      ];
+    };
+  };
+
+  meta = {
+    description = "Terminal diff viewer for agentic changesets";
+    homepage = "https://github.com/modem-dev/hunk";
+    changelog = "https://github.com/modem-dev/hunk/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    mainProgram = "hunk";
+    maintainers = with lib.maintainers; [
+      MarkusZoppelt
+      kaynetik
+    ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
+  };
+}


### PR DESCRIPTION
Initialises https://github.com/modem-dev/hunk

This PR inherits what was done in [this PR](https://github.com/NixOS/nixpkgs/pull/517626) and bumps to the latest version. Meat of the changes were applied in the parent PR over the past 3 months, and Markus did everything that was requested - but for some reason it wasn't approved by a committer yet.

---

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
