### PR TITLE
vnote: 3.20.1 -> 4.1.1

### DIFF
--- a/pkgs/by-name/vn/vnote/package.nix
+++ b/pkgs/by-name/vn/vnote/package.nix
@@ -5,26 +5,20 @@
   fetchpatch,
   cmake,
   qt6,
+  qt6Packages,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "vnote";
-  version = "3.20.1";
+  version = "4.1.1";
 
   src = fetchFromGitHub {
     owner = "vnotex";
     repo = "vnote";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-Ukik02qP7a86dgBTghD9wGKGpXkdGdxczg01APtcOAM=";
+    hash = "sha256-N7vH6nEA8RI/HyPslzBLEUzdh1WHPwZ7UxUtQ7O4mxU=";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/vnotex/vnote/commit/7c59d0d061d30f8f1f57eab855b73d3b1f452df1.patch";
-      hash = "sha256-gt2JDO9kGR/bjTtqTaAdHDHm9UC3XMG6KgKeDdhhNNg=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake
@@ -38,6 +32,12 @@ stdenv.mkDerivation (finalAttrs: {
     qt6.qttools
     qt6.qt5compat
     qt6.qtwayland
+    qt6Packages.qtkeychain
+  ];
+
+  cmakeFlags = [
+    "-Dqtkeychain_SOURCE_DIR=${qt6Packages.qtkeychain}/include/qt6keychain"
+    "-Dqtkeychain_BINARY_DIR=${qt6Packages.qtkeychain}/lib"
   ];
 
   meta = {


### PR DESCRIPTION
## Description of changes

Major upgrade from v3 to v4. Please don't backport.

https://github.com/vnotex/vnote/releases/tag/v4.1.0
https://github.com/vnotex/vnote/releases/tag/v4.1.1

VNote v4 still contains a few critical bugs, leaving this PR a draft until these are fixed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
