### PR TITLE
git-repo: 2.59 -> 2.65

### DIFF
--- a/pkgs/by-name/gi/git-repo/package.nix
+++ b/pkgs/by-name/gi/git-repo/package.nix
@@ -1,9 +1,8 @@
 {
   lib,
   stdenv,
-  fetchFromGitHub,
+  fetchFromGitiles,
   makeWrapper,
-  nix-update-script,
   python3,
   git,
   gnupg,
@@ -13,13 +12,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "git-repo";
-  version = "2.59";
+  version = "2.65";
 
-  src = fetchFromGitHub {
-    owner = "aosp-mirror";
-    repo = "tools_repo";
+  src = fetchFromGitiles {
+    url = "https://android.googlesource.com/tools/repo";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-5ffk5B4ZA/Wy2bQNahFaXPFRSZdKz5t6TaGbN00mfxo=";
+    hash = "sha256-ToJj5WS74vwCAX53UB5zgy1K54y1gNK+1d4qQLmp1L8=";
   };
 
   # Fix 'NameError: name 'ssl' is not defined'
@@ -57,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    updateScript = nix-update-script { };
+    updateScript = ./update.sh;
   };
 
   meta = {
@@ -70,7 +68,10 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://android.googlesource.com/tools/repo";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ otavio ];
+    maintainers = with lib.maintainers; [
+      otavio
+      ungeskriptet
+    ];
     platforms = lib.platforms.unix;
     mainProgram = "repo";
   };

--- a/pkgs/by-name/gi/git-repo/update.sh
+++ b/pkgs/by-name/gi/git-repo/update.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p common-updater-scripts git
+set -euo pipefail
+latest_tag=$(list-git-tags --url="https://android.googlesource.com/tools/repo" | sort -V | tail -n1)
+latest_tag=${latest_tag##v}
+cd "$(git rev-parse --show-toplevel)"
+update-source-version git-repo "$latest_tag"


### PR DESCRIPTION
Following changes have been done:
* Update to v2.65
* Use upstream git repository (Previous GitHub mirror has been archived)
* Add custom update script
* Add myself as maintainer

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
