### PR TITLE
nixos/rtorrent: remove deprecated commands from default config

### DIFF
--- a/nixos/modules/services/torrent/rtorrent.nix
+++ b/nixos/modules/services/torrent/rtorrent.nix
@@ -149,13 +149,6 @@ in
 
       protocol.encryption.set = allow_incoming,try_outgoing,enable_retry
 
-      # Limits for file handle resources, this is optimized for
-      # an `ulimit` of 1024 (a common default). You MUST leave
-      # a ceiling of handles reserved for rTorrent's internal needs!
-      network.http.max_open.set = 50
-      network.max_open_files.set = 600
-      network.max_open_sockets.set = 3000
-
       # Memory resource usage (increase if you have a large number of items loaded,
       # and/or the available resources to spend)
       pieces.memory.max.set = 1800M
@@ -169,15 +162,14 @@ in
       execute.nothrow = sh, -c, (cat, "echo >", (session.path), "rtorrent.pid", " ", (system.pid))
 
       # Other operational settings (check & adapt)
-      encoding.add = utf8
       system.umask.set = 0027
       system.cwd.set = (cfg.basedir)
       network.http.dns_cache_timeout.set = 25
-      schedule2 = monitor_diskspace, 15, 60, ((close_low_diskspace, 1000M))
+      schedule = monitor_diskspace, 15, 60, ((close_low_diskspace, 1000M))
 
       # Watch directories (add more as you like, but use unique schedule names)
-      #schedule2 = watch_start, 10, 10, ((load.start, (cat, (cfg.watch), "start/*.torrent")))
-      #schedule2 = watch_load, 11, 10, ((load.normal, (cat, (cfg.watch), "load/*.torrent")))
+      #schedule = watch_start, 10, 10, ((load.start, (cat, (cfg.watch), "start/*.torrent")))
+      #schedule = watch_load, 11, 10, ((load.normal, (cat, (cfg.watch), "load/*.torrent")))
 
       # Logging:
       #   Levels = critical error warn notice info debug
@@ -217,6 +209,10 @@ in
               ExecStart = "${cfg.package}/bin/rtorrent -n -o system.daemon.set=true -o import=${rtorrentConfigFile}";
               RuntimeDirectory = "rtorrent";
               RuntimeDirectoryMode = 750;
+
+              # rtorrent derives socket limits from this value since 0.16.15; see table in
+              # https://github.com/rakshasa/rtorrent/wiki/Socket-Manager-and-Resource-Allocation
+              LimitNOFILE = lib.mkDefault 16384;
 
               CapabilityBoundingSet = [ "" ];
               LockPersonality = true;


### PR DESCRIPTION
Fix rtorrent NixOS module default config to work with rtorrent 0.16.17.

The 0.16.13 → 0.16.17 bump of rtorrent, in #539221, enabled several command removals/deprecations that were disabled in 0.16.14/0.16.15 but were updated neither in the rtorrent example/wiki configs nor in the NixOS module. (See eg. https://github.com/rakshasa/rtorrent/issues/1842 that discusses the discrepancy between rtorrent's behaviour and its documentation/wiki.)

The NixOS module's default `configText` still uses those now-broken commands, causing rtorrent to crash on startup with:

```
rtorrent: caughtN7torrent11input_errorE : Failed to parse command line option: Error in option file: /nix/store/<hash>-rtorrent.rc:36: Command "network.http.max_open.set" does not exist.
```

I'm not sure how this made it into `master` since there is a test `nix build -f . 'nixosTests.rtorrent'` which should have failed in CI? But I'm not super familiar with the nixpkgs setup.

## Things done

### Removed deprecated commands from default `configText`

These commands were deprecated in rtorrent 0.16.14/0.16.15 and cause startup errors:

- `network.http.max_open.set` — removed in 0.16.14
- `network.max_open_files.set` — deprecated in 0.16.15
- `network.max_open_sockets.set` — deprecated in 0.16.15
- `encoding.add = utf8` — removed in 0.16.14

Socket/resource allocation is now handled automatically by rtorrent's Socket Manager, which calculates per-category limits from the process `LimitNOFILE`.

### Replaced `schedule2` with `schedule`

`schedule2` was a compat alias removed in 0.16.14. `schedule` is the canonical command with identical semantics in modern rtorrent.

### Added `LimitNOFILE = 16384` to the systemd service

Since the Socket Manager auto-allocates resources from `ulimit -n`, we need to raise this from the systemd default (typically 1024). I chose 16384 as it seems to produce limits that are somewhat similar to those of before: per the auto-allocation table at https://github.com/rakshasa/rtorrent/wiki/Socket-Manager-and-Resource-Allocation, this yields approximately:
- Generic (peer connections): 6144
- HTTP: 64
- Internal (DHT, UDP, listening): 32
- RPC: 48
- Files: 1024

## Testing

- `nix build -f . 'nixosTests.rtorrent'` — **passes** (previously failed with the above error)
- Manual verification: rtorrent 0.16.17 starts and accepts connections with the default config

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
