### PR TITLE
glabels-qt: unstable-2025-12-03 -> unstable-2026-05-24

### DIFF
--- a/pkgs/by-name/gl/glabels-qt/package.nix
+++ b/pkgs/by-name/gl/glabels-qt/package.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation {
   pname = "glabels-qt";
-  version = "unstable-2025-12-03";
+  version = "unstable-2026-05-24";
 
   src = fetchFromGitHub {
     owner = "j-evins";
     repo = "glabels-qt";
-    tag = "3.99-master602";
-    hash = "sha256-7MQufoU1GBvmZd8FRn331/PwmwQMuZeuFKQqViRI754=";
+    tag = "3.99-master638";
+    hash = "sha256-oi9WOzt3o+5QpfHeosCnbvDmLirE7jXaQUJ5ADd3LY4=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Update provides fix for: https://github.com/j-evins/glabels-qt/issues/256

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].