### PR TITLE
asciiquarium-transparent: 1.4 -> 1.6

### DIFF
--- a/pkgs/by-name/as/asciiquarium-transparent/package.nix
+++ b/pkgs/by-name/as/asciiquarium-transparent/package.nix
@@ -7,13 +7,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "asciiquarium-transparent";
-  version = "1.4";
+  version = "1.6";
 
   src = fetchFromGitHub {
     owner = "nothub";
     repo = "asciiquarium";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-lUNPg+/R/UwnHxjVXROMjvQxBZuCPBrYWB546OHplJM=";
+    hash = "sha256-p9P9sJZhcNdlIxyz5ulFXFrwJaE7b48D4aWeoTWmIgk=";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
Bumps `asciiquarium-transparent` from 1.4 to 1.6.

Upstream release: https://github.com/nothub/asciiquarium/releases/tag/v1.6
(tag `v1.6` resolves to commit `cc3108f04158d7b3b7bb0143bbd073fe0a05090b`)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/` (launched `result/bin/asciiquarium`; animation renders).
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
