### PR TITLE
gdal: only build tests that can work on current feature flags

### DIFF
--- a/pkgs/by-name/gd/gdal/package.nix
+++ b/pkgs/by-name/gd/gdal/package.nix
@@ -319,7 +319,24 @@ stdenv.mkDerivation (finalAttrs: {
     popd # autotest
   '';
 
-  passthru.tests = callPackage ./tests.nix { gdal = finalAttrs.finalPackage; };
+  passthru.tests = callPackage ./tests.nix {
+    gdal = finalAttrs.finalPackage;
+    inherit
+      useArmadillo
+      useArrow
+      useHDF
+      useJava
+      useLibAvif
+      useLibHEIF
+      useLibJXL
+      useMysql
+      useNetCDF
+      usePoppler
+      usePostgres
+      useTiledb
+      ;
+
+  };
 
   __darwinAllowLocalNetworking = true;
 

--- a/pkgs/by-name/gd/gdal/tests.nix
+++ b/pkgs/by-name/gd/gdal/tests.nix
@@ -4,6 +4,18 @@
   jdk,
   lib,
   testers,
+  useArmadillo,
+  useArrow,
+  useHDF,
+  useJava,
+  useLibAvif,
+  useLibHEIF,
+  useLibJXL,
+  useMysql,
+  useNetCDF,
+  usePoppler,
+  usePostgres,
+  useTiledb,
 }:
 
 let
@@ -54,16 +66,18 @@ in
     touch $out
   '';
 
-  java-bindings = runCommand "${pname}-java-bindings" { } ''
-    cat <<EOF > main.java
-    import org.gdal.gdal.gdal;
-    class Main {
-      public static void main(String[] args) {
-      gdal.AllRegister();
+  java-bindings = lib.optional useJava (
+    runCommand "${pname}-java-bindings" { } ''
+      cat <<EOF > main.java
+      import org.gdal.gdal.gdal;
+      class Main {
+        public static void main(String[] args) {
+        gdal.AllRegister();
+        }
       }
-    }
-    EOF
-    ${lib.getExe jdk} -Djava.library.path=${gdal}/lib/ -cp ${gdal}/share/java/gdal-${version}.jar main.java
-    touch $out
-  '';
+      EOF
+      ${lib.getExe jdk} -Djava.library.path=${gdal}/lib/ -cp ${gdal}/share/java/gdal-${version}.jar main.java
+      touch $out
+    ''
+  );
 }


### PR DESCRIPTION
While figuring out why FreeCAD has failing dependencies on master I've stumbled into this.

A new upstream test requires NetCDF, but that is an optional
dependency. They forgot the test marker.

While at it, I also passed the feature flags into the `tests.nix` so we can disable tests that aren't supposed to work (e.g. the java bindings) to avoid false negative signals.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
  - [x] [Package tests] at `passthru.tests`.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - via the tests in `test.nix`
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
