### PR TITLE
python3Packages.slidge: init at 0.4.0

### DIFF
--- a/pkgs/development/python-modules/slidge/default.nix
+++ b/pkgs/development/python-modules/slidge/default.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromCodeberg,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # dependencies
+  aiohttp,
+  alembic,
+  configargparse,
+  defusedxml,
+  pillow,
+  python-magic,
+  qrcode,
+  slixmpp,
+  sqlalchemy,
+  thumbhash,
+
+  # check dependencies
+  pytestCheckHook,
+  pytest-asyncio,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "slidge";
+  version = "0.4.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromCodeberg {
+    owner = "slidge";
+    repo = "slidge";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-VdK6GE3P9iZabR/qjaqkaq3VNRtDn0O7ty2NIHMOmBE=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    aiohttp
+    alembic
+    configargparse
+    defusedxml
+    pillow
+    python-magic
+    qrcode
+    slixmpp
+    sqlalchemy
+    thumbhash
+  ];
+
+  pythonRelaxDeps = true;
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+  ];
+
+  disabledTestPaths = [
+    # Using slixmpp.test.ComponentXMPP which was removed in latest slixmpp
+    "tests/test_adhoc/test_confirmation.py"
+    "tests/test_chat_commands.py"
+  ];
+
+  disabledTests = [
+    "test_vcard_temp"
+  ];
+
+  meta = {
+    changelog = "https://codeberg.org/slidge/slidge/releases/tag/${finalAttrs.src.tag}";
+    description = "Gateway Library for XMPP to Other Networks";
+    homepage = "https://slidge.im/";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ haansn08 ];
+  };
+
+})

--- a/pkgs/development/python-modules/thumbhash/default.nix
+++ b/pkgs/development/python-modules/thumbhash/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  hatchling,
+  pillow,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "thumbhash";
+  version = "0.1.2";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  # the pyproject.toml of GitHub release "v0.1.2" uses "thumbhash-py"
+  # for the project name and does not build.
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-705jmPk/O1rUgNyOOjs6IAgTyGqIV/sGn4R4voCfgkc=";
+  };
+
+  build-system = [ hatchling ];
+
+  optional-dependencies = [ pillow ];
+
+  meta = {
+    description = "Python port of thumbhash, a representation of an image placeholder";
+    homepage = "https://github.com/justinforlenza/thumbhash-py";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ haansn08 ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20230,6 +20230,8 @@ self: super: with self; {
 
   thttp = callPackage ../development/python-modules/thttp { };
 
+  thumbhash = callPackage ../development/python-modules/thumbhash { };
+
   tianshou = callPackage ../development/python-modules/tianshou { };
 
   tidalapi = callPackage ../development/python-modules/tidalapi { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18730,6 +18730,8 @@ self: super: with self; {
 
   slicerator = callPackage ../development/python-modules/slicerator { };
 
+  slidge = callPackage ../development/python-modules/slidge { };
+
   slip10 = callPackage ../development/python-modules/slip10 { };
 
   slither-analyzer = callPackage ../development/python-modules/slither-analyzer { };


### PR DESCRIPTION
This PR adds [slidge](https://slidge.im/), a Python library for creating gateways from XMPP to other chat networks.

This will help the [efforts](https://discourse.nixos.org/t/need-help-to-package-slidge-whatsapp/78883) by @mirror230469 to package `slidge-whatsapp` and my [efforts to package `matridge`](https://github.com/NixOS/nixpkgs/pull/527267).

Slidge is already included in Debian and other distributions: https://repology.org/project/slidge/versions

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
