### PR TITLE
python3Packages.pygraphviz: unbreak on Darwin

### DIFF
--- a/pkgs/by-name/gr/graphviz/package.nix
+++ b/pkgs/by-name/gr/graphviz/package.nix
@@ -22,6 +22,7 @@
   libxrender,
   python3,
   withXorg ? true,
+  withQuartz ? false,
 
   # for passthru.tests
   exiv2,
@@ -75,7 +76,8 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-ltdl-lib=${libtool.lib}/lib"
     "--with-ltdl-include=${libtool}/include"
     (lib.withFeature withXorg "x")
-  ];
+  ]
+  ++ optional withQuartz "--with-quartz";
 
   enableParallelBuilding = true;
   strictDeps = true;

--- a/pkgs/development/python-modules/pygraphviz/default.nix
+++ b/pkgs/development/python-modules/pygraphviz/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   replaceVars,
+  stdenv,
   graphviz,
   coreutils,
   pkg-config,
@@ -11,6 +12,10 @@
   pytest,
 }:
 
+let
+  # TODO: remove once #540793 makes it to master
+  graphviz' = graphviz.override { withQuartz = stdenv.hostPlatform.isDarwin; };
+in
 buildPythonPackage (finalAttrs: {
   pname = "pygraphviz";
   version = "2.0";
@@ -27,7 +32,7 @@ buildPythonPackage (finalAttrs: {
     # pygraphviz depends on graphviz executables and wc being in PATH
     (replaceVars ./path.patch {
       path = lib.makeBinPath [
-        graphviz
+        graphviz'
         coreutils
       ];
     })
@@ -38,19 +43,19 @@ buildPythonPackage (finalAttrs: {
       --replace-fail ', "swig>4.1.0"' ""
   '';
 
-  env.GRAPHVIZ_PREFIX = graphviz;
+  env.GRAPHVIZ_PREFIX = graphviz';
 
   build-system = [
     setuptools
   ];
 
   nativeBuildInputs = [
-    graphviz # for dot
+    graphviz' # for dot
     pkg-config
     swig
   ];
 
-  buildInputs = [ graphviz ];
+  buildInputs = [ graphviz' ];
 
   nativeCheckInputs = [ pytest ];
 


### PR DESCRIPTION
- **graphviz: support building Quartz plugin on Darwin**
  Analogous to 023d279213f8396224ebb992ef8528c31204de70, but disabled by default so we can have it on master. I'll handle the master -> staging-next -> staging merge conflicts.
- **python3Packages.pygraphviz: unbreak on Darwin**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
