### PR TITLE
libseccomp: 2.6.0 -> 2.6.1

### DIFF
--- a/pkgs/by-name/li/libseccomp/package.nix
+++ b/pkgs/by-name/li/libseccomp/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  fetchpatch,
   getopt,
   util-linuxMinimal,
   which,
@@ -13,30 +12,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libseccomp";
-  version = "2.6.0";
+  version = "2.6.1";
 
   src = fetchurl {
     url = "https://github.com/seccomp/libseccomp/releases/download/v${finalAttrs.version}/libseccomp-${finalAttrs.version}.tar.gz";
-    hash = "sha256-g7YIUjLRWIw3ncm5yuR7s3QHzyYubnSZPGG6ctKnhNw=";
+    hash = "sha256-UB9mxmciXVN5G5fh18+Fq3ZMKX0EiB9g849FHEsO4b4=";
   };
-
-  patches = [
-    # Remove when version > 2.6.0
-    # Fixes test failures on big-endian archs
-    (fetchpatch {
-      name = "0001-libseccomp-remove-fuzzer-from-test-62-sim-arch_transactions.patch";
-      url = "https://github.com/seccomp/libseccomp/commit/2f0f3b0e9121720108431c5d054164016f476230.patch";
-      hash = "sha256-AKAQyALJlLgxnS23OEoqfyDswp0kU2vmja5ohgvFojw=";
-    })
-
-    # Remove when version > 2.6.0
-    # Fixes OOB reads & tests on musl
-    (fetchpatch {
-      name = "0002-libseccomp-fix-seccomp_export_bpf_mem-out-of-bounds-read.patch";
-      url = "https://github.com/seccomp/libseccomp/commit/dd759e8c4f5685b526638fba9ec4fc24c37c9aec.patch";
-      hash = "sha256-TdfQ5T8FrGE6+P24MIi9rKSC3fQu/Jlr4bsFiJd4yVY=";
-    })
-  ];
 
   outputs = [
     "out"


### PR DESCRIPTION
Changes: https://github.com/seccomp/libseccomp/releases/tag/v2.6.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
