### PR TITLE
orioledb: 17.20 -> 18.1 (orioledb-postgres); beta16-pre-3 -> beta16 (orioledb)

### DIFF
--- a/pkgs/by-name/or/orioledb/extension.nix
+++ b/pkgs/by-name/or/orioledb/extension.nix
@@ -10,14 +10,14 @@
 
 postgresqlBuildExtension (finalAttrs: {
   pname = "orioledb";
-  # SQL extension version is 1.8, official version is beta16-pre-3
-  version = "1.8-beta16-pre-3";
+  # SQL extension version is 1.8, official version is beta16
+  version = "1.8-beta16";
 
   src = fetchFromGitHub {
     owner = "orioledb";
     repo = "orioledb";
-    tag = "beta16-pre-3";
-    hash = "sha256-nBLyc9VFETRo75HfBSLmQ13a6Vcc9rlSCp06y/SnDqQ=";
+    tag = "beta16";
+    hash = "sha256-HCfNzMPt80nGeVwlstUCeMpdNZYd9KhLLHYyD/Hvuhk=";
   };
 
   buildInputs = postgresql.buildInputs ++ [

--- a/pkgs/by-name/or/orioledb/package.nix
+++ b/pkgs/by-name/or/orioledb/package.nix
@@ -1,20 +1,20 @@
 {
   fetchFromGitHub,
   lib,
-  postgresql_17,
+  postgresql_18,
 }:
 
 let
-  orioledb-postgres = postgresql_17.overrideAttrs (
+  orioledb-postgres = postgresql_18.overrideAttrs (
     finalAttrs: oldAttrs: {
       pname = "orioledb-postgres";
-      version = "17.20";
+      version = "18.1";
 
       src = fetchFromGitHub {
         owner = "orioledb";
         repo = "postgres";
-        tag = "patches17_20";
-        hash = "sha256-3dC00fFpD8fJDKed37oQvILMtA3GKBsWo1GEdUQzXzQ=";
+        tag = "patches18_1";
+        hash = "sha256-TCpmTa9R+a+rrTRSNkfhBDaVto1RtKf1R+qnepw9bV0=";
       };
 
       # Configure extracts the patch version from the git tag. This

--- a/pkgs/servers/sql/postgresql/wrapper.nix
+++ b/pkgs/servers/sql/postgresql/wrapper.nix
@@ -64,6 +64,11 @@ buildEnv (finalAttrs: {
       };
     };
 
+    tests = lib.mapAttrs (
+      _: test:
+      if test.passthru or { } ? "override" then test.passthru.override finalAttrs.finalPackage else test
+    ) postgresql.tests;
+
     withJIT = recurse (_: installedExtensions ++ [ postgresql.jit ]);
     withoutJIT = recurse (_: lib.remove postgresql.jit installedExtensions);
 


### PR DESCRIPTION
Release Notes:
https://github.com/orioledb/postgres/releases/tag/patches18_1
https://github.com/orioledb/orioledb/releases/tag/beta16

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [Package tests] at `passthru.tests`.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
