### PR TITLE
sox: fix version scheme

### DIFF
--- a/pkgs/by-name/so/sox/package.nix
+++ b/pkgs/by-name/so/sox/package.nix
@@ -36,7 +36,7 @@
   libpulseaudio,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "sox";
   version = "14.4.2-unstable-2021-05-09";
 
@@ -90,4 +90,4 @@ stdenv.mkDerivation {
     license = if enableAMR then lib.licenses.unfree else lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/so/sox/package.nix
+++ b/pkgs/by-name/so/sox/package.nix
@@ -38,7 +38,7 @@
 
 stdenv.mkDerivation {
   pname = "sox";
-  version = "unstable-2021-05-09";
+  version = "14.4.2-unstable-2021-05-09";
 
   src = fetchgit {
     # not really needed, but when this src was updated from `fetchurl ->

--- a/pkgs/by-name/so/sox/package.nix
+++ b/pkgs/by-name/so/sox/package.nix
@@ -41,10 +41,6 @@ stdenv.mkDerivation {
   version = "14.4.2-unstable-2021-05-09";
 
   src = fetchgit {
-    # not really needed, but when this src was updated from `fetchurl ->
-    # fetchgit`, we spared the mass rebuild by changing this `name` and
-    # therefor merge this to `master` and not to `staging`.
-    name = "source";
     url = "https://git.code.sf.net/p/sox/code";
     rev = "42b3557e13e0fe01a83465b672d89faddbe65f49";
     hash = "sha256-9cpOwio69GvzVeDq79BSmJgds9WU5kA/KUlAkHcpN5c=";


### PR DESCRIPTION
Part of #541820
```
$ sox --version
sox:      SoX v14.4.2
```
Not sure if this is the release commit, so keeping unstable.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
