### PR TITLE
python3Packages.gensim: fix build with python 3.14

### DIFF
--- a/pkgs/development/python-modules/gensim/default.nix
+++ b/pkgs/development/python-modules/gensim/default.nix
@@ -19,17 +19,27 @@
   testfixtures,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "gensim";
   version = "4.4.0";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "piskvorky";
     repo = "gensim";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-TXutcU43ReBj9ss9+zBJFUxb5JqVHpl+B0c7hqcJAJY=";
   };
+
+  patches = [
+    # Fall back to serial chunkize when the multiprocessing start method is not
+    # "fork" (the default changed to "forkserver" on Linux with Python 3.14).
+    # Vendored (filtered to gensim/utils.py) from the not yet merged
+    # https://github.com/piskvorky/gensim/pull/3649
+    ./python314-chunkize-forkserver.patch
+  ];
 
   build-system = [
     cython
@@ -70,7 +80,8 @@ buildPythonPackage rec {
     description = "Topic-modelling library";
     homepage = "https://radimrehurek.com/gensim/";
     downloadPage = "https://github.com/piskvorky/gensim";
-    changelog = "https://github.com/RaRe-Technologies/gensim/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/RaRe-Technologies/gensim/blob/${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.lgpl21Only;
+    maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/gensim/python314-chunkize-forkserver.patch
+++ b/pkgs/development/python-modules/gensim/python314-chunkize-forkserver.patch
@@ -1,0 +1,149 @@
+diff --git a/gensim/utils.py b/gensim/utils.py
+index 2abd5179e09671de1ea9ef48a9dc3fc4bce9b465..20bad4857bf4e159bc0e244522aa21bd41af8712 100644
+--- a/gensim/utils.py
++++ b/gensim/utils.py
+@@ -1302,90 +1302,68 @@
+             self.q.put(wrapped_chunk.pop(), block=True)
+ 
+ 
+-# Multiprocessing on Windows (and on OSX with python3.8+) uses "spawn" mode, which
+-# causes issues with pickling.
+-# So for these two platforms, use simpler serial processing in `chunkize`.
+-# See https://github.com/RaRe-Technologies/gensim/pull/2800#discussion_r410890171
+-if os.name == 'nt' or (sys.platform == "darwin" and sys.version_info >= (3, 8)):
+-    def chunkize(corpus, chunksize, maxsize=0, as_numpy=False):
+-        """Split `corpus` into fixed-sized chunks, using :func:`~gensim.utils.chunkize_serial`.
++def chunkize(corpus, chunksize, maxsize=0, as_numpy=False):
++    """Split `corpus` into fixed-sized chunks, using :func:`~gensim.utils.chunkize_serial`.
+ 
+-        Parameters
+-        ----------
+-        corpus : iterable of object
+-            An iterable.
+-        chunksize : int
+-            Split `corpus` into chunks of this size.
+-        maxsize : int, optional
+-            Ignored. For interface compatibility only.
+-        as_numpy : bool, optional
+-            Yield chunks as `np.ndarray` s instead of lists?
+-
+-        Yields
+-        ------
+-        list OR np.ndarray
+-            "chunksize"-ed chunks of elements from `corpus`.
+-
+-        """
+-        if maxsize > 0:
+-            entity = "Windows" if os.name == 'nt' else "OSX with python3.8+"
+-            warnings.warn("detected %s; aliasing chunkize to chunkize_serial" % entity)
+-        for chunk in chunkize_serial(corpus, chunksize, as_numpy=as_numpy):
+-            yield chunk
+-else:
+-    def chunkize(corpus, chunksize, maxsize=0, as_numpy=False):
+-        """Split `corpus` into fixed-sized chunks, using :func:`~gensim.utils.chunkize_serial`.
+-
+-        Parameters
+-        ----------
+-        corpus : iterable of object
+-            An iterable.
+-        chunksize : int
+-            Split `corpus` into chunks of this size.
+-        maxsize : int, optional
+-            If > 0, prepare chunks in a background process, filling a chunk queue of size at most `maxsize`.
+-        as_numpy : bool, optional
+-            Yield chunks as `np.ndarray` instead of lists?
+-
+-        Yields
+-        ------
+-        list OR np.ndarray
+-            "chunksize"-ed chunks of elements from `corpus`.
++    Parameters
++    ----------
++    corpus : iterable of object
++        An iterable.
++    chunksize : int
++        Split `corpus` into chunks of this size.
++    maxsize : int, optional
++        If > 0, prepare chunks in a background process, filling a chunk queue of size at most `maxsize`.
++    as_numpy : bool, optional
++        Yield chunks as `np.ndarray` instead of lists?
+ 
+-        Notes
+-        -----
+-        Each chunk is of length `chunksize`, except the last one which may be smaller.
+-        A once-only input stream (`corpus` from a generator) is ok, chunking is done efficiently via itertools.
++    Yields
++    ------
++    list OR np.ndarray
++        "chunksize"-ed chunks of elements from `corpus`.
+ 
+-        If `maxsize > 0`, don't wait idly in between successive chunk `yields`, but rather keep filling a short queue
+-        (of size at most `maxsize`) with forthcoming chunks in advance. This is realized by starting a separate process,
+-        and is meant to reduce I/O delays, which can be significant when `corpus` comes from a slow medium
+-        like HDD, database or network.
++    Notes
++    -----
++    Each chunk is of length `chunksize`, except the last one which may be smaller.
++    A once-only input stream (`corpus` from a generator) is ok, chunking is done efficiently via itertools.
+ 
+-        If `maxsize == 0`, don't fool around with parallelism and simply yield the chunksize
+-        via :func:`~gensim.utils.chunkize_serial` (no I/O optimizations).
++    If `maxsize > 0`, don't wait idly in between successive chunk `yields`, but rather keep filling a short queue
++    (of size at most `maxsize`) with forthcoming chunks in advance. This is realized by starting a separate process,
++    and is meant to reduce I/O delays, which can be significant when `corpus` comes from a slow medium
++    like HDD, database or network.
+ 
+-        Yields
+-        ------
+-        list of object OR np.ndarray
+-            Groups based on `iterable`
++    If `maxsize == 0`, don't fool around with parallelism and simply yield the chunksize
++    via :func:`~gensim.utils.chunkize_serial` (no I/O optimizations).
+ 
+-        """
+-        assert chunksize > 0
++    Yields
++    ------
++    list of object OR np.ndarray
++        Groups based on `iterable`
+ 
++    """
++    assert chunksize > 0
++
++    # 1. Evaluate the start method dynamically at runtime
++    # 2. Only attempt multiprocessing if maxsize > 0 AND the method is 'fork'
++    # See https://github.com/RaRe-Technologies/gensim/pull/2800#discussion_r410890171
++    if maxsize > 0 and multiprocessing.get_start_method() == "fork":
++        q = multiprocessing.Queue(maxsize=maxsize)
++        worker = InputQueue(q, corpus, chunksize, maxsize=maxsize, as_numpy=as_numpy)
++        worker.daemon = True
++        worker.start()
++        while True:
++            chunk = [q.get(block=True)]
++            if chunk[0] is None:
++                break
++            yield chunk.pop()
++    else:
++        # Fallback to serial processing
+         if maxsize > 0:
+-            q = multiprocessing.Queue(maxsize=maxsize)
+-            worker = InputQueue(q, corpus, chunksize, maxsize=maxsize, as_numpy=as_numpy)
+-            worker.daemon = True
+-            worker.start()
+-            while True:
+-                chunk = [q.get(block=True)]
+-                if chunk[0] is None:
+-                    break
+-                yield chunk.pop()
+-        else:
+-            for chunk in chunkize_serial(corpus, chunksize, as_numpy=as_numpy):
+-                yield chunk
++            # We only warn if they asked for multiprocessing but we have to deny it
++            current_method = multiprocessing.get_start_method()
++            warnings.warn(f"start method is '{current_method}', not 'fork'; aliasing chunkize to chunkize_serial")
++
++        for chunk in chunkize_serial(corpus, chunksize, as_numpy=as_numpy):
++            yield chunk
+ 
+ 
+ def smart_extension(fname, ext):

--- a/pkgs/development/python-modules/pyemd/default.nix
+++ b/pkgs/development/python-modules/pyemd/default.nix
@@ -1,24 +1,27 @@
 {
   lib,
   buildPythonPackage,
-  cython,
   fetchPypi,
   numpy,
-  oldest-supported-numpy,
-  packaging,
+  pot,
   pytestCheckHook,
+  pythonOlder,
   setuptools-scm,
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pyemd";
-  version = "1.0.0";
+  version = "2.0.0";
   pyproject = true;
 
+  __structuredAttrs = true;
+
+  disabled = pythonOlder "3.12";
+
   src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-tCta57LRWx1N7mOBDqeYo5IX6Kdre0nA62OoTg/ZAP4=";
+    inherit (finalAttrs) pname version;
+    hash = "sha256-FZaflENcK+mOajakkwfINm49/BpnASrMMG6SyQtQP+U=";
   };
 
   build-system = [
@@ -26,28 +29,18 @@ buildPythonPackage rec {
     setuptools-scm
   ];
 
-  nativeBuildInputs = [
-    cython
+  dependencies = [
     numpy
-    oldest-supported-numpy
-    packaging
+    pot
   ];
-
-  dependencies = [ numpy ];
 
   nativeCheckInputs = [ pytestCheckHook ];
-
-  disabledTests = [
-    # Broken with Numpy 2.x, https://github.com/wmayner/pyemd/issues/68
-    "test_emd_samples_2"
-    "test_emd_samples_3"
-  ];
 
   meta = {
     description = "Python wrapper for Ofir Pele and Michael Werman's implementation of the Earth Mover's Distance";
     homepage = "https://github.com/wmayner/pyemd";
-    changelog = "https://github.com/wmayner/pyemd/releases/tag/${version}";
+    changelog = "https://github.com/wmayner/pyemd/blob/v${finalAttrs.version}/CHANGELOG.rst";
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})


### PR DESCRIPTION
## Things done

**pyemd 1.0.0** fails to build: it imports `pkg_resources` at runtime, which is no longer available. Fixed by the bump itself.

**gensim** (depends on pyemd for tests) fails 21 tests with `TypeError: cannot pickle 'generator' object`: Python 3.14 changed the default multiprocessing start method on Linux from `fork` to `forkserver`, and gensim's `chunkize` spawns a background process carrying the corpus generator, which can't be pickled. Fixed by applying the upstream patch from piskvorky/gensim#3649 (filtered to `gensim/utils.py`), which falls back to serial chunking when the start method isn't `fork`.


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
