### PR TITLE
python313Packages.fs: mark broken

### DIFF
--- a/pkgs/development/python-modules/fontfeatures/default.nix
+++ b/pkgs/development/python-modules/fontfeatures/default.nix
@@ -1,11 +1,9 @@
 {
   lib,
+  babelfont,
   buildPythonPackage,
   fetchPypi,
-  beziers,
   fonttools,
-  fs,
-  glyphtools,
   lxml,
   pytestCheckHook,
   youseedee,
@@ -25,12 +23,13 @@ buildPythonPackage rec {
     hash = "sha256-3PpUgaTXyFcthJrFaQqeUOvDYYFosJeXuRFnFrwp0R8=";
   };
 
-  propagatedBuildInputs = [
-    beziers
+  dependencies = [
     fonttools
-    fs
-    glyphtools
     lxml
+  ];
+
+  optional-dependencies.shaper = [
+    babelfont
     youseedee
   ];
 

--- a/pkgs/development/python-modules/fs/default.nix
+++ b/pkgs/development/python-modules/fs/default.nix
@@ -88,6 +88,8 @@ buildPythonPackage rec {
   __darwinAllowLocalNetworking = true;
 
   meta = {
+    # https://github.com/PyFilesystem/pyfilesystem2/issues/577
+    broken = lib.versionAtLeast setuptools.version "82";
     description = "Filesystem abstraction";
     homepage = "https://github.com/PyFilesystem/pyfilesystem2";
     changelog = "https://github.com/PyFilesystem/pyfilesystem2/blob/v${version}/CHANGELOG.md";

--- a/pkgs/development/python-modules/fs/default.nix
+++ b/pkgs/development/python-modules/fs/default.nix
@@ -12,7 +12,7 @@
   pytestCheckHook,
   pythonAtLeast,
   pytz,
-  setuptools_80,
+  setuptools,
   six,
 }:
 
@@ -35,10 +35,10 @@ buildPythonPackage rec {
       --replace ThreadedTestFTPd FtpdThreadWrapper
   '';
 
-  build-system = [ setuptools_80 ];
+  build-system = [ setuptools ];
 
   dependencies = [
-    setuptools_80
+    setuptools
     six
     appdirs
     pytz

--- a/pkgs/development/python-modules/statmake/default.nix
+++ b/pkgs/development/python-modules/statmake/default.nix
@@ -5,8 +5,6 @@
   cattrs,
   fetchFromGitHub,
   fonttools,
-  fs,
-  poetry-core,
   pytestCheckHook,
   ufo2ft,
   ufolib2,
@@ -30,16 +28,12 @@ buildPythonPackage rec {
     hatchling
     hatch-vcs
   ];
-
-  nativeBuildInputs = [ poetry-core ];
-
-  propagatedBuildInputs = [
+  dependencies = [
     attrs
     cattrs
     fonttools
-    # required by fonttools[ufo]
-    fs
-  ];
+  ]
+  ++ fonttools.optional-dependencies.ufo;
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/ufolint/default.nix
+++ b/pkgs/development/python-modules/ufolint/default.nix
@@ -4,14 +4,14 @@
   fetchFromGitHub,
   commandlines,
   fonttools,
-  fs,
   pytestCheckHook,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "ufolint";
   version = "1.2.0";
-  format = "setuptools";
+  pyproject = true;
 
   # PyPI source tarballs omit tests, fetch from Github instead
   src = fetchFromGitHub {
@@ -21,11 +21,13 @@ buildPythonPackage rec {
     hash = "sha256-sv8WbnDd2LFHkwNsB9FO04OlLhemdzwjq0tC9+Fd6/M=";
   };
 
+  build-system = [ setuptools ];
+
   propagatedBuildInputs = [
     commandlines
-    fs
     fonttools
-  ];
+  ]
+  ++ fonttools.optional-dependencies.ufo;
 
   nativeBuildInputs = [ pytestCheckHook ];
 


### PR DESCRIPTION
This reverts commit 6c81b30e2cd1aa5d76191ae549726cfc4cc31ae1 because versioned attributes are not allowed in `dependencies`. This lead to two versions of setuptools in bentoml's closure.
It doesn't suffice to use setuptools_80 in `build-system` because fs imports pkg_resources.
Alternatively we can apply patches mentioned in https://github.com/PyFilesystem/pyfilesystem2/pull/590#issuecomment-4160501089

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
