### PR TITLE
sketchybar: fix darwin build

### DIFF
--- a/pkgs/by-name/sk/sketchybar/package.nix
+++ b/pkgs/by-name/sk/sketchybar/package.nix
@@ -5,6 +5,7 @@
   nix-update-script,
   apple-sdk_15,
   versionCheckHook,
+  llvmPackages,
 }:
 
 let
@@ -28,11 +29,19 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-5tyc/yYzdV/3JTtujuj7le/14XkC7TlN/nZg7tOZsNg=";
   };
 
+  nativeBuildInputs = [
+    # TODO: Remove once #536365 reaches this branch
+    llvmPackages.lld
+  ];
+
   buildInputs = [
     apple-sdk_15
   ];
 
   makeFlags = [ target ];
+
+  # TODO: Remove once #536365 reaches this branch
+  env.NIX_CFLAGS_LINK = "-fuse-ld=lld";
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
Build currently fails on darwin with:

```
/nix/store/pnd38c1w69ajjfmpsajbz7i72jd2i62v-cctools-binutils-darwin-wrapper-1010.6/bin/ld: line 292: 22808 Trace/BPT trap: 5          /nix/store/zhb8xrwn0mp0xk3argfbh8w73c4ci>
clang: error: linker command failed with exit code 133 (use -v to see invocation)
make: *** [makefile:59: bin/sketchybar] Error 1
```

This fixes it.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
