### PR TITLE
liblouis: 3.33.0 → 3.38.0

### DIFF
--- a/pkgs/by-name/li/liblouis/package.nix
+++ b/pkgs/by-name/li/liblouis/package.nix
@@ -14,7 +14,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "liblouis";
-  version = "3.33.0";
+  version = "3.38.0";
 
   outputs = [
     "out"
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "liblouis";
     repo = "liblouis";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-+p/2eLbQ5aYtxQIkoHaVE1xDqstveedf+56aRNX9C7M=";
+    hash = "sha256-OmYMldo2id2HKAM0Hxi6r86khSUnzu22CkJhGBhaaL8=";
   };
 
   strictDeps = true;
@@ -63,7 +63,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     patchShebangs tests
-    substituteInPlace python/louis/__init__.py.in --replace "###LIBLOUIS_SONAME###" "$out/lib/liblouis.so"
+    substituteInPlace python/louis/__init__.py.in \
+      --replace-fail "###LIBLOUIS_SONAME###" "$out/lib/liblouis.so"
   '';
 
   postInstall = ''
@@ -71,6 +72,12 @@ stdenv.mkDerivation (finalAttrs: {
     python -m build --no-isolation --outdir dist/ --wheel
     python -m installer --prefix $out dist/*.whl
     popd
+
+    make install-html MAKEINFOFLAGS="--no-headers --no-split"
+    pushd doc
+    make liblouis.txt
+    popd
+    install -D -t "$doc/share/doc/liblouis" doc/liblouis.txt
   '';
 
   doCheck = true;


### PR DESCRIPTION
https://github.com/liblouis/liblouis/compare/v3.33.0...v3.38.0

- https://github.com/liblouis/liblouis/releases/tag/v3.34.0

  No longer installs html and txt docs:

  As per <https://www.gnu.org/software/automake/manual/automake.html#Texinfo>:

  > Following the GNU Coding Standards, only the .info files are built by ‘make all’ and installed by ‘make install’

- https://github.com/liblouis/liblouis/releases/tag/v3.35.0
- https://github.com/liblouis/liblouis/releases/tag/v3.36.0
- https://github.com/liblouis/liblouis/releases/tag/v3.37.0
- https://github.com/liblouis/liblouis/releases/tag/v3.38.0

Also fix `substituteInPlace --replace` deprecation.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
