### PR TITLE
ente-web: update and fix build on new versions

### DIFF
--- a/pkgs/by-name/en/ente-web/package.nix
+++ b/pkgs/by-name/en/ente-web/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
       ;
     hash = "sha256-NYPxaVYEaJVcsRX6wLVJd+/UUJrNel0zTPYGdEv8a+U=";
   };
-  cargoRoot = "packages/wasm";
+  cargoRoot = "../rust";
 
   offlineCache = fetchYarnDeps {
     yarnLock = "${finalAttrs.src}/web/yarn.lock";
@@ -76,9 +76,15 @@ stdenv.mkDerivation (finalAttrs: {
   env = extraBuildEnv;
 
   postPatch =
+    # The Rust workspace lives in `../rust`, outside the `web` sourceRoot, so it
+    # is not made writable during unpacking. `wasm-pack` needs to create a cargo
+    # target directory there, so make it writable.
+    ''
+      chmod -R u+w ../rust
+    ''
     # Use our `wasm-pack` binary, rather than the Node version, which is
     # just a wrapper that tries to download the actual binary
-    ''
+    + ''
       substituteInPlace \
         packages/wasm/package.json \
         --replace-fail "wasm-pack " ${lib.escapeShellArg "${wasm-pack}/bin/wasm-pack "}
@@ -139,7 +145,7 @@ stdenv.mkDerivation (finalAttrs: {
       echo "Updated to version $new_version, checking wasm-bindgen..."
 
       # Fetch Cargo.lock from GitHub instead of cloning repository
-      cargo_lock_url="https://raw.githubusercontent.com/ente-io/ente/photos-v$new_version/web/packages/wasm/Cargo.lock"
+      cargo_lock_url="https://raw.githubusercontent.com/ente-io/ente/photos-v$new_version/rust/Cargo.lock"
 
       wasm_bindgen_version=$(curl -s "$cargo_lock_url" | tr -d '\r' | grep -A1 '^name = "wasm-bindgen"$' | grep -oP 'version = "\K[^"]+' | head -n1)
 

--- a/pkgs/by-name/en/ente-web/package.nix
+++ b/pkgs/by-name/en/ente-web/package.nix
@@ -8,7 +8,7 @@
   rustPlatform,
   rustc,
   sd,
-  wasm-bindgen-cli_0_2_108,
+  wasm-bindgen-cli_0_2_125,
   wasm-pack,
   writeScript,
   extraBuildEnv ? { },
@@ -24,7 +24,7 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "ente-web-${enteApp}";
-  version = "1.3.36";
+  version = "1.3.58";
 
   src = fetchFromGitHub {
     owner = "ente";
@@ -35,7 +35,7 @@ buildNpmPackage (finalAttrs: {
     ];
     tag = "photos-v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-o75r8LFgG3BT3IIPiD9x6gY3fRDoxJ3ZTBPAYr3hLWI=";
+    hash = "sha256-44iid/vsx3rKt/NGCgdZweJHW24ysQ7qSRq8Hayng9c=";
   };
   sourceRoot = "${finalAttrs.src.name}/web";
 
@@ -47,11 +47,11 @@ buildNpmPackage (finalAttrs: {
       sourceRoot
       cargoRoot
       ;
-    hash = "sha256-NYPxaVYEaJVcsRX6wLVJd+/UUJrNel0zTPYGdEv8a+U=";
+    hash = "sha256-dyDNhDNbcssV4mTzGZkysTftgFfKXNLX2S0jmkX5JR4=";
   };
   cargoRoot = "../rust";
 
-  npmDepsHash = "sha256-eGu+s8g0nGijYfjo8RkT5/iBfbwk5cBMacbe/gO03NI=";
+  npmDepsHash = "sha256-JZnF6MfEkm4HCslEgpAuCrSYQYnt8tNPUTFRb1CIVe4=";
 
   nativeBuildInputs = [
     binaryen
@@ -60,7 +60,7 @@ buildNpmPackage (finalAttrs: {
     rustc
     rustc.llvmPackages.lld
     nodejs
-    wasm-bindgen-cli_0_2_108
+    wasm-bindgen-cli_0_2_125
     wasm-pack
   ];
 

--- a/pkgs/by-name/en/ente-web/package.nix
+++ b/pkgs/by-name/en/ente-web/package.nix
@@ -1,18 +1,15 @@
 {
   lib,
-  stdenv,
+  buildNpmPackage,
   binaryen,
   cargo,
   fetchFromGitHub,
-  fetchYarnDeps,
   nodejs,
   rustPlatform,
   rustc,
   sd,
   wasm-bindgen-cli_0_2_108,
   wasm-pack,
-  yarnConfigHook,
-  yarnBuildHook,
   writeScript,
   extraBuildEnv ? { },
   # This package contains serveral sub-applications. This specifies which of them you want to build.
@@ -25,7 +22,7 @@
   nixosTests,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+buildNpmPackage (finalAttrs: {
   pname = "ente-web-${enteApp}";
   version = "1.3.36";
 
@@ -54,14 +51,9 @@ stdenv.mkDerivation (finalAttrs: {
   };
   cargoRoot = "../rust";
 
-  offlineCache = fetchYarnDeps {
-    yarnLock = "${finalAttrs.src}/web/yarn.lock";
-    hash = "sha256-eGu+s8g0nGijYfjo8RkT5/iBfbwk5cBMacbe/gO03NI=";
-  };
+  npmDepsHash = "sha256-eGu+s8g0nGijYfjo8RkT5/iBfbwk5cBMacbe/gO03NI=";
 
   nativeBuildInputs = [
-    yarnConfigHook
-    yarnBuildHook
     binaryen
     cargo
     rustPlatform.cargoSetupHook
@@ -98,7 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
       done
     '';
 
-  yarnBuildScript = "build:${enteApp}";
+  npmBuildScript = "build:${enteApp}";
   installPhase =
     let
       distName = if enteApp == "payments" then "dist" else "out";

--- a/pkgs/by-name/wa/wasm-bindgen-cli_0_2_125/package.nix
+++ b/pkgs/by-name/wa/wasm-bindgen-cli_0_2_125/package.nix
@@ -1,0 +1,19 @@
+{
+  buildWasmBindgenCli,
+  fetchCrate,
+  rustPlatform,
+}:
+
+buildWasmBindgenCli rec {
+  src = fetchCrate {
+    pname = "wasm-bindgen-cli";
+    version = "0.2.125";
+    hash = "sha256-zRawtjxMOdTMX+mZaiNR3YYfTiZJhf9qj7kXSSeMxrc=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit src;
+    inherit (src) pname version;
+    hash = "sha256-aZCfgR23Qb0Pn4Mm4ToMtuuRQqSJjXCR9li/VvP5CTM=";
+  };
+}


### PR DESCRIPTION
Updates the package definition to accommodate changes made in newer versions of the web package. Tested on a live instance of `museum`.

The `chmod` addition in 76a2c04dc8f6846153768d27cff874869dfe0041 was added using Claude Code (Opus 4.8 xhigh effort), everything else was myself and `nix-shell maintainers/scripts/update.nix --argstr package ente-web`. I didn't add the `Assisted-by:` trailer because I didn't know about it before making the commit, and I didn't go back to change it because it's not a significant change in my opinion (the issue was clear, I just didn't know I could use `chmod` there).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
