### PR TITLE
nixos-artwork.wallpapers: add KDE Plasma 6 support

### DIFF
--- a/pkgs/data/misc/nixos-artwork/wallpapers.nix
+++ b/pkgs/data/misc/nixos-artwork/wallpapers.nix
@@ -11,6 +11,7 @@ let
       version,
       src,
       description,
+      dimensions,
       license ? lib.licenses.free,
     }:
 
@@ -60,6 +61,18 @@ let
           X-KDE-PluginInfo-Name=${pname}
           _EOF
 
+                  # KDE 6
+                  ln -s $src $out/share/wallpapers/${pname}/contents/images/${dimensions}.png
+                  cat >>$out/share/wallpapers/${pname}/metadata.json <<_EOF
+          {
+            "KPlugin": {
+              "Id": "${pname}",
+              ${lib.optionalString (builtins.hasAttr "spdxId" license) "\"Licence\": \"${license.spdxId}\","}
+              "Name": "${pname}"
+            }
+          }
+          _EOF
+
                   runHook postInstall
         '';
 
@@ -89,6 +102,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/8957e93c95867faafec7f9988cedddd6837859fa/wallpapers/nix-wallpaper-binary-black.png";
       hash = "sha256-mhSh0wz2ntH/kri3PF5ZrFykjjdQLhmlIlDDGFQIYWw=";
     };
+    dimensions = "4096x4096";
     license = lib.licenses.cc-by-sa-40;
   };
 
@@ -100,6 +114,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/8957e93c95867faafec7f9988cedddd6837859fa/wallpapers/nix-wallpaper-binary-blue.png";
       hash = "sha256-oVIRSgool/CsduGingDr0FuJJIkGtfQHXYn0JBI2eho=";
     };
+    dimensions = "4096x4096";
     license = lib.licenses.cc-by-sa-40;
   };
 
@@ -111,6 +126,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/8957e93c95867faafec7f9988cedddd6837859fa/wallpapers/nix-wallpaper-binary-red.png";
       hash = "sha256-18UvtroyuAnluJ3EoLJWJAwN8T83s/ImPtsr5QTqvAA=";
     };
+    dimensions = "4096x4096";
     license = lib.licenses.cc-by-sa-40;
   };
 
@@ -122,6 +138,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/8957e93c95867faafec7f9988cedddd6837859fa/wallpapers/nix-wallpaper-binary-white.png";
       hash = "sha256-imj+OmuhTNxRtE54715wWQUA7pe1f32+q3qi2V37i8U=";
     };
+    dimensions = "4096x4096";
     license = lib.licenses.cc-by-sa-40;
   };
 
@@ -133,6 +150,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/97444e18b7fe97705e8caedd29ae05e62cb5d4b7/wallpapers/nixos-wallpaper-catppuccin-frappe.png";
       hash = "sha256-wtBffKK9rqSJo8+7Wo8OMruRlg091vdroyUZj5mDPfI=";
     };
+    dimensions = "3840x2160";
     license = lib.licenses.cc-by-sa-40;
   };
 
@@ -144,6 +162,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/97444e18b7fe97705e8caedd29ae05e62cb5d4b7/wallpapers/nixos-wallpaper-catppuccin-latte.png";
       hash = "sha256-Y6WCwmHOLBStj1D9mcU2082y1fhAFHna01ajfUHxehk=";
     };
+    dimensions = "3840x2160";
     license = lib.licenses.cc-by-sa-40;
   };
 
@@ -155,6 +174,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/97444e18b7fe97705e8caedd29ae05e62cb5d4b7/wallpapers/nixos-wallpaper-catppuccin-macchiato.png";
       hash = "sha256-SkXrLbHvBOItJ7+8vW+6iXV+2g0f8bUJf9KcCXYOZF0=";
     };
+    dimensions = "3840x2160";
     license = lib.licenses.cc-by-sa-40;
   };
 
@@ -166,6 +186,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/97444e18b7fe97705e8caedd29ae05e62cb5d4b7/wallpapers/nixos-wallpaper-catppuccin-mocha.png";
       hash = "sha256-fmKFYw2gYAYFjOv4lr8IkXPtZfE1+88yKQ4vjEcax1s=";
     };
+    dimensions = "3840x2160";
     license = lib.licenses.cc-by-sa-40;
   };
 
@@ -177,6 +198,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/03c6c20be96c38827037d2238357f2c777ec4aa5/wallpapers/nix-wallpaper-dracula.png";
       hash = "sha256-SykeFJXCzkeaxw06np0QkJCK28e0k30PdY8ZDVcQnh4=";
     };
+    dimensions = "1920x1080";
     license = lib.licenses.cc-by-sa-40;
   };
 
@@ -188,6 +210,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/bcdd2770f5f4839fddc9b503e68db2bc3a87ca4d/wallpapers/nix-wallpaper-gear.png";
       hash = "sha256-2sT6b49/iClTs9QuUvpmZ5gcIeXI9kebs5IqgQN1RL8=";
     };
+    dimensions = "3840x2160";
     license = lib.licenses.cc-by-sa-40;
   };
 
@@ -201,6 +224,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/3f7695afe75239720a32d6c38df7c9888b5ed581/wallpapers/NixOS-Gradient-grey.png";
       hash = "sha256-Tf4Xruf608hpl7YwL4Mq9l9egBOCN+W4KFKnqrgosLE=";
     };
+    dimensions = "2560x1440";
     # license not clarified
   };
 
@@ -212,6 +236,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/bcdd2770f5f4839fddc9b503e68db2bc3a87ca4d/wallpapers/nix-wallpaper-moonscape.png";
       hash = "sha256-AR3W8avHzQLxMNLfD/A1efyZH+vAdTLKllEhJwBl0xc=";
     };
+    dimensions = "3840x2160";
     license = lib.licenses.cc-by-sa-40;
   };
 
@@ -223,6 +248,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-mosaic-blue.png";
       hash = "sha256-xZbNK8s3/ooRvyeHGxhcYnnifeGAiAnUjw9EjJTWbLE=";
     };
+    dimensions = "1920x1080";
     license = lib.licenses.cc0;
   };
 
@@ -234,6 +260,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/da01f68d21ddfdc9f1c6e520c2170871c81f1cf5/wallpapers/nix-wallpaper-nineish.png";
       hash = "sha256-EMSD1XQLaqHs0NbLY0lS1oZ4rKznO+h9XOGDS121m9c=";
     };
+    dimensions = "3840x2160";
     license = lib.licenses.cc-by-sa-40;
   };
 
@@ -245,6 +272,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/f07707cecfd89bc1459d5dad76a3a4c5315efba1/wallpapers/nix-wallpaper-nineish-dark-gray.png";
       hash = "sha256-nhIUtCy/Hb8UbuxXeL3l3FMausjQrnjTVi1B3GkL9B8=";
     };
+    dimensions = "3840x2160";
     license = lib.licenses.cc-by-sa-40;
   };
 
@@ -256,6 +284,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/f99638d8d1a11d97a99ff7e0e1e7df58c28643ff/wallpapers/nix-wallpaper-nineish-solarized-dark.png";
       hash = "sha256-ZBrk9izKvsY4Hzsr7YovocCbkRVgUN9i/y1B5IzOOKo=";
     };
+    dimensions = "3840x2160";
     license = lib.licenses.cc-by-sa-40;
   };
 
@@ -267,6 +296,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/f99638d8d1a11d97a99ff7e0e1e7df58c28643ff/wallpapers/nix-wallpaper-nineish-solarized-light.png";
       hash = "sha256-gb5s5ePdw7kuIL3SI8VVhOcLcHu0cHMJJ623vg1kz40=";
     };
+    dimensions = "3840x2160";
     license = lib.licenses.cc-by-sa-40;
   };
 
@@ -278,6 +308,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/33856d7837cb8ba76c4fc9e26f91a659066ee31f/wallpapers/nix-wallpaper-nineish-catppuccin-frappe-alt.png";
       hash = "sha256-ZbtgfBE09FhCTPPCzDlOrSoRUmv1lmhxiNTvHDldF/4=";
     };
+    dimensions = "1920x1080";
     license = lib.licenses.cc-by-sa-40;
   };
 
@@ -289,6 +320,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/33856d7837cb8ba76c4fc9e26f91a659066ee31f/wallpapers/nix-wallpaper-nineish-catppuccin-frappe.png";
       hash = "sha256-/HAtpGwLxjNfJvX5/4YZfM8jPNStaM3gisK8+ImRmQ4=";
     };
+    dimensions = "1920x1080";
     license = lib.licenses.cc-by-sa-40;
   };
 
@@ -300,6 +332,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/33856d7837cb8ba76c4fc9e26f91a659066ee31f/wallpapers/nix-wallpaper-nineish-catppuccin-latte-alt.png";
       hash = "sha256-UyUQ4YQYlJrjoUX6qU6cGWjhA1AnIpQgniQermUtO2w=";
     };
+    dimensions = "1920x1080";
     license = lib.licenses.cc-by-sa-40;
   };
 
@@ -311,6 +344,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/33856d7837cb8ba76c4fc9e26f91a659066ee31f/wallpapers/nix-wallpaper-nineish-catppuccin-latte.png";
       hash = "sha256-+DirQiQ1TUeB+e2AeJD8mWjt0OTWtrqkeqZrVr5v5iY=";
     };
+    dimensions = "1920x1080";
     license = lib.licenses.cc-by-sa-40;
   };
 
@@ -322,6 +356,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/33856d7837cb8ba76c4fc9e26f91a659066ee31f/wallpapers/nix-wallpaper-nineish-catppuccin-macchiato-alt.png";
       hash = "sha256-OUT0SsToRH5Zdd+jOwhr9iVBoVNUKhUkJNBYFDKZGOU=";
     };
+    dimensions = "1920x1080";
     license = lib.licenses.cc-by-sa-40;
   };
 
@@ -333,6 +368,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/33856d7837cb8ba76c4fc9e26f91a659066ee31f/wallpapers/nix-wallpaper-nineish-catppuccin-macchiato.png";
       hash = "sha256-1JWgytxOvI0hwkCk+1hdZqhLB0u5aHEyEcsmlo4kMuw=";
     };
+    dimensions = "1920x1080";
     license = lib.licenses.cc-by-sa-40;
   };
 
@@ -344,6 +380,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/33856d7837cb8ba76c4fc9e26f91a659066ee31f/wallpapers/nix-wallpaper-nineish-catppuccin-mocha-alt.png";
       hash = "sha256-ThDrZIJIyO2DdIW41sV6iYyCNhM89cwHr8l6DAfbXjI=";
     };
+    dimensions = "1920x1080";
     license = lib.licenses.cc-by-sa-40;
   };
 
@@ -355,6 +392,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/33856d7837cb8ba76c4fc9e26f91a659066ee31f/wallpapers/nix-wallpaper-nineish-catppuccin-mocha.png";
       hash = "sha256-zlYqSid5Q1L5sUrAcvR+7aN2jImiuoR9gygBRk8x9Wo=";
     };
+    dimensions = "1920x1080";
     license = lib.licenses.cc-by-sa-40;
   };
 
@@ -366,6 +404,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/bcdd2770f5f4839fddc9b503e68db2bc3a87ca4d/wallpapers/nix-wallpaper-recursive.png";
       hash = "sha256-YvFrlysNGMwJ7eMFOoz0KI8AjoPN3ao+AVOgnVZzkFE=";
     };
+    dimensions = "3840x2160";
     license = lib.licenses.cc-by-sa-40;
   };
 
@@ -377,6 +416,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-simple-blue.png";
       hash = "sha256-utrcjzfeJoFOpUbFY2eIUNCKy5rjLt57xIoUUssJmdI=";
     };
+    dimensions = "1920x1080";
     license = lib.licenses.cc0;
   };
 
@@ -388,6 +428,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-simple-dark-gray.png";
       hash = "sha256-JaLHdBxwrphKVherDVe5fgh+3zqUtpcwuNbjwrBlAok=";
     };
+    dimensions = "1920x1080";
     license = lib.licenses.cc0;
   };
 
@@ -399,6 +440,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/9d1f11f652ed5ffe460b6c602fbfe2e7e9a08dff/bootloader/nix-wallpaper-simple-dark-gray_bootloader.png";
       hash = "sha256-Sd52CEw/pHmk6Cs+yrM/8wscG9bvYuECylQd27ybRmw=";
     };
+    dimensions = "628x535";
     # license not clarified
   };
 
@@ -410,6 +452,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/783c38b22de09f6ee33aacc817470a4513392d83/wallpapers/nix-wallpaper-simple-dark-gray_bottom.png";
       hash = "sha256-JUyzf9dYRyLQmxJPKptDxXL7yRqAFt5uM0C9crkkEY4=";
     };
+    dimensions = "1920x1080";
     # license not clarified
   };
 
@@ -421,6 +464,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-simple-light-gray.png";
       hash = "sha256-Ylo5H5OrU/t9vwLbfO0OyPIsB/0vS5iUPTt/G3YHzUQ=";
     };
+    dimensions = "1920x1080";
     license = lib.licenses.cc0;
   };
 
@@ -432,6 +476,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-simple-red.png";
       hash = "sha256-WnKjgvnn5Rg4R3xaJQ2mhBHQqCfl9jV6Xx3hEXW+uZk=";
     };
+    dimensions = "1920x1080";
     license = lib.licenses.cc0;
   };
 
@@ -443,6 +488,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-stripes-logo.png";
       hash = "sha256-1MoPwytw8kBiy+Sx70xmHnxMJgqEaOR9YEgQMO6bEjM=";
     };
+    dimensions = "1920x1080";
     license = lib.licenses.cc0;
   };
 
@@ -454,6 +500,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-stripes.png";
       hash = "sha256-o3GqbFZ/18ScLOlAL6GRy54l8P/U6wUeeK4HtPkZw4Q=";
     };
+    dimensions = "1920x1080";
     license = lib.licenses.cc0;
   };
 
@@ -465,6 +512,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/bcdd2770f5f4839fddc9b503e68db2bc3a87ca4d/wallpapers/nix-wallpaper-waterfall.png";
       hash = "sha256-ULFNUZPU9khDG6rtkMskLe5sYpUcrJVvcFvEkpvXjMM=";
     };
+    dimensions = "3840x2160";
     license = lib.licenses.cc-by-sa-40;
   };
 
@@ -476,6 +524,7 @@ rec {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/bcdd2770f5f4839fddc9b503e68db2bc3a87ca4d/wallpapers/nix-wallpaper-watersplash.png";
       hash = "sha256-6Gdjzq3hTvUH7GeZmZnf+aOQruFxReUNEryAvJSgycQ=";
     };
+    dimensions = "3840x2160";
     license = lib.licenses.cc-by-sa-40;
   };
 

--- a/pkgs/data/misc/nixos-artwork/wallpapers.nix
+++ b/pkgs/data/misc/nixos-artwork/wallpapers.nix
@@ -403,7 +403,7 @@ rec {
   };
 
   simple-dark-gray-bottom = mkNixBackground {
-    pname = "simple-dark-gray";
+    pname = "simple-dark-gray-bottom";
     version = "2018-08-28";
     description = "Simple dark gray background for NixOS, specifically bootloaders and graphical login";
     src = fetchurl {


### PR DESCRIPTION
I don't know if the nixos-artwork stuff is retired / deprecated (since the repository is archived), but I made this change for myself, so I figured I'd try contributing it either way.

The [nixos-artwork wallpapers](https://github.com/NixOS/nixos-artwork/tree/master/wallpapers) have derivations in nixpkgs, which includes setting up the directory structures expected by both GNOME and KDE Plasma. However, the metadata is only created using Plasma 5's `metadata.desktop` standard. With Plasma 6, KDE changed the way the metadata needs to be specified, requiring a `metadata.json` file, and expecting the image names to match their resolutions (for multi-resolution support). This PR adds the expected files to the wallpaper derivations so that they are recognized by KDE Plasma 6.

I kept the Plasma 5 metadata in the derivations, in case they are still required for some reason (namely, for anything that consumes the `passthru.kdeFilePath` value). However, we could also consider removing the Plasma 5 support, as I don't believe Plasma 5 is included in nixpkgs at this point. Let me know if you want me to add that change to this PR (otherwise it can be left for its own PR, to keep this PR backport-friendly).

I also made one other unrelated change I discovered while making the Plasma 6 changes, which is fixing the `pname` value for `simple-dark-gray-bottom`. This was incorrectly set to `"simple-dark-gray"`, conflicting with another wallpaper's `pname`, which caused issues with derivation building. I simply set the `pname` value to match the wallpaper name to correct for this.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
