### PR TITLE
lttng-tools: 2.14.1 -> 2.15.1

### DIFF
--- a/pkgs/by-name/lt/lttng-tools/package.nix
+++ b/pkgs/by-name/lt/lttng-tools/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   pkg-config,
+  python3,
   babeltrace2,
   popt,
   libuuid,
@@ -14,14 +15,21 @@
 
 stdenv.mkDerivation rec {
   pname = "lttng-tools";
-  version = "2.14.1";
+  version = "2.15.1";
 
   src = fetchurl {
     url = "https://lttng.org/files/lttng-tools/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-DmjrJ5I2IcS8Enz85AQi0oz35HP+32IprmwyulxbfG0=";
+    sha256 = "sha256-i21Lp64sA299r7tOKXF2d0EQePmp2WGy3HwboWJz6ek=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    python3
+  ];
+
+  # Used by the test source generator during the build.
+  makeFlags = [ "PYTHON=${lib.getExe python3}" ];
+
   buildInputs = [
     babeltrace2
     popt


### PR DESCRIPTION
Update `lttng-tools` to 2.15.1 to match `lttng-ust` 2.15.1 and restore build compatibility. Add Python for the test source generator introduced in 2.15.

Changelog: https://github.com/lttng/lttng-tools/releases/tag/v2.15.1

Closes #542041

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
