### PR TITLE
nixos/step-ca: add extraArgs option for additional step-ca CLI flags

### DIFF
--- a/nixos/modules/services/security/step-ca.nix
+++ b/nixos/modules/services/security/step-ca.nix
@@ -54,6 +54,15 @@ in
           :::
         '';
       };
+      extraArgs = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        example = [
+          "--resolver=10.1.2.3:53"
+          "--quiet"
+        ];
+        description = "Ad-hoc command-line arguments passed to the service at startup.";
+      };
       intermediatePasswordFile = lib.mkOption {
         type = lib.types.nullOr lib.types.externalPath;
         default = null;
@@ -114,6 +123,7 @@ in
               + lib.optionalString (
                 cfg.intermediatePasswordFile != null
               ) " --password-file \${CREDENTIALS_DIRECTORY}/intermediate_password"
+              + lib.optionalString (cfg.extraArgs != [ ]) " ${lib.escapeShellArgs cfg.extraArgs}"
             )
           ];
 


### PR DESCRIPTION
The step-ca NixOS module currently exposes a `settings` option for configuring `ca.json`, but it does not provide a way to pass additional command-line arguments to the step-ca process. Some runtime options, such as `--resolver`, are only available as CLI flags and therefore cannot be configured through the existing module.

This change adds a new `extraArgs` option that allows arbitrary command-line arguments to be passed to step-ca. Rather than exposing individual NixOS options for each CLI flag, `extraArgs` provides a generic mechanism that remains compatible as new step-ca releases introduce additional runtime options, reducing ongoing maintenance while increasing flexibility.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
