### PR TITLE
vvenc: fix pkg-config paths

### DIFF
--- a/pkgs/by-name/vv/vvenc/package.nix
+++ b/pkgs/by-name/vv/vvenc/package.nix
@@ -44,6 +44,16 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
   ];
 
+  postPatch = ''
+    substituteInPlace pkgconfig/libvvenc.pc.in \
+      --replace-fail \
+        'libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@' \
+        'libdir=@CMAKE_INSTALL_FULL_LIBDIR@' \
+      --replace-fail \
+        'includedir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@' \
+        'includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@'
+  '';
+
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   passthru = {


### PR DESCRIPTION
I recently ran into some issues trying to build my desktop's system (it has CUDA support enabled globally). `ffmpeg-full` was failing to build due to `ERROR: libvvenc >= 1.6.1 not found using pkg-config`, see below.

<details>

<summary>nix log /nix/store/x48clysdvj4l01yda26qxc2sin5ayd6z-ffmpeg-full-8.1.2.drv</summary>

```
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/lrsm8w8023kpna6kpw4kr4ixgkm850i9-ffmpeg
source root is ffmpeg
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
applying patch /nix/store/8ysv026pzkq2rab89wfvz4sf91ddqdv3-nvccflags-cpp14.patch
patching file configure
Hunk #1 succeeded at 7106 (offset 364 lines).
applying patch /nix/store/6v7njhg0nxy4lhs892fmg94rmygvdk0h-add-av_stream_get_first_dts-for-chromium.patch
patching file libavformat/avformat.h
Hunk #1 succeeded at 1178 with fuzz 2 (offset 50 lines).
patching file libavformat/mux_utils.c
Hunk #1 succeeded at 29 with fuzz 2 (offset -8 lines).
patching script interpreter paths in .
./compat/solaris/make_sunver.pl: interpreter directive changed from "#!/usr/bin/env perl" to "/nix/store/cc9zsahxyx5my7bqid4dzkljw2dd9ygm-perl-5.42.0/bin/perl"
./compat/windows/makedef: interpreter directive changed from "#!/bin/sh" to "/nix/store/v8llyqw71lygr2llhmcc8ya5bdlzq45v-bash-5.3p9/bin/sh"
./compat/windows/mslink: interpreter directive changed from "#!/bin/sh" to "/nix/store/v8llyqw71lygr2llhmcc8ya5bdlzq45v-bash-5.3p9/bin/sh"
./compat/windows/mswindres: interpreter directive changed from "#!/bin/sh" to "/nix/store/v8llyqw71lygr2llhmcc8ya5bdlzq45v-bash-5.3p9/bin/sh"
./doc/doxy-wrapper.sh: interpreter directive changed from "#!/bin/sh" to "/nix/store/v8llyqw71lygr2llhmcc8ya5bdlzq45v-bash-5.3p9/bin/sh"
./doc/texi2pod.pl: interpreter directive changed from "#!/usr/bin/env perl" to "/nix/store/cc9zsahxyx5my7bqid4dzkljw2dd9ygm-perl-5.42.0/bin/perl"
./doc/texidep.pl: interpreter directive changed from "#!/usr/bin/env perl" to "/nix/store/cc9zsahxyx5my7bqid4dzkljw2dd9ygm-perl-5.42.0/bin/perl"
./ffbuild/libversion.sh: interpreter directive changed from "#!/bin/sh" to "/nix/store/v8llyqw71lygr2llhmcc8ya5bdlzq45v-bash-5.3p9/bin/sh"
./ffbuild/pkgconfig_generate.sh: interpreter directive changed from "#!/bin/sh" to "/nix/store/v8llyqw71lygr2llhmcc8ya5bdlzq45v-bash-5.3p9/bin/sh"
./ffbuild/version.sh: interpreter directive changed from "#!/bin/sh" to "/nix/store/v8llyqw71lygr2llhmcc8ya5bdlzq45v-bash-5.3p9/bin/sh"
./tests/copycooker.sh: interpreter directive changed from "#!/bin/sh" to "/nix/store/v8llyqw71lygr2llhmcc8ya5bdlzq45v-bash-5.3p9/bin/sh"
./tests/fate/source-check.sh: interpreter directive changed from "#!/bin/sh" to "/nix/store/v8llyqw71lygr2llhmcc8ya5bdlzq45v-bash-5.3p9/bin/sh"
./tests/fate-run.sh: interpreter directive changed from "#!/bin/sh" to "/nix/store/v8llyqw71lygr2llhmcc8ya5bdlzq45v-bash-5.3p9/bin/sh"
./tests/fate.sh: interpreter directive changed from "#!/bin/sh" to "/nix/store/v8llyqw71lygr2llhmcc8ya5bdlzq45v-bash-5.3p9/bin/sh"
./tools/bisect-create: interpreter directive changed from "#!/bin/sh" to "/nix/store/v8llyqw71lygr2llhmcc8ya5bdlzq45v-bash-5.3p9/bin/sh"
./tools/check_arm_indent.sh: interpreter directive changed from "#!/bin/sh" to "/nix/store/v8llyqw71lygr2llhmcc8ya5bdlzq45v-bash-5.3p9/bin/sh"
./tools/clean-diff: interpreter directive changed from "#!/bin/sh" to "/nix/store/v8llyqw71lygr2llhmcc8ya5bdlzq45v-bash-5.3p9/bin/sh"
./tools/compare-cvelists.sh: interpreter directive changed from "#!/bin/bash" to "/nix/store/v8llyqw71lygr2llhmcc8ya5bdlzq45v-bash-5.3p9/bin/bash"
./tools/dvd2concat: interpreter directive changed from "#!/usr/bin/env perl" to "/nix/store/cc9zsahxyx5my7bqid4dzkljw2dd9ygm-perl-5.42.0/bin/perl"
./tools/gen-rc: interpreter directive changed from "#!/bin/sh" to "/nix/store/v8llyqw71lygr2llhmcc8ya5bdlzq45v-bash-5.3p9/bin/sh"
./tools/general_assembly.pl: interpreter directive changed from "#!/usr/bin/env perl" to "/nix/store/cc9zsahxyx5my7bqid4dzkljw2dd9ygm-perl-5.42.0/bin/perl"
./tools/indent_arm_assembly.pl: interpreter directive changed from "#!/usr/bin/env perl" to "/nix/store/cc9zsahxyx5my7bqid4dzkljw2dd9ygm-perl-5.42.0/bin/perl"
./tools/make_chlayout_test: interpreter directive changed from "#!/usr/bin/env perl" to "/nix/store/cc9zsahxyx5my7bqid4dzkljw2dd9ygm-perl-5.42.0/bin/perl"
./tools/merge-all-source-plugins: interpreter directive changed from "#!/bin/sh" to "/nix/store/v8llyqw71lygr2llhmcc8ya5bdlzq45v-bash-5.3p9/bin/sh"
./tools/missing_codec_desc: interpreter directive changed from "#!/bin/sh" to "/nix/store/v8llyqw71lygr2llhmcc8ya5bdlzq45v-bash-5.3p9/bin/sh"
./tools/murge: interpreter directive changed from "#!/bin/sh" to "/nix/store/v8llyqw71lygr2llhmcc8ya5bdlzq45v-bash-5.3p9/bin/sh"
./tools/patcheck: interpreter directive changed from "#!/bin/sh" to "/nix/store/v8llyqw71lygr2llhmcc8ya5bdlzq45v-bash-5.3p9/bin/sh"
./tools/plotframes: interpreter directive changed from "#!/usr/bin/env perl" to "/nix/store/cc9zsahxyx5my7bqid4dzkljw2dd9ygm-perl-5.42.0/bin/perl"
./tools/source2c: interpreter directive changed from "#!/bin/sh" to "/nix/store/v8llyqw71lygr2llhmcc8ya5bdlzq45v-bash-5.3p9/bin/sh"
./tools/target_dec_fate.sh: interpreter directive changed from "#!/bin/sh" to "/nix/store/v8llyqw71lygr2llhmcc8ya5bdlzq45v-bash-5.3p9/bin/sh"
./tools/unwrap-diff: interpreter directive changed from "#!/bin/sh" to "/nix/store/v8llyqw71lygr2llhmcc8ya5bdlzq45v-bash-5.3p9/bin/sh"
./configure.orig: interpreter directive changed from "#!/bin/sh" to "/nix/store/v8llyqw71lygr2llhmcc8ya5bdlzq45v-bash-5.3p9/bin/sh"
./configure: interpreter directive changed from "#!/bin/sh" to "/nix/store/v8llyqw71lygr2llhmcc8ya5bdlzq45v-bash-5.3p9/bin/sh"
substituteStream() in derivation ffmpeg-full-8.1.2: WARNING: '--replace' is deprecated, use --replace-{fail,warn,quiet}. (file 'libavfilter/vf_frei0r.c')
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
patching script interpreter paths in ./configure
configure flags: --disable-static --prefix=/nix/store/m9vxjrrw41yqb8g9pywrclr5w52b2pmb-ffmpeg-full-8.1.2 --target_os=linux --arch=x86_64 --pkg-config=pkg-config --enable-gpl --enable-version3 --disable-nonfree --disable-static --enable-shared --enable-pic --disable-thumb --disable-small --enable-runtime-cpudetect --enable-gray --enable-swscale-alpha --enable-hardcoded-tables --enable-safe-bitstream-reader --enable-pthreads --disable-w32threads --disable-os2threads --enable-network --enable-pixelutils --datadir=/nix/store/qssx1v36vbiv7l3llyqvssdr7m35z27p-ffmpeg-full-8.1.2-data/share/ffmpeg --enable-ffmpeg --enable-ffplay --enable-ffprobe --bindir=/nix/store/4hq4y9pzv0kkapp5w4nj5rhw2ic0h1bq-ffmpeg-full-8.1.2-bin/bin --enable-avcodec --enable-avdevice --enable-avfilter --enable-avformat --enable-avutil --enable-swresample --enable-swscale --libdir=/nix/store/6dpd7n85zybv8hhb0jrhk73x14qc9rqv-ffmpeg-full-8.1.2-lib/lib --incdir=/nix/store/4xri2vpms0nvn1nchs0q7cfphj9idmc1-ffmpeg-full-8.1.2-dev/include --enable-doc --enable-htmlpages --enable-manpages --mandir=/nix/store/gjrq9fc4dm7kb2bqxsgkmwmlcd0lmmp0-ffmpeg-full-8.1.2-man/share/man --enable-podpages --enable-txtpages --docdir=/nix/store/b9i6l160mjnbhbccm90nq84y7jpnf2dh-ffmpeg-full-8.1.2-doc/share/doc/ffmpeg --enable-alsa --enable-amf --enable-libaom --enable-libaribb24 --enable-libaribcaption --enable-libass --enable-avisynth --enable-libbluray --enable-libbs2b --enable-bzlib --enable-libcaca --enable-libcdio --enable-libcelt --enable-chromaprint --enable-libcodec2 --enable-cuda --enable-cuda-llvm --disable-cuda-nvcc --enable-cuvid --enable-libdav1d --enable-libdavs2 --enable-libdc1394 --enable-libdrm --enable-libdvdnav --enable-libdvdread --disable-libfdk-aac --enable-ffnvcodec --enable-libflite --enable-fontconfig --enable-libfontconfig --enable-libfreetype --enable-frei0r --enable-libfribidi --enable-libgme --enable-gmp --enable-gnutls --enable-libgsm --enable-libharfbuzz --enable-iconv --enable-libilbc --enable-libjack --enable-libjxl --enable-libkvazaar --enable-ladspa --enable-liblc3 --enable-liblcevc-dec --enable-lcms2 --enable-lzma --disable-metal --disable-libmfx --enable-libmodplug --enable-libmp3lame --enable-libmysofa --disable-libnpp --enable-nvdec --enable-nvenc --enable-openal --enable-liboapv --enable-opencl --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-opengl --enable-libopenh264 --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libplacebo --enable-libpulse --enable-libqrencode --enable-libquirc --enable-librav1e --enable-librist --disable-librtmp --enable-librubberband --enable-libsmbclient --enable-sdl2 --enable-libshaderc --enable-libshine --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libsrt --enable-libssh --enable-librsvg --enable-libsvtav1 --disable-libtensorflow --enable-libtheora --enable-libtwolame --enable-libuavs3d --enable-libv4l2 --enable-v4l2-m2m --enable-vaapi --enable-vdpau --enable-libvpl --enable-libvidstab --enable-libvmaf --enable-libvo-amrwbenc --enable-libvorbis --enable-libvpx --enable-vulkan --enable-libvvenc --enable-libwebp --enable-whisper --enable-libx264 --enable-libx265 --enable-libxavs --enable-libxavs2 --enable-libxcb --enable-libxcb-shape --enable-libxcb-shm --enable-libxcb-xfixes --enable-libxevd --enable-libxeve --enable-xlib --enable-libxml2 --enable-libxvid --enable-libzimg --enable-zlib --enable-libzmq --enable-libzvbi --disable-debug --enable-optimizations --disable-extra-warnings --disable-stripping
./configure: line 1036: 29038 Aborted                    (core dumped) "$@" >> $logfile 2>&1
./configure: line 1036: 29046 Aborted                    (core dumped) "$@" >> $logfile 2>&1
./configure: line 1036: 29058 Aborted                    (core dumped) "$@" >> $logfile 2>&1
./configure: line 1036: 29066 Aborted                    (core dumped) "$@" >> $logfile 2>&1
./configure: line 1036: 29078 Aborted                    (core dumped) "$@" >> $logfile 2>&1
ERROR: libvvenc >= 1.6.1 not found using pkg-config

If you think configure made a mistake, make sure you are using the latest
version from Git.  If the latest version fails, report the problem to the
ffmpeg-user@ffmpeg.org mailing list or IRC #ffmpeg on irc.libera.chat.
Include the log file "ffbuild/config.log" produced by configure as this will help
solve the problem.
```

</details>

I believe the issue then (and it fixes my build) is that `CMAKE_INSTALL_LIBDIR` is already absolute, and so `libvvenc` is prepending `CMAKE_INSTALL_PREFIX` anyway, leading to a bad path.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
