### PR TITLE
doc: fix malformed fenced divs

### DIFF
--- a/doc/build-helpers/fixed-point-arguments.chapter.md
+++ b/doc/build-helpers/fixed-point-arguments.chapter.md
@@ -143,3 +143,4 @@ lib.extendMkDerivation {
     });
 }
 ```
+:::

--- a/doc/build-helpers/trivial-build-helpers.chapter.md
+++ b/doc/build-helpers/trivial-build-helpers.chapter.md
@@ -165,7 +165,7 @@ They are useful for creating files from Nix expressions, and are all implemented
 Each of these functions will cause a derivation to be produced.
 When you coerce the result of each of these functions to a string with [string interpolation](https://nixos.org/manual/nix/stable/language/string-interpolation) or [`toString`](https://nixos.org/manual/nix/stable/language/builtins#builtins-toString), it will evaluate to the [store path](https://nixos.org/manual/nix/stable/store/store-path) of this derivation.
 
-:::: {.note}
+::: {.note}
 Some of these functions will put the resulting files within a directory inside the [derivation output](https://nixos.org/manual/nix/stable/language/derivations#attr-outputs).
 If you need to refer to the resulting files somewhere else in a Nix expression, append their path to the derivation's store path.
 
@@ -190,7 +190,7 @@ writeShellScript "evaluate-my-file.sh" ''
   cat ${my-file}/share/my-file
 ''
 ```
-::::
+:::
 
 ### `makeDesktopItem` {#trivial-builder-makeDesktopItem}
 

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -1140,7 +1140,7 @@ rec {
 
     For a function that gives you control over what counts as a leaf, see `mapAttrsRecursiveCond`.
 
-    :::{#map-attrs-recursive-example .example}
+    ::: {.example #map-attrs-recursive-example}
     # Map over leaf attributes
 
     ```nix
@@ -1165,7 +1165,7 @@ rec {
     If the predicate returns false, `mapAttrsRecursiveCond` does not recurse, but instead applies the mapping function.
     If the predicate returns true, it does recurse, and does not apply the mapping function.
 
-    :::{#map-attrs-recursive-cond-example .example}
+    ::: {.example #map-attrs-recursive-cond-example}
     # Map over an leaf attributes defined by a condition
 
     Map derivations to their `name` attribute.

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -564,7 +564,7 @@ rec {
 
     # Examples
 
-    :::{#ex-makeScope .example}
+    :::{.example #ex-makeScope}
     # Create an interdependent package set on top of `pkgs`
 
     The functions in `foo.nix` and `bar.nix` can depend on each other, in the sense that `foo.nix` can contain a function that expects `bar` as an attribute in its argument.
@@ -593,7 +593,7 @@ rec {
     ```
     :::
 
-    :::{#ex-makeScope-callPackage .example}
+    :::{.example #ex-makeScope-callPackage}
     # Using `callPackage` from a scope
 
     ```nix


### PR DESCRIPTION
## Description

Fix four malformed fenced divs in the Nixpkgs manual sources:

- put the admonition class before explicit IDs in attrsets and customisation examples
- correct the trivial-build-helpers note fence length
- close the final fixed-point build-helper example

The malformed fences produce unbalanced HTML and visibly corrupt pages in renderers that support Pandoc-style fenced divs.

## Testing

- nix-build . -A nixpkgs-manual --no-out-link
- all 88 nixos-render-docs tests passed as part of the build
- rendered the affected pages with mmdoc and verified balanced div markup