### PR TITLE
nixos/xandikos: modernise

### DIFF
--- a/nixos/modules/services/networking/xandikos.nix
+++ b/nixos/modules/services/networking/xandikos.nix
@@ -10,6 +10,7 @@ let
   cfg = config.services.xandikos;
 
   inherit (lib)
+    getExe
     mkDefault
     mkEnableOption
     mkIf
@@ -173,7 +174,7 @@ in
         RestrictRealtime = true;
         RestrictSUIDSGID = true;
         ExecStart = ''
-          ${cfg.package}/bin/xandikos ${
+          ${getExe cfg.package} ${
             toCommandLineShell (optionName: {
               option = if (builtins.stringLength optionName) > 1 then "--${optionName}" else "-${optionName}";
               sep = null;

--- a/nixos/modules/services/networking/xandikos.nix
+++ b/nixos/modules/services/networking/xandikos.nix
@@ -6,10 +6,27 @@
   ...
 }:
 
-with lib;
-
 let
   cfg = config.services.xandikos;
+
+  inherit (lib)
+    literalExpression
+    mkDefault
+    mkEnableOption
+    mkIf
+    mkMerge
+    mkOption
+    mkPackageOption
+    mkRemovedOptionModule
+    ;
+
+  inherit (lib.types)
+    listOf
+    nullOr
+    port
+    str
+    submodule
+    ;
 in
 {
   options = {
@@ -19,7 +36,7 @@ in
       package = mkPackageOption pkgs "xandikos" { };
 
       address = mkOption {
-        type = types.str;
+        type = str;
         default = "localhost";
         description = ''
           The IP address on which Xandikos will listen.
@@ -28,13 +45,13 @@ in
       };
 
       port = mkOption {
-        type = types.port;
+        type = port;
         default = 8080;
         description = "The port of the Xandikos web application";
       };
 
       routePrefix = mkOption {
-        type = types.str;
+        type = str;
         default = "/";
         description = ''
           Path to Xandikos.
@@ -44,7 +61,7 @@ in
 
       extraOptions = mkOption {
         default = [ ];
-        type = types.listOf types.str;
+        type = listOf str;
         example = literalExpression ''
           [ "--autocreate"
             "--defaults"
@@ -58,7 +75,7 @@ in
       };
 
       domain = mkOption {
-        type = types.nullOr types.str;
+        type = nullOr str;
         description = ''
           If non-null, enables an nginx reverse proxy virtual host at this FQDN for xandikos.
         '';

--- a/nixos/modules/services/networking/xandikos.nix
+++ b/nixos/modules/services/networking/xandikos.nix
@@ -138,6 +138,13 @@ in
   meta.maintainers = with lib.maintainers; [ _0x4A6F ];
 
   config = mkIf cfg.enable {
+    users.users.xandikos = {
+      isSystemUser = true;
+      group = "xandikos";
+    };
+
+    users.groups.xandikos = { };
+
     systemd.services.xandikos = {
       description = "A Simple Calendar and Contact Server";
       after = [ "network.target" ];
@@ -146,7 +153,6 @@ in
       serviceConfig = {
         User = "xandikos";
         Group = "xandikos";
-        DynamicUser = "yes";
         RuntimeDirectory = "xandikos";
         StateDirectory = "xandikos";
         StateDirectoryMode = "0700";

--- a/nixos/modules/services/networking/xandikos.nix
+++ b/nixos/modules/services/networking/xandikos.nix
@@ -2,6 +2,7 @@
   config,
   lib,
   pkgs,
+  options,
   ...
 }:
 
@@ -11,7 +12,6 @@ let
   cfg = config.services.xandikos;
 in
 {
-
   options = {
     services.xandikos = {
       enable = mkEnableOption "Xandikos CalDAV and CardDAV server";
@@ -57,89 +57,90 @@ in
         '';
       };
 
+      domain = mkOption {
+        type = types.nullOr types.str;
+        description = ''
+          If non-null, enables an nginx reverse proxy virtual host at this FQDN for xandikos.
+        '';
+        example = "xandikos.example.com";
+      };
+
       nginx = mkOption {
+        type = submodule {
+          imports = [
+            ../web-servers/nginx/vhost-options.nix
+            ../../misc/assertions.nix
+            (mkRemovedOptionModule [
+              "enable"
+            ] "Set ${options.services.xandikos.domain} to null if you want to disable the nginx integration.")
+            (mkRemovedOptionModule [ "hostName" ] "Set ${options.services.xandikos.domain} instead.")
+          ];
+        };
         default = { };
         description = ''
           Configuration for nginx reverse proxy.
         '';
-
-        type = types.submodule {
-          options = {
-            enable = mkOption {
-              type = types.bool;
-              default = false;
-              description = ''
-                Configure the nginx reverse proxy settings.
-              '';
-            };
-
-            hostName = mkOption {
-              type = types.str;
-              description = ''
-                The hostname use to setup the virtualhost configuration
-              '';
-            };
-          };
-        };
       };
-
     };
-
   };
 
   meta.maintainers = with lib.maintainers; [ _0x4A6F ];
 
-  config = mkIf cfg.enable (mkMerge [
-    {
+  config = mkIf cfg.enable {
+    systemd.services.xandikos = {
+      description = "A Simple Calendar and Contact Server";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
 
-      systemd.services.xandikos = {
-        description = "A Simple Calendar and Contact Server";
-        after = [ "network.target" ];
-        wantedBy = [ "multi-user.target" ];
-
-        serviceConfig = {
-          User = "xandikos";
-          Group = "xandikos";
-          DynamicUser = "yes";
-          RuntimeDirectory = "xandikos";
-          StateDirectory = "xandikos";
-          StateDirectoryMode = "0700";
-          PrivateDevices = true;
-          # Sandboxing
-          CapabilityBoundingSet = "CAP_NET_RAW CAP_NET_ADMIN";
-          ProtectSystem = "strict";
-          ProtectHome = true;
-          PrivateTmp = true;
-          ProtectKernelTunables = true;
-          ProtectKernelModules = true;
-          ProtectControlGroups = true;
-          RestrictAddressFamilies = "AF_INET AF_INET6 AF_UNIX AF_PACKET AF_NETLINK";
-          RestrictNamespaces = true;
-          LockPersonality = true;
-          MemoryDenyWriteExecute = true;
-          RestrictRealtime = true;
-          RestrictSUIDSGID = true;
-          ExecStart = ''
-            ${cfg.package}/bin/xandikos \
-              --directory /var/lib/xandikos \
-              --listen-address ${cfg.address} \
-              --port ${toString cfg.port} \
-              --route-prefix ${cfg.routePrefix} \
-              ${lib.concatStringsSep " " cfg.extraOptions}
-          '';
-        };
+      serviceConfig = {
+        User = "xandikos";
+        Group = "xandikos";
+        DynamicUser = "yes";
+        RuntimeDirectory = "xandikos";
+        StateDirectory = "xandikos";
+        StateDirectoryMode = "0700";
+        PrivateDevices = true;
+        # Sandboxing
+        CapabilityBoundingSet = "CAP_NET_RAW CAP_NET_ADMIN";
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        RestrictAddressFamilies = "AF_INET AF_INET6 AF_UNIX AF_PACKET AF_NETLINK";
+        RestrictNamespaces = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        ExecStart = ''
+          ${cfg.package}/bin/xandikos \
+            --directory /var/lib/xandikos \
+            --listen-address ${cfg.address} \
+            --port ${toString cfg.port} \
+            --route-prefix ${cfg.routePrefix} \
+            ${lib.concatStringsSep " " cfg.extraOptions}
+        '';
       };
-    }
+    };
 
-    (mkIf cfg.nginx.enable {
-      services.nginx = {
-        enable = true;
-        virtualHosts."${cfg.nginx.hostName}" = {
-          locations."/" = {
-            proxyPass = "http://${cfg.address}:${toString cfg.port}/";
+    services.nginx = mkIf (cfg.domain != null) {
+      enable = lib.mkDefault true;
+      virtualHosts."${cfg.domain}" = mkMerge [
+        (removeAttrs cfg.nginx [
+          "enable"
+          "hostName"
+          "assertions"
+          "warnings"
+        ])
+        {
+          locations."${cfg.routePrefix}" = {
+            proxyPass = mkDefault "http://${cfg.address}:${toString cfg.port}/";
+            recommendedProxySettings = mkDefault true;
           };
-        };
-      };
-    })
-  ]);
+        }
+      ];
+    };
+  };
 }

--- a/nixos/modules/services/networking/xandikos.nix
+++ b/nixos/modules/services/networking/xandikos.nix
@@ -10,7 +10,6 @@ let
   cfg = config.services.xandikos;
 
   inherit (lib)
-    literalExpression
     mkDefault
     mkEnableOption
     mkIf
@@ -18,60 +17,95 @@ let
     mkOption
     mkPackageOption
     mkRemovedOptionModule
+    mkRenamedOptionModule
     ;
 
+  inherit (lib.cli) toCommandLineShell;
+  inherit (lib.generators) mkValueStringDefault;
+
   inherit (lib.types)
-    listOf
+    attrsOf
+    bool
+    int
     nullOr
+    oneOf
     port
     str
     submodule
     ;
 in
 {
+  imports = [
+    (mkRenamedOptionModule [ "services" "xandikos" "port" ] [ "services" "xandikos" "settings" "port" ])
+    (mkRenamedOptionModule
+      [ "services" "xandikos" "routePrefix" ]
+      [ "services" "xandikos" "settings" "route-prefix" ]
+    )
+    (mkRenamedOptionModule
+      [ "services" "xandikos" "address" ]
+      [ "services" "xandikos" "settings" "listen-address" ]
+    )
+    (mkRemovedOptionModule [
+      "services"
+      "xandikos"
+      "extraOptions"
+    ] "Use ${options.services.xandikos.settings} instead.")
+  ];
+
   options = {
     services.xandikos = {
       enable = mkEnableOption "Xandikos CalDAV and CardDAV server";
 
       package = mkPackageOption pkgs "xandikos" { };
 
-      address = mkOption {
-        type = str;
-        default = "localhost";
-        description = ''
-          The IP address on which Xandikos will listen.
-          By default listens on localhost.
-        '';
-      };
+      settings = mkOption {
+        type = submodule {
+          freeformType = attrsOf (
+            nullOr (oneOf [
+              str
+              int
+              bool
+            ])
+          );
+          options = {
+            port = mkOption {
+              type = port;
+              default = 8080;
+              description = "The port of the Xandikos web application";
+            };
 
-      port = mkOption {
-        type = port;
-        default = 8080;
-        description = "The port of the Xandikos web application";
-      };
+            route-prefix = mkOption {
+              type = str;
+              default = "/";
+              description = ''
+                Path to Xandikos.
+                Useful when Xandikos is behind a reverse proxy.
+              '';
+            };
 
-      routePrefix = mkOption {
-        type = str;
-        default = "/";
-        description = ''
-          Path to Xandikos.
-          Useful when Xandikos is behind a reverse proxy.
-        '';
-      };
+            directory = mkOption {
+              type = str;
+              default = "/var/lib/xandikos";
+              description = "Path to where Xandikos stores its internal data.";
+            };
 
-      extraOptions = mkOption {
-        default = [ ];
-        type = listOf str;
-        example = literalExpression ''
-          [ "--autocreate"
-            "--defaults"
-            "--current-user-principal user"
-            "--dump-dav-xml"
-          ]
-        '';
-        description = ''
-          Extra command line arguments to pass to xandikos.
-        '';
+            listen-address = mkOption {
+              type = str;
+              default = "localhost";
+              description = ''
+                The IP address on which Xandikos will listen.
+              '';
+            };
+          };
+        };
+        default = { };
+        example = {
+          autocreate = true;
+          defaults = true;
+          current-user-principal = "user";
+          dump-dav-xml = true;
+        };
+        description = "Arguments passed to Xandikos";
       };
 
       domain = mkOption {
@@ -116,6 +150,7 @@ in
         RuntimeDirectory = "xandikos";
         StateDirectory = "xandikos";
         StateDirectoryMode = "0700";
+        RequiresMountsFor = [ cfg.settings.directory ];
         PrivateDevices = true;
         # Sandboxing
         CapabilityBoundingSet = "CAP_NET_RAW CAP_NET_ADMIN";
@@ -132,12 +167,14 @@ in
         RestrictRealtime = true;
         RestrictSUIDSGID = true;
         ExecStart = ''
-          ${cfg.package}/bin/xandikos \
-            --directory /var/lib/xandikos \
-            --listen-address ${cfg.address} \
-            --port ${toString cfg.port} \
-            --route-prefix ${cfg.routePrefix} \
-            ${lib.concatStringsSep " " cfg.extraOptions}
+          ${cfg.package}/bin/xandikos ${
+            toCommandLineShell (optionName: {
+              option = if (builtins.stringLength optionName) > 1 then "--${optionName}" else "-${optionName}";
+              sep = null;
+              explicitBool = false;
+              formatArg = mkValueStringDefault { };
+            }) cfg.settings
+          }
         '';
       };
     };
@@ -152,8 +189,8 @@ in
           "warnings"
         ])
         {
-          locations."${cfg.routePrefix}" = {
-            proxyPass = mkDefault "http://${cfg.address}:${toString cfg.port}/";
+          locations."${cfg.settings.route-prefix}" = {
+            proxyPass = mkDefault "http://${cfg.settings.listen-address}:${toString cfg.settings.port}/";
             recommendedProxySettings = mkDefault true;
           };
         }

--- a/nixos/tests/xandikos.nix
+++ b/nixos/tests/xandikos.nix
@@ -16,23 +16,16 @@
         80
         8080
       ];
-      services.xandikos.enable = true;
-      services.xandikos.address = "localhost";
-      services.xandikos.port = 8080;
-      services.xandikos.routePrefix = "/xandikos-prefix/";
-      services.xandikos.extraOptions = [
-        "--defaults"
-      ];
-      services.nginx = {
+      services.xandikos = {
         enable = true;
-        recommendedProxySettings = true;
-        virtualHosts."xandikos" = {
-          serverName = "xandikos.local";
-          basicAuth.xandikos = "snakeOilPassword";
-          locations."/xandikos/" = {
-            proxyPass = "http://localhost:8080/xandikos-prefix/";
-          };
+        settings = {
+          listen-address = "localhost";
+          port = 8080;
+          route-prefix = "/xandikos/";
+          defaults = true;
         };
+        domain = "xandikos.local";
+        nginx.basicAuth.xandikos = "snakeOilPassword";
       };
     };
   };


### PR DESCRIPTION
This breaks some things for the sake of RFC42 and using `vhost-options.nix` for better customizability, like setting basic auth. IMHO it's worth it.

The tests barely fail, and I have no idea why, since the app seems entirely functional to me. Oh well...

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
