### PR TITLE
discourse: Fix icu library mismatch in mini_racer

### DIFF
--- a/pkgs/servers/web-apps/discourse/default.nix
+++ b/pkgs/servers/web-apps/discourse/default.nix
@@ -34,7 +34,7 @@
   brotli,
   procps,
   rsync,
-  icu,
+  icu78,
   rustPlatform,
   buildRubyGem,
   rustc,
@@ -183,7 +183,7 @@ let
     gemset = import ./rubyEnv/gemset.nix;
     gemConfig = defaultGemConfig // {
       mini_racer = attrs: {
-        buildInputs = [ icu ];
+        buildInputs = [ icu78 ];
         dontBuild = false;
         NIX_LDFLAGS = "-licui18n";
       };


### PR DESCRIPTION
After #525241 ("nodejs: pin icu to newer version"), building discourse assets would fail with a library loading error:

LoadError: /nix/store/3sv7vxglmc6zwg68ycl9xpny87mm6fp7-discourse-ruby-env-2026.1.4/lib/ruby/gems/3.3.0/extensions/x86_64-linux/3.3.0/mini_racer-0.19.1/mini_racer_extension.so: undefined symbol: _ZN6icu_788ByteSink15GetAppendBufferEiiPciPi (LoadError)

This error apparently occurs when the ICU version used by libv8 does not match the ICU version mini_racer is built with.

Thanks to @0xB10C for identifying the problematic commit.

Fixes #538128


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
