### PR TITLE
cutesetup: init at 0.1.0.0

### DIFF
--- a/pkgs/by-name/cu/cutesetup/package.nix
+++ b/pkgs/by-name/cu/cutesetup/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  haskellPackages,
+  fetchFromGitHub,
+}:
+
+haskellPackages.mkDerivation {
+  pname = "cutesetup";
+  version = "0.1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "petalmaya";
+    repo = "cutesetup";
+    rev = "ab3cc74b5d0a7d3d3685f14d86f66d225d7c50d4";
+    hash = "sha256-55kvQM2SWtK1bF+5DHaPdOBs4emVulmHkiqPA0qdAy8=";
+  };
+
+  isExecutable = true;
+
+  executableHaskellDepends = with haskellPackages; [
+    base
+    brick
+    vty
+    vty-unix
+    vty-crossplatform
+    text
+    containers
+    microlens
+    microlens-platform
+    vector
+    directory
+    filepath
+    process
+    aeson
+    bytestring
+    async
+    stm
+  ];
+
+  testHaskellDepends = with haskellPackages; [
+    base
+    containers
+    directory
+    filepath
+    process
+    aeson
+    bytestring
+    vector
+    QuickCheck
+  ];
+
+  license = lib.licenses.mit;
+  maintainers = [ lib.maintainers.redhood ];
+  mainProgram = "cutesetup";
+  description = "Cute TUI for scaffolding Nix devshells";
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
