### PR TITLE
treewide: clean up `badPlatforms` after `x86_64-darwin` drop

### DIFF
--- a/pkgs/by-name/ha/handy/package.nix
+++ b/pkgs/by-name/ha/handy/package.nix
@@ -281,6 +281,5 @@ rustPlatform.buildRustPackage (finalAttrs: {
       philocalyst
     ];
     platforms = with lib.platforms; linux ++ darwin;
-    badPlatforms = [ ]; # We weren't able to get hashes here
   };
 })

--- a/pkgs/by-name/iv/iverilog/package.nix
+++ b/pkgs/by-name/iv/iverilog/package.nix
@@ -93,9 +93,5 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     maintainers = with lib.maintainers; [ thoughtpolice ];
     platforms = lib.platforms.all;
-    badPlatforms = [
-      # Several tests fail with:
-      # ==> Failed - running iverilog.
-    ];
   };
 })

--- a/pkgs/by-name/ki/kilo/package.nix
+++ b/pkgs/by-name/ki/kilo/package.nix
@@ -191,8 +191,5 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       "x86_64-linux"
       "aarch64-darwin"
     ];
-    badPlatforms = [
-      # Broken due to Bun requiring AVX when run via Rosetta 2 on Apple Silicon.
-    ];
   };
 })

--- a/pkgs/by-name/lu/luau-lsp/package.nix
+++ b/pkgs/by-name/lu/luau-lsp/package.nix
@@ -57,9 +57,5 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [ HeitorAugustoLN ];
     mainProgram = "luau-lsp";
     platforms = lib.platforms.all;
-    badPlatforms = [
-      # Could not find a package configuration file provided by "Protobuf"
-      # It is unclear why this is only happening on x86_64-darwin
-    ];
   };
 })

--- a/pkgs/by-name/mo/mongocxx/package.nix
+++ b/pkgs/by-name/mo/mongocxx/package.nix
@@ -59,6 +59,5 @@ stdenv.mkDerivation (finalAttrs: {
       "libbsoncxx"
     ];
     platforms = lib.platforms.all;
-    badPlatforms = [ ]; # needs sdk >= 10.14
   };
 })

--- a/pkgs/by-name/ne/nesting/package.nix
+++ b/pkgs/by-name/ne/nesting/package.nix
@@ -53,8 +53,5 @@ buildGoModule (finalAttrs: {
     license = lib.licenses.mit;
     mainProgram = "nesting";
     maintainers = with lib.maintainers; [ commiterate ];
-    badPlatforms = [
-      # Only supports AArch64 for Darwin.
-    ];
   };
 })

--- a/pkgs/by-name/op/openmvg/package.nix
+++ b/pkgs/by-name/op/openmvg/package.nix
@@ -94,8 +94,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/openMVG/openMVG/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mpl20;
     platforms = lib.platforms.unix;
-    badPlatforms = [
-    ];
     maintainers = with lib.maintainers; [
       mdaiter
       bouk

--- a/pkgs/by-name/sq/sqlpkg-cli/package.nix
+++ b/pkgs/by-name/sq/sqlpkg-cli/package.nix
@@ -40,7 +40,6 @@ buildGoModule (finalAttrs: {
     platforms = lib.platforms.unix;
     badPlatforms = [
       "aarch64-linux" # assets_test.go:44: BuildAssetPath: unexpected error unsupported platform: linux-arm64
-      # assets_test.go:44: BuildAssetPath: unexpected error unsupported platform: darwin-amd64
       "aarch64-darwin" # install_test.go:22: installation error: failed to dequarantine files: exec: "xattr": executable file not found in $PATH
     ];
   };

--- a/pkgs/by-name/to/tokenspeed-triton-llvm/package.nix
+++ b/pkgs/by-name/to/tokenspeed-triton-llvm/package.nix
@@ -78,8 +78,5 @@ stdenv.mkDerivation (finalAttrs: {
       ];
     maintainers = with lib.maintainers; [ prince213 ];
     platforms = with lib.platforms; aarch64 ++ x86;
-    badPlatforms = [
-      # clang++: error: clang frontend command failed with exit code 139
-    ];
   };
 })

--- a/pkgs/development/python-modules/jaxlib/bin.nix
+++ b/pkgs/development/python-modules/jaxlib/bin.nix
@@ -145,11 +145,5 @@ buildPythonPackage {
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ samuela ];
-    badPlatforms = [
-      # Fails at pythonImportsCheckPhase:
-      # ...-python-imports-check-hook.sh/nix-support/setup-hook: line 10: 28017 Illegal instruction: 4
-      # /nix/store/5qpssbvkzfh73xih07xgmpkj5r565975-python3-3.11.9/bin/python3.11 -c
-      # 'import os; import importlib; list(map(lambda mod: importlib.import_module(mod), os.environ["pythonImportsCheck"].split()))'
-    ];
   };
 }

--- a/pkgs/development/python-modules/pcodec/default.nix
+++ b/pkgs/development/python-modules/pcodec/default.nix
@@ -48,8 +48,5 @@ buildPythonPackage rec {
     maintainers = with lib.maintainers; [
       flokli
     ];
-    badPlatforms = [
-      # Illegal instruction: 4
-    ];
   };
 }

--- a/pkgs/development/python-modules/scalene/default.nix
+++ b/pkgs/development/python-modules/scalene/default.nix
@@ -138,8 +138,8 @@ buildPythonPackage (finalAttrs: {
       # The scalene doesn't seem to account for arm64 linux
       "aarch64-linux"
 
-      # On darwin, builds 1) assume aarch64 and 2) mistakenly compile one part as
-      # x86 and the other as arm64 then tries to link them into a single binary
+      # On darwin, builds mistakenly compile one part as x86 and the
+      # other as arm64 then tries to link them into a single binary
       # which fails.
       "aarch64-darwin"
     ];

--- a/pkgs/development/python-modules/tensorflow/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/bin.nix
@@ -240,7 +240,6 @@ buildPythonPackage (finalAttrs: {
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.asl20;
     maintainers = [ ];
-    badPlatforms = [ ];
     # unsupported combination
     broken = stdenv.hostPlatform.isDarwin && cudaSupport;
   };

--- a/pkgs/development/python-modules/ultralytics/default.nix
+++ b/pkgs/development/python-modules/ultralytics/default.nix
@@ -138,9 +138,5 @@ buildPythonPackage (finalAttrs: {
       osbm
       mana-byte
     ];
-    badPlatforms = [
-      # Tests crash with:
-      # Fatal Python error: Segmentation fault for x86_64 Darwin in tests/python.py
-    ];
   };
 })

--- a/pkgs/development/python-modules/vllm/default.nix
+++ b/pkgs/development/python-modules/vllm/default.nix
@@ -598,10 +598,6 @@ buildPythonPackage.override { stdenv = torch.stdenv; } (finalAttrs: {
       #   vLLM CPU backend requires AVX512, AVX2, Power9+ ISA, S390X ISA, ARMv8 or
       #   RISC-V support.
       "aarch64-darwin"
-
-      # CMake Error at cmake/cpu_extension.cmake:78 (find_isa):
-      # find_isa Function invoked with incorrect arguments for function named:
-      # find_isa
     ];
     knownVulnerabilities = [
       "CVE-2026-25960"


### PR DESCRIPTION
Stacked on top of https://github.com/NixOS/nixpkgs/pull/541145.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
