### PR TITLE
microfetch: 1.1.0 -> 1.2.0; re-enable checks & add Darwin to platforms

### DIFF
--- a/pkgs/by-name/mi/microfetch/package.nix
+++ b/pkgs/by-name/mi/microfetch/package.nix
@@ -9,24 +9,20 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "microfetch";
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "NotAShelf";
     repo = "microfetch";
     tag = "${finalAttrs.version}";
-    hash = "sha256-akJ44+X1POnV1dZnWq66X5vWokp9TGgJ5/Ey6kh/icA=";
+    hash = "sha256-Hi9U1WqCCoXnZx8ZgT5+fT2grTdNPC73fTAn0l9kzkg=";
   };
 
-  cargoHash = "sha256-mVS1fv/FI3rDoNm2D7ToiqZJZuySggK2zW2KbbxtpuQ=";
+  cargoHash = "sha256-7tN5E95uEJBUT1OMAnjkXnbSZjO23KWi8Vc3Cic9nek=";
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ mold ];
 
   passthru.updateScript = nix-update-script { };
-
-  # For whatever reason the cargo test build in the checkphase attempts to use dynamic libraries.
-  # Could be wrong, but rectifying this is probably more of an investment than it's worth.
-  doCheck = false;
 
   meta = {
     description = "Microscopic fetch script in Rust, for NixOS systems";
@@ -37,6 +33,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       NotAShelf
     ];
     mainProgram = "microfetch";
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ [ "aarch64-darwin" ];
   };
 })


### PR DESCRIPTION
Bumps Microfetch to 1.2.0, which includes some minor fixes and new platform support. Besides the ton of exotic arches, Darwin is now supported so we can enable it in platforms now. I've also went ahead and re-enabled the tests after fixing it upstream. @notarin has identified that `checkPhase` is broken, but with [this commit](https://github.com/NotAShelf/microfetch/commit/8cdeccbaf56e1dbcb63603b0494dd084dcc16098) it seems to be working again.

https://github.com/NotAShelf/microfetch/compare/1.1.0...1.2.0

Change-Id: I0b85aad1f06925802e7e1fbe1a2bac966a6a6964


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
