### PR TITLE
thunderbird-mcp: 0.7.3 -> 0.7.4

### DIFF
--- a/pkgs/by-name/th/thunderbird-mcp/package-lock.json
+++ b/pkgs/by-name/th/thunderbird-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thunderbird-mcp",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thunderbird-mcp",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "license": "MIT",
       "bin": {
         "thunderbird-mcp": "mcp-bridge.cjs"

--- a/pkgs/by-name/th/thunderbird-mcp/package.nix
+++ b/pkgs/by-name/th/thunderbird-mcp/package.nix
@@ -7,13 +7,13 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "thunderbird-mcp";
-  version = "0.7.3";
+  version = "0.7.4";
 
   src = fetchFromGitHub {
     owner = "TKasperczyk";
     repo = "thunderbird-mcp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-VIJUMMiJ2NCdMfxK4E/FAQ4P2ryS6KlxhPj749JH6sE=";
+    hash = "sha256-jrmHqToe+lJTpoG1QYaYHVk84PaO5zKAXLwr3Opl0A4=";
   };
 
   postPatch = ''
@@ -23,7 +23,7 @@ buildNpmPackage (finalAttrs: {
   forceEmptyCache = true;
   dontNpmBuild = true;
 
-  npmDepsHash = "sha256-6irpujYRk/OvoTA43CvtoaOmHvK4coMFXRfXhGrjFNk=";
+  npmDepsHash = "sha256-D0DAjK/u59rOKNf5kCu/OYkch+4lZYgdHkuib0sqtIw=";
 
   doCheck = true;
 


### PR DESCRIPTION
Updates thunderbird-mcp to v0.7.4. The release tightens attachment handling and extends contact and inline-message support.

[Changes](https://github.com/TKasperczyk/thunderbird-mcp/compare/v0.7.3...v0.7.4)

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
