### PR TITLE
ov: fix riscv64-linux build

### DIFF
--- a/pkgs/by-name/ov/ov/package.nix
+++ b/pkgs/by-name/ov/ov/package.nix
@@ -1,9 +1,11 @@
 {
   lib,
   stdenv,
+  buildPackages,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
+  buildDocs ? buildPackages.pandoc.compiler.bootstrapAvailable,
   pandoc,
   makeWrapper,
   testers,
@@ -34,14 +36,14 @@ buildGoModule (finalAttrs: {
 
   nativeBuildInputs = [
     installShellFiles
-    pandoc
     makeWrapper
-  ];
+  ]
+  ++ lib.optionals buildDocs [ pandoc ];
 
   outputs = [
     "out"
-    "doc"
-  ];
+  ]
+  ++ lib.optionals buildDocs [ "doc" ];
 
   postInstall =
     lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
@@ -55,6 +57,8 @@ buildGoModule (finalAttrs: {
       cp $src/ov-less.yaml $out/share/$name/less-config.yaml
       makeWrapper $out/bin/ov $out/bin/ov-less --add-flags "--config $out/share/$name/less-config.yaml"
 
+    ''
+    + lib.optionalString buildDocs ''
       mkdir -p $doc/share/doc/$name
       pandoc -s < $src/README.md > $doc/share/doc/$name/README.html
       mkdir -p $doc/share/$name


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] riscv64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
