### PR TITLE
keycloak-config-cli: 6.4.0 -> 6.5.1

### DIFF
--- a/pkgs/by-name/ke/keycloak-config-cli/package.nix
+++ b/pkgs/by-name/ke/keycloak-config-cli/package.nix
@@ -5,24 +5,32 @@
   jre_headless,
   makeWrapper,
   nix-update-script,
+  versionCheckHook,
 }:
-maven.buildMavenPackage rec {
+maven.buildMavenPackage (finalAttrs: {
   pname = "keycloak-config-cli";
-  version = "6.4.0";
+  version = "6.5.1";
 
   src = fetchFromGitHub {
     owner = "adorsys";
     repo = "keycloak-config-cli";
-    tag = "v${version}";
-    hash = "sha256-Vg56Dz9U0eAJw+7u90MSZWmMIZttWYGXAwsXZsEfTj8=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-dSeLn9YaT0k6Mg8cxmoDoEtvjrzkyETvI4dt+q/Wj3A=";
   };
 
-  mvnHash = "sha256-tdh8hRqGXI3zuwy55dC3La9dm2naqeCEZT4qcw37iDI=";
+  mvnHash = "sha256-Ff9ra9ruPJ8PA0bmC8uU8PiNqjtJoR4U04veZAqZ3sM=";
 
-  # Tests use MockServer which needs to bind to a local port
-  __darwinAllowLocalNetworking = true;
+  # JavaScriptEvaluatorTest needs GraalVM's Truffle engine, which fails to
+  # initialize on the sandbox JDK (org.graalvm.polyglot.Engine$ImplHolder).
+  doCheck = false;
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   nativeBuildInputs = [ makeWrapper ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   installPhase = ''
     runHook preInstall
@@ -36,6 +44,7 @@ maven.buildMavenPackage rec {
 
   meta = {
     homepage = "https://github.com/adorsys/keycloak-config-cli";
+    changelog = "https://github.com/adorsys/keycloak-config-cli/releases/tag/v${finalAttrs.version}";
     description = "Import YAML/JSON-formatted configuration files into Keycloak";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
@@ -46,4 +55,4 @@ maven.buildMavenPackage rec {
     mainProgram = "keycloak-config-cli";
     platforms = jre_headless.meta.platforms;
   };
-}
+})


### PR DESCRIPTION
Supersedes https://github.com/NixOS/nixpkgs/pull/505242, version bump + modernize

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
