### PR TITLE
depot-cli: init at 2.101.73

### DIFF
--- a/pkgs/by-name/de/depot-cli/package.nix
+++ b/pkgs/by-name/de/depot-cli/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  gitMinimal,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "depot-cli";
+  version = "2.101.73";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "depot";
+    repo = "cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-7nUA8NW+hy79x3u+WTISkNLCeIlrYux5ZBmwlPpq+/w=";
+  };
+
+  vendorHash = "sha256-/EcczS/e8vQiCOXaA2J2yY5xM9ymIt1LEObDnC0O1Rc=";
+
+  ldflags = [
+    "-s"
+    # https://github.com/depot/cli/blob/0b6ec9863dd8cbaab85f6be0b29b59057c4f8008/.github/workflows/ci.yml#L164
+    "-X github.com/depot/cli/internal/build.Version=${finalAttrs.version}"
+    "-X github.com/depot/cli/internal/build.Date=1970-01-01T00:00:00Z"
+    "-X github.com/depot/cli/internal/build.SentryEnvironment=release"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd depot \
+      --bash <($out/bin/depot completion bash) \
+      --fish <($out/bin/depot completion fish) \
+      --zsh <($out/bin/depot completion zsh)
+  '';
+
+  nativeCheckInputs = [ gitMinimal ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Official CLI for the Depot Docker image builder";
+    homepage = "https://github.com/depot/cli";
+    changelog = "https://github.com/depot/cli/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.ethancedwards8 ];
+    mainProgram = "depot";
+  };
+})


### PR DESCRIPTION
> [!NOTE]
> This work was sponsored by https://exa.ai 🐐

Homepage: https://github.com/depot/cli


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
