### PR TITLE
borgbackup: add noahbiewesch as maintainer

### DIFF
--- a/pkgs/by-name/bo/borgbackup/package.nix
+++ b/pkgs/by-name/bo/borgbackup/package.nix
@@ -165,6 +165,7 @@ python.pkgs.buildPythonApplication (finalAttrs: {
     mainProgram = "borg";
     maintainers = with lib.maintainers; [
       dotlambda
+      noahbiewesch
     ];
   };
 })


### PR DESCRIPTION
> https://github.com/NixOS/nixpkgs/blob/3513870dbc6d0f53df3b0ac9a6e450b142064f9b/maintainers/README.md#L8

I am subscribed to BorgBackup releases and security alerts to co-maintain this package by providing high-level secondary reviews.

See the pending PRs https://github.com/NixOS/nixpkgs/pull/478737 and https://github.com/NixOS/nixpkgs/pull/494875 for my existing BorgBackup involvement.

This PR is in the same spirit as https://github.com/NixOS/nixpkgs/pull/542299.

CC: @dotlambda

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
