### PR TITLE
rustdesk-flutter: 1.4.5 -> 1.4.9

### DIFF
--- a/pkgs/by-name/ru/rustdesk-flutter/package.nix
+++ b/pkgs/by-name/ru/rustdesk-flutter/package.nix
@@ -66,14 +66,14 @@ let
 in
 flutter329.buildFlutterApplication rec {
   pname = "rustdesk";
-  version = "1.4.5";
+  version = "1.4.9";
 
   src = fetchFromGitHub {
     owner = "rustdesk";
     repo = "rustdesk";
     tag = version;
     fetchSubmodules = true;
-    hash = "sha256-FRtYafsIKHnGPV8NaiaHxIHkon8/T2P83uq9taUD1Xc=";
+    hash = "sha256-AnwdIO4TveC48uMioBCvH60xun24ckK420ONSEB9lQI=";
   };
 
   strictDeps = true;
@@ -82,7 +82,8 @@ flutter329.buildFlutterApplication rec {
 
   # Configure the Flutter/Dart build
   sourceRoot = "${src.name}/flutter";
-  # curl https://raw.githubusercontent.com/rustdesk/rustdesk/1.4.1/flutter/pubspec.lock | yq > pubspec.lock.json
+  # curl -sL https://raw.githubusercontent.com/rustdesk/rustdesk/1.4.9/flutter/pubspec.lock | yq > pubspec.lock.json
+  # Then add flutter_test, fake_async, leak_tracker*, vm_service SDK deps manually
   pubspecLock = lib.importJSON ./pubspec.lock.json;
   gitHashes = lib.importJSON ./git-hashes.json;
 
@@ -95,7 +96,7 @@ flutter329.buildFlutterApplication rec {
       src
       patches
       ;
-    hash = "sha256-mEtTo1ony5w/dzJcHieG9WywHirBoQ/C0WpiAr7pUVc=";
+    hash = "sha256-HPvvsTcjSErGfdNwsHgWhs930Fe0hmK1g5J/ngtlkKM=";
   };
 
   dontCargoBuild = true;

--- a/pkgs/by-name/ru/rustdesk-flutter/pubspec.lock.json
+++ b/pkgs/by-name/ru/rustdesk-flutter/pubspec.lock.json
@@ -10,6 +10,12 @@
       "source": "hosted",
       "version": "85.0.0"
     },
+    "_macros": {
+      "dependency": "transitive",
+      "description": "dart",
+      "source": "sdk",
+      "version": "0.3.3"
+    },
     "after_layout": {
       "dependency": "transitive",
       "description": {
@@ -513,6 +519,16 @@
       "source": "hosted",
       "version": "1.0.3"
     },
+    "fake_async": {
+      "dependency": "transitive",
+      "description": {
+        "name": "fake_async",
+        "sha256": "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.3.2"
+    },
     "ffi": {
       "dependency": "direct main",
       "description": {
@@ -796,6 +812,12 @@
       "source": "hosted",
       "version": "2.2.1"
     },
+    "flutter_test": {
+      "dependency": "direct dev",
+      "description": "flutter",
+      "source": "sdk",
+      "version": "0.0.0"
+    },
     "flutter_web_plugins": {
       "dependency": "transitive",
       "description": "flutter",
@@ -1052,6 +1074,36 @@
       "source": "hosted",
       "version": "4.9.0"
     },
+    "leak_tracker": {
+      "dependency": "transitive",
+      "description": {
+        "name": "leak_tracker",
+        "sha256": "c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "10.0.8"
+    },
+    "leak_tracker_flutter_testing": {
+      "dependency": "transitive",
+      "description": {
+        "name": "leak_tracker_flutter_testing",
+        "sha256": "f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.0.9"
+    },
+    "leak_tracker_testing": {
+      "dependency": "transitive",
+      "description": {
+        "name": "leak_tracker_testing",
+        "sha256": "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.0.1"
+    },
     "lints": {
       "dependency": "transitive",
       "description": {
@@ -1071,6 +1123,16 @@
       },
       "source": "hosted",
       "version": "1.3.0"
+    },
+    "macros": {
+      "dependency": "transitive",
+      "description": {
+        "name": "macros",
+        "sha256": "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.1.3-main.0"
     },
     "matcher": {
       "dependency": "transitive",
@@ -1899,6 +1961,16 @@
       },
       "source": "hosted",
       "version": "0.4.0+2"
+    },
+    "vm_service": {
+      "dependency": "transitive",
+      "description": {
+        "name": "vm_service",
+        "sha256": "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "14.3.1"
     },
     "wakelock_plus": {
       "dependency": "direct main",


### PR DESCRIPTION
Upstream `pubspec.lock` omits `flutter_test` and its transitive SDK dependencies (`fake_async`, `leak_tracker*`, `vm_service`, `_macros`, `macros`) because those are normally resolved by `flutter pub get` at build time. Since the Nix build invokes `build_runner` directly without `flutter pub get`, these entries are added explicitly to keep the
package graph resolvable.

Build-time consequence without them:

```bash
error: Cannot build '/nix/store/7sv8rsrdvh7j9xyprxnq8w8fmczddzhv-rustdesk-1.4.9.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/qw7bb4pxjkbznffgrn7sc6s2xnpw3v2p-rustdesk-1.4.9-debug
         /nix/store/y0xr073win02icwy9y4gbpx69w1f51x6-rustdesk-1.4.9-pubcache
         /nix/store/zpplhmnb37qax4dnsckd2zgb5nqh5lrx-rustdesk-1.4.9
       Last 25 log lines:
       > [WARNING]: No definition found for declaration - (Cursor) spelling: Display, kind: 2, kindSpelling: StructDecl, type: 105, typeSpelling: struct Display, usr: c:@S@Display
       > [WARNING]: No definition found for declaration - (Cursor) spelling: Display, kind: 2, kindSpelling: StructDecl, type: 105, typeSpelling: struct Display, usr: c:@S@Display
       > [WARNING]: No definition found for declaration - (Cursor) spelling: Display, kind: 2, kindSpelling: StructDecl, type: 105, typeSpelling: struct Display, usr: c:@S@Display
       > [WARNING]: No definition found for declaration - (Cursor) spelling: Display, kind: 2, kindSpelling: StructDecl, type: 105, typeSpelling: struct Display, usr: c:@S@Display
       > [WARNING]: No definition found for declaration - (Cursor) spelling: Display, kind: 2, kindSpelling: StructDecl, type: 105, typeSpelling: struct Display, usr: c:@S@Display
       > [WARNING]: No definition found for declaration - (Cursor) spelling: Display, kind: 2, kindSpelling: StructDecl, type: 105, typeSpelling: struct Display, usr: c:@S@Display
       > [WARNING]: Generated declaration '_Dart_Handle' start's with '_' and therefore will be private.
       > Finished, Bindings generated in /build/.tmpkUpnvb
       > the path is "/build/.tmpLeyD6q.h"
       > 2026/07/13 13:27:24 [INFO] Phase: Running build_runner
       > 2026/07/13 13:27:24 [INFO] Running build_runner at /build/source/flutter
       > Unhandled exception:
       > Bad state: Dependency flutter_test of flutter_hbb not present, please run `dart pub get` or `flutter pub get` to fetch dependencies.
       > #0      PackageGraph.forPath.packageNode (package:build_runner_core/src/package_graph/package_graph.dart:141:9)
       > #1      PackageGraph.forPath.<anonymous closure> (package:build_runner_core/src/package_graph/package_graph.dart:155:20)
       > #2      MappedListIterable.elementAt (dart:_internal/iterable.dart:442:31)
       > #3      ListIterator.moveNext (dart:_internal/iterable.dart:371:26)
       > #4      List.addAll (dart:core-patch/growable_array.dart:330:17)
       > #5      PackageGraph.forPath (package:build_runner_core/src/package_graph/package_graph.dart:151:27)
       > <asynchronous suspension>
       > #6      main (file:///nix/store/f3j76xg3a8ch7309x1gxnrsxpdbvbdh1-pub-build_runner-2.5.4/bin/build_runner.dart:27:5)
       > <asynchronous suspension>
       > 2026/07/13 13:27:37 [WARN] command=cd "/build/source/flutter" && "sh" "-c" "\"build_runner\" \"build\" \"--delete-conflicting-outputs\" \"--enable-experiment=class-modifiers\"" stdout= stderr=
       > 2026/07/13 13:27:37 [ERROR] Fatal error encountered. Rerun with RUST_BACKTRACE=1 or RUST_BACKTRACE=full for more details.
       > Error: Failed to run build_runner for /build/source/flutter:
       For full logs, run:
         nix log /nix/store/7sv8rsrdvh7j9xyprxnq8w8fmczddzhv-rustdesk-1.4.9.drv
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
