### PR TITLE
 python3Packages.ansible-vault: 2.1.0 -> 4.1.0 

### DIFF
--- a/pkgs/development/python-modules/ansible-vault/default.nix
+++ b/pkgs/development/python-modules/ansible-vault/default.nix
@@ -14,8 +14,8 @@
 }:
 
 buildPythonPackage rec {
-  pname = "ansible-vault-rw";
-  version = "2.1.0";
+  pname = "ansible-vault";
+  version = "4.1.0";
   pyproject = true;
 
   src = fetchPypi {

--- a/pkgs/development/python-modules/ansible-vault/default.nix
+++ b/pkgs/development/python-modules/ansible-vault/default.nix
@@ -1,49 +1,71 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
 
   # build-system
   setuptools,
 
   # dependencies
   ansible-core,
+  pyyaml,
 
   # tests
   pytestCheckHook,
+  writableTmpDirAsHomeHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "ansible-vault";
   version = "4.1.0";
   pyproject = true;
 
-  src = fetchPypi {
-    pname = "ansible-vault";
-    inherit version;
-    hash = "sha256-XOj9tUcPFEm3a/B64qvFZIDa1INWrkBchbaG77ZNvV4";
+  # Fetched from GitHub because PyPI doesn't ship the test suite.
+  src = fetchFromGitHub {
+    owner = "tomoh1r";
+    repo = "ansible-vault";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JSFZavafUByn4u+WkPo01lPCzjv/ekCM8nvWSy4QrAs=";
   };
+
+  # The test helper resolves the ansible-vault CLI as a sibling of sys.executable,
+  # which holds in a venv but not under nix's split store; point it at ansible-core.
+  postPatch = ''
+    substituteInPlace test/lib/testing/__init__.py \
+      --replace-fail 'os.path.join(os.path.dirname(sys.executable), "ansible-vault")' \
+                     '"${lib.getExe' ansible-core "ansible-vault"}"'
+  '';
 
   nativeBuildInputs = [ setuptools ];
 
-  propagatedBuildInputs = [ ansible-core ];
+  propagatedBuildInputs = [
+    ansible-core
+    pyyaml
+  ];
 
-  # Otherwise tests will fail to create directory
-  # Permission denied: '/homeless-shelter'
-  preCheck = ''
-    export HOME=$(mktemp -d)
-  '';
+  nativeCheckInputs = [
+    pytestCheckHook
+    # importing ansible writes to HOME, without this import check and checkPhase would both fail
+    writableTmpDirAsHomeHook
+  ];
 
-  # no tests in sdist, no 2.1.0 tag on git
-  doCheck = false;
+  disabledTestPaths = [
+    # dev-only lint suite (black/flake8/isort/pylint), not useful for nixpkgs
+    "test/linter"
+  ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  disabledTests = [
+    # This fails on a benign reformatting of ansible-core's error message
+    "TestCannotLoadWithInvalidPassword"
+  ];
+
+  pythonImportsCheck = [ "ansible_vault" ];
 
   meta = {
-    description = "This project aim to R/W an ansible-vault yaml file";
+    description = "R/W an ansible-vault yaml file";
     homepage = "https://github.com/tomoh1r/ansible-vault";
     changelog = "https://github.com/tomoh1r/ansible-vault/blob/master/CHANGES.txt";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ StillerHarpo ];
   };
-}
+})

--- a/pkgs/development/python-modules/bittensor-wallet/default.nix
+++ b/pkgs/development/python-modules/bittensor-wallet/default.nix
@@ -9,7 +9,7 @@
   libsodium,
   libiconv,
   pytestCheckHook,
-  ansible-vault-rw,
+  ansible-vault,
   setuptools,
 }:
 
@@ -48,7 +48,7 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [
     pytestCheckHook
-    ansible-vault-rw
+    ansible-vault
     setuptools
   ];
 

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -86,6 +86,7 @@ mapAliases {
   amazon-kclpy = throw "amazon-kclpy has been removed because it has been marked as broken since at least November 2024."; # Added 2025-10-03
   amazon_kclpy = throw "'amazon_kclpy' has been renamed to/replaced by 'amazon-kclpy'"; # Converted to throw 2025-10-29
   amqplib = throw "amqplib has been removed as it was unmaintained upstream"; # Added 2025-11-22
+  ansible-vault-rw = ansible-vault; # Added 2026-07-10
   ansiconv = throw "ansiconv has been removed because it was archived upstream"; # Added 2026-01-14
   ansiwrap = throw "ansiwrap has been removed because it has been marked as broken since at least November 2024."; # Added 2025-10-03
   apkit = throw "apkit was removed because it is unmaintained upstream and different from apkit on PyPI"; # added 2025-09-13

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1139,7 +1139,7 @@ self: super: with self; {
 
   ansible-runner = callPackage ../development/python-modules/ansible-runner { };
 
-  ansible-vault-rw = callPackage ../development/python-modules/ansible-vault-rw { };
+  ansible-vault = callPackage ../development/python-modules/ansible-vault { };
 
   ansicolor = callPackage ../development/python-modules/ansicolor { };
 


### PR DESCRIPTION
Changes:
- rename `ansible-vault-rw` to `ansible-vault` (matching the upstream name)
- updates it to the latest version: https://github.com/tomoh1r/ansible-vault/compare/v2.1.0...v4.1.0
- refactors it to run upstream's tests

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
