### PR TITLE
cgt-calc: fix build by backporting uv-build relaxation

### DIFF
--- a/pkgs/by-name/cg/cgt-calc/package.nix
+++ b/pkgs/by-name/cg/cgt-calc/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  fetchpatch,
   python3Packages,
   withTeXLive ? true,
   texliveSmall,
@@ -16,6 +17,15 @@ python3Packages.buildPythonApplication (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-KPzADW+n82X08IMfSIl5JyYPm8fxbbowud8sBdUxRgA=";
   };
+
+  patches = [
+    (fetchpatch {
+      # https://github.com/KapJI/capital-gains-calculator/pull/781
+      name = "update uv-build requirement.patch";
+      url = "https://github.com/KapJI/capital-gains-calculator/commit/0222eafdcf1911f3e2fd781697dc53311f529f62.patch";
+      hash = "sha256-L8jgrdA9t3x8mdaLmAuW6vFhHCLGA+0gQ/8j9EcYKhE=";
+    })
+  ];
 
   build-system = with python3Packages; [
     uv-build


### PR DESCRIPTION
On latest unstable:
```
ERROR Missing dependencies:
        uv_build<0.11.0,>=0.8.23
error: Cannot build '/nix/store/w9vn8bl71zib3lgf4dfrdkrfasz9alnx-cgt-calc-2.0.0.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/kg4zwzbh10vn51h0r6g6jmlhh0wb6k93-cgt-calc-2.0.0-dist
         /nix/store/wnr2qzvnw7l0czbaa0qqm2wdjyfrbnfb-cgt-calc-2.0.0
       Last 25 log lines:
       > Using pypaBuildPhase
       > Sourcing python-runtime-deps-check-hook
       > Using pythonRuntimeDepsCheckHook
       > Sourcing pypa-install-hook
       > Using pypaInstallPhase
       > Sourcing python-imports-check-hook.sh
       > Using pythonImportsCheckPhase
       > Sourcing python-namespaces-hook
       > Sourcing python-catch-conflicts-hook.sh
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/xf1v660b4w4kv0sk1qhwx5lx9gapacgz-source
       > source root is source
       > setting SOURCE_DATE_EPOCH to timestamp 315619200 of file "source/uv.lock"
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > no configure script, doing nothing
       > Running phase: buildPhase
       > Executing pypaBuildPhase
       > Creating a wheel...
       > pypa build flags: --no-isolation --outdir dist/ --wheel
       > * Getting build dependencies for wheel...
       >
       > ERROR Missing dependencies:
       >     uv_build<0.11.0,>=0.8.23
       For full logs, run:
         nix log /nix/store/w9vn8bl71zib3lgf4dfrdkrfasz9alnx-cgt-calc-2.0.0.drv
```

Fix is upstream but not yet released: https://github.com/KapJI/capital-gains-calculator/pull/781


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
