### PR TITLE
mako: route D-Bus activation through mako.service

### DIFF
--- a/pkgs/by-name/ma/mako/package.nix
+++ b/pkgs/by-name/ma/mako/package.nix
@@ -70,6 +70,12 @@ stdenv.mkDerivation (finalAttrs: {
     substitute $src/contrib/systemd/mako.service $out/lib/systemd/user/mako.service \
       --replace-fail '/usr/bin' "$out/bin"
     chmod 0644 $out/lib/systemd/user/mako.service
+
+    # Route D-Bus activation through the unit installed above, so it
+    # waits for graphical-session.target instead of exec'ing mako
+    # before the compositor is up.
+    echo "SystemdService=mako.service" \
+      >> $out/share/dbus-1/services/fr.emersion.mako.service
   '';
 
   meta = {


### PR DESCRIPTION
The D-Bus activation file shipped by mako has no SystemdService= line,
so dbus execs mako directly when a notification arrives before
the compositor is up. mako then dies with "failed to create display",
repeatedly, and the notification is lost.

nixpkgs installs the upstream contrib systemd unit, which has
Type=dbus, After=graphical-session.target and an ExecCondition on
WAYLAND_DISPLAY. Point the activation file at it so early
notifications wait for the session instead of failing.

Upstream mako cannot do this unconditionally because meson does not
install the contrib unit.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
