### PR TITLE
kikit: pin solidpython to setuptools_80, patch for numpy2 changes

### DIFF
--- a/pkgs/by-name/ki/kikit/default.nix
+++ b/pkgs/by-name/ki/kikit/default.nix
@@ -4,6 +4,7 @@
   lib,
   bats,
   fetchFromGitHub,
+  fetchpatch,
   python,
   buildPythonApplication,
   callPackage,
@@ -46,6 +47,14 @@ buildPythonApplication (finalAttrs: {
       rm "$out/kikit/_version.py"
     '';
   };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-stencil-arc-numpy2.patch";
+      url = "https://github.com/yaqwsx/KiKit/commit/036ca08fc380dd2c5b8b3ba2adc4215f4114e975.patch?full_index=1";
+      hash = "sha256-AmvH822nAubqVhl1PEKvE0Ij/K0NrBsSvnMUJXgxmfI=";
+    })
+  ];
 
   build-system = [
     setuptools

--- a/pkgs/by-name/ki/kikit/solidpython/default.nix
+++ b/pkgs/by-name/ki/kikit/solidpython/default.nix
@@ -7,7 +7,7 @@
   poetry-core,
   prettytable,
   ply,
-  setuptools,
+  setuptools_80,
   euclid3,
 }:
 buildPythonPackage (finalAttrs: {
@@ -28,7 +28,8 @@ buildPythonPackage (finalAttrs: {
 
   propagatedBuildInputs = [
     ply
-    setuptools
+    # Pinned to v80 due to pkg_resources removal, see https://github.com/SolidCode/SolidPython/issues/216
+    setuptools_80
     euclid3
 
     prettytable


### PR DESCRIPTION
Fixes #541300

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
