### PR TITLE
python3Packages.stopit: fix build

### DIFF
--- a/pkgs/development/python-modules/stopit/default.nix
+++ b/pkgs/development/python-modules/stopit/default.nix
@@ -6,21 +6,27 @@
 
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "stopit";
   version = "1.1.2";
-  format = "setuptools";
+  pyproject = true;
+  __structuredAttrs = true;
 
   # tests are missing from the PyPi tarball
   src = fetchFromGitHub {
     owner = "glenfant";
     repo = "stopit";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-uXJUA70JOGWT2NmS6S7fPrTWAJZ0mZ/hICahIUzjfbw=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [
     setuptools # for pkg_resources
+  ];
+
+  patches = [
+    # https://github.com/glenfant/stopit/pull/34
+    ./import_lib.patch
   ];
 
   pythonImportsCheck = [ "stopit" ];
@@ -28,7 +34,8 @@ buildPythonPackage rec {
   meta = {
     description = "Raise asynchronous exceptions in other thread, control the timeout of blocks or callables with a context manager or a decorator";
     homepage = "https://github.com/glenfant/stopit";
+    changelog = "https://github.com/glenfant/stopit/blob/${finalAttrs.version}/CHANGES.rst";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ veprbl ];
   };
-}
+})

--- a/pkgs/development/python-modules/stopit/import_lib.patch
+++ b/pkgs/development/python-modules/stopit/import_lib.patch
@@ -1,0 +1,81 @@
+From 9204d1de2ae294b878ed726c8278b28696a91f87 Mon Sep 17 00:00:00 2001
+From: Jonathan Kamens <jik@jik6.kamens.us>
+Date: Wed, 25 Sep 2024 15:52:03 -0400
+Subject: [PATCH 1/2] Use importlib instead of pkg_resources to determine
+ package version
+
+`pkg_resources` is deprecated and no longer available for import by
+default as of Python 3.12.
+---
+ src/stopit/__init__.py | 22 ++++++++++++++--------
+ 1 file changed, 14 insertions(+), 8 deletions(-)
+
+diff --git a/src/stopit/__init__.py b/src/stopit/__init__.py
+index 6ca0180..d2fb01e 100644
+--- a/src/stopit/__init__.py
++++ b/src/stopit/__init__.py
+@@ -7,19 +7,25 @@
+ Public resources from ``stopit``
+ """
+ 
+-import pkg_resources
++try:
++    from importlib.metadata import version
++    __version__ = version(__name__)
++except Exception:
++    # pkg_resources is deprecated as of Python 3.12 and no longer available for
++    # import by default.
++    try:
++        import pkg_resources
++    except Exception:
++        LOG.warning(
++            "Could not get the package version from importlib or pkg_resources")
++        __version__ = 'unknown'
++    else:
++        __version__ = pkg_resources.get_distribution(__name__).version
+ 
+ from .utils import LOG, TimeoutException
+ from .threadstop import ThreadingTimeout, async_raise, threading_timeoutable
+ from .signalstop import SignalTimeout, signal_timeoutable
+ 
+-# PEP 396 style version marker
+-try:
+-    __version__ = pkg_resources.get_distribution(__name__).version
+-except:
+-    LOG.warning("Could not get the package version from pkg_resources")
+-    __version__ = 'unknown'
+-
+ __all__ = (
+     'ThreadingTimeout', 'async_raise', 'threading_timeoutable',
+     'SignalTimeout', 'signal_timeoutable'
+
+From a2f6bde8a29cd281577426800b186802c68dbd86 Mon Sep 17 00:00:00 2001
+From: Jonathan Kamens <jik@jik7>
+Date: Mon, 28 Jul 2025 09:13:25 -0400
+Subject: [PATCH 2/2] Import LOG before trying to use it
+
+---
+ src/stopit/__init__.py | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/stopit/__init__.py b/src/stopit/__init__.py
+index d2fb01e..bbf7068 100644
+--- a/src/stopit/__init__.py
++++ b/src/stopit/__init__.py
+@@ -7,6 +7,8 @@
+ Public resources from ``stopit``
+ """
+ 
++from .utils import LOG, TimeoutException
++
+ try:
+     from importlib.metadata import version
+     __version__ = version(__name__)
+@@ -22,7 +24,6 @@
+     else:
+         __version__ = pkg_resources.get_distribution(__name__).version
+ 
+-from .utils import LOG, TimeoutException
+ from .threadstop import ThreadingTimeout, async_raise, threading_timeoutable
+ from .signalstop import SignalTimeout, signal_timeoutable
+ 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
