### PR TITLE
godot: fix build on darwin by linking with lld

### DIFF
--- a/pkgs/development/tools/godot/common.nix
+++ b/pkgs/development/tools/godot/common.nix
@@ -38,6 +38,7 @@
   libxkbcommon,
   libxrandr,
   libxrender,
+  llvmPackages,
   makeWrapper,
   mbedtls,
   miniupnpc,
@@ -398,6 +399,8 @@ let
             "-I${lib.getDev harfbuzz-icu}/include/harfbuzz"
             "-I${lib.getDev recastnavigation}/include/recastnavigation"
           ];
+          # TODO: Remove when NixOS/nixpkgs#536365 reaches master.
+          NIX_CFLAGS_LINK = "--ld-path=${lib.getExe' llvmPackages.lld "ld64.lld"}";
         };
 
         preConfigure = lib.optionalString (editor && withMono) ''
@@ -643,6 +646,8 @@ let
         ++ lib.optionals stdenv.hostPlatform.isDarwin (
           [
             darwin.sigtool
+            # TODO: Remove when NixOS/nixpkgs#536365 reaches master.
+            llvmPackages.lld
           ]
           ++ lib.optionals (!editor) [
             strip-nondeterminism


### PR DESCRIPTION
Fixes the broken build on darwin by using llvm lld, similar to other darwin packages facing the same issue (eg #541023). Can be reverted with #536365

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
