### PR TITLE
navidromePlugins.listenbrainz-daily-playlist: 5.0.2 -> 6.0.0

### DIFF
--- a/pkgs/by-name/na/navidrome/plugins/listenbrainz-daily-playlist/package.nix
+++ b/pkgs/by-name/na/navidrome/plugins/listenbrainz-daily-playlist/package.nix
@@ -5,16 +5,16 @@
 }:
 buildNavidromePlugin rec {
   pname = "listenbrainz-daily-playlist";
-  version = "5.0.2";
+  version = "6.0.0";
 
   src = pkgs.fetchFromGitHub {
     owner = "kgarner7";
     repo = "navidrome-listenbrainz-daily-playlist";
     tag = "v${version}";
-    hash = "sha256-DsbnTu+Xi9pAG9fKgtlixxrd3od41TTeZ1hdjyEyGnk=";
+    hash = "sha256-Pzn6KwYzaCNGRH93lR4wfVnTiFr2zo8J2DAAZd41oas=";
   };
 
-  vendorHash = "sha256-zCKLwS85+aC4jfRcC2SjKGK/OYjW+izIhKKKLxNroQg=";
+  vendorHash = "sha256-wvRQjLom1ZmDabsPwin5uiR8ggSDWBrEvaFljuUd/bo=";
 
   meta = {
     description = "fetch daily/weekly playlists from ListenBrainz";


### PR DESCRIPTION
changelog: https://github.com/kgarner7/navidrome-listenbrainz-daily-playlist/releases/tag/v6.0.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
