### PR TITLE
python3Packages.beets:  plugin improvements

### DIFF
--- a/pkgs/development/python-modules/beets/default.nix
+++ b/pkgs/development/python-modules/beets/default.nix
@@ -279,6 +279,8 @@ buildPythonPackage (finalAttrs: {
         bpd = { };
         bpm.testPaths = [ ];
         bpsync = {
+          # plugin retired: https://github.com/beetbox/beets/issues/3862.
+          deprecated = true;
           testPaths = [ ];
         };
         bucket = { };

--- a/pkgs/development/python-modules/beets/default.nix
+++ b/pkgs/development/python-modules/beets/default.nix
@@ -88,6 +88,7 @@
   extraNativeBuildInputs ? [ ],
 
   # tests
+  doCheck ? true,
   pytestCheckHook,
   pytest-cov-stub,
   pytest-factoryboy,
@@ -193,6 +194,8 @@ buildPythonPackage (finalAttrs: {
     writableTmpDirAsHomeHook
   ]
   ++ finalAttrs.finalPackage.passthru.plugins.wrapperBins;
+
+  inherit doCheck;
 
   __darwinAllowLocalNetworking = true;
 

--- a/pkgs/development/python-modules/beets/default.nix
+++ b/pkgs/development/python-modules/beets/default.nix
@@ -419,23 +419,20 @@ buildPythonPackage (finalAttrs: {
         lib.throwIf (finalAttrs.finalPackage.passthru.plugins.builtins.${plugName}.deprecated or false)
           "beets evaluation error: Plugin ${plugName} was enabled in pluginOverrides, but it has been removed. Remove the override to fix evaluation."
       ) pluginOverrides;
-      all =
-        lib.mapAttrs
-          (
-            n: a:
-            {
-              name = n;
-              enable = !disableAllPlugins;
-              builtin = false;
-              propagatedBuildInputs = [ ];
-              testPaths = [ "test/plugins/test_${n}.py" ];
-              wrapperBins = [ ];
-            }
-            // a
-          )
-          (
-            lib.recursiveUpdate finalAttrs.finalPackage.passthru.plugins.base finalAttrs.finalPackage.passthru.plugins.overrides
-          );
+      all = lib.pipe finalAttrs.finalPackage.passthru.plugins.base [
+        (base: lib.recursiveUpdate base finalAttrs.finalPackage.passthru.plugins.overrides)
+        (lib.mapAttrs (
+          n: a:
+          lib.recursiveUpdate {
+            name = n;
+            enable = !disableAllPlugins;
+            builtin = false;
+            propagatedBuildInputs = [ ];
+            testPaths = [ "test/plugins/test_${n}.py" ];
+            wrapperBins = [ ];
+          } a
+        ))
+      ];
       enabled = lib.filterAttrs (_: p: p.enable) finalAttrs.finalPackage.passthru.plugins.all;
       disabled = lib.filterAttrs (_: p: !p.enable) finalAttrs.finalPackage.passthru.plugins.all;
       disabledTestPaths = lib.flatten (

--- a/pkgs/development/python-modules/beets/default.nix
+++ b/pkgs/development/python-modules/beets/default.nix
@@ -469,23 +469,6 @@ buildPythonPackage (finalAttrs: {
       );
     };
     tests = {
-      gstreamer =
-        runCommand "beets-gstreamer-test"
-          {
-            meta.timeout = 60;
-          }
-          ''
-            set -euo pipefail
-            export HOME=$(mktemp -d)
-            mkdir $out
-
-            cat << EOF > $out/config.yaml
-            replaygain:
-              backend: gstreamer
-            EOF
-
-            ${finalAttrs.finalPackage}/bin/beet -c $out/config.yaml > /dev/null
-          '';
       with-new-builtin-plugin = finalAttrs.finalPackage.overrideAttrs (
         newAttrs: oldAttrs: {
           postPatch = (oldAttrs.postPatch or "") + ''

--- a/pkgs/development/python-modules/beets/default.nix
+++ b/pkgs/development/python-modules/beets/default.nix
@@ -509,6 +509,7 @@ buildPythonPackage (finalAttrs: {
       doronbehar
       lovesegfault
       pjones
+      staticdev
     ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
     mainProgram = "beet";

--- a/pkgs/development/python-modules/beets/default.nix
+++ b/pkgs/development/python-modules/beets/default.nix
@@ -59,6 +59,7 @@
   aacgain,
   beautifulsoup4,
   chromaprint,
+  dbus-python,
   discogs-client,
   ffmpeg,
   flac,
@@ -363,7 +364,10 @@ buildPythonPackage (finalAttrs: {
         mbsubmit = { };
         mbsync = { };
         mbpseudo = { };
-        metasync.testPaths = [ ];
+        metasync = {
+          propagatedBuildInputs = [ dbus-python ];
+          testPaths = [ ];
+        };
         missing.testPaths = [ ];
         mpdstats.propagatedBuildInputs = [ python-mpd2 ];
         mpdupdate = {
@@ -405,7 +409,7 @@ buildPythonPackage (finalAttrs: {
         substitute = {
           testPaths = [ ];
         };
-        tidal = { };
+        tidal.propagatedBuildInputs = [ requests-oauthlib ];
         the = { };
         titlecase.propagatedBuildInputs = [ titlecase ];
         thumbnails = {

--- a/pkgs/development/python-modules/beets/default.nix
+++ b/pkgs/development/python-modules/beets/default.nix
@@ -278,7 +278,9 @@ buildPythonPackage (finalAttrs: {
         bench.testPaths = [ ];
         bpd = { };
         bpm.testPaths = [ ];
-        bpsync.testPaths = [ ];
+        bpsync = {
+          testPaths = [ ];
+        };
         bucket = { };
         chroma = {
           propagatedBuildInputs = [ pyacoustid ];
@@ -291,10 +293,15 @@ buildPythonPackage (finalAttrs: {
           propagatedBuildInputs = [ requests ];
           testPaths = [ ];
         };
-        discogs.propagatedBuildInputs = [
-          discogs-client
-          requests
-        ];
+        discogs = {
+          propagatedBuildInputs = [
+            discogs-client
+            requests
+          ];
+          singlePluginTest.config = {
+            user_token = "test";
+          };
+        };
         duplicates.testPaths = [ ];
         edit = { };
         embedart = {
@@ -337,7 +344,10 @@ buildPythonPackage (finalAttrs: {
           testPaths = [ ];
         };
         limit = { };
-        listenbrainz = { };
+        listenbrainz.singlePluginTest.config = {
+          token = "test";
+          username = "test";
+        };
         loadext = {
           propagatedBuildInputs = [ requests ];
           testPaths = [ ];
@@ -366,11 +376,14 @@ buildPythonPackage (finalAttrs: {
         plexupdate = { };
         random = { };
         replace = { };
-        replaygain.wrapperBins = [
-          aacgain
-          ffmpeg
-          mp3gain
-        ];
+        replaygain = {
+          singlePluginTest.config.backend = "gstreamer";
+          wrapperBins = [
+            aacgain
+            ffmpeg
+            mp3gain
+          ];
+        };
         rewrite.testPaths = [ ];
         scrub.testPaths = [ ];
         smartplaylist = { };
@@ -378,7 +391,10 @@ buildPythonPackage (finalAttrs: {
           propagatedBuildInputs = [ soco ];
           testPaths = [ ];
         };
-        spotify = { };
+        spotify.singlePluginTest.setup = ''
+          mkdir -p $HOME/.config/beets
+          echo '{"access_token":"test"}' > $HOME/.config/beets/spotify_token.json
+        '';
         subsonicplaylist = {
           propagatedBuildInputs = [ requests ];
           testPaths = [ ];
@@ -428,6 +444,10 @@ buildPythonPackage (finalAttrs: {
             enable = !disableAllPlugins;
             builtin = false;
             propagatedBuildInputs = [ ];
+            singlePluginTest = {
+              config = { };
+              setup = "";
+            };
             testPaths = [ "test/plugins/test_${n}.py" ];
             wrapperBins = [ ];
           } a
@@ -497,7 +517,66 @@ buildPythonPackage (finalAttrs: {
           -c $out/config.yaml \
           mpdstats --help 2> $out/mpdstats-help-stderr || true
       '';
-    };
+    }
+    # Build and start beets once for each supported built-in plugin. Keeping the
+    # plugins isolated makes missing optional dependencies visible.
+    // lib.pipe finalAttrs.finalPackage.passthru.plugins.all [
+      # Deprecated plugins are not useful regression targets.
+      (lib.filterAttrs (_: pluginAttrs: !(pluginAttrs.deprecated or false)))
+      (lib.concatMapAttrs (
+        pluginName: pluginAttrs:
+        let
+          testConfig = {
+            plugins = [ pluginName ];
+          }
+          # Some plugins do not accept an empty attribute set as config.
+          // lib.optionalAttrs (pluginAttrs.singlePluginTest.config != { }) {
+            ${pluginName} = pluginAttrs.singlePluginTest.config;
+          };
+          beetsWithSinglePlugin = beets.override {
+            disableAllPlugins = true;
+            pluginOverrides = {
+              ${pluginName}.enable = true;
+            };
+            # The runCommand below is the relevant check; avoid running
+            # the full upstream test suite once per plugin. NOTE that
+            # testing whether any plugin's `testPaths` is incorrect, is
+            # done for all plugins via the `beets-minimal` derivation.
+            doCheck = false;
+          };
+        in
+        {
+          "with-single-plugin-${pluginName}" = beetsWithSinglePlugin;
+          "single-plugin-${pluginName}" = runCommand "beets-single-plugin-${pluginName}-test" { } ''
+            set -euo pipefail
+            export HOME=$(mktemp -d)
+            ${pluginAttrs.singlePluginTest.setup}
+            mkdir $out
+
+            cat <<'EOF' > $out/config.yaml
+            ${lib.generators.toYAML { } testConfig}
+            EOF
+
+            status=0
+            ${lib.getExe beetsWithSinglePlugin} \
+              -c "$out/config.yaml" \
+              --help > "$out/stdout" 2> "$out/stderr" || status=$?
+
+            # beet exits successfully when a plugin fails to load, so its
+            # stderr must also be checked for the diagnostic.
+            if (( status != 0 )) || grep -Fq "error loading plugin" "$out/stderr"; then
+              {
+                printf '%s\n' '----- stdout -----'
+                cat "$out/stdout"
+                printf '%s\n' '----- stderr -----'
+                cat "$out/stderr"
+              } >&2
+              exit 1
+            fi
+          '';
+        }
+      ))
+    ];
   };
 
   meta = {


### PR DESCRIPTION
Fix missing runtime dependencies for two built-in beets plugins:

- Add `dbus-python` to the `metasync` plugin.
- Add `requests-oauthlib` to the `tidal` plugin.
- Add isolated-plugin passthru tests to ensure both plugins receive their required dependencies.
- Add `staticdev` as a maintainer.

These dependencies were previously missing when the plugins were enabled in isolation using `disableAllPlugins`. In the full package, `tidal` happened to receive `requests-oauthlib` through another enabled plugin, which masked the problem.

Automation disclosure: Codex (GPT-5) assisted with debugging, implementation and testing.
Assisted-by: Codex (GPT-5)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
