### PR TITLE
yosys: 0.62 -> 0.67

### DIFF
--- a/pkgs/by-name/yo/yosys/package.nix
+++ b/pkgs/by-name/yo/yosys/package.nix
@@ -5,12 +5,15 @@
 
   # nativeBuildInputs
   bison,
+  cmake,
   flex,
+  ninja,
   pkg-config,
-
-  # propagatedBuildInputs
-  libffi,
   python3,
+
+  # buildInputs
+  gtest,
+  libffi,
   readline,
   tcl,
   zlib,
@@ -62,84 +65,70 @@ let
   }
   // yosys-symbiflow;
 
+  pythonEnv = python3.withPackages (
+    pp:
+    with pp;
+    [ click ]
+    ++ lib.optionals enablePython [
+      pybind11
+      cxxheaderparser
+    ]
+  );
+
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "yosys";
-  version = "0.62";
+  version = "0.67";
 
   src = fetchFromGitHub {
     owner = "YosysHQ";
     repo = "yosys";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-FzvdjdAURB5iCkGwsYY6A2wP/Je/IW4AOd4kVOEOeVc=";
+    hash = "sha256-sJaekoBnLEn7j56duQOFMkT4fELHNgkYCbcY6E8hgyA=";
     fetchSubmodules = true;
   };
+
+  postPatch = ''
+    patchShebangs tests
+    substituteInPlace tests/aiger/generate_mk.py \
+      --replace-fail 'SHELL := /usr/bin/env bash' 'SHELL := ${stdenv.shell}'
+    # these plugin tests only work against the installed output, so skip them.
+    rm tests/various/plugin.sh tests/various/ezcmdline_plugin.sh
+  '';
 
   enableParallelBuilding = true;
 
   nativeBuildInputs = [
     bison
+    cmake
     flex
+    ninja
     pkg-config
+    pythonEnv
   ];
 
-  propagatedBuildInputs = [
+  buildInputs = [
+    gtest
     libffi
     readline
     tcl
     zlib
-    (python3.withPackages (
-      pp: with pp; [
-        click
-        cxxheaderparser
-        pybind11
-      ]
-    ))
   ]
   ++ lib.optionals enablePython [
-    python3.pkgs.boost
+    python3
   ];
 
-  makeFlags = [
-    "PREFIX=${placeholder "out"}"
-    "YOSYS_VER=${finalAttrs.version}"
+  cmakeFlags = [
+    (lib.cmakeBool "YOSYS_SKIP_ABC_SUBMODULE_CHECK" true)
+    (lib.cmakeFeature "YOSYS_CHECKOUT_INFO" "v${finalAttrs.version}")
+    # slang is not packaged yet.
+    (lib.cmakeBool "YOSYS_WITHOUT_SLANG" true)
+    (lib.cmakeBool "YOSYS_WITH_PYTHON" enablePython)
+  ]
+  ++ lib.optionals enablePython [
+    (lib.cmakeBool "YOSYS_INSTALL_PYTHON" true)
+    (lib.cmakeFeature "YOSYS_INSTALL_PYTHON_SITEDIR" "${placeholder "out"}/${python3.sitePackages}")
   ];
-
-  postPatch = ''
-    substituteInPlace Makefile \
-      --replace-fail 'GIT_REV := $(shell GIT_DIR=$(YOSYS_SRC)/.git git rev-parse --short=9 HEAD || echo UNKNOWN)' 'GIT_REV := v${finalAttrs.version}' \
-      --replace-fail 'GIT_DIRTY := $(shell GIT_DIR=$(YOSYS_SRC)/.git git diff --exit-code --quiet 2>/dev/null; if [ $$? -ne 0 ]; then echo "-dirty"; fi)' 'GIT_DIRTY := ""'
-
-    substituteInPlace Makefile \
-      --replace-fail "| check-git-abc" ""
-
-    substituteInPlace Makefile \
-      --replace-fail 'new=$$(cd abc 2>/dev/null && git rev-parse HEAD 2>/dev/null || echo none)' 'new=none'
-
-    sed -i 's/^YOSYS_VER :=.*/YOSYS_VER := ${finalAttrs.version}/' Makefile
-
-    patchShebangs tests ./misc/yosys-config.in
-  '';
-
-  preBuild = ''
-    chmod -R u+w .
-    make config-${if stdenv.cc.isClang or false then "clang" else "gcc"}
-
-    if ! grep -q "YOSYS_VER := ${finalAttrs.version}" Makefile; then
-      echo "ERROR: yosys version in Makefile isn't equivalent to version of the nix package, failing."
-      exit 1
-    fi
-  ''
-  + lib.optionalString enablePython ''
-    echo "PYOSYS_USE_UV := 0" >> Makefile.conf
-    echo "ENABLE_PYOSYS := 1" >> Makefile.conf
-    echo "PYTHON_DESTDIR := $out/${python3.sitePackages}" >> Makefile.conf
-    echo "BOOST_PYTHON_LIB := -lboost_python${lib.versions.major python3.version}${lib.versions.minor python3.version}" >> Makefile.conf
-  '';
-
-  preCheck = ''
-    tests/tools/autotest.sh
-  '';
 
   checkTarget = "test";
   doCheck = true;

--- a/pkgs/development/compilers/yosys/plugins/bluespec.nix
+++ b/pkgs/development/compilers/yosys/plugins/bluespec.nix
@@ -21,6 +21,12 @@ stdenv.mkDerivation {
     sha256 = "sha256-3cNFP/k4JsgLyUQHWU10Htl2Rh0staAcA3R4piD6hDE=";
   };
 
+  # yosys >=0.67 headers require C++20; the Makefile otherwise pins c++17.
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail '-std=c++17' '-std=c++20'
+  '';
+
   buildInputs = [
     yosys
     readline

--- a/pkgs/development/compilers/yosys/plugins/symbiflow.nix
+++ b/pkgs/development/compilers/yosys/plugins/symbiflow.nix
@@ -103,6 +103,8 @@ lib.genAttrs plugins (
       description = "Symbiflow ${plugin} plugin for Yosys";
       license = lib.licenses.isc;
       platforms = lib.platforms.all;
+      # incompatible with yosys >= 0.67
+      broken = true;
       maintainers = with lib.maintainers; [
         ollieB
         thoughtpolice


### PR DESCRIPTION
symbiflow marked broken, incompatible with 0.67. upstream looks dead so it'll probably need removing later.

slang left off, packaged separately in #472800.

changelog: https://github.com/YosysHQ/yosys/releases/tag/v0.67
compare: https://github.com/YosysHQ/yosys/compare/v0.62...v0.67

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
