### PR TITLE
python3Packages.tzlocal: 5.3.1 -> 5.4.4

### DIFF
--- a/pkgs/development/python-modules/tzlocal/default.nix
+++ b/pkgs/development/python-modules/tzlocal/default.nix
@@ -2,44 +2,41 @@
   lib,
   stdenv,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   setuptools,
   pytest-mock,
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "tzlocal";
-  version = "5.3.1"; # version needs to be compatible with APScheduler
-
+  version = "5.4.4"; # version needs to be compatible with APScheduler
   pyproject = true;
+  __structuredAttrs = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-zO/8ft7O/qH1lVQdvW6ZDLHqPRm/AbKAnzYqA915If0=";
+  src = fetchFromGitHub {
+    owner = "regebro";
+    repo = "tzlocal";
+    tag = finalAttrs.version;
+    hash = "sha256-kZ3+YpmJJ7ZHKbEp5RELVnGtwAOJph19Wf32lwuokNM=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
   nativeCheckInputs = [
     pytest-mock
     pytestCheckHook
   ];
 
-  disabledTests = [
-    "test_conflicting"
-    "test_noconflict"
-    "test_symlink_localtime"
-  ]
-  ++ lib.optional stdenv.hostPlatform.isDarwin "test_assert_tz_offset";
+  disabledTests = lib.optional stdenv.hostPlatform.isDarwin "test_assert_tz_offset";
 
   pythonImportsCheck = [ "tzlocal" ];
 
   meta = {
     description = "Tzinfo object for the local timezone";
     homepage = "https://github.com/regebro/tzlocal";
-    changelog = "https://github.com/regebro/tzlocal/blob/${version}/CHANGES.txt";
+    changelog = "https://github.com/regebro/tzlocal/blob/${finalAttrs.src.tag}/CHANGES.txt";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ dotlambda ];
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/regebro/tzlocal/compare/5.3.1...5.4.4

Changelog: https://github.com/regebro/tzlocal/blob/5.4.4/CHANGES.txt


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
