### PR TITLE
llvm-mos: init at 0-unstable-2026-04-23

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16123,6 +16123,13 @@
     githubId = 78693624;
     name = "llakala";
   };
+  llamato = {
+    email = "tguessbacher@gmx.de";
+    github = "llamato";
+    githubId = 7943059;
+    name = "llamato";
+    keys = [ { fingerprint = "5B27 0167 DF91 4022 28CA C1F2 9683 C220 A49A 0E99"; } ];
+  };
   llehouerou = {
     email = "laurent@lehouerou.net";
     github = "llehouerou";

--- a/pkgs/by-name/ll/llvm-mos/package.nix
+++ b/pkgs/by-name/ll/llvm-mos/package.nix
@@ -1,0 +1,134 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  python3,
+  libffi,
+  libxml2,
+  autoPatchelfHook,
+  pkg-config,
+  zlib,
+  SDL2,
+  zmusic,
+  libvpx,
+  libbacktrace,
+  ncurses,
+}:
+stdenv.mkDerivation {
+  pname = "llvm-mos";
+  version = "0-unstable-2026-04-23";
+
+  src = fetchFromGitHub {
+    owner = "llvm-mos";
+    repo = "llvm-mos";
+    rev = "9142aebae87d0bf6fc7c55b05a415f2c188b19f3";
+    fetchSubmodules = true;
+    hash = "sha256-nfd1m7FAIzTX+0Fgjv2bhN+YBv0a/6yo2Gm9m9g51qU=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    python3
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+    zlib
+    libxml2
+    libffi
+    SDL2
+    zmusic
+    libvpx
+    libbacktrace
+    ncurses
+  ];
+
+  configurePhase = ''
+    runHook preConfigure
+
+    cmake \
+      -G Ninja \
+      -S llvm \
+      -B build \
+      -C clang/cmake/caches/MOS.cmake \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DLLVM_ENABLE_PROJECTS="clang;lld" \
+      -DLLVM_ENABLE_RUNTIMES="" \
+      -DLLVM_BUILD_RUNTIME=OFF \
+      -DLLVM_INCLUDE_TESTS=OFF \
+      -DLLVM_INCLUDE_BENCHMARKS=OFF \
+      -DLLVM_INCLUDE_EXAMPLES=OFF \
+      -DLLVM_INCLUDE_DOCS=OFF \
+      -DLLVM_ENABLE_ASSERTIONS=OFF \
+      -DLLVM_ENABLE_DISTRIBUTION=OFF \
+      -DLLVM_DISTRIBUTION_COMPONENTS="" \
+      -DLLVM_INSTALL_TOOLCHAIN_ONLY=ON
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    cmake --build build \
+      --target \
+        clang \
+        lld \
+        llvm-ar \
+        llvm-ranlib \
+        llvm-objcopy \
+        llvm-objdump \
+        llvm-strip \
+      --parallel $NIX_BUILD_CORES
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+
+    install -Dm755 build/bin/clang \
+      $out/bin/mos-clang
+
+    install -Dm755 build/bin/clang++ \
+      $out/bin/mos-clang++
+
+    install -Dm755 build/bin/ld.lld \
+      $out/bin/mos-ld.lld
+
+    install -Dm755 build/bin/llvm-ar \
+      $out/bin/mos-ar
+
+    install -Dm755 build/bin/llvm-ranlib \
+      $out/bin/mos-ranlib
+
+    install -Dm755 build/bin/llvm-objcopy \
+      $out/bin/mos-objcopy
+
+    install -Dm755 build/bin/llvm-objdump \
+      $out/bin/mos-objdump
+
+    install -Dm755 build/bin/llvm-strip \
+      $out/bin/mos-strip
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "LLVM-MOS C compiler for 6502-based systems";
+    homepage = "https://llvm-mos.org";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ llamato ];
+  };
+}

--- a/pkgs/by-name/ll/llvm-mos/package.nix
+++ b/pkgs/by-name/ll/llvm-mos/package.nix
@@ -16,6 +16,7 @@
   libbacktrace,
   ncurses,
 }:
+
 stdenv.mkDerivation {
   pname = "llvm-mos";
   version = "0-unstable-2026-04-23";
@@ -51,82 +52,28 @@ stdenv.mkDerivation {
     ncurses
   ];
 
-  configurePhase = ''
-    runHook preConfigure
+  cmakeDir = "../llvm";
+  cmakeFlags = [
+    "-C"
+    "../clang/cmake/caches/MOS.cmake"
 
-    cmake \
-      -G Ninja \
-      -S llvm \
-      -B build \
-      -C clang/cmake/caches/MOS.cmake \
-      -DCMAKE_BUILD_TYPE=Release \
-      -DLLVM_ENABLE_PROJECTS="clang;lld" \
-      -DLLVM_ENABLE_RUNTIMES="" \
-      -DLLVM_BUILD_RUNTIME=OFF \
-      -DLLVM_INCLUDE_TESTS=OFF \
-      -DLLVM_INCLUDE_BENCHMARKS=OFF \
-      -DLLVM_INCLUDE_EXAMPLES=OFF \
-      -DLLVM_INCLUDE_DOCS=OFF \
-      -DLLVM_ENABLE_ASSERTIONS=OFF \
-      -DLLVM_ENABLE_DISTRIBUTION=OFF \
-      -DLLVM_DISTRIBUTION_COMPONENTS="" \
-      -DLLVM_INSTALL_TOOLCHAIN_ONLY=ON
-
-    runHook postConfigure
-  '';
-
-  buildPhase = ''
-    runHook preBuild
-
-    cmake --build build \
-      --target \
-        clang \
-        lld \
-        llvm-ar \
-        llvm-ranlib \
-        llvm-objcopy \
-        llvm-objdump \
-        llvm-strip \
-      --parallel $NIX_BUILD_CORES
-
-    runHook postBuild
-  '';
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/bin
-
-    install -Dm755 build/bin/clang \
-      $out/bin/mos-clang
-
-    install -Dm755 build/bin/clang++ \
-      $out/bin/mos-clang++
-
-    install -Dm755 build/bin/ld.lld \
-      $out/bin/mos-ld.lld
-
-    install -Dm755 build/bin/llvm-ar \
-      $out/bin/mos-ar
-
-    install -Dm755 build/bin/llvm-ranlib \
-      $out/bin/mos-ranlib
-
-    install -Dm755 build/bin/llvm-objcopy \
-      $out/bin/mos-objcopy
-
-    install -Dm755 build/bin/llvm-objdump \
-      $out/bin/mos-objdump
-
-    install -Dm755 build/bin/llvm-strip \
-      $out/bin/mos-strip
-
-    runHook postInstall
-  '';
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DLLVM_ENABLE_PROJECTS=clang;lld"
+    "-DLLVM_ENABLE_RUNTIMES="
+    "-DLLVM_BUILD_RUNTIME=OFF"
+    "-DLLVM_INCLUDE_TESTS=OFF"
+    "-DLLVM_INCLUDE_BENCHMARKS=OFF"
+    "-DLLVM_INCLUDE_EXAMPLES=OFF"
+    "-DLLVM_INCLUDE_DOCS=OFF"
+    "-DLLVM_ENABLE_ASSERTIONS=OFF"
+    "-DLLVM_ENABLE_DISTRIBUTION=OFF"
+    "-DLLVM_DISTRIBUTION_COMPONENTS="
+    "-DLLVM_INSTALL_TOOLCHAIN_ONLY=ON"
+  ];
 
   meta = {
     description = "LLVM-MOS C compiler for 6502-based systems";
-    homepage = "https://llvm-mos.org";
+    homepage = "https://llvm-mos.org/";
     license = lib.licenses.gpl3;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ llamato ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added llvm-mos c compiler for 6502 to nixpkgs.

This Toolchain brings modern C language features to the mos-65xx platform and the plethora of retro computer systems and game consoles running a cpu of that series.

Homepage: https://llvm-mos.org/
Github: https://github.com/llvm-mos/llvm-mos

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
