### PR TITLE
notion-app: 7.24.0 -> 7.25.1

### DIFF
--- a/pkgs/by-name/no/notion-app/sources.json
+++ b/pkgs/by-name/no/notion-app/sources.json
@@ -1,12 +1,12 @@
 {
   "x86_64-darwin": {
-    "version": "7.24.0",
-    "url": "https://desktop-release.notion-static.com/Notion-7.24.0.zip",
-    "hash": "sha512-3X7E6ZSEJMrArof7p/OgqUk4i3cewF0zMTPVhkhSgNVzOqHt9kvthGIpKUN6M/u0xdYAkRQgSWHkJ/RoA5Q6Hw=="
+    "version": "7.25.1",
+    "url": "https://desktop-release.notion-static.com/Notion-7.25.1.zip",
+    "hash": "sha512-HBhe2onWY44JbMVIfiLglyNDk1tqepwCerqbgUuI56mstBlg+B0KuepTl+plJODoTVtRasmrg/WRBw+ESWpEeg=="
   },
   "aarch64-darwin": {
-    "version": "7.24.0",
-    "url": "https://desktop-release.notion-static.com/Notion-arm64-7.24.0.zip",
-    "hash": "sha512-tQVL3z0SOMOeGaqYr4Gq1tULj/kKy4qmmsJN3uwCwDXkmenzLGCWiEmWmkK52T2xW8mMrbSBAAZGNDi0qQw5yA=="
+    "version": "7.25.1",
+    "url": "https://desktop-release.notion-static.com/Notion-arm64-7.25.1.zip",
+    "hash": "sha512-1t+hNS33R3CX+inR8ArKvm4LDn0Wu7JiCU91ucnaAgQm85XUcWFdxk/f421M9XqG1Wte+webFX45LXDlixKa2A=="
   }
 }


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
