### PR TITLE
terminal-notifier: fix darwin build

### DIFF
--- a/pkgs/by-name/te/terminal-notifier/package.nix
+++ b/pkgs/by-name/te/terminal-notifier/package.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   ibtool,
   lib,
+  llvmPackages,
   makeBinaryWrapper,
   stdenv,
   xcbuildHook,
@@ -23,6 +24,8 @@ stdenv.mkDerivation (finalAttrs: {
     ibtool
     makeBinaryWrapper
     xcbuildHook
+    # TODO: Clean up on `staging`
+    llvmPackages.lld
   ];
 
   buildInputs = [
@@ -35,6 +38,9 @@ stdenv.mkDerivation (finalAttrs: {
     "-configuration"
     "Release"
   ];
+
+  # TODO: Clean up on `staging`
+  env.NIX_CFLAGS_LINK = "-fuse-ld=lld";
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
Context: https://github.com/NixOS/nixpkgs/pull/536365

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
