### PR TITLE
chainctl: init at 0.2.308

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -75,6 +75,12 @@
     githubId = 54892055;
     name = "David mp";
   };
+  _0hlov3 = {
+    email = "dev@schoenwald.aero";
+    github = "0hlov3";
+    githubId = 36544727;
+    name = "0hlov3";
+  };
   _0nyr = {
     email = "onyr.maintainer@gmail.com";
     github = "0nyr";

--- a/pkgs/by-name/ch/chainctl/package.nix
+++ b/pkgs/by-name/ch/chainctl/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+}:
+
+let
+  versionMetadata = import ./sources.nix;
+  source =
+    versionMetadata.sources.${stdenvNoCC.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
+in
+stdenvNoCC.mkDerivation {
+  pname = "chainctl";
+  version = versionMetadata.version;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchurl {
+    inherit (source) url hash;
+  };
+
+  dontUnpack = true;
+  dontFixup = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 $src $out/bin/chainctl
+    ln -s chainctl $out/bin/docker-credential-cgr
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = stdenvNoCC.buildPlatform.canExecute stdenvNoCC.hostPlatform;
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    $out/bin/chainctl version
+
+    runHook postInstallCheck
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "CLI for the Chainguard platform";
+    homepage = "https://edu.chainguard.dev/platform/chainctl/chainctl-docs/chainctl/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ _0hlov3 ];
+    mainProgram = "chainctl";
+    platforms = lib.attrNames versionMetadata.sources;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/by-name/ch/chainctl/sources.nix
+++ b/pkgs/by-name/ch/chainctl/sources.nix
@@ -1,0 +1,25 @@
+{
+  version = "0.2.308";
+
+  sources = {
+    aarch64-darwin = {
+      url = "https://dl.enforce.dev/chainctl/0.2.308/chainctl_darwin_arm64";
+      hash = "sha256-K21a1x9onBszjxt+8xqgfX+WkLAWIaHxKsIbxCzsGf0=";
+    };
+
+    x86_64-darwin = {
+      url = "https://dl.enforce.dev/chainctl/0.2.308/chainctl_darwin_x86_64";
+      hash = "sha256-UwAT2HmbAYahW3qXukO93bKFt2nB1Vb0cdXx0ysDnBQ=";
+    };
+
+    aarch64-linux = {
+      url = "https://dl.enforce.dev/chainctl/0.2.308/chainctl_linux_arm64";
+      hash = "sha256-9CLSq1yA25+lUx2dMZAiImASNwHKKBnV+ylE4846+U4=";
+    };
+
+    x86_64-linux = {
+      url = "https://dl.enforce.dev/chainctl/0.2.308/chainctl_linux_x86_64";
+      hash = "sha256-vsL3b8CED414jGSUOI2hUUfuuOpb4VuM9oOFcVez29E=";
+    };
+  };
+}

--- a/pkgs/by-name/ch/chainctl/update.sh
+++ b/pkgs/by-name/ch/chainctl/update.sh
@@ -1,0 +1,41 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p bash curl jq nix
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+sources_file="${script_dir}/sources.nix"
+
+version="$(curl -fsSL "https://dl.enforce.dev/chainctl/latest/metadata.json" | jq -er '.version')"
+
+systems=(
+  "aarch64-darwin:darwin_arm64"
+  "x86_64-darwin:darwin_x86_64"
+  "aarch64-linux:linux_arm64"
+  "x86_64-linux:linux_x86_64"
+)
+
+{
+  printf '{\n'
+  printf '  version = "%s";\n\n' "${version}"
+  printf '  sources = {\n'
+
+  for system_platform in "${systems[@]}"; do
+    system="${system_platform%%:*}"
+    platform="${system_platform#*:}"
+    url="https://dl.enforce.dev/chainctl/${version}/chainctl_${platform}"
+    hash="$(nix store prefetch-file --json "${url}" | jq -r .hash)"
+
+    printf '    %s = {\n' "${system}"
+    printf '      url = "%s";\n' "${url}"
+    printf '      hash = "%s";\n' "${hash}"
+    printf '    };\n'
+
+    if [ "${system}" != "x86_64-linux" ]; then
+      printf '\n'
+    fi
+  done
+
+  printf '  };\n'
+  printf '}\n'
+} > "${sources_file}"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds Chainguard's command-line interface (chainctl) for managing Chainguard resources, including container images and IAM.

[https://edu.chainguard.dev/platform/chainctl-usage/how-to-install-chainctl/](https://edu.chainguard.dev/platform/chainctl-usage/how-to-install-chainctl/)

The package uses Chainguard's official prebuilt binaries and supports Linux and macOS on x86_64 and aarch64. Platform-specific sources are fetched from explicit versioned URLs with pinned hashes.

docker-credential-cgr is provided as a symlink to chainctl, matching Chainguard's official packaging.

A custom update script updates the version and hashes for all supported platforms from Chainguard's release metadata.

The package is currently marked as unfree because I could not find a clear public license grant for chainctl.

This contribution was assisted by OpenAI Codex using GPT-5.5. I manually reviewed and validated the resulting changes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
