### PR TITLE
chickenPackages.chickenEggs.mdh: mark as broken due to PCRE

### DIFF
--- a/pkgs/development/compilers/chicken/5/overrides.nix
+++ b/pkgs/development/compilers/chicken/5/overrides.nix
@@ -129,18 +129,8 @@ in
   leveldb = addToBuildInputs pkgs.leveldb;
   magic = addToBuildInputs pkgs.file;
   magic-pipes = addToBuildInputs pkgs.chickenPackages_5.chickenEggs.regex;
-  mdh =
-    old:
-    (addToBuildInputs pkgs.pcre old)
-    // {
-      postPatch = ''
-        substituteInPlace bmgsubs.c \
-          --replace-fail "char   *gotamatch();" "char *gotamatch(char *, int, int (*)(char *, int));" \
-          --replace-fail "int bmg_search(char *, int, int (*)());" "int bmg_search(char *, int, int (*)(char *, int));" \
-          --replace-fail "int	(*action)();" "int (*action)(char *, int);" \
-          --replace-fail "int (*action)();" "int (*action)(char *, int);"
-      '';
-    };
+  # requires PCRE
+  mdh = broken;
   # missing dependency in upstream egg
   mistie = addToPropagatedBuildInputs (with chickenEggs; [ srfi-1 ]);
   mosquitto = addToPropagatedBuildInputs [ pkgs.mosquitto ];


### PR DESCRIPTION
From #356387.  I had a look at porting this package to PCRE2, but it's not trivial.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
