### PR TITLE
mpv-unwrapped: fix build on Darwin

### DIFF
--- a/pkgs/by-name/mp/mpv-unwrapped/package.nix
+++ b/pkgs/by-name/mp/mpv-unwrapped/package.nix
@@ -37,6 +37,7 @@
   libva,
   libvdpau,
   libxkbcommon,
+  llvmPackages,
   lua,
   makeBinaryWrapper,
   libgbm,
@@ -162,6 +163,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     buildPackages.darwin.sigtool
     swift
+    llvmPackages.lld
     makeBinaryWrapper
   ]
   ++ lib.optionals waylandSupport [ wayland-scanner ];
@@ -233,6 +235,9 @@ stdenv.mkDerivation (finalAttrs: {
   # ./osdep/mac/swift.h:270:9: fatal error: '.../app_bridge_objc-1.pch' file not found
   env = lib.optionalAttrs (stdenv.hostPlatform.isDarwin) {
     NIX_SWIFTFLAGS_COMPILE = "-disable-bridging-pch";
+    # Work around ld64's libc++ hardening issue.
+    # TODO: Remove once #536365 reaches this branch.
+    NIX_CFLAGS_LINK = "-fuse-ld=lld";
   };
 
   postBuild = lib.optionalString stdenv.hostPlatform.isDarwin ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fixes a build failure on darwin, following (essentially) the same pattern as in #541626 and other similar PRs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
