### PR TITLE
Add yesser-todo-cli and yesser-todo-server

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -30264,6 +30264,12 @@
     githubId = 4113027;
     name = "Jesper Geertsen Jonsson";
   };
+  yesseruser = {
+    name = "yesseruser";
+    email = "yesseruseryt@gmail.com";
+    github = "yesseruser";
+    githubId = 67008763;
+  };
   yethal = {
     github = "yethal";
     githubId = 26117918;

--- a/pkgs/by-name/ye/yesser-todo-cli/package.nix
+++ b/pkgs/by-name/ye/yesser-todo-cli/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  openssl,
+  pkg-config,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "yesser-todo-cli";
+  version = "1.4.0";
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+
+  src = fetchFromGitHub {
+    owner = "yesser-studios";
+    repo = "yesser-todo-cli";
+    tag = "yesser-todo-cli-v${finalAttrs.version}";
+    hash = "sha256-e1Zstezojdk9FibY0kH58+LybdNrjIfp3gfIqWkAlK0=";
+  };
+
+  cargoHash = "sha256-4pA9oilXItjU8Wmwwd5lV+dXKMOt9RywGxpqGu3G4OU=";
+
+  cargoTestFlags = [
+    "--package"
+    "yesser-todo-cli"
+  ];
+  cargoBuildFlags = [
+    "--package"
+    "yesser-todo-cli"
+  ];
+
+  meta = {
+    description = "CLI app for managing your tasks";
+    homepage = "https://github.com/yesser-studios/yesser-todo-cli";
+    changelog = "https://github.com/yesser-studios/yesser-todo-cli/releases/tag/yesser-todo-cli-v${finalAttrs.version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [
+      yesseruser
+    ];
+    mainProgram = "todo";
+  };
+})

--- a/pkgs/by-name/ye/yesser-todo-server/package.nix
+++ b/pkgs/by-name/ye/yesser-todo-server/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "yesser-todo-server";
+  version = "2.0.1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "yesser-studios";
+    repo = "yesser-todo-cli";
+    tag = "yesser-todo-server-v${finalAttrs.version}";
+    hash = "sha256-YRuTbVbKXNGkwdImrLfpEBH+ij6dK3n84Bm8fUw057I=";
+  };
+
+  cargoHash = "sha256-/EoB6aRUHNZKJeK/IwwzO8tzbrm5cnUCBHaO1gMv2cE=";
+
+  cargoTestFlags = [
+    "--package"
+    "yesser-todo-server"
+  ];
+  cargoBuildFlags = [
+    "--package"
+    "yesser-todo-server"
+  ];
+
+  meta = {
+    description = "Server for yesser-todo-cli";
+    homepage = "https://github.com/yesser-studios/yesser-todo-cli";
+    changelog = "https://github.com/yesser-studios/yesser-todo-cli/commits/yesser-todo-server-${finalAttrs.version}/";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [
+      yesseruser
+    ];
+    mainProgram = "yesser-todo-server";
+  };
+})


### PR DESCRIPTION
Added packages yesser-todo-cli 1.4.0 and yesser-todo-server 2.0.1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
