### PR TITLE
yashiki: 0.14.0 -> 0.15.2, add Br1ght0ne to maintainers

### DIFF
--- a/pkgs/by-name/ya/yashiki/package.nix
+++ b/pkgs/by-name/ya/yashiki/package.nix
@@ -10,7 +10,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "yashiki";
-  version = "0.14.0";
+  version = "0.15.2";
 
   __structuredAttrs = true;
 
@@ -18,10 +18,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "typester";
     repo = "yashiki";
     tag = "yashiki-v${finalAttrs.version}";
-    hash = "sha256-ePZ8ONdvj3gaQps+5Ua0OLeFdzNdJhoB9yw6pC7qoEQ=";
+    hash = "sha256-nsmUuhi0yy6x6POC4qLbMib4fxS3QRjlK6QgCiVEnyQ=";
   };
 
-  cargoHash = "sha256-JMrftBKyD188SZqEGI4fA/MrfEK8JLKSeEqrQxhSs3U=";
+  cargoHash = "sha256-3JxtsSipMbMxQO58ZLJbQVrOFFC7FoVguNpqdoL+ziQ=";
 
   nativeBuildInputs = [
     installShellFiles
@@ -42,8 +42,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
     cp resources/icon/Assets.car "$app/Contents/Resources/Assets.car"
     substitute Info.plist.template "$app/Contents/Info.plist" \
-      --replace-fail VERSION_PLACEHOLDER "${finalAttrs.version}" \
-      --replace-fail "<string>yashiki-launcher</string>" "<string>yashiki</string>"
+      --replace-fail VERSION_PLACEHOLDER "${finalAttrs.version}"
 
     installShellCompletion --cmd yashiki --zsh completions/zsh/_yashiki
   '';

--- a/pkgs/by-name/ya/yashiki/package.nix
+++ b/pkgs/by-name/ya/yashiki/package.nix
@@ -61,7 +61,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://github.com/typester/yashiki/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     sourceProvenance = [ lib.sourceTypes.fromSource ];
-    maintainers = with lib.maintainers; [ anntnzrb ];
+    maintainers = with lib.maintainers; [
+      anntnzrb
+      Br1ght0ne
+    ];
     mainProgram = "yashiki";
     platforms = lib.platforms.darwin;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
