### PR TITLE
cc-switch: use cargo-tauri.hook for Darwin .app bundle

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14384,6 +14384,12 @@
     github = "keller00";
     githubId = 8452750;
   };
+  kenis1108 = {
+    email = "1836362346@qq.com";
+    github = "kenis1108";
+    githubId = 45393183;
+    name = "kenis";
+  };
   kenran = {
     email = "johannes.maier@mailbox.org";
     github = "kenranunderscore";

--- a/pkgs/by-name/cc/cc-switch/package.nix
+++ b/pkgs/by-name/cc/cc-switch/package.nix
@@ -124,7 +124,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://github.com/farion1231/cc-switch/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     mainProgram = "cc-switch";
-    maintainers = with lib.maintainers; [ imcvampire ];
+    maintainers = with lib.maintainers; [
+      imcvampire
+      kenis1108
+    ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })

--- a/pkgs/by-name/cc/cc-switch/package.nix
+++ b/pkgs/by-name/cc/cc-switch/package.nix
@@ -4,9 +4,10 @@
   rustPlatform,
   fetchFromGitHub,
 
-  copyDesktopItems,
+  cargo-tauri,
   jq,
-  makeDesktopItem,
+  makeBinaryWrapper,
+  moreutils,
   nodejs,
   pkg-config,
   pnpm_10,
@@ -48,7 +49,17 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-Vs+/KLICqciF7dnC3iRH9TFzNCtXDgOkWFPLxdwA0rE=";
   };
 
-  postPatch = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
+  postPatch = ''
+    jq '
+      del(.build.beforeBuildCommand) |
+      .bundle.createUpdaterArtifacts = false |
+      .plugins.updater.endpoints = []
+    ' src-tauri/tauri.conf.json | sponge src-tauri/tauri.conf.json
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    jq '.bundle.macOS.signingIdentity = null' src-tauri/tauri.conf.json | sponge src-tauri/tauri.conf.json
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
     # libappindicator-sys dlopens libayatana-appindicator3.so.1 at runtime; autoPatchelf can't catch it.
     substituteInPlace $cargoDepsCopy/*/libappindicator-sys-*/src/lib.rs \
       --replace-fail "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
@@ -60,18 +71,22 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = "sha256-gX32xCiVKHQ0BIIB9GyWHessIW30zbTcMZLtPJycxn8=";
 
   nativeBuildInputs = [
+    cargo-tauri.hook
     jq
+    moreutils
     nodejs
     pnpmConfigHook
     pnpm_10
   ]
-  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
-    copyDesktopItems
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     pkg-config
     wrapGAppsHook3
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    makeBinaryWrapper
   ];
 
-  buildInputs = lib.optionals (!stdenv.hostPlatform.isDarwin) [
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     glib-networking
     libayatana-appindicator
     libsoup_3
@@ -80,48 +95,25 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   # tauri-build embeds frontendDist (../dist) at compile time; populate it
-  # before cargo build runs.
+  # before cargo tauri build runs (beforeBuildCommand is stripped in postPatch).
   preBuild = ''
     pnpm run build:renderer
   '';
 
-  # cc_switch_lib is an internal staticlib+cdylib+rlib; only the binary is needed.
-  # tauri/custom-protocol enables embedded-asset serving via `tauri://localhost/`;
-  # without it, WKWebView/webkit2gtk fall through to devUrl (http://localhost:3000)
-  # and blank-screen with NSURLErrorCannotConnectToHost.
-  cargoBuildFlags = [
-    "--bin"
-    "cc-switch"
-    "--features=tauri/custom-protocol"
-  ];
+  # Upstream Cargo.lock resolves newer tauri crates than the pinned npm packages
+  # (e.g. tauri 2.10 vs @tauri-apps/api 2.8). cargo tauri build errors on that;
+  # the previous cargo-only packaging already shipped this combination.
+  tauriBuildFlags = [ "--ignore-version-mismatches" ];
 
   # Proxy startup test binds to a local address, which the darwin sandbox blocks.
   checkFlags = lib.optionals stdenv.hostPlatform.isDarwin [
     "--skip=services::provider::tests::update_current_claude_provider_syncs_live_when_proxy_takeover_detected_without_backup"
   ];
 
-  postInstall = ''
-    rm -rf $out/lib
-    install -Dm644 src-tauri/icons/32x32.png $out/share/icons/hicolor/32x32/apps/cc-switch.png
-    install -Dm644 src-tauri/icons/128x128.png $out/share/icons/hicolor/128x128/apps/cc-switch.png
-    install -Dm644 src-tauri/icons/128x128@2x.png $out/share/icons/hicolor/256x256/apps/cc-switch.png
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir -p "$out/bin"
+    makeWrapper "$out/Applications/CC Switch.app/Contents/MacOS/cc-switch" "$out/bin/cc-switch"
   '';
-
-  desktopItems = [
-    (makeDesktopItem {
-      name = "cc-switch";
-      desktopName = "CC Switch";
-      exec = finalAttrs.meta.mainProgram;
-      icon = "cc-switch";
-      comment = finalAttrs.meta.description;
-      categories = [
-        "Development"
-        "Utility"
-      ];
-      mimeTypes = [ "x-scheme-handler/ccswitch" ];
-      startupWMClass = "cc-switch";
-    })
-  ];
 
   passthru.updateScript = nix-update-script { };
 
@@ -133,6 +125,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = lib.licenses.mit;
     mainProgram = "cc-switch";
     maintainers = with lib.maintainers; [ imcvampire ];
-    platforms = lib.platforms.unix;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
