### PR TITLE
osu-lazer{,-bin}: 2026.624.0 -> 2026.711.0

### DIFF
--- a/pkgs/by-name/os/osu-lazer-bin/package.nix
+++ b/pkgs/by-name/os/osu-lazer-bin/package.nix
@@ -10,23 +10,23 @@
 
 let
   pname = "osu-lazer-bin";
-  version = "2026.624.0";
+  version = "2026.711.0";
 
   src =
     {
       aarch64-darwin = fetchzip {
         url = "https://github.com/ppy/osu/releases/download/${version}-lazer/osu.app.Apple.Silicon.zip";
-        hash = "sha256-kL2XGJzTRC+AtHH4+byaR1df9EYyIriuxzawDtAFWZ4=";
+        hash = "sha256-XwfNO38dDaUmu/3AEgRwV0VW6JrAUCxWD6Wt0Ew23Eo=";
         stripRoot = false;
       };
       x86_64-darwin = fetchzip {
         url = "https://github.com/ppy/osu/releases/download/${version}-lazer/osu.app.Intel.zip";
-        hash = "sha256-NOBKnsZpMYU6uBfVqYK3ZrPzZBQURw6bN5rr1iZG9nA=";
+        hash = "sha256-Crj40NkKasqc2JF1LeJwOlnCzHxsPiKG77SKTo8DS/8=";
         stripRoot = false;
       };
       x86_64-linux = fetchurl {
         url = "https://github.com/ppy/osu/releases/download/${version}-lazer/osu.AppImage";
-        hash = "sha256-EKmCq656djPGK5I1JqSDcTKtpbQZbO8WGWcPv+PT0q4=";
+        hash = "sha256-KyA5UCvb9epk7jRtdG5wl0LzKc6/D2rkw5EJQxIaihw=";
       };
     }
     .${stdenvNoCC.system} or (throw "osu-lazer-bin: ${stdenvNoCC.system} is unsupported.");

--- a/pkgs/by-name/os/osu-lazer/deps.json
+++ b/pkgs/by-name/os/osu-lazer/deps.json
@@ -616,8 +616,8 @@
   },
   {
     "pname": "ppy.osu.Framework",
-    "version": "2026.623.0",
-    "hash": "sha256-IcCFJvj5ydy0r6mEpHgV+UK9N7cd/3CtjOCV2GT8HOY="
+    "version": "2026.629.0",
+    "hash": "sha256-fb2rmHin/5kCQ4klLvWXHZLnLg4RkrDFn024YIm13R0="
   },
   {
     "pname": "ppy.osu.Framework.NativeLibs",
@@ -631,8 +631,8 @@
   },
   {
     "pname": "ppy.osu.Game.Resources",
-    "version": "2026.523.0",
-    "hash": "sha256-BLSFNtPU9d+Qv/sGY6d1c7rnKyJkKu66zRZGsw1oS4M="
+    "version": "2026.710.0",
+    "hash": "sha256-EvcxQx9Kq/9y5ox7fmwVSb/JUYDf3D3j/3uOgS4Kpb0="
   },
   {
     "pname": "ppy.osuTK.NS20",
@@ -646,8 +646,8 @@
   },
   {
     "pname": "ppy.SDL3-CS",
-    "version": "2026.623.0",
-    "hash": "sha256-LMT2AVjP/HIC3a7PZDR4Vhlr6CCEhPu5ZF1eSYDIjeY="
+    "version": "2026.629.0",
+    "hash": "sha256-ncHf+gj36u4x4lwFoGcU6rxMnjC2AS+FYBYCKatHt3E="
   },
   {
     "pname": "ppy.Veldrid",

--- a/pkgs/by-name/os/osu-lazer/package.nix
+++ b/pkgs/by-name/os/osu-lazer/package.nix
@@ -22,13 +22,13 @@
 
 buildDotnetModule rec {
   pname = "osu-lazer";
-  version = "2026.624.0";
+  version = "2026.711.0";
 
   src = fetchFromGitHub {
     owner = "ppy";
     repo = "osu";
     tag = "${version}-lazer";
-    hash = "sha256-qZPComGBdVReWQ0rVQeB9v8N2ul02AhGe8BlIzhz0+s=";
+    hash = "sha256-hdrbbPl7ClNx73bsjoN5u4bEmvl/sdcjgFnZ/uxYbOk=";
   };
 
   projectFile = "osu.Desktop/osu.Desktop.csproj";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: https://github.com/ppy/osu/releases/tag/2026.711.0-lazer

## Things done
- Updated version numbers and hashes for each platform, 
- Updated deps.json.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
