### PR TITLE
python3Packages.stone: 3.3.9 -> 3.5.2, python3Packages.dropbox: 12.0.2 -> 12.2.0

### DIFF
--- a/pkgs/development/python-modules/dropbox/default.nix
+++ b/pkgs/development/python-modules/dropbox/default.nix
@@ -2,9 +2,8 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  setuptools_80,
+  setuptools,
   requests,
-  six,
   stone,
   mock,
   pytest-mock,
@@ -13,9 +12,9 @@
   sphinx-rtd-theme,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "dropbox";
-  version = "12.0.2";
+  version = "12.2.0";
   pyproject = true;
 
   outputs = [
@@ -26,15 +25,14 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "dropbox";
     repo = "dropbox-sdk-python";
-    tag = "v${version}";
-    hash = "sha256-9Fsh06V226vIyJhrlLkh9Xr4UGoEIISnIFCtuKqI218=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Hkfv9+nofc9PMCw7crF3bw4bOFlzbJCHTW8hGxc91Pc=";
   };
 
-  build-system = [ setuptools_80 ];
+  build-system = [ setuptools ];
 
   dependencies = [
     requests
-    six
     stone
   ];
 
@@ -44,11 +42,6 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace-fail "'pytest-runner==5.2.0'," ""
-  '';
-
   pythonImportsCheck = [ "dropbox" ];
 
   nativeBuildInputs = [
@@ -56,17 +49,11 @@ buildPythonPackage rec {
     sphinx-rtd-theme
   ];
 
-  # Version 12.0.0 re-introduced Python 2 support and set some very restrictive version bounds
-  # https://github.com/dropbox/dropbox-sdk-python/commit/75596daf316b4a806f18057e2797a15bdf83cf6d
-  # This will be the last major version to support Python 2, so version bounds might be more reasonable again in the future.
-  pythonRelaxDeps = [
-    "stone"
-  ];
-
   # Set SCOPED_USER_DROPBOX_TOKEN environment variable to a valid value.
   disabledTests = [
-    "test_default_oauth2_urls"
     "test_bad_auth"
+    "test_bad_pins"
+    "test_bad_pins_session"
     "test_multi_auth"
     "test_refresh"
     "test_app_auth"
@@ -83,15 +70,14 @@ buildPythonPackage rec {
     "test_as_user"
     "test_as_admin"
     "test_clone_when_team_linked"
-    "test_bad_pins"
-    "test_bad_pins_session"
+    "test_upload_auto_content_hash"
   ];
 
   meta = {
     description = "Python library for Dropbox's HTTP-based Core and Datastore APIs";
     homepage = "https://github.com/dropbox/dropbox-sdk-python";
-    changelog = "https://github.com/dropbox/dropbox-sdk-python/releases/tag/${src.tag}";
+    changelog = "https://github.com/dropbox/dropbox-sdk-python/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ sfrijters ];
   };
-}
+})

--- a/pkgs/development/python-modules/maestral/default.nix
+++ b/pkgs/development/python-modules/maestral/default.nix
@@ -41,6 +41,13 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-mYFiQL4FumJWP2y1u5tIo1CZL027J8/EIYqJQde7G/c=";
   };
 
+  postPatch = ''
+    # is_not_closed was removed from dropbox in https://github.com/dropbox/dropbox-sdk-python/pull/537
+    # Upstream has been archived so we cannot expect a fix - use this workaround to keep the package alive a bit longer
+    substituteInPlace src/maestral/errorhandling.py \
+      --replace-fail "elif session_lookup_error.is_not_closed():" "elif False:"
+  '';
+
   build-system = [ setuptools ];
 
   dependencies = [

--- a/pkgs/development/python-modules/stone/default.nix
+++ b/pkgs/development/python-modules/stone/default.nix
@@ -8,33 +8,37 @@
   ply,
   pytestCheckHook,
   setuptools,
-  six,
+  setuptools-scm,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "stone";
-  version = "3.3.9";
+  version = "3.5.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "dropbox";
     repo = "stone";
-    tag = "v${version}";
-    hash = "sha256-3tUV2JrE3S2Tj/9aHvzfBTkIWUmWzkWNsVLr5yWRE/Q=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-05sAhyQx3IalHqNkSrJgRDJz85M331hF5Crc/gtP6jE=";
   };
 
   postPatch = ''
-    substituteInPlace setup.py \
-      --replace-fail "'pytest-runner == 5.3.2'," ""
+    # https://github.com/dropbox/stone/pull/373 pins setuptools-scm to <9,
+    # but that version is not in nixpkgs and it seems to work anyway?
+    substituteInPlace pyproject.toml \
+      --replace-fail "setuptools-scm>=8,<9" "setuptools-scm"
   '';
 
-  build-system = [ setuptools ];
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
 
   dependencies = [
     jinja2
-    ply
-    six
     packaging
+    ply
   ];
 
   nativeCheckInputs = [
@@ -47,9 +51,9 @@ buildPythonPackage rec {
   meta = {
     description = "Official API Spec Language for Dropbox API V2";
     homepage = "https://github.com/dropbox/stone";
-    changelog = "https://github.com/dropbox/stone/releases/tag/${src.tag}";
+    changelog = "https://github.com/dropbox/stone/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = [ ];
     mainProgram = "stone";
   };
-}
+})


### PR DESCRIPTION
Updated dropbox needs updated stone

https://github.com/dropbox/stone/compare/v3.3.9...v3.5.2
https://github.com/dropbox/dropbox-sdk-python/compare/v12.0.2...v12.2.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
