### PR TITLE
citrix-workspace: drop unused gtk2-era inputs

### DIFF
--- a/pkgs/by-name/ci/citrix-workspace/package.nix
+++ b/pkgs/by-name/ci/citrix-workspace/package.nix
@@ -332,6 +332,9 @@ stdenv.mkDerivation rec {
       # the tarball still contains the legacy WebKitGTK 4.0 bundle.
       rm -rf "$ICAInstDir/Webkit2gtk4.0"
 
+      # FHS launcher hinst generates even for non-root installs; it hardcodes
+      # store paths without any of the wrapper environment.
+      rm -f "$ICAInstDir/wfica.sh"
       if [ -f "$ICAInstDir/util/setlog" ]; then
         chmod +x "$ICAInstDir/util/setlog"
         ln -sf "$ICAInstDir/util/setlog" "$out/bin/citrix-setlog"

--- a/pkgs/by-name/ci/citrix-workspace/package.nix
+++ b/pkgs/by-name/ci/citrix-workspace/package.nix
@@ -18,12 +18,8 @@
   gdk-pixbuf,
   glib,
   glib-networking,
-  gnome2,
   gst_all_1,
-  gtk2,
-  gtk2-x11,
   gtk3,
-  gtk_engines,
   harfbuzzFull,
   heimdal,
   hyphen,
@@ -41,7 +37,6 @@
   libjson,
   libmanette,
   libnotify,
-  libpng12,
   libpulseaudio,
   libredirect,
   libseccomp,
@@ -77,7 +72,6 @@
   xprop,
   xdpyinfo,
   libxcb,
-  x264,
   zlib,
 
   extraCerts ? [ ],
@@ -168,11 +162,7 @@ stdenv.mkDerivation rec {
     fuse3'
     gdk-pixbuf
     glib-networking
-    gnome2.gtkglext
-    gtk2
-    gtk2-x11
     gtk3
-    gtk_engines
     harfbuzzFull
     heimdal
     hyphen
@@ -188,7 +178,6 @@ stdenv.mkDerivation rec {
     libjson
     libmanette
     libnotify
-    libpng12
     libpulseaudio
     libseccomp
     libsecret
@@ -212,7 +201,6 @@ stdenv.mkDerivation rec {
     libxaw
     libxmu
     libxtst
-    x264
     zlib
   ]
   ++ gstPackages;


### PR DESCRIPTION
gtk2, gtk2-x11, gtk_engines, gnome2.gtkglext, libpng12 and x264 are
leftovers from the era of bundling Citrix's WebKitGTK 4.0; no ELF in the
26.04 payload links any of them.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
