### PR TITLE
qbz: 1.2.15 -> 2.0.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -30328,6 +30328,11 @@
     githubId = 50072577;
     keys = [ { fingerprint = "309D A29B 4070 FDFD C01A  3AB4 9E60 CB44 5C4B BC4C"; } ];
   };
+  vicrodh = {
+    github = "vicrodh";
+    githubId = 103399283;
+    name = "Victor RH";
+  };
   videl = {
     email = "thibaut.smith@mailbox.org";
     github = "videl";

--- a/pkgs/by-name/qb/qbz/package.nix
+++ b/pkgs/by-name/qb/qbz/package.nix
@@ -1,98 +1,101 @@
 {
   alsa-lib,
-  cargo-tauri,
+  autoPatchelfHook,
   clang,
+  cmake,
   fetchFromGitHub,
-  fetchNpmDeps,
-  glib-networking,
+  fontconfig,
+  freetype,
   lib,
-  libappindicator,
-  libayatana-appindicator,
+  libglvnd,
+  libjack2,
+  libx11,
+  libxcursor,
+  libxi,
+  libxkbcommon,
   llvmPackages,
   makeWrapper,
+  nasm,
   nix-update-script,
-  nodejs,
-  npmHooks,
-  openssl,
-  pipewire, # pw-metadata for bit-perfect sample rate queries
+  pipewire, # pw-metadata/pw-dump for bit-perfect sample rate queries and DAC detection
   pkg-config,
   pulseaudio, # pactl for PipeWire device enumeration and sink routing
   rustPlatform,
-  webkitgtk_4_1,
-  wrapGAppsHook3,
+  vulkan-loader,
+  wayland,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "qbz";
-  version = "1.2.15";
+  version = "2.0.2";
 
   src = fetchFromGitHub {
     owner = "vicrodh";
     repo = "qbz";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-G7wR5HV0qwlrCPmKTv68+EeDTTyCAvvmPr7GDhrwTaA=";
+    hash = "sha256-zseGL7IcH/fdc4TDVwU3Tml1X6wCvSaYCji5D5RxAuA=";
   };
 
-  cargoHash = "sha256-nF3hoKn6NA5uuRLgKit83Yxqrc0r+/IaI+xFjrw+oG8=";
-  cargoRoot = "src-tauri";
+  cargoHash = "sha256-FPDyn61rO/hW9gEUU/yo+mXhnamwwXU1mj3wGQpHA3o=";
+  cargoRoot = "crates";
   buildAndTestSubdir = finalAttrs.cargoRoot;
 
-  tauriBuildFlags = [ "--no-sign" ];
-
-  npmDeps = fetchNpmDeps {
-    name = "qbz-${finalAttrs.version}-npm-deps";
-    inherit (finalAttrs) src;
-    hash = "sha256-RIR3erHN27fU9tTNQdUK0/5QDS9Dgd+O03PfqlYfRcM=";
-  };
-
-  env.LIBCLANG_PATH = "${lib.getLib llvmPackages.libclang}/lib";
-
   nativeBuildInputs = [
-    cargo-tauri.hook
-    clang
     makeWrapper
-    nodejs
-    npmHooks.npmConfigHook
     pkg-config
-    wrapGAppsHook3
+    autoPatchelfHook
   ];
 
   buildInputs = [
     alsa-lib
-    libappindicator
-    openssl
-    webkitgtk_4_1
+    fontconfig
+    freetype
+    libjack2
   ];
 
+  runtimeDependencies = [
+    libglvnd
+    libxkbcommon
+    libx11
+    libxcursor
+    libxi
+    vulkan-loader
+    wayland
+  ];
+
+  # The generated Slint UI module is a single very large compilation unit;
+  # running the test profile on top of the build doubles wall time and memory
+  # for no packaging value. Engine crates are tested in upstream CI.
   doCheck = false;
 
   postInstall = ''
-    gappsWrapperArgs+=(
+    wrapProgram $out/bin/qbz \
       --prefix PATH : ${
         lib.makeBinPath [
           pulseaudio
           pipewire
         ]
       }
-      --prefix LD_LIBRARY_PATH : ${
-        lib.makeLibraryPath [
-          libappindicator
-          libayatana-appindicator
-        ]
-      }
-      --prefix GIO_EXTRA_MODULES : "${glib-networking}/lib/gio/modules"
-    )
+
+    install -Dm644 $src/packaging/linux/qbz.desktop \
+      $out/share/applications/qbz.desktop
+    for size in 32 48 64 128 256 512; do
+      install -Dm644 $src/packaging/icons/"$size"x"$size".png \
+        $out/share/icons/hicolor/"$size"x"$size"/apps/qbz.png
+    done
   '';
 
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "A native, full-featured hi-fi Qobuz desktop player for Linux, with fast, bit-perfect audio playback";
+    description = "Native, full-featured hi-fi Qobuz desktop player for Linux, with fast, bit-perfect audio playback";
     homepage = "https://qbz.lol";
     changelog = "https://github.com/vicrodh/qbz/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       felixsinger
+      vicrodh
+      fpletz
     ];
     mainProgram = "qbz";
     platforms = lib.platforms.linux;


### PR DESCRIPTION
qbz 2.0 replaced the Tauri/webview frontend with a native Slint UI in a single Rust binary, so this is not a plain version bump, the derivation is rewritten. No more npm / cargo-tauri / webkitgtk, just plain buildRustPackage over the crates/ workspace. Changelog: https://github.com/vicrodh/qbz/releases/tag/v2.0.2

I'm the upstream author. Adding myself as co-maintainer next to @felixsinger who packaged qbz originally.

Heads up for reviewers: the generated Slint UI crate is one huge compilation unit and the release rustc for it peaks around 25-30 GB. My machine has 30GB so I couldnt run the full nix build locally, I verified vendoring, eval and formatting only. On Flathub and snapcraft we hit the same wall and ship from prebuilt binaries instead. I expect nixpkgs builders to handle the source build but wanted to be upfront about it.

Runtime wrapping keeps pactl/pw-metadata in PATH like 1.2.x (the app calls them for bit-perfect device queries) and adds the dlopen'd display/GPU libs to LD_LIBRARY_PATH.

Disclosure per the automation/AI policy: we rely heavily on agents (Claude and Codex) for development. Design and development practices still follow SOLID methodologies and best practices like ADRs, and the same criteria is applied to PRs recieved from contributors. This derivation is based on the nix flake I maintain upstream and was reviewed by me.

## Things done

- Built on platform:
  - [x] x86_64-linux (see note above, could not complete locally)
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests).
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`.
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.
- [x] Follows the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy).

