### PR TITLE
python3Packages.dbf: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/dbf/default.nix
+++ b/pkgs/development/python-modules/dbf/default.nix
@@ -2,6 +2,7 @@
   lib,
   fetchPypi,
   buildPythonPackage,
+  setuptools,
   aenum,
   python,
 }:
@@ -9,17 +10,19 @@
 buildPythonPackage rec {
   pname = "dbf";
   version = "0.99.11";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-IWnAUlLA776JfzRvBoMybsJYVL6rHQxkMN9ukDpXsxU=";
   };
 
+  build-system = [ setuptools ];
+
   # Workaround for https://github.com/ethanfurman/dbf/issues/48
   patches = lib.optional python.stdenv.hostPlatform.isDarwin ./darwin.patch;
 
-  propagatedBuildInputs = [ aenum ];
+  dependencies = [ aenum ];
 
   checkPhase = ''
     runHook preCheck

--- a/pkgs/development/python-modules/dbf/default.nix
+++ b/pkgs/development/python-modules/dbf/default.nix
@@ -7,13 +7,16 @@
   python,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "dbf";
   version = "0.99.11";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
-    inherit pname version;
+    pname = "dbf";
+    inherit (finalAttrs) version;
     hash = "sha256-IWnAUlLA776JfzRvBoMybsJYVL6rHQxkMN9ukDpXsxU=";
   };
 
@@ -38,4 +41,4 @@ buildPythonPackage rec {
     license = lib.licenses.bsd2;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/dbf/default.nix
+++ b/pkgs/development/python-modules/dbf/default.nix
@@ -4,6 +4,7 @@
   buildPythonPackage,
   setuptools,
   aenum,
+  pytestCheckHook,
   python,
 }:
 
@@ -27,11 +28,13 @@ buildPythonPackage (finalAttrs: {
 
   dependencies = [ aenum ];
 
-  checkPhase = ''
-    runHook preCheck
-    ${python.interpreter} -m dbf.test
-    runHook postCheck
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  preCheck = ''
+    sed -i '/^import tempfile$/a tempdir = tempfile.mkdtemp()' dbf/test.py
   '';
+
+  enabledTestPaths = [ "dbf/test.py" ];
 
   pythonImportsCheck = [ "dbf" ];
 


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
