### PR TITLE
openbao: 2.5.5 -> 2.6.0

### DIFF
--- a/pkgs/by-name/op/openbao/package.nix
+++ b/pkgs/by-name/op/openbao/package.nix
@@ -14,16 +14,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "openbao";
-  version = "2.5.5";
+  version = "2.6.0";
 
   src = fetchFromGitHub {
     owner = "openbao";
     repo = "openbao";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-75Rm9EGkvUKJ05d55bboPAE+Nm/GLLgH1TqDrExkJO0=";
+    hash = "sha256-FJ+34HeRT025EFwFXY8ewfnJbQirqFb3j+kPNxpGOA4=";
   };
 
-  vendorHash = "sha256-3d3g6f0O7X+aedYCfLbqLNuITKNQuxZkApWTTKSk7lA=";
+  vendorHash = "sha256-O0xx61S0KEk5QB/NsV+kBlErvVuKBfI/81o29rDye1w=";
 
   proxyVendor = true;
 

--- a/pkgs/by-name/op/openbao/ui.nix
+++ b/pkgs/by-name/op/openbao/ui.nix
@@ -1,48 +1,44 @@
 {
   stdenvNoCC,
   openbao,
-  yarn-berry_3,
-  nodejs_22,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  pnpmBuildHook,
+  pnpm_10,
+  # https://github.com/openbao/openbao/issues/731
+  nodejs-slim_22,
 }:
 let
-
-  yarn = yarn-berry_3.override { nodejs = nodejs_22; };
-
+  nodejs-slim = nodejs-slim_22;
+  pnpm = pnpm_10.override { inherit nodejs-slim; };
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = openbao.pname + "-ui";
   inherit (openbao) version src;
   sourceRoot = "${finalAttrs.src.name}/ui";
 
-  offlineCache = yarn.fetchYarnBerryDeps {
-    inherit (finalAttrs) src sourceRoot;
-    hash = "sha256-XK3ZVnzOTbFzrpPgaz1cx7okTycLhrvBHk9P2Nwv1cg=";
-  };
-
   nativeBuildInputs = [
-    yarn.yarnBerryConfigHook
-    nodejs_22
-    yarn
+    pnpmConfigHook
+    pnpmBuildHook
+    pnpm
+    nodejs-slim
   ];
 
-  env.YARN_ENABLE_SCRIPTS = 0;
-
-  preConfigure = ''
-    printYarnErrors() {
-      cat /build/*.log
-    }
-    failureHooks+=(printYarnErrors)
-  '';
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      sourceRoot
+      ;
+    inherit pnpm;
+    fetcherVersion = 4;
+    hash = "sha256-9Q5celZSwMgSS8qcj8sDH/JLv48lgDMOylANvXSnhsU=";
+  };
 
   postConfigure = ''
     substituteInPlace .ember-cli \
       --replace-fail "../http/web_ui" "$out"
-  '';
-
-  buildPhase = ''
-    runHook preBuild
-    yarn run ember build --environment=production
-    runHook postBuild
   '';
 
   dontInstall = true;


### PR DESCRIPTION
https://github.com/openbao/openbao/releases/tag/v2.6.0

diff: https://github.com/openbao/openbao/compare/v2.5.5...v2.6.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
