### PR TITLE
libsoup_3: 3.6.6 -> 3.7.1

### DIFF
--- a/pkgs/development/libraries/libsoup/3.x.nix
+++ b/pkgs/development/libraries/libsoup/3.x.nix
@@ -7,6 +7,7 @@
   ninja,
   pkg-config,
   gnome,
+  zstd,
   libsysprof-capture,
   sqlite,
   buildPackages,
@@ -24,7 +25,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libsoup";
-  version = "3.6.6";
+  version = "3.7.1";
 
   outputs = [
     "out"
@@ -34,7 +35,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    hash = "sha256-Ue0K4G+dWkD0Af9Fni5fZS+aUQt3MOE1nuZtFNSHJ0A=";
+    hash = "sha256-nJbhG7kWQf4hlIATSZynFjk8npM2Vi+f+EnEHU7auA4=";
   };
 
   depsBuildBuild = [
@@ -60,6 +61,7 @@ stdenv.mkDerivation rec {
     glib.out
     brotli
     libnghttp2
+    zstd
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     libsysprof-capture


### PR DESCRIPTION
Fixes varios security issues:
- CVE-2026-0719
- CVE-2026-0716 (previous fix was incomplete)
- CVE-2026-6324
- CVE-2026-5119
- CVE-2026-4271
- CVE-2026-1536
- CVE-2026-2708
- CVE-2026-2369

Upstream does not make it exactly obvious which commit fixes what CVE, and does not publish a full list of CVEs in the release notes. Above list was manually created by going through recent CVEs and reading associated fix MRs.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
