### PR TITLE
deadbeef: disable swift in libdispatch

### DIFF
--- a/pkgs/by-name/de/deadbeef/package.nix
+++ b/pkgs/by-name/de/deadbeef/package.nix
@@ -77,7 +77,7 @@ clangStdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     jansson
-    swift-corelibs-libdispatch
+    (swift-corelibs-libdispatch.override { useSwift = false; })
     gtk3
     gsettings-desktop-schemas
   ]


### PR DESCRIPTION
I noticed that recent DeaDBeeF build failures have been caused by corresponding Swift build failures:

- https://github.com/NixOS/nixpkgs/issues/540320
- https://github.com/NixOS/nixpkgs/issues/466710
- https://github.com/NixOS/nixpkgs/issues/449453
- https://github.com/NixOS/nixpkgs/issues/327836#issuecomment-2346755791

According to the build instructions here https://github.com/DeaDBeeF-Player/deadbeef/blob/master/README, there's no any mention of Swift. Swift is built only as a dependency of libdispatch and not used.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
