### PR TITLE
qtkeychain: fix build on Qt6

### DIFF
--- a/pkgs/development/libraries/qtkeychain/default.nix
+++ b/pkgs/development/libraries/qtkeychain/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   dontWrapQtApps = true;
 
   cmakeFlags = [
-    "-DBUILD_WITH_QT6=${if lib.versions.major qtbase.version == "6" then "ON" else "OFF"}"
+    "-DBUILD_WITH_QT5=${if lib.versions.major qtbase.version == "5" then "ON" else "OFF"}"
     "-DQT_TRANSLATIONS_DIR=share/qt/translations"
   ];
 


### PR DESCRIPTION
Resolves #542249

The upstream version 0.17.0 replaced the `BUILD_WITH_QT6` option with a `BUILD_WITH_QT5` option, defaulting to Qt6. The Nixpkgs derivation was still passing the old flag, causing the Qt6 build to fail. This PR updates the CMake flags to properly set `BUILD_WITH_QT5` based on the target Qt version.