### PR TITLE
makeBinaryWrapper: fix read past NUL

### DIFF
--- a/pkgs/by-name/ma/makeBinaryWrapper/make-binary-wrapper.sh
+++ b/pkgs/by-name/ma/makeBinaryWrapper/make-binary-wrapper.sh
@@ -365,9 +365,15 @@ void set_env_prefix(char *env, char *sep, char *prefix) {
       }
       unsigned long sep_len = strlen(sep);
       int n_before = existing_prefix - existing_env;
-      assert_success(asprintf(&val, \"%s%s%.*s%s\", prefix, sep,
-                              n_before, existing_env,
-                              existing_prefix + prefix_len + sep_len));
+      char *end_ptr = existing_prefix + prefix_len;
+      if (*end_ptr == '\0') {
+        assert_success(asprintf(&val, \"%s%s%.*s\", prefix, sep,
+                                n_before - (int)sep_len, existing_env));
+      } else {
+        assert_success(asprintf(&val, \"%s%s%.*s%s\", prefix, sep,
+                                n_before, existing_env,
+                                existing_prefix + prefix_len + sep_len));
+      }
     } else {
       assert_success(asprintf(&val, \"%s%s%s\", prefix, sep, existing_env));
     }

--- a/pkgs/test/make-binary-wrapper/combination/combination.c
+++ b/pkgs/test/make-binary-wrapper/combination/combination.c
@@ -3,31 +3,86 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <stdio.h>
+#include <string.h>
 
 #define assert_success(e) do { if ((e) < 0) { perror(#e); abort(); } } while (0)
 
-void set_env_prefix(char *env, char *sep, char *prefix) {
-    char *existing = getenv(env);
-    if (existing) {
-        char *val;
-        assert_success(asprintf(&val, "%s%s%s", prefix, sep, existing));
-        assert_success(setenv(env, val, 1));
-        free(val);
-    } else {
-        assert_success(setenv(env, prefix, 1));
+int is_surrounded_by_sep(char *env, char *ptr, unsigned long len, char *sep) {
+  unsigned long sep_len = strlen(sep);
+
+  // Check left side (if not at start)
+  if (env != ptr) {
+    if (ptr - env < sep_len)
+      return 0;
+    if (strncmp(sep, ptr - sep_len, sep_len) != 0) {
+      return 0;
     }
+  }
+  // Check right side (if not at end)
+  char *end_ptr = ptr + len;
+  if (*end_ptr != '\0') {
+    if (strncmp(sep, ptr + len, sep_len) != 0) {
+      return 0;
+    }
+  }
+
+  return 1;
+}
+
+void set_env_prefix(char *env, char *sep, char *prefix) {
+  char *existing_env = getenv(env);
+  if (existing_env) {
+    char *val;
+
+    char *existing_prefix = strstr(existing_env, prefix);
+    unsigned long prefix_len = strlen(prefix);
+    // If the prefix already exists, remove the original
+    if (existing_prefix && is_surrounded_by_sep(existing_env, existing_prefix, prefix_len, sep)) {
+      if (existing_env == existing_prefix) {
+        return;
+      }
+      unsigned long sep_len = strlen(sep);
+      int n_before = existing_prefix - existing_env;
+      assert_success(asprintf(&val, "%s%s%.*s%s", prefix, sep,
+                              n_before, existing_env,
+                              existing_prefix + prefix_len + sep_len));
+    } else {
+      assert_success(asprintf(&val, "%s%s%s", prefix, sep, existing_env));
+    }
+    assert_success(setenv(env, val, 1));
+    free(val);
+  } else {
+    assert_success(setenv(env, prefix, 1));
+  }
 }
 
 void set_env_suffix(char *env, char *sep, char *suffix) {
-    char *existing = getenv(env);
-    if (existing) {
-        char *val;
-        assert_success(asprintf(&val, "%s%s%s", existing, sep, suffix));
-        assert_success(setenv(env, val, 1));
-        free(val);
+  char *existing_env = getenv(env);
+  if (existing_env) {
+    char *val;
+
+    char *existing_suffix = strstr(existing_env, suffix);
+    unsigned long suffix_len = strlen(suffix);
+    // If the suffix already exists, remove the original
+    if (existing_suffix && is_surrounded_by_sep(existing_env, existing_suffix, suffix_len, sep)) {
+      char *end_ptr = existing_suffix + suffix_len;
+      if (*end_ptr == '\0') {
+        return;
+      }
+      unsigned long sep_len = strlen(sep);
+      int n_before = existing_suffix - existing_env;
+      assert_success(asprintf(&val, "%.*s%s%s%s",
+                              n_before, existing_env,
+                              existing_suffix + suffix_len + sep_len,
+                              sep, suffix));
     } else {
-        assert_success(setenv(env, suffix, 1));
+      assert_success(asprintf(&val, "%s%s%s", existing_env, sep, suffix));
     }
+    assert_success(setenv(env, val, 1));
+    free(val);
+  } else {
+    assert_success(setenv(env, suffix, 1));
+  }
 }
 
 int main(int argc, char **argv) {

--- a/pkgs/test/make-binary-wrapper/combination/combination.c
+++ b/pkgs/test/make-binary-wrapper/combination/combination.c
@@ -43,9 +43,15 @@ void set_env_prefix(char *env, char *sep, char *prefix) {
       }
       unsigned long sep_len = strlen(sep);
       int n_before = existing_prefix - existing_env;
-      assert_success(asprintf(&val, "%s%s%.*s%s", prefix, sep,
-                              n_before, existing_env,
-                              existing_prefix + prefix_len + sep_len));
+      char *end_ptr = existing_prefix + prefix_len;
+      if (*end_ptr == '\0') {
+        assert_success(asprintf(&val, "%s%s%.*s", prefix, sep,
+                                n_before - (int)sep_len, existing_env));
+      } else {
+        assert_success(asprintf(&val, "%s%s%.*s%s", prefix, sep,
+                                n_before, existing_env,
+                                existing_prefix + prefix_len + sep_len));
+      }
     } else {
       assert_success(asprintf(&val, "%s%s%s", prefix, sep, existing_env));
     }

--- a/pkgs/test/make-binary-wrapper/default.nix
+++ b/pkgs/test/make-binary-wrapper/default.nix
@@ -59,6 +59,7 @@ let
       "overlength-strings"
       "prefix"
       "suffix"
+      "prefix-dedup-last"
     ] makeGoldenTest
     // lib.optionalAttrs (!stdenv.hostPlatform.isDarwin) {
       cross =

--- a/pkgs/test/make-binary-wrapper/overlength-strings/overlength-strings.c
+++ b/pkgs/test/make-binary-wrapper/overlength-strings/overlength-strings.c
@@ -3,19 +3,57 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <stdio.h>
+#include <string.h>
 
 #define assert_success(e) do { if ((e) < 0) { perror(#e); abort(); } } while (0)
 
-void set_env_prefix(char *env, char *sep, char *prefix) {
-    char *existing = getenv(env);
-    if (existing) {
-        char *val;
-        assert_success(asprintf(&val, "%s%s%s", prefix, sep, existing));
-        assert_success(setenv(env, val, 1));
-        free(val);
-    } else {
-        assert_success(setenv(env, prefix, 1));
+int is_surrounded_by_sep(char *env, char *ptr, unsigned long len, char *sep) {
+  unsigned long sep_len = strlen(sep);
+
+  // Check left side (if not at start)
+  if (env != ptr) {
+    if (ptr - env < sep_len)
+      return 0;
+    if (strncmp(sep, ptr - sep_len, sep_len) != 0) {
+      return 0;
     }
+  }
+  // Check right side (if not at end)
+  char *end_ptr = ptr + len;
+  if (*end_ptr != '\0') {
+    if (strncmp(sep, ptr + len, sep_len) != 0) {
+      return 0;
+    }
+  }
+
+  return 1;
+}
+
+void set_env_prefix(char *env, char *sep, char *prefix) {
+  char *existing_env = getenv(env);
+  if (existing_env) {
+    char *val;
+
+    char *existing_prefix = strstr(existing_env, prefix);
+    unsigned long prefix_len = strlen(prefix);
+    // If the prefix already exists, remove the original
+    if (existing_prefix && is_surrounded_by_sep(existing_env, existing_prefix, prefix_len, sep)) {
+      if (existing_env == existing_prefix) {
+        return;
+      }
+      unsigned long sep_len = strlen(sep);
+      int n_before = existing_prefix - existing_env;
+      assert_success(asprintf(&val, "%s%s%.*s%s", prefix, sep,
+                              n_before, existing_env,
+                              existing_prefix + prefix_len + sep_len));
+    } else {
+      assert_success(asprintf(&val, "%s%s%s", prefix, sep, existing_env));
+    }
+    assert_success(setenv(env, val, 1));
+    free(val);
+  } else {
+    assert_success(setenv(env, prefix, 1));
+  }
 }
 
 int main(int argc, char **argv) {

--- a/pkgs/test/make-binary-wrapper/overlength-strings/overlength-strings.c
+++ b/pkgs/test/make-binary-wrapper/overlength-strings/overlength-strings.c
@@ -43,9 +43,15 @@ void set_env_prefix(char *env, char *sep, char *prefix) {
       }
       unsigned long sep_len = strlen(sep);
       int n_before = existing_prefix - existing_env;
-      assert_success(asprintf(&val, "%s%s%.*s%s", prefix, sep,
-                              n_before, existing_env,
-                              existing_prefix + prefix_len + sep_len));
+      char *end_ptr = existing_prefix + prefix_len;
+      if (*end_ptr == '\0') {
+        assert_success(asprintf(&val, "%s%s%.*s", prefix, sep,
+                                n_before - (int)sep_len, existing_env));
+      } else {
+        assert_success(asprintf(&val, "%s%s%.*s%s", prefix, sep,
+                                n_before, existing_env,
+                                existing_prefix + prefix_len + sep_len));
+      }
     } else {
       assert_success(asprintf(&val, "%s%s%s", prefix, sep, existing_env));
     }

--- a/pkgs/test/make-binary-wrapper/prefix-dedup-last/prefix-dedup-last.c
+++ b/pkgs/test/make-binary-wrapper/prefix-dedup-last/prefix-dedup-last.c
@@ -63,8 +63,8 @@ void set_env_prefix(char *env, char *sep, char *prefix) {
 }
 
 int main(int argc, char **argv) {
-    set_env_prefix("PATH", ":", "/usr/bin/");
-    set_env_prefix("PATH", ":", "/usr/local/bin/");
+    putenv("PATH=/usr/bin:/usr/local/bin");
+    set_env_prefix("PATH", ":", "/usr/local/bin");
     argv[0] = "/send/me/flags";
     return execv("/send/me/flags", argv);
 }

--- a/pkgs/test/make-binary-wrapper/prefix-dedup-last/prefix-dedup-last.cmdline
+++ b/pkgs/test/make-binary-wrapper/prefix-dedup-last/prefix-dedup-last.cmdline
@@ -1,0 +1,2 @@
+--set PATH /usr/bin:/usr/local/bin \
+--prefix PATH : /usr/local/bin

--- a/pkgs/test/make-binary-wrapper/prefix-dedup-last/prefix-dedup-last.env
+++ b/pkgs/test/make-binary-wrapper/prefix-dedup-last/prefix-dedup-last.env
@@ -1,0 +1,3 @@
+PATH=/usr/local/bin:/usr/bin
+CWD=SUBST_CWD
+SUBST_ARGV0

--- a/pkgs/test/make-binary-wrapper/prefix/prefix.c
+++ b/pkgs/test/make-binary-wrapper/prefix/prefix.c
@@ -3,19 +3,57 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <stdio.h>
+#include <string.h>
 
 #define assert_success(e) do { if ((e) < 0) { perror(#e); abort(); } } while (0)
 
-void set_env_prefix(char *env, char *sep, char *prefix) {
-    char *existing = getenv(env);
-    if (existing) {
-        char *val;
-        assert_success(asprintf(&val, "%s%s%s", prefix, sep, existing));
-        assert_success(setenv(env, val, 1));
-        free(val);
-    } else {
-        assert_success(setenv(env, prefix, 1));
+int is_surrounded_by_sep(char *env, char *ptr, unsigned long len, char *sep) {
+  unsigned long sep_len = strlen(sep);
+
+  // Check left side (if not at start)
+  if (env != ptr) {
+    if (ptr - env < sep_len)
+      return 0;
+    if (strncmp(sep, ptr - sep_len, sep_len) != 0) {
+      return 0;
     }
+  }
+  // Check right side (if not at end)
+  char *end_ptr = ptr + len;
+  if (*end_ptr != '\0') {
+    if (strncmp(sep, ptr + len, sep_len) != 0) {
+      return 0;
+    }
+  }
+
+  return 1;
+}
+
+void set_env_prefix(char *env, char *sep, char *prefix) {
+  char *existing_env = getenv(env);
+  if (existing_env) {
+    char *val;
+
+    char *existing_prefix = strstr(existing_env, prefix);
+    unsigned long prefix_len = strlen(prefix);
+    // If the prefix already exists, remove the original
+    if (existing_prefix && is_surrounded_by_sep(existing_env, existing_prefix, prefix_len, sep)) {
+      if (existing_env == existing_prefix) {
+        return;
+      }
+      unsigned long sep_len = strlen(sep);
+      int n_before = existing_prefix - existing_env;
+      assert_success(asprintf(&val, "%s%s%.*s%s", prefix, sep,
+                              n_before, existing_env,
+                              existing_prefix + prefix_len + sep_len));
+    } else {
+      assert_success(asprintf(&val, "%s%s%s", prefix, sep, existing_env));
+    }
+    assert_success(setenv(env, val, 1));
+    free(val);
+  } else {
+    assert_success(setenv(env, prefix, 1));
+  }
 }
 
 int main(int argc, char **argv) {

--- a/pkgs/test/make-binary-wrapper/suffix/suffix.c
+++ b/pkgs/test/make-binary-wrapper/suffix/suffix.c
@@ -3,19 +3,59 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <stdio.h>
+#include <string.h>
 
 #define assert_success(e) do { if ((e) < 0) { perror(#e); abort(); } } while (0)
 
-void set_env_suffix(char *env, char *sep, char *suffix) {
-    char *existing = getenv(env);
-    if (existing) {
-        char *val;
-        assert_success(asprintf(&val, "%s%s%s", existing, sep, suffix));
-        assert_success(setenv(env, val, 1));
-        free(val);
-    } else {
-        assert_success(setenv(env, suffix, 1));
+int is_surrounded_by_sep(char *env, char *ptr, unsigned long len, char *sep) {
+  unsigned long sep_len = strlen(sep);
+
+  // Check left side (if not at start)
+  if (env != ptr) {
+    if (ptr - env < sep_len)
+      return 0;
+    if (strncmp(sep, ptr - sep_len, sep_len) != 0) {
+      return 0;
     }
+  }
+  // Check right side (if not at end)
+  char *end_ptr = ptr + len;
+  if (*end_ptr != '\0') {
+    if (strncmp(sep, ptr + len, sep_len) != 0) {
+      return 0;
+    }
+  }
+
+  return 1;
+}
+
+void set_env_suffix(char *env, char *sep, char *suffix) {
+  char *existing_env = getenv(env);
+  if (existing_env) {
+    char *val;
+
+    char *existing_suffix = strstr(existing_env, suffix);
+    unsigned long suffix_len = strlen(suffix);
+    // If the suffix already exists, remove the original
+    if (existing_suffix && is_surrounded_by_sep(existing_env, existing_suffix, suffix_len, sep)) {
+      char *end_ptr = existing_suffix + suffix_len;
+      if (*end_ptr == '\0') {
+        return;
+      }
+      unsigned long sep_len = strlen(sep);
+      int n_before = existing_suffix - existing_env;
+      assert_success(asprintf(&val, "%.*s%s%s%s",
+                              n_before, existing_env,
+                              existing_suffix + suffix_len + sep_len,
+                              sep, suffix));
+    } else {
+      assert_success(asprintf(&val, "%s%s%s", existing_env, sep, suffix));
+    }
+    assert_success(setenv(env, val, 1));
+    free(val);
+  } else {
+    assert_success(setenv(env, suffix, 1));
+  }
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
This fixes a bug in makeBinaryWrapper which corrupts path-like environment variables when using the prefix option and the path had an existing duplicate element in the last element. In this case the nul byte is skipped and the value is overread (likely into the next element).

This bug causes issues as env vars intended values get concatenated with neighboring values.

On my system this causes Gstreamer directories to be appended onto GIO modules path. This causes every GIO application to dlload all gstreamer modules, creating a flood of error logs, and also running initialization code in each of those modules.

This was also interesting to debug as the env variables passed to the program look completely correct since they are corrupted by makeBinaryWrapper; observing what pam outputs or what gets passed to the program look correct. This allows manipulating path-like env vars such that they appear different to the application executing the program and the actual program under the wrapper.

The makeBinaryWrapper tests were also failing (at least since the commit that introduced the above bug), so I have updated those tests to work as a separate commit before my change, and updated them as needed as part of the change commit. I also added a new test for this case.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [X] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
