### PR TITLE
glslviewer: fix audio device handling

### DIFF
--- a/pkgs/by-name/gl/glslviewer/package.nix
+++ b/pkgs/by-name/gl/glslviewer/package.nix
@@ -44,6 +44,8 @@ stdenv.mkDerivation (finalAttrs: {
     python3
   ];
 
+  # https://github.com/patriciogonzalezvivo/vera/pull/31/changes
+  patches = [ ./patches/0001-fix-miniaudio-device-id-handling.patch ];
   postInstall = ''
     substituteInPlace $out/share/thumbnailers/glslViewer.thumbnailer \
       --replace-fail "TryExec=glslThumbnailer" "TryExec=$out/bin/glslThumbnailer" \

--- a/pkgs/by-name/gl/glslviewer/patches/0001-fix-miniaudio-device-id-handling.patch
+++ b/pkgs/by-name/gl/glslviewer/patches/0001-fix-miniaudio-device-id-handling.patch
@@ -1,0 +1,8 @@
+--- a/deps/vera/src/gl/textureStreamAudio.cpp
++++ b/deps/vera/src/gl/textureStreamAudio.cpp
+@@ -59,7 +59,6 @@ TextureStreamAudio::TextureStreamAudio(): TextureStream() {
+     m_dft_buffer = (float*)av_malloc_array(sizeof(float), m_buf_len);
+     m_buffer_wr.resize(m_buf_len, 0);
+     m_buffer_re.resize(m_buf_len, 0);
+-    m_dft_buffer = nullptr;
+ }


### PR DESCRIPTION
This fixes a bug in upstream that makes it crash when using audio, I up-streamed the fix but seems like the maintainer is not very active lately https://github.com/patriciogonzalezvivo/vera/pull/31/changes

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
