### PR TITLE
chromium,chromedriver: 150.0.7871.114 -> 150.0.7871.124

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,10 +1,10 @@
 {
   "chromium": {
-    "version": "150.0.7871.114",
+    "version": "150.0.7871.124",
     "chromedriver": {
-      "version": "150.0.7871.115",
-      "hash_darwin": "sha256-3QytnwfqPqpYL2TMTMykvT+yAfZqWiRHMbMEK+whe0Q=",
-      "hash_darwin_aarch64": "sha256-jJ1URVS4led/1rTODm3t8wewJ8oIOzKIrq1utn5JJ3s="
+      "version": "150.0.7871.125",
+      "hash_darwin": "sha256-HJTBS6eRmAsxrn7WW4hCxMCXdzn+1PYz1W0uZHJ38yk=",
+      "hash_darwin_aarch64": "sha256-VCgkc6MeMPbt0F2ZVTJNn9yJbSYNhy1zr8KzPVaVi0I="
     },
     "deps": {
       "depot_tools": {
@@ -21,8 +21,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "f405107495a07cb1bfcf687d4af8d91117098db6",
-        "hash": "sha256-VdDnFbE+/leFzR/PqR3ColKKqwkvuY/LsFje0nrwiXU=",
+        "rev": "9261fd0a595ac4964ea84e6bd4a025c1173a2ffa",
+        "hash": "sha256-YKkZfxFZ7mitD6YqJZW+NQByq71UVb0jCFIBXj0SyzU=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -92,8 +92,8 @@
       },
       "src/third_party/angle": {
         "url": "https://chromium.googlesource.com/angle/angle.git",
-        "rev": "8d3c5a8caebd836b99fa32062951a401910eba33",
-        "hash": "sha256-7X8FSWCA+BpAXbUPvjPyiGagmVXsadRGAY5haAEzRL8="
+        "rev": "13e691adf3d4d3ebee2f7239731a07d3b9704956",
+        "hash": "sha256-fbjREn3D+quRRADGwR7V65BZt5b+1DgnsG4ZMhwGq6o="
       },
       "src/third_party/angle/third_party/glmark2/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glmark2/glmark2",
@@ -552,8 +552,8 @@
       },
       "src/third_party/libyuv": {
         "url": "https://chromium.googlesource.com/libyuv/libyuv.git",
-        "rev": "3c5fa6ef272f6077d76816ee3d6a697ef1d6d272",
-        "hash": "sha256-FXFSC9dRb/KhSQdhJUqKEUpZbzU8ZpVnoSXtF/HPiJI="
+        "rev": "8aeb3a9ca36341a640528e59b34b5d641080dca8",
+        "hash": "sha256-FGl0xK7ooaRFzFBxuV6oOu3h1x2b/myLLO2En3xgVCk="
       },
       "src/third_party/lss": {
         "url": "https://chromium.googlesource.com/linux-syscall-support.git",
@@ -657,8 +657,8 @@
       },
       "src/third_party/skia": {
         "url": "https://skia.googlesource.com/skia.git",
-        "rev": "14d05ec761901b6e9e9193af8b347ab3a7f6fed0",
-        "hash": "sha256-KZGrztOKaT368KSCxiJAqnsgINpNODUlaXnH/maQNIA="
+        "rev": "bee4c917220040e147f14964635ff92ce6c5a3f6",
+        "hash": "sha256-SWmoX+sNaw4KnlTBPt63uBSYfQavJejB3+Vlw/gtWX8="
       },
       "src/third_party/smhasher/src": {
         "url": "https://chromium.googlesource.com/external/smhasher.git",
@@ -827,8 +827,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "ce0af5c0d181678bcda077c68d4beaec2854ad16",
-        "hash": "sha256-gjuH2HQAC0poQileS8JLusocBDoShuaQ9pbaAXmFj4g="
+        "rev": "209c9cea0db17d8caf23e9d2c7de08c351609744",
+        "hash": "sha256-3jUyRERu1r+Fl2uSAaRchV2L99XLp8XO9DHctk0lMjY="
       },
       "src/agents/shared": {
         "url": "https://chromium.googlesource.com/chromium/agents.git",


### PR DESCRIPTION
https://chromereleases.googleblog.com/2026/07/stable-channel-update-for-desktop_0353146366.html

This update includes 15 security fixes.

CVEs:
CVE-2026-15764 CVE-2026-15765 CVE-2026-15766 CVE-2026-15767
CVE-2026-15768 CVE-2026-15769 CVE-2026-15770 CVE-2026-15771
CVE-2026-15772 CVE-2026-15773 CVE-2026-15774 CVE-2026-15775
CVE-2026-15776 CVE-2026-15777 CVE-2026-15778

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests] (`nixosTests.chromium`).
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
