### PR TITLE
python3Packages.pylama: mark broken

### DIFF
--- a/pkgs/development/python-modules/pylama/default.nix
+++ b/pkgs/development/python-modules/pylama/default.nix
@@ -11,7 +11,7 @@
   pydocstyle,
   pyflakes,
   vulture,
-  setuptools_80,
+  setuptools,
   pylint,
   pytestCheckHook,
 }:
@@ -43,7 +43,7 @@ let
       pycodestyle
       pydocstyle
       pyflakes
-      setuptools_80
+      setuptools
       vulture
     ];
 

--- a/pkgs/development/python-modules/pylama/default.nix
+++ b/pkgs/development/python-modules/pylama/default.nix
@@ -73,6 +73,8 @@ let
     };
 
     meta = {
+      # https://github.com/klen/pylama/issues/249
+      broken = lib.versionAtLeast setuptools.version "82";
       description = "Code audit tool for python";
       mainProgram = "pylama";
       homepage = "https://github.com/klen/pylama";


### PR DESCRIPTION
This reverts commit 8ea0b4f2556c15e9736c87e5bb9862f161986b4b because versioned attributes may not be propagated.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
