### PR TITLE
nixos/frigate: document roles-vs-enabled distinction and config ephemerality

### DIFF
--- a/nixos/modules/services/video/frigate.nix
+++ b/nixos/modules/services/video/frigate.nix
@@ -89,7 +89,27 @@ let
                     "record"
                   ];
                   description = ''
-                    List of roles for this stream
+                    List of roles for this stream.
+
+                    Assigning a role only selects which ffmpeg stream to
+                    capture; it does not enable the corresponding feature.
+                    Each feature must additionally be turned on in the camera
+                    config, and all three default to off:
+
+                    - `audio` runs audio event detection only when
+                      `cameras.<name>.audio.enabled` is `true`
+                    - `detect` runs the object detector only when
+                      `cameras.<name>.detect.enabled` is `true`
+                    - `record` stores recording segments only when
+                      `cameras.<name>.record.enabled` is `true`
+
+                    For example, a camera with the `detect` role but no
+                    `detect.enabled = true` will still capture a detect
+                    stream and run motion detection (motion is on by
+                    default), but will never produce object detections.
+
+                    See the upstream reference for the full set of defaults:
+                    <https://docs.frigate.video/configuration/reference>
                   '';
                 };
               };
@@ -270,6 +290,13 @@ in
       default = { };
       description = ''
         Frigate configuration as a nix attribute set.
+
+        The configuration file served to Frigate is generated from this
+        option and copied into place on every start of the service, so any
+        change made through Frigate's admin UI (the config editor and the
+        per-camera Detect / Motion / Record toggles), the config API, or
+        MQTT config updates is overwritten on the next start. Declare all
+        desired configuration here rather than editing it at runtime.
 
         See the project documentation for how to configure frigate.
         - [Creating a config file](https://docs.frigate.video/guides/getting_started)


### PR DESCRIPTION
Just an update to the docs, to avoid a situation I found myself in, where I am expecting camera detection to be enabled, yet I have to enable it manually in the web UI.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
