### PR TITLE
lima: fix build on Darwin by linking with lld

### DIFF
--- a/pkgs/by-name/li/lima/package.nix
+++ b/pkgs/by-name/li/lima/package.nix
@@ -11,6 +11,7 @@
   apple-sdk_15,
   withAdditionalGuestAgents ? false,
   lima-additional-guestagents,
+  llvmPackages,
   writableTmpDirAsHomeHook,
   versionCheckHook,
   testers,
@@ -35,7 +36,16 @@ buildGoModule (finalAttrs: {
     # For checkPhase, and installPhase(required to build completion)
     writableTmpDirAsHomeHook
   ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.sigtool ];
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    darwin.sigtool
+    # TODO: Remove when NixOS/nixpkgs#536365 reaches master.
+    llvmPackages.lld
+  ];
+
+  # TODO: Remove when NixOS/nixpkgs#536365 reaches master.
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    NIX_CFLAGS_LINK = "-fuse-ld=${lib.getExe' llvmPackages.lld "ld64.lld"}";
+  };
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk_15 ];
 


### PR DESCRIPTION
Resolves #540426 with a temporary fix by linking with LLVM lld, similar to vfkit (#539768) and starship (#540463). Marked with a TODO for removal once #536365 reaches master.

Sanity check:
```
❯ ./result/bin/limactl --version
limactl version 2.1.4
```
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test