### PR TITLE
python314Packages.vtherm-api: don't propagate home-assistant

### DIFF
--- a/pkgs/development/python-modules/vtherm-api/default.nix
+++ b/pkgs/development/python-modules/vtherm-api/default.nix
@@ -3,9 +3,9 @@
   buildPythonPackage,
   fetchFromGitHub,
   home-assistant,
-  pythonOlder,
   pytest-asyncio,
   pytestCheckHook,
+  python,
   setuptools,
 }:
 
@@ -14,7 +14,7 @@ buildPythonPackage (finalAttrs: {
   version = "0.3.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.14";
+  disabled = python.version != home-assistant.python3Packages.python.version;
 
   src = fetchFromGitHub {
     owner = "jmcollin78";
@@ -25,9 +25,8 @@ buildPythonPackage (finalAttrs: {
 
   build-system = [ setuptools ];
 
-  dependencies = [ home-assistant ];
-
   nativeCheckInputs = [
+    home-assistant
     pytest-asyncio
     pytestCheckHook
   ];


### PR DESCRIPTION
Move `home-assistant` from `vtherm-api`'s propagated dependencies to its check inputs. Home Assistant is the host application provided by consumers; keeping it as a check input preserves the upstream tests and import check without adding the full application to the library closure. Restrict `vtherm-api` to Home Assistant's Python version, matching `homeassistant-stubs` and avoiding unsupported cross-version check environments.

Follow-up to #538043.

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
