### PR TITLE
sequoia-sop: 0.37.3 -> 0.38.0

### DIFF
--- a/pkgs/by-name/se/sequoia-sop/package.nix
+++ b/pkgs/by-name/se/sequoia-sop/package.nix
@@ -22,6 +22,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-iKC6vIT8fVFv/Yx3YJUSCHyTOZ7X860Ak0l/+7lrU9Y=";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   nativeBuildInputs = [
     pkg-config
     rustPlatform.bindgenHook

--- a/pkgs/by-name/se/sequoia-sop/package.nix
+++ b/pkgs/by-name/se/sequoia-sop/package.nix
@@ -7,6 +7,7 @@
   rustPlatform,
   sqlite,
   pkg-config,
+  versionCheckHook,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -51,6 +52,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   doCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgramArg = "version";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/se/sequoia-sop/package.nix
+++ b/pkgs/by-name/se/sequoia-sop/package.nix
@@ -35,15 +35,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   buildFeatures = [ "cli" ];
 
-  env.ASSET_OUT_DIR = "/tmp/";
+  env.ASSET_OUT_DIR = "target";
 
   # Install manual pages
   postInstall = ''
-    installManPage /tmp/man-pages/*.*
+    installManPage ${finalAttrs.env.ASSET_OUT_DIR}/man-pages/*.*
     installShellCompletion --cmd sqop \
-      --bash /tmp/shell-completions/sqop.bash \
-      --fish /tmp/shell-completions/sqop.fish \
-      --zsh /tmp/shell-completions/_sqop
+      --bash ${finalAttrs.env.ASSET_OUT_DIR}/shell-completions/sqop.bash \
+      --fish ${finalAttrs.env.ASSET_OUT_DIR}/shell-completions/sqop.fish \
+      --zsh ${finalAttrs.env.ASSET_OUT_DIR}/shell-completions/_sqop
     # Also elv and powershell are generated there
   '';
 

--- a/pkgs/by-name/se/sequoia-sop/package.nix
+++ b/pkgs/by-name/se/sequoia-sop/package.nix
@@ -11,16 +11,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sequoia-sop";
-  version = "0.37.3";
+  version = "0.38.0";
 
   src = fetchFromGitLab {
     owner = "sequoia-pgp";
     repo = "sequoia-sop";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-7fyItwtzNia97fbLJ1YkpkS7KmCo3I81uksh3lNvxwU=";
+    hash = "sha256-3PxUXMLRBqw9GO0+wRiwI7P6/RH9vuAkSN4OnSxV0SQ=";
   };
 
-  cargoHash = "sha256-NrJYFf2bK/QwfFpIrPD8Zc9N/tKVbN2I48jA2B0rNWk=";
+  cargoHash = "sha256-iKC6vIT8fVFv/Yx3YJUSCHyTOZ7X860Ak0l/+7lrU9Y=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/se/sequoia-sop/package.nix
+++ b/pkgs/by-name/se/sequoia-sop/package.nix
@@ -63,7 +63,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://gitlab.com/sequoia-pgp/sequoia-sop";
     changelog = "https://gitlab.com/sequoia-pgp/sequoia-sop/-/blob/${finalAttrs.src.tag}/NEWS";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ doronbehar ];
+    maintainers = with lib.maintainers; [
+      doronbehar
+      anish
+    ];
     mainProgram = "sqop";
   };
 })


### PR DESCRIPTION
- 0.38.0 adds post-quantum cryptography support (RFC 9980) via `sequoia-openpgp` 2.4 ([changelog](https://gitlab.com/sequoia-pgp/sequoia-sop/-/blob/v0.38.0/NEWS))
- `ASSET_OUT_DIR` was a shared `/tmp/`, which collides between `_nixbld` users on unsandboxed Darwin (`Permission denied` in `postInstall`). I switched to the in-tree `target` dir, matching `sequoia-git`

matches https://github.com/NixOS/nixpkgs/pull/541659

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
