### PR TITLE
nixos/systemd/tpm2: add systemd-pcrlogin@.service

### DIFF
--- a/nixos/modules/system/boot/systemd/tpm2.nix
+++ b/nixos/modules/system/boot/systemd/tpm2.nix
@@ -45,6 +45,7 @@
           "systemd-tpm2-setup.service"
           "systemd-pcrextend.socket"
           "systemd-pcrextend@.service"
+          "systemd-pcrlogin@.service"
         ];
       }
     )


### PR DESCRIPTION
systemd v261 added systemd-pcrlogin@.service, which logind starts on
first login of a user to measure the user record into the 'login'
NvPCR. NixOS does not install the unit, so every first login logs:

```
systemd-logind: Failed to start user measurement service
'systemd-pcrlogin@1000.service', ignoring: Unit not found.
```

Install the unit on systems with systemd.tpm2.enable. The unit has ConditionSecurity=measured-os and does nothing elsewhere.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
