### PR TITLE
various: drop `x86_64-darwin` mentions in comments

### DIFF
--- a/pkgs/by-name/ho/howl/package.nix
+++ b/pkgs/by-name/ho/howl/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [ euxane ];
     mainProgram = "howl";
 
-    # LuaJIT and Howl builds fail for x86_64-darwin and aarch64-linux respectively
+    # Howl builds fail for aarch64-linux
     platforms = [
       "i686-linux"
       "x86_64-linux"

--- a/pkgs/by-name/ja/jackett/package.nix
+++ b/pkgs/by-name/ja/jackett/package.nix
@@ -39,8 +39,6 @@ buildDotnetModule (finalAttrs: {
 
   runtimeDeps = [ openssl ];
   # mono is not available on aarch64-darwin
-  #x86_64-darwin is failed with
-  #System.Net.Sockets.SocketException (13): Permission denied
   doCheck = !stdenv.hostPlatform.isDarwin;
   nativeCheckInputs = [ mono ];
   testProjectFile = "src/Jackett.Test/Jackett.Test.csproj";

--- a/pkgs/by-name/pe/peertube/package.nix
+++ b/pkgs/by-name/pe/peertube/package.nix
@@ -174,7 +174,7 @@ stdenv.mkDerivation (finalAttrs: {
       "x86_64-linux"
       "aarch64-linux"
       # feasible, looking for maintainer to help out
-      # "x86_64-darwin" "aarch64-darwin"
+      # "aarch64-darwin"
     ];
     maintainers = with lib.maintainers; [
       immae

--- a/pkgs/by-name/po/podman-bootc/package.nix
+++ b/pkgs/by-name/po/podman-bootc/package.nix
@@ -66,8 +66,6 @@ buildGoModule (finalAttrs: {
     changelog = "https://github.com/bootc-dev/podman-bootc/releases/tag/${finalAttrs.src.tag}";
     maintainers = with lib.maintainers; [ evan-goode ];
     license = lib.licenses.asl20;
-    # x86_64-darwin does not seem to be supported at this time:
-    # https://github.com/containers/podman-bootc/issues/46
     platforms = [
       "aarch64-linux"
       "aarch64-darwin"

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -870,7 +870,7 @@ stdenv.mkDerivation (finalAttrs: {
       lib.platforms.linux ++ lib.platforms.darwin ++ lib.platforms.windows ++ lib.platforms.freebsd;
     mainProgram = executable;
     teams = [ lib.teams.python ];
-    # static build on x86_64-darwin/aarch64-darwin breaks with:
+    # static build on aarch64-darwin breaks with:
     # configure: error: C compiler cannot create executables
 
     # mingw patches only apply to Python 3.11 currently

--- a/pkgs/development/libraries/mesa/common.nix
+++ b/pkgs/development/libraries/mesa/common.nix
@@ -2,7 +2,7 @@
 # When updating this package, please verify at least these build (assuming x86_64-linux):
 # nix build .#mesa .#pkgsi686Linux.mesa .#pkgsCross.aarch64-multiplatform.mesa .#pkgsMusl.mesa
 # Ideally also verify:
-# nix build .#legacyPackages.x86_64-darwin.mesa .#legacyPackages.aarch64-darwin.mesa
+# nix build .#legacyPackages.aarch64-darwin.mesa
 rec {
   pname = "mesa";
   version = "26.1.4";

--- a/pkgs/development/python-modules/pyannote-audio/default.nix
+++ b/pkgs/development/python-modules/pyannote-audio/default.nix
@@ -124,7 +124,6 @@ buildPythonPackage (finalAttrs: {
     lib.optionals stdenv.hostPlatform.isDarwin [
       # Crashes the interpreter
       # - On aarch64-darwin: Trace/BPT trap: 5
-      # - On x86_64-darwin: Fatal Python error: Illegal instruction
       "tests/inference_test.py"
       "tests/test_train.py"
     ]


### PR DESCRIPTION
Stacked on top of https://github.com/NixOS/nixpkgs/pull/541145.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
