### PR TITLE
star-pixel-icons: init at 0-unstable-03-09-2025

### DIFF
--- a/pkgs/by-name/st/star-pixel-icons/package.nix
+++ b/pkgs/by-name/st/star-pixel-icons/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  hicolor-icon-theme,
+  adwaita-icon-theme,
+  kdePackages,
+  gnome-icon-theme,
+  gtk3,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "star-pixel-icons";
+  version = "0-unstable-03-09-2025";
+
+  src = fetchFromGitHub {
+    owner = "Starciad";
+    repo = "star-pixel-icons-theme";
+    rev = "44625afc5ee831f1513d6687c601d4805892129c";
+    hash = "sha256-XDAWlCbdVAC74qZ/E1sok9jRkB0yForhQnVVg1WYnQc=";
+  };
+
+  nativeBuildInputs = [ gtk3 ];
+
+  propagatedBuildInputs = [
+    hicolor-icon-theme
+    adwaita-icon-theme
+    gnome-icon-theme
+    kdePackages.breeze-icons
+    kdePackages.oxygen-icons
+  ];
+
+  dontDropIconThemeCache = true;
+
+  dontWrapQtApps = true;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    ICON_DIR=$out/share/icons/star-pixel-icons
+    mkdir -p $ICON_DIR
+    cp -r src/SPI/* $ICON_DIR
+    gtk-update-icon-cache $ICON_DIR
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/Starciad/star-pixel-icons-theme";
+    description = "Pixel icon theme for Linux";
+    license = lib.licenses.cc-by-sa-40;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.EarthGman ];
+  };
+}


### PR DESCRIPTION
Pixel icon theme for Linux
https://github.com/Starciad/star-pixel-icons-theme

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].