### PR TITLE
smux: 0.4.0 -> 0.6.0

### DIFF
--- a/pkgs/by-name/sm/smux/package.nix
+++ b/pkgs/by-name/sm/smux/package.nix
@@ -12,16 +12,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "smux";
-  version = "0.4.0";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "Aietes";
     repo = "smux";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-oEnlxIRk41hqkoIqcJAIqm5VcGvXJ29M1pfz2tj+S48=";
+    hash = "sha256-W8EAWYBYlXjXfa3+JLRGQInqGesl1QbDcQXTKJWRZ88=";
   };
 
-  cargoHash = "sha256-P4uzdP4eOlL6TDOSzVf8s6U9DyO0HbAdGIcObDC06fU=";
+  cargoHash = "sha256-zH9XMVluagzJQZz0Ensoci5KR6jGQqCzvbFDopbIcsI=";
 
   __structuredAttrs = true;
   strictDeps = true;


### PR DESCRIPTION
Version bump for smux, following its 0.5.0 release.

Release notes: https://github.com/Aietes/smux/releases/tag/v0.6.0

Highlights: safer initialization with overwrite protection and rollback, cleanup of incomplete tmux sessions after layout failures, explicit clone destinations via --dir, duplicate project-path validation, structured package.json dependency detection, and hardened picker temporary files and record encoding.

No nixpkgs packaging changes are needed beyond the version and fixed-output hashes. The existing postInstall continues to generate and install the full man-page set and zsh completion, and the wrapper continues to provide tmux, fzf, and zoxide.

## Things done

- Built on platform(s)
  - [x] aarch64-darwin
- [x] All package tests passed during the nixpkgs build (181 tests)
- [x] Ran the installed binary and verified smux 0.5.0
- [x] Verified section 1 and section 5 man pages, zsh completion, and runtime PATH wrapper
- [x] nixpkgs-review wip reports one impacted package and builds smux successfully
- [x] nixfmt passes on the changed file
- [x] Fits CONTRIBUTING.md