### PR TITLE
python-codegen: init at 1.0

### DIFF
--- a/pkgs/development/python-modules/python-codegen/default.nix
+++ b/pkgs/development/python-modules/python-codegen/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "python-codegen";
+  version = "1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "andreif";
+    repo = "codegen";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-SCYXTQzDVgVIfskKGEHhW73uT0M8E0KDLVj/RQ5XKOc=";
+  };
+
+  build-system = [ setuptools ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail "License :: OSI Approved :: BSD" ""
+  '';
+
+  pythonImportsCheck = [ "codegen" ];
+
+  meta = {
+    description = "Extension to ast that allows ast -> python code generation";
+    homepage = "https://github.com/andreif/codegen";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ aiyion ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16367,6 +16367,8 @@ self: super: with self; {
 
   python-code-minimap = callPackage ../development/python-modules/python-code-minimap { };
 
+  python-codegen = callPackage ../development/python-modules/python-codegen { };
+
   python-codon-tables = callPackage ../development/python-modules/python-codon-tables { };
 
   python-coinmarketcap = callPackage ../development/python-modules/python-coinmarketcap { };


### PR DESCRIPTION
This provides `python-codegen` a code generator.
One of its most prominent users is openembedded/bitbake.

As I'm currently working on running the reference implementation on nixos, this is a byproduct easy enough to review on its own.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - ~Package update: when the change is major or breaking.~
- NixOS Release Notes
  - ~Module addition: when adding a new NixOS module.~
  - ~Module update: when the change is significant.~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
