### PR TITLE
python3Packages.corner: 2.2.3 -> 2.3.0

### DIFF
--- a/pkgs/development/python-modules/arviz-base/default.nix
+++ b/pkgs/development/python-modules/arviz-base/default.nix
@@ -67,6 +67,11 @@ buildPythonPackage (finalAttrs: {
     writableTmpDirAsHomeHook
   ];
 
+  pytestFlags = [
+    # DeprecationWarning: Setting the shape on a NumPy array has been deprecated in NumPy 2.5.
+    "-Wignore::DeprecationWarning"
+  ];
+
   meta = {
     description = "Base ArviZ features and converters";
     homepage = "https://github.com/arviz-devs/arviz-base";

--- a/pkgs/development/python-modules/corner/default.nix
+++ b/pkgs/development/python-modules/corner/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  writableTmpDirAsHomeHook,
 
   # build-system
   hatch-vcs,
@@ -13,6 +12,7 @@
 
   # optional-dependencies
   arviz,
+  arviz-base,
   ipython,
   myst-nb,
   pandoc,
@@ -23,27 +23,19 @@
 
   # tests
   pytestCheckHook,
-  corner,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "corner";
-  version = "2.2.3";
+  version = "2.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "dfm";
     repo = "corner.py";
-    tag = "v${version}";
-    hash = "sha256-gK2yylteI3VLVJ0p7NB7bR7cirCo2BvFKnYIH3kfyh4=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-H59IVXKPT4CLApn4kUuSuiYA9EWdOaH88Rd4YXf0VlQ=";
   };
-
-  nativeBuildInputs = [
-    # During `pythonImportsCheck`, `corner` imports `arviz` which wants to write a stamp file to the
-    # homedir. It then needs to be writable.
-    # https://github.com/arviz-devs/arviz/commit/4db612908f588d89bb5bfb6b83a08ada3d54fd02
-    writableTmpDirAsHomeHook
-  ];
 
   build-system = [
     hatch-vcs
@@ -53,9 +45,13 @@ buildPythonPackage rec {
   dependencies = [ matplotlib ];
 
   optional-dependencies = {
-    arviz = [ arviz ];
+    arviz = [
+      arviz
+      arviz-base
+    ];
     docs = [
       arviz
+      arviz-base
       ipython
       myst-nb
       pandoc
@@ -71,10 +67,14 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "corner" ];
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ corner.optional-dependencies.test;
+  nativeCheckInputs = [
+    arviz
+    pytestCheckHook
+    scipy
+  ];
 
-  # matplotlib.testing.exceptions.ImageComparisonFailure: images not close
   disabledTests = [
+    # matplotlib.testing.exceptions.ImageComparisonFailure: images not close
     "test_1d_fig_argument"
     "test_arviz"
     "test_basic"
@@ -103,6 +103,8 @@ buildPythonPackage rec {
     "test_title_quantiles_raises"
     "test_titles1"
     "test_titles2"
+    "test_titles_fmt_multi"
+    "test_titles_fmt_single"
     "test_top_ticks"
     "test_truths"
   ];
@@ -110,8 +112,8 @@ buildPythonPackage rec {
   meta = {
     description = "Make some beautiful corner plots";
     homepage = "https://github.com/dfm/corner.py";
-    changelog = "https://github.com/dfm/corner.py/releases/tag/v${version}";
+    changelog = "https://github.com/dfm/corner.py/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ GaetanLepage ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/dfm/corner.py/compare/v2.2.3...v2.3.0
Changelog: https://github.com/dfm/corner.py/releases/tag/v2.3.0

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
