### PR TITLE
deskreen: 2.0.4 -> 3.2.16

### DIFF
--- a/pkgs/by-name/de/deskreen/package.nix
+++ b/pkgs/by-name/de/deskreen/package.nix
@@ -4,35 +4,39 @@
   fetchurl,
   appimageTools,
 }:
-
-stdenvNoCC.mkDerivation (finalAttrs: {
+appimageTools.wrapType2 rec {
   pname = "deskreen";
-  version = "2.0.4";
+  version = "3.2.16";
 
-  src = fetchurl {
-    url = "https://github.com/pavlobu/deskreen/releases/download/v${finalAttrs.version}/Deskreen-${finalAttrs.version}.AppImage";
-    hash = "sha256-0jI/mbXaXanY6ay2zn+dPWGvsqWRcF8aYHRvfGVsObE=";
-  };
-  deskreenUnwrapped = appimageTools.wrapType2 {
-    inherit (finalAttrs) pname version;
-    src = finalAttrs.src;
-  };
-
-  buildInputs = [
-    finalAttrs.deskreenUnwrapped
-  ];
-
-  dontUnpack = true;
-  dontBuild = true;
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/bin
-    ln -s ${finalAttrs.deskreenUnwrapped}/bin/deskreen $out/bin/deskreen
-
-    runHook postInstall
-  '';
+  src =
+    let
+      sources = {
+        x86_64-linux = {
+          arch = "x86_64";
+          hash = "sha256-JcVKRINEWHJXzpdyiMSzx+cp/BzHBhrXRxYizQmkerI=";
+        };
+        aarch64-linux = {
+          arch = "arm64";
+          hash = "sha256-FDZz3Aarz9j8ppaLO6C1IhVKr7Dns77fLdQQCaCoKg0=";
+        };
+      };
+      inherit (stdenvNoCC.hostPlatform) system;
+    in
+    fetchurl {
+      url = "https://github.com/pavlobu/deskreen/releases/download/v${version}/deskreen-ce-${version}-${sources.${system}.arch}.AppImage";
+      inherit (sources.${system}) hash;
+    };
+  extraInstallCommands =
+    let
+      contents = appimageTools.extractType2 { inherit pname version src; };
+    in
+    ''
+      install -m 444 -D ${contents}/deskreen-ce.desktop $out/share/applications/deskreen-ce.desktop
+      install -m 444 -D ${contents}/usr/share/icons/hicolor/256x256/apps/deskreen-ce.png \
+        $out/share/icons/hicolor/512x512/apps/deskreen-ce.png
+      substituteInPlace $out/share/applications/deskreen-ce.desktop \
+        --replace-fail 'Exec=AppRun' 'Exec=deskreen'
+    '';
 
   meta = {
     description = "Turn any device into a secondary screen for your computer";
@@ -42,6 +46,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       leo248
     ];
-    platforms = lib.platforms.linux;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
   };
-})
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
From #472261.
Providing more concise derivation and version updates.
The source code for previous versions of `deskreen` seems to have been maintained, but appimage seems to only be available for a few generations. (Has it been removed from the release?)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
