### PR TITLE
whatcable: init at 1.1.9

### DIFF
--- a/pkgs/by-name/wh/whatcable/package.nix
+++ b/pkgs/by-name/wh/whatcable/package.nix
@@ -1,0 +1,57 @@
+{
+  fetchzip,
+  lib,
+  nix-update-script,
+  re-plistbuddy,
+  stdenvNoCC,
+  versionCheckHook,
+  writeShellScript,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "whatcable";
+  version = "1.1.9";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchzip {
+    url = "https://github.com/darrylmorley/whatcable/releases/download/v${finalAttrs.version}/WhatCable.zip";
+    hash = "sha256-0taHQE4aUJrbRdWXZZyHfJ+2EzpEiXpsj8HWg04lgXg=";
+  };
+
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications/WhatCable.app" "$out/bin"
+    cp -R . "$out/Applications/WhatCable.app"
+    ln -s "$out/Applications/WhatCable.app/Contents/Helpers/whatcable" "$out/bin/whatcable"
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = writeShellScript "whatcable-version-check" ''
+    ${lib.getExe' re-plistbuddy "PlistBuddy"} -c "Print :CFBundleShortVersionString" "$1"
+  '';
+  versionCheckProgramArg = [ "${placeholder "out"}/Applications/WhatCable.app/Contents/Info.plist" ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "macOS menu bar app that explains USB-C cable capabilities";
+    homepage = "https://whatcable.uk";
+    changelog = "https://github.com/darrylmorley/whatcable/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tyceherrman ];
+    mainProgram = "whatcable";
+    platforms = [ "aarch64-darwin" ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
Adds WhatCable 1.1.9, the original macOS menu-bar app for inspecting USB-C cable, charger, and device capabilities. The existing GNOME extension package remains unchanged.

Packaging details:

- installs the signed upstream `WhatCable.app` release under `$out/Applications`
- exposes the bundled helper as `$out/bin/whatcable`
- preserves the Developer ID signatures and widget entitlements by disabling fixup
- checks `CFBundleShortVersionString` statically with PlistBuddy, avoiding execution during the build
- provides a `nix-update` update script

Validation performed on `aarch64-darwin`:

- formatted and evaluated the package
- built the package; `versionCheckHook` reported `1.1.9`
- ran the CLI with `--version`, `--help`, and `--json`
- verified the app and bundled helper with `codesign --verify --deep --strict`
- launched the app and completed its menu-bar onboarding
- ran the update script; version and hash remained current

Automation disclosure: the package expression and this pull request summary were prepared with OpenAI Codex (GPT-5) but reviewed by me.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
