### PR TITLE
ibm-plex: 0-unstable-2026-02-12 -> 0-unstable-2026-05-26

### DIFF
--- a/pkgs/by-name/ib/ibm-plex/fonts.nix
+++ b/pkgs/by-name/ib/ibm-plex/fonts.nix
@@ -6,10 +6,10 @@
     version = "1.1.0";
   };
   mono = {
-    hash = "sha256-OwUmrPfEehLDz0fl2ChYLK8FQM2p0G1+EMrGsYEq+6g=";
+    hash = "sha256-GK9KStu5KQ5g5+IUwJq4L+a5gOwzsNXH80OOIbyvOnM=";
     name = "IBM Plex Mono";
-    url = "https://github.com/IBM/plex/releases/download/@ibm/plex-mono@1.1.0/ibm-plex-mono.zip";
-    version = "1.1.0";
+    url = "https://github.com/IBM/plex/releases/download/%40ibm/plex-mono%402.5.0/ibm-plex-mono.zip";
+    version = "2.5.0";
   };
   sans = {
     hash = "sha256-mK+8GGl2ugF2+fS6yd3p5NWPHHcKEJWiShDS3lihOlI=";

--- a/pkgs/by-name/ib/ibm-plex/package.nix
+++ b/pkgs/by-name/ib/ibm-plex/package.nix
@@ -62,7 +62,7 @@ in
 assert lib.assertMsg (unknownFamilies == [ ]) "Unknown font(s): ${toString unknownFamilies}";
 symlinkJoin {
   pname = "ibm-plex";
-  version = "0-unstable-2026-02-12";
+  version = "0-unstable-2026-05-26";
   paths = lib.attrValues fontDerivations;
   passthru = fontDerivations // {
     updateScript = ./update.py;


### PR DESCRIPTION
The Mono variant of the font has been updated from version 1.1.0 to 2.5.0.

Release: https://github.com/IBM/plex/releases#release-@ibm/plex-mono@2.5.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
