### PR TITLE
yabai: remove inactive maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25602,12 +25602,6 @@
     githubId = 106669955;
     name = "Léon Gessner";
   };
-  shardy = {
-    email = "shardul@baral.ca";
-    github = "shardulbee";
-    githubId = 16765155;
-    name = "Shardul Baral";
-  };
   sharpchen = {
     github = "sharpchen";
     githubId = 77432836;

--- a/pkgs/by-name/ya/yabai/package.nix
+++ b/pkgs/by-name/ya/yabai/package.nix
@@ -106,7 +106,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "yabai";
     maintainers = with lib.maintainers; [
       cmacrae
-      shardy
       khaneliman
     ];
     sourceProvenance = [ lib.sourceTypes.fromSource ];


### PR DESCRIPTION
Remove the inactive `shardy` maintainer from Yabai and delete the now-unused maintainer registry entry.