### PR TITLE
at-spi2-core: Find `dbus-daemon` and `dbus-broker-launch` on `PATH`

### DIFF
--- a/pkgs/by-name/at/at-spi2-core/package.nix
+++ b/pkgs/by-name/at/at-spi2-core/package.nix
@@ -29,7 +29,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "at-spi2-core";
-  version = "2.60.4";
+  version = "2.60.5";
 
   outputs = [
     "out"
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/at-spi2-core/${lib.versions.majorMinor finalAttrs.version}/at-spi2-core-${finalAttrs.version}.tar.xz";
-    hash = "sha256-Gh9bqYBZF/QfxqpoI9z4h6KR1gekJ+LVr7a136ZQcMc=";
+    hash = "sha256-YFmnfVB0OP9sjW0GAl+Pn1d0+g+Oq+nJsFmxzEHhu8A=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/at/at-spi2-core/package.nix
+++ b/pkgs/by-name/at/at-spi2-core/package.nix
@@ -79,15 +79,14 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = false;
 
   mesonFlags = [
-    # Provide dbus-daemon fallback when it is not already running when
-    # at-spi2-bus-launcher is executed. This allows us to avoid
-    # including the entire dbus closure in libraries linked with
-    # the at-spi2-core libraries.
-    "-Ddbus_daemon=/run/current-system/sw/bin/dbus-daemon"
+    # Allows at-spi2-bus-launcher to use dbus-daemon from PATH.
+    # This allows us to avoid including the entire dbus closure in libraries
+    # linked with the at-spi2-core libraries.
+    "-Ddbus_daemon=dbus-daemon"
   ]
   ++ lib.optionals systemdSupport [
     # Same as the above, but for dbus-broker
-    "-Ddbus_broker=/run/current-system/sw/bin/dbus-broker-launch"
+    "-Ddbus_broker=dbus-broker-launch"
   ]
   ++ lib.optionals (!systemdSupport) [
     "-Duse_systemd=false"
@@ -108,10 +107,17 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   postFixup = ''
-    # Cannot use wrapGAppsHook'due to a dependency cycle
-    wrapProgram $out/libexec/at-spi-bus-launcher \
-      ${lib.optionalString withDconf ''--prefix GIO_EXTRA_MODULES : "${lib.getLib dconf}/lib/gio/modules"''} \
+    busLauncherWrapperArgs=(
+      # Prefer dbus-daemon and dbus-broker-launch from system locations.
+      --prefix PATH : "/run/current-system/sw/bin:/usr/bin"
+
+      # Access to accessibility settings.
+      ${lib.optionalString withDconf ''--prefix GIO_EXTRA_MODULES : "${lib.getLib dconf}/lib/gio/modules"''}
       --prefix XDG_DATA_DIRS : ${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}
+    )
+
+    # Cannot use wrapGAppsHook'due to a dependency cycle
+    wrapProgram "$out/libexec/at-spi-bus-launcher" "''${busLauncherWrapperArgs[@]}"
   '';
 
   meta = {


### PR DESCRIPTION
This is needed to allow using `at-spi-bus-launcher` in Nix build sandbox where the `/run/current-system` does not exist (e.g. for testing Orca). As a side benefit, we will be able to run `at-spi-bus-launcher` on non-NixOS systems.

Also, the comment introduced in f6260a3fe5b2844671eb5dc3ff9f010009c116d1 is slightly misleading. There is no fallback – `at-spi-bus-launcher` will always launch a new `dbus-daemon` instance (accessibility bus) to avoid clobbering the session bus. So I adjusted the text.

Since `at-spi-dbus-bus.service` is a systemd user service, it will use `PATH` from user profile, which might prioritize e.g. `~/.local/bin`. This could, in theory, allow an injection of a malicious D-Bus daemon wrapper that would exfiltrate the accessibility bus traffic. But attacker could just as well override `at-spi-dbus-bus.service` so this should not affect security properties. But just to reduce the chance of user profile interference, I am prepending system directories to PATH in the launcher wrapper.

While at it, I am updating the package: https://gitlab.gnome.org/GNOME/at-spi2-core/-/compare/2.60.4...2.60.5

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Checked that this fixes orca test suite.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
