### PR TITLE
docker-sbx: fix the update script, 0.34.0 -> 0.37.0

### DIFF
--- a/pkgs/by-name/do/docker-sbx/package.nix
+++ b/pkgs/by-name/do/docker-sbx/package.nix
@@ -15,9 +15,9 @@
 }:
 let
   hashes = {
-    "x86_64-linux" = "sha256-5H9LOyKi0/SBVJ0ld6OkcP1h9r9eHrAb4fsVVVdMusg=";
-    "aarch64-linux" = "sha256-dZ/ttnmaf62rA5Cs8YSmZGHVQoy9PQh3Ok/AnIjCqZ4=";
-    "aarch64-darwin" = "sha256-aBh6NbtQ5o2zxuR+d1U1gZpm2bch/J3Y8GZ73DeUBUk=";
+    "x86_64-linux" = "sha256-dwq/f5GxOrqGzHu31Ui44HyBLVoQkyGQXnt9oK0H2Zg=";
+    "aarch64-linux" = "sha256-tV65eOO1Zh3cpnGC+1wz086s/7wlnEw8YUGlRcmyvOw=";
+    "aarch64-darwin" = "sha256-uEb+wFj0z3pDQzQ5EyBsZbDDkWrd6iT82xmj2QyKuI8=";
   };
   platformName = {
     "x86_64-linux" = "linux-amd64";
@@ -27,7 +27,7 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "docker-sbx";
-  version = "0.34.0";
+  version = "0.37.0";
   src =
     let
       throwPlat = throw "Unsupported platform ${stdenvNoCC.hostPlatform.system}";

--- a/pkgs/by-name/do/docker-sbx/package.nix
+++ b/pkgs/by-name/do/docker-sbx/package.nix
@@ -12,29 +12,31 @@
   zlib,
   zstd,
   versionCheckHook,
-  nix-update-script,
 }:
+let
+  hashes = {
+    "x86_64-linux" = "sha256-5H9LOyKi0/SBVJ0ld6OkcP1h9r9eHrAb4fsVVVdMusg=";
+    "aarch64-linux" = "sha256-dZ/ttnmaf62rA5Cs8YSmZGHVQoy9PQh3Ok/AnIjCqZ4=";
+    "aarch64-darwin" = "sha256-aBh6NbtQ5o2zxuR+d1U1gZpm2bch/J3Y8GZ73DeUBUk=";
+  };
+  platformName = {
+    "x86_64-linux" = "linux-amd64";
+    "aarch64-linux" = "linux-arm64";
+    "aarch64-darwin" = "darwin";
+  };
+in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "docker-sbx";
   version = "0.34.0";
   src =
-    if stdenvNoCC.hostPlatform.system == "x86_64-linux" then
-      fetchurl {
-        url = "https://github.com/docker/sbx-releases/releases/download/v${finalAttrs.version}/DockerSandboxes-linux-amd64.tar.gz";
-        hash = "sha256-5H9LOyKi0/SBVJ0ld6OkcP1h9r9eHrAb4fsVVVdMusg=";
-      }
-    else if stdenvNoCC.hostPlatform.system == "aarch64-linux" then
-      fetchurl {
-        url = "https://github.com/docker/sbx-releases/releases/download/v${finalAttrs.version}/DockerSandboxes-linux-arm64.tar.gz";
-        hash = "sha256-dZ/ttnmaf62rA5Cs8YSmZGHVQoy9PQh3Ok/AnIjCqZ4=";
-      }
-    else if stdenvNoCC.hostPlatform.system == "aarch64-darwin" then
-      fetchurl {
-        url = "https://github.com/docker/sbx-releases/releases/download/v${finalAttrs.version}/DockerSandboxes-darwin.tar.gz";
-        hash = "sha256-aBh6NbtQ5o2zxuR+d1U1gZpm2bch/J3Y8GZ73DeUBUk=";
-      }
-    else
-      throw "Unsupported host platform ${stdenvNoCC.hostPlatform.system}";
+    let
+      throwPlat = throw "Unsupported platform ${stdenvNoCC.hostPlatform.system}";
+      p = platformName.${stdenvNoCC.hostPlatform.system} or throwPlat;
+    in
+    fetchurl {
+      url = "https://github.com/docker/sbx-releases/releases/download/v${finalAttrs.version}/DockerSandboxes-${p}.tar.gz";
+      hash = hashes.${stdenvNoCC.hostPlatform.system} or throwPlat;
+    };
 
   strictDeps = true;
   __structuredAttrs = true;
@@ -102,7 +104,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
         runHook postInstall
       '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = ./update.sh;
 
   meta = {
     description = "Safe environments for agents";
@@ -114,11 +116,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://docs.docker.com/reference/cli/sbx/";
     changelog = "https://github.com/docker/sbx-releases/releases/tag/v${finalAttrs.version}";
     mainProgram = "sbx";
-    platforms = [
-      "x86_64-linux"
-      "aarch64-linux"
-      "aarch64-darwin"
-    ];
+    platforms = builtins.attrNames hashes;
     license = lib.licenses.unfree;
     maintainers = [
       lib.maintainers.skyesoss

--- a/pkgs/by-name/do/docker-sbx/update.sh
+++ b/pkgs/by-name/do/docker-sbx/update.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bash gh gnugrep gnused
+# shellcheck shell=bash
+
+set -euo pipefail
+
+dir="$(CDPATH="" cd "$(dirname "$0")" && pwd)"
+pkg="$dir/package.nix"
+if ! [ -e "$pkg" ]; then
+  echo "Unable to find package.nix"
+  exit 1
+fi
+
+old_vsn="$(grep --only-matching --perl-regexp 'version = "\K[^"]+' "$pkg")"
+
+new_vsn="$(gh api repos/docker/sbx-releases/releases/latest --jq .tag_name | \
+  grep --only-matching --perl-regexp '\d+\.\d+\.\d+')"
+
+if [ "$old_vsn" = "$new_vsn" ]; then
+  echo "No new version available, skipping"
+  exit 0
+fi
+
+echo "docker-sbx: $old_vsn -> $new_vsn"
+
+fetch_arch () {
+  local vsn="$1" plat="$2" url hash
+  url="https://github.com/docker/sbx-releases/releases/download/v${vsn}/DockerSandboxes-${plat}.tar.gz"
+  hash="$(nix-prefetch-url --type sha256 "$url")";
+  nix-hash --to-sri --type sha256 "$hash"
+}
+
+declare -A hashes
+declare -A platNames=(
+  ["linux-amd64"]="x86_64-linux"
+  ["linux-arm64"]="aarch64-linux"
+  ["darwin"]="aarch64-darwin"
+)
+declare -a platforms=(
+  "linux-amd64"
+  "linux-arm64"
+  "darwin"
+)
+
+for plat in "${platforms[@]}"; do
+  hashes[$plat]="$(fetch_arch "$new_vsn" "$plat")"
+done
+
+declare -a sedArgs=(
+  -e 's:version = "'"$old_vsn"'":version = "'"$new_vsn"'":'
+)
+
+for plat in "${platforms[@]}"; do
+  p="${platNames[$plat]}"
+  sedArgs+=(
+    -e '0,/"'"$p"'" = / s:"'"$p"'" = .*;:"'"$p"'" = "'"${hashes[$plat]}"'";:'
+  )
+done
+sed -i "${sedArgs[@]}" "$pkg"


### PR DESCRIPTION
This PR includes the addition of a custom update script, since `nix-update-script` only updates the hashes seen during the evaluation of `x86_64-linux`.

~~I also wrote the update script in a custom manner, so that the non-existance of a given release binary will simply mark the hash as `null`. This is because the aarch64-linux build for 0.35.0 was pulled due to stability issues; the update script will then make the platform available once a release is created with an aarch64-linux build.~~

Replaces #540712

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
