### PR TITLE
python3Packages.mutf8: 1.0.6 -> 1.1.1

### DIFF
--- a/pkgs/development/python-modules/mutf8/default.nix
+++ b/pkgs/development/python-modules/mutf8/default.nix
@@ -3,25 +3,31 @@
   buildPythonPackage,
   fetchFromGitHub,
   pytest,
+  setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "mutf8";
-  version = "1.0.6";
-  format = "setuptools";
+  version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "TkTech";
     repo = "mutf8";
-    rev = "v${version}";
-    hash = "sha256-4Ojn3t0EbOVdrYEiY8JegJuvW9sz8jt9tKFwOluiGQo=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Vtfdik+g2jnadslfthGXJWJidzR1BJibod10Wla6lSg=";
   };
 
-  nativeCheckInputs = [ pytest ];
+  __structuredAttrs = true;
 
+  pyproject = true;
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ pytest ];
   checkPhase = ''
+    runHook preCheck
     # Using pytestCheckHook results in test failures
     pytest
+    runHook postCheck
   '';
 
   pythonImportsCheck = [ "mutf8" ];
@@ -32,4 +38,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})


### PR DESCRIPTION
Changelog: https://github.com/TkTech/mutf8/releases/tag/v1.1.0 (v1.1.1 seems to identical aside from the list of provided wheels)

Also migrate to `pyproject` (#515974), set `__structuredAttrs`, use `tag` instead of `rev`, `finalAttrs` instead of `rec`, and `runHook` where needed.

Closes #541572
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
