### PR TITLE
rectangle: fix darwin build

### DIFF
--- a/pkgs/by-name/re/rectangle/package.nix
+++ b/pkgs/by-name/re/rectangle/package.nix
@@ -5,6 +5,8 @@
   darwin,
   actool,
   ibtool,
+  # TODO: Clean up on `staging`
+  llvmPackages,
   makeWrapper,
   nix-update-script,
 }:
@@ -149,6 +151,8 @@ stdenv.mkDerivation (finalAttrs: {
     ibtool
     darwin.autoSignDarwinBinariesHook
     makeWrapper
+    # TODO: Clean up on `staging`
+    llvmPackages.lld
   ];
 
   dontConfigure = true;
@@ -161,6 +165,8 @@ stdenv.mkDerivation (finalAttrs: {
     commonSwiftFlags=(
       -O -disable-bridging-pch
       -Xlinker -platform_version -Xlinker macos -Xlinker 14.0 -Xlinker 26.0
+      # TODO: Clean up on `staging`
+      -use-ld=lld
     )
 
     nixLog "building Sparkle stub framework"
@@ -196,6 +202,8 @@ stdenv.mkDerivation (finalAttrs: {
     clang -dynamiclib "''${masObjFiles[@]}" \
       -framework AppKit -framework Carbon -framework Foundation \
       -install_name "@rpath/MASShortcut.framework/MASShortcut" \
+      # TODO: Clean up on `staging`
+      -fuse-ld=lld \
       -o "$buildDir/libMASShortcut.dylib"
 
     rectSwiftFiles=()


### PR DESCRIPTION
Context: https://github.com/NixOS/nixpkgs/pull/536365

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
