### PR TITLE
Slint viewer: Fix macos build, compile with gettext feature

### DIFF
--- a/pkgs/by-name/sl/slint-viewer/package.nix
+++ b/pkgs/by-name/sl/slint-viewer/package.nix
@@ -36,6 +36,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     libGL
   ];
 
+  buildFeatures = [ "gettext" ];
+
   nativeBuildInputs = [
     autoPatchelfHook
     pkg-config

--- a/pkgs/by-name/sl/slint-viewer/package.nix
+++ b/pkgs/by-name/sl/slint-viewer/package.nix
@@ -39,10 +39,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
   buildFeatures = [ "gettext" ];
 
   nativeBuildInputs = [
-    autoPatchelfHook
     pkg-config
     qt6.wrapQtAppsHook
-  ];
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ rustPlatform.bindgenHook ];
 
   # stolen from the surfer package
   runtimeDependencies = lib.optionals stdenv.hostPlatform.isLinux [


### PR DESCRIPTION
This PR fixes slint-viewer on macos, which was broken by the unconditional addition of an autoPatchelfHook. Furthermore, it enables the gettext feature to allow using the `--translation-domain`/`--translation-dir` arguments.

## Things done


- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
