### PR TITLE
bilibili-tui: 1.0.9 -> 1.0.12

### DIFF
--- a/pkgs/by-name/bi/bilibili-tui/package.nix
+++ b/pkgs/by-name/bi/bilibili-tui/package.nix
@@ -5,8 +5,9 @@
   nix-update-script,
   stdenv,
   pkg-config,
-  makeWrapper,
+  makeBinaryWrapper,
   openssl,
+  cacert,
   mpv-unwrapped,
   yt-dlp-light,
 
@@ -14,22 +15,27 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "bilibili-tui";
-  version = "1.0.9";
+  version = "1.0.12";
 
   src = fetchFromGitHub {
     owner = "MareDevi";
     repo = "bilibili-tui";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-LACNDpVhlYEgT3fN+Ff2MVipblUqPlqwOUpTLaXSCbk=";
+    hash = "sha256-G2aoPw8SMu3ytHbxcQrf1iH6i+b9viM+/EYorv6j5bg=";
   };
 
-  cargoHash = "sha256-q3jRjmzQA64sZjVShoEmu1x2CFOAgBGgZYyTq7Lg4is=";
+  cargoHash = "sha256-ojAN98of7vZp/F1n0a/88e6k4nBPG9HPKyTO1xc8o4Q=";
 
-  nativeBuildInputs = [ makeWrapper ] ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [ pkg-config ];
+  nativeBuildInputs = [
+    makeBinaryWrapper
+  ]
+  ++ lib.optional (!stdenv.hostPlatform.isDarwin) pkg-config;
 
-  buildInputs = lib.optionals (!stdenv.hostPlatform.isDarwin) [ openssl ];
+  buildInputs = lib.optional (!stdenv.hostPlatform.isDarwin) openssl;
 
   env.OPENSSL_NO_VENDOR = true;
+
+  nativeCheckInputs = [ cacert ];
 
   # Wrap mpv as fallback; users should prefer their system's mpv in PATH
   postInstall = lib.optionalString withMpv ''


### PR DESCRIPTION
https://github.com/MareDevi/bilibili-tui/blob/main/CHANGELOG.md
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
