### PR TITLE
swagger-typescript-api: 13.9.3 -> 13.12.4

### DIFF
--- a/pkgs/by-name/sw/swagger-typescript-api/package.nix
+++ b/pkgs/by-name/sw/swagger-typescript-api/package.nix
@@ -7,28 +7,20 @@
   nodejs,
   bun,
 }:
-let
-  pname = "swagger-typescript-api";
-  version = "13.9.3";
-
-  node-modules-hash = {
-    "x86_64-linux" = "sha256-0jTq1Ds8CNDGOaXZlBgtl5IspoLTGzfXwOhR9MwhoYQ=";
-    "aarch64-linux" = "sha256-7hR5cS8fFN1Eb82eKF+B24FdznfQn5roRqGe9dHk5H4=";
-  };
-in
 stdenv.mkDerivation (finalAttrs: {
-  inherit pname version;
+  pname = "swagger-typescript-api";
+  version = "13.12.4";
 
   src = fetchFromGitHub {
     owner = "acacode";
     repo = "swagger-typescript-api";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-Xy67aqkZAB54dz9yabJHvOLilb2C/oe8ZCprnqfBBj4=";
   };
 
   node_modules = stdenv.mkDerivation {
     inherit (finalAttrs) src version;
-    pname = "${pname}-node_modules";
+    pname = "${finalAttrs.pname}-node_modules";
 
     impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
       "GIT_PROXY_COMMAND"
@@ -41,6 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
     ];
 
     dontConfigure = true;
+
     # Skip fixup, would embed store paths or modify binaries,
     # making this fixed-output derivation's output hash unstable.
     dontFixup = true;
@@ -64,8 +57,14 @@ stdenv.mkDerivation (finalAttrs: {
     '';
 
     outputHash =
-      node-modules-hash.${stdenv.hostPlatform.system}
-        or (throw "${finalAttrs.pname}: Platform ${stdenv.hostPlatform.system} is not packaged yet. Supported platforms: x86_64-linux, aarch64-linux.");
+      {
+        aarch64-darwin = "sha256-6ECRpzXybtVEkuk4IIkinO8fT1l5vEkQk1U+8nr5gg8=";
+        aarch64-linux = "sha256-7hR5cS8fFN1Eb82eKF+B24FdznfQn5roRqGe9dHk5H4=";
+        x86_64-linux = "sha256-0jTq1Ds8CNDGOaXZlBgtl5IspoLTGzfXwOhR9MwhoYQ=";
+      }
+      .${stdenv.hostPlatform.system}
+        or (throw "${finalAttrs.pname}: Platform ${stdenv.hostPlatform.system} is not packaged yet.");
+
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
   };
@@ -93,7 +92,7 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/lib
     cp -r {dist,templates,node_modules} $out/lib
 
-    makeBinaryWrapper ${nodejs}/bin/node $out/bin/${pname} \
+    makeBinaryWrapper ${nodejs}/bin/node $out/bin/${finalAttrs.pname} \
       --add-flags $out/lib/dist/cli.cjs \
       --set NODE_ENV production \
       --set NODE_PATH "$out/lib/node_modules"
@@ -105,9 +104,9 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "swagger-typescript-api";
     description = "Generate TypeScript API client and definitions for fetch or axios from an OpenAPI specification";
     homepage = "https://github.com/acacode/swagger-typescript-api";
-    changelog = "https://github.com/acacode/swagger-typescript-api/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/acacode/swagger-typescript-api/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
     maintainers = with lib.maintainers; [ angelodlfrtr ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Diff: https://github.com/acacode/swagger-typescript-api/compare/v13.9.3...v13.12.4

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
