### PR TITLE
flytectl.tests: fix the eval

### DIFF
--- a/pkgs/by-name/fl/flytectl/package.nix
+++ b/pkgs/by-name/fl/flytectl/package.nix
@@ -49,7 +49,7 @@ buildGoModule (finalAttrs: {
   passthru.tests.version = testers.testVersion {
     package = finalAttrs.finalPackage;
     command = "flytectl version";
-    version = "v${finalAttrs.src.version}";
+    version = "v${finalAttrs.version}";
   };
 
   meta = {


### PR DESCRIPTION
Without the change the eval fails on` master` as:

    $ nix build --no-link -f. flytectl.tests
    error:
       … while calling the 'derivationStrict' builtin
         at «nix-internal»/derivation-internal.nix:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'flytectl-0.9.8-test-version'
         whose name attribute is located at pkgs/stdenv/generic/make-derivation.nix:651:11

       … while evaluating attribute 'buildCommand' of derivation 'flytectl-0.9.8-test-version'
         at pkgs/build-support/trivial-builders/default.nix:81:17:
           80|         enableParallelBuilding = true;
           81|         inherit buildCommand name;
             |                 ^
           82|         passAsFile = [ "buildCommand" ] ++ (derivationArgs.passAsFile or [ ]);

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'version' missing
       at pkgs/by-name/fl/flytectl/package.nix:52:19:
           51|     command = "flytectl version";
           52|     version = "v${finalAttrs.src.version}";
             |                   ^
           53|   };


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
