### PR TITLE
nixos/systemd/fido2: add libpcsclite_real.so.1 to initrd

### DIFF
--- a/nixos/modules/system/boot/systemd/fido2.nix
+++ b/nixos/modules/system/boot/systemd/fido2.nix
@@ -27,6 +27,8 @@ in
       "${cfg.package}/lib/udev/fido_id"
       "${cfg.package}/lib/cryptsetup/libcryptsetup-token-systemd-fido2.so"
       "${pkgs.libfido2}/lib/libfido2.so.1"
+      # dlopened by the libpcsclite.so.1 shim, invisible to make-initrd-ng
+      "${lib.getLib pkgs.pcsclite}/lib/libpcsclite_real.so.1"
     ];
   };
 }


### PR DESCRIPTION
libfido2 links against pcsclite's libpcsclite.so.1, which since
pcsclite 2.3.1 is a shim that dlopens libpcsclite_real.so.1. nixpkgs
patches that dlopen to an absolute store path. make-initrd-ng only
follows DT_NEEDED, so the real library never ends up in the initrd.

systemd-cryptsetup then logs at boot:

```
loading ".../pcsclite-2.4.1-lib/lib/libpcsclite_real.so.1" failed:
cannot open shared object file: No such file or directory
```

and FIDO2 tokens behind PC/SC (NFC readers) cannot be used to unlock
LUKS in stage 1. Add the real library to the initrd store paths.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
