### PR TITLE
i3-rounded: 4.20.1 -> 4.21.1

### DIFF
--- a/pkgs/by-name/i3/i3-rounded/package.nix
+++ b/pkgs/by-name/i3/i3-rounded/package.nix
@@ -2,21 +2,24 @@
   fetchFromGitHub,
   lib,
   i3,
-  pcre,
+  pcre2,
 }:
 
+let
+  version = "4.21.1";
+in
 i3.overrideAttrs (oldAttrs: {
   pname = "i3-rounded";
-  version = "4.21.1";
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "LinoBigatti";
     repo = "i3-rounded";
-    rev = "524c9f7b50f8c540b2ae3480b242c30d8775f98e";
-    hash = "sha256-lceeP+WZtBLNSDqcNn18MROLtBwj+nXufDs55IMO9Xg=";
+    rev = "v${version}";
+    hash = "sha256-KMpejS89Hg6Mrm94HTNA9mV/6Leu1yo2W1CsD6vGDRo=";
   };
 
-  buildInputs = oldAttrs.buildInputs ++ [ pcre ];
+  buildInputs = oldAttrs.buildInputs ++ [ pcre2 ];
 
   # Some tests are failing.
   doCheck = false;


### PR DESCRIPTION

## Things done

- Fix incorrect setup that still used old release
- migrated to pcre2 #356387

--

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
