### PR TITLE
nheko: add runtime support for kirigami

### DIFF
--- a/pkgs/by-name/nh/nheko/package.nix
+++ b/pkgs/by-name/nh/nheko/package.nix
@@ -21,6 +21,7 @@
   gst_all_1,
   libnice,
   qt6Packages,
+  kdePackages,
   fetchpatch,
   withVoipSupport ? stdenv.hostPlatform.isLinux,
 }:
@@ -89,6 +90,10 @@ stdenv.mkDerivation (finalAttrs: {
     (gst_all_1.gst-plugins-good.override { qt6Support = true; })
     gst_all_1.gst-plugins-bad
     libnice
+  ];
+
+  propagatedBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    kdePackages.kirigami
   ];
 
   cmakeFlags = [


### PR DESCRIPTION
Without this patch nheko displays a blank window on launch saying:
```
[2026-07-13 14:57:07.460] [qml] [warning] qrc:/resources/qml/Root.qml:14:1: Type Pane unavailable 
     Pane { 
     ^ (qrc:/resources/qml/Root.qml:14, )
[2026-07-13 14:57:07.460] [qml] [warning] qrc:/qt/qml/org/kde/desktop/Pane.qml:6:1: module "org.kde.kirigami" is not installed 
     import org.kde.kirigami as Kirigami 
     ^ (qrc:/qt/qml/org/kde/desktop/Pane.qml:6, )
```

Not sure how is this handled on darwin -- KDE framework packages are linux/bsd only.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
