### PR TITLE
mozphab: 1.9.0 -> 2.15.3, adopt

### DIFF
--- a/pkgs/build-support/rust/hooks/maturin-build-hook.sh
+++ b/pkgs/build-support/rust/hooks/maturin-build-hook.sh
@@ -22,10 +22,13 @@ maturinBuildHook() {
         "--offline"
         "--target" "@rustcTargetSpec@"
         "--manylinux" "off"
-        "--strip"
         "--out" "$dist"
         "--interpreter" "$interpreter_name"
     )
+
+    if [ -z "${dontStrip-}" ]; then
+      flagsArray+=("--strip")
+    fi
 
     if [ -n "${maturinBuildProfile}" ]; then
       flagsArray+=("--profile" "${maturinBuildProfile}")

--- a/pkgs/by-name/mo/mozphab/package.nix
+++ b/pkgs/by-name/mo/mozphab/package.nix
@@ -2,23 +2,27 @@
   lib,
   fetchFromGitHub,
   python3,
+  nix-update-script,
 
   # tests
   git,
+  jujutsu,
   mercurial,
   patch,
 }:
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "mozphab";
-  version = "1.9.0";
+  version = "2.15.3";
   pyproject = true;
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "mozilla-conduit";
     repo = "review";
     tag = finalAttrs.version;
-    hash = "sha256-CVpsq9YoEww47uruHYEsJk9YQ39ZFQsMdL0nBc8AHUM=";
+    hash = "sha256-QqWvwKkD0WL50E9NmgXmgxM8zATXdJTdK4l/CYk0lgk=";
   };
 
   build-system = with python3.pkgs; [
@@ -40,6 +44,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   nativeCheckInputs = [
     git
+    jujutsu
     mercurial
     patch
   ]
@@ -56,11 +61,9 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   '';
 
   disabledTests = [
-    # AttributeError: 'called_once' is not a valid assertion.
-    "test_commit"
-    # AttributeError: 'not_called' is not a valid assertion.
-    "test_finalize_no_evolve"
-    "test_patch"
+    # Seems to expect an older `jj` version:
+    # AssertionError: A broken `jj` config should surface a `jj git root` error.
+    "test_jj_broken_config_surfaces_error"
   ];
 
   disabledTestPaths = [
@@ -75,6 +78,8 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     "tests/test_sentry.py"
   ];
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Phabricator CLI from Mozilla to support submission of a series of commits";
     mainProgram = "moz-phab";
@@ -85,7 +90,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     '';
     homepage = "https://moz-conduit.readthedocs.io/en/latest/phabricator-user.html";
     license = lib.licenses.mpl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ choco98 ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/development/python-modules/glean-sdk/default.nix
+++ b/pkgs/development/python-modules/glean-sdk/default.nix
@@ -4,6 +4,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   glean-parser,
+  nix-update-script,
   pytest-localserver,
   pytestCheckHook,
   rustPlatform,
@@ -11,22 +12,26 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "glean-sdk";
-  version = "64.0.0";
+  version = "69.0.0";
   pyproject = true;
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "mozilla";
     repo = "glean";
-    rev = "v${version}";
-    hash = "sha256-6UAZkVBxFJ1CWRn9enCLBBidIugAtxP7stbYlhh1ArA=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KLYGbnKxuokvV/TBXLl1oplbTJkqMblh14daWalVz0M=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit pname version src;
-    hash = "sha256-Ppc+6ex3yLC4xuhbZGZDKLqxDjSdGpgrLDpbbbqMgPY=";
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-Vmxt8cRvkj0xEOc/WGDUxeQfH0uBvvboKc43ClqqEaQ=";
   };
+
+  dontStrip = true;
 
   build-system = [
     rustPlatform.cargoSetupHook
@@ -56,10 +61,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "glean" ];
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     broken = stdenv.hostPlatform.isDarwin;
     description = "Telemetry client libraries and are a part of the Glean project";
     homepage = "https://mozilla.github.io/glean/book/index.html";
+    maintainers = with lib.maintainers; [ choco98 ];
     license = lib.licenses.mpl20;
   };
-}
+})


### PR DESCRIPTION
*Note*: draft as I think #535394 should be discussed and merged on its own

This PR fixes glean-sdk and hence mozphab, but currently, #535394 is required for this PR to be merged. When it's merged I'll rebase on it and drop the commit from here. Otherwise it's pretty basic.

(Pretty sure this'll tag the Rust team again, if you guys see this, check out #535394 please, would love to hear your input!)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
