### PR TITLE
sage: disable ntl threading on darwin 

### DIFF
--- a/pkgs/by-name/sa/sage/package.nix
+++ b/pkgs/by-name/sa/sage/package.nix
@@ -12,12 +12,19 @@
 let
   inherit (pkgs) symlinkJoin callPackage mathjax;
 
+  ntl = pkgs.ntl.overrideAttrs (old: {
+    configureFlags = (old.configureFlags or [ ]) ++ [
+      "NTL_THREADS=off"
+    ];
+  });
+
   python3 = pkgs.python3 // {
     pkgs = pkgs.python3.pkgs.overrideScope (
       self: super: {
         # `sagelib`, i.e. all of sage except some wrappers and runtime dependencies
         sagelib = self.callPackage ./sagelib.nix {
           inherit flint;
+          inherit ntl;
           inherit sage-src env-locations singular;
           inherit (maxima) lisp-compiler;
           linbox = pkgs.linbox;
@@ -80,6 +87,7 @@ let
       singular
       palp
       flint
+      ntl
       pythonEnv
       maxima
       ;
@@ -94,6 +102,7 @@ let
   # sagelib with added wrappers and a dependency on sage-tests to make sure thet tests were run.
   sage-with-env = callPackage ./sage-with-env.nix {
     inherit python3 pythonEnv;
+    inherit ntl;
     inherit sage-env;
     inherit singular maxima;
     inherit three;

--- a/pkgs/by-name/sa/sage/package.nix
+++ b/pkgs/by-name/sa/sage/package.nix
@@ -1,5 +1,6 @@
 {
   pkgs,
+  stdenv,
   withDoc ? false,
   requireSageTests ? true,
   extraPythonPackages ? ps: [ ],
@@ -12,11 +13,16 @@
 let
   inherit (pkgs) symlinkJoin callPackage mathjax;
 
-  ntl = pkgs.ntl.overrideAttrs (old: {
-    configureFlags = (old.configureFlags or [ ]) ++ [
-      "NTL_THREADS=off"
-    ];
-  });
+  ntl = (
+    if stdenv.hostPlatform.isDarwin then
+      (pkgs.ntl.overrideAttrs (old: {
+        configureFlags = (old.configureFlags or [ ]) ++ [
+          "NTL_THREADS=off"
+        ];
+      }))
+    else
+      pkgs.ntl
+  );
 
   python3 = pkgs.python3 // {
     pkgs = pkgs.python3.pkgs.overrideScope (


### PR DESCRIPTION
Configure ntl dependency with NTL_THREADS=off on darwin, following how official sage builds configure it:

https://github.com/sagemath/sage/blob/80e56eaeb7089cfc5e4e0cc495ba8da43ee0a573/build/pkgs/ntl/spkg-install.in#L102

This change fixes darwin sage builds and together with two others makes `sage` operational on aarch64-darwin:

- https://github.com/NixOS/nixpkgs/pull/542059
- https://github.com/NixOS/nixpkgs/pull/541486

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
