### PR TITLE
ioquake3: fix riscv cross-compilation

### DIFF
--- a/pkgs/by-name/io/ioquake3/package.nix
+++ b/pkgs/by-name/io/ioquake3/package.nix
@@ -20,6 +20,7 @@
   mumble,
   unstableGitUpdater,
   bc,
+  buildPackages,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -32,6 +33,11 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "8d2c2b42a55598d99873203194d13161ec2789c6";
     hash = "sha256-OszPRlS5NTvajDZhtGw2wa275O8YodkIgiBz3POouYs=";
   };
+
+  makeFlags = [
+    "ARCH=${stdenv.hostPlatform.parsed.cpu.name}"
+    "NO_STRIP=1"
+  ];
 
   nativeBuildInputs = [
     copyDesktopItems
@@ -54,6 +60,8 @@ stdenv.mkDerivation (finalAttrs: {
     freetype
     mumble
   ];
+
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
Tested with
```
nix build -L .#pkgsCross.riscv64.ioquake3
```

Without this fix compilation will fail with:
```
ioquake3-riscv64-unknown-linux-gnu> CC code/asm/snapvector.c
ioquake3-riscv64-unknown-linux-gnu> CC code/asm/ftola.c
ioquake3-riscv64-unknown-linux-gnu> riscv64-unknown-linux-gnu-gcc: error: '-march=k8': ISA string must begin with rv32 or rv64
ioquake3-riscv64-unknown-linux-gnu> make[2]: *** [Makefile:2976: build/release-linux-x86_64/ded/snapvector.o] Error 1
ioquake3-riscv64-unknown-linux-gnu> make[2]: *** Waiting for unfinished jobs....
ioquake3-riscv64-unknown-linux-gnu> riscv64-unknown-linux-gnu-gcc: error: '-march=k8': ISA string must begin with rv32 or rv64
ioquake3-riscv64-unknown-linux-gnu> make[2]: *** [Makefile:2976: build/release-linux-x86_64/ded/ftola.o] Error 1
ioquake3-riscv64-unknown-linux-gnu> code/botlib/l_precomp.c: In function 'PC_StringizeTokens':
ioquake3-riscv64-unknown-linux-gnu> code/botlib/l_precomp.c:471:17: warning: '__builtin___strncat_chk' output may be truncated copying between 0 and 1023 bytes from a string of length 1023 [-Wstringop-truncation]
ioquake3-riscv64-unknown-linux-gnu>   471 |                 strncat(token->string, t->string, MAX_TOKEN - strlen(token->string) - 1);
ioquake3-riscv64-unknown-linux-gnu>       |                 ^
ioquake3-riscv64-unknown-linux-gnu> make[2]: Leaving directory '/build/source'
ioquake3-riscv64-unknown-linux-gnu> make[1]: *** [Makefile:1615: targets] Error 2
ioquake3-riscv64-unknown-linux-gnu> make[1]: Leaving directory '/build/source'
ioquake3-riscv64-unknown-linux-gnu> make: *** [Makefile:1526: release] Error 2
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
