### PR TITLE
codechecker: Split base components out into unwrapped package

### DIFF
--- a/pkgs/by-name/co/codechecker-unwrapped/package.nix
+++ b/pkgs/by-name/co/codechecker-unwrapped/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  fetchPypi,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "codechecker-unwrapped";
+  version = "6.28.0";
+  pyproject = true;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) version;
+    pname = "codechecker";
+    hash = "sha256-wxV+/hzsk7RrzWTXNz5HyweYdFFI1upNS508QRPCefo=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    alembic
+    argcomplete
+    authlib
+    distutils # required in python312 to call subcommands (see https://github.com/Ericsson/codechecker/issues/4350)
+    lxml
+    multiprocess
+    portalocker
+    psutil
+    semver
+    sqlalchemy
+    thrift
+    gitpython
+    pyyaml
+    requests
+    types-pyyaml
+    sarif-tools
+    types-psutil
+  ];
+
+  pythonRelaxDeps = true;
+  nativeBuildInputs = with python3Packages; [
+    pythonRelaxDepsHook
+  ];
+
+  meta = {
+    homepage = "https://github.com/Ericsson/codechecker";
+    changelog = "https://github.com/Ericsson/codechecker/releases/tag/v${finalAttrs.version}";
+    description = "Analyzer tooling, defect database and viewer extension for the Clang Static Analyzer and Clang Tidy";
+    license = with lib.licenses; [
+      asl20
+      llvm-exception
+    ];
+    maintainers = with lib.maintainers; [
+      zebreus
+      felixsinger
+      kacper-uminski
+    ];
+    mainProgram = "CodeChecker";
+    platforms = lib.platforms.darwin ++ lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/co/codechecker/package.nix
+++ b/pkgs/by-name/co/codechecker/package.nix
@@ -14,7 +14,8 @@
   withGcc ? false,
   withInfer ? false,
 }:
-python3Packages.buildPythonApplication rec {
+
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "codechecker";
   version = "6.28.0";
   pyproject = true;
@@ -23,7 +24,7 @@ python3Packages.buildPythonApplication rec {
   __structuredAttrs = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-wxV+/hzsk7RrzWTXNz5HyweYdFFI1upNS508QRPCefo=";
   };
 
@@ -71,7 +72,7 @@ python3Packages.buildPythonApplication rec {
 
   meta = {
     homepage = "https://github.com/Ericsson/codechecker";
-    changelog = "https://github.com/Ericsson/codechecker/releases/tag/v${version}";
+    changelog = "https://github.com/Ericsson/codechecker/releases/tag/v${finalAttrs.version}";
     description = "Analyzer tooling, defect database and viewer extension for the Clang Static Analyzer and Clang Tidy";
     license = with lib.licenses; [
       asl20
@@ -85,4 +86,4 @@ python3Packages.buildPythonApplication rec {
     mainProgram = "CodeChecker";
     platforms = lib.platforms.darwin ++ lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/co/codechecker/package.nix
+++ b/pkgs/by-name/co/codechecker/package.nix
@@ -1,13 +1,13 @@
 {
-  lib,
-  fetchPypi,
-  makeWrapper,
-  python3Packages,
-  libclang,
   clang-tools,
+  codechecker-unwrapped,
   cppcheck,
   gcc,
   infer,
+  lib,
+  libclang,
+  makeWrapper,
+  symlinkJoin,
   withClang ? false,
   withClangTools ? false,
   withCppcheck ? false,
@@ -15,75 +15,32 @@
   withInfer ? false,
 }:
 
-python3Packages.buildPythonApplication (finalAttrs: {
+symlinkJoin {
   pname = "codechecker";
-  version = "6.28.0";
-  pyproject = true;
+
+  inherit (codechecker-unwrapped) version meta;
 
   strictDeps = true;
   __structuredAttrs = true;
 
-  src = fetchPypi {
-    inherit (finalAttrs) pname version;
-    hash = "sha256-wxV+/hzsk7RrzWTXNz5HyweYdFFI1upNS508QRPCefo=";
-  };
-
-  build-system = with python3Packages; [
-    setuptools
+  paths = [
+    codechecker-unwrapped
   ];
 
-  dependencies = with python3Packages; [
-    alembic
-    argcomplete
-    authlib
-    distutils # required in python312 to call subcommands (see https://github.com/Ericsson/codechecker/issues/4350)
-    lxml
-    multiprocess
-    portalocker
-    psutil
-    semver
-    sqlalchemy
-    thrift
-    gitpython
-    pyyaml
-    requests
-    types-pyyaml
-    sarif-tools
-    types-psutil
-  ];
-
-  pythonRelaxDeps = true;
-  nativeBuildInputs = with python3Packages; [
+  nativeBuildInputs = [
     makeWrapper
-    pythonRelaxDepsHook
   ];
 
-  postInstall = ''
-    wrapProgram "$out/bin/CodeChecker" --prefix PATH : ${
-      lib.makeBinPath (
-        lib.optional withClang libclang
-        ++ lib.optional withClangTools clang-tools
-        ++ lib.optional withCppcheck cppcheck
-        ++ lib.optional withGcc gcc
-        ++ lib.optional withInfer infer
-      )
-    }
+  postBuild = ''
+    wrapProgram "$out/bin/CodeChecker" \
+      --prefix PATH : ${
+        lib.makeBinPath (
+          lib.optional withClang libclang
+          ++ lib.optional withClangTools clang-tools
+          ++ lib.optional withCppcheck cppcheck
+          ++ lib.optional withGcc gcc
+          ++ lib.optional withInfer infer
+        )
+      }
   '';
-
-  meta = {
-    homepage = "https://github.com/Ericsson/codechecker";
-    changelog = "https://github.com/Ericsson/codechecker/releases/tag/v${finalAttrs.version}";
-    description = "Analyzer tooling, defect database and viewer extension for the Clang Static Analyzer and Clang Tidy";
-    license = with lib.licenses; [
-      asl20
-      llvm-exception
-    ];
-    maintainers = with lib.maintainers; [
-      zebreus
-      felixsinger
-      kacper-uminski
-    ];
-    mainProgram = "CodeChecker";
-    platforms = lib.platforms.darwin ++ lib.platforms.linux;
-  };
-})
+}


### PR DESCRIPTION
    In order to avoid rebuilds on the actual CodeChecker software, split it
    up into an unwrapped and wrapped package, while the wrapped one serves
    as a layer on top of the unwrapped one pulling in the desired compiler
    backends.

Tested that `codechecker-unwrapped` and `codechecker` work.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
