### PR TITLE
pass-secret-service: fix startup crash on Python 3.14

### DIFF
--- a/pkgs/by-name/pa/pass-secret-service/package.nix
+++ b/pkgs/by-name/pa/pass-secret-service/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  fetchpatch,
   python3,
   dbus,
   gnupg,
@@ -23,6 +24,15 @@ python3.pkgs.buildPythonApplication {
     rev = "6335c85d9a790a6472e3de6eff87a15208caa5dc";
     hash = "sha256-SSmI3HJCUWuwFXCu3Zg66X18POlzp3ADRj7HeE8GRio=";
   };
+
+  patches = [
+    # Fix startup crash on Python 3.14
+    # https://github.com/mdellweg/pass_secret_service/pull/44
+    (fetchpatch {
+      url = "https://github.com/mdellweg/pass_secret_service/commit/b88e7bac743c9037b012149b13ebfdaa279b8a5d.patch";
+      hash = "sha256-BCLPKZ6a8nj1W04YaEmrVtDVFIEgm7yt72hN0YAnWGU=";
+    })
+  ];
 
   # Need to specify session.conf file for tests because it won't be found under
   # /etc/ in check phase.


### PR DESCRIPTION
Since Python 3.14 update, the `pass-secret-service` service crashes at login:

```
RuntimeError: There is no current event loop in thread 'MainThread'.
  File ".../pass_secret_service.py", line 37, in _main
    mainloop = asyncio.get_event_loop()
```

This PR brings a fix from a PR to the upstream: https://github.com/mdellweg/pass_secret_service/pull/44


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
