### PR TITLE
qemu_test: Remove hostCpuOnly flag

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -153,6 +153,7 @@ in
     console-log = runTest ./nixos-test-driver/console-log.nix;
     containers = runTest ./nixos-test-driver/containers.nix;
     nspawn-daemon-reexec-dbus = runTest ./nspawn-daemon-reexec-dbus.nix;
+    multi-arch-test = runTest ./nixos-test-driver/multi-arch-test.nix;
     skip-typecheck = runTest ./nixos-test-driver/skip-typecheck.nix;
     console-timeout = runTest ./nixos-test-driver/console-timeout.nix;
     options-doc-regression = import ./nixos-test-driver/options-doc-regression.nix { inherit pkgs; };

--- a/nixos/tests/nixos-test-driver/multi-arch-test.nix
+++ b/nixos/tests/nixos-test-driver/multi-arch-test.nix
@@ -1,0 +1,55 @@
+{ pkgs, lib, ... }:
+{
+  name = "multi-arch-test";
+  meta.maintainers = with pkgs.lib.maintainers; [ tfc ];
+
+  node.pkgsReadOnly = false;
+
+  nodes = {
+    # Setting build = host platform because such standard VM setups
+    # are well-cached by the multi-arch build infrastructure of the
+    # project.
+    vmIntel = {
+      nixpkgs.buildPlatform = "x86_64-linux";
+      nixpkgs.hostPlatform = "x86_64-linux";
+    };
+    vmArm = {
+      nixpkgs.buildPlatform = "aarch64-linux";
+      nixpkgs.hostPlatform = "aarch64-linux";
+    };
+  };
+
+  defaults = {
+    # not needed for this test and shrinks the closure
+    # because we dont' need qemu for all architectures
+    virtualisation.qemu.guestAgent.enable = false;
+
+    # the test is already very slow but we don't need DHCP anyway
+    networking.dhcpcd.enable = false;
+
+    # fix the network-online target, otherwise it doesn't work
+    # properly as a synchronization mechanism.
+    systemd.network.wait-online.enable = true;
+    systemd.network.wait-online.anyInterface = true;
+  };
+
+  # slow due to SW emulation but shouldn't be slower than that
+  globalTimeout = 5 * 60;
+
+  testScript = { nodes, ... }: /* python */ ''
+    start_all()
+
+    vmIntel.systemctl("start network-online.target")
+    vmArm.systemctl("start network-online.target")
+    vmIntel.wait_for_unit("network-online.target")
+    vmArm.wait_for_unit("network-online.target")
+
+    vmIntel.succeed("ping -c 1 vmArm")
+    vmArm.succeed("ping -c 1 vmIntel")
+
+    archIntel = vmIntel.succeed("uname -m")
+    t.assertIn("${nodes.vmIntel.nixpkgs.hostPlatform.qemuArch}", archIntel, "machine1 is an intel VM")
+    archArm = vmArm.succeed("uname -m")
+    t.assertIn("${nodes.vmArm.nixpkgs.hostPlatform.qemuArch}", archArm, "machine1 is an ARM VM")
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8022,7 +8022,6 @@ with pkgs;
 
   qemu_test = lowPrio (
     qemu.override {
-      hostCpuOnly = true;
       nixosTestRunner = true;
     }
   );


### PR DESCRIPTION
In a NixOS integration test, it is already possible to mix VMs of different architectures in the same test by setting `node.pkgsReadOnly = false;` and then `hostPlatform = "some-architecture";`.

This is merely a thing of the right configuration.
However, `pkgs.qemu_test` also needs to be overridden, because it sets `hostCpuOnly` and also reduces the set of dependencies with other settings.

This PR removes the `hostOnlyCpu` flag, which makes the package size in bytes bigger *but* does *not* increase the list of dependencies, so we won't have unnecessarily many rebuilds when deps like systemd, gtk, etc. change.

I think this is a good balance between increasing the standard capabilities of the test driver for more use cases but at the same time not increasing the dependencies. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
