### PR TITLE
foundationdb: support aarch64-darwin

### DIFF
--- a/pkgs/by-name/fo/foundationdb/package.nix
+++ b/pkgs/by-name/fo/foundationdb/package.nix
@@ -16,9 +16,11 @@
   jemalloc,
   doctest,
   zlib,
+  llvm,
 }:
 let
   boost = boost186;
+  isDarwin = stdenv.hostPlatform.isDarwin;
   # Only even numbered versions compile on aarch64; odd numbered versions have avx enabled.
   avxEnabled =
     version:
@@ -27,6 +29,8 @@ let
       patch = lib.toInt (lib.versions.patch version);
     in
     isOdd patch;
+  # ".so" on Linux, ".dylib" on Darwin - used to point CMake at the right OpenSSL libs.
+  sharedLibExt = stdenv.hostPlatform.extensions.sharedLibrary;
 in
 stdenv.mkDerivation rec {
   pname = "foundationdb";
@@ -93,9 +97,23 @@ stdenv.mkDerivation rec {
     openjdk
     pkg-config
     python3
-  ];
+  ]
+  # On Darwin FDB archives LTO objects with llvm-ar/llvm-ranlib (Linux uses
+  # gold + gcc-ar).
+  ++ lib.optional isDarwin llvm;
 
-  separateDebugInfo = true;
+  # The vendored fmt 8.1.1 fails to compile its consteval format-string checks
+  # under the non-Apple LLVM clang used on Darwin ("call to consteval function
+  # ... is not a constant expression"). fmt only enables the consteval path when
+  # __apple_build_version__ is undefined - true here - so defining FMT_CONSTEVAL
+  # empty drops back to runtime checks, which clang accepts. Kept in an
+  # optionalAttrs so non-Darwin derivations are untouched.
+  env = lib.optionalAttrs isDarwin {
+    NIX_CFLAGS_COMPILE = "-DFMT_CONSTEVAL=";
+  };
+
+  # separateDebugInfo relies on objcopy and ELF; it is a no-op / unsupported on Darwin.
+  separateDebugInfo = stdenv.hostPlatform.isLinux;
 
   cmakeFlags = [
     "-DFDB_RELEASE=TRUE"
@@ -118,15 +136,20 @@ stdenv.mkDerivation rec {
     # LTO brings up overall build time, but results in much smaller
     # binaries for all users and the cache.
     "-DUSE_LTO=ON"
-
-    # Gold helps alleviate the link time, especially when LTO is
-    # enabled. But even then, it still takes a majority of the time.
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    # Gold helps alleviate the link time, especially when LTO is enabled. But
+    # even then, it still takes a majority of the time. Gold is a binutils/ELF
+    # linker: on Darwin FDB would pass "-fuse-ld=gold -Wl,--disable-new-dtags",
+    # neither of which the system linker (ld64) understands, so leave USE_LD at
+    # its default (the system linker) there.
     "-DUSE_LD=GOLD"
-
+  ]
+  ++ [
     # FIXME: why can't openssl be found automatically?
     "-DOPENSSL_USE_STATIC_LIBS=FALSE"
-    "-DOPENSSL_CRYPTO_LIBRARY=${openssl.out}/lib/libcrypto.so"
-    "-DOPENSSL_SSL_LIBRARY=${openssl.out}/lib/libssl.so"
+    "-DOPENSSL_CRYPTO_LIBRARY=${openssl.out}/lib/libcrypto${sharedLibExt}"
+    "-DOPENSSL_SSL_LIBRARY=${openssl.out}/lib/libssl${sharedLibExt}"
   ];
 
   # the install phase for cmake is pretty wonky right now since it's not designed to
@@ -173,7 +196,13 @@ stdenv.mkDerivation rec {
     description = "Open source, distributed, transactional key-value store";
     homepage = "https://www.foundationdb.org";
     license = lib.licenses.asl20;
-    platforms = [ "x86_64-linux" ] ++ lib.optionals (!(avxEnabled version)) [ "aarch64-linux" ];
+    platforms = [
+      "x86_64-linux"
+    ]
+    ++ lib.optionals (!(avxEnabled version)) [
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
     # Fails when cross-compiling with "/bin/sh: gcc-ar: not found"
     broken = stdenv.buildPlatform != stdenv.hostPlatform;
     maintainers = with lib.maintainers; [


### PR DESCRIPTION
## Description

FoundationDB was Linux-only in nixpkgs. This makes it build and run on aarch64-darwin. All changes are gated to Darwin, so other platforms' derivations are byte-for-byte unchanged (verified: the x86_64-linux `.drv` is identical to master).

FoundationDB needs `mono` to compile and run its C# actor compiler for every C++ component (client included). `mono` was itself broken on aarch64-darwin by the ld64 hardening SIGTRAP, but that is now fixed on master (#536365, via staging-next #541843), so no mono change is needed here.

> ~~This PR also includes a `mono: fix build on aarch64-darwin` commit (link with `lld`), because `mono` is a hard build dependency of FoundationDB and was broken on aarch64-darwin.~~ Superseded by #536365 - the mono commit has been **dropped**; unpatched `mono` now builds on master.

### Darwin adjustments

- archive LTO objects with `llvm-ar` / `llvm-ranlib` (Linux uses gold + gcc-ar)
- drop `-DUSE_LD=GOLD` on Darwin (gold / `--disable-new-dtags` are ELF-only)
- point OpenSSL at `.dylib` instead of `.so`
- define `FMT_CONSTEVAL` empty: the vendored fmt 8.1.1 fails its consteval format-string checks under the non-Apple LLVM clang used here
- `separateDebugInfo` is Linux/ELF only
- ~~link with `lld` via `env.NIX_CFLAGS_LINK = "-fuse-ld=lld"`: the default cctools `ld` SIGTRAPs on FDB's large LTO links~~ **removed** - after #536365 disabled ld64 hardening on master, FDB links cleanly with the default ld64 (`libfdb_c.dylib` and all executables, no SIGTRAP)

`fdbserver`, `fdbcli`, `fdbbackup`, `fdbmonitor`, `libfdb_c.dylib` and the Java/C/Python bindings all build; the binaries run (`fdbserver --version` reports `7.3.68`). Verified with a clean sandboxed `nix build` producing all four outputs (`out`, `dev`, `lib`, `pythonsrc`) against current master.

## Things done

- Built on `aarch64-darwin` via a sandboxed `nix build` (all four outputs), no `lld` override, unpatched `mono`
- Ran the resulting `fdbserver` / `fdbcli` binaries
- Confirmed the x86_64-linux `.drv` is byte-for-byte identical to master (no rebuild)

## History

This PR originally targeted a master that predated the central ld64 hardening fix, so it carried two temporary `lld` workarounds:

- ~~a `mono: fix build on aarch64-darwin` commit~~
- ~~`foundationdb`: `env.NIX_CFLAGS_LINK = "-fuse-ld=lld"`~~

Both are now removed since #536365 landed on master, leaving a single foundationdb-only commit.
