### PR TITLE
Add predefined modules and configs for Speechd module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -73,6 +73,19 @@
 
 - Support for the legacy U‐Boot image format has been removed from the initrd generators, as it is deprecated upstream and no longer used by any platform in Nixpkgs.
 
+- The `services.speechd` module has been rewritten.
+  Output modules (eSpeak NG, Flite, Pico, Festival, MaryTTS, etc.) are now configured through typed, predefined options under `services.speechd.modules.<name>` instead of raw configuration strings.
+  General Speechd settings (e.g. `logLevel`, `logDir`, `defaultVolume`, `symbolsPreproc`, `audioOutputMethod`, `defaultModule`) are now configured through typed options directly under `services.speechd.<name>` instead of a raw `config` string.
+
+
+  The following options have been renamed:
+
+  - `services.speechd.modules` (freeform strings) → `services.speechd.extraModules`
+  - `services.speechd.config` → `services.speechd.extraConfig`
+  - `services.speechd.clients` → `services.speechd.extraClients`
+
+  Backward compatibility is preserved for now: string values assigned to `services.speechd.modules.<name>` are automatically moved to `services.speechd.extraModules.<name>` with a warning. This compatibility shim will be removed in 27.05.
+
 - Rustical migrates from `settings.http.host` and `settings.http.port` to `settings.http.bind` to support UNIX domain sockets as well as TCP sockets in one setting.
 
 - A number of options for `services.llama-cpp` have been removed in favor of the structured [](#opt-services.llama-cpp.settings) option, attributes from which are used as arguments to `llama-server` executable, you can see all available options by running `llama-server --help`. Configuring model presets using Nix attribute set via `services.llama-cpp.modelsPreset` is no longer supported, please use `services.llama-cpp.settings.models-preset` with a path to an INI file containing desired options.

--- a/nixos/modules/services/accessibility/speechd-modules/baratinoo.nix
+++ b/nixos/modules/services/accessibility/speechd-modules/baratinoo.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  pkgs,
+  mkEnableOption,
+  mkOption,
+  mkExtraConfigOption,
+  ...
+}:
+{
+  type = lib.types.submodule {
+    options = {
+      enable = mkEnableOption "Baratinoo text to speech output module";
+      debug = mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Enable debug output.
+        '';
+        example = true;
+      };
+
+      extraConfig = mkExtraConfigOption { };
+    };
+  };
+
+  # TODO Delete if Baratinoo gets packaged in Nixpkgs
+  visible = false;
+  displayName = "Baratinoo";
+  binary = "sd_baratinoo";
+  confFile = "baratinoo.conf";
+
+}

--- a/nixos/modules/services/accessibility/speechd-modules/cicero.nix
+++ b/nixos/modules/services/accessibility/speechd-modules/cicero.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  pkgs,
+  mkEnableOption,
+  mkOption,
+  mkExtraConfigOption,
+  ...
+}:
+{
+  type = lib.types.submodule {
+    options = {
+      enable = mkEnableOption "Cicero text to speech output module";
+      debug = mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Enable debug output.
+        '';
+        example = true;
+      };
+
+      extraConfig = mkExtraConfigOption { };
+    };
+  };
+
+  # TODO Delete if Cicero gets packaged in Nixpkgs
+  visible = false;
+  displayName = "Cicero";
+  binary = "sd_cicero";
+  confFile = "cicero.conf";
+}

--- a/nixos/modules/services/accessibility/speechd-modules/dtk.nix
+++ b/nixos/modules/services/accessibility/speechd-modules/dtk.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  pkgs,
+  mkEnableOption,
+  mkOption,
+  mkExtraConfigOption,
+  ...
+}:
+{
+  type = lib.types.submodule {
+    options = {
+      enable = mkEnableOption "DTK text to speech output module";
+
+      debug = mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Enable debug output.
+        '';
+        example = true;
+      };
+
+      extraConfig = mkExtraConfigOption { };
+    };
+  };
+
+  # Dtk is not packaged in Nixpkgs
+  visible = false;
+  displayName = "DTK";
+  confFile = "dtk-generic.conf";
+}

--- a/nixos/modules/services/accessibility/speechd-modules/epos.nix
+++ b/nixos/modules/services/accessibility/speechd-modules/epos.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  pkgs,
+  mkEnableOption,
+  mkOption,
+  mkExtraConfigOption,
+  ...
+}:
+{
+  type = lib.types.submodule {
+    options = {
+      enable = mkEnableOption "Epos text to speech output module";
+
+      # TODO use mkPackageOption if Epos is packaged
+      package = mkOption {
+        type = lib.types.nullOr lib.types.package;
+        default = pkgs.epos or null;
+        defaultText = "pkgs.epos";
+        description = ''
+          The Epos text-to-spech package to use.
+
+          Since `epos` is not yet in nixpkgs, you must override this
+          with your own derivation (or a package from an overlay) if you
+          want to enable the module.
+        '';
+        example = "pkgs.epos";
+      };
+
+      debug = mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Enable debug output.
+        '';
+        example = true;
+      };
+
+      extraConfig = mkExtraConfigOption { };
+    };
+  };
+
+  # TODO remove if Epos is packaged in Nixpkgs
+  visible = false;
+  displayName = "Epos";
+  confFile = "epos-generic.conf";
+
+}

--- a/nixos/modules/services/accessibility/speechd-modules/espeak-ng.nix
+++ b/nixos/modules/services/accessibility/speechd-modules/espeak-ng.nix
@@ -1,0 +1,159 @@
+{
+  lib,
+  pkgs,
+  mkEnableOption,
+  mkPackageOption,
+  mkOption,
+  mkExtraConfigOption,
+  ...
+}:
+{
+  type = lib.types.submodule (
+    { config, ... }:
+    {
+      options = {
+        enable = mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "Whether to enable eSpeak NG text to speech output module.";
+        };
+
+        package = mkPackageOption pkgs "espeak-ng" { };
+
+        debug = mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Enable debug output.";
+          example = true;
+        };
+
+        soundIconFolder = mkOption {
+          type = lib.types.path;
+          default = "${pkgs.sound-icons}/share/sounds/sound-icons";
+          defaultText = lib.literalExpression ''"''${pkgs.sound-icons}/share/sounds/sound-icons"'';
+          description = ''
+            Path to a directory containing sound icon WAV files.
+            When an application requests a sound icon by name, eSpeak NG will
+            look for a matching file in this directory and play it instead of
+            speaking the icon name.
+
+            Sets {var}`EspeakSoundIconFolder`.
+          '';
+          example = lib.literalExpression ''"''${pkgs.sound-icons}/share/sounds/sound-icons"'';
+        };
+
+        mbrola = mkOption {
+          type = lib.types.bool;
+          default = false;
+          # FIXME remove when MBROLA voices are fixed in eSpeak
+          # https://github.com/NixOS/nixpkgs/pull/541467
+          visible = false;
+          description = ''
+            Enabling this makes eSpeak NG only show MBROLA voices.
+
+            Sets {var}`EspeakMbrola`.
+          '';
+          example = "true";
+        };
+
+        mbrolaPackage = mkPackageOption pkgs "mbrola" { };
+
+        mbrolaVoices = mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          # FIXME remove when MBROLA voices are fixed in eSpeak
+          # https://github.com/NixOS/nixpkgs/pull/541467
+          visible = false;
+          description = ''
+            List of MBROLA voice.
+            If the list is empty then all voices will be added.
+          '';
+          example = [
+            "en1"
+            "de6"
+          ];
+        };
+
+        mbrolaVoicesPackage = mkPackageOption pkgs "mbrola-voices" { };
+
+        finalPackage = mkOption {
+          type = lib.types.package;
+          visible = false;
+          readOnly = true;
+          default =
+            if config.mbrola then
+              config.package.override {
+                mbrolaSupport = true;
+                mbrola = config.mbrolaPackage.override {
+                  mbrola-voices = config.mbrolaVoicesPackage.override {
+                    languages = config.mbrolaVoices;
+                  };
+                };
+              }
+            else
+              config.package.override {
+                mbrolaSupport = false;
+              };
+
+          description = ''
+            The eSpeak Ng package used by the submodule.
+          '';
+        };
+
+        extraConfig = mkExtraConfigOption { };
+      };
+    }
+  );
+
+  displayName = "eSpeak NG";
+  binary = modCfg: if modCfg.mbrola then "sd_espeak-ng-mbrola" else "sd_espeak-ng";
+  confFile = "espeak-ng.conf";
+  generateEtc =
+    modCfg:
+    lib.optionalAttrs modCfg.enable {
+      "speech-dispatcher/modules/espeakNg.conf".text = ''
+        Debug ${if modCfg.debug then "1" else "0"}
+        EspeakSoundIconFolder "${modCfg.soundIconFolder}/"
+
+        EspeakPunctuationList "@+_"
+        EspeakCapitalPitchRise 0
+        EspeakMinRate 80
+        EspeakNormalRate 170
+        EspeakMaxRate 449
+        EspeakAudioChunkSize 300
+        EspeakAudioQueueMaxSize 441000
+        EspeakIndexing "1"
+
+        EspeakMbrola ${if modCfg.mbrola then "1" else "0"}
+      ''
+      + "\n"
+      + modCfg.extraConfig;
+    };
+
+  assertions =
+    modCfg:
+    lib.mapAttrsToList
+      (directive: option: {
+        assertion = !(lib.hasInfix directive modCfg.extraConfig);
+        message = ''
+          `services.speechd.modules.espeakNg.extraConfig` contains an ${directive} directive.
+          Use `services.speechd.modules.espeakNg.${option}` instead.
+        '';
+      })
+      {
+        EspeakSoundIconFolder = "soundIconFolder";
+        EspeakMbrola = "mbrola";
+      }
+    ++ [
+      {
+        assertion = !modCfg.mbrola || modCfg.mbrolaVoices != [ ];
+        message = ''
+          `services.speechd.modules.espeakNg.mbrola` is enabled.
+          However, no voices are set in `services.speechd.modules.espeakNg.mbrolaVoices`.
+          This with give a silent error in speechd.
+          Either disable `services.speechd.modules.espeakNg.mbrola` or
+          place voices in `services.speechd.modules.espeakNg.mbrolaVoices`.
+        '';
+      }
+    ];
+}

--- a/nixos/modules/services/accessibility/speechd-modules/festival.nix
+++ b/nixos/modules/services/accessibility/speechd-modules/festival.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  pkgs,
+  mkEnableOption,
+  mkOption,
+  mkExtraConfigOption,
+  ...
+}:
+{
+  type = lib.types.submodule {
+    options = {
+      enable = mkEnableOption "Festival text to speech output module";
+      port = mkOption {
+        type = lib.types.port;
+        default = 1314;
+        description = ''
+          Festival server port.
+          Set the {var}`FestivalServerPort`.
+        '';
+        example = 6456;
+      };
+      host = mkOption {
+        type = lib.types.str;
+        default = "localhost";
+        description = ''
+          Festival server host address.
+          Set the {var}`FestivalServerHost`.
+        '';
+        example = "127.0.0.1";
+      };
+      debug = mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Enable debug output.
+        '';
+        example = true;
+      };
+
+      extraConfig = mkExtraConfigOption { };
+    };
+  };
+
+  # FIXME Remove this comment when PR 536089 is merged
+  # https://github.com/NixOS/nixpkgs/pull/536089
+  #
+  # Festival is not packaged in Nixpkgs.
+  # However, it works on a server/client model.
+  # Festival does not need to run on the same
+  # machine as Speechd
+  visible = true;
+  displayName = "Festival";
+  binary = "sd_festival";
+  confFile = "festival.conf";
+  generateEtc =
+    modCfg:
+    lib.optionalAttrs modCfg.enable {
+      "speech-dispatcher/modules/festival.conf".text = ''
+        Debug ${if modCfg.debug then "1" else "0"}
+        FestivalServerHost ${toString modCfg.host}
+        FestivalServerPort ${toString modCfg.port}
+      ''
+      + "\n"
+      + modCfg.extraConfig;
+    };
+  assertions =
+    modCfg:
+    lib.mapAttrsToList
+      (directive: option: {
+        assertion = !(lib.hasInfix directive modCfg.extraConfig);
+        message = ''
+          `services.speechd.modules.festival.extraConfig` contains an ${directive} directive.
+          Use `services.speechd.modules.festival.${option}` instead.
+        '';
+      })
+      {
+        FestivalServerPort = "port";
+        FestivalServerHost = "host";
+      };
+}

--- a/nixos/modules/services/accessibility/speechd-modules/flite.nix
+++ b/nixos/modules/services/accessibility/speechd-modules/flite.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  pkgs,
+  mkPackageOption,
+  mkEnableOption,
+  mkOption,
+  mkExtraConfigOption,
+  ...
+}:
+{
+  type = lib.types.submodule {
+    options = {
+      enable = mkEnableOption "Flite text to speech output module";
+      package = mkPackageOption pkgs "flite" { };
+      debug = mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Enable debug output.
+        '';
+        example = true;
+      };
+      extraConfig = mkExtraConfigOption { };
+    };
+  };
+
+  displayName = "Flite";
+  binary = "sd_flite";
+  confFile = "flite.conf";
+}

--- a/nixos/modules/services/accessibility/speechd-modules/kali.nix
+++ b/nixos/modules/services/accessibility/speechd-modules/kali.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  pkgs,
+  mkEnableOption,
+  mkOption,
+  mkExtraConfigOption,
+  ...
+}:
+{
+  type = lib.types.submodule {
+    options = {
+      enable = mkEnableOption "Kali text to speech output module";
+
+      # TODO use mkPackageOption if Kali is packaged
+      package = mkOption {
+        type = lib.types.nullOr lib.types.package;
+        default = pkgs.kali or null;
+        defaultText = "pkgs.kali";
+        description = ''
+          The Kali text-to-spech package to use.
+
+          Since `kali` is not yet in nixpkgs, you must override this
+          with your own derivation (or a package from an overlay) if you
+          want to enable the module.
+        '';
+        example = "pkgs.kali";
+      };
+
+      debug = mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Enable debug output.
+        '';
+        example = true;
+      };
+
+      extraConfig = mkExtraConfigOption { };
+    };
+  };
+
+  # TODO remove if Kali is packaged in Nixpkgs.
+  visible = false;
+  displayName = "Kali";
+  binary = "sd_kali";
+  confFile = "kali.conf";
+}

--- a/nixos/modules/services/accessibility/speechd-modules/llia-phon.nix
+++ b/nixos/modules/services/accessibility/speechd-modules/llia-phon.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  pkgs,
+  mkEnableOption,
+  mkOption,
+  mkExtraConfigOption,
+  ...
+}:
+{
+  type = lib.types.submodule {
+    options = {
+      enable = mkEnableOption "Llia Phon text to speech output module";
+
+      # TODO use mkPackageOption if Llia Phon gets packaged
+      package = mkOption {
+        type = lib.types.nullOr lib.types.package;
+        default = pkgs.llia-phon or null;
+        defaultText = "pkgs.llia-phon";
+        description = ''
+          The Llia Phon text-to-spech package to use.
+
+          Since `llia-phon` is not yet in nixpkgs, you must override this
+          with your own derivation (or a package from an overlay) if you
+          want to enable the module.
+        '';
+        example = "pkgs.llia-phon";
+      };
+
+      debug = mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Enable debug output.
+        '';
+        example = true;
+      };
+
+      extraConfig = mkExtraConfigOption { };
+    };
+  };
+
+  # TODO remove if Llia Phon is packaged in Nixpkgs.
+  visible = false;
+  displayName = "Llia Phon";
+  confFile = "llia_phon-generic.conf";
+}

--- a/nixos/modules/services/accessibility/speechd-modules/mary.nix
+++ b/nixos/modules/services/accessibility/speechd-modules/mary.nix
@@ -1,0 +1,162 @@
+{
+  lib,
+  pkgs,
+  mkEnableOption,
+  mkOption,
+  mkExtraConfigOption,
+  ...
+}:
+{
+  type = lib.types.submodule {
+    options = {
+      enable = mkEnableOption "Mary text to speech output module";
+
+      port = mkOption {
+        type = lib.types.port;
+        default = 59125;
+        description = ''
+          MaryTTS server port.
+
+          Set the {var}`GenericPortDependency`.
+        '';
+        example = 44545;
+      };
+
+      host = mkOption {
+        type = lib.types.str;
+        default = "localhost";
+        description = ''
+          MaryTTS server host address.
+
+          Sets the host in the {var}`GenericExecuteSynth` curl command.
+        '';
+        example = "192.168.1.10";
+      };
+
+      defaultVoice = mkOption {
+        type = lib.types.str;
+        default = "dfki-spike";
+        description = ''
+          Default MaryTTS voice to use.
+          Must match a voice name from an {var}`AddVoice` directive.
+
+          Sets {var}`DefaultVoice`.
+        '';
+        example = "cmu-slt";
+      };
+
+      debug = mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Enable debug output.
+        '';
+        example = true;
+      };
+
+      extraConfig = mkExtraConfigOption { };
+    };
+  };
+
+  displayName = "MaryTTS";
+  confFile = "mary-generic.conf";
+  generateEtc =
+    modCfg:
+    let
+      mktemp = "${pkgs.coreutils}/bin/mktemp";
+      curl = "${pkgs.curl}/bin/curl";
+      xxd = "${pkgs.tinyxxd}/bin/xxd";
+      tr = "${pkgs.coreutils}/bin/tr";
+      sed = "${pkgs.gnused}/bin/sed";
+      sox = "${pkgs.sox}/bin/sox";
+    in
+    lib.optionalAttrs modCfg.enable {
+      "speech-dispatcher/modules/mary.conf".text = ''
+        Debug ${if modCfg.debug then "1" else "0"}
+
+        GenericExecuteSynth "tmp=$(${mktemp} --suffix=.wav) && \
+        ${curl} \"http://${modCfg.host}:${toString modCfg.port}/process?INPUT_TEXT=`printf %s \'$DATA\' | ${xxd} -plain | \
+        ${tr} -d '\\n' | ${sed} 's/\\\(..\\\)/%\\\1/g'`&INPUT_TYPE=TEXT&OUTPUT_TYPE=AUDIO&AUDIO=WAVE_FILE&LOCALE=$LANGUAGE&VOICE=$VOICE\" | \
+        ${sox} -v $VOLUME \"$tmp\" tempo $RATE pitch $PITCH norm && $PLAY_COMMAND \"$tmp\"; \
+        rm -f \"$tmp\""
+
+        GenericCmdDependency "${curl}"
+        GenericPortDependency ${toString modCfg.port}
+        GenericSoundIconFolder "${pkgs.sound-icons}/share/sounds/sound-icons/"
+
+        GenericPunctNone ""
+        GenericPunctSome "--punct=\"()[]{};:\""
+        GenericPunctMost "--punct=\"()[]{};:\""
+        GenericPunctAll "--punct"
+
+        GenericLanguage  "en" "en_GB" "utf-8"
+        GenericLanguage  "en" "en_US" "utf-8"
+
+        GenericDefaultCharset "utf-8"
+
+        #English GB
+        AddVoice        "en_GB"    "MALE1"         "dfki-spike"
+        AddVoice        "en_GB"    "FEMALE1"       "dfki-prudence"
+        AddVoice        "en_GB"    "CHILD_FEMALE"  "dfki-poppy"
+        AddVoice        "en_GB"    "MALE2"         "dfki-obadiah"
+
+        #English US
+        AddVoice        "en_US"    "MALE1"         "cmu-bdl"
+        AddVoice        "en_US"    "MALE2"         "cmu-rms"
+        AddVoice        "en_US"    "FEMALE1"       "cmu-slt"
+
+        #German
+        AddVoice        "de"    "MALE1"         "dfki-pavoque-styles"
+        AddVoice        "de"    "FEMALE1"       "bits1"
+        AddVoice        "de"    "MALE2"         "bits2"
+        AddVoice        "de"    "MALE3"         "bits3"
+        AddVoice        "de"    "FEMALE2"       "bits4"
+        AddVoice        "de"    "MALE4"         "dfki-pavoque-neutral"
+
+        #Turkish
+        AddVoice        "tr"    "MALE1"         "dfki-ot"
+
+        #French
+        AddVoice        "fr"    "FEMALE1"       "upmc-jessica"
+        AddVoice        "fr"    "MALE1"         "upmc-pierre"
+        AddVoice        "fr"    "FEMALE2"       "enst-camille"
+        AddVoice        "fr"    "MALE2"         "enst-dennys-hsmm"
+
+        #Telugu
+        AddVoice        "te"    "FEMALE1"       "cmu-nk-hsmm"
+
+        #Italian
+        AddVoice        "it"    "FEMALE1"       "istc-lucia-hsmm"
+
+        DefaultVoice ${modCfg.defaultVoice}
+
+        GenericRateAdd          1
+        GenericPitchAdd         1
+        GenericVolumeAdd        1
+
+        GenericRateMultiply     1
+        GenericPitchMultiply 750
+        GenericVolumeMultiply 2
+
+        GenericRateForceInteger     0
+        GenericPitchForceInteger    1
+        GenericVolumeForceInteger   0
+      ''
+      + "\n"
+      + modCfg.extraConfig;
+    };
+
+  assertions =
+    modCfg:
+    lib.mapAttrsToList
+      (directive: option: {
+        assertion = !(lib.hasInfix directive modCfg.extraConfig);
+        message = ''
+          `services.speechd.modules.mary.extraConfig` contains an ${directive} directive.
+          Use `services.speechd.modules.mary.${option}` instead.
+        '';
+      })
+      {
+        GenericPortDependency = "port";
+      };
+}

--- a/nixos/modules/services/accessibility/speechd-modules/mimic3.nix
+++ b/nixos/modules/services/accessibility/speechd-modules/mimic3.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  pkgs,
+  mkEnableOption,
+  mkOption,
+  mkExtraConfigOption,
+  ...
+}:
+{
+  type = lib.types.submodule {
+    options = {
+      enable = mkEnableOption "Mimic3 text to speech output module";
+
+      debug = mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Enable debug output.
+        '';
+        example = true;
+      };
+
+      extraConfig = mkExtraConfigOption { };
+    };
+  };
+
+  # TODO delete if mimic3 is packaged in nixpkgs
+  visible = false;
+  displayName = "Mimic 3";
+  confFile = "mimic3-generic.conf";
+
+}

--- a/nixos/modules/services/accessibility/speechd-modules/openjtalk.nix
+++ b/nixos/modules/services/accessibility/speechd-modules/openjtalk.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  pkgs,
+  mkPackageOption,
+  mkEnableOption,
+  mkOption,
+  mkExtraConfigOption,
+  ...
+}:
+{
+  type = lib.types.submodule {
+    options = {
+      enable = mkEnableOption "Open JTalk text to speech output module";
+
+      # TODO use mkPackageOption when Open JTalk is packaged
+      package = mkOption {
+        type = lib.types.nullOr lib.types.package;
+        default = pkgs.openjtalk or null; # safe even if attr doesn't exist
+        defaultText = "pkgs.openjtalk";
+        description = ''
+          The Open JTalk package to use.
+
+          Since `openjtalk` is not yet in nixpkgs, you must override this
+          with your own derivation (or a package from an overlay) if you
+          want to enable the module.
+        '';
+        example = "pkgs.openjtalk";
+      };
+
+      extraConfig = mkExtraConfigOption { };
+    };
+  };
+
+  # TODO remove if Open JTalk is packaged in Nixpkgs
+  visible = false;
+  displayName = "Open JTalk";
+  binary = "sd_openjtalk";
+  confFile = "openjtalk.conf";
+
+  generateEtc =
+    modCfg:
+    lib.optionalAttrs modCfg.enable {
+      "speech-dispatcher/modules/openjtalk.conf".text =
+        (builtins.readFile "${pkgs.speechd}/etc/speech-dispatcher/modules/${modCfg.confFile}")
+        + "\n"
+        + modCfg.extraConfig;
+    };
+}

--- a/nixos/modules/services/accessibility/speechd-modules/pico.nix
+++ b/nixos/modules/services/accessibility/speechd-modules/pico.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  pkgs,
+  mkPackageOption,
+  mkEnableOption,
+  mkOption,
+  mkExtraConfigOption,
+  ...
+}:
+{
+  type = lib.types.submodule (
+    { config, ... }:
+    {
+      options = {
+        enable = mkEnableOption "Pico text to speech output module";
+        package = mkPackageOption pkgs "picotts" { };
+        lingwarePath = mkOption {
+          type = lib.types.path;
+          default = "${config.package}/share/pico/lang/";
+          defaultText = lib.literalExpression ''"''${config.package}/share/pico/lang/"'';
+          description = ''
+            Path to the Pico lingware directory containing the `.bin`
+            text-analysis and signal-generation resource files.
+
+            Sets {var}`PicoLingwarePath`.
+          '';
+          example = "/etc/pico/lang/";
+        };
+        debug = mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = ''
+            Enable debug output.
+          '';
+          example = true;
+        };
+        extraConfig = mkExtraConfigOption { };
+      };
+    }
+  );
+
+  displayName = "SVOX Pico";
+  binary = "sd_pico";
+  confFile = "pico.conf";
+
+  generateEtc =
+    modCfg:
+    lib.optionalAttrs modCfg.enable {
+      "speech-dispatcher/modules/pico.conf".text = ''
+        Debug ${if modCfg.debug then "1" else "0"}
+        PicoLingwarePath "${modCfg.lingwarePath}"
+      ''
+      + "\n"
+      + modCfg.extraConfig;
+    };
+
+  assertions =
+    modCfg:
+    lib.mapAttrsToList
+      (directive: option: {
+        assertion = !(lib.hasInfix directive modCfg.extraConfig);
+        message = ''
+          services.speechd.modules.pico.extraConfig contains an ${directive} directive.
+          Use services.speechd.modules.pico.${option} instead.
+        '';
+      })
+      {
+        PicoLingwarePath = "lingwarePath";
+      };
+
+}

--- a/nixos/modules/services/accessibility/speechd-modules/swift.nix
+++ b/nixos/modules/services/accessibility/speechd-modules/swift.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  pkgs,
+  mkEnableOption,
+  mkOption,
+  mkExtraConfigOption,
+  ...
+}:
+{
+  type = lib.types.submodule {
+    options = {
+      enable = mkEnableOption "Swift text to speech output module";
+
+      debug = mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Enable debug output.
+        '';
+        example = true;
+      };
+
+      extraConfig = mkExtraConfigOption { };
+    };
+  };
+
+  # TODO delete if SwiftTTS is packaged in Nixpkgs.
+  visible = false;
+  displayName = "SwiftTTS";
+  confFile = "swift-generic.conf";
+}

--- a/nixos/modules/services/accessibility/speechd-modules/voxin.nix
+++ b/nixos/modules/services/accessibility/speechd-modules/voxin.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  pkgs,
+  mkEnableOption,
+  mkOption,
+  mkExtraConfigOption,
+  ...
+}:
+{
+  type = lib.types.submodule {
+    options = {
+      enable = mkEnableOption "Voxin text to speech output module";
+
+      debug = mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Enable debug output.
+        '';
+        example = true;
+      };
+
+      extraConfig = mkExtraConfigOption { };
+    };
+  };
+
+  # TODO remove if mkPackageOption if Voxin is packaged
+  visible = false;
+  displayName = "Voxin";
+  binary = "sd_voxin";
+  confFile = "voxin.conf";
+}

--- a/nixos/modules/services/accessibility/speechd.nix
+++ b/nixos/modules/services/accessibility/speechd.nix
@@ -81,6 +81,7 @@ let
           {
             # keep-sorted start case=no
             espeakNg = "espeak-ng";
+            festival = "festival";
             flite = "flite";
             mary = "mary";
             pico = "pico";

--- a/nixos/modules/services/accessibility/speechd.nix
+++ b/nixos/modules/services/accessibility/speechd.nix
@@ -6,6 +6,10 @@
 }:
 let
   cfg = config.services.speechd;
+
+  # TODO: Remove this in 27.05
+  legacyStringModules = lib.filterAttrs (name: value: lib.isString value) cfg.modules;
+
   inherit (lib)
     mapAttrs'
     mkEnableOption
@@ -13,8 +17,104 @@ let
     mkPackageOption
     mkOption
     ;
+
+  mkExtraConfigOption =
+    { }:
+    mkOption {
+      type = lib.types.lines;
+      default = "";
+      description = ''
+        Extra lines appended verbatim to this module's Speech Dispatcher
+        configuration file.
+
+        See the [Speech Dispatcher manual](https://github.com/brailcom/speechd/blob/master/doc/speech-dispatcher.texi)
+        for the general directive syntax, and the default
+        shipped in `${"$"}{cfg.package}/etc/speech-dispatcher/modules/`
+        for the directives this specific module accepts.
+      '';
+      example = "";
+    };
+
+  mkSimpleGenerateEtc =
+    name: confFile: modCfg:
+    lib.optionalAttrs modCfg.enable {
+      "speech-dispatcher/modules/${name}.conf".text =
+        builtins.replaceStrings
+          [ "Debug 0" "Debug 1" ]
+          [
+            "Debug ${if modCfg.debug then "1" else "0"}"
+            "Debug ${if modCfg.debug then "1" else "0"}"
+          ]
+          (builtins.readFile "${cfg.package}/etc/speech-dispatcher/modules/${confFile}")
+        + "\n"
+        + modCfg.extraConfig;
+    };
+
+  mkDebugAssertion =
+    name: modCfg:
+    lib.optional (modCfg ? extraConfig && lib.hasInfix "Debug" modCfg.extraConfig) {
+      assertion = false;
+      message = ''
+        `services.speechd.modules.${name}.extraConfig` contains a Debug directive.
+        Use `services.speechd.modules.${name}.debug` instead.
+      '';
+    };
+
+  mkSimpleAddModule = binary: name: ''AddModule "${name}" "${binary}" "${name}.conf"'' + "\n";
+
+  outputModules =
+    let
+      mods =
+        lib.mapAttrs
+          (
+            name: filename:
+            import ./speechd-modules/${filename}.nix {
+              inherit lib pkgs;
+              inherit (lib)
+                mkPackageOption
+                mkEnableOption
+                mkOption
+                ;
+              inherit mkExtraConfigOption;
+            }
+          )
+          {
+            # keep-sorted start case=no
+            espeakNg = "espeak-ng";
+            flite = "flite";
+            pico = "pico";
+            #keep-sorted end
+          };
+      binaryFor =
+        mod: modCfg:
+        let
+          b = mod.binary or "sd_generic";
+        in
+        if lib.isFunction b then b modCfg else b;
+    in
+    lib.mapAttrs (
+      name: mod:
+      mod
+      // {
+        generateEtc = mod.generateEtc or (mkSimpleGenerateEtc name mod.confFile);
+        generateAddModule =
+          mod.generateAddModule or (modCfg: mkSimpleAddModule (binaryFor mod modCfg) name);
+        assertions = modCfg: (mkDebugAssertion name modCfg) ++ (mod.assertions or (_: [ ])) modCfg;
+      }
+    ) mods;
+
 in
 {
+  imports = [
+    # TODO: Remove in 27.05
+    (lib.mkRenamedOptionModule [ "services" "speechd" "config" ] [ "services" "speechd" "extraConfig" ])
+    # TODO: Remove in 27.05
+    (lib.mkRenamedOptionModule
+      [ "services" "speechd" "clients" ]
+      [ "services" "speechd" "extraClients" ]
+    )
+  ];
+
   options.services.speechd = {
     # FIXME: figure out how to deprecate this EXTREMELY CAREFULLY
     # default guessed conservatively in ../misc/graphical-desktop.nix
@@ -22,9 +122,132 @@ in
 
     package = mkPackageOption pkgs "speechd" { };
 
-    config = mkOption {
-      type = with lib.types; nullOr lines;
+    logLevel = mkOption {
+      type = lib.types.ints.between 0 5;
+      default = 3;
+      description = ''
+        Specifies the verbosity of information written to the logfile  or screen.
+        0 means nothing, 5 means everything (not recommended).
+
+        Sets {var}`LogLevel`.
+      '';
+      example = "5";
+    };
+
+    logDir = mkOption {
+      type = lib.types.either (lib.types.enum [
+        "default"
+        "stdout"
+      ]) lib.types.str;
+      default = "default";
+      description = ''
+        Directory where Speech Dispatcher logs are written.
+        Use {var}`"default"` for the standard system log destination,
+        {var}`"stdout"` for console output, or an absolute path to a
+        custom directory.
+
+        Sets {var}`LogDir`.
+      '';
+      example = "/var/log/speech-dispatcher/";
+    };
+
+    defaultVolume = mkOption {
+      type = lib.types.ints.between (-100) 100;
+      default = 100;
+      description = ''
+        Default volume of synthesized speech, ranging from -100 (quietest)
+        to 100 (the synthesizer's default volume).
+
+        Sets {var}`DefaultVolume`.
+      '';
+      example = "10";
+    };
+
+    symbolsPreproc = mkOption {
+      type = lib.types.enum [
+        "no"
+        "none"
+        "all"
+        "char"
+      ];
+      default = "char";
+      description = ''
+        Controls the level of punctuation symbol pre-processing performed
+        by the server rather than the output module.
+        {var}`"no"` disables pre-processing entirely.
+        {var}`"none"` enables only rules that are always active.
+        {var}`"all"` enables all server punctuation rules.
+        {var}`"char"` enables all server rules including spacing rules.
+
+        Sets {var}`SymbolsPreproc`.
+      '';
+    };
+
+    symbolsPreprocFiles = mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [
+        "gender-neutral.dic"
+        "font-variants.dic"
+        "symbols.dic"
+        "emojis.dic"
+        "orca.dic"
+        "orca-chars.dic"
+      ];
+      description = ''
+        Preprocessing dictionary files loaded by the server for symbol
+        substitution, in order from most to least specific localization.
+
+        Sets {var}`SymbolsPreprocFile`.
+      '';
+    };
+
+    audioOutputMethod = mkOption {
+      type = lib.types.nonEmptyListOf (
+        lib.types.enum [
+          "pulse"
+          "alsa"
+          "oss"
+          # "nas"
+
+          # FIXME uncomment when pipewire is a derivation input
+          # https://github.com/NixOS/nixpkgs/pull/470797
+          # "pipewire"
+          "libao"
+        ]
+      );
+      default = [
+        "libao"
+        "pulse"
+        "alsa"
+        # FIXME uncomment when pipewire is a derivation input
+        # https://github.com/NixOS/nixpkgs/pull/470797
+        # "pipewire"
+        "oss"
+      ];
+      description = ''
+        Ordered list of audio output backends to try at runtime, falling
+        back to the next one if opening a device fails.
+
+        Sets {var}`AudioOutputMethod` (as a comma-separated list).
+        Overrides {var}`speechd` to include the speciffic backend.
+      '';
+    };
+
+    defaultModule = mkOption {
+      type = lib.types.nullOr lib.types.str;
       default = null;
+      description = ''
+        Name of the default output module. Must match a name from an
+        {var}`AddModule` directive.
+
+        Sets {var}`DefaultModule`.
+      '';
+      example = "espeak-ng";
+    };
+
+    extraConfig = mkOption {
+      type = lib.types.lines;
+      default = "";
       description = ''
         System wide configuration file for Speech Dispatcher. This will be used if no user configuration file is found.
       '';
@@ -34,20 +257,40 @@ in
     };
 
     modules = mkOption {
+      description = ''
+        Predefined interfaces for Speech Dispatcher output modules.
+      '';
+      type = lib.types.submodule {
+        # TODO remove in 27.05
+        freeformType = lib.types.attrsOf (lib.types.either lib.types.lines lib.types.anything);
+        options = lib.mapAttrs (
+          name: mod:
+          mkOption {
+            type = mod.type;
+            default = { };
+            visible = mod.visible or true;
+            description = "Configuration for the ${mod.displayName} Speech Dispatcher output module.";
+          }
+        ) outputModules;
+      };
+    };
+
+    extraModules = mkOption {
       type = with lib.types; submodule { freeformType = attrsOf lines; };
       default = { };
       description = ''
-        Configuration files of output modules.
+        Extra configuration files of output modules.
       '';
       example = {
-        generic-epos = ''
+        # TODO find a better example
+        llia-generic = ''
           AddVoice        "cs"  "male1"   "kadlec"
           AddVoice        "sk"  "male1"   "bob"
         '';
       };
     };
 
-    clients = mkOption {
+    extraClients = mkOption {
       type = with lib.types; submodule { freeformType = attrsOf lines; };
       default = { };
       description = ''
@@ -62,31 +305,208 @@ in
         '';
       };
     };
+
+    finalPackage = mkOption {
+      type = lib.types.package;
+      visible = false;
+      readOnly = true;
+      description = ''
+        The Speech Dispatcher package used by the module.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
-    environment = {
-      systemPackages = [ cfg.package ];
+    services.speechd.finalPackage = (
+      cfg.package.override {
+        withEspeak = cfg.modules.espeakNg.enable;
+        espeak = cfg.modules.espeakNg.finalPackage;
+        withPico = cfg.modules.pico.enable;
+        picotts = cfg.modules.pico.package;
+        withFlite = cfg.modules.flite.enable;
+        flite = cfg.modules.flite.package;
+        # Use the defined audio output backend
+        withPulse = lib.elem "pulse" cfg.audioOutputMethod;
+        withLibao = lib.elem "libao" cfg.audioOutputMethod;
+        withAlsa = lib.elem "alsa" cfg.audioOutputMethod;
+        withOss = lib.elem "oss" cfg.audioOutputMethod;
 
-      etc =
-        if cfg.config == null then
-          { speech-dispatcher.source = "${cfg.package}/etc/speech-dispatcher"; }
-        else
+        # FIXME uncomment when pipewire is a derivation input
+        # https://github.com/NixOS/nixpkgs/pull/470797
+        # withPipewire = lib.elem "pipewire" cfg.audioOutputMethod;
+      }
+    );
+
+    # TODO: Remove this in 27.05
+    services.speechd.extraModules = legacyStringModules;
+
+    assertions =
+      # The user cannot add a module in `extraModules` that is already defined in `modules`
+      lib.concatLists (
+        lib.mapAttrsToList (name: mod: [
           {
-            "speech-dispatcher/speechd.conf".text = cfg.config;
+            assertion = !(cfg.extraModules ? "${lib.removeSuffix ".conf" mod.confFile}");
+            message = ''
+              ${name} is a predefined module in `services.speechd.modules.${name}`.
+              Use the predefined module instead of defining your own.
+            '';
           }
-          // (mapAttrs' (name: value: {
-            name = "speech-dispatcher/modules/${name}.conf";
-            value.text = value;
-          }) cfg.modules)
-          // (mapAttrs' (name: value: {
-            name = "speech-dispatcher/clients/${name}.conf";
-            value.text = value;
-          }) cfg.clients);
+        ]) outputModules
+      )
+      # The user cannot define a module in AddModule that is already defined in `modules`
+      ++ lib.concatLists (
+        lib.mapAttrsToList (name: mod: [
+          {
+            assertion =
+              !(lib.any (line: builtins.match ''[[:space:]]*AddModule[[:space:]]+"${name}".*'' line != null) (
+                lib.splitString "\n" cfg.extraConfig
+              ));
+            message = ''
+              services.speechd.extraConfig contains an AddModule directive for "${name}",
+              which collides with the predefined module services.speechd.modules.${name}.
+              Remove the duplicate AddModule line or rename the module.
+            '';
+          }
+        ]) outputModules
+      )
+      # The user cannot set a variable in any `extraConfig` that has a named variable
+      ++ lib.concatLists (
+        lib.mapAttrsToList (
+          name: mod:
+          lib.optionals (mod ? assertions) (
+            map (a: a // { message = "[services.speechd.modules.${name}] " + a.message; }) (
+              mod.assertions cfg.modules.${name}
+            )
+          )
+        ) outputModules
+      )
+      # The user cannot set a module in defaultModule that is not defined in `modules` or `extraModules`
+      ++ [
+        {
+          assertion =
+            cfg.defaultModule == null
+            || (outputModules ? ${cfg.defaultModule} && cfg.modules.${cfg.defaultModule}.enable)
+            || cfg.extraModules ? "${cfg.defaultModule}";
+          message = ''
+            services.speechd.defaultModule is set to "${toString cfg.defaultModule}" but it
+            does not match the attribute name of an enabled module under
+            services.speechd.modules, nor a key in services.speechd.extraModules.
+          '';
+        }
+      ]
+      ++ [
+        # TODO: Remove this assertion in 27.05
+        {
+          assertion = lib.all (
+            name: builtins.elem name (lib.attrNames outputModules) || lib.isString cfg.modules.${name}
+          ) (lib.attrNames cfg.modules);
+          message = ''
+            services.speechd.modules contains unrecognized backend name(s): ${
+              toString (
+                lib.filter (
+                  name: !(builtins.elem name (lib.attrNames outputModules) || lib.isString cfg.modules.${name})
+                ) (lib.attrNames cfg.modules)
+              )
+            }.
+            Valid backend names are: ${toString (lib.attrNames outputModules)}.
+          '';
+        }
+      ]
+      ++ [
+        # TODO: Remove this assertion in 27.05
+        {
+          assertion = lib.all (name: !(cfg.extraModules ? ${name})) (lib.attrNames legacyStringModules);
+          message = ''
+            The following `services.speechd.modules` entries are raw configuration
+            strings that collide with a same-named `services.speechd.extraModules`
+            entry: ${
+              toString (lib.filter (name: cfg.extraModules ? ${name}) (lib.attrNames legacyStringModules))
+            }.
+            Move everything to `services.speechd.extraModules.<name>`.
+          '';
+        }
+      ]
+      ++
+        lib.mapAttrsToList
+          (directive: option: {
+            assertion = !(lib.hasInfix directive cfg.extraConfig);
+            message = ''
+              services.speechd.extraConfig contains a ${directive} directive.
+              Use services.speechd.${option} instead.
+            '';
+          })
+          {
+            LogLevel = "logLevel";
+            LogDir = "logDir";
+            DefaultVolume = "defaultVolume";
+            SymbolsPreproc = "symbolsPreproc";
+            AudioOutputMethod = "audioOutputMethod";
+            DefaultModule = "defaultModule";
+          };
+
+    # TODO: Remove in 27.05 along with freeformType on `modules`.
+    warnings = lib.mapAttrsToList (name: _: ''
+      The option `services.speechd.modules.${name}` is set as a raw configuration string.
+      Raw configurations have moved to `services.speechd.extraModules.${name}` instead.
+    '') legacyStringModules;
+
+    environment = {
+      systemPackages = [
+        cfg.finalPackage
+      ];
+
+      etc = {
+        "speech-dispatcher/speechd.conf".text =
+          cfg.extraConfig
+          + "\n"
+          + ''
+            LogLevel ${toString cfg.logLevel}
+            LogDir "${cfg.logDir}"
+            DefaultVolume ${toString cfg.defaultVolume}
+            SymbolsPreproc "${cfg.symbolsPreproc}"
+          ''
+          + lib.concatMapStrings (file: ''
+            SymbolsPreprocFile "${file}"
+          '') cfg.symbolsPreprocFiles
+          + ''
+            AudioOutputMethod "${lib.concatStringsSep "," cfg.audioOutputMethod}"
+          ''
+          + lib.concatStrings (
+            lib.mapAttrsToList (
+              name: mod: lib.optionalString cfg.modules.${name}.enable (mod.generateAddModule cfg.modules.${name})
+            ) outputModules
+          )
+          + lib.optionalString (cfg.defaultModule != null) ''
+            DefaultModule ${toString cfg.defaultModule}
+          ''
+          + ''
+            Include "clients/*.conf"
+          '';
+      }
+      // (mapAttrs' (name: value: {
+        name = "speech-dispatcher/modules/${name}.conf";
+        value.text = value;
+      }) cfg.extraModules)
+      // (mapAttrs' (name: value: {
+        name = "speech-dispatcher/clients/${name}.conf";
+        value.text = value;
+      }) cfg.extraClients)
+      // lib.mergeAttrsList (
+        lib.mapAttrsToList (name: mod: mod.generateEtc cfg.modules.${name}) outputModules
+      );
     };
 
-    systemd.packages = [ cfg.package ];
+    # Ensure that the log directory is created
+    systemd.tmpfiles.rules = lib.optional (
+      cfg.logDir != "default" && cfg.logDir != "stdout"
+    ) "d ${cfg.logDir} 1777 - - - -";
+
+    systemd.packages = [ cfg.finalPackage ];
     # have to set `wantedBy` since `systemd.packages` ignores `[Install]`
     systemd.user.sockets.speech-dispatcher.wantedBy = [ "sockets.target" ];
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [ WiredMic ];
   };
 }

--- a/nixos/modules/services/accessibility/speechd.nix
+++ b/nixos/modules/services/accessibility/speechd.nix
@@ -80,11 +80,21 @@ let
           )
           {
             # keep-sorted start case=no
+            baratinoo = "baratinoo";
+            cicero = "cicero";
+            dtk = "dtk";
+            epos = "epos";
             espeakNg = "espeak-ng";
             festival = "festival";
             flite = "flite";
+            kali = "kali";
+            lliaPhon = "llia-phon";
             mary = "mary";
+            mimic3 = "mimic3";
+            openjtalk = "openjtalk";
             pico = "pico";
+            swift = "swift";
+            voxin = "voxin";
             #keep-sorted end
           };
       binaryFor =

--- a/nixos/modules/services/accessibility/speechd.nix
+++ b/nixos/modules/services/accessibility/speechd.nix
@@ -82,6 +82,7 @@ let
             # keep-sorted start case=no
             espeakNg = "espeak-ng";
             flite = "flite";
+            mary = "mary";
             pico = "pico";
             #keep-sorted end
           };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1574,6 +1574,10 @@ in
   sonic-server = runTest ./sonic-server.nix;
   spacecookie = runTest ./spacecookie.nix;
   spark = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./spark { };
+  speechd = import ./speechd/default.nix {
+    inherit runTest;
+    inherit (pkgs) lib pkgs;
+  };
   speedtest-tracker = runTest ./speedtest-tracker.nix;
   spiped = runTest ./spiped.nix;
   spire = runTest ./spire.nix;

--- a/nixos/tests/speechd/assertions.nix
+++ b/nixos/tests/speechd/assertions.nix
@@ -1,0 +1,174 @@
+{ lib, pkgs, ... }:
+
+let
+  evalSpeechd =
+    extraConfig:
+    (import ../../lib/eval-config.nix {
+      inherit lib;
+      system = pkgs.stdenv.hostPlatform.system;
+      modules = [
+        extraConfig
+        {
+          fileSystems."/" = {
+            device = "/dev/sda1";
+            fsType = "ext4";
+          };
+          boot.loader.grub.device = "/dev/sda";
+        }
+      ];
+    }).config;
+
+  hasFailingAssertion =
+    needle: cfg: lib.any (a: !a.assertion && lib.hasInfix needle a.message) cfg.assertions;
+
+  allAssertionsPass =
+    cfg:
+    let
+      failing = lib.filter (a: !a.assertion) cfg.assertions;
+    in
+    if failing == [ ] then
+      true
+    else
+      lib.trace (lib.concatMapStringsSep "\n" (a: "FAILED ASSERTION: ${a.message}") failing) false;
+
+in
+lib.runTests {
+
+  testCleanConfigHasNoAssertions = {
+    expr = allAssertionsPass (evalSpeechd {
+      services.speechd.enable = true;
+    });
+    expected = true;
+  };
+
+  testDefaultModuleValidNoAssertion = {
+    expr = allAssertionsPass (evalSpeechd {
+      services.speechd = {
+        enable = true;
+        modules.pico.enable = true;
+        defaultModule = "pico";
+      };
+    });
+    expected = true;
+  };
+
+  testModuleExtraModuleCollision = {
+    expr = hasFailingAssertion "is a predefined module in `services.speechd" (evalSpeechd {
+      services.speechd = {
+        enable = true;
+        extraModules.pico = "Debug 0";
+      };
+    });
+    expected = true;
+  };
+
+  testModuleExtraModuleCollisionEvenWhenEnabled = {
+    expr = hasFailingAssertion "is a predefined module in `services.speechd" (evalSpeechd {
+      services.speechd = {
+        enable = true;
+        modules.pico.enable = true;
+        extraModules.pico = "Debug 0";
+      };
+    });
+    expected = true;
+  };
+
+  testModuleExtraConfigAddModuleCollisionWithEnabledModule = {
+    expr =
+      hasFailingAssertion ''services.speechd.extraConfig contains an AddModule directive for "''
+        (evalSpeechd {
+          services.speechd = {
+            enable = true;
+            modules.espeakNg.enable = true;
+            extraConfig = ''
+              AddModule "espeakNg" "sd_espeak-ng" "espeak-ng.conf"
+            '';
+          };
+        });
+    expected = true;
+  };
+
+  testModuleExtraConfigAddModuleCollisionWithDisabledModule = {
+    expr =
+      hasFailingAssertion ''services.speechd.extraConfig contains an AddModule directive for "''
+        (evalSpeechd {
+          services.speechd = {
+            enable = true;
+            modules.pico.enable = false;
+            extraConfig = ''
+              AddModule "pico" "sd_pico"      "pico.conf"
+            '';
+          };
+        });
+    expected = true;
+  };
+
+  testModuleExtraConfigAddModuleCollisionWithDisabledModuleExtraWhiteSpace = {
+    expr =
+      hasFailingAssertion ''services.speechd.extraConfig contains an AddModule directive for "''
+        (evalSpeechd {
+          services.speechd = {
+            enable = true;
+            modules.pico.enable = false;
+            extraConfig = ''
+              AddModule                       "pico" "sd_pico"      "pico.conf"
+            '';
+          };
+        });
+    expected = true;
+  };
+
+  testModuleExtraConfigAddModuleCollisionWithExtraModule = {
+    expr =
+      hasFailingAssertion ''services.speechd.extraConfig contains an AddModule directive for "''
+        (evalSpeechd {
+          services.speechd = {
+            enable = true;
+            extraModules.myModules = ''Debug "1"'';
+            extraConfig = ''
+              AddModule "mymodules" "sd_generic"  "myModules.conf"
+            '';
+          };
+        });
+    expected = false;
+  };
+
+  testDefaultModuleUnknown = {
+    expr =
+      hasFailingAssertion
+        ''
+          but it
+          does not match the attribute name of an enabled module under
+          services.speechd.modules, nor a key in services.speechd.extraModules.
+        ''
+        (evalSpeechd {
+          services.speechd = {
+            enable = true;
+            defaultModule = "does-not-exist";
+          };
+        });
+    expected = true;
+  };
+
+  testUnrecognizedBackendName = {
+    expr =
+      hasFailingAssertion "services.speechd.modules contains unrecognized backend name(s):"
+        (evalSpeechd {
+          services.speechd = {
+            enable = true;
+            modules.doesNotExist.enable = true;
+          };
+        });
+    expected = true;
+  };
+
+  testExtraConfigLogLevelDirective = {
+    expr = hasFailingAssertion "services.speechd.extraConfig contains a" (evalSpeechd {
+      services.speechd = {
+        enable = true;
+        extraConfig = "LogLevel 5\n";
+      };
+    });
+    expected = true;
+  };
+}

--- a/nixos/tests/speechd/default.nix
+++ b/nixos/tests/speechd/default.nix
@@ -45,6 +45,28 @@
       moduleConfig.debug = true;
     }
   );
+  mary = runTest (
+    import ./module-test.nix {
+      inherit lib;
+      defaultModule = "mary";
+      moduleConfig = {
+        debug = true;
+        port = 5646;
+      };
+      extraNodeConfig = {
+        services.marytts = {
+          enable = true;
+          port = 5646;
+          voices = [
+            (pkgs.fetchzip {
+              url = "https://github.com/marytts/voice-bits1-hsmm/releases/download/v5.2/voice-bits1-hsmm-5.2.zip";
+              hash = "sha256-1nK+qZxjumMev7z5lgKr660NCKH5FDwvZ9sw/YYYeaA=";
+            })
+          ];
+        };
+      };
+    }
+  );
   pico = runTest (
     import ./module-test.nix {
       inherit lib;

--- a/nixos/tests/speechd/default.nix
+++ b/nixos/tests/speechd/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  pkgs,
+  runTest,
+}:
+{
+
+  # Assertion Tests
+  assertions =
+    let
+      failures = import ./assertions.nix { inherit lib pkgs; };
+      checked = lib.debug.throwTestFailures { inherit failures; };
+    in
+    builtins.seq checked (pkgs.runCommand "speechd-assertions-test" { } "touch $out");
+
+  # Modules tests
+  # keep-sorted start block=yes case=no
+  espeakNg = runTest (
+    import ./module-test.nix {
+      inherit lib;
+      defaultModule = "espeakNg";
+      moduleConfig.debug = true;
+    }
+  );
+  # FIXME uncomment when MBROLA voices are fixed in eSpeak
+  # https://github.com/NixOS/nixpkgs/pull/541467
+  # espeakNgMbrola = runTest (
+  #   import ./module-test.nix {
+  #     inherit lib;
+  #     defaultModule = "espeakNg";
+  #     moduleConfig = {
+  #       debug = true;
+  #       mbrola = true;
+  #       mbrolaVoices = [
+  #         "us1"
+  #         "en1"
+  #       ];
+  #     };
+  #   }
+  # );
+  flite = runTest (
+    import ./module-test.nix {
+      inherit lib;
+      defaultModule = "flite";
+      moduleConfig.debug = true;
+    }
+  );
+  pico = runTest (
+    import ./module-test.nix {
+      inherit lib;
+      defaultModule = "pico";
+      moduleConfig.debug = true;
+    }
+  );
+  # keep-sorted end
+}

--- a/nixos/tests/speechd/module-test.nix
+++ b/nixos/tests/speechd/module-test.nix
@@ -1,0 +1,124 @@
+{
+  lib,
+  defaultModule,
+  moduleConfig ? { },
+  otherModules ? { },
+  extraModulesConfig ? { },
+  extraConfigLines ? "",
+  extraChecks ? "",
+  audioOutputMethod ? [ "libao" ],
+  extraNodeConfig ? { },
+}:
+{
+  name = "speechd-${defaultModule}-${lib.concatStringsSep "-" audioOutputMethod}";
+
+  nodes.machine =
+    { config, pkgs, ... }:
+    lib.recursiveUpdate {
+      boot.kernelModules = [ "snd-aloop" ];
+
+      services.speechd = {
+        enable = true;
+        modules =
+          otherModules
+          // lib.optionalAttrs (moduleConfig != null) {
+            ${defaultModule} = {
+              enable = true;
+            }
+            // moduleConfig;
+          };
+        extraModules = extraModulesConfig;
+        defaultModule = defaultModule;
+        audioOutputMethod = audioOutputMethod;
+        logLevel = 5;
+        logDir = "/tmp/speech-debug";
+        extraConfig = extraConfigLines;
+      };
+
+      environment.systemPackages = [
+        pkgs.alsa-utils
+      ];
+
+      users.users.machine = {
+        isNormalUser = true;
+        linger = true;
+        password = "machine";
+      };
+    } extraNodeConfig;
+
+  testScript =
+    { nodes, ... }:
+    let
+      logDir = nodes.machine.services.speechd.logDir;
+    in
+    ''
+      import re
+
+      machine.start()
+      machine.wait_for_unit("multi-user.target")
+
+      machine.systemctl("reset-failed speech-dispatcher.service", "machine")
+      machine.systemctl("start speech-dispatcher.service", "machine")
+      machine.wait_for_unit("speech-dispatcher.service", "machine")
+
+      # --- Module test ---
+      machine.wait_until_succeeds(
+        "su - machine -c 'XDG_RUNTIME_DIR=/run/user/1000 spd-say -O | grep -q \"${defaultModule}\"'",
+        timeout=30,
+      )
+
+      # --- Log directory and Catch Start ---
+      machine.succeed("test -d ${logDir}")
+      machine.succeed("test -n \"$(ls ${logDir})\"")
+
+      # --- Sound Icons Test ---
+      machine.execute("arecord -D hw:Loopback,1,0 -f S16_LE -r 16000 -c 1 -d 5 /tmp/sound-icon-out.wav &")
+      machine.sleep(1)
+      status, out = machine.execute(
+        "su - machine -c 'XDG_RUNTIME_DIR=/run/user/1000 spd-say -I message' 2>&1"
+      )
+      print(f"sound_icon exit={status}\n{out}")
+      machine.sleep(2)
+      icon_size = int(machine.succeed("stat -c %s /tmp/sound-icon-out.wav").strip())
+      assert icon_size > 1_000, f"sound icon produced no audio: {icon_size} bytes"
+
+      # --- Audio output test ---
+      machine.execute("arecord -D hw:Loopback,1,0 -f S16_LE -r 16000 -c 1 -d 10 /tmp/spd-out.wav &")
+      machine.sleep(1)
+
+      machine.wait_until_succeeds("su - machine -c \"XDG_RUNTIME_DIR=/run/user/1000 spd-say -o ${defaultModule} -w 'Test a single sentence.'\"",
+        timeout=30,
+      )
+      machine.wait_until_succeeds("su - machine -c \"XDG_RUNTIME_DIR=/run/user/1000 spd-say -o ${defaultModule} -w 'Test from Speech Dispatcher via ${defaultModule}. Second sentence.'\"",
+        timeout=30,
+      )
+      machine.sleep(2)
+      spd_size = int(machine.succeed("stat -c %s /tmp/spd-out.wav").strip())
+      assert spd_size > 100_000, f"spd→${defaultModule} WAV too small, likely no audio: {spd_size} bytes"
+
+      # --- Rate / pitch / volume options ---
+      machine.succeed("su - machine -c \"XDG_RUNTIME_DIR=/run/user/1000 spd-say -o ${defaultModule} -r 50 -w 'Fast speech rate test.'\"")
+      machine.succeed("su - machine -c \"XDG_RUNTIME_DIR=/run/user/1000 spd-say -o ${defaultModule} -r -50 -w 'Slow speech rate test.'\"")
+      machine.succeed("su - machine -c \"XDG_RUNTIME_DIR=/run/user/1000 spd-say -o ${defaultModule} -p 50 -w 'High pitch test.'\"")
+      machine.succeed("su - machine -c \"XDG_RUNTIME_DIR=/run/user/1000 spd-say -o ${defaultModule} -i 50 -w 'High volume test.'\"")
+
+      # --- Log directory and content ---
+      machine.succeed("test -d ${logDir}")
+      machine.succeed("test -n \"$(ls ${logDir})\"")
+      machine.succeed("ls ${logDir}/${defaultModule}.log")
+
+      # --- No fatal errors in journal ---
+      journal = machine.succeed("su - machine -c 'journalctl --user --no-pager -o cat'")
+      pattern = re.compile(
+        r"Unknown Config-Option|Could not initialize engine|has no voice|"
+        r"Failed to set synthesis voice|Failed to set punctuation list|FATAL|core dumped",
+        re.IGNORECASE,
+      )
+      matches = [line for line in journal.splitlines() if pattern.search(line)]
+      if matches:
+        print("Found problem lines:\n" + "\n".join(matches))
+        raise AssertionError("Found error patterns in journal")
+
+      ${extraChecks}
+    '';
+}

--- a/pkgs/by-name/so/sound-icons/package.nix
+++ b/pkgs/by-name/so/sound-icons/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+
+  pname = "sound-icons";
+  version = "0.1";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchurl {
+    url = "https://freebsoft.org/pub/projects/${finalAttrs.pname}/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
+    hash = "sha256-OC3aHRSgezElqLUIRpWqm6XLD/8C5aq2n9bH4jy89Nc=";
+  };
+
+  dontBuild = true;
+  dontConfigure = true;
+  dontFixup = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/sounds/sound-icons
+    cp -r * $out/share/sounds/sound-icons
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Sound icons are a set of wave file used by eSpeak developed for Free(b)soft";
+    homepage = "https://freebsoft.org/index";
+    license = with lib.licenses; [
+      gpl2Only
+    ];
+    maintainers = with lib.maintainers; [ WiredMic ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I wanted to configure Speechd with the nix module system.
I later found https://github.com/NixOS/nixpkgs/issues/371533. 
However I think this PR is still vaild.

Speechd is old and does not move very fast.
I have only preconfigured what I think are the most useful options.
The TTS modules that I have not configured are either abandoned or not packaged in nixpkgs. 
I left them in for others to pick up later however I am willing to delete the commit where they came in. [nixos/speechd: add submodules the rest of spd modules](https://github.com/NixOS/nixpkgs/pull/541549/changes/fdbdee93287de31ce7b64d389f7f5170bd2aa605).

I other goal was to try and test that the TTS modules worked end to end with a NixOS test.

## Things done

### Sound-Icon
I packaged sound-icons which is used by Speechd and some of its modules.
It is a small set of audio files used to indicate a specific thing has happend. Like reaching the end of a line.

### Configuration
The configuration I added are based on the configs in `etc/speech-dispatcher/speechd.conf`.
- logLevel: Tells Speechd how much to log in its logfile
- logDir: This is where all log files are placed. It must be created. Done with `systemd.tmpfiles`.
- audioOutputMethod: Libao, Alsa, PulseAudio, and OSS. These where chosen because they where configured in the derivation.
- defaultModule

The freeform `config` has been renamed to `extraConfig`.

### Modules
I have added all modules in `etc/speech-dispatcher/modules`.
Many of them are a generic config because the text to speech module is not packaged in nixpkgs.
The modules where the text to speech engine is not packaged is set to be not visible.

The modules with I have configured are
- Pico
- eSpeak
- Flite
- Mary TTS
- Festival
In the future I would like to add Piper, when Speechd has a fixed version with its updated to include its `[cxxpiper](https://github.com/brailcom/speechd/blob/master/src/modules/cxxpiper.cpp)` module.

I chose these five deliberately: Festival because I use it personally and can verify it end-to-end; eSpeak, Flite, and Pico because they're existing dependencies of speechd/speech-dispatcher already in the closure; MaryTTS because it was already packaged in Nixpkgs and the config was cheap to add.

The freeform `modules` has been renamed to `extraModules`.
Freeform strings in `modules` will be passed to `extraModules` with a warning.
This will be removed in 27.05, together with the rename. 

### Client
The freeform `client` has been renamed to `extraClient` to make it possible to make predefined clients in the future.

### Tests

I have made tested the functionality and modules with a NixOS test.
It tests 
- Does the module appear  in `spd-say -O`. This forces an initiation of all of the modules.
- Does sound Icons work.
- Does the module produce audio. This is done with a loopback device. It test if it can speak with one and two sentences.
- Does the module produce sound with with different pitches and rates.
- The log test. Does the module place it log file in the LogDir
- Check jounalctl for errors.

Festival cannot be tested because it is not merged. 
However there is a speechd test i https://github.com/NixOS/nixpkgs/pull/536089 is a blocker.

I never found a good way to test the different audio output methods.


### Blokers
- [ ] For MBROLA to work with eSpeak then https://github.com/NixOS/nixpkgs/pull/541467 is a blocker.
- [ ] Festival is configured but untested. This is because Festival is not yest merged into nixpkgs https://github.com/NixOS/nixpkgs/pull/536089.
- [ ] For Pipewire as an audio output module https://github.com/NixOS/nixpkgs/pull/470797

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
