### PR TITLE
llvm_22: pick patch for selectiondag freeze condition miscompile

### DIFF
--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -230,6 +230,10 @@ stdenv.mkDerivation (
         # segfaulting code. The patch was made to LLVM 23, but the tests have
         # many conflicts, so we vendor a version-specific modified version.
         #
+        # This should be backported to older LLVM versions as well, but this
+        # has not yet been done in order to ship the more important fixes
+        # quickly.
+        #
         # Rust issue: https://github.com/rust-lang/rust/issues/159035
         # LLVM issue: https://github.com/llvm/llvm-project/issues/208611
         # LLVM PR: https://github.com/llvm/llvm-project/pull/208683

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -234,6 +234,18 @@ stdenv.mkDerivation (
         # LLVM issue: https://github.com/llvm/llvm-project/issues/208611
         # LLVM PR: https://github.com/llvm/llvm-project/pull/208683
         (getVersionFile "llvm/sdag-freeze-condition-in-select-of-load-fold.patch")
+      ]
+      ++ lib.optionals (lib.versions.major release_version == "22") [
+        # Same issue and fix as above, for LLVM 22. While LLVM 22 was EOL at
+        # the time of the LLVM PR, and was thus not backported upstream, the
+        # backport was made to Rust's LLVM fork on LLVM 22.1. Accordingly, we
+        # fetch the patch from there.
+        (fetchpatch {
+          name = "llvm-22-sdag-freeze-condition-in-select-of-load-fold.patch";
+          url = "https://github.com/rust-lang/llvm-project/commit/abcef279cd33492fe8301c8873fc535fa4dbf0d5.patch";
+          stripLen = 1;
+          hash = "sha256-HHVMVL7ZWiZkbfnD37zYxFWnfvI3LNS0Z2oFHhOaZsU=";
+        })
       ];
 
     nativeBuildInputs = [


### PR DESCRIPTION
see #542049. this commit backports that same change to LLVM 22. the fix is not available upstream since LLVM 22 is EOL, but we can pick the patch from the Rust fork of LLVM, as that is currently on version 22.1.

Rust issue: https://github.com/rust-lang/rust/issues/159035
Rust backport: https://github.com/rust-lang/llvm-project/commit/abcef279cd33492fe8301c8873fc535fa4dbf0d5
LLVM issue: https://github.com/llvm/llvm-project/issues/208611
LLVM PR: https://github.com/llvm/llvm-project/pull/208683

as per https://github.com/NixOS/nixpkgs/pull/542049#discussion_r3586948456, we also added a comment about backporting to older versions (18-20). we may not be the ones to do that backport (struggling with time and energy atm, and we only picked this up because we needed the 21 fix for staging-next and someone had to do it quickly), but it should probably be done at some point.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
