### PR TITLE
pyxel: 2.8.10 -> 2.9.7, fix build

### DIFF
--- a/pkgs/by-name/py/pyxel/package.nix
+++ b/pkgs/by-name/py/pyxel/package.nix
@@ -11,36 +11,26 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "pyxel";
-  version = "2.8.10";
+  version = "2.9.7";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "kitao";
     repo = "pyxel";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-+SitYe2HFA6rwqk5lipcKFdBy69zdAhw3Q+Nb0iBx6s=";
+    hash = "sha256-k86VRX25yVNZvsnsWl0EYGd8njhx9yl6gkqI7mznjEs=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "add-Cargo.lock.patch";
-      url = "https://github.com/kitao/pyxel/commit/821286112ea0c26141aa64b25aaa076611a2a91d.patch";
-      excludes = [ "CHANGELOG.md" ];
-      hash = "sha256-XtFdtmprPKrdjFOzEsNMJjc4PpNv6KDtWX2Hes2IKe0=";
-    })
-  ];
 
   cargoRoot = "crates";
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs)
       src
-      patches
       pname
       version
       cargoRoot
       ;
-    hash = "sha256-SGrQmGZeM2NcooDqCTO2HOXgLg7h+VvDIierDacqSFs=";
+    hash = "sha256-tpJSUdjdXwXK/n1nyMga5uTk7TAz/JLQVN0rSdbKxGk=";
   };
 
   buildAndTestSubdir = "python";
@@ -61,6 +51,11 @@ python3Packages.buildPythonApplication (finalAttrs: {
   buildInputs = [ SDL2 ];
 
   env.NIX_CFLAGS_COMPILE = "-I${lib.getDev SDL2}/include/SDL2";
+
+  preBuild = ''
+    # logic taken from Makefile
+    cp LICENSE README.md python/pyxel/
+  '';
 
   # Tests want to use the display
   doCheck = false;


### PR DESCRIPTION
https://github.com/kitao/pyxel/blob/main/CHANGELOG.md

The LICENSE and README.md files were not being found in 2.8.10 (probably due to a maturin update), so I updated the package in hopes that it is fixed.
Well yes, it is fixed mostly, but using a preBuild script.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
