### PR TITLE
amber-lsp: init at 0.3.0

### DIFF
--- a/pkgs/by-name/am/amber-lsp/package.nix
+++ b/pkgs/by-name/am/amber-lsp/package.nix
@@ -1,0 +1,44 @@
+{
+  fetchFromGitHub,
+  lib,
+  makeWrapper,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "amber-lsp";
+  version = "0.3.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "amber-lang";
+    repo = "amber-lsp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-d5FJGeQol6NPVCbZ8F97s6jiV/JrbVJMcXwro2hBJfI=";
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [ makeWrapper ];
+
+  cargoHash = "sha256-YSoNYjru/CWEYNqSkjCKFDps3XmmCRo4VaZ6n/7pI5A=";
+
+  # Each of the 380+ async tests spins up a tokio runtime which can exhaust
+  # memory if run in parallel on many cores.
+  checkFlags = [ "--test-threads=4" ];
+
+  postFixup = ''
+    # By default it wants to write to $out/amber-lsp-resources
+    wrapProgram $out/bin/amber-lsp \
+      --run '
+        export AMBER_LSP_RESOURCES_DIR="''${XDG_DATA_HOME:-$HOME/.local/share}/amber-lsp-resources"
+      '
+  '';
+
+  meta = {
+    description = "Amber's Language Server";
+    homepage = "https://github.com/amber-lang/amber-lsp";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "amber-lsp";
+    maintainers = with lib.maintainers; [ beeb ];
+  };
+})


### PR DESCRIPTION
Supersedes #447175 (abandoned it looks like)

This PR adds the [Amber language server](https://github.com/amber-lang/amber-lsp).

The [Amber compiler/runner](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/am/amber/package.nix) is already part of nixpkgs, it only makes sense to also provide the corresponding language server. The `AMBER_LSP_RESOURCES_DIR` config variable was [requested by me upstream](https://github.com/amber-lang/amber-lsp/issues/106) to enable nix packaging.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
