### PR TITLE
helm-secrets: Fix CLI compatibility with Helm v4

### DIFF
--- a/pkgs/applications/networking/cluster/helm/plugins/helm-secrets.nix
+++ b/pkgs/applications/networking/cluster/helm/plugins/helm-secrets.nix
@@ -40,8 +40,8 @@ stdenv.mkDerivation rec {
     runHook preInstall
 
     install -dm755 $out/helm-secrets $out/helm-secrets/scripts
-    install -m644 -Dt $out/helm-secrets plugin.yaml
-    cp -r scripts/* $out/helm-secrets/scripts
+    install -m644 -Dt $out/helm-secrets plugins/helm-secrets-cli/plugin.yaml
+    cp -r plugins/helm-secrets-cli/scripts/* $out/helm-secrets/scripts
     wrapProgram $out/helm-secrets/scripts/run.sh \
         --prefix PATH : ${
           lib.makeBinPath [


### PR DESCRIPTION
Fixes #536239, patch as discussed there with @yurrriq.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
