### PR TITLE
frame-media-converter: init at 0.31.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -289,6 +289,11 @@
     name = "6543";
     keys = [ { fingerprint = "8722 B61D 7234 1082 553B  201C B8BE 6D61 0E61 C862"; } ];
   };
+  _66HEX = {
+    name = "Marek Jóźwiak";
+    github = "66HEX";
+    githubId = 168720167;
+  };
   _6AA4FD = {
     email = "f6442954@gmail.com";
     github = "6AA4FD";

--- a/pkgs/by-name/fr/frame-media-converter/package.nix
+++ b/pkgs/by-name/fr/frame-media-converter/package.nix
@@ -1,0 +1,111 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  makeWrapper,
+  alsa-lib,
+  ffmpeg,
+  fontconfig,
+  freetype,
+  libdrm,
+  libGL,
+  libx11,
+  libxcb,
+  libxkbcommon,
+  vulkan-loader,
+  wayland,
+}:
+
+let
+  cargoFlags = [
+    "--package"
+    "frame-app"
+  ];
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "frame-media-converter";
+  version = "0.31.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "66HEX";
+    repo = "frame";
+    tag = finalAttrs.version;
+    hash = "sha256-QBwwa5z0BbNa0p7MbV2J+K+NOe0cFxXq9LyvalKTMFY=";
+  };
+
+  cargoHash = "sha256-HJZEY4noPypIXHB6ZMtPKuBawaMmmEpVbfo44v6tKws=";
+  cargoBuildFlags = cargoFlags;
+  cargoTestFlags = cargoFlags;
+
+  nativeBuildInputs = [
+    makeWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    alsa-lib
+    fontconfig
+    freetype
+    libdrm
+    libGL
+    libx11
+    libxcb
+    libxkbcommon
+    vulkan-loader
+    wayland
+  ];
+
+  postInstall = ''
+    install -Dm444 frame-app/resources/frame.desktop.in \
+      $out/share/applications/frame.desktop
+    substituteInPlace $out/share/applications/frame.desktop \
+      --replace-fail '$APP_NAME' Frame \
+      --replace-fail '$APP_CLI' frame \
+      --replace-fail '$APP_ICON' frame
+
+    for icon in \
+      32:32x32.png \
+      64:64x64.png \
+      128:128x128.png \
+      256:128x128@2x.png \
+      512:icon.png
+    do
+      size="''${icon%%:*}"
+      file="''${icon#*:}"
+      install -Dm444 "frame-app/resources/app-icons/$file" \
+        "$out/share/icons/hicolor/''${size}x''${size}/apps/frame.png"
+    done
+  '';
+
+  postFixup = ''
+    patchelf $out/bin/frame --add-rpath ${
+      lib.makeLibraryPath [
+        libGL
+        vulkan-loader
+        wayland
+      ]
+    }
+
+    wrapProgram $out/bin/frame \
+      --prefix PATH : ${lib.makeBinPath [ ffmpeg ]} \
+      --set FRAME_USE_SYSTEM_MEDIA_TOOLS 1 \
+      --set FRAME_UPDATE_EXPLANATION \
+        'This Nixpkgs build is managed by Nix. Install updates through your Nix profile, flake, or NixOS configuration.'
+  '';
+
+  meta = {
+    description = "Native desktop interface for FFmpeg media conversion";
+    homepage = "https://github.com/66HEX/frame";
+    changelog = "https://github.com/66HEX/frame/blob/${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "frame";
+    maintainers = [ lib.maintainers._66HEX ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add Frame 0.31.1 as `frame-media-converter`.

Frame is a native desktop interface for FFmpeg media conversion. The nixpkgs attribute is `frame-media-converter` because `frame` is already taken, while the installed binary remains `frame`.

Homepage: https://github.com/66HEX/frame  
Release: https://github.com/66HEX/frame/releases/tag/0.31.1  
Changelog: https://github.com/66HEX/frame/releases/tag/0.31.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Additional validation performed:

- `nix-build -A frame-media-converter` succeeded on `x86_64-linux`.
- Cross/system build validation for `aarch64-linux` succeeded in CI.
- Rust package check phase passed: `672 passed; 0 failed; 6 ignored`.
- `nix-build lib/tests/maintainers.nix` succeeded.
- `nixfmt-rfc-style` succeeded.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

