### PR TITLE
RFC: Supporting single-file C# scripts (File-based apps in .NET 10) in buildDotnetModule

### DIFF
--- a/pkgs/build-support/dotnet/build-dotnet-module/hook/dotnet-hook.sh
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hook/dotnet-hook.sh
@@ -13,7 +13,7 @@ dotnetConfigurePhase() {
   concatTo _rawProjectFiles dotnetProjectFiles
   local -a _convertedProjectFiles=()
   for f in "${_rawProjectFiles[@]}"; do
-    if [[ "$f" == *.cs || "$f" == *.fs ]]; then
+    if [[ "$f" == *.cs ]]; then
       dotnet project convert "$f"
       local baseName="${f##*/}"
       local baseNameNoExt="${baseName%.*}"

--- a/pkgs/build-support/dotnet/build-dotnet-module/hook/dotnet-hook.sh
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hook/dotnet-hook.sh
@@ -9,6 +9,38 @@ dotnetConfigurePhase() {
 
   runHook preConfigure
 
+  local -a _rawProjectFiles=()
+  concatTo _rawProjectFiles dotnetProjectFiles
+  local -a _convertedProjectFiles=()
+  for f in "${_rawProjectFiles[@]}"; do
+    if [[ "$f" == *.cs || "$f" == *.fs ]]; then
+      dotnet project convert "$f"
+      local baseName="${f##*/}"
+      local baseNameNoExt="${baseName%.*}"
+      local dirName="$(dirname "$f")"
+      _convertedProjectFiles+=("$dirName/$baseNameNoExt/$baseNameNoExt.csproj")
+    else
+      _convertedProjectFiles+=("$f")
+    fi
+  done
+  dotnetProjectFiles=("${_convertedProjectFiles[@]}")
+
+  local -a _rawTestProjectFiles=()
+  concatTo _rawTestProjectFiles dotnetTestProjectFiles
+  local -a _convertedTestProjectFiles=()
+  for f in "${_rawTestProjectFiles[@]}"; do
+    if [[ "$f" == *.cs || "$f" == *.fs ]]; then
+      dotnet project convert "$f"
+      local baseName="${f##*/}"
+      local baseNameNoExt="${baseName%.*}"
+      local dirName="$(dirname "$f")"
+      _convertedTestProjectFiles+=("$dirName/$baseNameNoExt/$baseNameNoExt.csproj")
+    else
+      _convertedTestProjectFiles+=("$f")
+    fi
+  done
+  dotnetTestProjectFiles=("${_convertedTestProjectFiles[@]}")
+
   local -a projectFiles flags runtimeIds
   concatTo projectFiles dotnetProjectFiles dotnetTestProjectFiles
   concatTo flags dotnetFlags dotnetRestoreFlags


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

.NET 10 introduced support for File-based apps, allowing us to run C# scripts directly using `dotnet run script.cs` without needing a project file. This feature is incredibly practical—especially on Linux—and I’ve personally started using it as an alternative to Python or Shell scripts. I’m wondering if we could provide better support for this.

I know that we could easily write a `.cs` file and run it at runtime (similar to how `writeShellScriptBin` works). However, performing the build step at compile time (e.g., during the `nix-build` phase) would yield much better runtime performance. More importantly, it allows us to perform static analysis and checks beforehand—which is a major advantage of C# over Python or Shell scripts.

Compared to shipping a full `.csproj` project, a standalone `.cs` file is much easier to distribute alongside `.nix` files. It could be referenced directly as a sidecar script (e.g., `./script.cs`), or even inline-embedded directly within a `.nix` file (which would be far too messy and complex to do with a full C# project).

To explore this, I've made some experimental modifications to `buildDotnetModule` to support these single-file projects, by programmatically converting them into standard C# projects via `dotnet project convert`.

That said, I am still relatively new to Nix/NixOS. I’m not sure if this approach might introduce any unintended side effects or break existing conventions. Because of this, I’m opening this PR as a draft to gather feedback and kickstart a discussion. (I did some searching beforehand but couldn't find any existing discussions on this—please let me know if I missed something!)

Finally, thank you so much for your time and your incredible contributions to the project!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
