### PR TITLE
nixos/prometheus-exporters/fail2ban: correctly concatenate arguments

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters/fail2ban.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/fail2ban.nix
@@ -9,11 +9,12 @@ let
   cfg = config.services.prometheus.exporters.fail2ban;
 
   inherit (lib)
-    mkOption
-    types
+    concatStringsSep
     getExe
-    optionalString
     mkIf
+    mkOption
+    optionalString
+    types
     ;
 in
 {
@@ -62,16 +63,15 @@ in
     requires = mkIf config.services.fail2ban.enable [ "prometheus-fail2ban-exporter-setup.service" ];
     serviceConfig = {
       DynamicUser = false;
-      ExecStart = ''
-        ${getExe pkgs.prometheus-fail2ban-exporter} \
-          ${optionalString cfg.exitOnError ''--collector.f2b.exit-on-socket-connection-error \''}
-          ${optionalString (cfg.username != null) ''
-            --web.basic-auth.username="${cfg.username}" \
-            --web.basic-auth.password="$(cat ${cfg.passwordFile})" \
-          ''}
-          --web.listen-address="${cfg.host}:${toString cfg.port}" \
-          --collector.f2b.socket=${cfg.fail2banSocket}
-      '';
+      ExecStart = concatStringsSep " " [
+        (getExe pkgs.prometheus-fail2ban-exporter)
+        ''--web.listen-address="${cfg.host}:${toString cfg.port}"''
+        ''--collector.f2b.socket="${cfg.fail2banSocket}"''
+        (optionalString cfg.exitOnError "--collector.f2b.exit-on-socket-connection-error")
+        (optionalString (cfg.username != null)
+          ''--web.basic-auth.username="${cfg.username}" --web.basic-auth.password="$(cat ${cfg.passwordFile})"''
+        )
+      ];
       RestrictAddressFamilies = [
         "AF_INET"
         "AF_INET6"


### PR DESCRIPTION
Uses `lib.concatStringsSep " "` instead of inline optional strings. This had the edge-case that certain newlines were incorrectly inserted, throwing away the arguments right after those empty lines.
Opted to use this solution as several other exporters (e.g. [mysqld](https://github.com/NixOS/nixpkgs/blob/922beff01ebd3959098f6bb4315a6835dd874a0f/nixos/modules/services/monitoring/prometheus/exporters/mysqld.nix#L61)) seem to do this as well.

Resolves #541038


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
