### PR TITLE
dblatex: use default python3

### DIFF
--- a/pkgs/by-name/db/dblatex/package.nix
+++ b/pkgs/by-name/db/dblatex/package.nix
@@ -1,8 +1,9 @@
 {
   lib,
   stdenv,
+  fetchpatch,
   fetchurl,
-  python311,
+  python3,
   libxslt,
   texliveBasic,
   enableAllFeatures ? false,
@@ -62,8 +63,26 @@ stdenv.mkDerivation rec {
     sha256 = "0yd09nypswy3q4scri1dg7dr99d7gd6r2dwx0xm81l9f4y32gs0n";
   };
 
+  patches = [
+    (fetchpatch {
+      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/dblatex/-/raw/067a586a688635a8ad6c15b1bd8ef3b16eb3f9f4/dblatex-0.3.12-replace-imp-by-importlib.patch";
+      hash = "sha256-ND9fS8KkQKnML6EwJFSUFhqiIn4yEvu1KOxTRPjXsd0=";
+    })
+    (fetchpatch {
+      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/dblatex/-/raw/067a586a688635a8ad6c15b1bd8ef3b16eb3f9f4/dblatex-0.3.12-adjust-submodule-imports.patch";
+      hash = "sha256-0wOn2IvCSCtrE0rM56yw3FcGggTsDk3owQa1UmFsbVo=";
+    })
+    (fetchpatch {
+      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/dblatex/-/raw/067a586a688635a8ad6c15b1bd8ef3b16eb3f9f4/dblatex-0.3.12-script_path.patch";
+      hash = "sha256-JGN9NxOiqoZ0Yz5ZbYwsis3tujBA2OWX5PZtrc/iTJY=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    (python3.withPackages (ps: [ ps.setuptools_80 ]))
+  ];
+
   buildInputs = [
-    python311
     libxslt
     tex
   ]
@@ -100,7 +119,7 @@ stdenv.mkDerivation rec {
   dontBuild = true;
 
   installPhase = ''
-    ${python311.interpreter} ./setup.py install --prefix="$out" --use-python-path --verbose
+    python ./setup.py install --prefix="$out" --use-python-path --verbose
   '';
 
   passthru = { inherit tex; };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
