### PR TITLE
mermaid-cli: 11.12.0 -> 11.16.0

### DIFF
--- a/pkgs/by-name/me/mermaid-cli/package.nix
+++ b/pkgs/by-name/me/mermaid-cli/package.nix
@@ -7,7 +7,7 @@
   nix-update-script,
 }:
 let
-  version = "11.12.0";
+  version = "11.16.0";
 in
 buildNpmPackage {
   pname = "mermaid-cli";
@@ -17,14 +17,14 @@ buildNpmPackage {
     owner = "mermaid-js";
     repo = "mermaid-cli";
     rev = version;
-    hash = "sha256-OpYq0nOYCGTorzDxybsEjJmhL646wMBbQw3eHVxTuqU=";
+    hash = "sha256-jK87Ffsv9qeh0UPJaLTuIJYbnR9HVqjm7hWrwUaP5zA=";
   };
 
   patches = [
     ./remove-puppeteer-from-dev-deps.patch # https://github.com/mermaid-js/mermaid-cli/issues/830
   ];
 
-  npmDepsHash = "sha256-Ex+tEm13feR/Vru0CHlvM3xS5wgGlYyqANeIquvRHwM=";
+  npmDepsHash = "sha256-sOEDz8ZT2zF+TH+ZJhb+LSyyUF1HWVVLzCqtYtg7A0E=";
 
   env = {
     PUPPETEER_SKIP_DOWNLOAD = true;

--- a/pkgs/by-name/me/mermaid-cli/remove-puppeteer-from-dev-deps.patch
+++ b/pkgs/by-name/me/mermaid-cli/remove-puppeteer-from-dev-deps.patch
@@ -1,16 +1,11 @@
-Subject: [PATCH] remove pupperteer from dev dependencies
+Subject: [PATCH] remove puppeteer from dev dependencies
 ---
 Index: package.json
-<+>UTF-8
 ===================================================================
 diff --git a/package.json b/package.json
---- a/package.json	(revision fa593dc39619f44b57a922927a66346248f31d7d)
-+++ b/package.json	(date 1736721981718)
-@@ -45,7 +45,6 @@
-     "@tsconfig/node18": "^18.2.4",
-     "@types/node": "~18.19.31",
-     "jest": "^30.0.5",
--    "puppeteer": "^23.1.1",
-     "standard": "^17.0.0",
-     "typescript": "^5.0.1-rc",
-     "vite": "^6.0.2",
+--- a/package.json
++++ b/package.json
+@@ -47,3 +47,2 @@
+     "prettier": "^3.8.3",
+-    "puppeteer": "^25.0.0",
+     "typescript": "^6.0.3",


### PR DESCRIPTION
Update to 11.16.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
