### PR TITLE
python3Packages.pylsp-mypy: 0.7.0 -> 0.8.0

### DIFF
--- a/pkgs/development/python-modules/pylsp-mypy/default.nix
+++ b/pkgs/development/python-modules/pylsp-mypy/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
+  fetchPypi,
 
   # build-system
   setuptools,
@@ -17,11 +17,10 @@ buildPythonPackage (finalAttrs: {
   version = "0.7.0";
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "python-lsp";
-    repo = "pylsp-mypy";
-    tag = finalAttrs.version;
-    hash = "sha256-rS0toZaAygNJ3oe3vfP9rKJ1A0avIdp5yjNx7oGOB4o=";
+  src = fetchPypi {
+    pname = "pylsp_mypy";
+    inherit (finalAttrs) version;
+    hash = "sha256-6U9THUzlIyIsKvdHGr45bP60zDxLGB1URi+21VPh4LM=";
   };
 
   build-system = [ setuptools ];
@@ -42,8 +41,7 @@ buildPythonPackage (finalAttrs: {
 
   meta = {
     description = "Mypy plugin for the Python LSP Server";
-    homepage = "https://github.com/python-lsp/pylsp-mypy";
-    changelog = "https://github.com/python-lsp/pylsp-mypy/releases/tag/${finalAttrs.version}";
+    homepage = "https://pypi.org/project/pylsp-mypy/";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ cpcloud ];
   };

--- a/pkgs/development/python-modules/pylsp-mypy/default.nix
+++ b/pkgs/development/python-modules/pylsp-mypy/default.nix
@@ -14,13 +14,13 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pylsp-mypy";
-  version = "0.7.0";
+  version = "0.8.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "pylsp_mypy";
     inherit (finalAttrs) version;
-    hash = "sha256-6U9THUzlIyIsKvdHGr45bP60zDxLGB1URi+21VPh4LM=";
+    hash = "sha256-ANhur6TlRO6Bpzl57/GpmPvUDUrpwYIf6IAjMmp1bcI=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
See commit msgs for details. Beware the src is changing.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
