### PR TITLE
python3Packages.logbook: add typing-extensions dependency

### DIFF
--- a/pkgs/development/python-modules/logbook/default.nix
+++ b/pkgs/development/python-modules/logbook/default.nix
@@ -35,10 +35,6 @@ buildPythonPackage (finalAttrs: {
     setuptools-rust
   ];
 
-  propagatedBuildInputs = [
-    typing-extensions
-  ];
-
   nativeBuildInputs = [
     cargo
     rustc
@@ -49,6 +45,10 @@ buildPythonPackage (finalAttrs: {
     inherit (finalAttrs) pname version src;
     hash = "sha256-xIjcK69rwtE86DfvD9qXEn8MDIvU0Dl+d4Fmw9BUuCM=";
   };
+
+  dependencies = [
+    typing-extensions
+  ];
 
   optional-dependencies = {
     execnet = [ execnet ];

--- a/pkgs/development/python-modules/logbook/default.nix
+++ b/pkgs/development/python-modules/logbook/default.nix
@@ -15,6 +15,7 @@
   setuptools,
   setuptools-rust,
   sqlalchemy,
+  typing-extensions,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -32,6 +33,10 @@ buildPythonPackage (finalAttrs: {
   build-system = [
     setuptools
     setuptools-rust
+  ];
+
+  propagatedBuildInputs = [
+    typing-extensions
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added `typing-extensions` as a `propagatedBuildInput` to the Python module `logbook`.

## Things done

Tested that `python3 -c "import logbook"` does not return a `ModuleNotFoundError` for `typing_extensions`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
