### PR TITLE
expresslrs-configurator: 1.7.11 -> 1.8.1

### DIFF
--- a/pkgs/by-name/ex/expresslrs-configurator/package.nix
+++ b/pkgs/by-name/ex/expresslrs-configurator/package.nix
@@ -12,7 +12,7 @@
 
 let
   pname = "expresslrs-configurator";
-  version = "1.7.11";
+  version = "1.8.1";
   installPath = "share/${pname}";
   resourcesPath = "${installPath}/resources";
 in
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
   src = fetchzip {
     url = "https://github.com/ExpressLRS/ExpressLRS-Configurator/releases/download/v${version}/${pname}-${version}.zip";
     stripRoot = false;
-    hash = "sha256-BIbJzNWjYFbbwCEWoym3g6XBpQGi2owbf2XsQiXwHmw=";
+    hash = "sha256-3f2/ifXLs/gHZVVDI0EUBP05FEHH8exDvBzALDXq0Wo=";
   };
 
   nativeBuildInputs = [
@@ -52,10 +52,6 @@ stdenv.mkDerivation {
     cp -r $src/locales $src/resources $out/${installPath}/
     chmod -R u+w $out/${resourcesPath}
 
-    # broken symlink
-    rm -f $out/${resourcesPath}/app.asar.unpacked/node_modules/@serialport/bindings-cpp/build/node_gyp_bins/python3
-    touch $out/${resourcesPath}/app.asar.unpacked/node_modules/@serialport/bindings-cpp/build/node_gyp_bins/python3
-
     # patch asar absolute paths
     asar extract $out/${resourcesPath}/app.asar $TMPDIR/app
     substituteInPlace $TMPDIR/app/dist/main/main.js \
@@ -70,6 +66,7 @@ stdenv.mkDerivation {
     makeWrapper '${lib.getExe electron}' "$out/bin/${pname}" \
       --add-flags "$out/${resourcesPath}/app.asar" \
       --prefix PATH : ${lib.makeBinPath [ git ]} \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ (lib.getLib stdenv.cc.cc) ]} \
       --set ELECTRON_OVERRIDE_DIST_PATH "${electron}/lib/electron" \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto}}"
 


### PR DESCRIPTION
Release notes:
https://github.com/ExpressLRS/ExpressLRS-Configurator/releases/tag/v1.8.1

Drop the serialport node_gyp_bins workaround because the path is no longer present in the 1.8.1 bundle. Add the C++ runtime library to the wrapper for the updated serialport native module.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
