### PR TITLE
python3Packages.dpcontracts: fix tests in Python 3.14

### DIFF
--- a/pkgs/development/python-modules/dpcontracts/default.nix
+++ b/pkgs/development/python-modules/dpcontracts/default.nix
@@ -25,7 +25,8 @@ buildPythonPackage {
     substituteInPlace README.rst \
       --replace-fail " PreconditionError" " dpcontracts.PreconditionError" \
       --replace-fail " PostconditionError" " dpcontracts.PostconditionError" \
-      --replace-fail ">>> class Counter:" $'>>> from dpcontracts import preserve\n    >>> class Counter:'
+      --replace-fail ">>> class Counter:" $'>>> from dpcontracts import preserve\n    >>> class Counter:' \
+      --replace-fail "asyncio.get_event_loop().run_until_complete(" "asyncio.run("
   '';
 
   build-system = [


### PR DESCRIPTION
In Python 3.14, asyncio.get_event_loop().run_until_complete() fails when no event loop exists. Switching to asyncio.run() fixes this issue.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
