### PR TITLE
libnfs: `__structuredAtts`, `strictDeps`, `meta.license`, `outputs`

### DIFF
--- a/pkgs/by-name/li/libnfs/package.nix
+++ b/pkgs/by-name/li/libnfs/package.nix
@@ -26,6 +26,11 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
   enableParallelBuilding = true;
 
+  outputs = [
+    "out"
+    "dev"
+  ];
+
   meta = {
     description = "NFS client library";
     homepage = "https://github.com/sahlberg/libnfs";

--- a/pkgs/by-name/li/libnfs/package.nix
+++ b/pkgs/by-name/li/libnfs/package.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation (finalAttrs: {
     "-DENABLE_MULTITHREADING=ON"
   ];
 
+  __structuredAtts = true;
+  strictDeps = true;
   enableParallelBuilding = true;
 
   meta = {

--- a/pkgs/by-name/li/libnfs/package.nix
+++ b/pkgs/by-name/li/libnfs/package.nix
@@ -28,9 +28,9 @@ stdenv.mkDerivation (finalAttrs: {
     description = "NFS client library";
     homepage = "https://github.com/sahlberg/libnfs";
     license = with lib.licenses; [
-      lgpl2
-      bsd2
-      gpl3
+      lgpl21Plus # sources and includes
+      bsd2 # protocol definitions in *.x files
+      gpl3Plus # examples directory (not actually included in the derivation output)
     ];
     maintainers = with lib.maintainers; [ peterhoeg ];
     platforms = lib.platforms.unix;


### PR DESCRIPTION
More precise licenses in `meta.license`. This does not change the derivation.

Set `__structuredAttrs` & `strictDeps`. This does not affect the output (i.e. `nix store make-content-addressed` still gives the same output).

Then also split out the `dev` output.
This resulted in the following output size changes:
- `out`: `872K` -> `492K`
- `dev`: `0K` -> `384K`


cc:
- https://github.com/NixOS/nixpkgs/issues/178468
- https://github.com/NixOS/nixpkgs/issues/205690
- https://github.com/NixOS/nixpkgs/issues/515268


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
