### PR TITLE
breakpad: fix build on musl and modernise

### DIFF
--- a/pkgs/by-name/br/breakpad/package.nix
+++ b/pkgs/by-name/br/breakpad/package.nix
@@ -13,8 +13,9 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "breakpad";
-
   version = "2024.02.16";
+
+  __structuredAttrs = true;
 
   src = fetchgit {
     url = "https://chromium.googlesource.com/breakpad/breakpad";
@@ -22,7 +23,13 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-yk+TSzjmAr9QMTYduKVe/Aizph/NNmSS385pvGJckiQ=";
   };
 
+  strictDeps = true;
+
+  enableParallelBuilding = true;
+
   buildInputs = [ zlib ];
+
+  configureFlags = lib.optionals stdenv.hostPlatform.isMusl [ "--disable-tools" ];
 
   postUnpack = ''
     ln -s ${lss} $sourceRoot/src/third_party/lss


### PR DESCRIPTION
Fixes the build for breakpad on musl (`pkgsMusl` and `pkgsStatic`) by disabling tools, so the `stab.h` header isn't attempted to be used

```
> src/common/stabs_reader.cc:41:10: fatal error: stab.h: No such file or directory
>    41 | #include <stab.h>
>       |          ^~~~~~~~
> compilation terminated.
```

Also modernises the derivation by adding `__structuredAttrs`, `strictDeps` and `enableParallelBuilding`. I saw a build time reduction from `1m 10s` to `13s` on my machine after adding the latter, which is a 5x improvement

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
