### PR TITLE
agent-safehouse: 0.10.1 -> 0.11.0

### DIFF
--- a/pkgs/by-name/ag/agent-safehouse/package.nix
+++ b/pkgs/by-name/ag/agent-safehouse/package.nix
@@ -2,18 +2,19 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  versionCheckHook,
   nix-update-script,
 }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "safehouse";
-  version = "0.10.1";
+  version = "0.11.0";
 
   src = fetchFromGitHub {
     owner = "eugene1g";
     repo = "agent-safehouse";
     rev = "v" + version;
-    hash = "sha256-Nm04UnyQ2mVLkIIEspDd2vbdcJxZ17MH07fW6PvokJI=";
+    hash = "sha256-2GWxh5J9qqudc2QM/CACXpqJLcNULKSfTAHBzR++UAE=";
   };
 
   postPatch = "patchShebangs scripts bin";
@@ -36,6 +37,9 @@ stdenvNoCC.mkDerivation rec {
 
     runHook postInstall
   '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   meta = {
     description = "Sandbox your local AI agents so they can read/write only what they need";

--- a/pkgs/by-name/ag/agent-safehouse/package.nix
+++ b/pkgs/by-name/ag/agent-safehouse/package.nix
@@ -47,6 +47,9 @@ stdenvNoCC.mkDerivation rec {
     mainProgram = "safehouse";
     license = lib.licenses.asl20;
     platforms = lib.platforms.darwin;
-    maintainers = with lib.maintainers; [ myzel394 ];
+    maintainers = with lib.maintainers; [
+      myzel394
+      Br1ght0ne
+    ];
   };
 }


### PR DESCRIPTION
https://github.com/eugene1g/agent-safehouse/releases/tag/v0.11.0
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
