### PR TITLE
gawk: 5.4.0 -> 5.4.1, apply upstream patch for bug when building without gmp/mpfr 

### DIFF
--- a/pkgs/tools/text/gawk/default.nix
+++ b/pkgs/tools/text/gawk/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   removeReferencesTo,
   runtimeShellPackage,
   texinfo,
@@ -31,6 +32,16 @@ stdenv.mkDerivation rec {
     url = "mirror://gnu/gawk/gawk-${version}.tar.xz";
     hash = "sha256-B/b3NCt/6+QxP8LCVCrZPWT+IK2HFyABCfEFqCb1/Tc=";
   };
+
+  patches = [
+    # When building gawk without gmp and mpfr, gawk 5.4.1 causes build failures
+    # in downstream packages such as GCC and libpng.
+    # Discussion on bug-gawk:
+    # https://lists.gnu.org/archive/html/bug-gawk/2026-07/msg00013.html
+    # Vendored since we can't use fetchpatch:
+    # https://gitweb.git.savannah.gnu.org/gitweb/?p=gawk.git;a=commit;h=bf85f8a3175af703597082d4c7e0abc2066a44d3
+    ./node-struct-without-gmp-mpfr.patch
+  ];
 
   # When we do build separate interactive version, it makes sense to always include man.
   outputs = [

--- a/pkgs/tools/text/gawk/default.nix
+++ b/pkgs/tools/text/gawk/default.nix
@@ -25,11 +25,11 @@ assert (doCheck && stdenv.hostPlatform.isLinux) -> glibcLocales != null;
 
 stdenv.mkDerivation rec {
   pname = "gawk" + lib.optionalString interactive "-interactive";
-  version = "5.4.0";
+  version = "5.4.1";
 
   src = fetchurl {
     url = "mirror://gnu/gawk/gawk-${version}.tar.xz";
-    hash = "sha256-PdQw8M07RCjGw/avwCG5zTwfjJP3pojcJoykKKkLSsE=";
+    hash = "sha256-B/b3NCt/6+QxP8LCVCrZPWT+IK2HFyABCfEFqCb1/Tc=";
   };
 
   # When we do build separate interactive version, it makes sense to always include man.

--- a/pkgs/tools/text/gawk/node-struct-without-gmp-mpfr.patch
+++ b/pkgs/tools/text/gawk/node-struct-without-gmp-mpfr.patch
@@ -1,0 +1,79 @@
+From bf85f8a3175af703597082d4c7e0abc2066a44d3 Mon Sep 17 00:00:00 2001
+From: "Arnold D. Robbins" <arnold@skeeve.com>
+Date: Tue, 14 Jul 2026 10:14:50 +0300
+Subject: [PATCH] Workaround fix for systems without MPFR and GMP.
+
+---
+ ChangeLog |  8 ++++++++
+ awk.h     | 23 ++++++++++++++---------
+ 2 files changed, 22 insertions(+), 9 deletions(-)
+
+diff --git a/ChangeLog b/ChangeLog
+index 6a955eed..42bd2c48 100644
+--- a/ChangeLog
++++ b/ChangeLog
+@@ -3,6 +3,14 @@
+ 	* builtin.c (do_dump_node): Add the size of each object to
+ 	the printout.
+ 
++	Unrelated: Make things works when built on systems without
++	the GMP and MPFR libraries.  Thanks to Thomas Trepl <ttrepl@yahoo.de>
++	and Bruce Dubbs <bdubbs@linuxfromscratch.org> for the reports.
++
++	* awk.h (struct exp_node): Add alignment padding when we don't
++	have MPFR. This is a hack, pending a total refactoring of
++	the NODE structure.
++
+ 2026-07-08         Arnold D. Robbins     <arnold@skeeve.com>
+ 
+ 	* 5.4.1: Release tar ball made.
+diff --git a/awk.h b/awk.h
+index dbad0d81..f4a84300 100644
+--- a/awk.h
++++ b/awk.h
+@@ -406,17 +406,24 @@ typedef struct exp_node {
+ 		} nodep;
+ 
+ 		struct {
+-#ifdef HAVE_MPFR
+ 			union {
+ 				AWKNUM fltnum;
++#ifdef HAVE_MPFR
+ 				mpfr_t mpnum;
+ 				mpz_t mpi;
+-			} nm;
+-			int rndmode;
+ #else
+-			AWKNUM fltnum;
+-			int for_alignment_only;	// especially on 32-bit
+-#endif
++				// 7/2026:
++				// This is a workaround for systems that build
++				// gawk without MPFR and GMP.  The NODE struct
++				// desperately needs to be refactored.
++#if SIZEOF_VOID_P == 4
++				char alignment[28];
++#else	// SIZEOF_VOID_P != 4
++				char alignment[48];
++#endif	// SIZEOF_VOID_P != 4
++#endif	// HAVE_MPFR
++			} nm;
++			int rndmode;	// only used for MPFR.
+ 			char *sp;
+ 			size_t slen;
+ 			int idx;
+@@ -561,10 +568,8 @@ typedef struct exp_node {
+ #ifdef HAVE_MPFR
+ #define mpg_numbr	sub.val.nm.mpnum
+ #define mpg_i		sub.val.nm.mpi
+-#define numbr		sub.val.nm.fltnum
+-#else
+-#define numbr		sub.val.fltnum
+ #endif
++#define numbr		sub.val.nm.fltnum
+ #define typed_re	sub.val.typre
+ 
+ /*
+-- 
+2.54.0
+


### PR DESCRIPTION
see #540158. this pr is targeted at staging-next solely because that's the only place where the revert commit is (and thus the only place the "reapply" commit makes sense). we do not particularly care whether this goes via staging or staging-next, and can retarget once periodic merges happen.

when using gawk 5.4.1 without gmp and mpfr, some alignment is broken in a NODE struct. this causes build failures in downstream packages such as `libpng` and `gcc16`. a discussion of the latter occurred on bug-gawk (https://lists.gnu.org/archive/html/bug-gawk/2026-07/msg00013.html) where the issue was found and pushed to the relevant branch, but has not been released. accordingly, we fetch (manually, since fetchpatch infrecs) the patch from the savannah gitweb. this fixes `libpng` and `gcc16`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
