### PR TITLE
whisp: init at 1.3.8

### DIFF
--- a/pkgs/by-name/wh/whisp/package.nix
+++ b/pkgs/by-name/wh/whisp/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  wrapGAppsHook4,
+  gobject-introspection,
+  gettext,
+  python3Packages,
+  pkg-config,
+  glib,
+  gtk4,
+  libadwaita,
+  nix-update-script,
+}:
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "whisp";
+  version = "1.3.8";
+
+  pyproject = false;
+
+  src = fetchFromGitHub {
+    owner = "tanaybhomia";
+    repo = "whisp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-OzD8Htha/BhOGiTgq42ZEIUZIywy4VK61zqiaBPaFbc=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook4
+    gobject-introspection
+    gettext
+  ];
+
+  buildInputs = [
+    glib
+    gtk4
+    libadwaita
+  ];
+
+  pythonPath = with python3Packages; [
+    pygobject3
+  ];
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "The Anti-Note for GNOME";
+    longDescription = ''
+      The Anti-Note for GNOME.
+      A fluid, gesture-driven scratchpad designed for absolute speed.
+    '';
+    homepage = "https://tanaybhomia.github.io/Whisp/";
+    license = lib.licenses.gpl3;
+    mainProgram = "whisp";
+    maintainers = [ lib.maintainers.luminarleaf ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Add https://github.com/tanaybhomia/Whisp

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
