### PR TITLE
[release-26.05] codechecker: 6.24.0 -> 6.28.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13854,6 +13854,14 @@
     name = "Kenichi Kamiya";
     keys = [ { fingerprint = "9121 5D87 20CA B405 C63F  24D2 EF6E 574D 040A E2A5"; } ];
   };
+  kacper-uminski = {
+    name = "Kacper Uminski";
+    email = "kacper+nixpkgs@lysator.liu.se";
+    github = "kacper-uminski";
+    githubId = 57466578;
+    matrix = "@kacper.uminski:matrix.org";
+    keys = [ { fingerprint = "3DF9 3DEB CAA9 81FA B3E2  A7F0 87DA 201D E02F 14B1"; } ];
+  };
   kaction = {
     name = "Dmitry Bogatov";
     email = "KAction@disroot.org";

--- a/pkgs/by-name/co/codechecker/package.nix
+++ b/pkgs/by-name/co/codechecker/package.nix
@@ -1,65 +1,30 @@
 {
   lib,
-  python3,
   fetchPypi,
-  fetchFromGitHub,
-  clang,
+  makeWrapper,
+  python3Packages,
+  libclang,
   clang-tools,
   cppcheck,
   gcc,
-  makeWrapper,
+  infer,
   withClang ? false,
   withClangTools ? false,
   withCppcheck ? false,
   withGcc ? false,
+  withInfer ? false,
 }:
-let
-  python = python3.override {
-    packageOverrides = self: super: rec {
-      # codechecker is incompatible with SQLAlchemy greater than 1.3
-      sqlalchemy = super.sqlalchemy_1_4.overridePythonAttrs (oldAttrs: rec {
-        version = "1.3.23";
-        pname = oldAttrs.pname;
-        src = fetchFromGitHub {
-          owner = "sqlalchemy";
-          repo = "sqlalchemy";
-          rev = "rel_${lib.replaceStrings [ "." ] [ "_" ] version}";
-          hash = "sha256-hWA0/f7rQpEfYTg10i0rBK3qeJbw3p6HW7S59rLnD0Q=";
-        };
-        doCheck = false;
-        # That test does not exist in the 1.3 branch so we get an error for disabling it
-        disabledTestPaths = builtins.filter (
-          testPath: testPath != "test/ext/mypy"
-        ) oldAttrs.disabledTestPaths;
-      });
-      sqlalchemy_1_4 = sqlalchemy;
-
-      # The current alembic version is not compatible with SQLAlchemy 1.3 so we need to downgrade it
-      alembic = super.alembic.overridePythonAttrs (oldAttrs: rec {
-        pname = "alembic";
-        version = "1.5.5";
-        src = fetchPypi {
-          inherit pname version;
-          hash = "sha256-3wAowZJ1os/xN+OWF6Oc3NvRFzczuHtr+iV7fAhgITs=";
-        };
-        doCheck = false;
-        dependencies = oldAttrs.dependencies ++ [
-          super.python-dateutil
-          super.python-editor
-        ];
-      });
-    };
-  };
-  python3Packages = python.pkgs;
-in
 python3Packages.buildPythonApplication rec {
   pname = "codechecker";
-  version = "6.24.0";
+  version = "6.28.0";
   pyproject = true;
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-ftZACUf2lAHokcUXj45LRA7/3goOcIy521cGl6qhR98=";
+    hash = "sha256-wxV+/hzsk7RrzWTXNz5HyweYdFFI1upNS508QRPCefo=";
   };
 
   build-system = with python3Packages; [
@@ -67,40 +32,39 @@ python3Packages.buildPythonApplication rec {
   ];
 
   dependencies = with python3Packages; [
+    alembic
+    argcomplete
+    authlib
     distutils # required in python312 to call subcommands (see https://github.com/Ericsson/codechecker/issues/4350)
     lxml
-    sqlalchemy
-    alembic
+    multiprocess
     portalocker
     psutil
-    multiprocess
+    semver
+    sqlalchemy
     thrift
     gitpython
     pyyaml
+    requests
     types-pyyaml
     sarif-tools
+    types-psutil
   ];
 
-  pythonRelaxDeps = [
-    "thrift"
-    "portalocker"
-    "types-pyyaml"
-    "lxml"
-    "psutil"
-    "multiprocess"
-    "gitpython"
-    "sarif-tools"
-    "pyyaml"
+  pythonRelaxDeps = true;
+  nativeBuildInputs = with python3Packages; [
+    makeWrapper
+    pythonRelaxDepsHook
   ];
 
   postInstall = ''
     wrapProgram "$out/bin/CodeChecker" --prefix PATH : ${
       lib.makeBinPath (
-        [ ]
-        ++ lib.optional withClang clang
+        lib.optional withClang libclang
         ++ lib.optional withClangTools clang-tools
         ++ lib.optional withCppcheck cppcheck
         ++ lib.optional withGcc gcc
+        ++ lib.optional withInfer infer
       )
     }
   '';
@@ -116,6 +80,7 @@ python3Packages.buildPythonApplication rec {
     maintainers = with lib.maintainers; [
       zebreus
       felixsinger
+      kacper-uminski
     ];
     mainProgram = "CodeChecker";
     platforms = lib.platforms.darwin ++ lib.platforms.linux;

--- a/pkgs/by-name/co/codechecker/package.nix
+++ b/pkgs/by-name/co/codechecker/package.nix
@@ -7,12 +7,10 @@
   clang-tools,
   cppcheck,
   gcc,
-  infer,
   withClang ? false,
   withClangTools ? false,
   withCppcheck ? false,
   withGcc ? false,
-  withInfer ? false,
 }:
 python3Packages.buildPythonApplication rec {
   pname = "codechecker";
@@ -64,7 +62,6 @@ python3Packages.buildPythonApplication rec {
         ++ lib.optional withClangTools clang-tools
         ++ lib.optional withCppcheck cppcheck
         ++ lib.optional withGcc gcc
-        ++ lib.optional withInfer infer
       )
     }
   '';


### PR DESCRIPTION
- **maintainers: add kacper-uminski**
- **codechecker: 6.24.0 -> 6.28.0**
- **codechecker: remove withInfer (not backported)**

partial backport of https://github.com/NixOS/nixpkgs/pull/535237


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
