### PR TITLE
python3Packages.pyiceberg: allow rich 15

### DIFF
--- a/pkgs/by-name/ex/exegol/package.nix
+++ b/pkgs/by-name/ex/exegol/package.nix
@@ -22,6 +22,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   pythonRelaxDeps = [
     "argcomplete"
     "cryptography"
+    "pydantic"
     "requests"
     "rich"
     "supabase"

--- a/pkgs/development/python-modules/pyiceberg/default.nix
+++ b/pkgs/development/python-modules/pyiceberg/default.nix
@@ -79,6 +79,11 @@ buildPythonPackage (finalAttrs: {
   # Prevents the cython build to fail silently
   env.CIBUILDWHEEL = "1";
 
+  pythonRelaxDeps = [
+    # rich<15.0.0,>=10.11.0 not satisfied by version 15.0.0
+    "rich"
+  ];
+
   dependencies = [
     cachetools
     click
@@ -289,6 +294,10 @@ buildPythonPackage (finalAttrs: {
     # Timing sensitive
     # AssertionError: assert 8 == 5
     "test_hive_wait_for_lock"
+
+    # Schema comparison faildue to `string` becoming `large_string`
+    "test_read_map "
+    "test_projection_maps_of_structs"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # ImportError: The pyarrow installation is not built with support for 'GcsFileSystem'


### PR DESCRIPTION

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
