### PR TITLE
python3Packages.paho-mqtt: regenerate certificates for tests

### DIFF
--- a/pkgs/by-name/es/esphome/package.nix
+++ b/pkgs/by-name/es/esphome/package.nix
@@ -18,16 +18,7 @@ let
     packageOverrides = self: super: {
       esphome-dashboard = self.callPackage ./dashboard.nix { };
 
-      paho-mqtt = super.paho-mqtt.overridePythonAttrs (oldAttrs: rec {
-        version = "1.6.1";
-        src = fetchFromGitHub {
-          inherit (oldAttrs.src) owner repo;
-          tag = "v${version}";
-          hash = "sha256-9nH6xROVpmI+iTKXfwv2Ar1PAmWbEunI3HO0pZyK6Rg=";
-        };
-        build-system = with self; [ setuptools ];
-        doCheck = false;
-      });
+      paho-mqtt = self.paho-mqtt_1;
     };
   };
 in

--- a/pkgs/development/python-modules/paho-mqtt/1.nix
+++ b/pkgs/development/python-modules/paho-mqtt/1.nix
@@ -1,0 +1,62 @@
+{
+  buildPythonPackage,
+  esphome,
+  fetchFromGitHub,
+  lib,
+  pytestCheckHook,
+  setuptools,
+}:
+
+let
+  testing = fetchFromGitHub {
+    owner = "eclipse";
+    repo = "paho.mqtt.testing";
+    rev = "a4dc694010217b291ee78ee13a6d1db812f9babd";
+    hash = "sha256-SQoNdkWMjnasPjpXQF2yV97MUra8gb27pc3rNoA8Rjw=";
+  };
+in
+buildPythonPackage (finalAttrs: {
+  pname = "paho-mqtt";
+  version = "1.6.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "eclipse";
+    repo = "paho.mqtt.python";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9nH6xROVpmI+iTKXfwv2Ar1PAmWbEunI3HO0pZyK6Rg=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "paho.mqtt" ];
+
+  doCheck = false;
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    ln -s ${testing} paho.mqtt.testing
+
+    # paho.mqtt not in top-level dir to get caught by this
+    export PYTHONPATH=".:$PYTHONPATH"
+  '';
+
+  disabledTests = [
+    # Fails during teardown
+    # RuntimeError: Client 01-zero-length-clientid.py exited with code None, expected 0
+    "test_01_zero_length_clientid"
+  ];
+
+  __darwinAllowLocalNetworking = true;
+
+  meta = {
+    changelog = "https://github.com/eclipse/paho.mqtt.python/blob/${finalAttrs.src.tag}/ChangeLog.txt";
+    description = "MQTT version 5.0/3.1.1 client class";
+    homepage = "https://eclipse.org/paho";
+    license = lib.licenses.epl20;
+    inherit (esphome.meta) maintainers;
+  };
+})

--- a/pkgs/development/python-modules/paho-mqtt/default.nix
+++ b/pkgs/development/python-modules/paho-mqtt/default.nix
@@ -4,6 +4,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   hatchling,
+  openssl,
   pytestCheckHook,
 }:
 
@@ -27,11 +28,17 @@ buildPythonPackage rec {
     hash = "sha256-VMq+WTW+njK34QUUTE6fR2j2OmHxVzR0wrC92zYb1rY=";
   };
 
+  postPatch = ''
+    substituteInPlace tests/ssl/gen.sh \
+      --replace-fail "c_rehash certs" "#c_rehash certs"
+  '';
+
   build-system = [
     hatchling
   ];
 
   nativeCheckInputs = [
+    openssl
     pytestCheckHook
   ];
 
@@ -44,6 +51,10 @@ buildPythonPackage rec {
 
     # paho.mqtt not in top-level dir to get caught by this
     export PYTHONPATH=".:$PYTHONPATH"
+
+    pushd tests/ssl
+    HOME="$(mktemp -d)" ./gen.sh
+    popd
   '';
 
   disabledTests = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12713,6 +12713,8 @@ self: super: with self; {
 
   paho-mqtt = callPackage ../development/python-modules/paho-mqtt/default.nix { };
 
+  paho-mqtt_1 = callPackage ../development/python-modules/paho-mqtt/1.nix { };
+
   paintcompiler = callPackage ../development/python-modules/paintcompiler { };
 
   pajgps-api = callPackage ../development/python-modules/pajgps-api { };


### PR DESCRIPTION
The certificate tests/ssl/server.crt expired on July 6, 2026, leading to

    ssl.SSLError: [SSL: SSLV3_ALERT_CERTIFICATE_EXPIRED] ssl/tls alert certificate expired (_ssl.c:1032)

in the tests.
See https://github.com/eclipse-paho/paho.mqtt.python/issues/927 and https://github.com/NixOS/nixpkgs/pull/538950#issuecomment-4969024377.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
