### PR TITLE
qemu: add optional BrlAPI support

### DIFF
--- a/pkgs/by-name/qe/qemu/package.nix
+++ b/pkgs/by-name/qe/qemu/package.nix
@@ -99,6 +99,8 @@
   capstone,
   valgrindSupport ? false,
   valgrind-light,
+  brlttySupport ? !minimal,
+  brltty,
   pluginsSupport ? !stdenv.hostPlatform.isStatic,
   enableDocs ? !minimal || toolsOnly,
   enableTools ? !minimal || toolsOnly,
@@ -259,6 +261,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals u2fEmuSupport [ libu2f-emu ]
   ++ lib.optionals capstoneSupport [ capstone ]
   ++ lib.optionals valgrindSupport [ valgrind-light ]
+  ++ lib.optionals brlttySupport [ brltty ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk_15 ];
 
   dontUseMesonConfigure = true; # meson's configurePhase isn't compatible with qemu build
@@ -344,6 +347,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional canokeySupport "--enable-canokey"
   ++ lib.optional u2fEmuSupport "--enable-u2f"
   ++ lib.optional capstoneSupport "--enable-capstone"
+  ++ lib.optional brlttySupport "--enable-brlapi"
   ++ lib.optional (!pluginsSupport) "--disable-plugins"
   ++ lib.optional (!enableBlobs) "--disable-install-blobs"
   ++ lib.optional userOnly "--disable-system"


### PR DESCRIPTION
## Description

Expose QEMU's BrlAPI support through the `brlttySupport` package argument and enable it by default.

This follows the existing packaging approach for most other QEMU features in nixpkgs while still allowing users to disable BrlAPI support if needed:

```nix
pkgs.qemu.override {
  brlttySupport = false;
}
```

When enabled, BRLTTY is added to QEMU's build inputs and QEMU is configured with `--enable-brlapi`.

## Testing

* Built the default QEMU package successfully.
* Confirmed that the `braille` character backend is available with `qemu-system-x86_64 -chardev help`.
* Tested the resulting build successfully on NixOS with BRLTTY and a real Braille display.
