### PR TITLE
cliphist: Handle contrib/ files properly and adopt

### DIFF
--- a/pkgs/by-name/cl/cliphist/package.nix
+++ b/pkgs/by-name/cl/cliphist/package.nix
@@ -4,6 +4,12 @@
   buildGoModule,
   fetchFromGitHub,
   nix-update-script,
+  gawk,
+  wl-clipboard,
+  fuzzel,
+  fzf,
+  chafa,
+  wofi,
 }:
 
 buildGoModule (finalAttrs: {
@@ -19,8 +25,23 @@ buildGoModule (finalAttrs: {
 
   vendorHash = "sha256-4XyDLOJHdre/1BpjgFt/W6gOlPOvKztE+MsbwE3JAaQ=";
 
+  postPatch = ''
+    substituteInPlace contrib/cliphist-{fuzzel,rofi,wofi}-img \
+      --replace-fail "gawk" "${lib.getExe gawk}"
+    substituteInPlace contrib/cliphist-{fuzzel-img,fzf,fzf-sixel,rofi,rofi-img,wofi-img} \
+      --replace-fail "wl-copy" "${lib.getExe' wl-clipboard "wl-copy"}"
+    substituteInPlace contrib/cliphist-fuzzel-img \
+      --replace-fail "fuzzel " "${lib.getExe fuzzel} "
+    substituteInPlace contrib/cliphist-fzf{,-sixel} \
+      --replace-fail "fzf " "${lib.getExe fzf} "
+    substituteInPlace contrib/cliphist-fzf-sixel \
+      --replace-fail "chafa " "${lib.getExe chafa} "
+    substituteInPlace contrib/cliphist-wofi-img \
+      --replace-fail "| wofi" "| ${lib.getExe wofi}"
+  '';
+
   postInstall = ''
-    cp ${finalAttrs.src}/contrib/* $out/bin/
+    cp ./contrib/cliphist-{fuzzel-img,fzf,fzf-sixel,rofi,rofi-img,wofi-img} $out/bin/
   '';
 
   passthru = {

--- a/pkgs/by-name/cl/cliphist/package.nix
+++ b/pkgs/by-name/cl/cliphist/package.nix
@@ -55,7 +55,7 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/sentriz/cliphist";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.linux;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ klea ];
     mainProgram = "cliphist";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- Instead of copying stuff from `${finalAttrs.src}/contrib` copy from the working directory, to let patches work.
- Only copy binaries
- Patch the contrib binaries so they reference full store paths.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy]. <!-- meow !-->

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
