### PR TITLE
libgpg-error: Fix t-printf test on some platforms, patch around failures on others

### DIFF
--- a/pkgs/by-name/li/libgpg-error/libgpg-error-tests-skip-a-test-when-not-HAVE_LONG_DOUBLE_WIDER.patch
+++ b/pkgs/by-name/li/libgpg-error/libgpg-error-tests-skip-a-test-when-not-HAVE_LONG_DOUBLE_WIDER.patch
@@ -1,0 +1,59 @@
+commit bfdf7b0b7b62f4463451a7d5f8408cec75520dca
+Author: NIIBE Yutaka <gniibe@fsij.org>
+Date:   Thu Jun 25 10:53:29 2026 +0900
+
+    tests: Skip a test when !HAVE_LONG_DOUBLE_WIDER.
+    
+    * configure.ac (AC_TYPE_LONG_DOUBLE_WIDER): New.
+    * tests/t-printf.c (check_large_float): Fix a typo.
+    [!HAVE_LONG_DOUBLE_WIDER]: Skip the LDBL_MAX test.
+    
+    --
+    
+    GnuPG-bug-id: 8309
+    Signed-off-by: NIIBE Yutaka <gniibe@fsij.org>
+
+diff --git a/configure.ac b/configure.ac
+index e9abe0d..7871769 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -276,6 +276,7 @@ AC_C_CONST
+ AC_CHECK_SIZEOF(int)
+ AC_CHECK_SIZEOF(long)
+ AC_CHECK_SIZEOF(long long)
++AC_TYPE_LONG_DOUBLE_WIDER
+ 
+ GNUPG_FUNC_MKDIR_TAKES_ONE_ARG
+ 
+diff --git a/tests/t-printf.c b/tests/t-printf.c
+index 6cbd03f..b0a3f3f 100644
+--- a/tests/t-printf.c
++++ b/tests/t-printf.c
+@@ -449,7 +449,7 @@ check_large_float (void)
+             errno, strerror (errno));
+     }
+   else if (verbose)
+-    show ("format \"%%.100f\" with DBL_MAX: ->%s<-\n", buf2);
++    show ("format \"%%.101f\" with DBL_MAX: ->%s<-\n", buf2);
+ 
+   if (strcmp (buf, buf2))
+     fail ("format \"%%.100f\" does not match \"%%.101f\"\n" );
+@@ -469,6 +469,7 @@ check_large_float (void)
+     show ("format \"%%.100Lf\" with DBL_MAX: ->%s<-\n", buf);
+   gpgrt_free (buf);
+ 
++# ifdef HAVE_LONG_DOUBLE_WIDER
+   ld = LDBL_MAX;
+   buf = gpgrt_bsprintf ("%.100Lf\n", ld);
+   if (buf)
+@@ -478,6 +479,10 @@ check_large_float (void)
+   else if (verbose)
+     show ("format \"%%.100Lf\" with LDBL_MAX failed as expected\n");
+   gpgrt_free (buf);
++# else
++  if (verbose)
++    show ("LDBL_MAX == DBL_MAX - skipping LDBL_MAX test\n");
++# endif
+ 
+ #endif /*HAVE_LONG_DOUBLE*/
+ }

--- a/pkgs/by-name/li/libgpg-error/package.nix
+++ b/pkgs/by-name/li/libgpg-error/package.nix
@@ -1,6 +1,7 @@
 {
   stdenv,
   lib,
+  autoreconfHook,
   buildPackages,
   fetchurl,
   gettext,
@@ -32,6 +33,12 @@ stdenv.mkDerivation (
       hash = "sha256-eoVBPyvDVPT4qoMrcYrxIuSJZeng65AS7mWcE8Y4XJM=";
     };
 
+    patches = [
+      # Fixes t-printf test on platforms where LDBL_MAX == DBL_MAX (armhf, ppc64)
+      # Upstream's git forge doesn't seem to have a nice way to download it :/
+      ./libgpg-error-tests-skip-a-test-when-not-HAVE_LONG_DOUBLE_WIDER.patch
+    ];
+
     postPatch = ''
       sed '/BUILD_TIMESTAMP=/s/=.*/=1970-01-01T00:01+0000/' -i ./configure
     ''
@@ -39,6 +46,17 @@ stdenv.mkDerivation (
     # so add one for FreeBSD.
     + lib.optionalString (stdenv.hostPlatform.system == "x86_64-freebsd") ''
       cp ${./lock-obj-pub.x86_64-unknown-freebsd.h} src/syscfg/lock-obj-pub.freebsd.h
+    ''
+    # Fails on powerpc64-linux
+    # https://lists.gnupg.org/pipermail/gnupg-users/2026-July/068440.html
+    + lib.optionalString (stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isBigEndian) ''
+      substituteInPlace tests/t-printf.c \
+        --replace-fail \
+          '# ifdef HAVE_LONG_DOUBLE_WIDER' \
+          '# if 0' \
+        --replace-fail \
+          'show ("LDBL_MAX == DBL_MAX - skipping LDBL_MAX test\n")' \
+          'show ("LDBL_MAX is weird on this platform - skipping LDBL_MAX test\n")'
     '';
 
     hardeningDisable = [ "strictflexarrays3" ];
@@ -58,7 +76,10 @@ stdenv.mkDerivation (
     # If architecture-dependent MO files aren't available, they're generated
     # during build, so we need gettext for cross-builds.
     depsBuildBuild = [ buildPackages.stdenv.cc ];
-    nativeBuildInputs = [ gettext ];
+    nativeBuildInputs = [
+      autoreconfHook # HAVE_LONG_DOUBLE_WIDER patch changes configure.ac
+      gettext
+    ];
 
     postConfigure =
       # For some reason, /bin/sh on OpenIndiana leads to this at the end of the


### PR DESCRIPTION
Patch resulted from https://dev.gnupg.org/T8309, which applies to at least 32-bit ARMs.

Noticed on powerpc64-linux, where the above patch doesn't fix the issue. Prolly an issue with `long double` on this platform being extra-wack. Sent a message to their mailing list about it: https://lists.gnupg.org/pipermail/gnupg-users/2026-July/068440.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] powerpc64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
