### PR TITLE
nixos/pam: remove explicit hardcoded yescrypt

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -1422,7 +1422,6 @@ let
                 modulePath = config.security.pam.pam_unixModulePath;
                 settings = {
                   nullok = true;
-                  yescrypt = lib.mkIf config.security.pam.enableLegacySettings true;
                 };
               }
               {

--- a/nixos/modules/services/display-managers/gdm.nix
+++ b/nixos/modules/services/display-managers/gdm.nix
@@ -577,7 +577,6 @@ in
               control = "requisite";
               modulePath = "${config.security.pam.package}/lib/security/pam_unix.so";
               settings.nullok = true;
-              settings.yescrypt = true;
             }
           ];
 

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -456,7 +456,6 @@ in
             control = "requisite";
             modulePath = "${config.security.pam.package}/lib/security/pam_unix.so";
             settings.nullok = true;
-            settings.yescrypt = true;
           }
         ];
 

--- a/nixos/tests/login-nosuid.nix
+++ b/nixos/tests/login-nosuid.nix
@@ -49,6 +49,7 @@
     with subtest("create user"):
         machine.succeed("useradd -m alice")
         machine.succeed("(echo foobar; echo foobar) | passwd alice")
+        machine.succeed("grep -F 'alice:$y$' /etc/shadow")
 
     with subtest("Check whether switching VTs works"):
         machine.fail("pgrep -f 'agetty.*tty2'")

--- a/nixos/tests/login.nix
+++ b/nixos/tests/login.nix
@@ -28,6 +28,7 @@
     with subtest("create user"):
         machine.succeed("useradd -m alice")
         machine.succeed("(echo foobar; echo foobar) | passwd alice")
+        machine.succeed("grep -F 'alice:$y$' /etc/shadow")
 
     with subtest("Check whether switching VTs works"):
         machine.fail("pgrep -f 'agetty.*tty2'")


### PR DESCRIPTION
Both `pam_unix.so` and `pam_unix_ng.so` look at `ENCRYPT_METHOD` in `/etc/login.defs` to determine the algorithm to use for password encryption: https://github.com/thkukuk/account-utils/blob/66fbd0382be49d99cb70410a4696c796684ffbf8/src/pam_unix_ng-common.c#L27-L62 If this is not set, both already default to `YESCRYPT`. The shadow module makes this configurable via
`security.loginDefs.settings.ENCRYPT_METHOD`, which also defaults to `YESCRYPT`. Seeing as what was previously hardcoded is default anyways, with a global configuration option to change it, there is no point to keep this.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. 
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
