### PR TITLE
lammps: add `extraNativeBuildInputs` and remove cuda

### DIFF
--- a/pkgs/by-name/la/lammps-mpi/package.nix
+++ b/pkgs/by-name/la/lammps-mpi/package.nix
@@ -6,8 +6,11 @@
 
 lib.lowPrio (
   lammps.override {
-    extraBuildInputs = [
+    extraNativeBuildInputs = [
       mpi
     ];
+    extraCmakeFlags = {
+      BUILD_MPI = "ON";
+    };
   }
 )

--- a/pkgs/by-name/la/lammps/package.nix
+++ b/pkgs/by-name/la/lammps/package.nix
@@ -45,6 +45,7 @@
   extraCmakeFlags ? { },
   # Extra `buildInputs` - meant for packages that require more inputs
   extraBuildInputs ? [ ],
+  extraNativeBuildInputs ? [ ],
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -68,10 +69,8 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     pkg-config
-    # Although not always needed, it is needed if cmakeFlags include
-    # GPU_API=cuda, and it doesn't users that don't enable the GPU package.
-    autoAddDriverRunpath
   ]
+  ++ extraNativeBuildInputs
   ++ lib.optionals packages.PYTHON [
     python3
   ];
@@ -80,6 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
     inherit packages;
     inherit extraCmakeFlags;
     inherit extraBuildInputs;
+    inherit extraNativeBuildInputs;
   };
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" true)

--- a/pkgs/by-name/la/lammps/package.nix
+++ b/pkgs/by-name/la/lammps/package.nix
@@ -40,7 +40,6 @@
     SRD = true;
     REAXFF = true;
     PYTHON = true;
-    MPIIO = true;
   },
   # Extra cmakeFlags to add as "-D${attr}=${value}"
   extraCmakeFlags ? { },
@@ -75,9 +74,6 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals packages.PYTHON [
     python3
-  ]
-  ++ lib.optionals packages.MPIIO [
-    mpich
   ];
 
   passthru = {


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test