### PR TITLE
sequoia-sq: 1.3.1 -> 1.4.0

### DIFF
--- a/pkgs/by-name/se/sequoia-sq/package.nix
+++ b/pkgs/by-name/se/sequoia-sq/package.nix
@@ -14,16 +14,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sequoia-sq";
-  version = "1.3.1";
+  version = "1.4.0";
 
   src = fetchFromGitLab {
     owner = "sequoia-pgp";
     repo = "sequoia-sq";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-lM+j1KtH3U/lbPXnKALAP75YokDufbdz8s8bjb0VXUY=";
+    hash = "sha256-+6QVRp0zDJIIv23YlAI/cspHuGc+YcWdPfJZIOxQRW8=";
   };
 
-  cargoHash = "sha256-3z1Qm/eeVlH0/x3C8PSSPIlQaRKk1U6mRlEiKk0AaVQ=";
+  cargoHash = "sha256-I6hPpRpILV+iU9erfVBQOXuICx4IvWvGyHWdep7jRm4=";
 
   nativeBuildInputs = [
     pkg-config
@@ -46,6 +46,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   env.ASSET_OUT_DIR = "/tmp/";
+
+  # key store daemon binds a loopback socket
+  __darwinAllowLocalNetworking = true;
 
   doCheck = true;
 

--- a/pkgs/by-name/se/sequoia-sq/package.nix
+++ b/pkgs/by-name/se/sequoia-sq/package.nix
@@ -25,6 +25,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-I6hPpRpILV+iU9erfVBQOXuICx4IvWvGyHWdep7jRm4=";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   nativeBuildInputs = [
     pkg-config
     rustPlatform.bindgenHook

--- a/pkgs/by-name/se/sequoia-sq/package.nix
+++ b/pkgs/by-name/se/sequoia-sq/package.nix
@@ -45,7 +45,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
   '';
 
-  env.ASSET_OUT_DIR = "/tmp/";
+  env.ASSET_OUT_DIR = "target";
 
   # key store daemon binds a loopback socket
   __darwinAllowLocalNetworking = true;
@@ -53,12 +53,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
   doCheck = true;
 
   postInstall = ''
-    installManPage /tmp/man-pages/*.*
+    installManPage ${finalAttrs.env.ASSET_OUT_DIR}/man-pages/*.*
     installShellCompletion \
       --cmd sq \
-      --bash /tmp/shell-completions/sq.bash \
-      --fish /tmp/shell-completions/sq.fish \
-      --zsh /tmp/shell-completions/_sq
+      --bash ${finalAttrs.env.ASSET_OUT_DIR}/shell-completions/sq.bash \
+      --fish ${finalAttrs.env.ASSET_OUT_DIR}/shell-completions/sq.fish \
+      --zsh ${finalAttrs.env.ASSET_OUT_DIR}/shell-completions/_sq
   '';
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/se/sequoia-sq/package.nix
+++ b/pkgs/by-name/se/sequoia-sq/package.nix
@@ -10,6 +10,7 @@
   openssl,
   cacert,
   sqlite,
+  versionCheckHook,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -54,6 +55,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   __darwinAllowLocalNetworking = true;
 
   doCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgramArg = "version";
 
   postInstall = ''
     installManPage ${finalAttrs.env.ASSET_OUT_DIR}/man-pages/*.*

--- a/pkgs/by-name/se/sequoia-sq/package.nix
+++ b/pkgs/by-name/se/sequoia-sq/package.nix
@@ -79,6 +79,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       minijackson
       doronbehar
       dvn0
+      anish
     ];
     mainProgram = "sq";
   };


### PR DESCRIPTION
- 1.4.0 adds post-quantum cryptography support (RFC 9980) via `sequoia-openpgp` 2.4 ([changelog](https://gitlab.com/sequoia-pgp/sequoia-sq/-/blob/v1.4.0/NEWS))
- `ASSET_OUT_DIR` was a shared `/tmp/`, which collides between `_nixbld` users on unsandboxed Darwin (`Permission denied` in `postInstall`). I switched to the in-tree `target` dir, matching `sequoia-git`

matches https://github.com/NixOS/nixpkgs/pull/541664. `sequoia-wot` will also likely be getting PQC soon in v0.16.0, these changes can get replicated there when that happens

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
