### PR TITLE
fetchutils: 0.1.0-unstable-2021-03-16 -> 0.1.0-unstable-2025-06-23 (and fix version scheme)

### DIFF
--- a/pkgs/by-name/fe/fetchutils/package.nix
+++ b/pkgs/by-name/fe/fetchutils/package.nix
@@ -6,9 +6,9 @@
   scdoc,
 }:
 
-stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "fetchutils";
-  version = "unstable-2021-03-16";
+  version = "0.1.0-unstable-2021-03-16";
 
   src = fetchFromGitHub {
     owner = "kiedtl";
@@ -33,9 +33,9 @@ stdenvNoCC.mkDerivation {
 
   meta = {
     description = "Collection of small shell utilities to fetch system information";
-    homepage = "https://github.com/lptstr/fetchutils";
+    homepage = "https://github.com/kiedtl/fetchutils";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ moni ];
   };
-}
+})

--- a/pkgs/by-name/fe/fetchutils/package.nix
+++ b/pkgs/by-name/fe/fetchutils/package.nix
@@ -8,13 +8,13 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "fetchutils";
-  version = "0.1.0-unstable-2021-03-16";
+  version = "0.1.0-unstable-2025-06-23";
 
   src = fetchFromGitHub {
     owner = "kiedtl";
     repo = "fetchutils";
-    rev = "882781a297e86f4ad4eaf143e0777fb3e7c69526";
-    sha256 = "sha256-ONrVZC6GBV5v3TeBekW9ybZjDHF3FNyXw1rYknqKRbk=";
+    rev = "462bf40a9b4121bb56b78bc8782a5d67ffefd0a2";
+    hash = "sha256-reJXgEyoMRk+SEcwMXuW5BDB83PqgAbbAsugwYBHwC8=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fix version scheme per #541820, and upgrade package to latest version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
