### PR TITLE
newsflash: 5.1.0 -> 5.2.3

### DIFF
--- a/pkgs/by-name/ne/newsflash/package.nix
+++ b/pkgs/by-name/ne/newsflash/package.nix
@@ -29,18 +29,18 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "newsflash";
-  version = "5.1.0";
+  version = "5.2.3";
 
   src = fetchFromGitLab {
     owner = "news-flash";
     repo = "news_flash_gtk";
     tag = "v.${finalAttrs.version}";
-    hash = "sha256-BfzrnTyMLFiM+aHtrppvl/j/fjB4TbEkbl/yHYOnXa8=";
+    hash = "sha256-EeB2DNXxvo7biIv426+dkCKbjn2uxyXgvA1FbKevaFQ=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-4z2RGelDhi4RmVQ/+Ba340Pm05x4ruaRYAtJ1HuRHqA=";
+    hash = "sha256-OPxMsNhdMSt8mLhsNIBTjggSL1f3bZMH/5shESDV6yE=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/ne/newsflash/package.nix
+++ b/pkgs/by-name/ne/newsflash/package.nix
@@ -18,13 +18,11 @@
   gtksourceview5,
   libadwaita,
   libglycin,
-  libseccomp,
   libxml2,
   openssl,
   sqlite,
   webkitgtk_6_0,
   glib-networking,
-  librsvg,
   gst_all_1,
   nix-update-script,
 }:
@@ -79,7 +77,6 @@ stdenv.mkDerivation (finalAttrs: {
     gtksourceview5
     libadwaita
     libglycin
-    libseccomp
     libxml2
     openssl
     sqlite
@@ -87,9 +84,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     # TLS support for loading external content in webkitgtk WebView
     glib-networking
-
-    # SVG support for gdk-pixbuf
-    librsvg
   ]
   ++ (with gst_all_1; [
     # Audio & video support for webkitgtk WebView

--- a/pkgs/by-name/ne/newsflash/package.nix
+++ b/pkgs/by-name/ne/newsflash/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   postPatch = ''
-    patchShebangs build-aux/cargo.sh
+    patchShebangs --build build-aux/cargo.sh
     meson rewrite kwargs set project / version '${finalAttrs.version}'
     substituteInPlace src/meson.build --replace-fail \
       "'src' / rust_target / 'news_flash_gtk'" \


### PR DESCRIPTION
https://gitlab.com/news-flash/news_flash_gtk/-/raw/v.5.2.3/data/io.gitlab.news_flash.NewsFlash.appdata.xml.in.in#:~:text=%3Crelease%20version=%225.2.3%22,%3C/release%3E

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
