### PR TITLE
python3Packages.face-recognition-models: unpin setuptools

### DIFF
--- a/pkgs/development/python-modules/face-recognition/0001-use-importlib-resources.patch
+++ b/pkgs/development/python-modules/face-recognition/0001-use-importlib-resources.patch
@@ -1,0 +1,42 @@
+From c142485d6f34c633d67c5e7ccbbc0baf7a1d695f Mon Sep 17 00:00:00 2001
+From: Erik Janssen <30315129+janssen70@users.noreply.github.com>
+Date: Thu, 6 Nov 2025 22:29:41 +0100
+Subject: [PATCH] Refactor from pkg_resources to importlib.resources
+
+Eliminate startup warning by replacing  pkg_resources with importlib.resources.files() for accessing package data files. Includes fallback to importlib_resources  for Python 3.7-3.8 compatibility.
+---
+ face_recognition_models/__init__.py | 15 ++++++++++-----
+ 1 file changed, 10 insertions(+), 5 deletions(-)
+
+diff --git a/face_recognition_models/__init__.py b/face_recognition_models/__init__.py
+index 6201432..2f2a29e 100644
+--- a/face_recognition_models/__init__.py
++++ b/face_recognition_models/__init__.py
+@@ -4,17 +4,22 @@
+ __email__ = 'ageitgey@gmail.com'
+ __version__ = '0.1.0'
+ 
+-from pkg_resources import resource_filename
++try:
++    # Python 3.9+
++    from importlib.resources import files
++except ImportError:
++    # Python 3.7-3.8 fallback
++    from importlib_resources import files
+ 
+ def pose_predictor_model_location():
+-    return resource_filename(__name__, "models/shape_predictor_68_face_landmarks.dat")
++    return str(files(__name__).joinpath("models", "shape_predictor_68_face_landmarks.dat"))
+ 
+ def pose_predictor_five_point_model_location():
+-    return resource_filename(__name__, "models/shape_predictor_5_face_landmarks.dat")
++    return str(files(__name__).joinpath("models", "shape_predictor_5_face_landmarks.dat"))
+ 
+ def face_recognition_model_location():
+-    return resource_filename(__name__, "models/dlib_face_recognition_resnet_model_v1.dat")
++    return str(files(__name__).joinpath("models", "dlib_face_recognition_resnet_model_v1.dat"))
+ 
+ def cnn_face_detector_model_location():
+-    return resource_filename(__name__, "models/mmod_human_face_detector.dat")
++    return str(files(__name__).joinpath("models", "mmod_human_face_detector.dat"))
+ 

--- a/pkgs/development/python-modules/face-recognition/models.nix
+++ b/pkgs/development/python-modules/face-recognition/models.nix
@@ -2,7 +2,7 @@
   buildPythonPackage,
   lib,
   fetchPypi,
-  setuptools_80,
+  setuptools,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -16,7 +16,13 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-t5vSAKiMh8mp1EbJkK5xxaYm0fNzAXTm1XAVf/HYls8=";
   };
 
-  build-system = [ setuptools_80 ];
+  patches = [
+    # Replace deprecated pkg_resources with importlib.resources
+    # https://github.com/ageitgey/face_recognition_models/pull/24
+    ./0001-use-importlib-resources.patch
+  ];
+
+  build-system = [ setuptools ];
 
   # no tests
   doCheck = false;


### PR DESCRIPTION
`python3Packages.face-recognition`'s [pytestCheckHook failed](https://hydra.nixos.org/build/337021787/nixlog/1) because `python3Packages.face-recognition-models` uses setuptools_80.

The patch is fetched from the [open pull request](https://github.com/ageitgey/face_recognition_models/pull/24) upstream.

- Closes #541849

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
