### PR TITLE
raspi-utils: init at 0-unstable-2026-07-08

### DIFF
--- a/pkgs/by-name/ra/raspi-utils/package.nix
+++ b/pkgs/by-name/ra/raspi-utils/package.nix
@@ -1,0 +1,135 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  unstableGitUpdater,
+  cmake,
+  makeBinaryWrapper,
+  pkg-config,
+  bashNonInteractive,
+  coreutils,
+  dtc,
+  gawk,
+  gitMinimal,
+  gnugrep,
+  gnutls,
+  gnutar,
+  kmod,
+  ncurses,
+  perl,
+  python3,
+  targetPackages,
+  util-linux,
+  which,
+  zstd,
+  cc ? targetPackages.stdenv.cc,
+}:
+
+let
+  runtimePath = lib.makeBinPath [
+    coreutils
+    dtc
+    gawk
+    gitMinimal
+    gnugrep
+    gnutar
+    kmod
+    cc
+    util-linux
+    which
+    zstd
+  ];
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "raspi-utils";
+  version = "0-unstable-2026-07-08";
+
+  src = fetchFromGitHub {
+    owner = "raspberrypi";
+    repo = "utils";
+    rev = "5edd399260b5081f9c1c96fc7f369b920d6732d1";
+    hash = "sha256-qxwASdmEH47oCjuPtboWuUkcNsw5j6eCSsWrNejpIMU=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    makeBinaryWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    bashNonInteractive
+    dtc
+    gnutls
+    ncurses
+    perl
+    python3
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" true)
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "add_subdirectory(raspinfo)" ""
+
+    substituteInPlace dtapply/dtapply \
+      --replace-fail \
+        "parser = argparse.ArgumentParser(" \
+        'parser = argparse.ArgumentParser(prog="dtapply",'
+    substituteInPlace eeptools/eepflash.sh \
+      --replace-fail 'me=$(basename "$0")' 'me=eepflash.sh'
+    substituteInPlace otamaker/otamaker \
+      --replace-fail \
+        "parser = argparse.ArgumentParser()" \
+        "parser = argparse.ArgumentParser(prog='otamaker')"
+    substituteInPlace otpset/otpset \
+      --replace-fail \
+        "parser = argparse.ArgumentParser(description=" \
+        "parser = argparse.ArgumentParser(prog='otpset', description="
+    substituteInPlace overlaycheck/overlaycheck \
+      --replace-fail \
+        'my $exclusions_file = $0 . "_exclusions.txt";' \
+        'my $exclusions_file = "${placeholder "out"}/bin/overlaycheck_exclusions.txt";'
+  '';
+
+  postFixup = ''
+    for program in \
+      dtapply \
+      dtoverlay \
+      eepflash.sh \
+      kdtc \
+      otamaker \
+      otpset \
+      overlaycheck \
+      ovmerge
+    do
+      wrapProgram "$out/bin/$program" \
+        --prefix PATH : "$out/bin:${runtimePath}"
+    done
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Scripts and applications for interfacing with Raspberry Pi hardware";
+    homepage = "https://github.com/raspberrypi/utils";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ jamiemagee ];
+    platforms = [
+      "armv6l-linux"
+      "armv7l-linux"
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+  };
+})


### PR DESCRIPTION
Adds Raspberry Pi's current hardware utilities (except the Raspberry Pi OS-specific `raspinfo`). Supersedes #449925.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
