### PR TITLE
add end to end MBROLA support for eSpeak and voice tests

### DIFF
--- a/pkgs/by-name/es/espeak-ng/mbrola.patch
+++ b/pkgs/by-name/es/espeak-ng/mbrola.patch
@@ -7,7 +7,7 @@ index e3e4b702..de06dd21 100644
  
  		snprintf(charbuf, sizeof(charbuf), "%g", mbr_volume);
 -		execlp("mbrola", "mbrola", "-e", "-v", charbuf,
-+		execlp("@mbrola/bin/mbrola@", "mbrola", "-e", "-v", charbuf,
++		execlp("@mbrola@/bin/mbrola", "mbrola", "-e", "-v", charbuf,
  		       voice_path, "-", "-.wav", (char *)NULL);
  		/* if execution reaches this point then the exec() failed */
  		snprintf(mbr_errorbuf, sizeof(mbr_errorbuf),

--- a/pkgs/by-name/es/espeak-ng/mbrola.patch
+++ b/pkgs/by-name/es/espeak-ng/mbrola.patch
@@ -12,15 +12,24 @@ index e3e4b702..de06dd21 100644
  		/* if execution reaches this point then the exec() failed */
  		snprintf(mbr_errorbuf, sizeof(mbr_errorbuf),
 diff --git a/src/libespeak-ng/synth_mbrola.c b/src/libespeak-ng/synth_mbrola.c
-index 5f9b0458..26a05635 100644
+index 5f9b0458..f051e7b7 100644
 --- a/src/libespeak-ng/synth_mbrola.c
 +++ b/src/libespeak-ng/synth_mbrola.c
+@@ -80,7 +80,7 @@ espeak_ng_STATUS LoadMbrolaTable(const char *mbrola_voice, const char *phtrans,
+ 	int ix;
+ 	int *pw;
+ 	FILE *f_in;
+-	char path[sizeof(path_home)+15];
++	char path[4096];
+ 
+ 	mbrola_name[0] = 0;
+ 	mbrola_delay = 0;
 @@ -95,7 +95,7 @@ espeak_ng_STATUS LoadMbrolaTable(const char *mbrola_voice, const char *phtrans,
  	if (!load_MBR())
  		return ENS_MBROLA_NOT_FOUND;
  
 -	sprintf(path, "%s/mbrola/%s", path_home, mbrola_voice);
-+	sprintf(path, "%s/@mbrola@/%s", path_home, mbrola_voice);
++	sprintf(path, "@mbrola@/share/mbrola/%s/%s", mbrola_voice, mbrola_voice);
  #if PLATFORM_POSIX
  	// if not found, then also look in
  	//   $data_dir/mbrola/xx, $data_dir/mbrola/xx/xx, $data_dir/mbrola/voices/xx

--- a/pkgs/by-name/es/espeak-ng/package.nix
+++ b/pkgs/by-name/es/espeak-ng/package.nix
@@ -15,6 +15,7 @@
   pkg-config,
   ronn,
   which,
+  runCommandLocal,
 
   # dependencies
   alsa-plugins,
@@ -63,9 +64,12 @@ let
   };
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "espeak-ng";
   inherit version src;
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   patches = [
     # https://github.com/espeak-ng/espeak-ng/pull/2274
@@ -134,6 +138,80 @@ stdenv.mkDerivation rec {
 
   passthru = {
     inherit mbrolaSupport ucd-tools;
+
+    tests = {
+      voices = runCommandLocal "espeak-ng-voices-test" { } ''
+        set -u
+        fail=0
+
+        voices=$(
+          ${lib.getExe finalAttrs.finalPackage} --voices \
+            | tail -n +2 \
+            | awk '{print $5}'
+        )
+
+        mkdir -p "$out"
+        for voice in $voices; do
+          # Replace / with _ for safe filenames in $out
+          safe_name=$(echo "$voice" | tr '/' '_')
+          wav="$out/$safe_name.wav"
+          err="$out/$safe_name.err"
+
+          if ! ${lib.getExe finalAttrs.finalPackage} -v "$voice" "This is a test" -w "$wav" 2>"$err"; then
+            echo "FAIL (exit code): $voice" >&2
+            cat "$err" >&2
+            fail=1
+            continue
+          fi
+
+          size=$(stat -c%s "$wav" 2>/dev/null || echo 0)
+          if [ "$size" -le 44 ]; then
+            echo "FAIL (empty output): $voice" >&2
+            fail=1
+          else
+            echo "OK: $voice" >&2
+          fi
+        done
+
+        exit "$fail"
+      '';
+    }
+    // lib.optionalAttrs mbrolaSupport {
+      mbrolaVoices = runCommandLocal "espeak-ng-mbrola-voices-test" { } ''
+        set -u
+        fail=0
+
+        voices=$(
+          ${lib.getExe finalAttrs.finalPackage} --voices=mb \
+            | tail -n +2 \
+            | awk '{print $5}'
+        )
+
+        mkdir -p "$out"
+        for voice in $voices; do
+          safe_name=$(echo "$voice" | tr '/' '_')
+          wav="$out/$safe_name.wav"
+          err="$out/$safe_name.err"
+
+          if ! ${lib.getExe finalAttrs.finalPackage} -v "$voice" "This is a test" -w "$wav" 2>"$err"; then
+            echo "FAIL (exit code): $voice" >&2
+            cat "$err" >&2
+            fail=1
+            continue
+          fi
+
+          size=$(stat -c%s "$wav" 2>/dev/null || echo 0)
+          if [ "$size" -le 44 ]; then
+            echo "FAIL (empty output): $voice" >&2
+            fail=1
+          else
+            echo "OK: $voice" >&2
+          fi
+        done
+
+        exit "$fail"
+      '';
+    };
   };
 
   meta = {
@@ -145,4 +223,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.all;
     mainProgram = "espeak-ng";
   };
-}
+})

--- a/pkgs/by-name/mb/mbrola-voices/package.nix
+++ b/pkgs/by-name/mb/mbrola-voices/package.nix
@@ -24,27 +24,28 @@ let
   };
 in
 
-if (languages == [ ]) then
-  src
-else
-  stdenv.mkDerivation {
-    inherit src;
+stdenv.mkDerivation {
+  inherit src;
 
-    postPatch = ''
-      shopt -s extglob
-      pushd data
-      rm -rfv !(${lib.concatStringsSep "|" languages})
-      popd
-    '';
+  __structuredAttrs = true;
+  strictDeps = true;
 
-    installPhase = ''
-      runHook preInstall
+  postPatch = lib.optionalString (languages != [ ]) ''
+    shopt -s extglob
+    pushd data
+    rm -rfv !(${lib.concatStringsSep "|" languages})
+    popd
+  '';
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/mbrola
+    cp -R data/* $out/share/mbrola
+    runHook postInstall
+  '';
 
-      mkdir $out
-      cp -R data $out/
-
-      runHook postInstall
-    '';
-
-    inherit pname version meta;
-  }
+  inherit
+    pname
+    version
+    meta
+    ;
+}

--- a/pkgs/by-name/mb/mbrola/package.nix
+++ b/pkgs/by-name/mb/mbrola/package.nix
@@ -29,6 +29,9 @@ let
       hash = "sha256-ZjCl1gx/6sGtpXAYO4sAh6dutjwzClQ7kZoq0WaaBlU=";
     };
 
+    __structuredAttrs = true;
+    strictDeps = true;
+
     # required for cross compilation
     makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
@@ -54,7 +57,7 @@ runCommandLocal "${pname}-${version}"
     inherit pname version meta;
   }
   ''
-    mkdir -p "$out/share/mbrola"
-    ln -s '${mbrola-voices}/data' "$out/share/mbrola/voices"
+    mkdir -p "$out/share"
+    ln -s '${mbrola-voices}/share/mbrola' "$out/share/mbrola"
     ln -s '${bin}/bin' "$out/"
   ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

When I tested https://github.com/NixOS/nixpkgs/pull/511135 eSpeak could not find the MBROLA voices.
eSpeak check 3 places
 - $data_dir/mbrola/<voice>
 - $data_dir/mbrola/<voice>/<voice>
 - $data_dir/mbrola/voices/<voice>

However MBROLA placed its voices in
$data_dir/mbrola/voices/<voice>/<voice

I changed where mbrola-voices placed it voices to `share/mbrola/<voice>/voice>`.
I changed both MBROLA and eSpeak to use this new path.

To test if all of the voices worked I added a two tests.
One for eSpeak voices and one for MBROLA voices.

Because I now have a test I also added this to eSpeak, MBROLA, and mbrola-voices.
```
  __structuredAttrs = true;
  strictDeps = true;
```

I have a version of MBROLA were all of the voices has been made into a package set.
```nix
mbrola.withVoices(v: with: v; [
  us1
])
```


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
