### PR TITLE
minecraft-server: 26.1.2 -> 26.2, support updateScript generated commits

### DIFF
--- a/maintainers/scripts/update.py
+++ b/maintainers/scripts/update.py
@@ -307,7 +307,7 @@ async def commit_changes(
             commit_message = "{attrPath}: {oldVersion} -> {newVersion}".format(**change)
             if "commitMessage" in change:
                 commit_message = change["commitMessage"]
-            elif "commitBody" in change:
+            if "commitBody" in change:
                 commit_message = commit_message + "\n\n" + change["commitBody"]
             await check_subprocess_output(
                 "git",

--- a/pkgs/by-name/mi/minecraft-server/derivation.nix
+++ b/pkgs/by-name/mi/minecraft-server/derivation.nix
@@ -36,7 +36,11 @@ stdenv.mkDerivation {
 
   passthru = {
     tests = { inherit (nixosTests) minecraft-server; };
-    updateScript = ./update.py;
+    updateScript = {
+      command = [ ./update.py ];
+
+      supportedFeatures = [ "commit" ];
+    };
   };
 
   meta = {

--- a/pkgs/by-name/mi/minecraft-server/derivation.nix
+++ b/pkgs/by-name/mi/minecraft-server/derivation.nix
@@ -52,6 +52,7 @@ stdenv.mkDerivation {
     maintainers = with lib.maintainers; [
       thoughtpolice
       tomberek
+      wrench-exile-legacy
       costrouc
     ];
     mainProgram = "minecraft-server";

--- a/pkgs/by-name/mi/minecraft-server/update.py
+++ b/pkgs/by-name/mi/minecraft-server/update.py
@@ -110,6 +110,32 @@ def group_major_releases(releases: List[Version]) -> Dict[str, List[Version]]:
     return groups
 
 
+def slugify(version: str) -> str:
+    return version.replace(".", "-")
+
+
+def get_changelog_url(version: str) -> Optional[str]:
+    """
+    Attempt to resolve the Minecraft changelog article URL.
+    Returns the URL if it exists, otherwise None.
+    """
+    url = f"https://www.minecraft.net/en-us/article/minecraft-java-edition-{slugify(version)}"
+
+    # our request is denied without a human user-agent
+    headers = {
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:140.0) Gecko/20100101 Firefox/140.0"
+    }
+
+    try:
+        response = requests.head(url, headers=headers, timeout=3)
+        if response.status_code == 200:
+            return url
+    except requests.RequestException as e:
+        pass
+
+    return None
+
+
 def get_latest_major_releases(releases: List[Version]) -> Dict[str, Version]:
     """
     Return a dictionary containing the latest version for each major release.
@@ -118,8 +144,12 @@ def get_latest_major_releases(releases: List[Version]) -> Dict[str, Version]:
     """
     return {
         major_release: max(
-            (release for release in releases if get_major_release(release.id) == major_release),
-            key=lambda x: tuple(map(int, x.id.split('.'))),
+            (
+                release
+                for release in releases
+                if get_major_release(release.id) == major_release
+            ),
+            key=lambda x: tuple(map(int, x.id.split("."))),
         )
         for major_release in group_major_releases(releases)
     }
@@ -153,7 +183,101 @@ def generate() -> Dict[str, Dict[str, str]]:
     return servers
 
 
+def get_latest(servers: Dict[str, Dict[str, str]]) -> str | None:
+    return max(
+        (v.get("version") for v in servers.values()),
+        key=lambda x: tuple(map(int, x.split("."))) if x is not None else (),
+    )
+
+
+def generate_commit(
+    previous_servers: Dict[str, Dict[str, str]],
+    servers: Dict[str, Dict[str, str]],
+    versions_file: Path,
+) -> List[Dict[str, str | list[str]]]:
+    actions = []
+    commit_body_lines = []
+
+    old_latest = get_latest(previous_servers)
+    new_latest = get_latest(servers)
+
+    for major_version, server in servers.items():
+        version = server.get("version")
+        previous_server = previous_servers.get(major_version)
+
+        if version is None:
+            continue
+
+        attribute = f"minecraftServers.vanilla-{slugify(major_version)}"
+
+        if not previous_server:
+            # this version didn't exist before
+            # check if its now the latest version
+            if version == new_latest:
+                action = f"{old_latest} -> {new_latest}"
+                attribute = "minecraft-server"
+            else:
+                action = f"init {version}"
+
+        else:
+            previous_version = previous_server.get("version")
+            if previous_version == version:
+                continue
+
+            action = f"{previous_version} -> {version}"
+
+        actions.append(action)
+
+        commit_body_lines.append(f"{attribute}: {action}")
+
+        changelog_url = get_changelog_url(version)
+        if changelog_url:
+            commit_body_lines.append(f"Release notes: {changelog_url}")
+
+    if not commit_body_lines:
+        return []
+
+    if len(actions) == 1:
+        commit_message = commit_body_lines[0]
+
+        # the body should only be the release notes to avoid repeatition
+        # if the release notes don't exist this will be blank
+        commit_body = "\n".join(commit_body_lines[1:]).strip()
+    else:
+        detailed_message = f"minecraft-server: {', '.join(actions)}"
+
+        commit_message = (
+            detailed_message
+            if len(detailed_message) <= 72
+            else "minecraft-server: update multiple versions"
+        )
+
+        commit_body = "\n".join(commit_body_lines).strip()
+
+    commit_json = {
+        "attrPath": "minecraftServers.vanilla",
+        "files": [str(versions_file)],
+        "commitMessage": commit_message,
+    }
+
+    if commit_body:
+        commit_json["commitBody"] = commit_body
+
+    return [commit_json]
+
+
 if __name__ == "__main__":
-    with open(Path(__file__).parent / "versions.json", "w") as file:
-        json.dump(generate(), file, indent=2)
+    versions_file = Path(__file__).parent / "versions.json"
+
+    with open(versions_file, "r") as file:
+        previous_servers = json.load(file)
+
+    servers = generate()
+
+    commit_json = generate_commit(previous_servers, servers, versions_file)
+
+    with open(versions_file, "w") as file:
+        json.dump(servers, file, indent=2)
         file.write("\n")
+
+    print(json.dumps(commit_json))

--- a/pkgs/by-name/mi/minecraft-server/versions.json
+++ b/pkgs/by-name/mi/minecraft-server/versions.json
@@ -1,4 +1,10 @@
 {
+  "26.2": {
+    "sha1": "823e2250d24b3ddac457a60c92a6a941943fcd6a",
+    "url": "https://piston-data.mojang.com/v1/objects/823e2250d24b3ddac457a60c92a6a941943fcd6a/server.jar",
+    "version": "26.2",
+    "javaVersion": 25
+  },
   "26.1": {
     "sha1": "97ccd4c0ed3f81bbb7bfacddd1090b0c56f9bc51",
     "url": "https://piston-data.mojang.com/v1/objects/97ccd4c0ed3f81bbb7bfacddd1090b0c56f9bc51/server.jar",


### PR DESCRIPTION
Changelog: https://www.minecraft.net/en-us/article/minecraft-java-edition-26-2

---
Updates `minecraft-server` from `26.1.2` to `26.2`. 

The goal of this PR is to make updating `minecraft-server` really easy. 
As such, the commit containing the version bump and the changelog in the body is entirely generated by the `updateScript`.


This PR adds support for the `updateScript` commit feature, that allows `maintainers/scripts/update.nix` to automatically generate commit messages, alongside the changes to the `versions.json` file. 

The changes allow the update script to generate commits for multiple version bumps (while respecting a 72 character limit) and attempts to add changelog for each version bump in the body of the commit message.

This also fixes a small bug identified inside of  `maintainers/scripts/update.py`, which would ignore the outputted `commitBody` if `commitMessage` was manually passed.

 
If you want to test the commit generation, try downgrading or deleting versions from `pkgs/by-name/ma/minecraft-server/versions.json` and run:
```
nix-shell ./maintainers/scripts/update.nix --argstr package minecraft-server --argstr commit true
```

Example commit message with multiple version updates:
```
Author: wrench-exile-legacy <user@wrench-exile-legacy.site>
Date:   Sun Jul 12 21:23:33 2026 +0000

    minecraft-server: update multiple versions

    minecraft-server: 26.1.2 -> 26.2
    Release notes: https://www.minecraft.net/en-us/article/minecraft-java-edition-26-2
    minecraftServers.vanilla-1-21: 1.21.10 -> 1.21.11
    Release notes: https://www.minecraft.net/en-us/article/minecraft-java-edition-1-21-11
    minecraftServers.vanilla-1-20: 1.20.3 -> 1.20.6
    Release notes: https://www.minecraft.net/en-us/article/minecraft-java-edition-1-20-6
    minecraftServers.vanilla-1-19: 1.19.2 -> 1.19.4
    Release notes: https://www.minecraft.net/en-us/article/minecraft-java-edition-1-19-4
```
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
