### PR TITLE
motus: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/by-name/mo/motus/package.nix
+++ b/pkgs/by-name/mo/motus/package.nix
@@ -13,23 +13,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
   __structuredAttrs = true;
 
   pname = "motus";
-  version = "0.4.0";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "oleiade";
     repo = "motus";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-lMNXg6YYTxAycxOiVtBGrSHpccLwerIQcY25K/NkqMo=";
+    hash = "sha256-7lFKlU9+/NvJi9NsVpve3IvzpS8OVHaH9cs/WRGjBV8=";
   };
 
-  cargoHash = "sha256-6MKEHnB2MJVB4cNvz3JYlhuzxhzsA+Pq5OkpLNoAEyU=";
-
-  # The CLI crate version was not bumped to match the v0.4.0 release tag:
-  # https://github.com/oleiade/motus/issues/58
-  postPatch = ''
-    substituteInPlace crates/motus-cli/src/main.rs \
-      --replace-fail '#[command(version = "0.3.1")]' '#[command(version = "${finalAttrs.version}")]'
-  '';
+  cargoHash = "sha256-0qK3omTkzVxkjFn2fIowl+sFmjF/hSHAROyge5CDdFg=";
 
   buildInputs = lib.optionals (withClipboard && stdenv.hostPlatform.isLinux) [ libxcb ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
