### PR TITLE
python3Packages.seekpath: 2.2.0 -> 2.2.1

### DIFF
--- a/pkgs/development/python-modules/seekpath/default.nix
+++ b/pkgs/development/python-modules/seekpath/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "seekpath";
-  version = "2.2.0";
+  version = "2.2.1";
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "giovannipizzi";
+    owner = "materialscloud-org";
     repo = "seekpath";
     tag = "v${version}";
-    hash = "sha256-mrutQCSSiiLPt0KEohZeYcQ8aw2Jhy02bEvn6Of8w6U=";
+    hash = "sha256-yz9IX68AmFP8P8uzZMKa4d/pdzbOm0IcQsZMvC7MuSU=";
   };
 
   env.LC_ALL = "en_US.utf-8";
@@ -43,7 +43,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Module to obtain and visualize band paths in the Brillouin zone of crystal structures";
-    homepage = "https://github.com/giovannipizzi/seekpath";
+    homepage = "https://github.com/materialscloud-org/seekpath";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ psyanticy ];
   };


### PR DESCRIPTION
Updates seekpath to 2.2.1 and follows the upstream repository transfer to `materialscloud-org`.

Changelog: https://github.com/materialscloud-org/seekpath/blob/v2.2.1/CHANGELOG.md#v221

Supersedes #502993 by addressing the requested repository-owner change.

## Things done

- [x] Built on x86_64-linux with `nix build .#python3Packages.seekpath`.
- [x] Package test suite: 76 tests passed; runtime dependency and import checks passed.
- [x] `nixpkgs-review rev HEAD -b master -p python3Packages.seekpath --no-shell`: 1 package built.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)
