### PR TITLE
glasgow: fix build

### DIFF
--- a/pkgs/by-name/gl/glasgow/package.nix
+++ b/pkgs/by-name/gl/glasgow/package.nix
@@ -2,13 +2,30 @@
   lib,
   python3,
   fetchFromGitHub,
+  fetchPypi,
   sdcc,
   yosys,
   icestorm,
   nextpnr,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+let
+  # glasgow uses importlib_resources' open_text(), removed in 7.x; pin it to 6.x.
+  pythonPackages = python3.pkgs.overrideScope (
+    final: prev: {
+      importlib-resources = prev.importlib-resources.overridePythonAttrs (old: rec {
+        version = "6.5.2";
+        src = fetchPypi {
+          pname = "importlib_resources";
+          inherit version;
+          hash = "sha256-GF+Hre9bzCiESdmPtPugfOp4vANkVd1ExfxKL+eP7Sw=";
+        };
+        doCheck = false;
+      });
+    }
+  );
+in
+pythonPackages.buildPythonApplication rec {
   pname = "glasgow";
   version = "0-unstable-2025-12-22";
   # Similar to `pdm show`, but without the commit counter
@@ -36,10 +53,10 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   build-system = [
-    python3.pkgs.pdm-backend
+    pythonPackages.pdm-backend
   ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = with pythonPackages; [
     aiohttp
     amaranth
     cobs
@@ -54,7 +71,7 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeCheckInputs = [
     # pytestCheckHook discovers way less tests
-    python3.pkgs.unittestCheckHook
+    pythonPackages.unittestCheckHook
     icestorm
     nextpnr
     yosys
@@ -67,10 +84,10 @@ python3.pkgs.buildPythonApplication rec {
   __darwinAllowLocalNetworking = true;
 
   preBuild = ''
-    make -C firmware GIT_REV_SHORT=${firmwareGitRev} LIBFX2=${python3.pkgs.fx2}/share/libfx2
+    make -C firmware GIT_REV_SHORT=${firmwareGitRev} LIBFX2=${pythonPackages.fx2}/share/libfx2
 
     # Normalize the .ihex file, see ./software/deploy-firmware.sh.
-    ${python3.withPackages (p: [ p.fx2 ])}/bin/python firmware/normalize.py \
+    ${pythonPackages.python.withPackages (p: [ p.fx2 ])}/bin/python firmware/normalize.py \
       firmware/glasgow.ihex firmware/glasgow.ihex
 
     # Ensure the compiled firmware is exactly the same as the one shipped in the repo.


### PR DESCRIPTION
importlib-resources is now 7.x, which dropped the `open_text()` API glasgow uses (upstream still pins `~=6.5.2`). pin it to 6.5.2 just for glasgow so it builds again.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
