### PR TITLE
absolute: init at 0.3

### DIFF
--- a/pkgs/by-name/ab/absolute/package.nix
+++ b/pkgs/by-name/ab/absolute/package.nix
@@ -1,0 +1,18 @@
+{ lib, ocamlPackages }:
+
+let
+  inherit (ocamlPackages) buildDunePackage libabsolute;
+in
+
+buildDunePackage {
+  pname = "absolute";
+  inherit (libabsolute) src version;
+
+  __structuredAttrs = true;
+
+  buildInputs = [ libabsolute ];
+
+  meta = libabsolute.meta // {
+    description = "A constraint solver based on abstract domains from the theory of abstract interpretation";
+  };
+}

--- a/pkgs/development/ocaml-modules/apron/default.nix
+++ b/pkgs/development/ocaml-modules/apron/default.nix
@@ -31,13 +31,15 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   buildInputs = [
     gmp
-    mpfr
     ppl
-    camlidl
     flint
     pplite
   ];
-  propagatedBuildInputs = [ mlgmpidl ];
+  propagatedBuildInputs = [
+    camlidl
+    mlgmpidl
+    mpfr
+  ];
 
   outputs = [
     "out"

--- a/pkgs/development/ocaml-modules/apronext/default.nix
+++ b/pkgs/development/ocaml-modules/apronext/default.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildDunePackage,
+  apron,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "apronext";
+  version = "1.0.4";
+
+  src = fetchFromGitHub {
+    owner = "ghilesZ";
+    repo = "apronext";
+    rev = "39610de5930e12c8d0156ed2d55fedc220f1e77d";
+    hash = "sha256-K19hmvyI1RJlKv24VJustDfkGTdrW4PcR8xif/y/giQ=";
+  };
+
+  propagatedBuildInputs = [ apron ];
+
+  meta = {
+    license = lib.licenses.asl20;
+    homepage = "https://github.com/ghilesZ/apronext";
+    description = "Extension for the OCaml interface of the apron library";
+  };
+
+})

--- a/pkgs/development/ocaml-modules/libabsolute/default.nix
+++ b/pkgs/development/ocaml-modules/libabsolute/default.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildDunePackage,
+  menhir,
+  apronext,
+  picasso,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "libabsolute";
+  version = "0.3";
+
+  src = fetchFromGitHub {
+    owner = "mpelleau";
+    repo = "absolute";
+    tag = finalAttrs.version;
+    hash = "sha256-q2QxqZJn71MODJ1+Yf9m33qu8xERTqExMANqgk7aksQ=";
+  };
+
+  nativeBuildInputs = [ menhir ];
+
+  propagatedBuildInputs = [
+    apronext
+    picasso
+  ];
+  meta = {
+    license = lib.licenses.lgpl3Plus;
+    homepage = "https://github.com/mpelleau/AbSolute";
+    description = "A constraint programming library based on abstract domains";
+  };
+})

--- a/pkgs/development/ocaml-modules/picasso/default.nix
+++ b/pkgs/development/ocaml-modules/picasso/default.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildDunePackage,
+  apronext,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "picasso";
+  version = "0.4";
+
+  src = fetchFromGitHub {
+    owner = "ghilesZ";
+    repo = "picasso";
+    tag = finalAttrs.version;
+    hash = "sha256-VYrN77IVXPdzPV1CNe5N4D2jgrVIHJFMvfRP6cQq/eI=";
+  };
+
+  propagatedBuildInputs = [ apronext ];
+
+  meta = {
+    description = "An Abstract element drawing library";
+    license = lib.licenses.lgpl2Plus;
+    homepage = "https://github.com/ghilesZ/picasso";
+  };
+})

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -58,6 +58,8 @@ let
 
         apron = callPackage ../development/ocaml-modules/apron { };
 
+        apronext = callPackage ../development/ocaml-modules/apronext { };
+
         argon2 = callPackage ../development/ocaml-modules/argon2 { };
 
         arg-complete = callPackage ../development/ocaml-modules/arg-complete { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1127,6 +1127,8 @@ let
 
         letters = callPackage ../development/ocaml-modules/letters { };
 
+        libabsolute = callPackage ../development/ocaml-modules/libabsolute { };
+
         libc = callPackage ../development/ocaml-modules/libc { };
 
         lilv = callPackage ../development/ocaml-modules/lilv {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1765,6 +1765,8 @@ let
 
         piaf = callPackage ../development/ocaml-modules/piaf { };
 
+        picasso = callPackage ../development/ocaml-modules/picasso { };
+
         piqi = callPackage ../development/ocaml-modules/piqi { };
 
         piqi-ocaml = callPackage ../development/ocaml-modules/piqi-ocaml { };


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
