### PR TITLE
mokuro: fix build by patching out pkg_resources

### DIFF
--- a/pkgs/by-name/mo/mokuro/dont-use-pkg-resources.patch
+++ b/pkgs/by-name/mo/mokuro/dont-use-pkg-resources.patch
@@ -1,0 +1,35 @@
+diff --git a/comic_text_detector/utils/yolov5_utils.py b/comic_text_detector/utils/yolov5_utils.py
+index 2173263..e12d614 100644
+--- a/comic_text_detector/utils/yolov5_utils.py
++++ b/comic_text_detector/utils/yolov5_utils.py
+@@ -1,7 +1,7 @@
+ import math
+ import torch
+ import torch.nn as nn
+-import pkg_resources as pkg
++from packaging.version import Version
+ import torch.nn.functional as F
+ import cv2
+ import numpy as np
+@@ -73,7 +73,7 @@ def intersect_dicts(da, db, exclude=()):
+ 
+ def check_version(current='0.0.0', minimum='0.0.0', name='version ', pinned=False, hard=False):
+     # Check version vs. required version
+-    current, minimum = (pkg.parse_version(x) for x in (current, minimum))
++    current, minimum = (Version(x) for x in (current, minimum))
+     result = (current == minimum) if pinned else (current >= minimum)  # bool
+     if hard:  # assert min requirements met
+         assert result, f'{name}{minimum} required by YOLOv5, but {name}{current} is currently installed'
+diff --git a/pyproject.toml b/pyproject.toml
+index 7d96687..5abe0d6 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -23,7 +23,7 @@ dependencies = [
+     "pyclipper",
+     "requests",
+     "scipy",
+-    "setuptools<81",
++    "packaging",
+     "shapely",
+     "torch>=1.7.0",
+     "torchsummary",

--- a/pkgs/by-name/mo/mokuro/package.nix
+++ b/pkgs/by-name/mo/mokuro/package.nix
@@ -17,6 +17,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
     fetchSubmodules = true;
   };
 
+  patches = [ ./dont-use-pkg-resources.patch ];
+
   build-system = with python3Packages; [ setuptools-scm ];
 
   dependencies = with python3Packages; [
@@ -26,6 +28,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     natsort
     numpy
     opencv-python
+    packaging
     pillow
     pyclipper
     requests


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
