### PR TITLE
screen: 5.0.1 -> 5.0.2

### DIFF
--- a/pkgs/by-name/sc/screen/package.nix
+++ b/pkgs/by-name/sc/screen/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  fetchpatch,
   autoreconfHook,
   texinfo,
   ncurses,
@@ -12,39 +11,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "screen";
-  version = "5.0.1";
+  version = "5.0.2";
 
   src = fetchurl {
     url = "mirror://gnu/screen/screen-${finalAttrs.version}.tar.gz";
-    hash = "sha256-La429Ns3n/zRS2kVlrpuwYrDqeIrxHrCOXiatYQJhp0=";
+    hash = "sha256-yposfiQJGbx6wSEkWTrkUpu0619zSdiFeCm34/CzszI=";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://file.savannah.gnu.org/file/0001-test-fix-unit-tests.patch?file_id=57558";
-      stripLen = 1;
-      hash = "sha256-q3jQQrzweLf2T/V5X9iL4ZZK342QEXLG5fZTaMOB4tY=";
-    })
-    # Following 3 commits fix screen.info file issues
-    (fetchpatch {
-      name = "screen.info-1st.patch";
-      url = "https://cgit.git.savannah.gnu.org/cgit/screen.git/patch/?id=7333452aa52d61a170b1fc199869ea6059849058";
-      stripLen = 1;
-      hash = "sha256-fYkljMNefDJtf+uA9qPotQEOxwhlQj0nZfTszhl/oik=";
-    })
-    (fetchpatch {
-      name = "screen.info-2nd.patch";
-      url = "https://cgit.git.savannah.gnu.org/cgit/screen.git/patch/?id=6790fb8e1931783646c07a364657fadb5c9d1e63";
-      stripLen = 1;
-      hash = "sha256-+fRPfCbJKYUW/ZE6C63xB2WEtTv6KPi8waXLt9N+AuU=";
-    })
-    (fetchpatch {
-      name = "screen.info-3rd.patch";
-      url = "https://cgit.git.savannah.gnu.org/cgit/screen.git/patch/?id=94c3e1fd81826ce3b677d49f7a452e6fe77ed63b";
-      stripLen = 1;
-      hash = "sha256-Wq4Bx5wCqsOWtrfUON5wTuhpBH8JxyoOiHHfDT2CsHw=";
-    })
-  ];
 
   configureFlags = [
     "--enable-telnet"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
