### PR TITLE
python3Packages.user-agents: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/user-agents/default.nix
+++ b/pkgs/development/python-modules/user-agents/default.nix
@@ -2,13 +2,14 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
   ua-parser,
 }:
 
 buildPythonPackage rec {
   pname = "user-agents";
   version = "2.2.0";
-  format = "setuptools";
+  pyproject = true;
 
   # PyPI is missing devices.json
   src = fetchFromGitHub {
@@ -18,7 +19,9 @@ buildPythonPackage rec {
     sha256 = "0pcbjqj21c2ixhl414bh2h8khi8y1igzfpkyqwan1pakix0lq45a";
   };
 
-  propagatedBuildInputs = [ ua-parser ];
+  build-system = [ setuptools ];
+
+  dependencies = [ ua-parser ];
 
   meta = {
     description = "Python library to identify devices by parsing user agent strings";

--- a/pkgs/development/python-modules/user-agents/default.nix
+++ b/pkgs/development/python-modules/user-agents/default.nix
@@ -6,22 +6,26 @@
   ua-parser,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "user-agents";
   version = "2.2.0";
   pyproject = true;
+
+  __structuredAttrs = true;
 
   # PyPI is missing devices.json
   src = fetchFromGitHub {
     owner = "selwin";
     repo = "python-user-agents";
-    rev = "v${version}";
-    sha256 = "0pcbjqj21c2ixhl414bh2h8khi8y1igzfpkyqwan1pakix0lq45a";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-qhBMQY9T3WAVx35e918MHkU4ERRwkUAo7FGwICSWi10=";
   };
 
   build-system = [ setuptools ];
 
   dependencies = [ ua-parser ];
+
+  pythonImportsCheck = [ "user_agents" ];
 
   meta = {
     description = "Python library to identify devices by parsing user agent strings";
@@ -30,4 +34,4 @@ buildPythonPackage rec {
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ dotlambda ];
   };
-}
+})


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
