### PR TITLE
coqPackages.coq-hammer: 1.3.2 → 1.3.3

### DIFF
--- a/pkgs/development/coq-modules/coq-hammer/tactics.nix
+++ b/pkgs/development/coq-modules/coq-hammer/tactics.nix
@@ -13,7 +13,8 @@ let
   defaultVersion =
 
     lib.switch coq.coq-version [
-      (case "9.1" "1.3.2+9.1")
+      (case "9.2" "1.3.3+9.2")
+      (case "9.1" "1.3.3+9.1")
       (case "9.0" "1.3.2+9.0")
       (case "8.20" "1.3.2+8.20")
       (case "8.19" "1.3.2+8.19")
@@ -23,6 +24,8 @@ let
     ] null;
 
   release = {
+    "1.3.3+9.2".hash = "sha256-2KE0mXpGTvoJXLoWsDTHKGrXKF0y8XEUSCXUQ4q+0YA=";
+    "1.3.3+9.1".hash = "sha256-iDOZii/JMXqtVGvuh3I1R4YxjqWKcAwCLWTPYca2Dik=";
     "1.3.2+9.1".hash = "sha256-tf+Hrfv/ZrLXryTjJchvLfydxzjkXB2hbL7P280Clzw=";
     "1.3.2+9.0".hash = "sha256-/UHtK9fjpHTbra4/Cnsjt8fg1fvxx7U6kGjQPm15NwM=";
     "1.3.2+8.20".hash = "sha256-RuX2aInSjwebs/aEOoisNxqcIPqDA2kWehN9tFYqOx4=";


### PR DESCRIPTION
Tested: https://github.com/rocq-community/coq-nix-toolbox/pull/484

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
