### PR TITLE
opentelemetry-collector: fix auto updates

### DIFF
--- a/pkgs/tools/misc/opentelemetry-collector/builder.nix
+++ b/pkgs/tools/misc/opentelemetry-collector/builder.nix
@@ -6,7 +6,7 @@
 buildGoModule rec {
   pname = "ocb";
   # Also update `pkgs/tools/misc/opentelemetry-collector/releases.nix`
-  # whenever that version changes.
+  # whenever this version changes.
   version = "0.155.0";
 
   src = fetchFromGitHub {
@@ -30,6 +30,8 @@ buildGoModule rec {
   checkFlags = [
     "-skip TestGenerateAndCompile|TestReplaceStatementsAreComplete|TestVersioning|TestRunInit"
   ];
+
+  passthru.updateScript = ./update.sh;
 
   # Rename to ocb (it's generated as "builder")
   postInstall = ''

--- a/pkgs/tools/misc/opentelemetry-collector/releases.nix
+++ b/pkgs/tools/misc/opentelemetry-collector/releases.nix
@@ -4,9 +4,7 @@
   fetchFromGitHub,
   installShellFiles,
   testers,
-  nixosTests,
   opentelemetry-collector-builder,
-  pkgs,
   go,
   git,
   cacert,
@@ -17,12 +15,10 @@ let
   builder = "${opentelemetry-collector-builder}/bin/ocb";
 
   # Keep the version in sync with the builder.
-  rev = opentelemetry-collector-builder.src.rev;
-
-  version = lib.removePrefix "cmd/builder/v" rev;
+  version = "0.151.0";
 
   # This is a weird meta-repo where all the open-telemetry collectors are.
-  src = fetchFromGitHub {
+  releasesSrc = fetchFromGitHub {
     owner = "open-telemetry";
     repo = "opentelemetry-collector-releases";
     rev = "v${version}";
@@ -39,7 +35,10 @@ let
       hash,
     }:
     stdenv.mkDerivation {
-      inherit name;
+      # Inherit the version from the builder, so that updates there trigger
+      # a rebuild here.
+      inherit version;
+      pname = "${name}-src";
 
       nativeBuildInputs = [
         cacert
@@ -47,7 +46,7 @@ let
         go
       ];
 
-      inherit src;
+      src = releasesSrc;
 
       outputHash = hash;
       outputHashMode = "recursive";
@@ -117,11 +116,16 @@ let
             --zsh <($out/bin/${name} completion zsh)
         '';
 
-        passthru.tests = {
-          version = testers.testVersion {
-            inherit package version;
-            command = "${name} -v";
+        passthru = {
+          tests = {
+            version = testers.testVersion {
+              inherit package version;
+              command = "${name} -v";
+            };
           };
+          # The updatescript for the builder updates the releases
+          updateScript = null;
+          inherit releasesSrc;
         };
 
         meta = {

--- a/pkgs/tools/misc/opentelemetry-collector/releases.nix
+++ b/pkgs/tools/misc/opentelemetry-collector/releases.nix
@@ -15,14 +15,14 @@ let
   builder = "${opentelemetry-collector-builder}/bin/ocb";
 
   # Keep the version in sync with the builder.
-  version = "0.151.0";
+  version = "0.155.0";
 
   # This is a weird meta-repo where all the open-telemetry collectors are.
   releasesSrc = fetchFromGitHub {
     owner = "open-telemetry";
     repo = "opentelemetry-collector-releases";
     rev = "v${version}";
-    hash = "sha256-5AoUgGZEvxbvlksD1P84lxMrHPAP05cN21fABK4UXRg=";
+    hash = "sha256-w4J5Q7cztSQyjqHH5L0blDUiFO6+fK4/dLoQT+ftUSE=";
   };
 
   # Then from this src, we use the tool to generate some go code, including
@@ -152,26 +152,26 @@ in
 lib.recurseIntoAttrs {
   otelcol = mkDistribution {
     name = "otelcol";
-    sourceHash = "sha256-4PpZ6anKPkFyVcARJJSEpyy3duTCyrMnnAnh6CWwjUc=";
-    vendorHash = "sha256-OoXz9rFIipM0tc6kvkkPdUtYXVIfo0L40V4SUfwSF6M=";
+    sourceHash = "sha256-JY/jg5SeZ90lVLo+t6MuxZAMZ5IpNwEQEz9kC2uYc+8=";
+    vendorHash = "sha256-tEA2wCtk2Pm7YJem5jOB/1Iz7K1jKKl/N9VKSumC+WA=";
   };
 
   otelcol-contrib = mkDistribution {
     name = "otelcol-contrib";
-    sourceHash = "sha256-wUmpivqLSnRYGTJn3IIlpwFXORmK4FJrc8U472YPV2o=";
-    vendorHash = "sha256-7Rb3Ku0q+5cBvgtd/oZaLaFa4chv0b/MzaHEpJvJ6rE=";
+    sourceHash = "sha256-ANIyUa0bibTYRWC1RZbvYFitaEkmLOiubQxFfmzj4kQ=";
+    vendorHash = "sha256-dPaDmhO4XASQ1y3NyetxnJuTr+pIDwF/rwrN5QkBBCA=";
     proxyVendor = true; # hash mismatch between linux and darwin
   };
 
   otelcol-k8s = mkDistribution {
     name = "otelcol-k8s";
-    sourceHash = "sha256-yNhE0CwMNus12QDSbP/x9irrIcOdez0e/RpXFFRQ2LE=";
-    vendorHash = "sha256-2ZzLCMTafbpmSpkpwvYgkP/Myg/QD1LHgiMigbj3x9I=";
+    sourceHash = "sha256-cZ+ok52ceYkQE9bG+FFTFYONUQfsC8kbJk5SLZ8IIYU=";
+    vendorHash = "sha256-qwlZr0LoXZWf72flpORf19PAkHdITY8bxJGkacG2j+A=";
   };
 
   otelcol-otlp = mkDistribution {
     name = "otelcol-otlp";
-    sourceHash = "sha256-+cffC4sOlyPWtydkPZz7M0NF2Q3heQ04/pEB8d+942c=";
-    vendorHash = "sha256-WiP+TYj7VZBt3tP4C/ZvQwkDP8/b4F+Bc7Z95p0tBTI=";
+    sourceHash = "sha256-W1QHjHMn6xWVN08FpJi2YcKzkpxTPbq9MYIbdQxVHHY=";
+    vendorHash = "sha256-gX1D+RPCwcp9UMpzAzEYHDsBrn2KdfN/4RxcgKHViYQ=";
   };
 }

--- a/pkgs/tools/misc/opentelemetry-collector/update.sh
+++ b/pkgs/tools/misc/opentelemetry-collector/update.sh
@@ -1,0 +1,19 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p curl jq nix-update common-updater-scripts
+set -euf
+
+# Get latest version from releases repo
+version=$(curl https://api.github.com/repos/open-telemetry/opentelemetry-collector-releases/releases/latest | jq -r '.name')
+version=${version#v}
+
+# Update builder
+nix-update opentelemetry-collector-builder --version="${version}"
+
+# Update the otel-collector-releases source
+update-source-version opentelemetry-collector-releases.otelcol "${version}" --source-key="releasesSrc"
+
+# Update the individual distributions
+for dist in {"",-contrib,-k8s,-otlp}
+do
+  nix-update "opentelemetry-collector-releases.otelcol${dist}" --version skip
+done


### PR DESCRIPTION
Added an updateScript to opentelemetry-collector-builder so that the builder and the opentelemetry-collector-releases get updated at the same time. In the past the builder was updated without the releases, causing the versioning to break. More details here https://github.com/NixOS/nixpkgs/issues/480348 and here https://github.com/NixOS/nixpkgs/pull/525828.

Also contains an update to 0.155.0 because the current version is "broken".
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
