### PR TITLE
lomiri.lomiri-session: 0.3 -> 0.4

### DIFF
--- a/pkgs/desktops/lomiri/data/lomiri-session/1001-Unset-QT_QPA_PLATFORMTHEME.patch
+++ b/pkgs/desktops/lomiri/data/lomiri-session/1001-Unset-QT_QPA_PLATFORMTHEME.patch
@@ -13,13 +13,13 @@ index 50dd4cb..ffc20c4 100755
 --- a/lomiri-session.in
 +++ b/lomiri-session.in
 @@ -55,6 +55,7 @@ dbus-update-activation-environment --systemd MALIIT_FORCE_DBUS_CONNECTION=1
- dbus-update-activation-environment --systemd QT_IM_MODULE=maliit
- dbus-update-activation-environment --systemd GTK_IM_MODULE=maliit
- dbus-update-activation-environment --systemd QT_QPA_PLATFORM=wayland
+ dbus-update-activation-environment --systemd QT_IM_MODULE="${QT_IM_MODULE}"
+ dbus-update-activation-environment --systemd GTK_IM_MODULE="${DEFAULT_GTK_IM_MODULE:-maliit}"
+ dbus-update-activation-environment --systemd QT_QPA_PLATFORM="${QT_QPA_PLATFORM}"
 +dbus-update-activation-environment --systemd QT_QPA_PLATFORMTHEME=
- dbus-update-activation-environment --systemd SDL_VIDEODRIVER=wayland
- dbus-update-activation-environment --systemd QT_WAYLAND_DISABLE_WINDOWDECORATION=1
- dbus-update-activation-environment --systemd QT_ACCESSIBILITY=1
+ dbus-update-activation-environment --systemd SDL_VIDEODRIVER="${DEFAULT_SDL_VIDEODRIVER:-wayland}"
+ dbus-update-activation-environment --systemd QT_WAYLAND_DISABLE_WINDOWDECORATION="${DEFAULT_QT_WAYLAND_DISABLE_WINDOWDECORATION:-1}"
+ dbus-update-activation-environment --systemd QT_ACCESSIBILITY="${DEFAULT_QT_ACCESSIBILITY:-1}"
 -- 
 2.44.1
 

--- a/pkgs/desktops/lomiri/data/lomiri-session/default.nix
+++ b/pkgs/desktops/lomiri/data/lomiri-session/default.nix
@@ -8,23 +8,26 @@
   cmake,
   dbus,
   deviceinfo,
+  glib,
   inotify-tools,
   lomiri,
+  lomiri-schemas,
   makeWrapper,
   pkg-config,
   systemd,
+  wrapGAppsHook4,
   xdg-user-dirs,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "lomiri-session";
-  version = "0.3";
+  version = "0.4";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lomiri-session";
     rev = finalAttrs.version;
-    hash = "sha256-XduE3tPUjw/wIjFCACasxtN33KO4bDLWrpl7pZcYaAA=";
+    hash = "sha256-zEH1VNBgOs9xP18toBc2VqMloDM6uL+tSIIEKZTHY0c=";
   };
 
   patches = [ ./1001-Unset-QT_QPA_PLATFORMTHEME.patch ];
@@ -41,10 +44,17 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       --replace-fail '@CMAKE_INSTALL_FULL_LIBEXECDIR@/lomiri-session/run-systemd-session' '${lib.getExe' xdg-user-dirs "xdg-user-dirs-update"} && @CMAKE_INSTALL_FULL_LIBEXECDIR@/lomiri-session/run-systemd-session'
   '';
 
+  # Checks for run-time tools at configure-time
+  strictDeps = false;
+
+  __structuredAttrs = true;
+
   nativeBuildInputs = [
     cmake
+    glib # hook for wrapper arguments
     makeWrapper
     pkg-config
+    wrapGAppsHook4
   ];
 
   buildInputs = [
@@ -53,8 +63,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     dbus
     inotify-tools
     lomiri
+    lomiri-schemas # for hook to pick up schemas
     systemd
   ];
+
+  dontWrapGApps = true;
 
   cmakeFlags = [
     # Requires lomiri-system-compositor -> not ported to Mir 2.x yet
@@ -63,14 +76,24 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   postInstall = ''
     patchShebangs $out/bin/lomiri-session
-    wrapProgram $out/bin/lomiri-session \
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
       --prefix PATH : ${
         lib.makeBinPath [
-          deviceinfo
+          deviceinfo # device-info
+          glib # gsettings
           inotify-tools
           lomiri
+          systemd # systemd-detect-virt
         ]
       }
+    )
+  '';
+
+  postFixup = ''
+    wrapGApp $out/bin/lomiri-session
   '';
 
   passthru = {
@@ -79,7 +102,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       # not packaged/working yet
       # "lomiri-touch"
     ];
-    tests.lomiri = nixosTests.lomiri;
+    tests = nixosTests.lomiri;
     updateScript = gitUpdater { };
   };
 


### PR DESCRIPTION
https://gitlab.com/ubports/development/core/lomiri-session/-/blob/0.4/ChangeLog

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
