### PR TITLE
mpv.tests.mpv-scripts-should-not-collide: unbreak

### DIFF
--- a/pkgs/by-name/mp/mpv/package.nix
+++ b/pkgs/by-name/mp/mpv/package.nix
@@ -117,6 +117,8 @@ symlinkJoin {
   passthru.tests.mpv-scripts-should-not-collide = buildEnv {
     name = "mpv-scripts-env";
     paths = lib.pipe mpvScripts [
+      # filters "throw" aliases
+      (lib.filterAttrs (key: script: (builtins.tryEval (lib.isDerivation script)).success))
       # filters "override" "overrideDerivation" "recurseForDerivations"
       (lib.filterAttrs (key: script: lib.isDerivation script))
       # replaces unfree and meta.broken scripts with decent placeholders

--- a/pkgs/by-name/mp/mpv/package.nix
+++ b/pkgs/by-name/mp/mpv/package.nix
@@ -121,6 +121,8 @@ symlinkJoin {
       (lib.filterAttrs (key: script: (builtins.tryEval (lib.isDerivation script)).success))
       # filters "override" "overrideDerivation" "recurseForDerivations"
       (lib.filterAttrs (key: script: lib.isDerivation script))
+      # filters mpv scripts that opt out of this check
+      (lib.filterAttrs (key: script: !(script.passthru.dontCollideCheck or false)))
       # replaces unfree and meta.broken scripts with decent placeholders
       (lib.mapAttrsToList (
         key: script:

--- a/pkgs/by-name/mp/mpv/scripts/modernx-zydezu.nix
+++ b/pkgs/by-name/mp/mpv/scripts/modernx-zydezu.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   installFonts,
   makeFontsConf,
+  mpvScripts,
   nix-update-script,
 }:
 buildLua (finalAttrs: {
@@ -29,6 +30,9 @@ buildLua (finalAttrs: {
   ];
 
   passthru.updateScript = nix-update-script { };
+
+  # FIXME?: collides with mpvScripts.modernx
+  passthru.dontCollideCheck = lib.hasAttr "modernx" mpvScripts;
 
   meta = {
     description = "Modern OSC UI replacement for MPV that retains the functionality of the default OSC";

--- a/pkgs/by-name/mp/mpv/scripts/mpv-osc-tethys.nix
+++ b/pkgs/by-name/mp/mpv/scripts/mpv-osc-tethys.nix
@@ -2,6 +2,7 @@
   lib,
   buildLua,
   fetchFromGitHub,
+  mpvScripts,
 }:
 buildLua (finalAttrs: {
   pname = "mpv-osc-tethys";
@@ -10,6 +11,9 @@ buildLua (finalAttrs: {
   scriptPath = "osc_tethys.lua";
   extraScriptsToCopy = [ "mpv_thumbnail_script_server.lua" ];
   extraScriptsToLoad = [ "mpv_thumbnail_script_server.lua" ];
+
+  # FIXME?: collides with mpvScripts.thumbnail, this one yields since it is unfree
+  passthru.dontCollideCheck = lib.hasAttr "thumbnail" mpvScripts;
 
   src = fetchFromGitHub {
     owner = "Zren";


### PR DESCRIPTION
- **mpv.tests.mpv-scripts-should-not-collide: handle "throw" aliases in mpvScripts**
- **mpv.tests.mpv-scripts-should-not-collide: add opt-out mechanism, use on modernx-zydezu**

---

* discovered in https://github.com/NixOS/nixpkgs/pull/540762#issuecomment-4970358906

---

pinging maintainers manually, since ofborg may not understand this one

@fpletz
@SchweGELBin
@uninsane

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
