### PR TITLE
viser: allow rich 15

### DIFF
--- a/pkgs/development/python-modules/viser/default.nix
+++ b/pkgs/development/python-modules/viser/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
 
-  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -169,6 +168,11 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [
     "viser"
+  ];
+
+  pythonRelaxDeps = [
+    # rich<15.0.0,>=13.3.3 not satisfied by version 15.0.0
+    "rich"
   ];
 
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION
fix:

```
python3.14-viser> Checking runtime dependencies for viser-1.0.30-py3-none-any.whl
python3.14-viser>   - rich<15.0.0,>=13.3.3 not satisfied by version 15.0.0
```

seems to work fine:
<img width="405" height="790" alt="image" src="https://github.com/user-attachments/assets/93d89910-d480-48e0-9f93-05df7b6f55ff" />


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
