### PR TITLE
Change default Rocq packages' name prefix

### DIFF
--- a/doc/languages-frameworks/rocq.section.md
+++ b/doc/languages-frameworks/rocq.section.md
@@ -59,7 +59,7 @@ The recommended way of defining a derivation for a Rocq library, is to use the `
 * `releaseRev` (optional, defaults to `(v: v)`), provides a default mapping from release names to revision hashes/branch names/tags,
 * `releaseArtifact` (optional, defaults to `(v: null)`), provides a default mapping from release names to artifact names (only works for github artifact for now),
 * `displayVersion` (optional), provides a way to alter the computation of `name` from `pname`, by explaining how to display version numbers,
-* `namePrefix` (optional, defaults to `[ "rocq-core" ]`), provides a way to alter the computation of `name` from `pname`, by explaining which dependencies must occur in `name`,
+* `namePrefix` (optional, defaults to `[ "rocq" ]`), provides a way to alter the computation of `name` from `pname`, by explaining which dependencies must occur in `name`,
 * `nativeBuildInputs` (optional), is a list of executables that are required to build the current derivation, in addition to the default ones (namely `which`, `dune` and `ocaml` depending on whether `useDune`, `useDuneifVersion` and `mlPlugin` are set).
 * `extraNativeBuildInputs` (optional, deprecated), an additional list of derivation to add to `nativeBuildInputs`,
 * `overrideNativeBuildInputs` (optional) replaces the default list of derivation to which `nativeBuildInputs` and `extraNativeBuildInputs` adds extra elements,

--- a/pkgs/build-support/rocq/default.nix
+++ b/pkgs/build-support/rocq/default.nix
@@ -55,7 +55,7 @@ in
   extraNativeBuildInputs ? [ ],
   overrideBuildInputs ? [ ],
   overrideNativeBuildInputs ? [ ],
-  namePrefix ? [ "rocq-core" ],
+  namePrefix ? null,
   enableParallelBuilding ? true,
   extraInstallFlags ? [ ],
   setROCQBIN ? true,
@@ -66,7 +66,7 @@ in
   dropDerivationAttrs ? [ ],
   useDuneifVersion ? (x: false),
   useDune ? false,
-  opam-name ? (concatStringsSep "-" (namePrefix ++ [ pname ])),
+  opam-name ? null,
   useCoq ? false,
   useCoqifVersion ? (x: false),
   ...
@@ -160,10 +160,12 @@ let
       ] ""
     )
     + optionalString (v == null) "-broken";
-  append-version = p: n: p + display-pkg n "" rocqPackages.${n}.version + "-";
-  prefix-name = foldl append-version "" namePrefix;
   useDune = args.useDune or (useDuneifVersion fetched.version);
   useCoq = args.useCoq or (useCoqifVersion fetched.version);
+  namePrefix = args.namePrefix or [ (if useCoq then "coq" else "rocq-core") ];
+  append-version = p: n: p + display-pkg n "" rocqPackages.${n}.version + "-";
+  prefix-name = foldl append-version "" namePrefix;
+  opam-name = args.opam-name or (concatStringsSep "-" (namePrefix ++ [ pname ]));
   rocq-core = if useCoq then coq // { rocq-version = coq.coq-version; } else args0.rocq-core;
   rocqlib-flags = [
     "COQLIBINSTALL=$(out)/lib/coq/${rocq-core.rocq-version}/user-contrib"

--- a/pkgs/build-support/rocq/default.nix
+++ b/pkgs/build-support/rocq/default.nix
@@ -162,8 +162,13 @@ let
     + optionalString (v == null) "-broken";
   useDune = args.useDune or (useDuneifVersion fetched.version);
   useCoq = args.useCoq or (useCoqifVersion fetched.version);
-  namePrefix = args.namePrefix or [ (if useCoq then "coq" else "rocq-core") ];
-  append-version = p: n: p + display-pkg n "" rocqPackages.${n}.version + "-";
+  namePrefix = args.namePrefix or [ (if useCoq then "coq" else "rocq") ];
+  append-version =
+    p: n:
+    let
+      version = if n == "rocq" then rocqPackages.rocq-core.version else rocqPackages.${n}.version;
+    in
+    p + display-pkg n "" version + "-";
   prefix-name = foldl append-version "" namePrefix;
   opam-name = args.opam-name or (concatStringsSep "-" (namePrefix ++ [ pname ]));
   rocq-core = if useCoq then coq // { rocq-version = coq.coq-version; } else args0.rocq-core;

--- a/pkgs/development/rocq-modules/mathcomp-analysis/default.nix
+++ b/pkgs/development/rocq-modules/mathcomp-analysis/default.nix
@@ -85,7 +85,7 @@ let
           ;
 
         namePrefix = [
-          "rocq-core"
+          "rocq"
           "mathcomp"
         ];
 

--- a/pkgs/development/rocq-modules/mathcomp-bigenough/default.nix
+++ b/pkgs/development/rocq-modules/mathcomp-bigenough/default.nix
@@ -9,7 +9,7 @@
 mkRocqDerivation {
 
   namePrefix = [
-    "rocq-core"
+    "rocq"
     "mathcomp"
   ];
   pname = "bigenough";

--- a/pkgs/development/rocq-modules/mathcomp-finmap/default.nix
+++ b/pkgs/development/rocq-modules/mathcomp-finmap/default.nix
@@ -9,7 +9,7 @@
 mkRocqDerivation {
 
   namePrefix = [
-    "rocq-core"
+    "rocq"
     "mathcomp"
   ];
   pname = "finmap";

--- a/pkgs/development/rocq-modules/mathcomp-real-closed/default.nix
+++ b/pkgs/development/rocq-modules/mathcomp-real-closed/default.nix
@@ -10,7 +10,7 @@
 mkRocqDerivation {
 
   namePrefix = [
-    "rocq-core"
+    "rocq"
     "mathcomp"
   ];
   pname = "real-closed";


### PR DESCRIPTION
The first commit is the same as in #541797. The second commit on top changes the default Rocq packages' name prefix from `[ "rocq-core" ]` to `[ "rocq" ]`, which means that in turns the default `opam-name` will be consistent with what is actually done in opam, and Dune builds will work (for now, we don't have any examples to test Dune builds because Dune support for Rocq is very recent).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
