### PR TITLE
darwin.mkAppleDerivation: verify xcodeHash on the build platform

### DIFF
--- a/pkgs/os-specific/darwin/by-name/po/PowerManagement/package.nix
+++ b/pkgs/os-specific/darwin/by-name/po/PowerManagement/package.nix
@@ -20,7 +20,7 @@ in
 mkAppleDerivation {
   releaseName = "PowerManagement";
 
-  xcodeHash = "sha256-06rCxqBUrYqBY7BDZ6s/vSoviUAmIbsQP1pfrvR2Gpk=";
+  xcodeHash = "sha256-8dASJnzc7yZ4LNbanNjWuCoJunxAz/7R1Ulj/zOrkkI=";
 
   env.NIX_CFLAGS_COMPILE = "-I${privateHeaders}/include";
 

--- a/pkgs/os-specific/darwin/mk-apple-derivation/default.nix
+++ b/pkgs/os-specific/darwin/mk-apple-derivation/default.nix
@@ -3,6 +3,7 @@
   bootstrapStdenv,
   meson,
   ninja,
+  runCommand,
   sourceRelease,
   xcodeProjectCheckHook,
 }:
@@ -51,25 +52,46 @@ lib.extendMkDerivation {
       }
       // args.meta or { };
     }
-    // lib.optionalAttrs (args ? xcodeHash) {
-      postUnpack =
-        args.postUnpack or ""
-        + lib.concatMapStrings (
-          file:
-          if baseNameOf file == "meson.build.in" then
-            "substitute ${lib.escapeShellArg "${file}"} \"$sourceRoot/meson.build\" --subst-var version\n"
-          else
-            "cp ${lib.escapeShellArg "${file}"} \"$sourceRoot/\"${lib.escapeShellArg (baseNameOf file)}\n"
-        ) mesonFiles;
+    // lib.optionalAttrs (args ? xcodeHash) (
+      let
+        xcodeProject = args.xcodeProject or "${releaseName}.xcodeproj";
+      in
+      {
+        postUnpack =
+          args.postUnpack or ""
+          + lib.concatMapStrings (
+            file:
+            if baseNameOf file == "meson.build.in" then
+              "substitute ${lib.escapeShellArg "${file}"} \"$sourceRoot/meson.build\" --subst-var version\n"
+            else
+              "cp ${lib.escapeShellArg "${file}"} \"$sourceRoot/\"${lib.escapeShellArg (baseNameOf file)}\n"
+          ) mesonFiles;
 
-      xcodeProject = args.xcodeProject or "${releaseName}.xcodeproj";
+        inherit xcodeProject;
 
-      nativeBuildInputs = args.nativeBuildInputs or [ ] ++ [
-        meson
-        ninja
-        xcodeProjectCheckHook
-      ];
+        nativeBuildInputs = args.nativeBuildInputs or [ ] ++ [
+          meson
+          ninja
+          xcodeProjectCheckHook
+        ];
 
-      mesonBuildType = "release";
-    };
+        mesonBuildType = "release";
+
+        # build-platform check so CI catches stale xcodeHashes the Darwin-only postUnpack hook misses
+        passthru = lib.recursiveUpdate (args.passthru or { }) {
+          tests.xcodeProjectHash =
+            runCommand "${finalAttrs.pname}-xcodeproject-hash-check"
+              {
+                sourceRoot = "${finalAttrs.src}";
+                inherit xcodeProject;
+                inherit (args) xcodeHash;
+                nativeBuildInputs = [ xcodeProjectCheckHook ];
+              }
+              ''
+                verifyXcodeProjectHash
+                touch "$out"
+              '';
+        };
+      }
+    );
 }


### PR DESCRIPTION
- Corrects the darwin.PowerManagement xcodeHash, which still matched the previous source pin (1846.81.1) after the bump to 1846.101.2
- Adds a `passthru.tests.xcodeProjectHash` to `mkAppleDerivation` that re-checks the pinned Xcode project hash as an ordinary build-platform derivation, so a stale `xcodehash` fails in CI

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
