### PR TITLE
chez-racket: fix eval on unsupported systems

### DIFF
--- a/pkgs/by-name/ch/chez-racket/package.nix
+++ b/pkgs/by-name/ch/chez-racket/package.nix
@@ -15,7 +15,7 @@ let
     else if stdenv.hostPlatform.isPower then
       "ppc${toString stdenv.hostPlatform.parsed.cpu.bits}"
     else
-      throw "Add ${stdenv.hostPlatform.parsed.cpu.arch} to chezArch to enable building chez-racket";
+      throw "Add ${stdenv.hostPlatform.parsed.cpu.name} to chezArch to enable building chez-racket";
 
   chezOs =
     if stdenv.hostPlatform.isDarwin then

--- a/pkgs/by-name/ch/chez-racket/shared.nix
+++ b/pkgs/by-name/ch/chez-racket/shared.nix
@@ -56,7 +56,9 @@ stdenv.mkDerivation (
       homepage = "https://github.com/racket/ChezScheme";
       license = lib.licenses.asl20;
       maintainers = [ ];
-      platforms = lib.platforms.unix;
+      platforms = lib.intersectLists lib.platforms.unix (
+        lib.platforms.x86 ++ lib.platforms.aarch64 ++ lib.platforms.arm ++ lib.platforms.power
+      );
     };
   }
 )


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
