### PR TITLE
cpplint: fix build on Python 3.14

### DIFF
--- a/pkgs/by-name/cp/cpplint/package.nix
+++ b/pkgs/by-name/cp/cpplint/package.nix
@@ -2,6 +2,7 @@
   lib,
   python3Packages,
   fetchFromGitHub,
+  fetchpatch2,
   versionCheckHook,
 }:
 
@@ -16,6 +17,20 @@ python3Packages.buildPythonApplication (finalAttrs: {
     tag = finalAttrs.version;
     hash = "sha256-4crTuqynQt8Nyjqea6DpREtLy7ydRF0hNVnc7tUnO1k=";
   };
+
+  # Fix Python 3.14 test failures. Remove with the next release.
+  patches = [
+    (fetchpatch2 {
+      name = "drop-codecs-open.patch";
+      url = "https://github.com/cpplint/cpplint/commit/89bff410afed72e58d23ae084de4103986ea8630.patch?full_index=1";
+      hash = "sha256-Jdeewj3GM7GMoRF7+Qz/9n1hc8PYPcXLgtSGwSUpT1E=";
+    })
+    (fetchpatch2 {
+      name = "use-universal-newlines.patch";
+      url = "https://github.com/cpplint/cpplint/commit/d15a8715a6e848f784fda700758c4ac2d252fd31.patch?full_index=1";
+      hash = "sha256-Oo2doknEGnuxDJA0y17n1DCaKwadtMW/14a5wnIgfkw=";
+    })
+  ];
 
   # We use pytest-cov-stub instead
   postPatch = ''


### PR DESCRIPTION
Backports [cpplint#405](https://github.com/cpplint/cpplint/pull/405) to replace deprecated `codecs.open()` calls. Python 3.14 emits warnings for these calls, which caused cpplint's upstream tests to fail.

Closes #541361

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
