### PR TITLE
openroad: 26Q2 -> 26Q3

### DIFF
--- a/pkgs/by-name/op/openroad/package.nix
+++ b/pkgs/by-name/op/openroad/package.nix
@@ -43,14 +43,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "openroad";
-  version = "26Q2";
+  version = "26Q3";
 
   src = fetchFromGitHub {
     owner = "The-OpenROAD-Project";
     repo = "OpenROAD";
     tag = finalAttrs.version;
     fetchSubmodules = true;
-    hash = "sha256-dB9PfPlp6vZ9+Th8LJE65BW9YeuUL0G4JtjzQxg6UpQ=";
+    hash = "sha256-jElAb8mM2lhGwa8wTONfQgs7esL9p1beAReJXAWns9o=";
   };
 
   nativeBuildInputs = [
@@ -103,22 +103,6 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-W9USjqp/hL1s3w3nKVMo/a5aSkeQ4Lp7gqASbZSlo9Y=";
       stripLen = 1;
       extraPrefix = "src/sta/";
-    })
-    # Feature-test std::from_chars to fix aarch64-darwin build where
-    # libcxx marks from_chars unavailable (macOS 26.0).
-    # https://github.com/The-OpenROAD-Project/OpenSTA/commit/a5921d1ca
-    (fetchpatch {
-      url = "https://github.com/The-OpenROAD-Project/OpenSTA/commit/a5921d1ca964971ada83be2c7c65bb84504fe179.patch";
-      hash = "sha256-j9BneXSIya/euYiol16swmrFkXTDZNTQwq3tPFkCLH0=";
-      stripLen = 1;
-      extraPrefix = "src/sta/";
-    })
-    # Replace deprecated sprintf with snprintf in Logger::error.
-    # macOS Apple SDK 14.4+ marks sprintf as deprecated, breaking -Werror builds.
-    # https://github.com/The-OpenROAD-Project/OpenROAD/pull/10127
-    (fetchpatch {
-      url = "https://github.com/The-OpenROAD-Project/OpenROAD/commit/2a9191bc5b2841a0c357886a2a1bc3ac0fe5271a.patch";
-      hash = "sha256-lxFZvybfG0Qpg1TyKdfZhKLYI3DSCYDE54ta6EnDBDo=";
     })
   ];
 


### PR DESCRIPTION
## Motivation

Bump `openroad` 26Q2 → 26Q3.

Changelog: https://github.com/The-OpenROAD-Project/OpenROAD/compare/26Q2...26Q3

Two patches carried for 26Q2 are now upstream in 26Q3 and are dropped:
- OpenSTA `a5921d1ca` (`std::from_chars` feature-test) — verified present in 26Q3's `OpenSTA/util/StringUtil.cc` (the `#if defined(__cpp_lib_to_chars)` guard).
- OpenROAD `2a9191bc` (`sprintf` → `snprintf`, PR #10127) — verified present in 26Q3's `src/utl/include/utl/Logger.h` (now uses `fmt::format`; no bare `sprintf` remains).

The OpenSTA PinIdLess GCC-15 UB fix (still-open [OpenSTA PR #346](https://github.com/The-OpenROAD-Project/OpenSTA/pull/346)) is **kept** — still needed for the OpenSTA `dcalc` tests to pass under GCC 15.

## ⚠️ Note on CI: unrelated `or-tools` breakage on master

At the time of opening, nixpkgs `master` marks **`or-tools` broken** under the in-progress **Python 3.14** migration (`broken = python3.pythonAtLeast "3.14"`; its `python3.14-pybind11-2.13.6` dependency currently fails a test). Because `openroad` depends on `or-tools`, **ofborg may fail to build `openroad` on master until that transitive breakage is resolved — this is unrelated to this bump.**

To validate the bump itself I built against a nixpkgs rev predating the 3.14 switch (where `or-tools` builds): **OpenROAD 26Q3 builds and its full `make test` suite (8101 tests) passes on x86_64-linux**, and `versionCheckHook` confirms `openroad -version` → `26Q3`. Happy to re-trigger once `or-tools`/`pybind11` are unbroken on master.

## Things done

- Built on platform(s):
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests in `nixos/tests` (n/a — no NixOS module)
  - [ ] Package tests at `passthru.tests`
  - [ ] Tests in `lib/tests` or `pkgs/test` (n/a)
- [ ] Ran `nixpkgs-review` on this PR (blocked on master by the `or-tools`/py3.14 breakage above; built against a pre-3.14 rev instead).
- [x] Tested basic functionality of the binary (`./result/bin/openroad -version` → `26Q3`); full `make test` (8101 tests) passes under `doCheck`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking. (n/a — routine bump)
- [x] Fits `CONTRIBUTING.md`, `pkgs/README.md`, `maintainers/README.md` and other READMEs.
