### PR TITLE
rust/import-cargo-lock: performance cleanups

### DIFF
--- a/pkgs/build-support/rust/import-cargo-lock.nix
+++ b/pkgs/build-support/rust/import-cargo-lock.nix
@@ -26,6 +26,46 @@ let
     readFile
     removePrefix
     ;
+
+  # Parse a git source into different components.
+  parseGit =
+    src:
+    let
+      parts = match ''git\+([^?]+)(\?(rev|tag|branch)=(.*))?#(.*)'' src;
+      type = elemAt parts 2; # rev, tag or branch
+      value = elemAt parts 3;
+    in
+    if parts == null then
+      null
+    else
+      {
+        url = elemAt parts 0;
+        sha = elemAt parts 4;
+      }
+      // optionalAttrs (type != null) { inherit type value; };
+
+  nameGitSha =
+    pkg:
+    let
+      gitParts = parseGit pkg.source;
+    in
+    {
+      name = "${pkg.name}-${pkg.version}";
+      value = gitParts.sha;
+    };
+
+  # Replaces values inherited by workspace members.
+  replaceWorkspaceValues = writers.writePython3 "replace-workspace-values" {
+    libraries = with python3Packages; [
+      tomli
+      tomli-w
+    ];
+    flakeIgnore = [
+      "E501"
+      "W503"
+    ];
+  } (readFile ./replace-workspace-values.py);
+
 in
 {
   # Cargo lock file
@@ -55,23 +95,6 @@ in
 assert (lockFile == null) != (lockFileContents == null);
 
 let
-  # Parse a git source into different components.
-  parseGit =
-    src:
-    let
-      parts = match ''git\+([^?]+)(\?(rev|tag|branch)=(.*))?#(.*)'' src;
-      type = elemAt parts 2; # rev, tag or branch
-      value = elemAt parts 3;
-    in
-    if parts == null then
-      null
-    else
-      {
-        url = elemAt parts 0;
-        sha = elemAt parts 4;
-      }
-      // optionalAttrs (type != null) { inherit type value; };
-
   # shadows args.lockFileContents
   lockFileContents = if lockFile != null then readFile lockFile else args.lockFileContents;
 
@@ -97,16 +120,6 @@ let
 
   # Map package name + version to git commit SHA for packages with a git source.
   namesGitShas = listToAttrs (map nameGitSha (filter (pkg: hasPrefix "git+" pkg.source) depPackages));
-
-  nameGitSha =
-    pkg:
-    let
-      gitParts = parseGit pkg.source;
-    in
-    {
-      name = "${pkg.name}-${pkg.version}";
-      value = gitParts.sha;
-    };
 
   # Convert the attrset provided through the `outputHashes` argument to a
   # a mapping from git commit SHA -> output hash.
@@ -154,18 +167,6 @@ let
     "https://github.com/rust-lang/crates.io-index" = "https://static.crates.io/crates";
   }
   // extraRegistries;
-
-  # Replaces values inherited by workspace members.
-  replaceWorkspaceValues = writers.writePython3 "replace-workspace-values" {
-    libraries = with python3Packages; [
-      tomli
-      tomli-w
-    ];
-    flakeIgnore = [
-      "E501"
-      "W503"
-    ];
-  } (readFile ./replace-workspace-values.py);
 
   # Fetch and unpack a crate.
   mkCrate =

--- a/pkgs/build-support/rust/import-cargo-lock.nix
+++ b/pkgs/build-support/rust/import-cargo-lock.nix
@@ -27,6 +27,11 @@ let
     removePrefix
     ;
 
+  hasGitPrefix = hasPrefix "git+";
+  hasSparsePrefix = hasPrefix "sparse+";
+  hasRegistryPrefix = hasPrefix "registry+";
+  removeRegistryPrefix = removePrefix "registry+";
+
   # Parse a git source into different components.
   parseGit =
     src:
@@ -119,7 +124,7 @@ let
   depCrates = deepSeq gitShaOutputHash (map mkCrate depPackages);
 
   # Map package name + version to git commit SHA for packages with a git source.
-  namesGitShas = listToAttrs (map nameGitSha (filter (pkg: hasPrefix "git+" pkg.source) depPackages));
+  namesGitShas = listToAttrs (map nameGitSha (filter (pkg: hasGitPrefix pkg.source) depPackages));
 
   # Convert the attrset provided through the `outputHashes` argument to a
   # a mapping from git commit SHA -> output hash.
@@ -173,11 +178,10 @@ let
     pkg:
     let
       gitParts = parseGit pkg.source;
-      registryIndexUrl = removePrefix "registry+" pkg.source;
+      registryIndexUrl = removeRegistryPrefix pkg.source;
     in
     if
-      (hasPrefix "registry+" pkg.source || hasPrefix "sparse+" pkg.source)
-      && hasAttr registryIndexUrl registries
+      (hasRegistryPrefix pkg.source || hasSparsePrefix pkg.source) && hasAttr registryIndexUrl registries
     then
       let
         crateTarball = fetchCrate pkg registries.${registryIndexUrl};

--- a/pkgs/build-support/rust/import-cargo-lock.nix
+++ b/pkgs/build-support/rust/import-cargo-lock.nix
@@ -18,10 +18,10 @@ let
     getExe
     hasAttr
     hasPrefix
+    head
     listToAttrs
     mapAttrs'
     match
-    optionalAttrs
     optionalString
     readFile
     removePrefix
@@ -44,10 +44,11 @@ let
       null
     else
       {
-        url = elemAt parts 0;
+        url = head parts;
         sha = elemAt parts 4;
-      }
-      // optionalAttrs (type != null) { inherit type value; };
+        ${if type == null then null else "type"} = type;
+        ${if type == null then null else "value"} = value;
+      };
 
   nameGitSha =
     pkg:

--- a/pkgs/build-support/rust/import-cargo-lock.nix
+++ b/pkgs/build-support/rust/import-cargo-lock.nix
@@ -8,7 +8,25 @@
   cargo,
   jq,
 }:
-
+let
+  inherit (lib)
+    attrNames
+    deepSeq
+    elemAt
+    escapeShellArg
+    filter
+    getExe
+    hasAttr
+    hasPrefix
+    listToAttrs
+    mapAttrs'
+    match
+    optionalAttrs
+    optionalString
+    readFile
+    removePrefix
+    ;
+in
 {
   # Cargo lock file
   lockFile ? null,
@@ -41,21 +59,21 @@ let
   parseGit =
     src:
     let
-      parts = builtins.match ''git\+([^?]+)(\?(rev|tag|branch)=(.*))?#(.*)'' src;
-      type = builtins.elemAt parts 2; # rev, tag or branch
-      value = builtins.elemAt parts 3;
+      parts = match ''git\+([^?]+)(\?(rev|tag|branch)=(.*))?#(.*)'' src;
+      type = elemAt parts 2; # rev, tag or branch
+      value = elemAt parts 3;
     in
     if parts == null then
       null
     else
       {
-        url = builtins.elemAt parts 0;
-        sha = builtins.elemAt parts 4;
+        url = elemAt parts 0;
+        sha = elemAt parts 4;
       }
-      // lib.optionalAttrs (type != null) { inherit type value; };
+      // optionalAttrs (type != null) { inherit type value; };
 
   # shadows args.lockFileContents
-  lockFileContents = if lockFile != null then builtins.readFile lockFile else args.lockFileContents;
+  lockFileContents = if lockFile != null then readFile lockFile else args.lockFileContents;
 
   parsedLockFile = fromTOML lockFileContents;
 
@@ -68,19 +86,17 @@ let
   # There is no source attribute for the source package itself. But
   # since we do not want to vendor the source package anyway, we can
   # safely skip it.
-  depPackages = builtins.filter (p: p ? "source") packages;
+  depPackages = filter (p: p ? "source") packages;
 
   # Create dependent crates from packages.
   #
   # Force evaluation of the git SHA -> hash mapping, so that an error is
   # thrown if there are stale hashes. We cannot rely on gitShaOutputHash
   # being evaluated otherwise, since there could be no git dependencies.
-  depCrates = builtins.deepSeq gitShaOutputHash (map mkCrate depPackages);
+  depCrates = deepSeq gitShaOutputHash (map mkCrate depPackages);
 
   # Map package name + version to git commit SHA for packages with a git source.
-  namesGitShas = builtins.listToAttrs (
-    map nameGitSha (builtins.filter (pkg: lib.hasPrefix "git+" pkg.source) depPackages)
-  );
+  namesGitShas = listToAttrs (map nameGitSha (filter (pkg: hasPrefix "git+" pkg.source) depPackages));
 
   nameGitSha =
     pkg:
@@ -100,7 +116,7 @@ let
   # workspace). By using the git commit SHA as a universal identifier,
   # the user does not have to specify the output hash for every package
   # individually.
-  gitShaOutputHash = lib.mapAttrs' (
+  gitShaOutputHash = mapAttrs' (
     nameVer: hash:
     let
       unusedHash = throw "A hash was specified for ${nameVer}, but there is no corresponding git dependency.";
@@ -149,18 +165,18 @@ let
       "E501"
       "W503"
     ];
-  } (builtins.readFile ./replace-workspace-values.py);
+  } (readFile ./replace-workspace-values.py);
 
   # Fetch and unpack a crate.
   mkCrate =
     pkg:
     let
       gitParts = parseGit pkg.source;
-      registryIndexUrl = lib.removePrefix "registry+" pkg.source;
+      registryIndexUrl = removePrefix "registry+" pkg.source;
     in
     if
-      (lib.hasPrefix "registry+" pkg.source || lib.hasPrefix "sparse+" pkg.source)
-      && builtins.hasAttr registryIndexUrl registries
+      (hasPrefix "registry+" pkg.source || hasPrefix "sparse+" pkg.source)
+      && hasAttr registryIndexUrl registries
     then
       let
         crateTarball = fetchCrate pkg registries.${registryIndexUrl};
@@ -245,12 +261,12 @@ let
         # Cargo is happy with empty metadata.
         printf '{"files":{},"package":null}' > "$out/.cargo-checksum.json"
 
-        ${lib.optionalString (gitParts ? type) ''
-          gitPartsValue=${lib.escapeShellArg gitParts.value}
+        ${optionalString (gitParts ? type) ''
+          gitPartsValue=${escapeShellArg gitParts.value}
           # starting with lockfile version v4 the git source url contains encoded query parameters
           # our regex parser does not know how to unescape them to get the actual value, so we do it here
-          ${lib.optionalString (lockFileVersion >= 4) ''
-            gitPartsValue=$(${lib.getExe python3Packages.python} -c "import sys, urllib.parse; print(urllib.parse.unquote(sys.argv[1]))" "$gitPartsValue")
+          ${optionalString (lockFileVersion >= 4) ''
+            gitPartsValue=$(${getExe python3Packages.python} -c "import sys, urllib.parse; print(urllib.parse.unquote(sys.argv[1]))" "$gitPartsValue")
           ''}
         ''}
 
@@ -258,7 +274,7 @@ let
         cat > $out/.cargo-config <<EOF
         [source."${pkg.source}"]
         git = "${gitParts.url}"
-        ${lib.optionalString (gitParts ? type) "${gitParts.type} = \"$gitPartsValue\""}
+        ${optionalString (gitParts ? type) "${gitParts.type} = \"$gitPartsValue\""}
         replace-with = "vendored-sources"
         EOF
       ''
@@ -306,7 +322,7 @@ let
 
             declare -A keysSeen
 
-            for registry in ${toString (builtins.attrNames extraRegistries)}; do
+            for registry in ${toString (attrNames extraRegistries)}; do
               cat >> $out/.cargo/config.toml <<EOF
 
         [source."$registry"]


### PR DESCRIPTION
Flagged this function as taking ~1% of time in the profiler. Should be some minor improvements.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
