### PR TITLE
llvm_21: backport patch for selectiondag freeze condition miscompile

### DIFF
--- a/pkgs/development/compilers/llvm/21/llvm/sdag-freeze-condition-in-select-of-load-fold.patch
+++ b/pkgs/development/compilers/llvm/21/llvm/sdag-freeze-condition-in-select-of-load-fold.patch
@@ -1,0 +1,3975 @@
+diff --git a/lib/CodeGen/SelectionDAG/DAGCombiner.cpp b/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+index 91fd2d843f..d5b3ad2797 100644
+--- a/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
++++ b/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+@@ -28487,10 +28487,12 @@
+            SDNode::hasPredecessorHelper(RLD, Visited, Worklist)))
+         return false;
+ 
+-      Addr = DAG.getSelect(SDLoc(TheSelect),
+-                           LLD->getBasePtr().getValueType(),
+-                           TheSelect->getOperand(0), LLD->getBasePtr(),
+-                           RLD->getBasePtr());
++      // If the condition is poison, originally this would result in a poison
++      // result. After the transform, this would result in a load of poison,
++      // which is UB. Freeze the condition to prevent this.
++      Addr = DAG.getSelect(SDLoc(TheSelect), LLD->getBasePtr().getValueType(),
++                           DAG.getFreeze(TheSelect->getOperand(0)),
++                           LLD->getBasePtr(), RLD->getBasePtr());
+     } else {  // Otherwise SELECT_CC
+       // We cannot do this optimization if any pair of {RLD, LLD} is a
+       // predecessor to {RLD, LLD, CondLHS, CondRHS}. As we've already compared
+@@ -28509,10 +28511,10 @@
+            SDNode::hasPredecessorHelper(RLD, Visited, Worklist)))
+         return false;
+ 
++      SDValue FrozenOp0 = DAG.getFreeze(TheSelect->getOperand(0));
++      SDValue FrozenOp1 = DAG.getFreeze(TheSelect->getOperand(1));
+       Addr = DAG.getNode(ISD::SELECT_CC, SDLoc(TheSelect),
+-                         LLD->getBasePtr().getValueType(),
+-                         TheSelect->getOperand(0),
+-                         TheSelect->getOperand(1),
++                         LLD->getBasePtr().getValueType(), FrozenOp0, FrozenOp1,
+                          LLD->getBasePtr(), RLD->getBasePtr(),
+                          TheSelect->getOperand(4));
+     }
+diff --git a/test/CodeGen/AArch64/icmp.ll b/test/CodeGen/AArch64/icmp.ll
+index 18665bcbea..ea6fff4a6d 100644
+--- a/test/CodeGen/AArch64/icmp.ll
++++ b/test/CodeGen/AArch64/icmp.ll
+@@ -1379,26 +1379,22 @@
+ define <2 x i128> @v2i128_i128(<2 x i128> %a, <2 x i128> %b, <2 x i128> %d, <2 x i128> %e) {
+ ; CHECK-SD-LABEL: v2i128_i128:
+ ; CHECK-SD:       // %bb.0: // %entry
++; CHECK-SD-NEXT:    cmp x2, x6
+ ; CHECK-SD-NEXT:    add x10, sp, #32
+ ; CHECK-SD-NEXT:    mov x11, sp
++; CHECK-SD-NEXT:    sbcs xzr, x3, x7
++; CHECK-SD-NEXT:    cset w8, lt
+ ; CHECK-SD-NEXT:    cmp x0, x4
+-; CHECK-SD-NEXT:    orr x12, x10, #0x8
+-; CHECK-SD-NEXT:    orr x13, x11, #0x8
+ ; CHECK-SD-NEXT:    sbcs xzr, x1, x5
++; CHECK-SD-NEXT:    cset w9, lt
++; CHECK-SD-NEXT:    cmp w9, #0
++; CHECK-SD-NEXT:    csel x9, x11, x10, ne
++; CHECK-SD-NEXT:    cmp w8, #0
+ ; CHECK-SD-NEXT:    add x8, sp, #48
+-; CHECK-SD-NEXT:    add x9, sp, #16
+-; CHECK-SD-NEXT:    csel x12, x13, x12, lt
+-; CHECK-SD-NEXT:    csel x10, x11, x10, lt
+-; CHECK-SD-NEXT:    cmp x2, x6
+-; CHECK-SD-NEXT:    orr x11, x8, #0x8
+-; CHECK-SD-NEXT:    orr x13, x9, #0x8
+-; CHECK-SD-NEXT:    sbcs xzr, x3, x7
+-; CHECK-SD-NEXT:    ldr x0, [x10]
+-; CHECK-SD-NEXT:    csel x8, x9, x8, lt
+-; CHECK-SD-NEXT:    csel x9, x13, x11, lt
+-; CHECK-SD-NEXT:    ldr x1, [x12]
+-; CHECK-SD-NEXT:    ldr x2, [x8]
+-; CHECK-SD-NEXT:    ldr x3, [x9]
++; CHECK-SD-NEXT:    add x10, sp, #16
++; CHECK-SD-NEXT:    ldp x0, x1, [x9]
++; CHECK-SD-NEXT:    csel x8, x10, x8, ne
++; CHECK-SD-NEXT:    ldp x2, x3, [x8]
+ ; CHECK-SD-NEXT:    ret
+ ;
+ ; CHECK-GI-LABEL: v2i128_i128:
+diff --git a/test/CodeGen/ARM/fp16-promote.ll b/test/CodeGen/ARM/fp16-promote.ll
+index 1bd0150880..7c2e738e49 100644
+--- a/test/CodeGen/ARM/fp16-promote.ll
++++ b/test/CodeGen/ARM/fp16-promote.ll
+@@ -150,7 +150,7 @@
+ ; No conversion is needed
+ define void @test_select(ptr %p, ptr %q, i1 zeroext %c) #0 {
+ ; CHECK-ALL-LABEL: test_select:
+-; CHECK-ALL: cmp {{r[0-9]+}}, #0
++; CHECK-ALL: tst {{r[0-9]+}}, #1
+ ; CHECK-ALL: movne {{r[0-9]+}}, {{r[0-9]+}}
+ ; CHECK-ALL: ldrh {{r[0-9]+}}, [{{r[0-9]+}}]
+ ; CHECK-ALL: strh {{r[0-9]+}}, [{{r[0-9]+}}]
+diff --git a/test/CodeGen/Mips/cconv/vector.ll b/test/CodeGen/Mips/cconv/vector.ll
+index c64c60ddef..5cd2b77615 100644
+--- a/test/CodeGen/Mips/cconv/vector.ll
++++ b/test/CodeGen/Mips/cconv/vector.ll
+@@ -6038,15 +6038,15 @@
+ define <4 x float> @select(<4 x i32> %cond, <4 x float> %arg1, <4 x float> %arg2) {
+ ; MIPS32-LABEL: select:
+ ; MIPS32:       # %bb.0: # %entry
+-; MIPS32-NEXT:    andi $1, $7, 1
+-; MIPS32-NEXT:    lw $2, 16($sp)
+-; MIPS32-NEXT:    andi $2, $2, 1
++; MIPS32-NEXT:    lw $1, 16($sp)
++; MIPS32-NEXT:    andi $2, $7, 1
++; MIPS32-NEXT:    andi $1, $1, 1
+ ; MIPS32-NEXT:    addiu $3, $sp, 44
+ ; MIPS32-NEXT:    addiu $5, $sp, 28
+ ; MIPS32-NEXT:    addiu $7, $sp, 48
+ ; MIPS32-NEXT:    addiu $8, $sp, 32
+-; MIPS32-NEXT:    movn $7, $8, $2
+-; MIPS32-NEXT:    movn $3, $5, $1
++; MIPS32-NEXT:    movn $7, $8, $1
++; MIPS32-NEXT:    movn $3, $5, $2
+ ; MIPS32-NEXT:    andi $1, $6, 1
+ ; MIPS32-NEXT:    addiu $2, $sp, 40
+ ; MIPS32-NEXT:    addiu $5, $sp, 24
+diff --git a/test/CodeGen/Mips/cmov.ll b/test/CodeGen/Mips/cmov.ll
+index bb3c7c27a1..ee60b353b8 100644
+--- a/test/CodeGen/Mips/cmov.ll
++++ b/test/CodeGen/Mips/cmov.ll
+@@ -65,7 +65,7 @@
+ 
+ ; 64-CMOV:      daddiu $[[R1:[0-9]+]], ${{[0-9]+}}, %got_disp(d)
+ ; 64-CMOV:      daddiu $[[R0:[0-9]+]], ${{[0-9]+}}, %got_disp(c)
+-; 64-CMOV:      movn  $[[R1]], $[[R0]], $4
++; 64-CMOV:      movn  $[[R1]], $[[R0]], $2
+ 
+ ; 64-CMP-DAG:   daddiu $[[R1:[0-9]+]], ${{[0-9]+}}, %got_disp(d)
+ ; 64-CMP-DAG:   daddiu $[[R0:[0-9]+]], ${{[0-9]+}}, %got_disp(c)
+diff --git a/test/CodeGen/X86/cmovcmov.ll b/test/CodeGen/X86/cmovcmov.ll
+index d2d1c4db46..2a69289291 100644
+--- a/test/CodeGen/X86/cmovcmov.ll
++++ b/test/CodeGen/X86/cmovcmov.ll
+@@ -165,37 +165,40 @@
+ ; NOCMOV-NEXT:    fnstsw %ax
+ ; NOCMOV-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; NOCMOV-NEXT:    sahf
+-; NOCMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; NOCMOV-NEXT:    jne .LBB4_3
+-; NOCMOV-NEXT:  # %bb.1: # %entry
+-; NOCMOV-NEXT:    jp .LBB4_3
++; NOCMOV-NEXT:    setnp %al
++; NOCMOV-NEXT:    sete %cl
++; NOCMOV-NEXT:    andb %al, %cl
++; NOCMOV-NEXT:    testb %cl, %cl
++; NOCMOV-NEXT:    jne .LBB4_1
+ ; NOCMOV-NEXT:  # %bb.2: # %entry
+ ; NOCMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; NOCMOV-NEXT:  .LBB4_3: # %entry
++; NOCMOV-NEXT:    je .LBB4_5
++; NOCMOV-NEXT:  .LBB4_4:
+ ; NOCMOV-NEXT:    leal {{[0-9]+}}(%esp), %edx
+-; NOCMOV-NEXT:    jne .LBB4_6
+-; NOCMOV-NEXT:  # %bb.4: # %entry
+-; NOCMOV-NEXT:    jp .LBB4_6
+-; NOCMOV-NEXT:  # %bb.5: # %entry
++; NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %eax
++; NOCMOV-NEXT:    je .LBB4_8
++; NOCMOV-NEXT:  .LBB4_7:
++; NOCMOV-NEXT:    leal {{[0-9]+}}(%esp), %esi
++; NOCMOV-NEXT:    jmp .LBB4_9
++; NOCMOV-NEXT:  .LBB4_1:
++; NOCMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
++; NOCMOV-NEXT:    jne .LBB4_4
++; NOCMOV-NEXT:  .LBB4_5: # %entry
+ ; NOCMOV-NEXT:    leal {{[0-9]+}}(%esp), %edx
+-; NOCMOV-NEXT:  .LBB4_6: # %entry
+ ; NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %eax
+-; NOCMOV-NEXT:    leal {{[0-9]+}}(%esp), %esi
+-; NOCMOV-NEXT:    jne .LBB4_9
+-; NOCMOV-NEXT:  # %bb.7: # %entry
+-; NOCMOV-NEXT:    jp .LBB4_9
+-; NOCMOV-NEXT:  # %bb.8: # %entry
++; NOCMOV-NEXT:    jne .LBB4_7
++; NOCMOV-NEXT:  .LBB4_8: # %entry
+ ; NOCMOV-NEXT:    leal {{[0-9]+}}(%esp), %esi
+ ; NOCMOV-NEXT:  .LBB4_9: # %entry
+ ; NOCMOV-NEXT:    movl (%ecx), %ecx
+ ; NOCMOV-NEXT:    movl (%edx), %edx
+ ; NOCMOV-NEXT:    movl (%esi), %esi
+-; NOCMOV-NEXT:    leal {{[0-9]+}}(%esp), %edi
+-; NOCMOV-NEXT:    jne .LBB4_12
+-; NOCMOV-NEXT:  # %bb.10: # %entry
+-; NOCMOV-NEXT:    jp .LBB4_12
++; NOCMOV-NEXT:    jne .LBB4_10
+ ; NOCMOV-NEXT:  # %bb.11: # %entry
+ ; NOCMOV-NEXT:    leal {{[0-9]+}}(%esp), %edi
++; NOCMOV-NEXT:    jmp .LBB4_12
++; NOCMOV-NEXT:  .LBB4_10:
++; NOCMOV-NEXT:    leal {{[0-9]+}}(%esp), %edi
+ ; NOCMOV-NEXT:  .LBB4_12: # %entry
+ ; NOCMOV-NEXT:    movl (%edi), %edi
+ ; NOCMOV-NEXT:    movl %edi, 12(%eax)
+diff --git a/test/CodeGen/X86/fp-strict-scalar-cmp-fp16.ll b/test/CodeGen/X86/fp-strict-scalar-cmp-fp16.ll
+index 6a6b86e8ef..1c06160584 100644
+--- a/test/CodeGen/X86/fp-strict-scalar-cmp-fp16.ll
++++ b/test/CodeGen/X86/fp-strict-scalar-cmp-fp16.ll
+@@ -49,10 +49,13 @@
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vucomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setnp %al
++; X86-FP16-NEXT:    sete %cl
++; X86-FP16-NEXT:    andb %al, %cl
++; X86-FP16-NEXT:    testb $1, %cl
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X86-FP16-NEXT:    cmovnel %eax, %ecx
+-; X86-FP16-NEXT:    cmovpl %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -112,9 +115,11 @@
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vucomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    seta %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmoval %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -173,9 +178,11 @@
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vucomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setae %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovael %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -236,9 +243,11 @@
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vucomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    seta %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmoval %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -299,9 +308,11 @@
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vucomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setae %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovael %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -360,6 +371,8 @@
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vucomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setne %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X86-FP16-NEXT:    cmovnel %eax, %ecx
+@@ -421,9 +434,11 @@
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vucomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setnp %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovnpl %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -482,9 +497,11 @@
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vucomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    sete %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovel %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -545,9 +562,11 @@
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vucomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setb %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovbl %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -608,9 +627,11 @@
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vucomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setbe %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovbel %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -669,9 +690,11 @@
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vucomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setb %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovbl %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -730,9 +753,11 @@
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vucomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setbe %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovbel %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -793,10 +818,13 @@
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vucomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setp %al
++; X86-FP16-NEXT:    setne %cl
++; X86-FP16-NEXT:    orb %al, %cl
++; X86-FP16-NEXT:    testb $1, %cl
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X86-FP16-NEXT:    cmovnel %eax, %ecx
+-; X86-FP16-NEXT:    cmovpl %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -856,9 +884,11 @@
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vucomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setp %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovpl %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -919,10 +949,13 @@
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vcomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setnp %al
++; X86-FP16-NEXT:    sete %cl
++; X86-FP16-NEXT:    andb %al, %cl
++; X86-FP16-NEXT:    testb $1, %cl
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X86-FP16-NEXT:    cmovnel %eax, %ecx
+-; X86-FP16-NEXT:    cmovpl %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -982,9 +1015,11 @@
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vcomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    seta %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmoval %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -1043,9 +1078,11 @@
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vcomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setae %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovael %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -1106,9 +1143,11 @@
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vcomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    seta %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmoval %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -1169,9 +1208,11 @@
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vcomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setae %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovael %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -1230,6 +1271,8 @@
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vcomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setne %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X86-FP16-NEXT:    cmovnel %eax, %ecx
+@@ -1291,9 +1334,11 @@
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vcomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setnp %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovnpl %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -1352,9 +1397,11 @@
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vcomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    sete %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovel %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -1415,9 +1462,11 @@
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vcomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setb %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovbl %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -1478,9 +1527,11 @@
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vcomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setbe %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovbel %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -1539,9 +1590,11 @@
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vcomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setb %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovbl %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -1600,9 +1653,11 @@
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vcomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setbe %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovbel %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -1663,10 +1718,13 @@
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vcomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setp %al
++; X86-FP16-NEXT:    setne %cl
++; X86-FP16-NEXT:    orb %al, %cl
++; X86-FP16-NEXT:    testb $1, %cl
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X86-FP16-NEXT:    cmovnel %eax, %ecx
+-; X86-FP16-NEXT:    cmovpl %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -1726,9 +1784,11 @@
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vcomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setp %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovpl %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+diff --git a/test/CodeGen/X86/fp-strict-scalar-cmp.ll b/test/CodeGen/X86/fp-strict-scalar-cmp.ll
+index e3e2b6225a..b9823fd564 100644
+--- a/test/CodeGen/X86/fp-strict-scalar-cmp.ll
++++ b/test/CodeGen/X86/fp-strict-scalar-cmp.ll
+@@ -13,10 +13,13 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    ucomiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setnp %al
++; SSE-32-NEXT:    sete %cl
++; SSE-32-NEXT:    andb %al, %cl
++; SSE-32-NEXT:    testb $1, %cl
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SSE-32-NEXT:    cmovnel %eax, %ecx
+-; SSE-32-NEXT:    cmovpl %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -32,10 +35,13 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vucomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setnp %al
++; AVX-32-NEXT:    sete %cl
++; AVX-32-NEXT:    andb %al, %cl
++; AVX-32-NEXT:    testb $1, %cl
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; AVX-32-NEXT:    cmovnel %eax, %ecx
+-; AVX-32-NEXT:    cmovpl %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -56,13 +62,17 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:    jne .LBB0_3
+-; X87-NEXT:  # %bb.1:
+-; X87-NEXT:    jp .LBB0_3
++; X87-NEXT:    setnp %al
++; X87-NEXT:    sete %cl
++; X87-NEXT:    andb %al, %cl
++; X87-NEXT:    testb $1, %cl
++; X87-NEXT:    jne .LBB0_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:  .LBB0_3:
++; X87-NEXT:    movl (%eax), %eax
++; X87-NEXT:    retl
++; X87-NEXT:  .LBB0_1:
++; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+ ; X87-NEXT:    retl
+ ;
+@@ -73,10 +83,13 @@
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setnp %al
++; X87-CMOV-NEXT:    sete %cl
++; X87-CMOV-NEXT:    andb %al, %cl
++; X87-CMOV-NEXT:    testb $1, %cl
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+-; X87-CMOV-NEXT:    cmovpl %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f32(
+@@ -91,9 +104,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    ucomiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    seta %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmoval %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -108,9 +123,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vucomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    seta %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmoval %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -130,7 +147,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    ja .LBB1_1
++; X87-NEXT:    seta %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB1_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -147,9 +166,11 @@
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    seta %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmoval %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f32(
+@@ -164,9 +185,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    ucomiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setae %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovael %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -181,9 +204,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vucomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setae %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovael %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -203,7 +228,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jae .LBB2_1
++; X87-NEXT:    setae %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB2_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -220,9 +247,11 @@
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setae %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovael %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f32(
+@@ -237,9 +266,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    ucomiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    seta %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmoval %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -254,9 +285,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vucomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    seta %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmoval %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -276,7 +309,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    ja .LBB3_1
++; X87-NEXT:    seta %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB3_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -293,9 +328,11 @@
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    seta %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmoval %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f32(
+@@ -310,9 +347,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    ucomiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setae %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovael %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -327,9 +366,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vucomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setae %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovael %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -349,7 +390,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jae .LBB4_1
++; X87-NEXT:    setae %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB4_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -366,9 +409,11 @@
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setae %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovael %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f32(
+@@ -383,6 +428,8 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    ucomiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setne %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SSE-32-NEXT:    cmovnel %eax, %ecx
+@@ -400,6 +447,8 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vucomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setne %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; AVX-32-NEXT:    cmovnel %eax, %ecx
+@@ -422,6 +471,8 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
++; X87-NEXT:    setne %al
++; X87-NEXT:    testb $1, %al
+ ; X87-NEXT:    jne .LBB5_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+@@ -439,6 +490,8 @@
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setne %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+@@ -456,9 +509,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    ucomiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setnp %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovnpl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -473,9 +528,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vucomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setnp %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovnpl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -495,7 +552,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jnp .LBB6_1
++; X87-NEXT:    setnp %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB6_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -512,9 +571,11 @@
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setnp %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovnpl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f32(
+@@ -529,9 +590,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    ucomiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    sete %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovel %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -546,9 +609,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vucomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    sete %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovel %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -568,7 +633,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    je .LBB7_1
++; X87-NEXT:    sete %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB7_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -585,9 +652,11 @@
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    sete %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovel %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f32(
+@@ -602,9 +671,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    ucomiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setb %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -619,9 +690,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vucomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setb %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -641,7 +714,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jb .LBB8_1
++; X87-NEXT:    setb %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB8_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -658,9 +733,11 @@
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setb %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f32(
+@@ -675,9 +752,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    ucomiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setbe %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbel %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -692,9 +771,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vucomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setbe %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbel %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -714,7 +795,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jbe .LBB9_1
++; X87-NEXT:    setbe %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB9_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -731,9 +814,11 @@
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setbe %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbel %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f32(
+@@ -748,9 +833,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    ucomiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setb %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -765,9 +852,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vucomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setb %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -787,7 +876,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jb .LBB10_1
++; X87-NEXT:    setb %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB10_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -804,9 +895,11 @@
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setb %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f32(
+@@ -821,9 +914,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    ucomiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setbe %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbel %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -838,9 +933,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vucomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setbe %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbel %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -860,7 +957,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jbe .LBB11_1
++; X87-NEXT:    setbe %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB11_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -877,9 +976,11 @@
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setbe %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbel %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f32(
+@@ -894,10 +995,13 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    ucomiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setp %al
++; SSE-32-NEXT:    setne %cl
++; SSE-32-NEXT:    orb %al, %cl
++; SSE-32-NEXT:    testb $1, %cl
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SSE-32-NEXT:    cmovnel %eax, %ecx
+-; SSE-32-NEXT:    cmovpl %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -913,10 +1017,13 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vucomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setp %al
++; AVX-32-NEXT:    setne %cl
++; AVX-32-NEXT:    orb %al, %cl
++; AVX-32-NEXT:    testb $1, %cl
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; AVX-32-NEXT:    cmovnel %eax, %ecx
+-; AVX-32-NEXT:    cmovpl %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -937,13 +1044,17 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:    jne .LBB12_3
+-; X87-NEXT:  # %bb.1:
+-; X87-NEXT:    jp .LBB12_3
++; X87-NEXT:    setp %al
++; X87-NEXT:    setne %cl
++; X87-NEXT:    orb %al, %cl
++; X87-NEXT:    testb $1, %cl
++; X87-NEXT:    jne .LBB12_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:  .LBB12_3:
++; X87-NEXT:    movl (%eax), %eax
++; X87-NEXT:    retl
++; X87-NEXT:  .LBB12_1:
++; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+ ; X87-NEXT:    retl
+ ;
+@@ -954,10 +1065,13 @@
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setp %al
++; X87-CMOV-NEXT:    setne %cl
++; X87-CMOV-NEXT:    orb %al, %cl
++; X87-CMOV-NEXT:    testb $1, %cl
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+-; X87-CMOV-NEXT:    cmovpl %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f32(
+@@ -972,9 +1086,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    ucomiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setp %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovpl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -989,9 +1105,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vucomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setp %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovpl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -1011,7 +1129,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jp .LBB13_1
++; X87-NEXT:    setp %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB13_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -1028,9 +1148,11 @@
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setp %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovpl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f32(
+@@ -1045,10 +1167,13 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    ucomisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setnp %al
++; SSE-32-NEXT:    sete %cl
++; SSE-32-NEXT:    andb %al, %cl
++; SSE-32-NEXT:    testb $1, %cl
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SSE-32-NEXT:    cmovnel %eax, %ecx
+-; SSE-32-NEXT:    cmovpl %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -1064,10 +1189,13 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vucomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setnp %al
++; AVX-32-NEXT:    sete %cl
++; AVX-32-NEXT:    andb %al, %cl
++; AVX-32-NEXT:    testb $1, %cl
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; AVX-32-NEXT:    cmovnel %eax, %ecx
+-; AVX-32-NEXT:    cmovpl %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -1088,13 +1216,17 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:    jne .LBB14_3
+-; X87-NEXT:  # %bb.1:
+-; X87-NEXT:    jp .LBB14_3
++; X87-NEXT:    setnp %al
++; X87-NEXT:    sete %cl
++; X87-NEXT:    andb %al, %cl
++; X87-NEXT:    testb $1, %cl
++; X87-NEXT:    jne .LBB14_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:  .LBB14_3:
++; X87-NEXT:    movl (%eax), %eax
++; X87-NEXT:    retl
++; X87-NEXT:  .LBB14_1:
++; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+ ; X87-NEXT:    retl
+ ;
+@@ -1105,10 +1237,13 @@
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setnp %al
++; X87-CMOV-NEXT:    sete %cl
++; X87-CMOV-NEXT:    andb %al, %cl
++; X87-CMOV-NEXT:    testb $1, %cl
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+-; X87-CMOV-NEXT:    cmovpl %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f64(
+@@ -1123,9 +1258,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    ucomisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    seta %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmoval %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -1140,9 +1277,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vucomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    seta %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmoval %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -1162,7 +1301,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    ja .LBB15_1
++; X87-NEXT:    seta %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB15_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -1179,9 +1320,11 @@
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    seta %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmoval %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f64(
+@@ -1196,9 +1339,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    ucomisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setae %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovael %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -1213,9 +1358,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vucomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setae %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovael %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -1235,7 +1382,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jae .LBB16_1
++; X87-NEXT:    setae %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB16_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -1252,9 +1401,11 @@
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setae %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovael %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f64(
+@@ -1269,9 +1420,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    ucomisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    seta %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmoval %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -1286,9 +1439,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vucomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    seta %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmoval %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -1308,7 +1463,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    ja .LBB17_1
++; X87-NEXT:    seta %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB17_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -1325,9 +1482,11 @@
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    seta %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmoval %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f64(
+@@ -1342,9 +1501,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    ucomisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setae %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovael %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -1359,9 +1520,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vucomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setae %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovael %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -1381,7 +1544,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jae .LBB18_1
++; X87-NEXT:    setae %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB18_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -1398,9 +1563,11 @@
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setae %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovael %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f64(
+@@ -1415,6 +1582,8 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    ucomisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setne %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SSE-32-NEXT:    cmovnel %eax, %ecx
+@@ -1432,6 +1601,8 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vucomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setne %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; AVX-32-NEXT:    cmovnel %eax, %ecx
+@@ -1454,6 +1625,8 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
++; X87-NEXT:    setne %al
++; X87-NEXT:    testb $1, %al
+ ; X87-NEXT:    jne .LBB19_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+@@ -1471,6 +1644,8 @@
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setne %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+@@ -1488,9 +1663,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    ucomisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setnp %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovnpl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -1505,9 +1682,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vucomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setnp %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovnpl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -1527,7 +1706,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jnp .LBB20_1
++; X87-NEXT:    setnp %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB20_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -1544,9 +1725,11 @@
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setnp %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovnpl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f64(
+@@ -1561,9 +1744,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    ucomisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    sete %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovel %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -1578,9 +1763,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vucomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    sete %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovel %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -1600,7 +1787,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    je .LBB21_1
++; X87-NEXT:    sete %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB21_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -1617,9 +1806,11 @@
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    sete %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovel %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f64(
+@@ -1634,9 +1825,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    ucomisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setb %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -1651,9 +1844,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vucomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setb %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -1673,7 +1868,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jb .LBB22_1
++; X87-NEXT:    setb %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB22_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -1690,9 +1887,11 @@
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setb %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f64(
+@@ -1707,9 +1906,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    ucomisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setbe %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbel %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -1724,9 +1925,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vucomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setbe %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbel %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -1746,7 +1949,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jbe .LBB23_1
++; X87-NEXT:    setbe %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB23_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -1763,9 +1968,11 @@
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setbe %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbel %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f64(
+@@ -1780,9 +1987,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    ucomisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setb %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -1797,9 +2006,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vucomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setb %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -1819,7 +2030,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jb .LBB24_1
++; X87-NEXT:    setb %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB24_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -1836,9 +2049,11 @@
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setb %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f64(
+@@ -1853,9 +2068,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    ucomisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setbe %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbel %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -1870,9 +2087,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vucomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setbe %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbel %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -1892,7 +2111,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jbe .LBB25_1
++; X87-NEXT:    setbe %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB25_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -1909,9 +2130,11 @@
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setbe %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbel %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f64(
+@@ -1926,10 +2149,13 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    ucomisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setp %al
++; SSE-32-NEXT:    setne %cl
++; SSE-32-NEXT:    orb %al, %cl
++; SSE-32-NEXT:    testb $1, %cl
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SSE-32-NEXT:    cmovnel %eax, %ecx
+-; SSE-32-NEXT:    cmovpl %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -1945,10 +2171,13 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vucomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setp %al
++; AVX-32-NEXT:    setne %cl
++; AVX-32-NEXT:    orb %al, %cl
++; AVX-32-NEXT:    testb $1, %cl
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; AVX-32-NEXT:    cmovnel %eax, %ecx
+-; AVX-32-NEXT:    cmovpl %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -1969,13 +2198,17 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:    jne .LBB26_3
+-; X87-NEXT:  # %bb.1:
+-; X87-NEXT:    jp .LBB26_3
++; X87-NEXT:    setp %al
++; X87-NEXT:    setne %cl
++; X87-NEXT:    orb %al, %cl
++; X87-NEXT:    testb $1, %cl
++; X87-NEXT:    jne .LBB26_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:  .LBB26_3:
++; X87-NEXT:    movl (%eax), %eax
++; X87-NEXT:    retl
++; X87-NEXT:  .LBB26_1:
++; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+ ; X87-NEXT:    retl
+ ;
+@@ -1986,10 +2219,13 @@
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setp %al
++; X87-CMOV-NEXT:    setne %cl
++; X87-CMOV-NEXT:    orb %al, %cl
++; X87-CMOV-NEXT:    testb $1, %cl
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+-; X87-CMOV-NEXT:    cmovpl %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f64(
+@@ -2004,9 +2240,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    ucomisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setp %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovpl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -2021,9 +2259,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vucomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setp %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovpl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -2043,7 +2283,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jp .LBB27_1
++; X87-NEXT:    setp %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB27_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -2060,9 +2302,11 @@
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setp %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovpl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f64(
+@@ -2077,10 +2321,13 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    comiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setnp %al
++; SSE-32-NEXT:    sete %cl
++; SSE-32-NEXT:    andb %al, %cl
++; SSE-32-NEXT:    testb $1, %cl
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SSE-32-NEXT:    cmovnel %eax, %ecx
+-; SSE-32-NEXT:    cmovpl %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -2096,10 +2343,13 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vcomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setnp %al
++; AVX-32-NEXT:    sete %cl
++; AVX-32-NEXT:    andb %al, %cl
++; AVX-32-NEXT:    testb $1, %cl
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; AVX-32-NEXT:    cmovnel %eax, %ecx
+-; AVX-32-NEXT:    cmovpl %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -2120,13 +2370,17 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:    jne .LBB28_3
+-; X87-NEXT:  # %bb.1:
+-; X87-NEXT:    jp .LBB28_3
++; X87-NEXT:    setnp %al
++; X87-NEXT:    sete %cl
++; X87-NEXT:    andb %al, %cl
++; X87-NEXT:    testb $1, %cl
++; X87-NEXT:    jne .LBB28_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:  .LBB28_3:
++; X87-NEXT:    movl (%eax), %eax
++; X87-NEXT:    retl
++; X87-NEXT:  .LBB28_1:
++; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+ ; X87-NEXT:    retl
+ ;
+@@ -2137,10 +2391,13 @@
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setnp %al
++; X87-CMOV-NEXT:    sete %cl
++; X87-CMOV-NEXT:    andb %al, %cl
++; X87-CMOV-NEXT:    testb $1, %cl
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+-; X87-CMOV-NEXT:    cmovpl %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(
+@@ -2155,9 +2412,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    comiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    seta %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmoval %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -2172,9 +2431,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vcomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    seta %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmoval %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -2194,7 +2455,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    ja .LBB29_1
++; X87-NEXT:    seta %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB29_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -2211,9 +2474,11 @@
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    seta %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmoval %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(
+@@ -2228,9 +2493,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    comiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setae %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovael %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -2245,9 +2512,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vcomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setae %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovael %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -2267,7 +2536,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jae .LBB30_1
++; X87-NEXT:    setae %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB30_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -2284,9 +2555,11 @@
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setae %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovael %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(
+@@ -2301,9 +2574,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    comiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    seta %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmoval %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -2318,9 +2593,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vcomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    seta %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmoval %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -2340,7 +2617,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    ja .LBB31_1
++; X87-NEXT:    seta %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB31_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -2357,9 +2636,11 @@
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    seta %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmoval %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(
+@@ -2374,9 +2655,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    comiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setae %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovael %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -2391,9 +2674,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vcomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setae %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovael %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -2413,7 +2698,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jae .LBB32_1
++; X87-NEXT:    setae %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB32_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -2430,9 +2717,11 @@
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setae %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovael %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(
+@@ -2447,6 +2736,8 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    comiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setne %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SSE-32-NEXT:    cmovnel %eax, %ecx
+@@ -2464,6 +2755,8 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vcomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setne %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; AVX-32-NEXT:    cmovnel %eax, %ecx
+@@ -2486,6 +2779,8 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
++; X87-NEXT:    setne %al
++; X87-NEXT:    testb $1, %al
+ ; X87-NEXT:    jne .LBB33_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+@@ -2503,6 +2798,8 @@
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setne %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+@@ -2520,9 +2817,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    comiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setnp %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovnpl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -2537,9 +2836,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vcomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setnp %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovnpl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -2559,7 +2860,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jnp .LBB34_1
++; X87-NEXT:    setnp %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB34_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -2576,9 +2879,11 @@
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setnp %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovnpl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(
+@@ -2593,9 +2898,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    comiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    sete %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovel %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -2610,9 +2917,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vcomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    sete %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovel %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -2632,7 +2941,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    je .LBB35_1
++; X87-NEXT:    sete %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB35_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -2649,9 +2960,11 @@
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    sete %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovel %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(
+@@ -2666,9 +2979,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    comiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setb %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -2683,9 +2998,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vcomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setb %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -2705,7 +3022,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jb .LBB36_1
++; X87-NEXT:    setb %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB36_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -2722,9 +3041,11 @@
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setb %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(
+@@ -2739,9 +3060,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    comiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setbe %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbel %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -2756,9 +3079,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vcomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setbe %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbel %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -2778,7 +3103,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jbe .LBB37_1
++; X87-NEXT:    setbe %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB37_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -2795,9 +3122,11 @@
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setbe %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbel %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(
+@@ -2812,9 +3141,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    comiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setb %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -2829,9 +3160,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vcomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setb %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -2851,7 +3184,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jb .LBB38_1
++; X87-NEXT:    setb %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB38_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -2868,9 +3203,11 @@
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setb %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(
+@@ -2885,9 +3222,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    comiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setbe %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbel %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -2902,9 +3241,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vcomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setbe %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbel %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -2924,7 +3265,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jbe .LBB39_1
++; X87-NEXT:    setbe %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB39_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -2941,9 +3284,11 @@
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setbe %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbel %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(
+@@ -2958,10 +3303,13 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    comiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setp %al
++; SSE-32-NEXT:    setne %cl
++; SSE-32-NEXT:    orb %al, %cl
++; SSE-32-NEXT:    testb $1, %cl
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SSE-32-NEXT:    cmovnel %eax, %ecx
+-; SSE-32-NEXT:    cmovpl %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -2977,10 +3325,13 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vcomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setp %al
++; AVX-32-NEXT:    setne %cl
++; AVX-32-NEXT:    orb %al, %cl
++; AVX-32-NEXT:    testb $1, %cl
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; AVX-32-NEXT:    cmovnel %eax, %ecx
+-; AVX-32-NEXT:    cmovpl %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -3001,13 +3352,17 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:    jne .LBB40_3
+-; X87-NEXT:  # %bb.1:
+-; X87-NEXT:    jp .LBB40_3
++; X87-NEXT:    setp %al
++; X87-NEXT:    setne %cl
++; X87-NEXT:    orb %al, %cl
++; X87-NEXT:    testb $1, %cl
++; X87-NEXT:    jne .LBB40_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:  .LBB40_3:
++; X87-NEXT:    movl (%eax), %eax
++; X87-NEXT:    retl
++; X87-NEXT:  .LBB40_1:
++; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+ ; X87-NEXT:    retl
+ ;
+@@ -3018,10 +3373,13 @@
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setp %al
++; X87-CMOV-NEXT:    setne %cl
++; X87-CMOV-NEXT:    orb %al, %cl
++; X87-CMOV-NEXT:    testb $1, %cl
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+-; X87-CMOV-NEXT:    cmovpl %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(
+@@ -3036,9 +3394,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    comiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setp %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovpl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -3053,9 +3413,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vcomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setp %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovpl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -3075,7 +3437,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jp .LBB41_1
++; X87-NEXT:    setp %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB41_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -3092,9 +3456,11 @@
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setp %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovpl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(
+@@ -3109,10 +3475,13 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    comisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setnp %al
++; SSE-32-NEXT:    sete %cl
++; SSE-32-NEXT:    andb %al, %cl
++; SSE-32-NEXT:    testb $1, %cl
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SSE-32-NEXT:    cmovnel %eax, %ecx
+-; SSE-32-NEXT:    cmovpl %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -3128,10 +3497,13 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vcomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setnp %al
++; AVX-32-NEXT:    sete %cl
++; AVX-32-NEXT:    andb %al, %cl
++; AVX-32-NEXT:    testb $1, %cl
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; AVX-32-NEXT:    cmovnel %eax, %ecx
+-; AVX-32-NEXT:    cmovpl %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -3152,13 +3524,17 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:    jne .LBB42_3
+-; X87-NEXT:  # %bb.1:
+-; X87-NEXT:    jp .LBB42_3
++; X87-NEXT:    setnp %al
++; X87-NEXT:    sete %cl
++; X87-NEXT:    andb %al, %cl
++; X87-NEXT:    testb $1, %cl
++; X87-NEXT:    jne .LBB42_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:  .LBB42_3:
++; X87-NEXT:    movl (%eax), %eax
++; X87-NEXT:    retl
++; X87-NEXT:  .LBB42_1:
++; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+ ; X87-NEXT:    retl
+ ;
+@@ -3169,10 +3545,13 @@
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setnp %al
++; X87-CMOV-NEXT:    sete %cl
++; X87-CMOV-NEXT:    andb %al, %cl
++; X87-CMOV-NEXT:    testb $1, %cl
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+-; X87-CMOV-NEXT:    cmovpl %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(
+@@ -3187,9 +3566,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    comisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    seta %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmoval %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -3204,9 +3585,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vcomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    seta %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmoval %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -3226,7 +3609,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    ja .LBB43_1
++; X87-NEXT:    seta %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB43_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -3243,9 +3628,11 @@
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    seta %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmoval %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(
+@@ -3260,9 +3647,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    comisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setae %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovael %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -3277,9 +3666,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vcomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setae %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovael %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -3299,7 +3690,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jae .LBB44_1
++; X87-NEXT:    setae %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB44_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -3316,9 +3709,11 @@
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setae %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovael %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(
+@@ -3333,9 +3728,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    comisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    seta %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmoval %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -3350,9 +3747,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vcomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    seta %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmoval %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -3372,7 +3771,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    ja .LBB45_1
++; X87-NEXT:    seta %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB45_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -3389,9 +3790,11 @@
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    seta %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmoval %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(
+@@ -3406,9 +3809,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    comisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setae %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovael %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -3423,9 +3828,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vcomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setae %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovael %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -3445,7 +3852,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jae .LBB46_1
++; X87-NEXT:    setae %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB46_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -3462,9 +3871,11 @@
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setae %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovael %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(
+@@ -3479,6 +3890,8 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    comisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setne %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SSE-32-NEXT:    cmovnel %eax, %ecx
+@@ -3496,6 +3909,8 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vcomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setne %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; AVX-32-NEXT:    cmovnel %eax, %ecx
+@@ -3518,6 +3933,8 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
++; X87-NEXT:    setne %al
++; X87-NEXT:    testb $1, %al
+ ; X87-NEXT:    jne .LBB47_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+@@ -3535,6 +3952,8 @@
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setne %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+@@ -3552,9 +3971,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    comisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setnp %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovnpl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -3569,9 +3990,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vcomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setnp %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovnpl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -3591,7 +4014,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jnp .LBB48_1
++; X87-NEXT:    setnp %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB48_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -3608,9 +4033,11 @@
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setnp %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovnpl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(
+@@ -3625,9 +4052,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    comisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    sete %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovel %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -3642,9 +4071,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vcomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    sete %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovel %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -3664,7 +4095,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    je .LBB49_1
++; X87-NEXT:    sete %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB49_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -3681,9 +4114,11 @@
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    sete %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovel %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(
+@@ -3698,9 +4133,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    comisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setb %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -3715,9 +4152,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vcomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setb %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -3737,7 +4176,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jb .LBB50_1
++; X87-NEXT:    setb %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB50_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -3754,9 +4195,11 @@
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setb %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(
+@@ -3771,9 +4214,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    comisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setbe %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbel %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -3788,9 +4233,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vcomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setbe %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbel %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -3810,7 +4257,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jbe .LBB51_1
++; X87-NEXT:    setbe %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB51_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -3827,9 +4276,11 @@
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setbe %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbel %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(
+@@ -3844,9 +4295,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    comisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setb %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -3861,9 +4314,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vcomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setb %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -3883,7 +4338,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jb .LBB52_1
++; X87-NEXT:    setb %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB52_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -3900,9 +4357,11 @@
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setb %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(
+@@ -3917,9 +4376,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    comisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setbe %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbel %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -3934,9 +4395,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vcomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setbe %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbel %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -3956,7 +4419,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jbe .LBB53_1
++; X87-NEXT:    setbe %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB53_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -3973,9 +4438,11 @@
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setbe %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbel %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(
+@@ -3990,10 +4457,13 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    comisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setp %al
++; SSE-32-NEXT:    setne %cl
++; SSE-32-NEXT:    orb %al, %cl
++; SSE-32-NEXT:    testb $1, %cl
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SSE-32-NEXT:    cmovnel %eax, %ecx
+-; SSE-32-NEXT:    cmovpl %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -4009,10 +4479,13 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vcomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setp %al
++; AVX-32-NEXT:    setne %cl
++; AVX-32-NEXT:    orb %al, %cl
++; AVX-32-NEXT:    testb $1, %cl
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; AVX-32-NEXT:    cmovnel %eax, %ecx
+-; AVX-32-NEXT:    cmovpl %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -4033,13 +4506,17 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:    jne .LBB54_3
+-; X87-NEXT:  # %bb.1:
+-; X87-NEXT:    jp .LBB54_3
++; X87-NEXT:    setp %al
++; X87-NEXT:    setne %cl
++; X87-NEXT:    orb %al, %cl
++; X87-NEXT:    testb $1, %cl
++; X87-NEXT:    jne .LBB54_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:  .LBB54_3:
++; X87-NEXT:    movl (%eax), %eax
++; X87-NEXT:    retl
++; X87-NEXT:  .LBB54_1:
++; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+ ; X87-NEXT:    retl
+ ;
+@@ -4050,10 +4527,13 @@
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setp %al
++; X87-CMOV-NEXT:    setne %cl
++; X87-CMOV-NEXT:    orb %al, %cl
++; X87-CMOV-NEXT:    testb $1, %cl
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+-; X87-CMOV-NEXT:    cmovpl %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(
+@@ -4068,9 +4548,11 @@
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    comisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setp %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovpl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -4085,9 +4567,11 @@
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vcomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setp %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovpl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -4107,7 +4591,9 @@
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jp .LBB55_1
++; X87-NEXT:    setp %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB55_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -4124,9 +4610,11 @@
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setp %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovpl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(
+diff --git a/test/CodeGen/X86/fp128-libcalls-strict.ll b/test/CodeGen/X86/fp128-libcalls-strict.ll
+index ad2d690fd7..5dbc28230d 100644
+--- a/test/CodeGen/X86/fp128-libcalls-strict.ll
++++ b/test/CodeGen/X86/fp128-libcalls-strict.ll
+@@ -3898,6 +3898,7 @@
+ ; X86-NEXT:    calll __unordtf2
+ ; X86-NEXT:    addl $32, %esp
+ ; X86-NEXT:    orb %bl, %al
++; X86-NEXT:    testb $1, %al
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X86-NEXT:    cmovnel %eax, %ecx
+@@ -3981,6 +3982,7 @@
+ ; WIN-X86-NEXT:    calll ___unordtf2
+ ; WIN-X86-NEXT:    addl $32, %esp
+ ; WIN-X86-NEXT:    orb %bl, %al
++; WIN-X86-NEXT:    testb $1, %al
+ ; WIN-X86-NEXT:    jne LBB39_1
+ ; WIN-X86-NEXT:  # %bb.2:
+ ; WIN-X86-NEXT:    leal 16(%ebp), %ecx
+diff --git a/test/CodeGen/X86/fp80-strict-scalar-cmp.ll b/test/CodeGen/X86/fp80-strict-scalar-cmp.ll
+index cb2361fbb8..f95738d9e5 100644
+--- a/test/CodeGen/X86/fp80-strict-scalar-cmp.ll
++++ b/test/CodeGen/X86/fp80-strict-scalar-cmp.ll
+@@ -12,13 +12,17 @@
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X86-NEXT:    jne .LBB0_3
+-; X86-NEXT:  # %bb.1:
+-; X86-NEXT:    jp .LBB0_3
++; X86-NEXT:    setnp %al
++; X86-NEXT:    sete %cl
++; X86-NEXT:    andb %al, %cl
++; X86-NEXT:    testb $1, %cl
++; X86-NEXT:    jne .LBB0_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X86-NEXT:  .LBB0_3:
++; X86-NEXT:    movl (%eax), %eax
++; X86-NEXT:    retl
++; X86-NEXT:  .LBB0_1:
++; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+ ; X86-NEXT:    retl
+ ;
+@@ -50,7 +54,9 @@
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    ja .LBB1_1
++; X86-NEXT:    seta %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB1_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -87,7 +93,9 @@
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jae .LBB2_1
++; X86-NEXT:    setae %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB2_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -124,7 +132,9 @@
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    ja .LBB3_1
++; X86-NEXT:    seta %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB3_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -161,7 +171,9 @@
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jae .LBB4_1
++; X86-NEXT:    setae %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB4_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -198,6 +210,8 @@
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
++; X86-NEXT:    setne %al
++; X86-NEXT:    testb $1, %al
+ ; X86-NEXT:    jne .LBB5_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+@@ -235,7 +249,9 @@
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jnp .LBB6_1
++; X86-NEXT:    setnp %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB6_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -272,7 +288,9 @@
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    je .LBB7_1
++; X86-NEXT:    sete %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB7_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -309,7 +327,9 @@
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jb .LBB8_1
++; X86-NEXT:    setb %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB8_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -346,7 +366,9 @@
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jbe .LBB9_1
++; X86-NEXT:    setbe %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB9_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -383,7 +405,9 @@
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jb .LBB10_1
++; X86-NEXT:    setb %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB10_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -420,7 +444,9 @@
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jbe .LBB11_1
++; X86-NEXT:    setbe %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB11_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -457,13 +483,17 @@
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X86-NEXT:    jne .LBB12_3
+-; X86-NEXT:  # %bb.1:
+-; X86-NEXT:    jp .LBB12_3
++; X86-NEXT:    setp %al
++; X86-NEXT:    setne %cl
++; X86-NEXT:    orb %al, %cl
++; X86-NEXT:    testb $1, %cl
++; X86-NEXT:    jne .LBB12_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X86-NEXT:  .LBB12_3:
++; X86-NEXT:    movl (%eax), %eax
++; X86-NEXT:    retl
++; X86-NEXT:  .LBB12_1:
++; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+ ; X86-NEXT:    retl
+ ;
+@@ -495,7 +525,9 @@
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jp .LBB13_1
++; X86-NEXT:    setp %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB13_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -532,13 +564,17 @@
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X86-NEXT:    jne .LBB14_3
+-; X86-NEXT:  # %bb.1:
+-; X86-NEXT:    jp .LBB14_3
++; X86-NEXT:    setnp %al
++; X86-NEXT:    sete %cl
++; X86-NEXT:    andb %al, %cl
++; X86-NEXT:    testb $1, %cl
++; X86-NEXT:    jne .LBB14_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X86-NEXT:  .LBB14_3:
++; X86-NEXT:    movl (%eax), %eax
++; X86-NEXT:    retl
++; X86-NEXT:  .LBB14_1:
++; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+ ; X86-NEXT:    retl
+ ;
+@@ -570,7 +606,9 @@
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    ja .LBB15_1
++; X86-NEXT:    seta %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB15_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -607,7 +645,9 @@
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jae .LBB16_1
++; X86-NEXT:    setae %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB16_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -644,7 +684,9 @@
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    ja .LBB17_1
++; X86-NEXT:    seta %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB17_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -681,7 +723,9 @@
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jae .LBB18_1
++; X86-NEXT:    setae %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB18_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -718,6 +762,8 @@
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
++; X86-NEXT:    setne %al
++; X86-NEXT:    testb $1, %al
+ ; X86-NEXT:    jne .LBB19_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+@@ -755,7 +801,9 @@
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jnp .LBB20_1
++; X86-NEXT:    setnp %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB20_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -792,7 +840,9 @@
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    je .LBB21_1
++; X86-NEXT:    sete %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB21_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -829,7 +879,9 @@
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jb .LBB22_1
++; X86-NEXT:    setb %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB22_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -866,7 +918,9 @@
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jbe .LBB23_1
++; X86-NEXT:    setbe %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB23_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -903,7 +957,9 @@
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jb .LBB24_1
++; X86-NEXT:    setb %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB24_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -940,7 +996,9 @@
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jbe .LBB25_1
++; X86-NEXT:    setbe %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB25_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -977,13 +1035,17 @@
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X86-NEXT:    jne .LBB26_3
+-; X86-NEXT:  # %bb.1:
+-; X86-NEXT:    jp .LBB26_3
++; X86-NEXT:    setp %al
++; X86-NEXT:    setne %cl
++; X86-NEXT:    orb %al, %cl
++; X86-NEXT:    testb $1, %cl
++; X86-NEXT:    jne .LBB26_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X86-NEXT:  .LBB26_3:
++; X86-NEXT:    movl (%eax), %eax
++; X86-NEXT:    retl
++; X86-NEXT:  .LBB26_1:
++; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+ ; X86-NEXT:    retl
+ ;
+@@ -1015,7 +1077,9 @@
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jp .LBB27_1
++; X86-NEXT:    setp %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB27_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+diff --git a/test/CodeGen/X86/isel-select-cmov.ll b/test/CodeGen/X86/isel-select-cmov.ll
+index d013ad2c7f..6ced7f45b6 100644
+--- a/test/CodeGen/X86/isel-select-cmov.ll
++++ b/test/CodeGen/X86/isel-select-cmov.ll
+@@ -47,7 +47,7 @@
+ ;
+ ; SDAG-X86-LABEL: select_cmov_i8:
+ ; SDAG-X86:       ## %bb.0:
+-; SDAG-X86-NEXT:    cmpb $0, {{[0-9]+}}(%esp)
++; SDAG-X86-NEXT:    testb $1, {{[0-9]+}}(%esp)
+ ; SDAG-X86-NEXT:    jne LBB0_1
+ ; SDAG-X86-NEXT:  ## %bb.2:
+ ; SDAG-X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+@@ -60,7 +60,7 @@
+ ;
+ ; SDAG-X86-CMOV-LABEL: select_cmov_i8:
+ ; SDAG-X86-CMOV:       ## %bb.0:
+-; SDAG-X86-CMOV-NEXT:    cmpb $0, {{[0-9]+}}(%esp)
++; SDAG-X86-CMOV-NEXT:    testb $1, {{[0-9]+}}(%esp)
+ ; SDAG-X86-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SDAG-X86-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SDAG-X86-CMOV-NEXT:    cmovnel %eax, %ecx
+@@ -155,7 +155,7 @@
+ ;
+ ; SDAG-X86-LABEL: select_cmov_i16:
+ ; SDAG-X86:       ## %bb.0:
+-; SDAG-X86-NEXT:    cmpb $0, {{[0-9]+}}(%esp)
++; SDAG-X86-NEXT:    testb $1, {{[0-9]+}}(%esp)
+ ; SDAG-X86-NEXT:    jne LBB1_1
+ ; SDAG-X86-NEXT:  ## %bb.2:
+ ; SDAG-X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+@@ -168,7 +168,7 @@
+ ;
+ ; SDAG-X86-CMOV-LABEL: select_cmov_i16:
+ ; SDAG-X86-CMOV:       ## %bb.0:
+-; SDAG-X86-CMOV-NEXT:    cmpb $0, {{[0-9]+}}(%esp)
++; SDAG-X86-CMOV-NEXT:    testb $1, {{[0-9]+}}(%esp)
+ ; SDAG-X86-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SDAG-X86-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SDAG-X86-CMOV-NEXT:    cmovnel %eax, %ecx
+@@ -360,7 +360,7 @@
+ ;
+ ; SDAG-X86-LABEL: select_cmov_i32:
+ ; SDAG-X86:       ## %bb.0:
+-; SDAG-X86-NEXT:    cmpb $0, {{[0-9]+}}(%esp)
++; SDAG-X86-NEXT:    testb $1, {{[0-9]+}}(%esp)
+ ; SDAG-X86-NEXT:    jne LBB3_1
+ ; SDAG-X86-NEXT:  ## %bb.2:
+ ; SDAG-X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+@@ -373,7 +373,7 @@
+ ;
+ ; SDAG-X86-CMOV-LABEL: select_cmov_i32:
+ ; SDAG-X86-CMOV:       ## %bb.0:
+-; SDAG-X86-CMOV-NEXT:    cmpb $0, {{[0-9]+}}(%esp)
++; SDAG-X86-CMOV-NEXT:    testb $1, {{[0-9]+}}(%esp)
+ ; SDAG-X86-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SDAG-X86-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SDAG-X86-CMOV-NEXT:    cmovnel %eax, %ecx
+@@ -549,7 +549,7 @@
+ ;
+ ; SDAG-X86-LABEL: select_cmov_i64:
+ ; SDAG-X86:       ## %bb.0:
+-; SDAG-X86-NEXT:    cmpb $0, {{[0-9]+}}(%esp)
++; SDAG-X86-NEXT:    testb $1, {{[0-9]+}}(%esp)
+ ; SDAG-X86-NEXT:    jne LBB5_1
+ ; SDAG-X86-NEXT:  ## %bb.2:
+ ; SDAG-X86-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+@@ -563,7 +563,7 @@
+ ;
+ ; SDAG-X86-CMOV-LABEL: select_cmov_i64:
+ ; SDAG-X86-CMOV:       ## %bb.0:
+-; SDAG-X86-CMOV-NEXT:    cmpb $0, {{[0-9]+}}(%esp)
++; SDAG-X86-CMOV-NEXT:    testb $1, {{[0-9]+}}(%esp)
+ ; SDAG-X86-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SDAG-X86-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SDAG-X86-CMOV-NEXT:    cmovnel %eax, %ecx
+diff --git a/test/CodeGen/X86/select-constant-xor.ll b/test/CodeGen/X86/select-constant-xor.ll
+index efc367d204..5d80e04fef 100644
+--- a/test/CodeGen/X86/select-constant-xor.ll
++++ b/test/CodeGen/X86/select-constant-xor.ll
+@@ -172,8 +172,10 @@
+ define i32 @icmpasreq(i32 %input, i32 %a, i32 %b) {
+ ; X86-LABEL: icmpasreq:
+ ; X86:       # %bb.0:
+-; X86-NEXT:    cmpl $0, {{[0-9]+}}(%esp)
+-; X86-NEXT:    js .LBB8_1
++; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
++; X86-NEXT:    sarl $31, %eax
++; X86-NEXT:    cmpl $-1, %eax
++; X86-NEXT:    je .LBB8_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -198,8 +200,10 @@
+ define i32 @icmpasrne(i32 %input, i32 %a, i32 %b) {
+ ; X86-LABEL: icmpasrne:
+ ; X86:       # %bb.0:
+-; X86-NEXT:    cmpl $0, {{[0-9]+}}(%esp)
+-; X86-NEXT:    jns .LBB9_1
++; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
++; X86-NEXT:    sarl $31, %eax
++; X86-NEXT:    cmpl $-1, %eax
++; X86-NEXT:    jne .LBB9_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+diff --git a/test/CodeGen/X86/select-mmx.ll b/test/CodeGen/X86/select-mmx.ll
+index 8a4308a5af..cc66033820 100644
+--- a/test/CodeGen/X86/select-mmx.ll
++++ b/test/CodeGen/X86/select-mmx.ll
+@@ -85,8 +85,8 @@
+ ; X86-NEXT:    .cfi_def_cfa_register %ebp
+ ; X86-NEXT:    andl $-8, %esp
+ ; X86-NEXT:    subl $8, %esp
+-; X86-NEXT:    movl 8(%ebp), %eax
+-; X86-NEXT:    orl 12(%ebp), %eax
++; X86-NEXT:    movl 12(%ebp), %eax
++; X86-NEXT:    orl 8(%ebp), %eax
+ ; X86-NEXT:    je .LBB1_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal 24(%ebp), %eax
+diff --git a/test/CodeGen/X86/select-of-load-poison.ll b/test/CodeGen/X86/select-of-load-poison.ll
+new file mode 100644
+index 0000000000..1f71f812d2
+--- /dev/null
++++ b/test/CodeGen/X86/select-of-load-poison.ll
+@@ -0,0 +1,20 @@
++; NOTE: Assertions have been autogenerated by utils/update_llc_test_checks.py UTC_ARGS: --version 6
++; RUN: llc -mtriple=x86_64-unknown-linux-gnu < %s | FileCheck %s
++
++; Make sure there is an and 1, otherwise a case where the select condition
++; was poison could result in an out of bounds read instead.
++define i32 @test(i32 %x, ptr %p) {
++; CHECK-LABEL: test:
++; CHECK:       # %bb.0:
++; CHECK-NEXT:    # kill: def $edi killed $edi def $rdi
++; CHECK-NEXT:    andl $1, %edi
++; CHECK-NEXT:    movl 4(%rsi,%rdi,4), %eax
++; CHECK-NEXT:    retq
++  %p1 = getelementptr i8, ptr %p, i64 4
++  %v1 = load i32, ptr %p1
++  %p2 = getelementptr i8, ptr %p, i64 8
++  %v2 = load i32, ptr %p2
++  %c = trunc nuw i32 %x to i1
++  %v = select i1 %c, i32 %v2, i32 %v1
++  ret i32 %v
++}

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -222,7 +222,19 @@ stdenv.mkDerivation (
               hash = "sha256-3hkbYPUVRAtWpo5qBmc2jLZLivURMx8T0GQomvNZesc=";
               stripLen = 1;
             }
-          );
+          )
+      ++ lib.optionals (lib.versions.major release_version == "21") [
+        # Several LLVM versions have a bug in SelectionDAG that causes
+        # miscompilations around conditional poisions. This was exposed due to
+        # Rust 1.97.0 exercising the involved code path heavily and generating
+        # segfaulting code. The patch was made to LLVM 23, but the tests have
+        # many conflicts, so we vendor a version-specific modified version.
+        #
+        # Rust issue: https://github.com/rust-lang/rust/issues/159035
+        # LLVM issue: https://github.com/llvm/llvm-project/issues/208611
+        # LLVM PR: https://github.com/llvm/llvm-project/pull/208683
+        (getVersionFile "llvm/sdag-freeze-condition-in-select-of-load-fold.patch")
+      ];
 
     nativeBuildInputs = [
       cmake


### PR DESCRIPTION
Several LLVM versions have a bug in SelectionDAG that causes miscompilations around conditional poisions. This was exposed due to Rust 1.97.0 exercising the involved code path heavily and generating segfaulting code, but the bug existed beforehand as well. The patch was made to LLVM 23, but the tests have many conflicts, so this is a manual backport. This backport was made by:

- applying the code change to `llvm/lib`
- hand-updating `test/CodeGen/Mips/cmov.ll` with the same diff as the LLVM PR
- updating the rest with `utils/update_llc_test_checks.py` from the LLVM source tree, and verifying that the diff looks similar to the PR

The last step made this a rather large and gnarly patch, but it's mostly mechanical.

Rust issue: https://github.com/rust-lang/rust/issues/159035
LLVM issue: https://github.com/llvm/llvm-project/issues/208611
LLVM PR: https://github.com/llvm/llvm-project/pull/208683

This will need porting to at least LLVM 22 as well, but we might just be able to `fetchpatch` the patch from rust-lang/llvm-project for that one. Just doing 21 for now since it's the default, and we can do 22 later.

~~**DRAFT:** We have *not* verified that `llvm_21` builds. There is a solid chance that the build of this will completely fail in tests since we missed fixing one. We *have* verified that the `llc` based reproducer in the LLVM issue no longer appears to produce the incorrect assembly based on an `llc` built in an LLVM devshell, but this really needs a test with the Rust reproducers from the Rust issue. We're going to queue up `llvm_21` and `rustc` builds and head to bed though, and hope this hasn't failed by the time we wake up.~~

now built `llvm_21` and `rustc`, and confirmed that both reproducers from the Rust issue no longer segfault and instead produce the correct result.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
