### PR TITLE
rPackages.redatamx: fix build, set unfree

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -2863,19 +2863,50 @@ let
       postPatch = "patchShebangs configure";
     });
 
-    redatamx = old.redatamx.overrideAttrs (attrs: {
-      preConfigure =
-        let
-          redatam-core = pkgs.fetchzip {
-            url = "https://redatam-core.s3.us-west-2.amazonaws.com/core-dev/linux/redatamx-core-linux-20241222.zip";
-            hash = "sha256-CagDpv7v5fj/NgaC5fmYc5UuKuBVlT3gauH2ItVnIIY=";
+    redatamx = old.redatamx.overrideAttrs (
+      finalAttrs: previousAttrs:
+      let
+        fetchCore =
+          { platform, hash }:
+          pkgs.fetchzip {
+            name = "redatam-core-${platform}-${finalAttrs.version}";
+            url = "https://redatam-core.s3.us-west-2.amazonaws.com/core-dev/${platform}/redatamx-core-${platform}-${finalAttrs.version}-final.zip";
+            inherit hash;
           };
-        in
-        ''
-          mkdir -p ./inst/redengine/
-          cp ${redatam-core}/lib/libredengine-1.0.0-rc2.so ./inst/redengine/libredengine-1.0.0-rc2.so
+      in
+      {
+        passthru = (previousAttrs.passthru or { }) // {
+          redatam-core-per-system = {
+            "x86_64-linux" = fetchCore {
+              platform = "linux";
+              hash = "sha256-LNusDc4K6B+kAd+qWo789eiQG0dToEwu/RWwoFEjgRo=";
+            };
+            "aarch64-darwin" = fetchCore {
+              platform = "macos-arm64";
+              hash = "sha256-l7qLjM6jDtytAPgY7qVuVPEE6HUnZ1fPFxAzS6VnFY4=";
+            };
+          };
+
+          redatam-core = finalAttrs.passthru.redatam-core-per-system.${stdenv.hostPlatform.system};
+        };
+
+        # upstream is checking for the wrong filename, so it tries and fails to download redatam-core
+        # even if it's already installed to the target location, so let's just disable the check
+        postPatch = ''
+          substituteInPlace configure \
+            --replace-fail '[ ! -e inst/redengine/$engine_file ]' 'false'
         '';
-    });
+
+        preConfigure = ''
+          install -Dm755 ${finalAttrs.passthru.redatam-core}/lib/libredengine* -t ./inst/redengine/
+        '';
+
+        meta = (previousAttrs.meta or { }) // {
+          platforms = lib.attrNames finalAttrs.passthru.redatam-core-per-system;
+          license = lib.licenses.unfree; # See https://github.com/ideasybits/redatamx4r/blob/main/inst/License.txt
+        };
+      }
+    );
 
     redland = old.redland.overrideAttrs (attrs: {
       env = (attrs.env or { }) // {


### PR DESCRIPTION
Targeting: https://github.com/NixOS/nixpkgs/pull/539315

The old url used was outdated, and probably has been yanked.

Added a mechanism to specify hashes for multiple platforms:
You can build `rPackages.redatamx.redatam-core-per-system` to regenerate hashes for both supported platforms.

Since we download some unfree stuff, I set the license as unfree.

Also, I opened an upstream issue: https://github.com/ideasybits/redatamx4r/issues/2

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
