### PR TITLE
shdoc: init at 1.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14215,6 +14215,11 @@
     githubId = 56224949;
     name = "Mia Kanashi";
   };
+  kangazero = {
+    github = "KangaZero";
+    githubId = 107836643;
+    name = "Samuel Wai Weng Yong";
+  };
   kaptcha0 = {
     name = "J'C Kabunga";
     github = "kaptcha0";

--- a/pkgs/by-name/sh/shdoc/package.nix
+++ b/pkgs/by-name/sh/shdoc/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  gawk,
+  versionCheckHook,
+  nix-update-script,
+  installShellFiles,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "shdoc";
+  version = "1.4";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "reconquest";
+    repo = "shdoc";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jJSSN9rVKsYkqCABFdtW3W3hDNfivhR+Y6axjbexwds=";
+  };
+
+  buildInputs = [ gawk ];
+  nativeBuildInputs = [ installShellFiles ];
+  # shdoc release already ships the tool built and runnable
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm555 shdoc -t $out/bin
+    installManPage contrib/shdoc.1
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Javadoc documentation generator for shell scripts (bash, sh, zsh)";
+    homepage = "https://github.com/reconquest/shdoc";
+    changelog = "https://github.com/reconquest/shdoc/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "shdoc";
+    maintainers = with lib.maintainers; [ kangazero ];
+    platforms = gawk.meta.platforms;
+  };
+})

--- a/pkgs/by-name/sh/shdoc/package.nix
+++ b/pkgs/by-name/sh/shdoc/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  gawk,
+  versionCheckHook,
+  nix-update-script,
+  installShellFiles,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "shdoc";
+  version = "1.4";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "reconquest";
+    repo = "shdoc";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jJSSN9rVKsYkqCABFdtW3W3hDNfivhR+Y6axjbexwds=";
+  };
+
+  buildInputs = [ gawk ];
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  postPatch = ''
+    # Skip tests
+    # Upstream takes from submodule "import.bash", of which the script imports another submodule "test-runner.bash"
+    # See https://github.com/reconquest/import.bash/blob/b8d543eadad8fc21b80e512aff83f2c7502e9ef0/import.bash#L29-L51
+    substituteInPlace Makefile \
+      --replace-fail "include vendor/github.com/reconquest/test-runner.bash/Makefile" ""
+
+    patchShebangs shdoc
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm555 shdoc -t $out/bin
+    installManPage contrib/shdoc.1
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Javadoc documentation generator for shell scripts (bash, sh, zsh)";
+    homepage = "https://github.com/reconquest/shdoc";
+    changelog = "https://github.com/reconquest/shdoc/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    mainProgram = "shdoc";
+    maintainers = with lib.maintainers; [ kangazero ];
+    platforms = gawk.meta.platforms;
+  };
+})


### PR DESCRIPTION
Adds `shdoc`,  [](https://github.com/reconquest/shdoc) a Javadoc documentation generator for shell scripts (bash, sh, zsh). 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
