### PR TITLE
jedi-language-server: 0.46.0 -> 0.47.0

### DIFF
--- a/pkgs/development/python-modules/jedi-language-server/default.nix
+++ b/pkgs/development/python-modules/jedi-language-server/default.nix
@@ -5,7 +5,7 @@
   fetchFromGitHub,
 
   # build-system
-  poetry-core,
+  hatchling,
 
   # dependencies
   docstring-to-markdown,
@@ -23,18 +23,18 @@
 
 buildPythonPackage rec {
   pname = "jedi-language-server";
-  version = "0.46.0";
+  version = "0.47.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pappasam";
     repo = "jedi-language-server";
     tag = "v${version}";
-    hash = "sha256-8B/FYktdWtZvB8Us6zQ3gvx1MxJTzP2xyj1VhnM+Viw=";
+    hash = "sha256-UXFIVj2g/s669vgS9uLH+5qFjNFoIFhS5S6XDbzRYwU=";
   };
 
   build-system = [
-    poetry-core
+    hatchling
   ];
 
   pythonRelaxDeps = [


### PR DESCRIPTION
## Description

Bumps `jedi-language-server` 0.46.0 → 0.47.0.

0.47.0 switched its build backend from `poetry-core` to `hatchling`, so
`build-system` is updated to match. Upstream also relaxed its `jedi` bound to
`<0.21`; nixpkgs' `jedi` 0.20.0 and `pygls` 2.1.1 satisfy 0.47.0's
requirements, so no dependency changes are needed.

Changelog: https://github.com/pappasam/jedi-language-server/blob/v0.47.0/CHANGELOG.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Ran the package's own test suite in the sandbox (104 passed) via
  `nix-build -A python3Packages.jedi-language-server`
- [x] Tested compilation of all packages that depend on this change using
  `nixpkgs-review` — **5 packages built, 0 failed**:
  `python313Packages.jedi-language-server`, `python314Packages.jedi-language-server`,
  `ycmd`, `vimPlugins.YouCompleteMe`, `vscode-extensions.ms-python.python`
- [x] Tested basic functionality of the resulting binary:
  `result/bin/jedi-language-server --version` → `0.47.0`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).