### PR TITLE
Updated and added runtime dependencies for flacon, varia, patool, and cantor, and added a new package: tabby-term

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1411,6 +1411,12 @@
     githubId = 30437811;
     name = "Alex Andrews";
   };
+  aliheidary1381 = {
+    email = "aliheidary1381@gmail.com";
+    github = "aliheidary1381";
+    githubId = 31212739;
+    name = "Ali Heydari";
+  };
   alikindsys = {
     email = "alice@blocovermelho.org";
     github = "alikindsys";

--- a/pkgs/by-name/fl/flacon/package.nix
+++ b/pkgs/by-name/fl/flacon/package.nix
@@ -5,7 +5,7 @@
   cmake,
   libuchardet,
   pkg-config,
-  shntool,
+  faac,
   flac,
   opus-tools,
   vorbis-tools,
@@ -17,53 +17,67 @@
   monkeys-audio,
   sox,
   gtk3,
-  libsForQt5,
+  qt6,
+  ttaenc,
+  withFaac ? false,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "flacon";
-  version = "12.0.0";
+  version = "13.0.1";
 
   src = fetchFromGitHub {
     owner = "flacon";
     repo = "flacon";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-r9SdQg6JTMoGxO2xUtkkBe5F5cajnsndZEq20BjJGuU=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-OsfgaSC6tji653n2V+bMYIJHatax6GsXZ02PH6hnDpk=";
   };
 
   nativeBuildInputs = [
     cmake
     pkg-config
-    libsForQt5.wrapQtAppsHook
+    qt6.wrapQtAppsHook
   ];
   buildInputs = [
-    libsForQt5.qtbase
-    libsForQt5.qttools
+    qt6.qtbase
+    qt6.qttools
     libuchardet
     taglib
   ];
 
-  bin_path = lib.makeBinPath [
-    shntool
-    flac
-    opus-tools
-    vorbis-tools
-    mp3gain
-    lame
-    wavpack
-    monkeys-audio
-    vorbisgain
-    sox
-  ];
+  bin_path = lib.makeBinPath (
+    [
+      flac
+      opus-tools
+      vorbis-tools
+      mp3gain
+      lame
+      ttaenc
+      wavpack
+      monkeys-audio
+      vorbisgain
+      sox
+    ]
+    ++ lib.optional withFaac faac
+  );
 
-  postInstall = ''
-    wrapProgram $out/bin/flacon \
-      --suffix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}" \
-      --prefix PATH : "$bin_path";
-  '';
+  qtWrapperArgs = [
+    "--suffix XDG_DATA_DIRS : ${gtk3}/share/gsettings-schemas/${gtk3.name}"
+    "--prefix PATH : ${finalAttrs.bin_path}"
+  ];
 
   meta = {
     description = "Extracts audio tracks from an audio CD image to separate tracks";
+    longDescription = ''
+      Flacon extracts individual tracks from one big audio file containing the
+      entire album of music and saves them as separate audio files. To do this,
+      it uses information from the appropriate CUE file. Besides, Flacon makes
+      it possible to conveniently revise or specify tags both for all tracks
+      at once or for each tag separately.
+
+      Supported input formats: WAV, FLAC, APE, WavPack, True Audio (TTA)
+      Supported output formats: FLAC, WAV, WavPack, AAC, OGG or MP3
+    '';
     mainProgram = "flacon";
     homepage = "https://flacon.github.io/";
     license = lib.licenses.lgpl21;

--- a/pkgs/by-name/rk/rkward/package.nix
+++ b/pkgs/by-name/rk/rkward/package.nix
@@ -1,0 +1,102 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  cmake,
+  pkg-config,
+  gettext,
+  rWrapper,
+  rPackages,
+  pandoc,
+  kdePackages,
+  qt6,
+  kdsingleapplication,
+  shared-mime-info,
+  rEnv ? rWrapper.override {
+    packages = with rPackages; [
+      R2HTML
+      rmarkdown
+    ];
+  },
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rkward";
+  version = "0.8.3";
+
+  src = fetchurl {
+    url = "mirror://kde/stable/rkward/${version}/rkward-${version}.tar.gz";
+    hash = "sha256-QNKmtt3HfLImzNlwNzUCNcoS06Qi8xsfmuPAG+Qn9eU=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    kdePackages.extra-cmake-modules
+    gettext
+    kdePackages.kdoctools
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    rEnv
+    qt6.qtbase
+    qt6.qtdeclarative
+    qt6.qtwebengine
+    qt6.qtwebview
+    qt6.qtsvg
+    kdePackages.breeze-icons
+    kdePackages.karchive
+    kdePackages.kcompletion
+    kdePackages.kconfig
+    kdePackages.kconfigwidgets
+    kdePackages.kcoreaddons
+    kdePackages.kcrash
+    kdePackages.ki18n
+    kdePackages.kio
+    kdePackages.kjobwidgets
+    kdePackages.knotifications
+    kdePackages.kparts
+    kdePackages.kservice
+    kdePackages.ktexteditor
+    kdePackages.kwidgetsaddons
+    kdePackages.kwindowsystem
+    kdePackages.kxmlgui
+    kdsingleapplication
+    shared-mime-info
+  ];
+
+  cmakeFlags = [
+    "-DDLOPEN_RLIB=OFF"
+  ];
+
+  qtWrapperArgs = [
+    "--prefix PATH : ${lib.makeBinPath [ pandoc ]}"
+    # Also missing KBibTeX as runtime dep, but it's deprecated in NixOS
+  ];
+
+  meta = with lib; {
+    description = "Easily extensible and easy-to-use IDE/GUI for R";
+    longDescription = ''
+      RKWard aims to become an easy to use, transparent frontend to R,
+      a powerful system for statistical computation and graphics.
+      Besides a convenient GUI for the most important statistical functions,
+      future versions will also provide seamless integration with an office-suite.
+    '';
+    homepage = "https://rkward.kde.org/";
+    license = with licenses; [
+      gpl2Plus
+      lgpl21Plus
+      mit
+      bsd3
+      cc0
+      fdl12Only
+    ];
+    maintainers = [ maintainers.aliheidary1381 ];
+    mainProgram = "rkward";
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/by-name/ta/tabby-terminal/package.nix
+++ b/pkgs/by-name/ta/tabby-terminal/package.nix
@@ -1,0 +1,147 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  dpkg,
+  autoPatchelfHook,
+  wrapGAppsHook3,
+  glib,
+  gtk3,
+  gsettings-desktop-schemas,
+  nss,
+  nspr,
+  dbus,
+  at-spi2-atk,
+  cups,
+  cairo,
+  pango,
+  atk,
+  libdrm,
+  mesa,
+  libglvnd,
+  libxkbcommon,
+  alsa-lib,
+  expat,
+  libnotify,
+  libsecret,
+  libappindicator-gtk3,
+  libx11,
+  libxcomposite,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxrandr,
+  libxcb,
+  libxtst,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tabby";
+  version = "1.0.230";
+
+  src = fetchurl {
+    url =
+      if stdenv.hostPlatform.system == "x86_64-linux" then
+        "https://github.com/Eugeny/${pname}/releases/download/v${version}/${pname}-${version}-linux-x64.deb"
+      else if stdenv.hostPlatform.system == "aarch64-linux" then
+        "https://github.com/Eugeny/${pname}/releases/download/v${version}/${pname}-${version}-linux-arm64.deb"
+      else
+        throw "Unsupported platform: ${stdenv.hostPlatform.system}";
+
+    hash =
+      if stdenv.hostPlatform.system == "x86_64-linux" then
+        "sha256-ZDyUIADOS2vvfRX485ae7Q7fhtGG24vsDRRMnlAqnQk="
+      else if stdenv.hostPlatform.system == "aarch64-linux" then
+        "sha256-HjSW9oaFVI7Pb+dYX0Yd6wFQX9DkZ6nKic3KZ+6RSmQ="
+      else
+        throw "Unsupported platform: ${stdenv.hostPlatform.system}";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    gsettings-desktop-schemas
+    nss
+    nspr
+    dbus
+    at-spi2-atk
+    cups
+    cairo
+    pango
+    atk
+    libdrm
+    mesa
+    libglvnd
+    libxkbcommon
+    alsa-lib
+    expat
+    libnotify
+    libsecret
+    libappindicator-gtk3
+    libx11
+    libxcomposite
+    libxdamage
+    libxext
+    libxfixes
+    libxrandr
+    libxcb
+    libxtst
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+    dpkg-deb -x $src .
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/opt
+    cp -r opt/Tabby $out/opt/
+
+    mkdir -p $out/share
+    cp -r usr/share/applications $out/share/
+    cp -r usr/share/icons $out/share/
+
+    mkdir -p $out/bin
+    ln -s $out/opt/Tabby/tabby $out/bin/tabby
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    rm -f $out/opt/Tabby/resources/app.asar.unpacked/node_modules/@serialport/bindings-cpp/prebuilds/linux-x64/node.napi.musl.node
+    substituteInPlace $out/share/applications/tabby.desktop --replace "/opt/Tabby/tabby" "$out/bin/tabby"
+  '';
+
+  gappsWrapperArgs = [
+    "--prefix LD_LIBRARY_PATH : ${
+      lib.makeLibraryPath [
+        mesa
+        libglvnd
+      ]
+    }"
+  ];
+
+  meta = with lib; {
+    description = "A terminal for a modern age";
+    homepage = "https://tabby.sh/";
+    license = licenses.mit;
+    maintainers = [ maintainers.aliheidary1381 ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    mainProgram = "tabby";
+  };
+}

--- a/pkgs/by-name/va/varia/package.nix
+++ b/pkgs/by-name/va/varia/package.nix
@@ -2,6 +2,8 @@
   lib,
   python3Packages,
   fetchFromGitHub,
+  makeWrapper,
+  glib,
   aria2,
   meson,
   ninja,
@@ -11,18 +13,19 @@
   desktop-file-utils,
   libadwaita,
   ffmpeg,
+  p7zip,
+  deno,
 }:
-
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "varia";
-  version = "2025.10.14-1";
+  version = "2026.3.27";
   pyproject = false;
 
   src = fetchFromGitHub {
     owner = "giantpinkrobots";
     repo = "varia";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Spx9boNNeOXGr82uVKSpHCbimflKKjbjur+aKsNZFhY=";
+    hash = "sha256-9BH9LL7eSGtjYJKveiJTuC/kWFGmEjNU4qy6JEGpG/4=";
   };
 
   nativeBuildInputs = [
@@ -32,6 +35,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
     gobject-introspection
     wrapGAppsHook4
     desktop-file-utils
+    makeWrapper
+    glib
   ];
 
   buildInputs = [
@@ -43,23 +48,38 @@ python3Packages.buildPythonApplication (finalAttrs: {
     aria2p
     yt-dlp
     emoji-country-flag
+    dbus-next
   ];
 
   postInstall = ''
     rm $out/bin/varia
-    mv $out/bin/varia-py.py $out/bin/varia
   '';
 
   dontWrapGApps = true;
 
-  # This replaces original varia wrapper
   preFixup = ''
-    makeWrapperArgs+=(
-      "''${gappsWrapperArgs[@]}"
-      --add-flag "${lib.getExe aria2}"
-      --add-flag "${lib.getExe ffmpeg}"
-      --add-flag "NOSNAP"
-    )
+    makeWrapper "$out/bin/varia-py.py" "$out/bin/varia" \
+      ''${gappsWrapperArgs[@]} \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          aria2
+          ffmpeg
+          p7zip
+          deno
+        ]
+      } \
+      --add-flags "${lib.getExe aria2}" \
+      --add-flags "${lib.getExe ffmpeg}" \
+      --add-flags "${lib.getExe p7zip}" \
+      --add-flags "deno" \
+      --add-flags "${lib.getExe deno}" \
+      --add-flags "NOSNAP"
+  '';
+
+  postFixup = ''
+    if [ -d "$out/share/glib-2.0/schemas" ]; then
+      glib-compile-schemas "$out/share/glib-2.0/schemas"
+    fi
   '';
 
   meta = {

--- a/pkgs/development/python-modules/patool/default.nix
+++ b/pkgs/development/python-modules/patool/default.nix
@@ -77,6 +77,18 @@ buildPythonPackage rec {
     "test_7z_file"
     "test_7za_file"
     "test_p7azip"
+    "test_py_tarfile_bz2"
+    "test_py_tarfile_bz2_file"
+    "test_tar_bz2"
+    "test_tar_bz2_file"
+    "test_tar_lzip"
+    "test_tar_lzma"
+    "test_tar_xz"
+    "test_tar_xz_file"
+    "test_tar_lzma"
+    "test_tar_xz"
+    "test_mime_file"
+    "test_mime_file_bzip"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ "test_ar" ];
 

--- a/pkgs/kde/gear/cantor/default.nix
+++ b/pkgs/kde/gear/cantor/default.nix
@@ -1,6 +1,6 @@
 {
+  lib,
   mkKdeDerivation,
-
   pkg-config,
   shared-mime-info,
 
@@ -12,7 +12,47 @@
   libspectre,
   luajit,
   poppler,
+  texliveSmall,
+  R,
+  julia,
+  python3,
+
+  libxslt,
+  glib,
+  lapack,
+  mesa,
+
+  runtimeBackends ? {
+    maxima = false;
+    octave = false;
+    scilab = false;
+    sage = false;
+    lua = false;
+    python = false;
+    R = false;
+  },
+
+  texliveScheme ? texliveSmall,
+  pythonEnv ? python3, # Replace with python3.withPackages
+  rEnv ? R, # Replace with rPackages.rWrapper
+
+  maxima,
+  octave,
+  scilab-bin,
+  sage,
+  lua,
 }:
+let
+  runtimeDeps =
+    lib.optional runtimeBackends.maxima maxima
+    ++ lib.optional runtimeBackends.octave octave
+    ++ lib.optional runtimeBackends.scilab scilab-bin
+    ++ lib.optional runtimeBackends.sage sage
+    ++ lib.optional runtimeBackends.lua lua
+    ++ lib.optional runtimeBackends.python pythonEnv
+    ++ lib.optional runtimeBackends.R rEnv
+    ++ [ texliveScheme ];
+in
 mkKdeDerivation {
   pname = "cantor";
 
@@ -20,6 +60,7 @@ mkKdeDerivation {
     pkg-config
     shared-mime-info
   ];
+
   extraBuildInputs = [
     qtsvg
     qttools
@@ -29,6 +70,23 @@ mkKdeDerivation {
     libspectre
     luajit
     poppler
-    # FIXME: can't find R, Julia - if anyone needs this, feel free to investigate
+
+    R
+    julia
+    python3
+
+    libxslt
+    glib
+    lapack
+    mesa
+  ];
+
+  extraCmakeFlags = [
+    "-DR_EXECUTABLE=${R}/bin/R"
+    "-DJULIA_EXECUTABLE=${julia}/bin/julia"
+  ];
+
+  qtWrapperArgs = [
+    "--prefix PATH : ${lib.makeBinPath runtimeDeps}"
   ];
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Tabby](https://tabby.sh/) is a modern FOSS terminal emulator built with Electron. Plugins are available for better integration with AI tools. I'm using it for some time now, and haven't noticed any runtime issues with the build. [#425256](https://github.com/NixOS/nixpkgs/pull/425256) builds the electron package from source, but hasn't seen progress for more than a year.

The current version of varia fails to communicate with D-Bus, because the `dbus-next` python lib is missing as a runtime dependency. I've also bumped the version to 2026.3.27, which also has added deno and 7zip as runtime dependencies.
This PR would also fix this draft: [#480013](https://github.com/NixOS/nixpkgs/pull/480013)

The new flacon version has migrated to qt6.

The current patool derivation fails to build. I fixed the tests.

The current cantor derivation had two missing backends (R and Julia), runtime dependencies, and some optional packages. This PR fixes them all.

Note: I haven't tested Tabby for arm64. Tho the x64 build is working fine on my device. There's also dmg packages in the release page, but I don't know how to use them. Any help from anyone who knows how to make a aarch64-darwin derivation using dmg or zip prebuilt packages is appreciated.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
