### PR TITLE
singular: fix omalloc on aarch64-darwin

### DIFF
--- a/pkgs/by-name/si/singular/package.nix
+++ b/pkgs/by-name/si/singular/package.nix
@@ -55,11 +55,6 @@ stdenv.mkDerivation rec {
     "--with-ntl=${ntl}"
     "--with-flint=${flint}"
   ]
-  ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
-    # omalloc does not support pagesizes >= 16K
-    # https://github.com/Singular/Singular/blob/spielwiese/omalloc/configure.ac
-    "--disable-omalloc"
-  ]
   ++ lib.optionals enableDocs [
     "--enable-doc-build"
   ];
@@ -76,8 +71,8 @@ stdenv.mkDerivation rec {
     patchShebangs .
   '';
 
-  # Use fq_nmod_mat_entry instead of row pointer (removed in flint 3.3.0)
   patches = [
+    # Use fq_nmod_mat_entry instead of row pointer (removed in flint 3.3.0)
     (fetchpatch {
       url = "https://github.com/Singular/Singular/commit/05f5116e13c8a4f5f820c78c35944dd6d197d442.patch";
       hash = "sha256-4l7JaCCFzE+xINU+E92eBN5CJKIdtQHly4Ed3ZwbKTA=";
@@ -85,6 +80,15 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       url = "https://github.com/Singular/Singular/commit/595d7167e6e019d45d9a4f1e18ae741df1f3c41d.patch";
       hash = "sha256-hpTZy/eAiHAaleasWPAenxM35aqeNAZ//o6OqqdGOJ4=";
+    })
+    # Fix omalloc on aarch64-darwin
+    (fetchpatch {
+      url = "https://github.com/Singular/Singular/commit/6a47eae152527e3147e3168989301b676576e9eb.patch";
+      hash = "sha256-JW72CoDg0Pkmcg+uklkyV94F9qaT3cnHUhUG/6bStKY=";
+    })
+    (fetchpatch {
+      url = "https://github.com/Singular/Singular/commit/935a043cac58180942ab753efbd576ba59eaab8e.patch";
+      hash = "sha256-T9ml6SnXCKImnQDnBU4zrpYGRi2wlTYvjmln0r1AvPM=";
     })
   ];
 


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/541155 aims to propose additional patches for disabling omalloc on aarch64-darwin. But why not just fix omalloc as is done upstream?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
