### PR TITLE
Update vkd3d-proton, add derivation with DLLs

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3950,6 +3950,12 @@
     githubId = 144260188;
     matrix = "@boralg:matrix.org";
   };
+  borgvall = {
+    email = "joroehl@gmx.de";
+    github = "Borgvall";
+    githubId = 1449771;
+    name = "Johannes Röhl";
+  };
   borisbabic = {
     email = "boris.ivan.babic@gmail.com";
     github = "borisbabic";

--- a/pkgs/by-name/vk/vkd3d-proton/package.nix
+++ b/pkgs/by-name/vk/vkd3d-proton/package.nix
@@ -63,7 +63,7 @@ let
           homepage = "https://github.com/HansKristian-Work/vkd3d-proton";
           description = "Fork of VKD3D, which aims to implement the full Direct3D 12 API on top of Vulkan";
           license = lib.licenses.lgpl21Plus;
-          maintainers = [ ];
+          maintainers = with lib.maintainers; [ borgvall ];
           platforms = if isWindows then lib.platforms.windows else wine.meta.platforms;
         };
       }

--- a/pkgs/by-name/vk/vkd3d-proton/package.nix
+++ b/pkgs/by-name/vk/vkd3d-proton/package.nix
@@ -4,47 +4,72 @@
   glslang,
   meson,
   ninja,
+  pkgsCross,
   stdenv,
   wine,
 }:
 
 let
   sources = callPackage ./sources.nix { };
+
+  # `stdenv'` is an explicit parameter (rather than pulling the mingw one via
+  # pkgsCross.mingwW64.callPackage) so that nativeBuildInputs like `wine`
+  # (needed for widl) stay bound to their plain build-platform derivation
+  # instead of going through Nix's cross-splicing, which currently crashes
+  # resolving wine's `wine32 = pkgsi686Linux.callPackage ...` under the mingw
+  # target combination.
+  mkVkd3dProton =
+    stdenv':
+    let
+      isWindows = stdenv'.hostPlatform.isWindows;
+    in
+    stdenv'.mkDerivation (
+      {
+        inherit (sources.vkd3d-proton) pname version src;
+
+        outputs = [
+          "out"
+          "dev"
+        ];
+
+        nativeBuildInputs = [
+          glslang
+          meson
+          ninja
+          wine
+        ];
+
+        buildInputs = lib.optionals isWindows [ pkgsCross.mingwW64.windows.pthreads ];
+
+        strictDeps = true;
+
+        postPatch = ''
+          substituteInPlace meson.build \
+            --replace-fail "vkd3d_build = vcs_tag(" \
+                           "vkd3d_build = vcs_tag( fallback : '$(cat .nixpkgs-auxfiles/vkd3d_build)'", \
+            --replace-fail "vkd3d_version = vcs_tag(" \
+                           "vkd3d_version = vcs_tag( fallback : '$(cat .nixpkgs-auxfiles/vkd3d_version)'",
+        '';
+
+        passthru = {
+          inherit sources;
+        }
+        // lib.optionalAttrs (!isWindows) {
+          # Real d3d12.dll / d3d12core.dll PE binaries, built in release mode.
+          dll = mkVkd3dProton pkgsCross.mingwW64.stdenv;
+        };
+
+        meta = {
+          homepage = "https://github.com/HansKristian-Work/vkd3d-proton";
+          description = "Fork of VKD3D, which aims to implement the full Direct3D 12 API on top of Vulkan";
+          license = lib.licenses.lgpl21Plus;
+          maintainers = [ ];
+          platforms = if isWindows then lib.platforms.windows else wine.meta.platforms;
+        };
+      }
+      // lib.optionalAttrs isWindows {
+        mesonBuildType = "release";
+      }
+    );
 in
-stdenv.mkDerivation (finalAttrs: {
-  inherit (sources.vkd3d-proton) pname version src;
-
-  outputs = [
-    "out"
-    "dev"
-  ];
-
-  nativeBuildInputs = [
-    glslang
-    meson
-    ninja
-    wine
-  ];
-
-  strictDeps = true;
-
-  postPatch = ''
-    substituteInPlace meson.build \
-      --replace-fail "vkd3d_build = vcs_tag(" \
-                     "vkd3d_build = vcs_tag( fallback : '$(cat .nixpkgs-auxfiles/vkd3d_build)'", \
-      --replace-fail "vkd3d_version = vcs_tag(" \
-                     "vkd3d_version = vcs_tag( fallback : '$(cat .nixpkgs-auxfiles/vkd3d_version)'",
-  '';
-
-  passthru = {
-    inherit sources;
-  };
-
-  meta = {
-    homepage = "https://github.com/HansKristian-Work/vkd3d-proton";
-    description = "Fork of VKD3D, which aims to implement the full Direct3D 12 API on top of Vulkan";
-    license = lib.licenses.lgpl21Plus;
-    maintainers = [ ];
-    inherit (wine.meta) platforms;
-  };
-})
+mkVkd3dProton stdenv

--- a/pkgs/by-name/vk/vkd3d-proton/sources.nix
+++ b/pkgs/by-name/vk/vkd3d-proton/sources.nix
@@ -5,7 +5,7 @@
     let
       self = {
         pname = "vkd3d-proton";
-        version = "2.14.1";
+        version = "3.0.1";
 
         src = fetchFromGitHub {
           owner = "HansKristian-Work";
@@ -31,7 +31,7 @@
             git describe --always --tags --dirty=+ > .nixpkgs-auxfiles/vkd3d_version
             find $out -name .git -print0 | xargs -0 rm -fr
           '';
-          hash = "sha256-8YA/I5UL6G5v4uZE2qKqXzHWeZxg67jm20rONKocvvE=";
+          hash = "sha256-PFJU5x/Zd5+AytNag69aqessmZTSvDdTZ62z74w5xlU=";
         };
       };
     in


### PR DESCRIPTION
Updated vkd3d-proton to newest upstream version 3.0.1. In addition add a passthru derivation `vkd3d-proton.dll`, which provides the Widowe-PE-DLLs of vkd3d built in release mode. They are built in release mode, as this is the default mode tested by upstream.

I have played Ghostrunner in D3D12 mode using the built DLL.

AI disclosure:

I have discussed, how to build the DLLs, with Claude Code/Somnet 5.

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
