### PR TITLE
gtk4: fix build on darwin by linking with lld

### DIFF
--- a/pkgs/by-name/gt/gtk4/package.nix
+++ b/pkgs/by-name/gt/gtk4/package.nix
@@ -60,6 +60,7 @@
   compileSchemas ? stdenv.hostPlatform.emulatorAvailable buildPackages,
   cups,
   libexecinfo,
+  llvmPackages,
   broadwaySupport ? true,
   testers,
   darwinMinVersionHook,
@@ -129,6 +130,10 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals vulkanSupport [
     shaderc # for glslc
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # TODO: Remove when NixOS/nixpkgs#536365 reaches master.
+    llvmPackages.lld
   ]
   ++ finalAttrs.setupHooks;
 
@@ -221,6 +226,10 @@ stdenv.mkDerivation (finalAttrs: {
   }
   // lib.optionalAttrs stdenv.hostPlatform.isMusl {
     NIX_LDFLAGS = "-lexecinfo";
+  }
+  // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    # TODO: Remove when NixOS/nixpkgs#536365 reaches master.
+    NIX_CFLAGS_LINK = "--ld-path=${lib.getExe' llvmPackages.lld "ld64.lld"}";
   };
 
   postPatch = ''


### PR DESCRIPTION
Resolves #541734 with a temporary fix similar to lima (#541023) and other affected darwin packages, can be reverted with #536365 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
