### PR TITLE
afew: 3.0.1 -> 4.0.1

### DIFF
--- a/pkgs/by-name/af/afew/package.nix
+++ b/pkgs/by-name/af/afew/package.nix
@@ -9,17 +9,17 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "afew";
-  version = "3.0.1";
+  version = "4.0.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
-    sha256 = "0wpfqbqjlfb9z0hafvdhkm7qw56cr9kfy6n8vb0q42dwlghpz1ff";
+    hash = "sha256-d6WfXt4K5nLawwdsWXHgy0+nMJXqxs9QQ0xmVeX1m3Q=";
   };
 
   nativeBuildInputs = with python3Packages; [
     sphinxHook
-    setuptools_80
+    setuptools
     setuptools-scm
   ];
 
@@ -31,7 +31,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   propagatedBuildInputs = with python3Packages; [
     chardet
     dkimpy
-    notmuch
+    notmuch2
     setuptools
   ];
 

--- a/pkgs/by-name/af/afew/package.nix
+++ b/pkgs/by-name/af/afew/package.nix
@@ -9,12 +9,12 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "afew";
-  version = "4.0.0";
+  version = "4.0.1";
   pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
-    hash = "sha256-d6WfXt4K5nLawwdsWXHgy0+nMJXqxs9QQ0xmVeX1m3Q=";
+    hash = "sha256-LPKSD4aMAREtf5Y4A9oa6Sh5lv/uuLpamcP35SBgA/M=";
   };
 
   nativeBuildInputs = with python3Packages; [

--- a/pkgs/by-name/af/afew/package.nix
+++ b/pkgs/by-name/af/afew/package.nix
@@ -17,10 +17,13 @@ python3Packages.buildPythonApplication (finalAttrs: {
     hash = "sha256-LPKSD4aMAREtf5Y4A9oa6Sh5lv/uuLpamcP35SBgA/M=";
   };
 
-  nativeBuildInputs = with python3Packages; [
-    sphinxHook
-    setuptools
-    setuptools-scm
+  build-system = [
+    python3Packages.setuptools
+    python3Packages.setuptools-scm
+  ];
+
+  nativeBuildInputs = [
+    python3Packages.sphinxHook
   ];
 
   sphinxBuilders = [
@@ -28,11 +31,10 @@ python3Packages.buildPythonApplication (finalAttrs: {
     "man"
   ];
 
-  propagatedBuildInputs = with python3Packages; [
-    chardet
-    dkimpy
-    notmuch2
-    setuptools
+  dependencies = [
+    python3Packages.chardet
+    python3Packages.dkimpy
+    python3Packages.notmuch2
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
Afew still uses pkg_resources instead of importlib.metadata (the latest unreleased master branch has switched).  Until we can upgrade the afew package to a new version we use a compatible version of setuptools.

Context: Python was updated from 3.13 to 3.14 in #521373 with the default then being setuptools 82 which does not support pkg_resources any longer.  In 7b235832bc2996c42b5b74d9952c41015dff71f4 the build time dependency on setuptools was already fixed.

Fixes #541332.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
