### PR TITLE
catdvi: enable __structuredAttrs, strictDeps

### DIFF
--- a/pkgs/by-name/ca/catdvi/package.nix
+++ b/pkgs/by-name/ca/catdvi/package.nix
@@ -19,6 +19,10 @@ in
 stdenv.mkDerivation (finalAttrs: {
   pname = "catdvi";
   version = "0.14";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
   src = fetchurl {
     url = with finalAttrs; "http://downloads.sourceforge.net/catdvi/catdvi-${version}.tar.bz2";
     hash = "sha256-orVQVdQuRXp//OGkA7xRidNi4+J+tkw398LPZ+HX+k8=";
@@ -51,13 +55,9 @@ stdenv.mkDerivation (finalAttrs: {
     '') buildPlatformTools
   );
 
-  nativeBuildInputs = [
-    texlive.bin.core
-    texlive.bin.core.dev
-  ];
-
   buildInputs = [
     tex
+    texlive.bin.core
   ];
 
   makeFlags = [


### PR DESCRIPTION
#178468 

## Things done

Build logs are equivalent

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
