### PR TITLE
lib.attrsets.mergeAttrsList: simplify

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -1608,8 +1608,7 @@ rec {
 
     :::
   */
-  # Since earlier elements take precedence in `listToAttrs`, we need to reverse first.
-  mergeAttrsList = list: listToAttrs (reverseList (concatMap attrsToList list));
+  mergeAttrsList = zipAttrsWith (_: values: elemAt values (length values - 1));
 
   /**
     Update `lhs` so that `rhs` wins for any given attribute path that occurs in both.

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -1582,7 +1582,6 @@ rec {
     Merge a list of attribute sets together using the `//` operator.
     In case of duplicate attributes, values from later list elements take precedence over earlier ones.
     The result is the same as `foldl mergeAttrs { }`, but the performance is better for large inputs.
-    For n list elements, each with an attribute set containing m unique attributes, the complexity of this operation is O(nm log n).
 
     # Inputs
 
@@ -1609,29 +1608,8 @@ rec {
 
     :::
   */
-  mergeAttrsList =
-    list:
-    let
-      # `binaryMerge start end` merges the elements at indices `index` of `list` such that `start <= index < end`
-      # Type: Int -> Int -> AttrSet
-      binaryMerge =
-        start: end:
-        # assert start < end; # Invariant
-        if end - start == 1 then
-          # Base case - there will be exactly 1 element due to the invariant, in
-          # which case we just return it directly
-          elemAt list start
-        else
-          # If there's at least 2 elements, split the range in two, recurse on each part and merge the result
-          # Relies on floor for odd results
-          # The invariant is satisfied because each half will have at least 1 element
-          binaryMerge start ((start + end) / 2) // binaryMerge ((start + end) / 2) end;
-    in
-    if list == [ ] then
-      # Calling binaryMerge as below would not satisfy its invariant
-      { }
-    else
-      binaryMerge 0 (length list);
+  # Since earlier elements take precedence in `listToAttrs`, we need to reverse first.
+  mergeAttrsList = list: listToAttrs (reverseList (concatMap attrsToList list));
 
   /**
     Update `lhs` so that `rhs` wins for any given attribute path that occurs in both.

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -2292,9 +2292,10 @@ runTests {
             m:
             let
               # Integer divide n by two to create duplicate attributes
-              str = "halfn${toString (n / 2)}m${toString m}";
+              key = "halfn${toString (n / 2)}m${toString m}";
+              val = "n${toString n}m${toString m}";
             in
-            nameValuePair str str
+            nameValuePair key val
           ) 100
         )
       ) 100;


### PR DESCRIPTION
This is a further improvement after https://github.com/NixOS/nixpkgs/pull/528677.

The most basic `mergeAttrsList` using `foldl' mergeAttrs { }`:
```
Benchmark 1: nix-instantiate --eval --strict ./benchmark.nix -A a
  Time (mean ± σ):     13.218 s ±  0.517 s    [User: 13.870 s, System: 0.183 s]
  Range (min … max):   12.496 s … 13.890 s    10 runs
```
`mergeAttrsList` as introduced by https://github.com/NixOS/nixpkgs/pull/528677:
```
Benchmark 2: nix-instantiate --eval --strict ./benchmark.nix -A b
  Time (mean ± σ):     206.3 ms ±   1.9 ms    [User: 178.6 ms, System: 27.5 ms]
  Range (min … max):   203.6 ms … 210.4 ms    14 runs
```
The new `mergeAttrsList`:
```
Benchmark 3: nix-instantiate --eval --strict ./benchmark.nix -A c
  Time (mean ± σ):     206.8 ms ±   1.8 ms    [User: 184.3 ms, System: 22.4 ms]
  Range (min … max):   204.3 ms … 210.8 ms    14 runs
```
The new `mergeAttrsList'`:
```
Benchmark 4: nix-instantiate --eval --strict ./benchmark.nix -A d
  Time (mean ± σ):     192.4 ms ±   1.9 ms    [User: 170.2 ms, System: 22.2 ms]
  Range (min … max):   190.1 ms … 197.1 ms    15 runs
```
```
Summary
  nix-instantiate --eval --strict ./benchmark.nix -A d ran
    1.07 ± 0.01 times faster than nix-instantiate --eval --strict ./benchmark.nix -A b
    1.07 ± 0.01 times faster than nix-instantiate --eval --strict ./benchmark.nix -A c
   68.71 ± 2.77 times faster than nix-instantiate --eval --strict ./benchmark.nix -A a
```
I'm not sure this warrants adding `mergeAttrsList'`, especially since I didn't see a performance improvement in running `nix eval --expr 'import ./pkgs/top-level/by-name-overlay.nix ./pkgs/by-name' --impure` when using it in `pkgs/top-level/by-name-overlay.nix`.

<details>
<summary>How I benchmarked.</summary>

I used the following `benchmark.nix` to run `hyperfine "nix-instantiate --eval --strict ./benchmark.nix -A "{a,b,c,d}`.

```nix
let
  inherit (builtins)
    attrValues
    concatMap
    elemAt
    foldl'
    genList
    length
    listToAttrs
    mapAttrs
    ;
  attrsToList = mapAttrsToList nameValuePair;
  mapAttrsToList = f: attrs: attrValues (mapAttrs f attrs);
  mergeAttrs = a: b: a // b;
  nameValuePair = name: value: { inherit name value; };
  reverseList =
    xs:
    let
      lastIndex = length xs - 1;
    in
    genList (n: elemAt xs (lastIndex - n)) (lastIndex + 1);

  data = genList (n: {
    ${toString n} = n;
  }) 100000;

  functions = {
    a = foldl' mergeAttrs { };
    b =
      list:
      let
        binaryMerge =
          start: end:
          if end - start == 1 then
            elemAt list start
          else
            binaryMerge start ((start + end) / 2) // binaryMerge ((start + end) / 2) end;
      in
      if list == [ ] then { } else binaryMerge 0 (length list);
    c = list: listToAttrs (reverseList (concatMap attrsToList list));
    d = list: listToAttrs (concatMap attrsToList list);
  };
  outputs = mapAttrs (_: f: f data) functions;
in
outputs
```

</details>
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
