### PR TITLE
llama-swap: 224 -> 240; nixos/llama-swap: share model cache with llama-cpp

### DIFF
--- a/nixos/modules/services/networking/llama-swap.nix
+++ b/nixos/modules/services/networking/llama-swap.nix
@@ -42,6 +42,15 @@ in
       '';
     };
 
+    useLlamaCppCacheDir = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to use {file}`/var/cache/llama-cpp` as {env}`LLAMA_CACHE` instead
+        of {file}`/var/cache/llama-swap` to share models and other cache with {option}`services.llama-cpp`.
+      '';
+    };
+
     tls = {
       enable = lib.mkEnableOption "TLS encryption";
 
@@ -113,6 +122,10 @@ in
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
 
+      environment = {
+        LLAMA_CACHE = lib.mkDefault "/var/cache/${config.systemd.services.llama-swap.serviceConfig.CacheDirectory}";
+      };
+
       serviceConfig = {
         Type = "exec";
         ExecStart = "${lib.getExe cfg.package} ${
@@ -129,6 +142,12 @@ in
         }";
         Restart = "on-failure";
         RestartSec = 3;
+
+        CacheDirectory =
+          if cfg.useLlamaCppCacheDir then
+            config.systemd.services.llama-cpp.serviceConfig.CacheDirectory
+          else
+            "llama-swap";
 
         # for GPU acceleration
         PrivateDevices = false;

--- a/pkgs/by-name/ll/llama-swap-minimal/package.nix
+++ b/pkgs/by-name/ll/llama-swap-minimal/package.nix
@@ -1,0 +1,5 @@
+{ llama-swap }:
+
+llama-swap.override {
+  withUI = false;
+}

--- a/pkgs/by-name/ll/llama-swap/package.nix
+++ b/pkgs/by-name/ll/llama-swap/package.nix
@@ -12,6 +12,8 @@
 
   nixosTests,
   nix-update-script,
+
+  withUI ? true,
 }:
 
 let
@@ -46,7 +48,7 @@ buildGoModule (finalAttrs: {
   vendorHash = "sha256-jQRnFGqQvk6my7ejnesv1pylCmEXLs9GKbQJEZdsaYg=";
 
   # Upstream only embeds the UI when this build tag is set.
-  tags = [ "embed_ui" ];
+  tags = lib.optionals withUI [ "embed_ui" ];
 
   passthru.ui = callPackage ./ui.nix { llama-swap = finalAttrs.finalPackage; };
 
@@ -73,8 +75,10 @@ buildGoModule (finalAttrs: {
     ldflags+=" -X main.commit=$(cat COMMIT)"
     ldflags+=" -X main.date=$(cat SOURCE_DATE_EPOCH)"
 
-    # copy for go:embed in internal/server/ui_embed.go
-    cp -r ${finalAttrs.passthru.ui}/ui_dist internal/server/
+    ${lib.optionalString withUI ''
+      # copy for go:embed in internal/server/ui_embed.go
+      cp -r ${finalAttrs.passthru.ui}/ui_dist internal/server/
+    ''}
   '';
 
   excludedPackages = [

--- a/pkgs/by-name/ll/llama-swap/package.nix
+++ b/pkgs/by-name/ll/llama-swap/package.nix
@@ -19,7 +19,7 @@ let
 in
 buildGoModule (finalAttrs: {
   pname = "llama-swap";
-  version = "224";
+  version = "240";
 
   outputs = [
     "out"
@@ -30,7 +30,7 @@ buildGoModule (finalAttrs: {
     owner = "mostlygeek";
     repo = "llama-swap";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-IblAaM9FBdI2Y9rg36SWpclQ0jV6Y93RC+N+cXWEO94=";
+    hash = "sha256-cvxF4J9Qvi522dBGjaNZvwwY/bV3wXSE0oGFATjzD4U=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -43,7 +43,10 @@ buildGoModule (finalAttrs: {
     '';
   };
 
-  vendorHash = "sha256-b+RreafBMCWT/jbWTlXaiDRzA4DRe76WaCEbrfRxV/4=";
+  vendorHash = "sha256-jQRnFGqQvk6my7ejnesv1pylCmEXLs9GKbQJEZdsaYg=";
+
+  # Upstream only embeds the UI when this build tag is set.
+  tags = [ "embed_ui" ];
 
   passthru.ui = callPackage ./ui.nix { llama-swap = finalAttrs.finalPackage; };
 

--- a/pkgs/by-name/ll/llama-swap/package.nix
+++ b/pkgs/by-name/ll/llama-swap/package.nix
@@ -145,6 +145,8 @@ buildGoModule (finalAttrs: {
     ];
   };
 
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://github.com/mostlygeek/llama-swap";
     changelog = "https://github.com/mostlygeek/llama-swap/releases/tag/${finalAttrs.src.tag}";

--- a/pkgs/by-name/ll/llama-swap/package.nix
+++ b/pkgs/by-name/ll/llama-swap/package.nix
@@ -88,7 +88,7 @@ buildGoModule (finalAttrs: {
 
   checkFlags =
     let
-      skippedTests = lib.optionals (stdenv.hostPlatform.isDarwin) [
+      skippedTests = lib.optionals stdenv.hostPlatform.isDarwin [
         # Fail only on *-darwin intermittently
         # https://github.com/mostlygeek/llama-swap/issues/320
         "TestProcess_AutomaticallyStartsUpstream"

--- a/pkgs/by-name/ll/llama-swap/package.nix
+++ b/pkgs/by-name/ll/llama-swap/package.nix
@@ -62,7 +62,7 @@ buildGoModule (finalAttrs: {
 
   postPatch = ''
     substituteInPlace internal/process/process_command_forking_test.go \
-      --replace "#!/bin/bash" "#!${lib.getExe bash}"
+      --replace-fail "#!/bin/bash" "#!${lib.getExe bash}"
   '';
 
   preBuild = ''

--- a/pkgs/by-name/ll/llama-swap/ui.nix
+++ b/pkgs/by-name/ll/llama-swap/ui.nix
@@ -7,7 +7,7 @@
 buildNpmPackage (finalAttrs: {
   pname = "${llama-swap.pname}-ui";
   inherit (llama-swap) version src;
-  npmDepsHash = "sha256-NJqEJ+XTdpPFtJJxP4CGu+JDUW7lKDcFgsixQJ3SXtQ=";
+  npmDepsHash = "sha256-cAdFKDhmyaYCoKqSYEuAhu29rBxs7i8uTmU2SHwTLnY=";
 
   postPatch = ''
     substituteInPlace vite.config.ts \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Supercedes #525623

- Updated llama-swap package to v240
- made ui optional.
- added cache directory to llama-swap NixOS module
- set LLAMA_CACHE to cache directory
- added option to llama-swap NixOS module to share models with llama-cpp NixOS module because both can download same models via `llama-cpp` `-hf` flag. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
