### PR TITLE
intel-llvm: fix build

### DIFF
--- a/pkgs/by-name/in/intel-llvm/unwrapped.nix
+++ b/pkgs/by-name/in/intel-llvm/unwrapped.nix
@@ -57,7 +57,11 @@ let
         cp $out/bin/clang-${llvmMajorVersion} $out/bin/clang
         cp $out/bin/clang-${llvmMajorVersion} $out/bin/clang++
       '';
-      passthru.isClang = true;
+      passthru = {
+        isClang = true;
+        langC = true;
+        langCC = true;
+      };
     }
   );
 
@@ -296,6 +300,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     isClang = true;
+    langC = true;
+    langCC = true;
 
     inherit unified-runtime;
 


### PR DESCRIPTION
After the latest staging-next merge, `intel-llvm` broke due to a change in how `cc-wrapper` queries for C++ support (`gccForLibs.langCC` -> `cc.langCC`) which dropped the injection of `-cxx-isystem`, breaking the build.

Closes https://github.com/NixOS/nixpkgs/issues/542015 (cc @eclairevoyant)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
