### PR TITLE
blackhole: 0.6.1 -> 0.7.1

### DIFF
--- a/pkgs/by-name/bl/blackhole/package.nix
+++ b/pkgs/by-name/bl/blackhole/package.nix
@@ -7,15 +7,18 @@
   nix-update-script,
   channel ? "256ch",
 }:
+let
+  numChannels = lib.toIntBase10 (lib.removeSuffix "ch" channel);
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "blackhole";
-  version = "0.6.1";
+  version = "0.7.1";
 
   src = fetchFromGitHub {
     owner = "existentialaudio";
     repo = "BlackHole";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-jFKi5LJdTOMFa1mErH6WsjgCtLCKzwpgn2+T3Fp9MtQ=";
+    hash = "sha256-kuIaoXA0K7SFPXKFHqcilTbf1zn9Ol3JYVpnkFuQEZg=";
   };
 
   nativeBuildInputs = [
@@ -31,14 +34,14 @@ stdenv.mkDerivation (finalAttrs: {
     "-configuration"
     "Release"
     "PRODUCT_BUNDLE_IDENTIFIER=${finalAttrs.bundleId}"
-    "GCC_PREPROCESSOR_DEFINITIONS=$GCC_PREPROCESSOR_DEFINITIONS kDriver_Name=\\\"blackhole${channel}\\\" kPlugIn_BundleID=\\\"${finalAttrs.bundleId}\\\" kPlugIn_Icon=\\\"BlackHole.icns\\\""
+    "GCC_PREPROCESSOR_DEFINITIONS=$GCC_PREPROCESSOR_DEFINITIONS kNumber_Of_Channels=${toString numChannels} kDriver_Name=\\\"BlackHole\\\" kPlugIn_BundleID=\\\"${finalAttrs.bundleId}\\\" kPlugIn_Icon=\\\"BlackHole.icns\\\""
   ];
 
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/Library/Audio/Plug-Ins/HAL
-    mv Products/Release/BlackHole.driver $out/Library/Audio/Plug-Ins/HAL/Blackhole${channel}.driver
+    mv Products/Release/BlackHole.driver $out/Library/Audio/Plug-Ins/HAL/BlackHole${channel}.driver
 
     runHook postInstall
   '';


### PR DESCRIPTION
Bump BlackHole from 0.6.1 to 0.7.1 and fix the `kNumber_Of_Channels` compiler flag.

Previously, the `kNumber_Of_Channels` preprocessor definition was not passed,
causing it to always default to 2 regardless of the `channel` parameter
(e.g., "256ch" would report only 2 audio channels). Now the numeric channel
count is extracted from the `channel` parameter and passed to the compiler.

Changelog: https://github.com/ExistentialAudio/BlackHole/releases/tag/v0.7.1
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ x Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
