### PR TITLE
audacity: use ffmpeg 8

### DIFF
--- a/pkgs/by-name/au/audacity/package.nix
+++ b/pkgs/by-name/au/audacity/package.nix
@@ -31,7 +31,7 @@
   libid3tag,
   libopus,
   libuuid,
-  ffmpeg_7,
+  ffmpeg_8,
   soundtouch,
   portaudio, # given up fighting their portaudio.patch?
   portmidi,
@@ -59,7 +59,7 @@
 # 1. detach sbsms
 
 let
-  ffmpeg = ffmpeg_7;
+  ffmpeg = ffmpeg_8;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "audacity";


### PR DESCRIPTION
## Description of changes

Audacity is currently pinned to `ffmpeg_7`.

This pin was necessary when Audacity 3.7.5 did not support FFmpeg 8. Upstream has since added FFmpeg 8 support in:

- https://github.com/audacity/audacity/pull/9742

nixpkgs currently packages Audacity 3.7.8, so this switches the package to `ffmpeg_8`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

- Tested:
  - [x] `nix build .#audacity`
  - [x] Launched Audacity locally