### PR TITLE
openllm, python3Packages.bentoml: mark insecure

### DIFF
--- a/pkgs/by-name/op/openllm/package.nix
+++ b/pkgs/by-name/op/openllm/package.nix
@@ -64,6 +64,9 @@ python3Packages.buildPythonApplication (finalAttrs: {
     description = "Run any open-source LLMs, such as Llama 3.1, Gemma, as OpenAI compatible API endpoint in the cloud";
     homepage = "https://github.com/bentoml/OpenLLM";
     changelog = "https://github.com/bentoml/OpenLLM/releases/tag/${finalAttrs.src.tag}";
+    knownVulnerabilities = [
+      "CVE-2026-15035"
+    ];
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       happysalada

--- a/pkgs/development/python-modules/bentoml/default.nix
+++ b/pkgs/development/python-modules/bentoml/default.nix
@@ -248,6 +248,14 @@ buildPythonPackage {
     description = "Build Production-Grade AI Applications";
     homepage = "https://github.com/bentoml/BentoML";
     changelog = "https://github.com/bentoml/BentoML/releases/tag/${src.tag}";
+    knownVulnerabilities = [
+      "CVE-2026-27905"
+      "CVE-2026-33744"
+      "CVE-2026-35043"
+      "CVE-2026-35044"
+      "CVE-2026-44345"
+      "CVE-2026-44346"
+    ];
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       happysalada


### PR DESCRIPTION
closes https://github.com/NixOS/nixpkgs/issues/496646
closes https://github.com/NixOS/nixpkgs/issues/504453
closes https://github.com/NixOS/nixpkgs/issues/508656
closes https://github.com/NixOS/nixpkgs/issues/507891
closes https://github.com/NixOS/nixpkgs/issues/525292
closes https://github.com/NixOS/nixpkgs/issues/525296
closes https://github.com/NixOS/nixpkgs/issues/539903

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
