### PR TITLE
autobean-format: init at 0.1.8

### DIFF
--- a/pkgs/by-name/au/autobean-format/package.nix
+++ b/pkgs/by-name/au/autobean-format/package.nix
@@ -1,0 +1,1 @@
+{ python3Packages }: python3Packages.toPythonApplication python3Packages.autobean-format

--- a/pkgs/development/python-modules/autobean-format/default.nix
+++ b/pkgs/development/python-modules/autobean-format/default.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchpatch,
+  autobean-refactor,
+  nix-update-script,
+  pdm-backend,
+  pytest-cov-stub,
+  pytestCheckHook,
+  typing-extensions,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "autobean-format";
+  version = "0.1.8";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "SEIAROTg";
+    repo = "autobean-format";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-NeuGCUS/7ZS5GnvtAwlbAWU7PY7FBNwwA6uoANMXnlg=";
+  };
+
+  patches = [
+    # Fix for https://github.com/SEIAROTg/autobean-format/issues/15 not yet released
+    (fetchpatch {
+      name = "support-multi-semi-colon-in-block-comments.patch";
+      url = "https://github.com/SEIAROTg/autobean-format/commit/545fbb8ba4b29622f0716919b8798f435bbf414c.patch";
+      hash = "sha256-Qdud7CH/FQ1pVAXmgXcRWsrPmg3w1fT2q+1Td12aIuU=";
+    })
+    # Fix for https://github.com/SEIAROTg/autobean-format/issues/16 not yet released
+    (fetchpatch {
+      name = "accept-ignored-lines-as-compartment-separator.patch";
+      url = "https://github.com/SEIAROTg/autobean-format/commit/e73c0159b4d0cdc8ea219565c7da2f5fbe97ead6.patch";
+      hash = "sha256-sYaCUQPR1Own31oY/aFTb7v4lEsgEi/zb4Wg18cBCmA=";
+    })
+  ];
+
+  build-system = [
+    pdm-backend
+  ];
+
+  dependencies = [
+    autobean-refactor
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [
+    pytest-cov-stub
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "autobean_format" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://github.com/SEIAROTg/autobean-format";
+    description = "Yet another formatter for beancount";
+    mainProgram = "autobean-format";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ambroisie ];
+  };
+})

--- a/pkgs/development/python-modules/autobean-refactor/default.nix
+++ b/pkgs/development/python-modules/autobean-refactor/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchpatch,
+  lark,
+  mako,
+  nix-update-script,
+  pdm-backend,
+  pytest-benchmark,
+  pytest-cov-stub,
+  pytestCheckHook,
+  stringcase,
+  typing-extensions,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "autobean-refactor";
+  version = "0.3.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "SEIAROTg";
+    repo = "autobean-refactor";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-VNqyr46yqOs5ynEfpD/FJKRljEpb9emqyNlL+w8jGmo=";
+  };
+
+  build-system = [
+    pdm-backend
+  ];
+
+  dependencies = [
+    lark
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [
+    mako
+    pytest-benchmark
+    pytest-cov-stub
+    pytestCheckHook
+    stringcase
+  ];
+
+  pythonImportsCheck = [ "autobean_refactor" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://autobean-refactor.readthedocs.io";
+    description = "Ergonomic and losess beancount manipulation library";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ambroisie ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1603,6 +1603,8 @@ self: super: with self; {
 
   autobean = callPackage ../development/python-modules/autobean { };
 
+  autobean-format = callPackage ../development/python-modules/autobean-format { };
+
   autobean-refactor = callPackage ../development/python-modules/autobean-refactor { };
 
   autocommand = callPackage ../development/python-modules/autocommand { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1603,6 +1603,8 @@ self: super: with self; {
 
   autobean = callPackage ../development/python-modules/autobean { };
 
+  autobean-refactor = callPackage ../development/python-modules/autobean-refactor { };
+
   autocommand = callPackage ../development/python-modules/autocommand { };
 
   autodocsumm = callPackage ../development/python-modules/autodocsumm { };


### PR DESCRIPTION
Based on #540917 and #540918, as they would otherwise immediately conflict once merged.

Please only review the two top commits.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
