### PR TITLE
e-imzo: add disable-startup option

### DIFF
--- a/nixos/modules/services/security/e-imzo.nix
+++ b/nixos/modules/services/security/e-imzo.nix
@@ -12,6 +12,10 @@ in
     services.e-imzo = {
       enable = lib.mkEnableOption "E-IMZO";
 
+      autostart = lib.mkEnableOption "auto startup" // {
+        default = true;
+      };
+
       package = lib.mkPackageOption pkgs "e-imzo" {
         extraDescription = "Official mirror deletes old versions as soon as they release new one. Feel free to use either unstable or your own custom e-imzo package and ping maintainer.";
       };
@@ -22,17 +26,17 @@ in
     systemd.user.services.e-imzo = {
       enable = true;
       description = "E-IMZO, uzbek state web signing service";
-      documentation = [ "https://github.com/xinux-org/e-imzo" ];
+      documentation = [ "https://git.oss.uzinfocom.uz/xinux/e-imzo-manager/" ];
 
-      after = [
-        "network-online.target"
-        "graphical.target"
-      ];
       wants = [
         "network-online.target"
         "graphical.target"
       ];
-      wantedBy = [ "default.target" ];
+      after = lib.optionals cfg.autostart [
+        "network-online.target"
+        "graphical.target"
+      ];
+      wantedBy = lib.optionals cfg.autostart [ "default.target" ];
 
       serviceConfig = {
         Type = "simple";


### PR DESCRIPTION
Adding option for users to disable auto-startup, so users can manually turn it on via our e-imzo-manager GTK application. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
