### PR TITLE
backrest.services.default: init

### DIFF
--- a/nixos/modules/misc/documentation/modular-services.nix
+++ b/nixos/modules/misc/documentation/modular-services.nix
@@ -23,6 +23,7 @@ let
         fakeSubmodule pkgs.autopush-rs.services.autoconnect;
       "<imports = [ pkgs.autopush-rs.services.autoendpoint ]>" =
         fakeSubmodule pkgs.autopush-rs.services.autoendpoint;
+      "<imports = [ pkgs.backrest.services.default ]>" = fakeSubmodule pkgs.backrest.services.default;
       "<imports = [ pkgs.ghostunnel.services.default ]>" = fakeSubmodule pkgs.ghostunnel.services.default;
       "<imports = [ pkgs.ktls-utils.services.default ]>" = fakeSubmodule pkgs.ktls-utils.services.default;
       "<imports = [ pkgs.php.services.default ]>" = fakeSubmodule pkgs.php.services.default;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -268,6 +268,7 @@ in
   ax25 = runTest ./ax25.nix;
   ayatana-indicators = runTest ./ayatana-indicators.nix;
   babeld = runTest ./babeld.nix;
+  backrest-modular = runTest ./backrest/modular-service.nix;
   bazarr = runTest ./bazarr.nix;
   bcache = runTestOn [ "x86_64-linux" "aarch64-linux" ] ./bcache.nix;
   bcachefs = runTestOn [ "x86_64-linux" "aarch64-linux" ] ./bcachefs.nix;

--- a/nixos/tests/backrest/config.json
+++ b/nixos/tests/backrest/config.json
@@ -1,0 +1,22 @@
+{
+    "version": 6,
+    "instance": "nixos-test",
+    "repos": [
+        {
+            "id": "local-repo",
+            "uri": "/var/lib/backrest/restic-repo",
+            "password": "testpass",
+            "prunePolicy": {},
+            "auto_initialize": true
+        }
+    ],
+    "plans": [
+        {
+            "id": "test-backup",
+            "repo": "local-repo",
+            "paths": [
+                "/srv/backup-source"
+            ]
+        }
+    ]
+}

--- a/nixos/tests/backrest/modular-service.nix
+++ b/nixos/tests/backrest/modular-service.nix
@@ -1,0 +1,42 @@
+{ lib, hostPkgs, ... }:
+{
+  _class = "nixosTest";
+  name = "backrest-modular";
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      system.services.backrest = {
+        imports = [ pkgs.backrest.services.default ];
+        backrest = {
+          address = "0.0.0.0";
+          configPath = "/var/lib/backrest/config.json";
+        };
+      };
+
+      systemd.services.backrest.preStart = ''
+        mkdir -p /var/lib/backrest
+        cp ${./config.json} /var/lib/backrest/config.json
+        chmod 644 /var/lib/backrest/config.json
+      '';
+      networking.firewall.allowedTCPPorts = [ 9898 ];
+    };
+
+  testScript = /* py */ ''
+    machine.succeed("mkdir -p /srv/backup-source")
+    machine.succeed("echo 'important backup data' > /srv/backup-source/data.txt")
+    machine.succeed("echo 'testpass' > /srv/restic-password")
+
+    machine.start_job("backrest.service")
+    machine.wait_for_unit("backrest.service")
+    machine.wait_for_open_port(9898)
+
+    machine.succeed("curl -fsS http://localhost:9898")
+
+    # Trigger a backup manually via the API and wait for it to complete
+    machine.succeed("curl -fsS -X POST -H 'Content-Type: application/json' -d '{\"value\": \"test-backup\"}' http://localhost:9898/v1.Backrest/Backup")
+
+    machine.succeed("${hostPkgs.restic}/bin/restic -r /var/lib/backrest/restic-repo --password-file /srv/restic-password ls latest | grep -q data.txt")
+  '';
+
+  meta.maintainers = with lib.maintainers; [ phanirithvij ];
+}

--- a/nixos/tests/backrest/modular-service.nix
+++ b/nixos/tests/backrest/modular-service.nix
@@ -24,6 +24,11 @@
   testScript = /* py */ ''
     machine.succeed("mkdir -p /srv/backup-source")
     machine.succeed("echo 'important backup data' > /srv/backup-source/data.txt")
+
+    machine.succeed("echo 'root owned data' > /srv/backup-source/root.txt")
+    machine.succeed("chown root:root /srv/backup-source/root.txt")
+    machine.succeed("chmod 600 /srv/backup-source/root.txt")
+
     machine.succeed("echo 'testpass' > /srv/restic-password")
 
     machine.start_job("backrest.service")
@@ -33,9 +38,11 @@
     machine.succeed("curl -fsS http://localhost:9898")
 
     # Trigger a backup manually via the API and wait for it to complete
-    machine.succeed("curl -fsS -X POST -H 'Content-Type: application/json' -d '{\"value\": \"test-backup\"}' http://localhost:9898/v1.Backrest/Backup")
+    machine.succeed("""curl -fsS -X POST -H 'Content-Type: application/json' -d '{"value": "test-backup"}' http://localhost:9898/v1.Backrest/Backup""")
 
-    machine.succeed("${hostPkgs.restic}/bin/restic -r /var/lib/backrest/restic-repo --password-file /srv/restic-password ls latest | grep -q data.txt")
+    restic_cmd = "${hostPkgs.restic}/bin/restic -r /var/lib/backrest/restic-repo --password-file /srv/restic-password"
+    machine.succeed(f"{restic_cmd} ls latest | grep -q data.txt")
+    machine.succeed(f"{restic_cmd} ls latest | grep -q root.txt")
   '';
 
   meta.maintainers = with lib.maintainers; [ phanirithvij ];

--- a/pkgs/by-name/ba/backrest/package.nix
+++ b/pkgs/by-name/ba/backrest/package.nix
@@ -17,6 +17,7 @@
   versionCheckHook,
   nix-update-script,
   _experimental-update-script-combinators,
+  nixosTests,
 }:
 let
   pnpm = pnpm_11;
@@ -194,6 +195,9 @@ buildGoModule (finalAttrs: {
       })
       ./update-inlang-plugins.sh
     ];
+    tests = {
+      inherit (nixosTests) backrest-modular;
+    };
     services.default = {
       imports = [ (lib.modules.importApply ./service.nix { }) ];
       backrest.package = finalAttrs.finalPackage;

--- a/pkgs/by-name/ba/backrest/package.nix
+++ b/pkgs/by-name/ba/backrest/package.nix
@@ -17,6 +17,8 @@
   versionCheckHook,
   nix-update-script,
   _experimental-update-script-combinators,
+  symlinkJoin,
+  bash,
   nixosTests,
 }:
 let
@@ -199,7 +201,11 @@ buildGoModule (finalAttrs: {
       inherit (nixosTests) backrest-modular;
     };
     services.default = {
-      imports = [ (lib.modules.importApply ./service.nix { }) ];
+      imports = [
+        (lib.modules.importApply ./service.nix {
+          inherit bash symlinkJoin makeBinaryWrapper;
+        })
+      ];
       backrest.package = finalAttrs.finalPackage;
     };
   };

--- a/pkgs/by-name/ba/backrest/package.nix
+++ b/pkgs/by-name/ba/backrest/package.nix
@@ -194,6 +194,10 @@ buildGoModule (finalAttrs: {
       })
       ./update-inlang-plugins.sh
     ];
+    services.default = {
+      imports = [ (lib.modules.importApply ./service.nix { }) ];
+      backrest.package = finalAttrs.finalPackage;
+    };
   };
 
   meta = {

--- a/pkgs/by-name/ba/backrest/service.nix
+++ b/pkgs/by-name/ba/backrest/service.nix
@@ -1,5 +1,9 @@
 # Non-module dependencies (`importApply`)
-{ }:
+{
+  bash,
+  symlinkJoin,
+  makeBinaryWrapper,
+}:
 
 # Service module
 {
@@ -11,10 +15,27 @@
 let
   inherit (lib)
     getExe
+    literalExpression
     mkOption
     types
     ;
   cfg = config.backrest;
+
+  backrestWrapped = symlinkJoin {
+    name = "backrest-wrapped";
+    paths = [ cfg.package ];
+    nativeBuildInputs = [ makeBinaryWrapper ];
+    postBuild = ''
+      wrapProgram $out/bin/backrest \
+        ${
+          lib.optionalString (cfg.extraPackages != [ ]) "--prefix PATH : ${lib.makeBinPath cfg.extraPackages}"
+        } \
+        --set-default BACKREST_PORT ${cfg.address}:${toString cfg.port} \
+        --set-default BACKREST_DATA ${cfg.dataDir} \
+        ${lib.optionalString (cfg.configPath != null) "--set-default BACKREST_CONFIG ${cfg.configPath}"}
+    '';
+    meta.mainProgram = "backrest";
+  };
 in
 {
   # https://nixos.org/manual/nixos/unstable/#modular-services
@@ -57,20 +78,19 @@ in
         type = types.listOf types.str;
         default = [ ];
       };
+
+      extraPackages = mkOption {
+        description = "Extra packages to add make available to backrest's PATH, useful for backrest hooks.";
+        type = types.listOf types.package;
+        defaultText = literalExpression "[ pkgs.bash ]"; # TODO: can I use pkgs in modular services?
+        default = [ bash ];
+      };
     };
   };
 
   config = {
     process.argv = [
-      (getExe cfg.package)
-      "-bind-address"
-      "${cfg.address}:${toString cfg.port}"
-      "-data-dir"
-      cfg.dataDir
-    ]
-    ++ lib.optionals (cfg.configPath != null) [
-      "-config-file"
-      cfg.configPath
+      (getExe backrestWrapped)
     ]
     ++ cfg.extraArgs;
   }

--- a/pkgs/by-name/ba/backrest/service.nix
+++ b/pkgs/by-name/ba/backrest/service.nix
@@ -84,6 +84,8 @@ in
         DynamicUser = true;
         StateDirectory = "backrest";
         Environment = "HOME=${cfg.dataDir}";
+        AmbientCapabilities = [ "CAP_DAC_READ_SEARCH" ];
+        CapabilityBoundingSet = [ "CAP_DAC_READ_SEARCH" ];
       };
     };
   };

--- a/pkgs/by-name/ba/backrest/service.nix
+++ b/pkgs/by-name/ba/backrest/service.nix
@@ -106,6 +106,30 @@ in
         Environment = "HOME=${cfg.dataDir}";
         AmbientCapabilities = [ "CAP_DAC_READ_SEARCH" ];
         CapabilityBoundingSet = [ "CAP_DAC_READ_SEARCH" ];
+        NoNewPrivileges = true;
+        LockPersonality = true;
+        UMask = "0077";
+        DevicePolicy = "closed";
+        ProtectKernelLogs = true;
+        SystemCallArchitectures = "native";
+        RestrictSUIDSGID = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+        SystemCallFilter = [
+          "~@reboot"
+          "~@swap"
+          "~@obsolete"
+          "~@mount"
+          "~@module"
+          "~@debug"
+          "~@cpu-emulation"
+          "~@clock"
+          "~@raw-io"
+          "~@privileged"
+          "~@resources"
+        ];
       };
     };
   };

--- a/pkgs/by-name/ba/backrest/service.nix
+++ b/pkgs/by-name/ba/backrest/service.nix
@@ -1,0 +1,92 @@
+# Non-module dependencies (`importApply`)
+{ }:
+
+# Service module
+{
+  lib,
+  config,
+  options,
+  ...
+}:
+let
+  inherit (lib)
+    getExe
+    mkOption
+    types
+    ;
+  cfg = config.backrest;
+in
+{
+  # https://nixos.org/manual/nixos/unstable/#modular-services
+  _class = "service";
+
+  options = {
+    backrest = {
+      package = mkOption {
+        description = "Package to use for backrest.";
+        defaultText = "The backrest package that provided this module.";
+        type = types.package;
+      };
+
+      address = mkOption {
+        description = "Address to listen on.";
+        type = types.str;
+        default = "127.0.0.1";
+      };
+
+      port = mkOption {
+        description = "Port to listen on.";
+        type = types.port;
+        default = 9898;
+      };
+
+      dataDir = mkOption {
+        description = "Directory for internal data.";
+        type = types.str;
+        default = "/var/lib/backrest";
+      };
+
+      configPath = mkOption {
+        description = "Path to config.json.";
+        type = types.nullOr types.str;
+        default = null;
+      };
+
+      extraArgs = mkOption {
+        description = "Extra arguments to pass to backrest.";
+        type = types.listOf types.str;
+        default = [ ];
+      };
+    };
+  };
+
+  config = {
+    process.argv = [
+      (getExe cfg.package)
+      "-bind-address"
+      "${cfg.address}:${toString cfg.port}"
+      "-data-dir"
+      cfg.dataDir
+    ]
+    ++ lib.optionals (cfg.configPath != null) [
+      "-config-file"
+      cfg.configPath
+    ]
+    ++ cfg.extraArgs;
+  }
+  // lib.optionalAttrs (options ? systemd) {
+    systemd.service = {
+      after = [ "network.target" ];
+      wants = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Restart = "always";
+        DynamicUser = true;
+        StateDirectory = "backrest";
+        Environment = "HOME=${cfg.dataDir}";
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ phanirithvij ];
+}


### PR DESCRIPTION
I have been using this with home-manager and nimi for a few months.

```nix
  imports = [
    flake-inputs.nimi.homeModules.default
  ];

  nimi.backrest = {
    services.backrest = {
      imports = [ pkgs.backrest.services.default ];
      backrest.dataDir = "${config.home.homeDirectory}/.local/share/backrest";
      backrest.configPath = "${config.home.homeDirectory}/.config/backrest/config.json";
    };
    settings.restart.mode = "up-to-count";
    settings.restart.time = 2000;
  };
```

There is an open PR which adds it for regular nixos module https://github.com/NixOS/nixpkgs/pull/422093, the pr is halted a bit, so I am opening this.

Currently I use `DyanmicUser = true;` and give the backrest service no capabilities, so it is not going to backup root or other user owned directories.
I will take some time to incorporate that PR's contributions into this and add @M0ustach3 as co author.

## TODO

- [x] `additionalPaths` from nixos module pr, now `extraPackages`
- [x] systemd hardening
- [x] basic nixos test
- [ ] other changes from nixos module pr
- [ ] more things noted in comments below
- [ ] home-manager module based on top of this modular service (in home-manager repo)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
