### PR TITLE
material-maker: 1.6 -> 1.7

### DIFF
--- a/pkgs/by-name/ma/material-maker/package.nix
+++ b/pkgs/by-name/ma/material-maker/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  godot_4_6,
+  godot_4_7,
   vulkan-headers,
   vulkan-loader,
   libx11,
@@ -15,19 +15,21 @@
   libxrender,
   nix-update-script,
 }:
-
+let
+  godot = godot_4_7;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "material-maker";
-  version = "1.6";
+  version = "1.7";
 
   src = fetchFromGitHub {
     owner = "RodZill4";
     repo = "material-maker";
     rev = finalAttrs.version;
-    hash = "sha256-jSbauK9eXoTW2xjZsipWcPs/8qmK8ztmT+doCgu8zrU=";
+    hash = "sha256-/oBAbdYNfIeNKnv1NGP05Nk5G8gov1yqRsG0jnFMW/Y=";
   };
 
-  nativeBuildInputs = [ godot_4_6 ];
+  nativeBuildInputs = [ godot ];
 
   buildInputs = [
     vulkan-headers
@@ -48,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     export HOME=$TMPDIR
     mkdir -p "$HOME/.local/share/godot"
-    ln -s "${godot_4_6.export-templates-bin}/share/godot/export_templates" "$HOME/.local/share/godot/export_templates"
+    ln -s "${godot.export-templates-bin}/share/godot/export_templates" "$HOME/.local/share/godot/export_templates"
 
     mkdir -vp build
     godot4 -v --headless --export-release 'Linux/X11' build/material-maker


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

needed to bump godot to 4.7

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
