### PR TITLE
immich-kiosk: 0.39.3 -> 0.41.0

### DIFF
--- a/pkgs/by-name/im/immich-kiosk/package.nix
+++ b/pkgs/by-name/im/immich-kiosk/package.nix
@@ -10,28 +10,28 @@
 
 buildGoModule rec {
   pname = "immich-kiosk";
-  version = "0.39.3";
+  version = "0.41.0";
 
   src = fetchFromGitHub {
     owner = "damongolding";
     repo = "immich-kiosk";
     tag = "v${version}";
-    hash = "sha256-kdTEvH8MqL3oXe0QZlPTVpeByLpqAdNfPGfu5f2G6g0=";
+    hash = "sha256-mr0cxHdekpzfKfJ2IKpm79vTu5qnSl8q2c8eWose7tg=";
   };
 
   postPatch = ''
     # Delete vendor directory to regenerate it consistently across platforms
     rm -rf vendor
     # immich-kiosk bumps go at a faster cadence than nixpkgs
-    sed 's/^go 1\.26\.\d+$/go 1.26/' go.mod
+    sed -i -E 's/^go 1\.26\.[0-9]+$/go 1.26/' go.mod
   '';
-  vendorHash = "sha256-y6Xl00G+mkhRKVGwMS0WCXZhQqqGGX5qY8PhMxtw7z8=";
+  vendorHash = "sha256-5mMU73/XvHfvT8VaseSymZjDalvHj/KR6cTz1nvXHPQ=";
   proxyVendor = true;
 
   npmDeps = fetchNpmDeps {
     inherit src;
     sourceRoot = "${src.name}/frontend";
-    hash = "sha256-lNON0/lxix2aczC0+m7Er5Te1+4fsSoLkk6Z2pYzQYQ=";
+    hash = "sha256-1m0JvPZDYjd2cNy9atENRS3/GHWzLnPISwGnJbSZwAo=";
   };
   # Frontend is in a subdirectory
   npmRoot = "frontend";


### PR DESCRIPTION
https://github.com/damongolding/immich-kiosk/compare/v0.39.3..v0.41.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
