### PR TITLE
daqp: init at 0.9.1, python3Packages.daqp: 0.8.4 -> 0.9.1, tsid: add daqp support

### DIFF
--- a/pkgs/by-name/da/daqp/package.nix
+++ b/pkgs/by-name/da/daqp/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  eigen,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "daqp";
+  version = "0.9.1";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "darnstrom";
+    repo = "daqp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ms+N/m33zqO0qgtQykOI++eCkDPf50qf8lbi+tO5ae0=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    eigen
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "EIGEN" true)
+  ];
+
+  doCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/darnstrom/daqp/releases/tag/${finalAttrs.src.tag}";
+    description = "Dual active-set algorithm for convex quadratic programming";
+    homepage = "https://github.com/darnstrom/daqp";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      nim65s
+      renesat
+    ];
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
+  };
+})

--- a/pkgs/by-name/ts/tsid/package.nix
+++ b/pkgs/by-name/ts/tsid/package.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   jrl-cmakemodules,
   lib,
+  daqp,
   osqp-eigen,
   pinocchio,
   proxsuite,
@@ -22,6 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = jrl-cmakemodules.docsCmakeFlags ++ [
     (lib.cmakeBool "BUILD_PYTHON_INTERFACE" false)
+    (lib.cmakeBool "BUILD_WITH_DAQP" true)
     (lib.cmakeBool "BUILD_WITH_OSQP" true)
     (lib.cmakeBool "BUILD_WITH_PROXQP" true)
     (lib.cmakeBool "INSTALL_DOCUMENTATION" true)
@@ -39,6 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   propagatedBuildInputs = [
+    daqp
     eiquadprog
     osqp-eigen
     pinocchio

--- a/pkgs/development/python-modules/daqp/default.nix
+++ b/pkgs/development/python-modules/daqp/default.nix
@@ -9,21 +9,20 @@
 }:
 buildPythonPackage (finalAttrs: {
   pname = "daqp";
-  version = "0.8.4";
+  version = "0.9.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "darnstrom";
     repo = "daqp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-UakuHHsz4LXDfI7+VT5TO+jg90gpgu3lTJL8RGhtODQ=";
+    hash = "sha256-ms+N/m33zqO0qgtQykOI++eCkDPf50qf8lbi+tO5ae0=";
   };
 
   # Don't try to `rmtree` to "Cleanup C-source"
-  # TODO: to update on next release, master already has `if daqp_src_exists:`
   postPatch = ''
     substituteInPlace setup.py --replace-fail \
-      "if src_path.exists():" \
+      "if daqp_src_exists:" \
       "if False:"
   '';
 


### PR DESCRIPTION
Hi,

This add `pkgs.daqp`, and update `python3Packages.daqp` to re-use what it can from it: I think we should keep those in sync.

@renesat: I added you as maintainer of `pkgs.daqp`, but obviously if this is an issue we can avoid that.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
