### PR TITLE
vita3k: 3821 -> 4064

### DIFF
--- a/pkgs/by-name/vi/vita3k/package.nix
+++ b/pkgs/by-name/vi/vita3k/package.nix
@@ -8,11 +8,11 @@
 
 appimageTools.wrapType2 rec {
   pname = "vita3k";
-  version = "3821";
+  version = "4064";
 
   src = fetchurl {
     url = "https://github.com/Vita3K/Vita3K-builds/releases/download/${version}/Vita3K-x86_64.AppImage";
-    sha256 = "sha256-U2sGt8zHGODes2DB7qK5xJVAhkxyQ6ku/UCmd1D1184=";
+    sha256 = "sha256-QUzu+7BqiJ8gWWugwyMyKyQ3bXzmAx/zSxJ2+AeVQB4=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -28,7 +28,9 @@ appimageTools.wrapType2 rec {
         --replace-fail "Exec=Vita3K" "Exec=vita3k"
       cp -r ${appimageContents}/usr/share/icons $out/share
       wrapProgram $out/bin/vita3k \
-        --set APPIMAGE 1
+        --set APPIMAGE 1 \
+        --unset QT_PLUGIN_PATH \
+        --unset QML2_IMPORT_PATH
     '';
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
Version bump, along with some fixes due to the introduction of a Qt 6 GUI since version 3998. Tested manually by launching a game, seems to be working fine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
