### PR TITLE
python3Packages.svgdigitizer: relax dependency on `astropy` to fix build

### DIFF
--- a/pkgs/development/python-modules/svgdigitizer/default.nix
+++ b/pkgs/development/python-modules/svgdigitizer/default.nix
@@ -26,15 +26,16 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "svgdigitizer";
   version = "0.14.4";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "echemdb";
     repo = "svgdigitizer";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-sDMSzoXa8RnygFjveh1SrF+bFit7OMQh2kbiZ478cM4=";
   };
 
@@ -86,8 +87,8 @@ buildPythonPackage rec {
   meta = {
     description = "Extract numerical data points from SVG files";
     homepage = "https://github.com/echemdb/svgdigitizer";
-    changelog = "https://github.com/echemdb/svgdigitizer/blob/${src.tag}/ChangeLog";
+    changelog = "https://github.com/echemdb/svgdigitizer/blob/${finalAttrs.src.tag}/ChangeLog";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ doronbehar ];
   };
-}
+})

--- a/pkgs/development/python-modules/svgdigitizer/default.nix
+++ b/pkgs/development/python-modules/svgdigitizer/default.nix
@@ -42,6 +42,11 @@ buildPythonPackage rec {
     setuptools
   ];
 
+  # https://github.com/echemdb/svgdigitizer/issues/298
+  pythonRelaxDeps = [
+    "astropy"
+  ];
+
   dependencies = [
     astropy
     click


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/337387832

1. Filed https://github.com/echemdb/svgdigitizer/issues/298
2. Relaxed dep on `astropy`
3. Applied `finalAttrs` and `__structuredAttrs` to match current best practices

Darwin build depends on #541124


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
