### PR TITLE
phantun: init at 0.8.1

### DIFF
--- a/pkgs/by-name/ph/phantun/package.nix
+++ b/pkgs/by-name/ph/phantun/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "phantun";
+  version = "0.8.1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "dndx";
+    repo = "phantun";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Syz2W0IYm9nzu2Ph09uJxeo/odznDC9aMe+TEMhWurc=";
+  };
+
+  cargoHash = "sha256-xvWk1OmF/oWc2Pw3rxkkRNZ63XSkSf41klzQz1+2O9I=";
+
+  postInstall = ''
+    mv "$out/bin/client" "$out/bin/phantun_client"
+    mv "$out/bin/server" "$out/bin/phantun_server"
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  doInstallCheck = true;
+
+  postVersionCheck = ''
+    "$out/bin/phantun_server" --version | grep -F "${finalAttrs.version}"
+  '';
+
+  meta = {
+    description = "Lightweight and fast UDP to TCP obfuscator";
+    homepage = "https://github.com/dndx/phantun";
+    changelog = "https://github.com/dndx/phantun/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = with lib.maintainers; [ peigongdsd ];
+    mainProgram = "phantun_client";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
