### PR TITLE
python3Packages.dogpile-cache: update disabled tests for darwin

### DIFF
--- a/pkgs/development/python-modules/dogpile-cache/default.nix
+++ b/pkgs/development/python-modules/dogpile-cache/default.nix
@@ -7,9 +7,7 @@
   pytestCheckHook,
   mako,
   decorator,
-  stdenv,
   stevedore,
-  typing-extensions,
 }:
 
 buildPythonPackage rec {
@@ -28,7 +26,6 @@ buildPythonPackage rec {
   dependencies = [
     decorator
     stevedore
-    typing-extensions
   ];
 
   nativeCheckInputs = [
@@ -37,24 +34,11 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  disabledTestPaths = lib.optionals stdenv.hostPlatform.isLinux [
+  disabledTestPaths = [
     # flaky
     "tests/cache/test_dbm_backend.py"
-  ];
-
-  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
-    # AssertionError: <dogpile.cache.api.NoValue object> != 'some value 1'
-    "test_expire_override"
-    # flaky
-    "test_get_value_plus_created_long_create"
-    "test_get_value_plus_created_registry_safe_cache_quick"
-    "test_get_value_plus_created_registry_safe_cache_slow"
-    "test_get_value_plus_created_registry_unsafe_cache"
-    "test_quick"
-    "test_region_set_get_value"
-    "test_region_set_multiple_values"
-    "test_return_while_in_progress"
-    "test_slow"
+    # timing sensitive
+    "tests/test_lock.py::ConcurrencyTest"
   ];
 
   meta = {


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
