### PR TITLE
nixos/phosh: migrate to services.desktopManager namespace

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -138,6 +138,8 @@
   This makes fully declarative deployments safer: Otherwise the user needed to either accept Plausible's unauthenticated "first launch" setup wizard, which lets anyone reaching the instance create the first admin account, or do more work (deploying with NixOS's default binding to `localhost` without exposing it publicly, going through the wizard, and then deploying Plausible exposed to the Internet).
   This option was previously removed with NixOS 25.05 due to an upstream Plausible change making declarative admin creation more difficult, but this change re-implements the admin creation directly.
 
+- `services.xserver.desktopManager.phosh` has been renamed to [`services.desktopManager.phosh`](#opt-services.desktopManager.phosh.enable). The old option path continues to work via a compatibility alias.
+
 - The `newuidmap` and `newgidmap` security wrappers are now installed with `cap_setuid`/`cap_setgid` file capabilities instead of the setuid-root bit, matching shadow's `--with-fcaps` install mode and other major distributions. Rootless containers (podman, docker-rootless, unprivileged user namespaces) are unaffected. The only behavioural change is that mapping host uid 0 via `/etc/subuid` (which NixOS never configures by default) additionally requires `cap_setfcap`; users who explicitly grant uid 0 in a subuid range can restore the previous behaviour with `security.wrappers.newuidmap.capabilities = lib.mkForce "cap_setuid,cap_setfcap+ep";`.
 
 - `zoneminder` has been updated to 1.38.x release. See [upstream release note](https://github.com/ZoneMinder/zoneminder/releases/tag/1.38.0). While database migration should happen automatically, it's recommended that you make a backup of the database before upgrading your system.

--- a/nixos/modules/services/desktop-managers/phosh.nix
+++ b/nixos/modules/services/desktop-managers/phosh.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  cfg = config.services.xserver.desktopManager.phosh;
+  cfg = config.services.desktopManager.phosh;
 
   phocConfigType = lib.types.submodule {
     options = {
@@ -131,8 +131,15 @@ in
     maintainers = with lib.maintainers; [ armelclo ];
   };
 
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "services" "xserver" "desktopManager" "phosh" ]
+      [ "services" "desktopManager" "phosh" ]
+    )
+  ];
+
   options = {
-    services.xserver.desktopManager.phosh = {
+    services.desktopManager.phosh = {
       enable = lib.mkOption {
         type = lib.types.bool;
         default = false;

--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -24,7 +24,7 @@ in
   imports = [
     ./none.nix
     ./xterm.nix
-    ./phosh.nix
+    ../../desktop-managers/phosh.nix
     ./xfce.nix
     ../../desktop-managers/plasma6.nix
     ./lumina.nix

--- a/nixos/tests/phosh.nix
+++ b/nixos/tests/phosh.nix
@@ -17,7 +17,7 @@ in
           password = pin;
         };
 
-        services.xserver.desktopManager.phosh = {
+        services.desktopManager.phosh = {
           enable = true;
           user = "nixos";
           group = "users";


### PR DESCRIPTION
Move the phosh module out of services.xserver, completing the desktop-manager namespace migration already done for gnome, cosmic, plasma6, pantheon, budgie, and lomiri.

The old option path `services.xserver.desktopManager.phosh` keeps working via a mkRenamedOptionModule compatibility alias with a deprecation warning.

Enabling phosh no longer implies `services.xserver.enable`, so the `lightdm.enable = mkDefault true` default in `xserver.nix` no longer fires on phosh hosts -- removing a silent conflict where LightDM and phosh's self-managed tty1 session fought over the seat.

Assisted-by: Claude-Code:GLM-5.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
