### PR TITLE
various: drop obsolete `broken`

### DIFF
--- a/pkgs/by-name/fl/flamp/package.nix
+++ b/pkgs/by-name/fl/flamp/package.nix
@@ -36,7 +36,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ stteague ];
     platforms = lib.platforms.unix;
-    broken = stdenv.system == "x86_64-darwin";
     mainProgram = "flamp";
   };
 })

--- a/pkgs/by-name/im/imagineer/package.nix
+++ b/pkgs/by-name/im/imagineer/package.nix
@@ -51,7 +51,5 @@ rustPlatform.buildRustPackage (finalAttrs: {
     ];
     maintainers = [ lib.maintainers.progrm_jarvis ];
     mainProgram = "ig";
-    # The last successful Darwin Hydra build was in 2024
-    broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64;
   };
 })

--- a/pkgs/by-name/qo/qolibri/package.nix
+++ b/pkgs/by-name/qo/qolibri/package.nix
@@ -57,7 +57,6 @@ stdenv.mkDerivation {
     license = lib.licenses.gpl2;
     maintainers = [ lib.maintainers.azahi ];
     platforms = lib.platforms.unix;
-    broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64; # Looks like a libcxx version mismatch problem.
     mainProgram = "qolibri";
   };
 }

--- a/pkgs/by-name/sc/scalapack/package.nix
+++ b/pkgs/by-name/sc/scalapack/package.nix
@@ -61,9 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
     mpi
   ];
 
-  # xslu and xsllt tests seem to time out on x86_64-darwin.
-  # this line is left so those who force installation on x86_64-darwin can still build
-  doCheck = !(stdenv.hostPlatform.isx86_64 && stdenv.hostPlatform.isDarwin);
+  doCheck = true;
 
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
@@ -93,7 +91,5 @@ stdenv.mkDerivation (finalAttrs: {
       markuskowa
       gdinh
     ];
-    # xslu and xsllt tests fail on x86 darwin
-    broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64;
   };
 })

--- a/pkgs/by-name/vi/visp/package.nix
+++ b/pkgs/by-name/vi/visp/package.nix
@@ -99,8 +99,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Open Source Visual Servoing Platform";
-    # ref. https://github.com/lagadic/visp/pull/1658
-    broken = stdenv.hostPlatform.system == "x86_64-darwin";
     homepage = "https://visp.inria.fr";
     changelog = "https://github.com/lagadic/visp/blob/v${finalAttrs.version}/ChangeLog.txt";
     license = lib.licenses.gpl2Plus;

--- a/pkgs/development/compilers/ccl/default.nix
+++ b/pkgs/development/compilers/ccl/default.nix
@@ -105,8 +105,6 @@ stdenv.mkDerivation (finalAttrs: {
   hardeningDisable = [ "format" ];
 
   meta = {
-    # assembler failures during build, x86_64-darwin broken since 2020-10-14
-    broken = (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64);
     description = "Clozure Common Lisp";
     homepage = "https://ccl.clozure.com/";
     license = lib.licenses.asl20;

--- a/pkgs/development/compilers/dotnet/source/vmr.nix
+++ b/pkgs/development/compilers/dotnet/source/vmr.nix
@@ -541,8 +541,5 @@ stdenv.mkDerivation {
       "aarch64-linux"
       "aarch64-darwin"
     ];
-    # build deadlocks intermittently on rosetta
-    # https://github.com/dotnet/runtime/issues/111628
-    broken = stdenv.hostPlatform.system == "x86_64-darwin";
   };
 }


### PR DESCRIPTION
Stacked on top of https://github.com/NixOS/nixpkgs/pull/541145.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
