### PR TITLE
orca: Enable integration tests

### DIFF
--- a/pkgs/by-name/at/at-spi2-core/package.nix
+++ b/pkgs/by-name/at/at-spi2-core/package.nix
@@ -29,7 +29,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "at-spi2-core";
-  version = "2.60.4";
+  version = "2.60.5";
 
   outputs = [
     "out"
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/at-spi2-core/${lib.versions.majorMinor finalAttrs.version}/at-spi2-core-${finalAttrs.version}.tar.xz";
-    hash = "sha256-Gh9bqYBZF/QfxqpoI9z4h6KR1gekJ+LVr7a136ZQcMc=";
+    hash = "sha256-YFmnfVB0OP9sjW0GAl+Pn1d0+g+Oq+nJsFmxzEHhu8A=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/at/at-spi2-core/package.nix
+++ b/pkgs/by-name/at/at-spi2-core/package.nix
@@ -79,15 +79,14 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = false;
 
   mesonFlags = [
-    # Provide dbus-daemon fallback when it is not already running when
-    # at-spi2-bus-launcher is executed. This allows us to avoid
-    # including the entire dbus closure in libraries linked with
-    # the at-spi2-core libraries.
-    "-Ddbus_daemon=/run/current-system/sw/bin/dbus-daemon"
+    # Allows at-spi2-bus-launcher to use dbus-daemon from PATH.
+    # This allows us to avoid including the entire dbus closure in libraries
+    # linked with the at-spi2-core libraries.
+    "-Ddbus_daemon=dbus-daemon"
   ]
   ++ lib.optionals systemdSupport [
     # Same as the above, but for dbus-broker
-    "-Ddbus_broker=/run/current-system/sw/bin/dbus-broker-launch"
+    "-Ddbus_broker=dbus-broker-launch"
   ]
   ++ lib.optionals (!systemdSupport) [
     "-Duse_systemd=false"
@@ -108,10 +107,17 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   postFixup = ''
-    # Cannot use wrapGAppsHook'due to a dependency cycle
-    wrapProgram $out/libexec/at-spi-bus-launcher \
-      ${lib.optionalString withDconf ''--prefix GIO_EXTRA_MODULES : "${lib.getLib dconf}/lib/gio/modules"''} \
+    busLauncherWrapperArgs=(
+      # Prefer dbus-daemon and dbus-broker-launch from system locations.
+      --prefix PATH : "/run/current-system/sw/bin:/usr/bin"
+
+      # Access to accessibility settings.
+      ${lib.optionalString withDconf ''--prefix GIO_EXTRA_MODULES : "${lib.getLib dconf}/lib/gio/modules"''}
       --prefix XDG_DATA_DIRS : ${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}
+    )
+
+    # Cannot use wrapGAppsHook'due to a dependency cycle
+    wrapProgram "$out/libexec/at-spi-bus-launcher" "''${busLauncherWrapperArgs[@]}"
   '';
 
   meta = {

--- a/pkgs/by-name/li/liblouis/package.nix
+++ b/pkgs/by-name/li/liblouis/package.nix
@@ -14,7 +14,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "liblouis";
-  version = "3.33.0";
+  version = "3.38.0";
 
   outputs = [
     "out"
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "liblouis";
     repo = "liblouis";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-+p/2eLbQ5aYtxQIkoHaVE1xDqstveedf+56aRNX9C7M=";
+    hash = "sha256-OmYMldo2id2HKAM0Hxi6r86khSUnzu22CkJhGBhaaL8=";
   };
 
   strictDeps = true;
@@ -63,7 +63,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     patchShebangs tests
-    substituteInPlace python/louis/__init__.py.in --replace "###LIBLOUIS_SONAME###" "$out/lib/liblouis.so"
+    substituteInPlace python/louis/__init__.py.in \
+      --replace-fail "###LIBLOUIS_SONAME###" "$out/lib/liblouis.so"
   '';
 
   postInstall = ''
@@ -71,6 +72,12 @@ stdenv.mkDerivation (finalAttrs: {
     python -m build --no-isolation --outdir dist/ --wheel
     python -m installer --prefix $out dist/*.whl
     popd
+
+    make install-html MAKEINFOFLAGS="--no-headers --no-split"
+    pushd doc
+    make liblouis.txt
+    popd
+    install -D -t "$doc/share/doc/liblouis" doc/liblouis.txt
   '';
 
   doCheck = true;

--- a/pkgs/by-name/or/orca/fix-mock-typing.patch
+++ b/pkgs/by-name/or/orca/fix-mock-typing.patch
@@ -1,0 +1,64 @@
+diff --git a/tests/unit_tests/test_dbus_service.py b/tests/unit_tests/test_dbus_service.py
+index bf8cab8a7..0db3afd60 100644
+--- a/tests/unit_tests/test_dbus_service.py
++++ b/tests/unit_tests/test_dbus_service.py
+@@ -59,6 +59,7 @@ class TestDBusService:
+         external_modules = [
+             "gi",
+             "gi.repository",
++            "gi.repository.Atspi",
+             "dasbus",
+             "dasbus.connection",
+             "dasbus.error",
+@@ -96,8 +97,16 @@ class TestDBusService:
+                 """Unpack the variant value."""
+                 return self._value
+ 
+-        essential_modules["gi.repository"].GLib = test_context.Mock()
+-        essential_modules["gi.repository"].GLib.Variant = MockGLibVariant
++        gi_repository_mock = essential_modules["gi.repository"]
++        gi_repository_mock.GLib = test_context.Mock()
++        gi_repository_mock.GLib.Variant = MockGLibVariant
++
++        class Fake():
++            pass
++
++        atspi_mock = essential_modules["gi.repository.Atspi"]
++        atspi_mock.Accessible = Fake
++        gi_repository_mock.Atspi = atspi_mock
+ 
+         class MockPublishable:
+             """Mock Publishable base class for inheritance."""
+
+
+Taken from https://gitlab.gnome.org/GNOME/orca/-/commit/20340d2075a34721aa6af46507d02525f3eac5f5
+
+diff --git a/src/orca/ax_utilities_application.py b/src/orca/ax_utilities_application.py
+index 2edcabf11..d59b8ae9e 100644
+--- a/src/orca/ax_utilities_application.py
++++ b/src/orca/ax_utilities_application.py
+@@ -21,6 +21,7 @@
+ 
+ """Utilities for accessible applications."""
+ 
++from __future__ import annotations
+ import gi
+ 
+ gi.require_version("Atspi", "2.0")
+
+
+Taken from https://gitlab.gnome.org/GNOME/orca/-/commit/6c18ba002c6fac3fb80a10791b0daab6ea85f072
+
+diff --git a/src/orca/ax_event_synthesizer.py b/src/orca/ax_event_synthesizer.py
+index 4b999ef75..cb0f0e31a 100644
+--- a/src/orca/ax_event_synthesizer.py
++++ b/src/orca/ax_event_synthesizer.py
+@@ -22,6 +22,8 @@
+ 
+ """Provides support for synthesizing accessible input events."""
+ 
++from __future__ import annotations
++
+ import gi
+ 
+ gi.require_version("Atspi", "2.0")

--- a/pkgs/by-name/or/orca/fix-paths.patch
+++ b/pkgs/by-name/or/orca/fix-paths.patch
@@ -1,70 +1,75 @@
-diff --git a/src/orca/ax_utilities_application.py b/src/orca/ax_utilities_application.py
-index 218c7bf22..4474f26cd 100644
---- a/src/orca/ax_utilities_application.py
-+++ b/src/orca/ax_utilities_application.py
-@@ -180,7 +180,7 @@ class AXUtilitiesApplication:
- 
-         pid = AXUtilitiesApplication.get_process_id(app)
-         try:
--            state = subprocess.getoutput(f"cat /proc/{pid}/status | grep State")
-+            state = subprocess.getoutput(f"@cat@ /proc/{pid}/status | @grep@ State")
-             state = state.split()[1]
-         except (GLib.GError, IndexError) as error:
-             tokens = [f"AXUtilitiesApplication: Exception checking state of pid {pid}: {error}"]
-diff --git a/src/orca/debugging_tools_manager.py b/src/orca/debugging_tools_manager.py
-index 5c607f3cd..18ddcd920 100644
---- a/src/orca/debugging_tools_manager.py
-+++ b/src/orca/debugging_tools_manager.py
-@@ -169,7 +169,7 @@ class DebuggingToolsManager:
-             else:
-                 name = AXObject.get_name(app) or "[DEAD]"
-             try:
--                cmdline = subprocess.getoutput(f"cat /proc/{pid}/cmdline")
-+                cmdline = subprocess.getoutput(f"@cat@ /proc/{pid}/cmdline")
-             except subprocess.SubprocessError as error:
-                 cmdline = f"EXCEPTION: {error}"
-             else:
 diff --git a/src/orca/orca_bin.py.in b/src/orca/orca_bin.py.in
-index 86a1413ca..f272c431d 100755
+index be3d4ebdd..1f83d6d6c 100755
 --- a/src/orca/orca_bin.py.in
 +++ b/src/orca/orca_bin.py.in
-@@ -211,7 +211,7 @@ def in_graphical_desktop() -> bool:
- def other_orcas() -> list[int]:
+@@ -209,7 +209,7 @@ def other_orcas() -> list[int]:
      """Returns the pid of any other instances of Orca owned by this user."""
  
--    with subprocess.Popen(f"pgrep -u {os.getuid()} -x orca",
-+    with subprocess.Popen(f"@pgrep@ -u {os.getuid()} -x orca",
-                           shell=True,
-                           stdout=subprocess.PIPE) as proc:
+     with subprocess.Popen(
+-        ["pgrep", "-u", str(os.getuid()), "-x", "orca"],
++        ["@pgrep@", "-u", str(os.getuid()), "-x", "orca"],
+         stdout=subprocess.PIPE,
+     ) as proc:
          pids = proc.stdout.read() if proc.stdout else b""
 diff --git a/src/orca/orca_modifier_manager.py b/src/orca/orca_modifier_manager.py
-index d1d95f5b9..e57993521 100644
+index eec1edc5f..e4ceee004 100644
 --- a/src/orca/orca_modifier_manager.py
 +++ b/src/orca/orca_modifier_manager.py
 @@ -289,7 +289,7 @@ class OrcaModifierManager:
  
          self._restore_original_xkbcomp()
-         with subprocess.Popen(
--            ["xkbcomp", display, "-"],
-+            ["@xkbcomp@", display, "-"],
+         with subprocess.Popen(  # noqa: S603 - xkbcomp is a system dependency, not untrusted input
+-            ["xkbcomp", display, "-"],  # noqa: S607 - full path would break across distros
++            ["@xkbcomp@", display, "-"],  # noqa: S607 - full path would break across distros
              stdout=subprocess.PIPE,
              stderr=subprocess.DEVNULL,
          ) as p:
 @@ -338,7 +338,7 @@ class OrcaModifierManager:
  
          self._caps_lock_cleared = False
-         with subprocess.Popen(
--            ["xkbcomp", "-w0", "-", display],
-+            ["@xkbcomp@", "-w0", "-", display],
+         with subprocess.Popen(  # noqa: S603 - xkbcomp is a system dependency, not untrusted input
+-            ["xkbcomp", "-w0", "-", display],  # noqa: S607 - full path would break across distros
++            ["@xkbcomp@", "-w0", "-", display],  # noqa: S607 - full path would break across distros
              stdin=subprocess.PIPE,
              stdout=None,
              stderr=None,
 @@ -449,7 +449,7 @@ class OrcaModifierManager:
          debug.print_message(debug.LEVEL_INFO, msg, True)
  
-         with subprocess.Popen(
--            ["xkbcomp", "-w0", "-", display],
-+            ["@xkbcomp@", "-w0", "-", display],
+         with subprocess.Popen(  # noqa: S603 - xkbcomp is a system dependency, not untrusted input
+-            ["xkbcomp", "-w0", "-", display],  # noqa: S607 - full path would break across distros
++            ["@xkbcomp@", "-w0", "-", display],  # noqa: S607 - full path would break across distros
              stdin=subprocess.PIPE,
              stdout=None,
              stderr=None,
+diff --git a/tests/unit_tests/test_orca_modifier_manager.py b/tests/unit_tests/test_orca_modifier_manager.py
+index 3c6c917cb..5d714f2a5 100644
+--- a/tests/unit_tests/test_orca_modifier_manager.py
++++ b/tests/unit_tests/test_orca_modifier_manager.py
+@@ -700,7 +700,7 @@ class TestOrcaModifierManager:
+         manager.refresh_orca_modifiers("test reason")
+         mock_restore.assert_called_once()
+         mock_popen.assert_called_once_with(
+-            ["xkbcomp", ":0", "-"],
++            ["@xkbcomp@", ":0", "-"],
+             stdout=subprocess.PIPE,
+             stderr=subprocess.DEVNULL,
+         )
+@@ -808,7 +808,7 @@ class TestOrcaModifierManager:
+         mock_unmap.assert_called_once()
+         if expects_popen_call:
+             mock_popen.assert_called_once_with(
+-                ["xkbcomp", "-w0", "-", ":0"],
++                ["@xkbcomp@", "-w0", "-", ":0"],
+                 stdin=subprocess.PIPE,
+                 stdout=None,
+                 stderr=None,
+@@ -880,7 +880,7 @@ class TestOrcaModifierManager:
+ 
+         if expects_popen_call:
+             mock_popen.assert_called_once_with(
+-                ["xkbcomp", "-w0", "-", ":0"],
++                ["@xkbcomp@", "-w0", "-", ":0"],
+                 stdin=subprocess.PIPE,
+                 stdout=None,
+                 stderr=None,

--- a/pkgs/by-name/or/orca/fix-paths.patch
+++ b/pkgs/by-name/or/orca/fix-paths.patch
@@ -73,3 +73,16 @@ index 3c6c917cb..5d714f2a5 100644
                  stdin=subprocess.PIPE,
                  stdout=None,
                  stderr=None,
+diff --git a/tests/integration_test_wrapper.py.in b/tests/integration_test_wrapper.py.in
+index 576a1d4f3..d117076a5 100644
+--- a/tests/integration_test_wrapper.py.in
++++ b/tests/integration_test_wrapper.py.in
+@@ -16,7 +16,7 @@ from typing import NoReturn
+ _SKIP_EXIT = 77
+ # Prefer this prefix's AT-SPI.
+ _ATSPI_DIRECTORIES = (
+-    os.path.join("@prefix@", "libexec"),
++    os.path.join("@at_spi2_core@", "libexec"),
+     os.path.join("@prefix@", "lib", "at-spi2-core"),
+     "/usr/libexec",
+     "/usr/lib/at-spi2-core",

--- a/pkgs/by-name/or/orca/package.nix
+++ b/pkgs/by-name/or/orca/package.nix
@@ -55,6 +55,30 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
       ];
     })
 
+    # Fix tests on Python < 3.15
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/orca/-/commit/6c18ba002c6fac3fb80a10791b0daab6ea85f072.patch";
+      hash = "sha256-jTwVN0hPkead7PiVo/KEUrP04XU/05LXnXutvVmyecc=";
+      excludes = [
+        # These do not apply, fixed in fix-mock-typing.patch
+        "src/orca/ax_event_synthesizer.py"
+        "tests/unit_tests/test_flat_review_presenter.py"
+      ];
+    })
+
+    # Fix more tests on Python < 3.15
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/orca/-/commit/0a1271f0d6ed6f6d73d41b227a9f6d84d994c154.patch";
+      hash = "sha256-ry8fmzUjtHR8/0UpB/zXuv6RYDS8z6fWRdb9eci6nLY=";
+      includes = [
+        "src/orca/sound.py"
+      ];
+    })
+
+    # Fix more tests on Python < 3.15
+    # https://gitlab.gnome.org/GNOME/orca/-/work_items/729
+    ./fix-mock-typing.patch
+
     (replaceVars ./fix-paths.patch {
       pgrep = "${procps}/bin/pgrep";
       xkbcomp = "${xkbcomp}/bin/xkbcomp";
@@ -107,10 +131,31 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     gst_all_1.gst-plugins-good
   ];
 
+  nativeCheckInputs = with python3.pkgs; [
+    pytest
+  ];
+
+  checkInputs = with python3.pkgs; [
+    pytest-mock
+  ];
+
+  postPatch = ''
+    # Disable broken tests
+    substituteInPlace tests/meson.build \
+      --replace-fail "  'unit_tests/test_preferences_grid_base.py'," "" \
+      --replace-fail "  'unit_tests/test_braille_presenter.py'," "" \
+      --replace-fail "  'unit_tests/test_profile_manager.py'," ""
+  '';
+
   # Help GI find typelibs during Meson's configure step in cross builds
   preConfigure = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
     export GI_TYPELIB_PATH=${buildPackages.gtk3}/lib/girepository-1.0''${GI_TYPELIB_PATH:+:$GI_TYPELIB_PATH}
   '';
+
+  # `buildPythonPackage` uses `installCheckPhase` and leaves `checkPhase`
+  # empty. It renames `doCheck` from its arguments, but not `checkPhase`.
+  # See: https://github.com/NixOS/nixpkgs/issues/47390
+  installCheckPhase = "mesonCheckPhase";
 
   dontWrapGApps = true; # Prevent double wrapping
 

--- a/pkgs/by-name/or/orca/package.nix
+++ b/pkgs/by-name/or/orca/package.nix
@@ -71,7 +71,6 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   pythonPath = with python3.pkgs; [
     dasbus
     pygobject3
-    dbus-python
     pyxdg
     brltty
     liblouis

--- a/pkgs/by-name/or/orca/package.nix
+++ b/pkgs/by-name/or/orca/package.nix
@@ -46,7 +46,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
       hash = "sha256-ts/ZCgEaTrnmMM1cUFJB2rDW9icMoi4jV34psD0IDCc=";
     })
 
-    # Required for next patch to apply.
+    # Required for fix-paths.patch to apply.
     (fetchpatch {
       url = "https://gitlab.gnome.org/GNOME/orca/-/commit/a7b10302b9ff9145a98cb3626f2488d15c558d3e.patch";
       hash = "sha256-lacy9vIyM3n84s+tbYvAUBKWCT+4nlI9uPVl7UPVS74=";
@@ -90,6 +90,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     speechd-minimal
     gst-python
     setproctitle
+    at-spi2-core
   ];
 
   strictDeps = false;

--- a/pkgs/by-name/or/orca/package.nix
+++ b/pkgs/by-name/or/orca/package.nix
@@ -4,6 +4,7 @@
   buildPackages,
   pkg-config,
   fetchurl,
+  fetchpatch,
   meson,
   ninja,
   wrapGAppsHook3,
@@ -20,8 +21,6 @@
   dbus,
   xkbcomp,
   procps,
-  gnugrep,
-  coreutils,
   gsettings-desktop-schemas,
   speechd-minimal,
   brltty,
@@ -41,9 +40,22 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   };
 
   patches = [
+    # Avoid running `cat` and `grep` subshells.
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/orca/-/commit/8f47283da2da7a7d34e769d9c129152decf632cb.patch";
+      hash = "sha256-ts/ZCgEaTrnmMM1cUFJB2rDW9icMoi4jV34psD0IDCc=";
+    })
+
+    # Required for next patch to apply.
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/orca/-/commit/a7b10302b9ff9145a98cb3626f2488d15c558d3e.patch";
+      hash = "sha256-lacy9vIyM3n84s+tbYvAUBKWCT+4nlI9uPVl7UPVS74=";
+      includes = [
+        "src/orca/orca_modifier_manager.py"
+      ];
+    })
+
     (replaceVars ./fix-paths.patch {
-      cat = "${coreutils}/bin/cat";
-      grep = "${gnugrep}/bin/grep";
       pgrep = "${procps}/bin/pgrep";
       xkbcomp = "${xkbcomp}/bin/xkbcomp";
     })

--- a/pkgs/by-name/or/orca/package.nix
+++ b/pkgs/by-name/or/orca/package.nix
@@ -34,54 +34,14 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   pyproject = false;
 
-  src = fetchurl {
-    url = "mirror://gnome/sources/orca/${lib.versions.major finalAttrs.version}/orca-${finalAttrs.version}.tar.xz";
-    hash = "sha256-BxRCHN6OxLr0fxjktKErTlxKPP47FhVp4HD+A3cT/QQ=";
-  };
+  src = /home/jtojnar/Projects/orca;
 
   patches = [
-    # Avoid running `cat` and `grep` subshells.
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/orca/-/commit/8f47283da2da7a7d34e769d9c129152decf632cb.patch";
-      hash = "sha256-ts/ZCgEaTrnmMM1cUFJB2rDW9icMoi4jV34psD0IDCc=";
-    })
-
-    # Required for fix-paths.patch to apply.
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/orca/-/commit/a7b10302b9ff9145a98cb3626f2488d15c558d3e.patch";
-      hash = "sha256-lacy9vIyM3n84s+tbYvAUBKWCT+4nlI9uPVl7UPVS74=";
-      includes = [
-        "src/orca/orca_modifier_manager.py"
-      ];
-    })
-
-    # Fix tests on Python < 3.15
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/orca/-/commit/6c18ba002c6fac3fb80a10791b0daab6ea85f072.patch";
-      hash = "sha256-jTwVN0hPkead7PiVo/KEUrP04XU/05LXnXutvVmyecc=";
-      excludes = [
-        # These do not apply, fixed in fix-mock-typing.patch
-        "src/orca/ax_event_synthesizer.py"
-        "tests/unit_tests/test_flat_review_presenter.py"
-      ];
-    })
-
-    # Fix more tests on Python < 3.15
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/orca/-/commit/0a1271f0d6ed6f6d73d41b227a9f6d84d994c154.patch";
-      hash = "sha256-ry8fmzUjtHR8/0UpB/zXuv6RYDS8z6fWRdb9eci6nLY=";
-      includes = [
-        "src/orca/sound.py"
-      ];
-    })
-
-    # Fix more tests on Python < 3.15
-    # https://gitlab.gnome.org/GNOME/orca/-/work_items/729
-    ./fix-mock-typing.patch
-
     (replaceVars ./fix-paths.patch {
       pgrep = "${procps}/bin/pgrep";
       xkbcomp = "${xkbcomp}/bin/xkbcomp";
+      at_spi2_core = at-spi2-core;
+      prefix = null;
     })
   ];
 
@@ -139,13 +99,9 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     pytest-mock
   ];
 
-  postPatch = ''
-    # Disable broken tests
-    substituteInPlace tests/meson.build \
-      --replace-fail "  'unit_tests/test_preferences_grid_base.py'," "" \
-      --replace-fail "  'unit_tests/test_braille_presenter.py'," "" \
-      --replace-fail "  'unit_tests/test_profile_manager.py'," ""
-  '';
+  mesonFlags = [
+    "-Dmathcat=false"
+  ];
 
   # Help GI find typelibs during Meson's configure step in cross builds
   preConfigure = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''

--- a/pkgs/by-name/or/orca/package.nix
+++ b/pkgs/by-name/or/orca/package.nix
@@ -26,6 +26,15 @@
   brltty,
   liblouis,
   gst_all_1,
+  vte,
+  xvfb,
+  less,
+  nano,
+  vim,
+  ncurses,
+  glibcLocales,
+  makeFontsConf,
+  dejavu_fonts,
 }:
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
@@ -93,9 +102,16 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   nativeCheckInputs = with python3.pkgs; [
     pytest
+    dbus
+    xvfb
+    less
+    nano
+    vim
+    ncurses # For clear
   ];
 
   checkInputs = with python3.pkgs; [
+    vte
     pytest-mock
   ];
 
@@ -103,11 +119,23 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     "-Dmathcat=false"
   ];
 
+  mesonCheckFlags = [
+    "-v"
+  ];
+
   # Help GI find typelibs during Meson's configure step in cross builds
   preConfigure = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
     export GI_TYPELIB_PATH=${buildPackages.gtk3}/lib/girepository-1.0''${GI_TYPELIB_PATH:+:$GI_TYPELIB_PATH}
   '';
 
+  preCheck = ''
+    export LOCALE_ARCHIVE=${glibcLocales}/lib/locale/locale-archive
+    # Silence fontconfig warnings about missing config during tests
+    export FONTCONFIG_FILE=${makeFontsConf { fontDirectories = [
+      # Tests require DejaVu Sans Mono
+      dejavu_fonts
+    ]; }}
+    export XDG_CACHE_HOME=$(mktemp -d)
   # `buildPythonPackage` uses `installCheckPhase` and leaves `checkPhase`
   # empty. It renames `doCheck` from its arguments, but not `checkPhase`.
   # See: https://github.com/NixOS/nixpkgs/issues/47390

--- a/pkgs/by-name/or/orca/package.nix
+++ b/pkgs/by-name/or/orca/package.nix
@@ -8,11 +8,13 @@
   meson,
   ninja,
   wrapGAppsHook3,
+  breakpointHook,
+  gdb,
   gobject-introspection,
   gettext,
   yelp-tools,
   itstool,
-  python3,
+  python313,
   gtk3,
   gnome,
   replaceVars,
@@ -20,10 +22,12 @@
   at-spi2-core,
   dbus,
   xkbcomp,
+  glib,
   procps,
   gsettings-desktop-schemas,
   speechd-minimal,
   brltty,
+  libsegfault,
   liblouis,
   gst_all_1,
   vte,
@@ -37,7 +41,7 @@
   dejavu_fonts,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python313.pkgs.buildPythonApplication (finalAttrs: {
   pname = "orca";
   version = "50.2";
 
@@ -61,11 +65,13 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     # cross-compilation support requires the host environment's build time
     # to make the following buildPackages available.
     buildPackages.gtk3
-    buildPackages.python3
-    buildPackages.python3Packages.pygobject3
+    buildPackages.python313
+    buildPackages.python313Packages.pygobject3
     meson
     ninja
     wrapGAppsHook3
+    breakpointHook
+    gdb
     pkg-config
     gettext
     yelp-tools
@@ -73,7 +79,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     gobject-introspection
   ];
 
-  pythonPath = with python3.pkgs; [
+  pythonPath = with python313.pkgs; [
     dasbus
     pygobject3
     pyxdg
@@ -83,16 +89,16 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     speechd-minimal
     gst-python
     setproctitle
-    at-spi2-core
+    # (at-spi2-core.override { python3 = python313; })
   ];
 
   strictDeps = false;
 
   buildInputs = [
-    python3
+    python313
     gtk3
-    at-spi2-atk
-    at-spi2-core
+    # at-spi2-atk
+    # at-spi2-core
     dbus
     gsettings-desktop-schemas
     gst_all_1.gstreamer
@@ -100,7 +106,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     gst_all_1.gst-plugins-good
   ];
 
-  nativeCheckInputs = with python3.pkgs; [
+  nativeCheckInputs = with python313.pkgs; [
     pytest
     dbus
     xvfb
@@ -110,7 +116,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     ncurses # For clear
   ];
 
-  checkInputs = with python3.pkgs; [
+  checkInputs = with python313.pkgs; [
     vte
     pytest-mock
   ];
@@ -129,6 +135,9 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   '';
 
   preCheck = ''
+    export LD_PRELOAD=${libsegfault}/lib/libsegfault.so
+    export NIX_DEBUG_INFO_DIRS=${glib.debug}/lib/debug:${gtk3.debug}/lib/debug:${at-spi2-core.debug}/lib/debug:${python313.pkgs.pygobject3.debug}/lib/debug
+    export SEGFAULT_SIGNALS=all
     export LOCALE_ARCHIVE=${glibcLocales}/lib/locale/locale-archive
     # Silence fontconfig warnings about missing config during tests
     export FONTCONFIG_FILE=${makeFontsConf { fontDirectories = [
@@ -136,6 +145,9 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
       dejavu_fonts
     ]; }}
     export XDG_CACHE_HOME=$(mktemp -d)
+    echo PPPPPPPPPPPPPPPPPPPPPPP=$PYTHONPATH
+  '';
+
   # `buildPythonPackage` uses `installCheckPhase` and leaves `checkPhase`
   # empty. It renames `doCheck` from its arguments, but not `checkPhase`.
   # See: https://github.com/NixOS/nixpkgs/issues/47390

--- a/pkgs/development/python-modules/dbus-python/default.nix
+++ b/pkgs/development/python-modules/dbus-python/default.nix
@@ -16,83 +16,83 @@
   dbus-glib,
 }:
 
-lib.fix (
-  finalPackage:
-  buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
+  pname = "dbus-python";
+  version = "1.4.0";
+  pyproject = true;
+
+  disabled = isPyPy;
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchPypi {
     pname = "dbus-python";
-    version = "1.4.0";
-    pyproject = true;
+    inherit (finalAttrs) version;
+    hash = "sha256-mRZm5Jj2Db8+Sbi3Z49VWbimUDT99hquYs3s232Jx3A=";
+  };
 
-    disabled = isPyPy;
+  patches = [
+    # reduce required dependencies
+    # https://gitlab.freedesktop.org/dbus/dbus-python/-/merge_requests/23
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/dbus/dbus-python/-/commit/d5e19698a8d6e1485f05b67a5b2daa2392819aaf.patch";
+      hash = "sha256-Rmj/ByRLiLnIF3JsMBElJugxsG8IARcBdixLhoWgIYU=";
+    })
+  ];
 
-    outputs = [
-      "out"
-      "dev"
-    ];
+  postPatch = ''
+    # we provide patchelf natively, not through the python package
+    sed -i '/patchelf/d' pyproject.toml
 
-    src = fetchPypi {
-      inherit pname version;
-      hash = "sha256-mRZm5Jj2Db8+Sbi3Z49VWbimUDT99hquYs3s232Jx3A=";
-    };
+    patchShebangs test/*.sh
+  '';
 
-    patches = [
-      # reduce required dependencies
-      # https://gitlab.freedesktop.org/dbus/dbus-python/-/merge_requests/23
-      (fetchpatch {
-        url = "https://gitlab.freedesktop.org/dbus/dbus-python/-/commit/d5e19698a8d6e1485f05b67a5b2daa2392819aaf.patch";
-        hash = "sha256-Rmj/ByRLiLnIF3JsMBElJugxsG8IARcBdixLhoWgIYU=";
-      })
-    ];
+  nativeBuildInputs = [
+    dbus # build systems checks for `dbus-run-session` in PATH
+    meson
+    meson-python
+    pkg-config
+  ];
 
-    postPatch = ''
-      # we provide patchelf natively, not through the python package
-      sed -i '/patchelf/d' pyproject.toml
+  buildInputs = [
+    dbus
+    dbus-glib
+  ];
 
-      patchShebangs test/*.sh
-    '';
+  mesonFlags = [
+    (lib.mesonBool "tests" finalAttrs.finalPackage.doInstallCheck)
+  ];
 
-    nativeBuildInputs = [
-      dbus # build systems checks for `dbus-run-session` in PATH
-      meson
-      meson-python
-      pkg-config
-    ];
+  # workaround bug in meson-python
+  # https://github.com/mesonbuild/meson-python/issues/240
+  postInstall = ''
+    mkdir -p $dev/lib
+    mv $out/${python.sitePackages}/.dbus_python.mesonpy.libs/pkgconfig/ $dev/lib
+  '';
 
-    buildInputs = [
-      dbus
-      dbus-glib
-    ];
+  # make sure the Cflags in the pkgconfig file are correct and make the structure backwards compatible
+  postFixup = ''
+    ln -s $dev/include/*/dbus_python/dbus-1.0/ $dev/include/dbus-1.0
+  '';
 
-    mesonFlags = [ (lib.mesonBool "tests" finalPackage.doInstallCheck) ];
+  nativeCheckInputs = [ dbus.out ];
 
-    # workaround bug in meson-python
-    # https://github.com/mesonbuild/meson-python/issues/240
-    postInstall = ''
-      mkdir -p $dev/lib
-      mv $out/${python.sitePackages}/.dbus_python.mesonpy.libs/pkgconfig/ $dev/lib
-    '';
+  checkPhase = ''
+    runHook preCheck
 
-    # make sure the Cflags in the pkgconfig file are correct and make the structure backwards compatible
-    postFixup = ''
-      ln -s $dev/include/*/dbus_python/dbus-1.0/ $dev/include/dbus-1.0
-    '';
+    meson test -C build --no-rebuild --print-errorlogs --timeout-multiplier 0
 
-    nativeCheckInputs = [ dbus.out ];
+    runHook postCheck
+  '';
 
-    checkPhase = ''
-      runHook preCheck
-
-      meson test -C build --no-rebuild --print-errorlogs --timeout-multiplier 0
-
-      runHook postCheck
-    '';
-
-    meta = {
-      description = "Python DBus bindings";
-      homepage = "https://gitlab.freedesktop.org/dbus/dbus-python";
-      license = lib.licenses.mit;
-      platforms = dbus.meta.platforms;
-      maintainers = [ ];
-    };
-  }
-)
+  meta = {
+    description = "Python DBus bindings";
+    homepage = "https://gitlab.freedesktop.org/dbus/dbus-python";
+    license = lib.licenses.mit;
+    platforms = dbus.meta.platforms;
+    maintainers = [ ];
+  };
+})

--- a/pkgs/development/python-modules/dbus-python/default.nix
+++ b/pkgs/development/python-modules/dbus-python/default.nix
@@ -41,6 +41,14 @@ buildPythonPackage (finalAttrs: {
       url = "https://gitlab.freedesktop.org/dbus/dbus-python/-/commit/d5e19698a8d6e1485f05b67a5b2daa2392819aaf.patch";
       hash = "sha256-Rmj/ByRLiLnIF3JsMBElJugxsG8IARcBdixLhoWgIYU=";
     })
+
+    # Fix on Python 3.15, the patch did not achieve what it aimed for anyway.
+    # https://gitlab.freedesktop.org/dbus/dbus-python/-/work_items/59
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/dbus/dbus-python/-/commit/ebecd1747c382a57ad8e47d0e32112cdbd454b40.patch";
+      hash = "sha256-Hg4o+FPJvQ1/RW9fd8UJg/YEeVOvbJCov7SS7bT0vvs=";
+      revert = true;
+    })
   ];
 
   postPatch = ''

--- a/pkgs/development/python-modules/dbus-python/default.nix
+++ b/pkgs/development/python-modules/dbus-python/default.nix
@@ -14,6 +14,9 @@
   # native dependencies
   dbus,
   dbus-glib,
+
+  # test dependencies
+  pygobject3,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -70,8 +73,12 @@ buildPythonPackage (finalAttrs: {
     dbus-glib
   ];
 
+  checkInputs = [
+    pygobject3
+  ];
+
   mesonFlags = [
-    (lib.mesonBool "tests" finalAttrs.finalPackage.doInstallCheck)
+    (lib.mesonEnable "tests" finalAttrs.finalPackage.doInstallCheck)
   ];
 
   # workaround bug in meson-python

--- a/pkgs/development/python-modules/pygobject/3.nix
+++ b/pkgs/development/python-modules/pygobject/3.nix
@@ -64,6 +64,9 @@ buildPythonPackage rec {
     "-Dpython=${python.pythonOnBuildForHost.interpreter}"
   ];
 
+separateDebugInfo =true;
+__structuredAttrs =true;
+
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "pygobject";

--- a/pkgs/development/python-modules/setproctitle/default.nix
+++ b/pkgs/development/python-modules/setproctitle/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   setuptools,
   pytestCheckHook,
   procps,
@@ -19,6 +20,13 @@ buildPythonPackage rec {
     tag = "version-${version}";
     hash = "sha256-dfOdtfOXRAoCQLW307+YMsFIWRv4CupbKUxckev1oUw=";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/dvarrazzo/py-setproctitle/commit/68125abf821ee6ebfb4a4eb86ffe655a4c072c9e.patch";
+      hash = "sha256-ZeY/4z7EFY9Tc4Y4T3BCyEt2Gweqts/8qwqdWT1e6BM=";
+    })
+  ];
 
   build-system = [ setuptools ];
 


### PR DESCRIPTION
These are currently only available on master branch and disabled by default upstream, parking the change here for Orca 51 release in September 2026.

Depends on #540921, #541158, #541067, #540549

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
