### PR TITLE
nixos/gitlab: add support for multiple gitlab sidekiq processes

### DIFF
--- a/nixos/modules/services/misc/gitlab.nix
+++ b/nixos/modules/services/misc/gitlab.nix
@@ -1060,6 +1060,38 @@ in
         '';
       };
 
+      sidekiq.queueGroups = mkOption {
+        type = types.attrsOf types.int;
+        default = {
+          "*" = 1;
+        };
+        example = {
+          "default" = 3;
+          "global_search,mailers" = 1;
+        };
+        description = ''
+          The queues that are created processes for on the sidekiq node.
+          By default, sidekiq runs on a single process and a number of
+          sidekiq.concurrency threads. This single process serves all queues
+          ("*").
+
+          You specify how many of each queues you want by first specifying which
+          queue you want, e.g. "default" or "*" and then how many processes for this
+          queue ought to be spawned.
+
+          Each of the processes will be assigned a number of os threads as specified
+          in sidekiq.concurrency.
+
+          Mind that too many processes and threads will ultimately reduce the throughput
+          since they're bound by the amount of connections that can be processed by the
+          redis instance.
+
+          See <https://docs.gitlab.com/administration/sidekiq/extra_sidekiq_processes> for
+          details and e.g. <https://docs.gitlab.com/integration/advanced_search/elasticsearch/#enable-advanced-search>
+          for motivation.
+        '';
+      };
+
       logrotate = {
         enable = mkOption {
           type = types.bool;
@@ -1646,8 +1678,8 @@ in
         ExecStart = utils.escapeSystemdExecArgs (
           [
             "${cfg.packages.gitlab}/share/gitlab/bin/sidekiq-cluster"
-            "*" # all queue groups
           ]
+          ++ lib.concatLists (lib.mapAttrsToList (k: v: lib.replicate v k) cfg.sidekiq.queueGroups)
           ++ lib.optionals (cfg.sidekiq.concurrency != null) [
             "--concurrency"
             (toString cfg.sidekiq.concurrency)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
