### PR TITLE
filius: 2.12.1 -> 2.13.0

### DIFF
--- a/pkgs/by-name/fi/filius/package.nix
+++ b/pkgs/by-name/fi/filius/package.nix
@@ -10,16 +10,16 @@
 
 maven.buildMavenPackage rec {
   pname = "filius";
-  version = "2.12.1";
+  version = "2.13.0";
 
   src = fetchFromGitLab {
     owner = "filius1";
     repo = "filius";
     tag = "v${version}";
-    hash = "sha256-sIcYjbWONg8Cq+dHpoBYj07cyHV7oX06Xh1zK0CHn64=";
+    hash = "sha256-u4X6jrlNzgm1vWyRFSzVjoQ3dtZUK9pAHSMxUHsSV84=";
   };
 
-  mvnHash = "sha256-41NirfgR9EhHLRT3V6P5KrakYKZ6dJTlXZu6rgCAK3I=";
+  mvnHash = "sha256-0xc/gnodgBo6gOkvz7Oe/5AQyjh2xMgyWEeEyktFqEA=";
   mvnParameters = "-Plinux";
 
   # tests want to create an X11 window which isn't often feasible
@@ -55,8 +55,10 @@ maven.buildMavenPackage rec {
   postInstall = ''
     install -Dm444 src/deb/application-filius-project.xml $out/share/mime/packages/application-filius-project.xml
 
-    install -Dm444 src/deb/filius32.png $out/share/icons/hicolor/80x56/mimetypes/filius.png
-    install -Dm444 src/deb/filius32.png $out/share/icons/hicolor/80x56/apps/filius.png
+    for size in {32,64,96}; do
+      install -Dm444 src/deb/icons/hicolor/"$size"x"$size"/apps/filius.png $out/share/icons/hicolor/"$size"x"$size"/apps/filius.png
+      install -Dm444 src/deb/icons/hicolor/"$size"x"$size"/apps/filius.png $out/share/icons/hicolor/"$size"x"$size"/mimetypes/filius.png
+    done
 
     mkdir -p $out/share/man/man1/
     cp src/deb/filius.1 $out/share/man/man1/


### PR DESCRIPTION
- updated version tag and hashes
- set it to copy the 2 new filius icons too

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
