### PR TITLE
waterfox-bin: init at 6.6.16.1

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1852,6 +1852,10 @@ in
   wasabibackend = runTest ./wasabibackend.nix;
   wastebin = runTest ./wastebin.nix;
   watchdogd = runTest ./watchdogd.nix;
+  waterfox-bin = runTest {
+    imports = [ ./firefox.nix ];
+    _module.args.firefoxPackage = pkgs.waterfox-bin;
+  };
   webhook = runTest ./webhook.nix;
   weblate = runTest ./web-apps/weblate.nix;
   wg-access-server = runTest ./wg-access-server.nix;

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -70,6 +70,7 @@ let
       pkcs11Modules ? [ ],
       useGlvnd ? (!isDarwin),
       cfg ? config.${applicationName} or { },
+      strictDeps ? false,
 
       ## Following options are needed for extra prefs & policies
       # For more information about anti tracking (german website)
@@ -215,6 +216,7 @@ let
     in
     stdenv.mkDerivation (finalAttrs: {
       __structuredAttrs = true;
+      inherit strictDeps;
       inherit pname version;
 
       desktopItem = makeDesktopItem (

--- a/pkgs/by-name/wa/waterfox-bin-unwrapped/package.nix
+++ b/pkgs/by-name/wa/waterfox-bin-unwrapped/package.nix
@@ -1,0 +1,143 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  config,
+  wrapGAppsHook3,
+  autoPatchelfHook,
+  alsa-lib,
+  curl,
+  dbus-glib,
+  gtk3,
+  libxtst,
+  libva,
+  pciutils,
+  pipewire,
+  adwaita-icon-theme,
+  writeText,
+  patchelfUnstable, # have to use patchelfUnstable to support --no-clobber-old-sections
+  applicationName ? "Waterfox",
+  undmg,
+  nixosTests,
+}:
+
+let
+
+  inherit (lib.importJSON ./version.json)
+    version
+    sources
+    ;
+
+  binaryName = "waterfox";
+
+  waterfoxPlatforms = {
+    x86_64-linux = "Linux_x86_64";
+    # bundles are universal and can be re-used for both darwin architectures
+    aarch64-darwin = "Darwin_x86_64-aarch64";
+    x86_64-darwin = "Darwin_x86_64-aarch64";
+  };
+
+  throwSystem = throw "Unsupported system: ${stdenv.hostPlatform.system}";
+
+  arch = waterfoxPlatforms.${stdenv.hostPlatform.system} or throwSystem;
+
+  policies = {
+    DisableAppUpdate = true;
+  }
+  // config.waterfox.policies or { };
+
+  policiesJson = writeText "waterfox-policies.json" (builtins.toJSON { inherit policies; });
+
+  source = lib.findFirst (source: source.arch == arch) { } sources;
+in
+
+stdenv.mkDerivation {
+  pname = "waterfox-bin-unwrapped";
+  inherit version;
+
+  src = fetchurl { inherit (source) url hash; };
+
+  sourceRoot = lib.optional stdenv.hostPlatform.isDarwin ".";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+  nativeBuildInputs = [
+    wrapGAppsHook3
+  ]
+  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
+    autoPatchelfHook
+    patchelfUnstable
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    undmg
+  ];
+  buildInputs = lib.optionals (!stdenv.hostPlatform.isDarwin) [
+    gtk3
+    adwaita-icon-theme
+    alsa-lib
+    dbus-glib
+    libxtst
+  ];
+  runtimeDependencies = [
+    curl
+    pciutils
+  ]
+  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
+    libva.out
+  ];
+  appendRunpaths = lib.optionals (!stdenv.hostPlatform.isDarwin) [
+    "${pipewire}/lib"
+  ];
+  # Firefox uses "relrhack" to manually process relocations from a fixed offset
+  patchelfFlags = [ "--no-clobber-old-sections" ];
+
+  # don't break code signing
+  dontFixup = stdenv.hostPlatform.isDarwin;
+
+  installPhase =
+    if stdenv.hostPlatform.isDarwin then
+      ''
+        mkdir -p $out/Applications
+        mv Waterfox*.app "$out/Applications/${applicationName}.app"
+      ''
+    else
+      ''
+        mkdir -p "$prefix/lib/waterfox-bin-${version}"
+        cp -r * "$prefix/lib/waterfox-bin-${version}"
+
+        mkdir -p "$out/bin"
+        ln -s "$prefix/lib/waterfox-bin-${version}/waterfox" "$out/bin/${binaryName}"
+
+        # See: https://github.com/mozilla/policy-templates/blob/master/README.md
+        mkdir -p "$out/lib/waterfox-bin-${version}/distribution";
+        ln -s ${policiesJson} "$out/lib/waterfox-bin-${version}/distribution/policies.json";
+      '';
+
+  passthru = {
+    inherit applicationName binaryName;
+    libName = "waterfox-bin-${version}";
+    ffmpegSupport = true;
+    gssSupport = true;
+    gtk3 = gtk3;
+
+    # update with:
+    # $ nix-shell maintainers/scripts/update.nix --argstr package waterfox-bin-unwrapped
+    updateScript = ./update.py;
+
+    tests = { inherit (nixosTests) waterfox-bin; };
+  };
+
+  meta = {
+    changelog = "https://www.waterfox.com/releases/${version}/";
+    description = "Waterfox, a privacy focused, performance oriented browser based on Firefox (binary package)";
+    homepage = "https://www.waterfox.com/";
+    license = lib.licenses.mpl20;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = builtins.attrNames waterfoxPlatforms;
+    hydraPlatforms = [ ];
+    maintainers = with lib.maintainers; [
+      maximsmol
+    ];
+    mainProgram = binaryName;
+  };
+}

--- a/pkgs/by-name/wa/waterfox-bin-unwrapped/update.py
+++ b/pkgs/by-name/wa/waterfox-bin-unwrapped/update.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i python3 --packages python3 prefetch-yarn-deps nix-prefetch-git nix-prefetch
+
+import json
+from pathlib import Path
+from sys import stderr
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+from base64 import b64encode
+
+
+def main() -> None:
+    headers = {"User-Agent": "nixpkgs update.py"}
+
+    print("Fetching latest release off GitHub", file=stderr)
+    with urlopen(
+        Request(
+            "https://api.github.com/repos/BrowserWorks/waterfox/releases/latest",
+            headers=headers,
+        )
+    ) as resp:
+        latest = json.loads(resp.read().decode())
+        tag = latest["tag_name"]
+
+    sources = [
+        ("Linux_x86_64", f"waterfox-{tag}.tar.bz2"),
+        ("Darwin_x86_64-aarch64", f"Waterfox {tag}.dmg"),
+    ]
+
+    out = {"version": tag, "sources": []}
+
+    print("Fetching hashes", file=stderr)
+    for arch, filename in sources:
+        src = f"https://cdn.waterfox.com/waterfox/releases/{quote(tag)}/{quote(arch)}/{quote(filename)}"
+        with urlopen(Request(src + quote(".sha512"), headers=headers)) as resp:
+            src_hash = resp.read().split(b"  ")[0].decode()
+
+            out["sources"].append(
+                {
+                    "url": src,
+                    "hash": f"sha512-{b64encode(bytes.fromhex(src_hash)).decode()}",
+                    "arch": arch,
+                }
+            )
+
+    (Path(__file__).parent / "version.json").write_text(
+        json.dumps(out, indent=2) + "\n"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/by-name/wa/waterfox-bin-unwrapped/version.json
+++ b/pkgs/by-name/wa/waterfox-bin-unwrapped/version.json
@@ -1,0 +1,15 @@
+{
+  "version": "6.6.16.1",
+  "sources": [
+    {
+      "url": "https://cdn.waterfox.com/waterfox/releases/6.6.16.1/Linux_x86_64/waterfox-6.6.16.1.tar.bz2",
+      "hash": "sha512-MW3qiphn/b5cxqyi1zJIQSa+70vMveWuJLxxw3CqPQ+l9WBb2Em5yEB9LuRg0QKoN790iped6binSmvHLWj4xQ==",
+      "arch": "Linux_x86_64"
+    },
+    {
+      "url": "https://cdn.waterfox.com/waterfox/releases/6.6.16.1/Darwin_x86_64-aarch64/Waterfox%206.6.16.1.dmg",
+      "hash": "sha512-WNtxepp6Acr1OeSz/AXFFZ4NmK8K6FpC/tJMtH6nWMkxBzpJZPTCFWr4PGpki+Aq2pR1k+pzeYIYIQySu/yDIg==",
+      "arch": "Darwin_x86_64-aarch64"
+    }
+  ]
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8769,6 +8769,11 @@ with pkgs;
     pname = "floorp-bin";
   };
 
+  waterfox-bin = wrapFirefox waterfox-bin-unwrapped {
+    pname = "waterfox-bin";
+    strictDeps = true;
+  };
+
   inherit
     ({
       freeoffice = callPackage ../applications/office/softmaker/freeoffice.nix { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Introduces a binary package for [Waterfox,](https://www.waterfox.com/) which is a fork of Firefox. The derivation is based on derivations for Firefox (which is canonical but old) and Librewolf (which seems to be the most popular of the forks).

Superseeds #388679, which is missing an updater script and diverges from the Firefox derivation more.

Also note #475318, which is a derivation that builds from source.

---

Need some committer to pick this up as a maintainer. See https://github.com/NixOS/nixpkgs/pull/388679/files#r2136057166 for context

---

Note: WebGPU loads but renders incorrectly

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux (unsupported)
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
