### PR TITLE
haskell.compiler.ghc966: bootstrap natively on riscv64-linux

### DIFF
--- a/pkgs/development/compilers/ghc/9.6.6-debian-binary.nix
+++ b/pkgs/development/compilers/ghc/9.6.6-debian-binary.nix
@@ -12,6 +12,7 @@
   libffi,
   coreutils,
   targetPackages,
+  llvmPackages_18,
 }:
 
 # Prebuilt only does native
@@ -24,6 +25,7 @@ let
   # We're using Debian's binary package, and patching it into a usable-in-Nixpkgs state.
   ghcDebs = {
     powerpc64-linux = {
+      toolPrefix = "powerpc64-linux-gnu-";
       src = {
         urls = [
           "http://ftp.ports.debian.org/debian-ports/pool-ppc64/main/g/ghc/ghc_9.6.6-4_ppc64.deb"
@@ -32,6 +34,35 @@ let
         sha256 = "722cc301b6ba70b342e5e3d9d0671440bcd749cd2f13dcccbd23c3f6a6060171";
       };
       exePathForLibraryCheck = null;
+      archSpecificLibraries = [
+        {
+          nixPackage = gmp;
+          fileToCheckFor = null;
+        }
+        {
+          nixPackage = ncurses6;
+          fileToCheckFor = "libtinfo.so.6";
+        }
+        {
+          nixPackage = numactl;
+          fileToCheckFor = null;
+        }
+        {
+          nixPackage = libffi;
+          fileToCheckFor = null;
+        }
+      ];
+    };
+    riscv64-linux = {
+      toolPrefix = "riscv64-linux-gnu-";
+      src = {
+        urls = [
+          "https://deb.debian.org/debian/pool/main/g/ghc/ghc_9.6.6-4_riscv64.deb"
+          "https://snapshot.debian.org/archive/debian/20250218T211057Z/pool/main/g/ghc/ghc_9.6.6-4_riscv64.deb"
+        ];
+        sha256 = "01ff1fdec9e7581b05998b216399b316c41bdbbc813e3379c7f7a38223550ad0";
+      };
+      exePathForLibraryCheck = "ghc-debian-binary-9.6.6/usr/lib/ghc/bin/ghc-9.6.6";
       archSpecificLibraries = [
         {
           nixPackage = gmp;
@@ -66,7 +97,9 @@ let
     targetPackages.stdenv.cc
     targetPackages.stdenv.cc.bintools
     coreutils # for cat
-  ];
+  ]
+  # GHC 9.6 has no NCG for riscv64, it uses LLVM.
+  ++ lib.optionals stdenv.hostPlatform.isRiscV64 [ llvmPackages_18.llvm ];
 
   extraLibraryMapping = {
     gmp = gmpUsed;
@@ -191,11 +224,11 @@ stdenv.mkDerivation (finalAttrs: {
     # Patch ghc settings
     + ''
       substituteInPlace $out/lib/ghc/lib/settings \
-        --replace-fail powerpc64-linux-gnu-gcc gcc \
-        --replace-fail powerpc64-linux-gnu-g++ g++ \
-        --replace-fail powerpc64-linux-gnu-ld ld \
-        --replace-fail powerpc64-linux-gnu-ar ar \
-        --replace-fail powerpc64-linux-gnu-ranlib ranlib \
+        --replace-fail ${debUsed.toolPrefix}gcc gcc \
+        --replace-fail ${debUsed.toolPrefix}g++ g++ \
+        --replace-fail ${debUsed.toolPrefix}ld ld \
+        --replace-fail ${debUsed.toolPrefix}ar ar \
+        --replace-fail ${debUsed.toolPrefix}ranlib ranlib \
         --replace-fail llc-18 llc \
         --replace-fail opt-18 opt
     '';

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -917,6 +917,7 @@ stdenv.mkDerivation (
 
       inherit llvmPackages;
       inherit enableShared;
+      inherit enableProfiledLibs;
       inherit hasHaddock;
 
       # Expose hadrian used for bootstrapping, for debugging purposes

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -121,7 +121,7 @@ in
   doHaddockQuickjump ? doHoogle,
   doInstallIntermediates ? false,
   editedCabalFile ? null,
-  enableLibraryProfiling ? !stdenv.hostPlatform.isGhcjs,
+  enableLibraryProfiling ? !stdenv.hostPlatform.isGhcjs && (ghc.enableProfiledLibs or true),
   enableExecutableProfiling ? false,
   profilingDetail ? "exported-functions",
   # TODO enable shared libs for cross-compiling

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -153,6 +153,8 @@ in
           then
             # No bindist, "borrowing" the GHC from Debian
             bb.packages.ghc966DebianBinary
+          else if stdenv.buildPlatform.isRiscV64 then
+            bb.packages.ghc966DebianBinary
           else if stdenv.buildPlatform.isi686 then
             bb.packages.ghc967
           else


### PR DESCRIPTION
This PR : 

Unlock GHC 9.10.3 for riscv64 example : pandoc or nixfmt (haskell version).

```
nixfmt --version
nixfmt 1.4.0
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] riscv64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
