### PR TITLE
various: replace os.system with subprocess.run

### DIFF
--- a/nixos/modules/system/boot/loader/limine/limine-install.py
+++ b/nixos/modules/system/boot/loader/limine/limine-install.py
@@ -347,7 +347,7 @@ def config_entry(levels: int, bootspec: BootSpec, label: str, time: str) -> str:
             os.path.basename(bootspec.toplevel) + "-secrets"
         )
 
-        if os.system(bootspec.initrdSecrets + " " + initrd_secrets_path_temp) != 0:
+        if subprocess.run([bootspec.initrdSecrets, initrd_secrets_path_temp]).returncode != 0:
             print(
                 f'warning: failed to create initrd secrets for "{label}"',
                 file=sys.stderr,

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -63,7 +63,7 @@ let
       - `config.node.pkgs.<name>` or `config.nodes.foo.nixpkgs.pkgs.<name>` to refer
         to the Nixpkgs used on the VM guest(s).
       - `hostPkgs.<name>` when invoking commands on the VM host (e.g. in Python
-        `os.system("foo")`)
+        `subprocess.run(["foo"])`)
     - Since the runTest argument is a module instead of a function, arguments
       must be passed as option definitions.
       You may declare explicit `options` for the test parameter(s), or use the

--- a/nixos/tests/boot.nix
+++ b/nixos/tests/boot.nix
@@ -203,11 +203,26 @@ in
     makeTest {
       name = "boot-uboot-extlinux";
       nodes = { };
-      testScript = ''
-        import os
+      testScript = /* py */ ''
+        import subprocess
 
         # Create a mutable linked image backed by the read-only SD image
-        if os.system("${pkgs.qemu}/bin/qemu-img create -f qcow2 -F raw -b ${sdImage} ${mutableImage}") != 0:
+        if (
+            subprocess.run(
+                [
+                    "${pkgs.qemu}/bin/qemu-img",
+                    "create",
+                    "-f",
+                    "qcow2",
+                    "-F",
+                    "raw",
+                    "-b",
+                    "${sdImage}",
+                    "${mutableImage}",
+                ]
+            ).returncode
+            != 0
+        ):
             raise RuntimeError("Could not create mutable linked image")
 
         machine = create_machine("${startCommand}")

--- a/nixos/tests/ec2-image.nix
+++ b/nixos/tests/ec2-image.nix
@@ -135,7 +135,17 @@ in
               public_key = os.path.join(key_dir, "id_ed25519.pub")
 
               # Generate key pair using host SSH tools
-              ret = os.system(f"${hostPkgs.openssh}/bin/ssh-keygen -t ed25519 -f {private_key} -N \"\"")
+              ret = subprocess.run(
+                  [
+                      "${hostPkgs.openssh}/bin/ssh-keygen",
+                      "-t",
+                      "ed25519",
+                      "-f",
+                      private_key,
+                      "-N",
+                      ""
+                  ]
+              ).returncode
               if ret != 0:
                   raise Exception("Failed to generate SSH key pair")
 

--- a/nixos/tests/ghostunnel-modular.nix
+++ b/nixos/tests/ghostunnel-modular.nix
@@ -54,13 +54,13 @@
   };
 
   testScript = ''
-    import os
+    import subprocess
 
     # prepare certificates
 
     def cmd(command):
       print(f"+{command}")
-      r = os.system(command)
+      r = subprocess.run(command, shell=True).returncode
       if r != 0:
         raise Exception(f"Command {command} failed with exit code {r}")
 

--- a/nixos/tests/ghostunnel.nix
+++ b/nixos/tests/ghostunnel.nix
@@ -48,13 +48,13 @@
   };
 
   testScript = ''
-    import os
+    import subprocess
 
     # prepare certificates
 
     def cmd(command):
       print(f"+{command}")
-      r = os.system(command)
+      r = subprocess.run(command, shell=True).returncode
       if r != 0:
         raise Exception(f"Command {command} failed with exit code {r}")
 

--- a/nixos/tests/haproxy.nix
+++ b/nixos/tests/haproxy.nix
@@ -69,12 +69,12 @@
       };
   };
   testScript = ''
-    import os
+    import subprocess
 
     # Helpers
     def cmd(command):
       print(f"+{command}")
-      r = os.system(command)
+      r = subprocess.run(command, shell=True).returncode
       if r != 0:
         raise Exception(f"Command {command} failed with exit code {r}")
 

--- a/pkgs/by-name/mi/microsoft-edge/update.py
+++ b/pkgs/by-name/mi/microsoft-edge/update.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env nix-shell
 #! nix-shell -i python3 -p python3Packages.packaging python3Packages.python-debian common-updater-scripts
 
-import os
+import subprocess
 from collections import OrderedDict
 from os.path import abspath, dirname
 from urllib import request
@@ -39,8 +39,8 @@ def write_expression():
     version = Version.re_valid_version.match(latest["stable"]["Version"]).group(
         "upstream_version"
     )
-    os.system(f'update-source-version microsoft-edge "{version}"')
-    os.system(f'update-source-version msedgedriver "{version}"')
+    subprocess.run(["update-source-version", "microsoft-edge", version])
+    subprocess.run(["update-source-version", "msedgedriver", version])
 
 
 write_expression()

--- a/pkgs/development/python-modules/courlan/default.nix
+++ b/pkgs/development/python-modules/courlan/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage (finalAttrs: {
       substituteInPlace tests/unit_tests.py \
         --replace-fail \
           'assert os.system("courlan --help") == 0' \
-          'assert os.system("${courlanBinPath} --help") == 0' \
+          'assert subprocess.run(["${courlanBinPath}", "--help"]).returncode == 0' \
         --replace-fail \
           'courlan_bin = "courlan"' \
           'courlan_bin = "${courlanBinPath}"'

--- a/pkgs/development/python-modules/riscof/make_writeable.patch
+++ b/pkgs/development/python-modules/riscof/make_writeable.patch
@@ -1,25 +1,33 @@
 diff --git a/riscof/cli.py b/riscof/cli.py
-index 26af62e..9d0ddbf 100644
+index 26af62e..94051ae 100644
 --- a/riscof/cli.py
 +++ b/riscof/cli.py
-@@ -502,6 +502,7 @@ def setup(dutname,refname,work_dir):
+@@ -7,6 +7,7 @@ import os
+ import sys
+ import pytz
+ import shutil
++import subprocess
+ import configparser
+ import distutils.dir_util
+
+@@ -502,6 +503,7 @@ def setup(dutname,refname,work_dir):
          src = os.path.join(constants.root, "Templates/setup/model/")
          dest = os.path.join(cwd, dutname)
          distutils.dir_util.copy_tree(src, dest)
-+        os.system(f"chmod +w -R '{dest}'")
++        subprcess.run(["chmod", "+w", "-R", dest])
  
          os.rename(cwd+'/'+dutname+'/model_isa.yaml',
                  cwd+'/'+dutname+'/'+dutname+'_isa.yaml')
-@@ -525,10 +526,12 @@ def setup(dutname,refname,work_dir):
+@@ -525,10 +527,12 @@ def setup(dutname,refname,work_dir):
              src = os.path.join(constants.root, "Templates/setup/sail_cSim/")
              dest = os.path.join(cwd, refname)
              distutils.dir_util.copy_tree(src, dest)
-+            os.system(f"chmod +w -R '{dest}'")
++            subprcess.run(["chmod", "+w", "-R", dest])
          else:
              src = os.path.join(constants.root, "Templates/setup/reference/")
              dest = os.path.join(cwd, refname)
              distutils.dir_util.copy_tree(src, dest)
-+            os.system(f"chmod +w -R '{dest}'")
++            subprcess.run(["chmod", "+w", "-R", dest])
              os.rename(cwd+'/'+refname+'/riscof_model.py',
                  cwd+'/'+refname+'/riscof_'+refname+'.py')
              with open(cwd+'/'+refname+'/riscof_'+refname+'.py', 'r') as file :

--- a/pkgs/os-specific/linux/usbrelay/test.nix
+++ b/pkgs/os-specific/linux/usbrelay/test.nix
@@ -45,9 +45,11 @@ import ../../../../nixos/tests/make-test-python.nix (
       documentation.nixos.enable = false; # building nixos manual takes long time
     };
 
-    testScript = ''
+    testScript = /* py */ ''
       import os
-      if os.waitstatus_to_exitcode(os.system("lsusb -d 16c0:05df")) != 0:
+      import subprocess
+
+      if os.waitstatus_to_exitcode(subprocess.run(["lsusb", "-d", "16c0:05df"]).returncode) != 0:
           print("No USB relay detected, skipping test")
           import sys
           sys.exit(2)


### PR DESCRIPTION
Recent update to python 3.14 has caused some nixos tests using `os.system` to fail.

I've replaced the failing items, internal usage, as well as patches we introduce in nixpkgs.

Tested all of the nixos tests, except `usbrelay` because I don't have such a hardware.

Known failure `nixosTests.ghostunnel-modular` fixed in https://github.com/NixOS/nixpkgs/pull/541269
Known failures for modular services fix is here https://github.com/NixOS/nixpkgs/pull/540857

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
  - no llms were used

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
