### PR TITLE
icloudpd: build with python313

### DIFF
--- a/pkgs/by-name/ic/icloudpd/package.nix
+++ b/pkgs/by-name/ic/icloudpd/package.nix
@@ -1,13 +1,13 @@
 {
   lib,
-  python3Packages,
+  python313Packages,
   fetchFromGitHub,
   nix-update-script,
   testers,
   icloudpd,
 }:
 
-python3Packages.buildPythonApplication (finalAttrs: {
+python313Packages.buildPythonApplication (finalAttrs: {
   pname = "icloudpd";
   version = "1.32.3";
   pyproject = true;
@@ -21,7 +21,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   pythonRelaxDeps = true;
 
-  dependencies = with python3Packages; [
+  dependencies = with python313Packages; [
     certifi
     click
     flask
@@ -42,9 +42,9 @@ python3Packages.buildPythonApplication (finalAttrs: {
     wheel
   ];
 
-  build-system = with python3Packages; [ setuptools ];
+  build-system = with python313Packages; [ setuptools ];
 
-  nativeCheckInputs = with python3Packages; [
+  nativeCheckInputs = with python313Packages; [
     freezegun
     mock
     pytest-timeout


### PR DESCRIPTION
`python3` now defaults to 3.14 in unstable, so `icloudpd` is being built against an interpreter [upstream doesn't support](https://github.com/icloud-photos-downloader/icloud_photos_downloader/blob/879c561240d993d748ddb4546f935090502b16d3/pyproject.toml#L13): `requires-python = ">=3.10,<3.14"`

python/cpython#120713 makes `datetime.strftime("%Y")` zero-pad years < 1000 on 3.14 (it was reverted on 3.12/3.13):

```
$ nix shell nixpkgs#python313 -c python -c 'import datetime; print(datetime.datetime(5, 1, 1).strftime("%Y"))'
5
$ nix shell nixpkgs#python314 -c python -c 'import datetime; print(datetime.datetime(5, 1, 1).strftime("%Y"))'
0005
```

icloudpd's default folder structure is `{:%Y/%m/%d}`, so this silently changes on-disk layout for out-of-range EXIF dates and fails `test_creation_date_without_century{,_name_id7}`.

Pinning to `python313Packages` rather than deselecting the tests, since the tests are correctly flagging an unsupported interpreter.

Not covered by #475732, which tracks `python314Packages.*` libraries (icloudpd is a top-level application)

cc @anpin 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
