### PR TITLE
python3Packages.swcgeom: 0.21.5 -> 0.21.6

### DIFF
--- a/pkgs/development/python-modules/swcgeom/default.nix
+++ b/pkgs/development/python-modules/swcgeom/default.nix
@@ -27,7 +27,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "swcgeom";
-  version = "0.21.5";
+  version = "0.21.6";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -35,7 +35,7 @@ buildPythonPackage (finalAttrs: {
     owner = "yzx9";
     repo = "swcgeom";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-QLo2tfoQFuoKee/e/t5l3bUwOtobV57Od9UvAze78FE=";
+    hash = "sha256-Q9YvHHUAYGX3m9jJ+ogTYRrdPaCdrcNY2cNlKK7ThX4=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/swcgeom/default.nix
+++ b/pkgs/development/python-modules/swcgeom/default.nix
@@ -25,18 +25,16 @@
   pytestCheckHook,
 }:
 
-let
-  version = "0.21.5";
-in
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "swcgeom";
-  inherit version;
+  version = "0.21.5";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "yzx9";
     repo = "swcgeom";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-QLo2tfoQFuoKee/e/t5l3bUwOtobV57Od9UvAze78FE=";
   };
 
@@ -88,8 +86,8 @@ buildPythonPackage rec {
   meta = {
     description = "Neuron geometry library for swc format";
     homepage = "https://github.com/yzx9/swcgeom";
-    changelog = "https://github.com/yzx9/swcgeom/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/yzx9/swcgeom/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ yzx9 ];
   };
-}
+})


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/337377670

0.21.5 fails `pythonImportsCheck` due to an overly tight version dependency. 0.21.6 [fixes this](https://github.com/yzx9/swcgeom/blob/972ba3cdbb58460eb5d7bd8801b115f9f16dbaf6/pyproject.toml#L27).

Note: Darwin build depends on #541124

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
