### PR TITLE
atomgit-cli: init at 0.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25962,6 +25962,12 @@
     name = "Nikolay Korotkiy";
     keys = [ { fingerprint = "ADF4 C13D 0E36 1240 BD01  9B51 D1DE 6D7F 6936 63A5"; } ];
   };
+  silicalet = {
+    name = "Mr. why";
+    email = "silicalet@outlook.com";
+    github = "silicalet";
+    githubId = 188071249;
+  };
   silky = {
     name = "Noon van der Silk";
     email = "noonsilk+nixpkgs@gmail.com";

--- a/pkgs/by-name/at/atomgit-cli/package.nix
+++ b/pkgs/by-name/at/atomgit-cli/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchgit,
+  gitMinimal,
+  makeWrapper,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+  xdg-utils,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "atomgit-cli";
+  version = "0.5.0";
+
+  src = fetchgit {
+    url = "https://atomgit.com/hust-open-atom-club/atomgit-cli.git";
+    rev = "11f1ff216053bf47c0a3baaed6698c9222f1ce77";
+    hash = "sha256-ZvQ8S0f1jUfN48UE/U+JnTTrtoWYZfwhDPDBbKKLlC0=";
+  };
+
+  vendorHash = "sha256-7K17JaXFsjf163g5PXCb5ng2gYdotnZ2IDKk8KFjNj0=";
+
+  subPackages = [ "cmd/ag" ];
+
+  preCheck = ''
+    # Test all packages, not only cmd/ag.
+    unset subPackages
+  '';
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X atomgit.com/hust-open-atom-club/atomgit-cli/internal/version.Version=v${finalAttrs.version}"
+    "-X atomgit.com/hust-open-atom-club/atomgit-cli/internal/version.Commit=${finalAttrs.src.rev}"
+    "-X atomgit.com/hust-open-atom-club/atomgit-cli/internal/version.BuildDate=2026-07-13T07:53:45Z"
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postFixup = ''
+    wrapProgram $out/bin/ag \
+      --prefix PATH : ${
+        lib.makeBinPath (
+          [ gitMinimal ] ++ lib.optionals stdenv.hostPlatform.isLinux [ xdg-utils ]
+        )
+      }
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  versionCheckProgramArg = "version";
+  versionCheckKeepEnvironment = [ "HOME" ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Command-line interface for AtomGit";
+    homepage = "https://atomgit.com/hust-open-atom-club/atomgit-cli";
+    changelog = "https://atomgit.com/hust-open-atom-club/atomgit-cli/tags/v${finalAttrs.version}";
+    license = lib.licenses.mulan-psl2;
+    mainProgram = "ag";
+    maintainers = [ lib.maintainers.silicalet ];
+  };
+})

--- a/pkgs/by-name/at/atomgit-cli/package.nix
+++ b/pkgs/by-name/at/atomgit-cli/package.nix
@@ -11,6 +11,8 @@
 }:
 
 buildGoModule (finalAttrs: {
+  __structuredAttrs = true;
+
   pname = "atomgit-cli";
   version = "0.5.0";
 
@@ -42,9 +44,7 @@ buildGoModule (finalAttrs: {
   postFixup = ''
     wrapProgram $out/bin/ag \
       --prefix PATH : ${
-        lib.makeBinPath (
-          [ gitMinimal ] ++ lib.optionals stdenv.hostPlatform.isLinux [ xdg-utils ]
-        )
+        lib.makeBinPath ([ gitMinimal ] ++ lib.optionals stdenv.hostPlatform.isLinux [ xdg-utils ])
       }
   '';
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

  Package AtomGit CLI (`ag`) at version 0.5.0.

  AtomGit CLI provides command-line access to AtomGit repositories, pull
  requests, issues, tags, authentication, SSH keys, and license compliance
  checks.

  The package builds from source, runs the complete upstream Go test suite,
  and performs an installed version check.

  [](https://atomgit.com/hust-open-atom-club/atomgit-cli)
