### PR TITLE
home-assistant-custom-component.hochwasserportal: init at 1.0.8

### DIFF
--- a/pkgs/development/python-modules/lhpapi/default.nix
+++ b/pkgs/development/python-modules/lhpapi/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  beautifulsoup4,
+  lxml,
+  hatchling,
+  requests,
+  tzdata,
+  buildPythonPackage,
+  fetchFromGitHub,
+}:
+
+buildPythonPackage rec {
+  pname = "lhpapi";
+  version = "1.0.10";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "stephan192";
+    repo = "lhpapi";
+    tag = "v${version}";
+    hash = "sha256-Q9X1STaWWbWWy8wmCQ3Cx+z19+X3EcGl0u/Mmc49rAM=";
+  };
+
+  dependencies = [
+    beautifulsoup4
+    lxml
+    requests
+    tzdata
+  ];
+
+  build-system = [ hatchling ];
+
+  pythonImportsCheck = [ "lhpapi" ];
+
+  meta = {
+    description = "API to retrieve data from the Länderübergreifendes Hochwasser Portal (LHP)";
+    homepage = "https://github.com/stephan192/lhpapi";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ _9R ];
+  };
+}

--- a/pkgs/servers/home-assistant/custom-components/hochwasserportal/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/hochwasserportal/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  pytest-homeassistant-custom-component,
+
+  # dependency
+  lhpapi,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "stephan192";
+  domain = "hochwasserportal";
+  version = "1.0.8";
+
+  src = fetchFromGitHub {
+    owner = "stephan192";
+    repo = "hochwasserportal";
+    tag = "v${version}";
+    hash = "sha256-q2usHeWcx/1UrM7MQ156SFy8cFIiCcsmIr6721hzSLI=";
+  };
+
+  dependencies = [
+    lhpapi
+  ];
+
+  nativeCheckInputs = [
+    pytest-homeassistant-custom-component
+  ];
+
+  meta = {
+    changelog = "https://github.com/stephan192/hochwasserportal/releases/tag/${version}";
+    description = "Home Assistant integration for Länderübergreifendes Hochwasser Portal";
+    homepage = "https://github.com/stephan192/hochwasserportal";
+    maintainers = with lib.maintainers; [ _9R ];
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9178,6 +9178,8 @@ self: super: with self; {
 
   lhapdf = toPythonModule (pkgs.lhapdf.override { python3 = python; });
 
+  lhpapi = callPackage ../development/python-modules/lhpapi { };
+
   lib4package = callPackage ../development/python-modules/lib4package { };
 
   lib4sbom = callPackage ../development/python-modules/lib4sbom { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds the home-assistant custom component hochwasserportal and it's missing dependency, the python library lhpapi. The integration allows monitoring of river levels in Germany as well as some neighbouring countries.

https://github.com/stephan192/hochwasserportal
https://github.com/stephan192/lhpapi

Functionality was tested and it works as expected.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
