### PR TITLE
qalculate-qt: 5.11.0 -> 5.12.0, add maintainer magicquark, set __structuredAttrs = true

### DIFF
--- a/pkgs/by-name/qa/qalculate-qt/package.nix
+++ b/pkgs/by-name/qa/qalculate-qt/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "qalculate-qt";
-  version = "5.11.0";
+  version = "5.12.0";
 
   src = fetchFromGitHub {
     owner = "qalculate";
     repo = "qalculate-qt";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-5u/YA5/k7JQclIqJUKvzGEenEhndo52m23XlFjkhw78=";
+    hash = "sha256-zeHpTe4DlurFqdsrJBlXSl+vXCOdhJRCjHLDpFf2u1o=";
   };
 
   nativeBuildInputs = with qt6; [

--- a/pkgs/by-name/qa/qalculate-qt/package.nix
+++ b/pkgs/by-name/qa/qalculate-qt/package.nix
@@ -47,7 +47,9 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Ultimate desktop calculator";
     homepage = "http://qalculate.github.io";
-    maintainers = [ ];
+    maintainers = [
+      lib.maintainers.magicquark
+    ];
     license = lib.licenses.gpl2Plus;
     mainProgram = "qalculate-qt";
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/qa/qalculate-qt/package.nix
+++ b/pkgs/by-name/qa/qalculate-qt/package.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-zeHpTe4DlurFqdsrJBlXSl+vXCOdhJRCjHLDpFf2u1o=";
   };
 
+  __structuredAttrs = true;
+
   nativeBuildInputs = with qt6; [
     qmake
     pkg-config


### PR DESCRIPTION
- Updated `qalculate-qt` from version 5.11.0 to 5.12.0.
 Changelog: https://github.com/Qalculate/qalculate-qt/releases/tag/v5.12.0
- Added myself as a maintainer.
- Set `__structuredAttrs = true`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
