### PR TITLE
muse-sounds-manager: use permalink provided by Muse Group and remove unzip dependency

### DIFF
--- a/pkgs/by-name/mu/muse-sounds-manager/package.nix
+++ b/pkgs/by-name/mu/muse-sounds-manager/package.nix
@@ -18,7 +18,7 @@
   makeWrapper,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "muse-sounds-manager";
   version = "2.2.1.953";
 
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     stdenv.cc.cc
     zlib
   ]
-  ++ runtimeDependencies;
+  ++ finalAttrs.runtimeDependencies;
 
   runtimeDependencies = map lib.getLib [
     icu
@@ -87,4 +87,4 @@ stdenv.mkDerivation rec {
     platforms = [ "x86_64-linux" ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
-}
+})

--- a/pkgs/by-name/mu/muse-sounds-manager/package.nix
+++ b/pkgs/by-name/mu/muse-sounds-manager/package.nix
@@ -13,9 +13,7 @@
   libice,
   libsm,
   openssl,
-  unzip,
   xdg-utils,
-  makeWrapper,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -30,7 +28,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     autoPatchelfHook
-    makeWrapper
   ];
 
   buildInputs = [
@@ -64,8 +61,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   postInstall = ''
     ln -s ${xdg-utils}/bin/xdg-open $out/bin/open
-    wrapProgram $out/bin/muse-sounds-manager \
-      --prefix PATH : ${lib.makeBinPath [ unzip ]}
   '';
 
   dontStrip = true;

--- a/pkgs/by-name/mu/muse-sounds-manager/package.nix
+++ b/pkgs/by-name/mu/muse-sounds-manager/package.nix
@@ -22,15 +22,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "muse-sounds-manager";
   version = "2.2.1.953";
 
-  # Use web.archive.org since upstream does not provide a stable (versioned) URL.
-  # To see if there are new versions on the Web Archive, visit
-  # http://web.archive.org/cdx/search/cdx?url=https://muse-cdn.com/Muse_Sounds_Manager_x64.tar.gz
-  # then replace the date in the URL below with date when the SHA1
-  # changes (currently CQDUS5RIVPTNZF65NNOVKDG2BCVCXH6H) and replace
-  # the version above with the version in the .deb metadata (or in the
-  # settings of muse-sounds-manager).
+  # Permalink from https://support.musehub.com/en/articles/15070607-changelog
   src = fetchurl {
-    url = "https://web.archive.org/web/20260710024139if_/https://muse-cdn.com/Muse_Sounds_Manager_x64.tar.gz";
+    url = "https://muse-cdn.com/muse-sounds-manager/Muse_Sounds_Manager_x64_${finalAttrs.version}.tar.gz";
     hash = "sha256-y7fKHh2pG8uT4p0vq20rsW8bSAp1mepkd2sW/06N3EI=";
   };
 


### PR DESCRIPTION
Yesterday, after I submitted #541036, Dominic Maas from Muse Group reached out to me privately about `muse-sounds-manager` with 2 important points

1. Permalink for MuseSounds Manager is provided via https://support.musehub.com/en/articles/15070607-changelog
2. `unzip` is no longer a dependency of `muse-sounds-manager`

This PR aims to address both points.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
