### PR TITLE
mango-lsp: init at 0.1.0

### DIFF
--- a/pkgs/by-name/ma/mango-lsp/package.nix
+++ b/pkgs/by-name/ma/mango-lsp/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "mango-lsp";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "ernestoCruz05";
+    repo = "mangolsp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-uyUZddpGZodNwgP0trwggKejIjGuLkMK3q45qrZyBsg=";
+  };
+
+  postPatch = ''
+    rm -rf vendor
+  '';
+
+  vendorHash = "sha256-ojp/l2cc64wimABFH13tonHr5fmvzd4c81PsPCBRG0I=";
+
+  subPackages = [ "cmd/mangolsp" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  __structuredAttrs = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Language server for mango (mangowm) config files";
+    homepage = "https://github.com/ernestoCruz05/mangolsp";
+    changelog = "https://github.com/ernestoCruz05/mangolsp/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yvnth ];
+    mainProgram = "mangolsp";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
LSP for `mango` window manager

Homepage: https://github.com/ernestoCruz05/mangolsp

## Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test