### PR TITLE
sideband: 1.9.7 -> 2.0.0

### DIFF
--- a/pkgs/by-name/si/sideband/package.nix
+++ b/pkgs/by-name/si/sideband/package.nix
@@ -1,11 +1,11 @@
 {
   lib,
-  python3Packages,
+  python313Packages, # Require a working version of Kivy, which is not yet working with Python 3.14
   fetchFromGitHub,
   versionCheckHook,
 }:
 
-python3Packages.buildPythonApplication (finalAttrs: {
+python313Packages.buildPythonApplication (finalAttrs: {
   pname = "sideband";
   version = "2.0.0";
   pyproject = true;
@@ -35,12 +35,12 @@ python3Packages.buildPythonApplication (finalAttrs: {
         "2.0.0"
   '';
 
-  build-system = with python3Packages; [
+  build-system = with python313Packages; [
     setuptools
   ];
 
   dependencies =
-    with python3Packages;
+    with python313Packages;
     [
       audioop-lts
       beautifulsoup4

--- a/pkgs/by-name/si/sideband/package.nix
+++ b/pkgs/by-name/si/sideband/package.nix
@@ -7,7 +7,7 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "sideband";
-  version = "1.9.8";
+  version = "2.0.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -15,7 +15,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     owner = "markqvist";
     repo = "Sideband";
     tag = finalAttrs.version;
-    hash = "sha256-DGX96QJS+T9CEgpF2X6aSkW66/6ORYAkNFi7hgNOEc4=";
+    hash = "sha256-RCSSyTtt2eN9hYT1xzPYjJloPjnkIS6bo21PHrlg5S8=";
   };
 
   # Unable to upstream all of this
@@ -32,7 +32,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     substituteInPlace sbapp/main.py \
       --replace-fail \
         "1.9.2" \
-        "1.9.8"
+        "2.0.0"
   '';
 
   build-system = with python3Packages; [

--- a/pkgs/by-name/si/sideband/package.nix
+++ b/pkgs/by-name/si/sideband/package.nix
@@ -7,7 +7,7 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "sideband";
-  version = "1.9.7";
+  version = "1.9.8";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -15,7 +15,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     owner = "markqvist";
     repo = "Sideband";
     tag = finalAttrs.version;
-    hash = "sha256-YL8wqZGBrMEtm+mLVjyaZpTPj8XVM0YUjP6Kfo7QHfw=";
+    hash = "sha256-DGX96QJS+T9CEgpF2X6aSkW66/6ORYAkNFi7hgNOEc4=";
   };
 
   # Unable to upstream all of this
@@ -32,7 +32,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     substituteInPlace sbapp/main.py \
       --replace-fail \
         "1.9.2" \
-        "1.9.7"
+        "1.9.8"
   '';
 
   build-system = with python3Packages; [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
