### PR TITLE
davit: init at 0.1.19

### DIFF
--- a/pkgs/by-name/da/davit/package.nix
+++ b/pkgs/by-name/da/davit/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "davit";
-  version = "0.1.13";
+  version = "0.1.19";
   __structuredAttrs = true;
   strictDeps = true;
 
   src = fetchurl {
     url = "https://github.com/wouterdebie/davit/releases/download/v${finalAttrs.version}/Davit-${finalAttrs.version}.zip";
-    hash = "sha256-x3OjT+h/dB232gw8UW1iklrjNACEi22MtyJCU8eciks=";
+    hash = "sha256-XWij8/6/3TebhWBIleiec+xEZ6ma6Yvlnw5JeTJJ0HQ=";
   };
 
   sourceRoot = ".";

--- a/pkgs/by-name/da/davit/package.nix
+++ b/pkgs/by-name/da/davit/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeWrapper,
+  unzip,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "davit";
+  version = "0.1.13";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchurl {
+    url = "https://github.com/wouterdebie/davit/releases/download/v${finalAttrs.version}/Davit-${finalAttrs.version}.zip";
+    hash = "sha256-x3OjT+h/dB232gw8UW1iklrjNACEi22MtyJCU8eciks=";
+  };
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [
+    makeWrapper
+    unzip
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    cp -r Davit.app $out/Applications/
+    makeWrapper $out/Applications/Davit.app/Contents/MacOS/Davit $out/bin/davit
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Native macOS UI for Apple's container platform";
+    homepage = "https://github.com/wouterdebie/davit";
+    changelog = "https://github.com/wouterdebie/davit/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ Br1ght0ne ];
+    platforms = lib.platforms.darwin;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    mainProgram = "davit";
+  };
+})


### PR DESCRIPTION
https://github.com/wouterdebie/davit/releases/tag/v0.1.19
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
