### PR TITLE
zed-editor: fix build failure on aarch64-darwin

### DIFF
--- a/pkgs/by-name/ze/zed-editor/package.nix
+++ b/pkgs/by-name/ze/zed-editor/package.nix
@@ -171,6 +171,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     libGL
     libx11
     libxext
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # required by installPhase
+    git
   ];
 
   cargoBuildFlags = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
The most recent hydra build of `zed-editor` [fails](https://hydra.nixos.org/build/337372687) with the following log:
<details>
  <summary>Tail of <a href="https://hydra.nixos.org/build/337372687/log">https://hydra.nixos.org/build/337372687/log</a></summary>
<pre><code>Running phase: fixupPhase
checking for references to /nix/var/nix/builds/nix-64129-3310804544/ in /nix/store/qx6vzq4anrvl98hbfcgk0k3qf2ivggfl-zed-editor-1.10.0-remote_server...
patching script interpreter paths in /nix/store/qx6vzq4anrvl98hbfcgk0k3qf2ivggfl-zed-editor-1.10.0-remote_server
stripping (with command strip and flags -S) in  /nix/store/qx6vzq4anrvl98hbfcgk0k3qf2ivggfl-zed-editor-1.10.0-remote_server/bin
checking for references to /nix/var/nix/builds/nix-64129-3310804544/ in /nix/store/pbdskvmi0ja2732jgagarvd0x6h604rf-zed-editor-1.10.0...
patching script interpreter paths in /nix/store/pbdskvmi0ja2732jgagarvd0x6h604rf-zed-editor-1.10.0
stripping (with command strip and flags -S) in  /nix/store/pbdskvmi0ja2732jgagarvd0x6h604rf-zed-editor-1.10.0/bin /nix/store/pbdskvmi0ja2732jgagarvd0x6h604rf-zed-editor-1.10.0/Applications
ERROR: noBrokenSymlinks: the symlink /nix/store/pbdskvmi0ja2732jgagarvd0x6h604rf-zed-editor-1.10.0/Applications/Zed.app/Contents/MacOS/git points to a missing target: /nix/store/01258rj9fvamcl4bf7yjffysmwyvd72i-git-2.54.0/bin/git
ERROR: noBrokenSymlinks: found 1 dangling symlinks, 0 reflexive symlinks and 0 unreadable symlinks
</code></pre>
</details>

The reason for the broken symlink is that `git` is actually _not depended on_ by `zed-editor` on `aarch64-darwin`; this can be fixed by simply adding it to the `buildInputs` for the derivation, conditioned on the `hostPlatform` being a Darwin platform.

NB. If you suggest any changes, I would appreciate if you could also build/test yourself... my laptop took ~1hr to build/test the derivation the first time, so I am unlikely to be able to build it again myself.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
