### PR TITLE
scamper: init at scamper-cvs-20260713

### DIFF
--- a/pkgs/by-name/sc/scamper/package.nix
+++ b/pkgs/by-name/sc/scamper/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  autoreconfHook,
+  stdenv,
+  libtool,
+  fetchFromGitHub,
+  testers,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "scamper";
+  version = "20260713";
+
+  src = fetchFromGitHub {
+    owner = "alistairking";
+    repo = "scamper";
+    rev = "0f77b971cb10b7ca821e7090ff5da1c0f1ff8393";
+    hash = "sha256-sFYYr9SUW+mRMyg9V4McCVZCWZP3xXknLcazW9ERvpI=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    libtool
+  ];
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command = "scamper -v";
+  };
+
+  meta = {
+    description = "Like its predecessor skitter, scamper is a feature-rich tool that actively probes the Internet in order to analyze topology and performance.";
+    homepage = "https://www.caida.org/catalog/software/scamper/";
+    license = lib.licenses.gpl2;
+    mainProgram = "scamper";
+    maintainers = with lib.maintainers; [ robertrichter ];
+    platforms = libtool.meta.platforms;
+  };
+})


### PR DESCRIPTION
scamper tooling for active Internet measurements.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
