### PR TITLE
zs: 0.4.1 -> 0.4.5

### DIFF
--- a/pkgs/by-name/zs/zs/package.nix
+++ b/pkgs/by-name/zs/zs/package.nix
@@ -8,17 +8,17 @@
 
 buildGoModule (finalAttrs: {
   pname = "zs";
-  version = "0.4.1";
+  version = "0.4.5";
 
   src = fetchFromGitea {
     domain = "git.mills.io";
     owner = "prologic";
     repo = "zs";
     rev = finalAttrs.version;
-    hash = "sha256-V8+p19kvVh64yCreNVp4RVdkJkjrq8Q5VbjaJWekZHY=";
+    hash = "sha256-NYnr0s730u4ICppPVZAAHB753XVooZtSSKIAp+z98Gw=";
   };
 
-  vendorHash = "sha256-KXcYTYO4wnWOup5uJ6T+XwthX5l2FL02JyOt1Nv51Sg=";
+  vendorHash = "sha256-21UukhXVVj1AO+HlTlEpHkf5zLHA6dapjrOriVQd1jM=";
 
   ldflags = [
     "-w"
@@ -41,7 +41,7 @@ buildGoModule (finalAttrs: {
     homepage = "https://git.mills.io/prologic/zs";
     changelog = "https://git.mills.io/prologic/zs/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ wariuccio ];
     mainProgram = "zs";
   };
 })


### PR DESCRIPTION
Updated `zs` to the latest released version. It's still fairly old but [this issue](https://git.mills.io/prologic/zs/issues/23) says there have been no further releases because after 0.4.5 there haven't been any new features or bug fixes.

Since the package had no maintainer I added myself.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
