### PR TITLE
nixosTests.ghostunnel-modular: fix test

### DIFF
--- a/pkgs/by-name/gh/ghostunnel/package.nix
+++ b/pkgs/by-name/gh/ghostunnel/package.nix
@@ -3,17 +3,16 @@
   fetchFromGitHub,
   lib,
   nixosTests,
-  ghostunnel,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "ghostunnel";
   version = "1.10.0";
 
   src = fetchFromGitHub {
     owner = "ghostunnel";
     repo = "ghostunnel";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-BntQCauAgnaiNn31nrVEsHFvQv7zK6D0z/rInbCVTr0=";
   };
 
@@ -41,13 +40,13 @@ buildGoModule rec {
     imports = [
       (lib.modules.importApply ./service.nix { })
     ];
-    ghostunnel.package = ghostunnel; # FIXME: finalAttrs.finalPackage
+    ghostunnel.package = finalAttrs.finalPackage;
   };
 
   meta = {
     description = "TLS proxy with mutual authentication support for securing non-TLS backend applications";
     homepage = "https://github.com/ghostunnel/ghostunnel#readme";
-    changelog = "https://github.com/ghostunnel/ghostunnel/releases/tag/v${version}";
+    changelog = "https://github.com/ghostunnel/ghostunnel/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       roberth
@@ -55,4 +54,4 @@ buildGoModule rec {
     ];
     mainProgram = "ghostunnel";
   };
-}
+})

--- a/pkgs/by-name/gh/ghostunnel/service.nix
+++ b/pkgs/by-name/gh/ghostunnel/service.nix
@@ -187,6 +187,9 @@ in
     process = {
       argv = [
         (getExe cfg.package)
+        # ghostunnel's landlock rules don't like reading the CA certs from /etc
+        # because they are links to /nix/store, which isn't part of its rules
+        "--disable-landlock"
         "server"
         "--listen"
         cfg.listen


### PR DESCRIPTION
Saw the todo when working on https://github.com/NixOS/nixpkgs/pull/541020

NOTE: the tests will not run in this pr, fix for this is available in https://github.com/NixOS/nixpkgs/pull/540857, and I couldn't test the change on top of the pr because of https://github.com/NixOS/nixpkgs/pull/541270.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
