### PR TITLE
slurp-fediverse: init at 1.1.1

### DIFF
--- a/pkgs/by-name/sl/slurp-fediverse/package.nix
+++ b/pkgs/by-name/sl/slurp-fediverse/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromCodeberg,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "slurp";
+  version = "1.1.1";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromCodeberg {
+    owner = "vyr";
+    repo = "slurp";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-bqIX+kG/VXLvw/ORqS+Gq8fezd0QW6dlKdLr2vW0YY0=";
+  };
+
+  vendorHash = "sha256-i/xoMJORuJbAQW+g9H95xQ5O3811NncCgJIL9OY+B5k=";
+
+  # Tests require networking
+  doCheck = false;
+
+  meta = {
+    description = "Tool for exporting data from and importing data to Fediverse instances";
+    homepage = "https://codeberg.org/vyr/slurp";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ onny ];
+    mainProgram = "slurp";
+  };
+})


### PR DESCRIPTION
Packaging [slurp](https://codeberg.org/vyr/slurp), a tool to migrate posts etc from fediverse instances. Named the package `slurp-fediverse` to avoid collision with existing slurp package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
