### PR TITLE
python3Packages.sqlalchemy_1_3: fix build on Python 3.14

### DIFF
--- a/pkgs/development/python-modules/sqlalchemy/1_3.nix
+++ b/pkgs/development/python-modules/sqlalchemy/1_3.nix
@@ -37,6 +37,11 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-6qAjyqMVrugABHssAQuql3z1YHTAOSm5hARJuJXJJvo=";
   };
 
+  patches = [
+    # Python 3.14 no longer creates an event loop implicitly
+    ./python-3.14-event-loop.patch
+  ];
+
   postPatch = ''
     sed -i '/tag_build = dev/d' setup.cfg
   '';

--- a/pkgs/development/python-modules/sqlalchemy/python-3.14-event-loop.patch
+++ b/pkgs/development/python-modules/sqlalchemy/python-3.14-event-loop.patch
@@ -1,0 +1,15 @@
+diff --git a/lib/sqlalchemy/util/_concurrency_py3k.py b/lib/sqlalchemy/util/_concurrency_py3k.py
+index 0ba6d3d..f08b783 100644
+--- a/lib/sqlalchemy/util/_concurrency_py3k.py
++++ b/lib/sqlalchemy/util/_concurrency_py3k.py
+@@ -190,6 +190,10 @@ def get_event_loop():
+         try:
+             return asyncio.get_running_loop()
+         except RuntimeError:
++            if sys.version_info >= (3, 14):
++                loop = asyncio.new_event_loop()
++                asyncio.set_event_loop(loop)
++                return loop
+             return asyncio.get_event_loop_policy().get_event_loop()
+     else:
+         return asyncio.get_event_loop()


### PR DESCRIPTION
Backport event-loop creation for Python 3.14, where `asyncio` no longer creates an event loop implicitly. This restores the SQLAlchemy 1.3 test suite and its `maubot` consumer.

Closes #540355

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
