### PR TITLE
nanoarrow: fix build

### DIFF
--- a/pkgs/by-name/na/nanoarrow/cpp20-arrow-cpp-fix.diff
+++ b/pkgs/by-name/na/nanoarrow/cpp20-arrow-cpp-fix.diff
@@ -1,0 +1,13 @@
+diff --git i/meson.build w/meson.build
+index 5c3032d..5ec2e56 100644
+--- i/meson.build
++++ w/meson.build
+@@ -22,7 +22,7 @@ project(
+     version: '0.8.0',
+     license: 'Apache-2.0',
+     meson_version: '>=0.58.0',
+-    default_options: ['c_std=c99', 'warning_level=2', 'cpp_std=c++17'],
++    default_options: ['c_std=c99', 'warning_level=2', 'cpp_std=c++20'],
+ )
+ 
+ cc = meson.get_compiler('c')

--- a/pkgs/by-name/na/nanoarrow/package.nix
+++ b/pkgs/by-name/na/nanoarrow/package.nix
@@ -30,6 +30,12 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "apache-arrow-nanoarrow-${finalAttrs.version}";
     hash = "sha256-1iLbT1eeyZaoB75uYTgg4qns+C7b4DErqMwJ9nQPRls=";
   };
+  patches = [
+    # Fixes an issue between our `arrow-cpp` and this version of `nanoarrow`.
+    # Not applicable for upstreaming so it seems. See discussion:
+    # https://github.com/apache/arrow-nanoarrow/issues/902
+    ./cpp20-arrow-cpp-fix.diff
+  ];
 
   nativeBuildInputs = [
     meson


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
