### PR TITLE
nixos/linkding: add options to configure process and thread counts

### DIFF
--- a/nixos/modules/services/web-apps/linkding.nix
+++ b/nixos/modules/services/web-apps/linkding.nix
@@ -151,6 +151,18 @@ in
       default = false;
       description = "Open the linkding port in the firewall.";
     };
+
+    processes = mkOption {
+      type = types.ints.positive;
+      default = 2;
+      description = "Number of uWSGI processes to spawn.";
+    };
+
+    threads = mkOption {
+      type = types.ints.positive;
+      default = 2;
+      description = "Number of threads to spawn (per uWSGI process).";
+    };
   };
 
   config = mkIf cfg.enable (
@@ -196,8 +208,8 @@ in
         plugin = python3
         module = bookmarks.wsgi:application
         env = DJANGO_SETTINGS_MODULE=bookmarks.settings.prod
-        processes = 2
-        threads = 2
+        processes = ${toString cfg.processes}
+        threads = ${toString cfg.threads}
         buffer-size = 8192
         die-on-term = true
         mime-file = ${pkgs.mailcap}/etc/mime.types


### PR DESCRIPTION
Presently, the number of threads and processes the service uses is fixed to 2 and 2, respectively.

[Upstream](https://github.com/sissbruecker/linkding/issues/420) recommends using a custom `uwsgi.ini` to configure these parameters.

Thus, add the `processes` and `threads` configuration options to allow this to be configured in the NixOS module.

I have tested the modified service configuration on my instance and it works as intended.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
