### PR TITLE
dovi-tool: 2.3.2 → 2.3.3

### DIFF
--- a/pkgs/by-name/do/dovi-tool/package.nix
+++ b/pkgs/by-name/do/dovi-tool/package.nix
@@ -54,7 +54,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
   versionCheckProgram = "${placeholder "out"}/bin/dovi_tool";
   doInstallCheck = true;
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^(?!libdovi-)(.*)$"
+    ];
+  };
 
   meta = {
     description = "CLI tool combining multiple utilities for working with Dolby Vision";

--- a/pkgs/by-name/do/dovi-tool/package.nix
+++ b/pkgs/by-name/do/dovi-tool/package.nix
@@ -17,16 +17,16 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "dovi-tool";
-  version = "2.3.2";
+  version = "2.3.3";
 
   src = fetchFromGitHub {
     owner = "quietvoid";
     repo = "dovi_tool";
     tag = finalAttrs.version;
-    hash = "sha256-8UG3p84wjuPpnwcz65dyDbLDaoFXtokxNvnldBZHqwc=";
+    hash = "sha256-oXHXt1u1zxWti22tT4nJQhVdCtIshKrlve8896QQg84=";
   };
 
-  cargoHash = "sha256-nr2F+QZurNN/iCFW62LZaheZkuCGId4TSRuYd1yYH88=";
+  cargoHash = "sha256-rJw9fEZ696N8xsFXCL5GWIuLYPXKp2K0WqFxbM1iGiw=";
 
   nativeBuildInputs = lib.optionals (!stdenv.hostPlatform.isDarwin) [
     pkg-config


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: https://github.com/quietvoid/dovi_tool/releases/tag/2.3.3
Commits: https://github.com/quietvoid/dovi_tool/compare/2.3.2...2.3.3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
