### PR TITLE
Eden: fix glib gio error

### DIFF
--- a/pkgs/by-name/ed/eden/package.nix
+++ b/pkgs/by-name/ed/eden/package.nix
@@ -10,13 +10,13 @@
   cubeb,
   enet,
   fetchFromGitea,
-  fetchpatch,
   fetchurl,
   ffmpeg-headless,
   fmt,
   frozen-containers,
   gamemode,
   glslang,
+  gtk3,
   httplib,
   kdePackages,
   libopus,
@@ -42,6 +42,7 @@
   zlib,
   zstd,
   writeScript,
+  wrapGAppsHook3,
   callPackage,
 }:
 
@@ -78,6 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
     python3
     qt6.qttools
     qt6.wrapQtAppsHook
+    wrapGAppsHook3
   ];
 
   buildInputs = [
@@ -165,6 +167,10 @@ stdenv.mkDerivation (finalAttrs: {
         pipewire
       ]
     })
+
+    gappsWrapperArgs+=(
+        --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}"
+      )
   '';
 
   passthru = {


### PR DESCRIPTION
Fixes GLib-GIO-ERROR when trying to open file chooser in eden GUI.

Settings schema 'org.gtk.Settings.FileChooser' is not installed. See [THIS](https://ryantm.github.io/nixpkgs/languages-frameworks/gnome/#ssec-gnome-common-issues-missing-schema) for reference.

fetchPatch was removed from arguments as it was unused.

This is my first time contributing to Nixpkgs, so please tell me if something is off in this PR.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].
