### PR TITLE
Nixos/graphical desktop omit empty xkb options

### DIFF
--- a/nixos/modules/services/misc/graphical-desktop.nix
+++ b/nixos/modules/services/misc/graphical-desktop.nix
@@ -23,16 +23,34 @@ in
   config = lib.mkIf cfg.enable {
     environment = {
       # localectl looks into 00-keyboard.conf
-      etc."X11/xorg.conf.d/00-keyboard.conf".text = ''
-        Section "InputClass"
-          Identifier "Keyboard catchall"
-          MatchIsKeyboard "on"
-          Option "XkbModel" "${xcfg.xkb.model}"
-          Option "XkbLayout" "${xcfg.xkb.layout}"
-          Option "XkbOptions" "${xcfg.xkb.options}"
-          Option "XkbVariant" "${xcfg.xkb.variant}"
-        EndSection
-      '';
+      # Empty Option values are omitted: systemd-localed (since v261) considers them invalid and then ignores the whole file, breaking keymap discovery via org.freedesktop.locale1.
+      etc."X11/xorg.conf.d/00-keyboard.conf".text =
+        let
+          options = lib.filter (opt: opt.value != "") [
+            {
+              name = "XkbModel";
+              value = xcfg.xkb.model;
+            }
+            {
+              name = "XkbLayout";
+              value = xcfg.xkb.layout;
+            }
+            {
+              name = "XkbOptions";
+              value = xcfg.xkb.options;
+            }
+            {
+              name = "XkbVariant";
+              value = xcfg.xkb.variant;
+            }
+          ];
+        in
+        ''
+          Section "InputClass"
+            Identifier "Keyboard catchall"
+            MatchIsKeyboard "on"
+          ${lib.concatMapStrings (opt: "  Option \"${opt.name}\" \"${opt.value}\"\n") options}EndSection
+        '';
       systemPackages = with pkgs; [
         nixos-icons # needed for gnome and pantheon about dialog, nixos-manual and maybe more
         xdg-utils

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -957,6 +957,7 @@ in
   lldap = runTest ./lldap.nix;
   local-content-share = runTest ./local-content-share.nix;
   locale = runTest ./locale.nix;
+  localed-keyboard = runTest ./localed-keyboard.nix;
   localsend = runTest ./localsend.nix;
   locate = runTest ./locate.nix;
   login = runTest ./login.nix;

--- a/nixos/tests/localed-keyboard.nix
+++ b/nixos/tests/localed-keyboard.nix
@@ -1,0 +1,40 @@
+# Checks that systemd-localed reports the X11 keyboard configuration from the
+# generated /etc/X11/xorg.conf.d/00-keyboard.conf. Compositors such as kwin
+# (kwin_wayland --locale1, used by the SDDM greeter) read the keymap from the
+# org.freedesktop.locale1 D-Bus interface, so localed failing to parse the file
+# leaves them on the default us layout.
+# Regression test for https://github.com/systemd/systemd/issues/43007.
+{ ... }:
+{
+  name = "localed-keyboard";
+  meta.maintainers = [ ];
+
+  nodes = {
+    # xkb.variant deliberately left at its default "": empty values must not
+    # end up in 00-keyboard.conf, where systemd-localed (since v261) treats
+    # them as invalid and then discards the whole file.
+    default_variant = {
+      services.graphical-desktop.enable = true;
+      services.xserver.xkb.layout = "gb";
+    };
+
+    with_variant = {
+      services.graphical-desktop.enable = true;
+      services.xserver.xkb.layout = "gb";
+      services.xserver.xkb.variant = "extd";
+    };
+  };
+
+  testScript = ''
+    start_all()
+
+    default_variant.wait_for_unit("multi-user.target")
+    out = default_variant.succeed("localectl status")
+    assert "X11 Layout: gb" in out, out
+
+    with_variant.wait_for_unit("multi-user.target")
+    out = with_variant.succeed("localectl status")
+    assert "X11 Layout: gb" in out, out
+    assert "X11 Variant: extd" in out, out
+  '';
+}


### PR DESCRIPTION
`00-keyboard.conf` is generated with all four `Option` entries unconditionally, including empty ones such as `Option "XkbVariant" ""` when `services.xserver.xkb.variant` is unset (the default).

Since systemd 261, `string_is_safe()` rejects empty strings (systemd/systemd@812aa57d2c), and systemd-localed applies it to every field parsed from `00-keyboard.conf`, discarding the entire parsed X11 context when any field fails. As a result `localectl status` reports `X11 Layout: (unset)` and the `X11Layout` property on `org.freedesktop.locale1` is empty, even though the file names a valid layout.

This has a serious user-facing consequence on Plasma 6: the SDDM greeter runs `kwin_wayland --locale1`, which reads the keymap from locale1 and falls back to the `us` layout when the property is empty. Users with a non-us layout and layout-dependent characters in their password cannot log in through the display manager (TTY logins still work since the console keymap does not go through localed).

This change writes only non-empty `Option` values, which is equivalent as far as the X server is concerned and restores correct localed behavior on systemd 261. The generated file is unchanged for configurations where all four xkb settings are non-empty.

The localed regression is also reported upstream: systemd/systemd#43007.

Closes #541408.

Verification: with a minimal NixOS VM (`services.graphical-desktop.enable`, `services.xserver.xkb.layout = "gb"`, systemd 261 from this branch), `localectl status` reports `X11 Layout: gb` with this change and `X11 Layout: (unset)` without it. Rendering the generated file with an empty and a non-empty variant confirms only the empty `Option` line is dropped. This PR adds `nixosTests.localed-keyboard` covering the localed path (fails without the fix, passes with it), and the existing `keymap` tests (`azerty`, `qwertz`, `colemak`) pass against this branch, confirming the X server treats the omitted empty options the same as explicitly empty ones.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
