### PR TITLE
[backport staging-26.05] gst_all_1.gst-plugins-good: fix GStreamer-SA-2026-0021 and GStreamer-SA-2026-0022

### DIFF
--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -108,6 +108,13 @@ stdenv.mkDerivation (finalAttrs: {
       sha256 = "sha256-a8P1YxLNMkYka01+8MhBO+uSzGbR186sumlQk5LuGfY=";
       stripLen = 2;
     })
+    # https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/11263
+    (fetchpatch {
+      name = "GStreamer-SA-2026-0022.patch";
+      url = "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/6db6dd058ebc3607452311b7dc47b0359b40b293.patch";
+      sha256 = "sha256-gaBUpEdZB0PrnI1IR53jtM0kecHpUIzavUdADN1NNlQ=";
+      stripLen = 2;
+    })
   ];
 
   strictDeps = true;

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -95,6 +95,19 @@ stdenv.mkDerivation (finalAttrs: {
     (replaceVars ./souploader.diff {
       nixLibSoup3Path = "${lib.getLib libsoup_3}/lib";
     })
+    # https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/11262
+    (fetchpatch {
+      name = "GStreamer-SA-2026-0021-1.patch";
+      url = "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/35a905a92f4cfc85941c6c820009ac9219f755b2.patch";
+      sha256 = "sha256-1SgQo+wb2Adcgrz3zn6/qn248vnBdPuk2oJ1v9+Dbzo=";
+      stripLen = 2;
+    })
+    (fetchpatch {
+      name = "GStreamer-SA-2026-0021-2.patch";
+      url = "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/0d819ceb654b06bbdd54381da5363c16751758a2.patch";
+      sha256 = "sha256-a8P1YxLNMkYka01+8MhBO+uSzGbR186sumlQk5LuGfY=";
+      stripLen = 2;
+    })
   ];
 
   strictDeps = true;


### PR DESCRIPTION
This is a backport of security fixes from GStreamer 1.28 for:

- GStreamer-SA-2026-0021: https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/11262
- GStreamer-SA-2026-0022 :https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/11263

There is nothing to backport from unstable, because it is already on 1.28.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
