### PR TITLE
reindeer: added patch for rlimit lowering and bumped version

### DIFF
--- a/pkgs/by-name/re/reindeer/fix-rlimit-lowering.patch
+++ b/pkgs/by-name/re/reindeer/fix-rlimit-lowering.patch
@@ -1,0 +1,22 @@
+diff --git a/src/rlimit.rs b/src/rlimit.rs
+index bbf2d31..d9c89b4 100644
+--- a/src/rlimit.rs
++++ b/src/rlimit.rs
+@@ -16,8 +16,16 @@
+ //! is silently capped at `kern.maxfilesperproc`.
+
+ pub fn raise_nofile_limit() {
++    let (before, hard) = rlimit::Resource::NOFILE.get().unwrap();
+     match rlimit::increase_nofile_limit(rlimit::INFINITY) {
+-        Ok(new_limit) => log::debug!("RLIMIT_NOFILE soft limit set to {new_limit}"),
++        Ok(new_limit) => {
++            if new_limit >= before {
++                log::debug!("RLIMIT_NOFILE soft limit set to {new_limit}");
++            } else {
++                rlimit::Resource::NOFILE.set(before, hard).unwrap();
++                log::debug!("RLIMIT_NOFILE soft limit restored to {before}");
++            }
++        }
+         Err(err) => log::warn!("failed to raise RLIMIT_NOFILE: {err}"),
+     }
+ }

--- a/pkgs/by-name/re/reindeer/package.nix
+++ b/pkgs/by-name/re/reindeer/package.nix
@@ -19,6 +19,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   cargoHash = "sha256-nJU9ClYxRkAfFkOq1V7k34pjdqJntDr3gJekUibq304=";
+  patches = [
+    # increase_nofile_limit caps at kern.maxfilesperproc on macOS,
+    # which can be lower than an already-raised soft limit (a-la nix).
+    # we restore the OG limit
+    ./fix-rlimit-lowering.patch
+  ];
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/by-name/re/reindeer/package.nix
+++ b/pkgs/by-name/re/reindeer/package.nix
@@ -9,22 +9,23 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "reindeer";
-  version = "2026.05.04.00";
+  version = "2026.07.06.00";
 
   src = fetchFromGitHub {
     owner = "facebookincubator";
     repo = "reindeer";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-m27zMZbDv/2bXhb16rFxUUokEn0bxyrhpxlOSZvVcfk=";
+    hash = "sha256-fGGssXTktQiJ5iW9XiaVVmizJfEpuE9TGeYfE5kYpCQ=";
   };
 
-  cargoHash = "sha256-nJU9ClYxRkAfFkOq1V7k34pjdqJntDr3gJekUibq304=";
   patches = [
     # increase_nofile_limit caps at kern.maxfilesperproc on macOS,
     # which can be lower than an already-raised soft limit (a-la nix).
     # we restore the OG limit
     ./fix-rlimit-lowering.patch
   ];
+
+  cargoHash = "sha256-Gti6H0TN211d7OAqEQcGaC/awBrAix5g+zUOFqKermI=";
 
   nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION
not really feasible for submission upstream, as they don't have some
kind of build provenance checker, or otherwise i'd ask them to remove
the test...<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
