### PR TITLE
nocturne: add versionCheckHook

### DIFF
--- a/pkgs/by-name/no/nocturne/package.nix
+++ b/pkgs/by-name/no/nocturne/package.nix
@@ -25,6 +25,8 @@
   webp-pixbuf-loader,
   libavif,
   libheif,
+  versionCheckHook,
+  fontconfig,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -103,6 +105,18 @@ stdenv.mkDerivation (finalAttrs: {
 
   # avoid installing Navidrome at runtime if not available, incompatible with the nix store
   patches = [ ./disable-navidrome-setup.patch ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckKeepEnvironment = [
+    "XDG_CACHE_HOME"
+    "FONTCONFIG_FILE"
+  ];
+  # it still errors due to lack of display, but the retcode is 0 and the version is printed
+  preInstallCheck = ''
+    export XDG_CACHE_HOME=$(mktemp -d)
+    export FONTCONFIG_FILE="${fontconfig.out}/etc/fonts/fonts.conf"
+  '';
 
   meta = {
     description = "Adwaita music player for OpenSubsonic servers like Navidrome";


### PR DESCRIPTION
* tested before and after https://github.com/NixOS/nixpkgs/pull/541518
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
