### PR TITLE
trivial-builders: minor performance cleanups

### DIFF
--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -19,6 +19,7 @@ let
     isList
     foldl'
     ;
+  hasRootPrefix = hasPrefix "/";
 in
 
 rec {
@@ -140,7 +141,7 @@ rec {
           ;
         destination =
           assert
-            (destination != "" -> (lib.hasPrefix "/" destination && destination != "/"))
+            (destination != "" -> (hasRootPrefix destination && destination != "/"))
             || throw ''
               destination must be an absolute path, relative to the derivation's out path,
               got '${destination}' instead.
@@ -571,7 +572,7 @@ rec {
         ...
       }:
       assert
-        (stripPrefix != "" -> (hasPrefix "/" stripPrefix && stripPrefix != "/"))
+        (stripPrefix != "" -> (hasRootPrefix stripPrefix && stripPrefix != "/"))
         || throw ''
           stripPrefix must be either an empty string (disable stripping behavior), or relative path prefixed with /.
 

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -106,6 +106,14 @@ rec {
     ];
 
     extendDrvArgs =
+      let
+        defaultPassAsFile = [ "text" ];
+        removedDerivationNames = [
+          "passAsFile"
+          "meta"
+          "passthru"
+        ];
+      in
       finalAttrs:
       {
         name,
@@ -140,7 +148,7 @@ rec {
               Ensure that the path starts with a / and specifies at least the filename.
             '';
           destination;
-        passAsFile = [ "text" ] ++ derivationArgs.passAsFile or [ ];
+        passAsFile = defaultPassAsFile ++ derivationArgs.passAsFile or [ ];
 
         buildCommand = ''
           target=$out$destination
@@ -171,11 +179,7 @@ rec {
           // derivationArgs.meta or { };
         passthru = passthru // derivationArgs.passthru or { };
       }
-      // removeAttrs derivationArgs [
-        "passAsFile"
-        "meta"
-        "passthru"
-      ];
+      // removeAttrs derivationArgs removedDerivationNames;
 
     # `writeTextFile`'s set pattern doesn't have ellipses.
     inheritFunctionArgs = false;

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -594,8 +594,6 @@ rec {
           done
           ${postBuild}
         '';
-      }
-      // {
         ${if !args ? meta then "pos" else null} =
           if args ? pname then
             builtins.unsafeGetAttrPos "pname" args

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -538,6 +538,19 @@ rec {
     ];
 
     extendDrvArgs =
+      let
+        mapPaths =
+          f:
+          map (
+            path:
+            if path == null then
+              null
+            else if isList path then
+              mapPaths f path
+            else
+              f path
+          );
+      in
       finalAttrs:
       args@{
         name ?
@@ -560,19 +573,6 @@ rec {
 
           Ensure that the path starts with / and specifies path to the subdirectory.
         '';
-      let
-        mapPaths =
-          f:
-          map (
-            path:
-            if path == null then
-              null
-            else if isList path then
-              mapPaths f path
-            else
-              f path
-          );
-      in
       {
         enableParallelBuilding = true;
         inherit name allowSubstitutes preferLocalBuild;

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -62,6 +62,8 @@ rec {
     let
       # prevent infinite recursion for the default stdenv value
       defaultStdenv = stdenv;
+      defaultPassAsFile = [ "buildCommand" ];
+      removedNames = [ "passAsFile" ];
     in
     {
       # which stdenv to use, defaults to a stdenv with a C compiler, pkgs.stdenv
@@ -79,7 +81,7 @@ rec {
       {
         enableParallelBuilding = true;
         inherit buildCommand name;
-        passAsFile = [ "buildCommand" ] ++ (derivationArgs.passAsFile or [ ]);
+        passAsFile = defaultPassAsFile ++ (derivationArgs.passAsFile or [ ]);
       }
       // {
         ${if !derivationArgs ? meta then "pos" else null} =
@@ -93,7 +95,7 @@ rec {
         ${if runLocal then "preferLocalBuild" else null} = true;
         ${if runLocal then "allowSubstitutes" else null} = false;
       }
-      // removeAttrs derivationArgs [ "passAsFile" ]
+      // removeAttrs derivationArgs removedNames
     );
 
   # Docs in doc/build-helpers/trivial-build-helpers.chapter.md

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -550,6 +550,10 @@ rec {
             else
               f path
           );
+        defaultPassAsFile = [
+          "buildCommand"
+          "paths"
+        ];
       in
       finalAttrs:
       args@{
@@ -576,10 +580,7 @@ rec {
       {
         enableParallelBuilding = true;
         inherit name allowSubstitutes preferLocalBuild;
-        passAsFile = [
-          "buildCommand"
-          "paths"
-        ];
+        passAsFile = defaultPassAsFile;
         paths = mapPaths (path: "${path}${stripPrefix}") paths;
         buildCommand = ''
           mkdir -p $out

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -82,8 +82,6 @@ rec {
         enableParallelBuilding = true;
         inherit buildCommand name;
         passAsFile = defaultPassAsFile ++ (derivationArgs.passAsFile or [ ]);
-      }
-      // {
         ${if !derivationArgs ? meta then "pos" else null} =
           let
             args = builtins.attrNames derivationArgs;


### PR DESCRIPTION
Noticed a no-op merge, and decided to just take a wander down the file.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
