### PR TITLE
fdroidserver: 2.4.3 -> 2.4.5-unstable-2026-06-11, python3Packages.androguard: 4.1.3 -> 4.1.4, gradlew-fdroid: init at 0.0.1-unstable-2026-06-06

### DIFF
--- a/pkgs/by-name/di/diffoscope/androguard-4.1.4.patch
+++ b/pkgs/by-name/di/diffoscope/androguard-4.1.4.patch
@@ -1,0 +1,20 @@
+diff --git a/diffoscope/comparators/apk.py b/diffoscope/comparators/apk.py
+index 061fbbb0..ce49b835 100644
+--- a/diffoscope/comparators/apk.py
++++ b/diffoscope/comparators/apk.py
+@@ -335,7 +335,14 @@ def get_v2_signing_keys(path):
+         return "\n".join(textwrap.wrap(binascii.hexlify(x).decode("utf-8")))
+
+     output = []
+-    for k, v in sorted(instance._v2_blocks.items()):
++    blocks = instance._v2_blocks
++    if isinstance(blocks, dict):
++        blocks = blocks.items()
++    else:
++        # androguard >= 4.1.4 preserves blocks with duplicate IDs in a list.
++        blocks = ((block.id, block.data) for block in blocks)
++
++    for k, v in sorted(blocks):
+         output.append("Key {}:\n{}\n".format(hex(k), format_key(v)))
+
+     return "\n".join(output)

--- a/pkgs/by-name/di/diffoscope/package.nix
+++ b/pkgs/by-name/di/diffoscope/package.nix
@@ -126,6 +126,7 @@ python.pkgs.buildPythonApplication rec {
   ];
 
   patches = [
+    ./androguard-4.1.4.patch
     ./ignore_links.patch
   ];
 

--- a/pkgs/by-name/fd/fdroidserver/package.nix
+++ b/pkgs/by-name/fd/fdroidserver/package.nix
@@ -1,32 +1,43 @@
 {
   lib,
+  stdenv,
   fetchFromGitLab,
   python3Packages,
   fetchPypi,
   apksigner,
+  gradlew-fdroid,
   installShellFiles,
+  withLibvirt ? false,
 }:
 
-python3Packages.buildPythonApplication (finalAttrs: {
+let
+  pythonPackages = python3Packages.overrideScope (
+    _final: prev: {
+      # Match Debian Trixie's version because ruamel.yaml output changes can break
+      # `fdroid rewritemeta`.
+      ruamel-yaml = prev.ruamel-yaml.overridePythonAttrs {
+        version = "0.18.10";
+        src = fetchPypi {
+          pname = "ruamel.yaml";
+          version = "0.18.10";
+          hash = "sha256-IMhqsprCFT+ApCjhJUqK32htM4PfBEkFFMo7eaNi21g=";
+        };
+      };
+    }
+  );
+in
+pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "fdroidserver";
-  version = "2.4.5";
+  version = "2.4.5-unstable-2026-06-11";
 
   pyproject = true;
 
   src = fetchFromGitLab {
     owner = "fdroid";
     repo = "fdroidserver";
-    tag = finalAttrs.version;
-    hash = "sha256-AiDhtYpaOXTRVY5QA7fOgfGbpCtdJYzt3tnY2lrGJao=";
+    rev = "00932d0a715b43b3ecf8da44826abf2ba65dd8b4";
+    hash = "sha256-ye+Zv8WreTXS+1dZZ6b56zPiRmcBrM2ea2nFcotrduQ=";
   };
-
-  pythonRelaxDeps = [
-    "androguard"
-    "pyasn1"
-    "pyasn1-modules"
-    "ruamel-yaml"
-    "ruamel.yaml"
-  ];
 
   pythonRemoveDeps = [
     "puremagic" # Only used as a fallback when magic is not installed
@@ -38,55 +49,56 @@ python3Packages.buildPythonApplication (finalAttrs: {
   '';
 
   preConfigure = ''
-    ${python3Packages.python.pythonOnBuildForHost.interpreter} setup.py compile_catalog
+    ${pythonPackages.python.pythonOnBuildForHost.interpreter} setup.py compile_catalog
   '';
 
   postInstall = ''
-    patchShebangs gradlew-fdroid
-    install -m 0755 gradlew-fdroid $out/bin
     installShellCompletion --cmd fdroid \
       --bash completion/bash-completion
   '';
 
   nativeBuildInputs = [ installShellFiles ];
 
-  build-system = with python3Packages; [
+  build-system = with pythonPackages; [
     setuptools
     babel
   ];
 
-  dependencies = with python3Packages; [
-    asn1crypto
-    androguard
-    biplist
-    clint
-    defusedxml
-    gitpython
-    libcloud
-    libvirt-python
-    magic
-    mwclient
-    oscrypto
-    paramiko
-    pillow
-    platformdirs
-    pyasn1
-    pyasn1-modules
-    pycountry
-    python-vagrant
-    pyyaml
-    qrcode
-    requests
-    ruamel-yaml
-    sdkmanager
-    yamllint
-  ];
+  dependencies =
+    with pythonPackages;
+    [
+      androguard
+      asn1crypto
+      defusedxml
+      gitpython
+      magic
+      oscrypto
+      paramiko
+      pillow
+      platformdirs
+      progress
+      python-vagrant
+      pyyaml
+      qrcode
+      requests
+      ruamel-yaml
+      sdkmanager
+      yamllint
+    ]
+    ++ lib.optional withLibvirt libvirt-python
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      biplist
+      pycountry
+    ];
 
   makeWrapperArgs = [
     "--prefix"
     "PATH"
     ":"
-    "${lib.makeBinPath [ apksigner ]}"
+    "${lib.makeBinPath [
+      apksigner
+      gradlew-fdroid
+    ]}"
   ];
 
   # no tests
@@ -96,7 +108,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   meta = {
     homepage = "https://gitlab.com/fdroid/fdroidserver";
-    changelog = "https://gitlab.com/fdroid/fdroidserver/-/blob/${finalAttrs.version}/CHANGELOG.md";
+    changelog = "https://gitlab.com/fdroid/fdroidserver/-/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     description = "Server and tools for F-Droid, the Free Software repository system for Android";
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/gr/gradlew-fdroid/package.nix
+++ b/pkgs/by-name/gr/gradlew-fdroid/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  fetchFromGitLab,
+  python3Packages,
+  writableTmpDirAsHomeHook,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "gradlew-fdroid";
+  version = "0-unstable-2026-06-06";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitLab {
+    owner = "fdroid";
+    repo = "gradlew-fdroid";
+    rev = "9f31b7ee881e46a5d7d234406c14e5e474bc5fc4";
+    hash = "sha256-ONBoQBgkWY0hfRy5Qlz87eYG5ORcI1XEDGTY4oKu5HE=";
+  };
+
+  build-system = [ python3Packages.hatchling ];
+
+  # The test suite downloads and executes Gradle distributions.
+  doCheck = false;
+
+  nativeBuildInputs = [
+    # needed for importing gradlew
+    writableTmpDirAsHomeHook
+  ];
+
+  pythonImportsCheck = [ "gradlew" ];
+
+  meta = {
+    description = "Reimplementation of the Gradle wrapper script";
+    homepage = "https://gitlab.com/fdroid/gradlew-fdroid";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ linsui ];
+    mainProgram = "gradlew-fdroid";
+  };
+})

--- a/pkgs/development/python-modules/androguard/default.nix
+++ b/pkgs/development/python-modules/androguard/default.nix
@@ -10,16 +10,13 @@
   colorama,
   cryptography,
   dataset,
-  frida-python,
   loguru,
-  matplotlib,
   asn1crypto,
   click,
   mutf8,
   pyyaml,
   pydot,
   ipython,
-  oscrypto,
   pyqt5,
   pytestCheckHook,
   python-magic,
@@ -35,14 +32,14 @@ assert lib.warnIf (!doCheck) "python3Packages.androguard: doCheck is deprecated"
 
 buildPythonPackage rec {
   pname = "androguard";
-  version = "4.1.3";
+  version = "4.1.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     repo = "androguard";
     owner = "androguard";
     tag = "v${version}";
-    sha256 = "sha256-qz6x7UgYXal1DbQGzi4iKnSGEn873rKibKme/pF7tLk=";
+    hash = "sha256-WajRUquDEzs0NanOLpb0gxnreqM8Jm/SxI2LYEifWxg=";
   };
 
   build-system = [
@@ -58,20 +55,15 @@ buildPythonPackage rec {
     colorama
     cryptography
     dataset
-    frida-python
     ipython
     loguru
     lxml
-    matplotlib
     mutf8
     networkx
-    oscrypto
     pydot
     pygments
     pyyaml
   ]
-  ++ networkx.optional-dependencies.default
-  ++ networkx.optional-dependencies.extra
   ++ lib.optionals withGui [
     pyqt5
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: https://github.com/f-droid/fdroidserver/blob/2.4.5/CHANGELOG.md

Closes: #477514
Closes: #521161
Closes: #529780

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
