### PR TITLE
python3Packages.trove-classifiers: 2026.5.20.19 -> 2026.6.1.19

### DIFF
--- a/pkgs/development/python-modules/trove-classifiers/default.nix
+++ b/pkgs/development/python-modules/trove-classifiers/default.nix
@@ -7,44 +7,41 @@
   setuptools,
 }:
 
-let
-  self = buildPythonPackage rec {
-    pname = "trove-classifiers";
-    version = "2026.6.1.19";
-    pyproject = true;
+buildPythonPackage (finalAttrs: {
+  pname = "trove-classifiers";
+  version = "2026.6.1.19";
+  pyproject = true;
 
-    src = fetchPypi {
-      pname = "trove_classifiers";
-      inherit version;
-      hash = "sha256-xRMrS2GoKdEc+9LXLpfyCkXtbtuV5Fxe/eteAINrJ0U=";
-    };
-
-    postPatch = ''
-      substituteInPlace tests/test_cli.py \
-        --replace-fail "BINDIR = Path(sys.executable).parent" "BINDIR = '$out/bin'"
-    '';
-
-    build-system = [
-      calver
-      setuptools
-    ];
-
-    doCheck = false; # avoid infinite recursion with hatchling
-
-    nativeCheckInputs = [ pytestCheckHook ];
-
-    pythonImportsCheck = [ "trove_classifiers" ];
-
-    passthru.tests.trove-classifiers = self.overridePythonAttrs { doCheck = true; };
-
-    meta = {
-      description = "Canonical source for classifiers on PyPI";
-      homepage = "https://github.com/pypa/trove-classifiers";
-      changelog = "https://github.com/pypa/trove-classifiers/releases/tag/${version}";
-      license = lib.licenses.asl20;
-      mainProgram = "trove-classifiers";
-      maintainers = with lib.maintainers; [ dotlambda ];
-    };
+  src = fetchPypi {
+    pname = "trove_classifiers";
+    inherit (finalAttrs) version;
+    hash = "sha256-xRMrS2GoKdEc+9LXLpfyCkXtbtuV5Fxe/eteAINrJ0U=";
   };
-in
-self
+
+  postPatch = ''
+    substituteInPlace tests/test_cli.py \
+      --replace-fail "BINDIR = Path(sys.executable).parent" "BINDIR = '$out/bin'"
+  '';
+
+  build-system = [
+    calver
+    setuptools
+  ];
+
+  doCheck = false; # avoid infinite recursion with hatchling
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "trove_classifiers" ];
+
+  passthru.tests.trove-classifiers = finalAttrs.finalPackage.overrideAttrs { doInstallCheck = true; };
+
+  meta = {
+    description = "Canonical source for classifiers on PyPI";
+    homepage = "https://github.com/pypa/trove-classifiers";
+    changelog = "https://github.com/pypa/trove-classifiers/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    mainProgram = "trove-classifiers";
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+})

--- a/pkgs/development/python-modules/trove-classifiers/default.nix
+++ b/pkgs/development/python-modules/trove-classifiers/default.nix
@@ -10,13 +10,13 @@
 let
   self = buildPythonPackage rec {
     pname = "trove-classifiers";
-    version = "2026.5.20.19";
+    version = "2026.6.1.19";
     pyproject = true;
 
     src = fetchPypi {
       pname = "trove_classifiers";
       inherit version;
-      hash = "sha256-bmEZk5h8qTJpaK1wRScz2t0xRxWZ05iWBFsolwqbuB4=";
+      hash = "sha256-xRMrS2GoKdEc+9LXLpfyCkXtbtuV5Fxe/eteAINrJ0U=";
     };
 
     postPatch = ''


### PR DESCRIPTION
Changelog: https://github.com/pypa/trove-classifiers/releases/tag/2026.6.1.19


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
