### PR TITLE
python3Packages.triton.gpuCheck: fix failing tests

### DIFF
--- a/pkgs/development/python-modules/triton/default.nix
+++ b/pkgs/development/python-modules/triton/default.nix
@@ -226,6 +226,7 @@ buildPythonPackage.override { stdenv = effectiveStdenv; } (finalAttrs: {
 
       nativeBuildInputs = [
         (python.withPackages (ps: [
+          ps.expecttest
           ps.scipy
           ps.torchWithCuda
           ps.triton-cuda
@@ -259,6 +260,10 @@ buildPythonPackage.override { stdenv = effectiveStdenv; } (finalAttrs: {
         # However, this is not the case here, as triton is built with TRITON_OFFLINE_BUILD=1
         # and TRITON_PTXAS_PATH=<path_to_nix_store_ptxas>
         "test_nvidia_tool"
+
+        # Assertion `ctaLayout.getNumOutDims() == rank' failed in
+        # TritonGPUAccelerateMatmul on Blackwell (compute capability 12.0).
+        "test_batched_mxfp"
       ]
       ++ lib.optionals (pythonAtLeast "3.14") [
         # triton.compiler.errors.CompilationError
@@ -276,6 +281,11 @@ buildPythonPackage.override { stdenv = effectiveStdenv; } (finalAttrs: {
         "test_temp_var_in_loop"
         "test_tensor_descriptor_rank_reducing_matmul"
         "test_tensor_descriptor_reshape_matmul"
+
+        # Python 3.14 adds an internal __annotate__ function which Triton 3.7
+        # incorrectly includes in the aggregate dependency hash.
+        "test_bound_unused_result"
+        "test_aggregate_with_tuple"
       ];
 
       disabledTestPaths = [


### PR DESCRIPTION
## Things done

Tested on 5090D.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
