### PR TITLE
darwin.stdenv: don't force outPath comparisons during eval, tests.eval-perf: init

### DIFF
--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -1177,8 +1177,8 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
     assert isFromNixpkgs prevStage.binutils-unwrapped.src;
     assert isBuiltByNixpkgsCompiler prevStage.curl;
 
-    # libiconv should be an alias for darwin.libiconv
-    assert prevStage.libiconv == prevStage.darwin.libiconv;
+    # `libiconv == darwin.libiconv` is checked in
+    # `tests.top-level.darwinLibiconvAlias` instead of being asserted here
 
     {
       inherit (prevStage) config overlays stdenv;

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -128,6 +128,8 @@ in
 
   config = callPackage ./config.nix { };
 
+  eval-perf = callPackage ./eval-perf { };
+
   top-level = callPackage ./top-level { };
 
   haskell = callPackage ./haskell { };

--- a/pkgs/test/eval-perf/default.nix
+++ b/pkgs/test/eval-perf/default.nix
@@ -1,0 +1,63 @@
+# Tests for the evaluation behavior of the Nixpkgs tree itself: they run a
+# Nix evaluator against Nixpkgs inside the build sandbox, using a scratch
+# store (NIX_STORE_DIR) to observe what evaluation writes to it.
+#
+# Evaluation performance *measurements* tracked by Hydra live in
+# pkgs/top-level/metrics.nix instead.
+{
+  lib,
+  nix,
+  runCommand,
+  path,
+}:
+
+let
+  nixpkgs = lib.cleanSource path;
+
+  supportedSystems = builtins.fromJSON (
+    builtins.readFile ../../top-level/release-supported-systems.json
+  );
+
+  tests = {
+    # Merely evaluating package metadata (such as `hello.name`) must not
+    # instantiate any derivations, i.e. no .drv files may be written to the
+    # store. This regressed in the past through top-level assertions comparing
+    # derivations, which forces their outPaths:
+    # https://github.com/NixOS/nixpkgs/pull/539613
+    lazy-metadata = runCommand "test-eval-lazy-metadata" { nativeBuildInputs = [ nix ]; } ''
+      export NIX_STORE_DIR=$(mktemp -d)
+      export NIX_STATE_DIR=$(mktemp -d)
+      nix-store --init
+
+      for system in ${toString supportedSystems}; do
+        echo "checking that metadata evaluation on $system does not write to the store"
+        # --read-write-mode is required: in the default read-only mode of
+        # `nix-instantiate --eval`, outPaths are computed without writing
+        # .drv files, which would mask the regression.
+        nix-instantiate --eval --strict --show-trace --read-write-mode \
+          ${nixpkgs} -A hello.name --argstr system "$system" \
+          --option allow-import-from-derivation false > /dev/null
+      done
+
+      drvFiles=$(find "$NIX_STORE_DIR" -name '*.drv')
+      if [[ -n $drvFiles ]]; then
+        echo "Evaluating package metadata wrote $(echo "$drvFiles" | wc -l) .drv files to the store, for example:"
+        echo "$drvFiles" | head -n 10
+        echo "Most likely something forces derivation comparisons (and thus their outPaths) during evaluation of the Nixpkgs top level."
+        exit 1
+      fi
+
+      touch $out
+    '';
+  };
+in
+runCommand "test-eval-perf"
+  {
+    passthru = tests;
+    # The tests check all supported systems in a single build, so there is no
+    # point in Hydra building them more than once.
+    meta.hydraPlatforms = [ "x86_64-linux" ];
+  }
+  ''
+    echo ${toString (lib.attrValues tests)} > $out
+  ''

--- a/pkgs/test/top-level/default.nix
+++ b/pkgs/test/top-level/default.nix
@@ -65,6 +65,22 @@ lib.recurseIntoAttrs {
     assert lib.all (p: p.stdenv.buildPlatform != p.stdenv.hostPlatform) pkgsCross;
     pkgs.emptyFile;
 
+  # libiconv should be an alias for darwin.libiconv. This used to be an
+  # assertion in the darwin stdenv bootstrap, but comparing two derivations
+  # forces their outPaths, which would write the .drv closure of the
+  # bootstrap to the store on every evaluation of the Nixpkgs top level
+  # (see https://github.com/NixOS/nixpkgs/pull/539613).
+  darwinLibiconvAlias =
+    let
+      pkgsDarwin = nixpkgsFun {
+        localSystem = {
+          system = "aarch64-darwin";
+        };
+      };
+    in
+    assert pkgsDarwin.libiconv == pkgsDarwin.darwin.libiconv;
+    pkgs.emptyFile;
+
   # appendOverlays must preserve splicing so that cross-compilation
   # works in NixOS modules (which go through appendOverlays via nixpkgs.nix).
   appendOverlaysPreservesSplicing =

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -172,6 +172,7 @@ let
         jobs.manual
         jobs.tests.lib-tests.x86_64-linux
         jobs.tests.pkgs-lib.formats-tests.x86_64-linux
+        jobs.tests.eval-perf.x86_64-linux
         jobs.stdenv.x86_64-linux
         jobs.cargo.x86_64-linux
         jobs.go.x86_64-linux


### PR DESCRIPTION
Merely evaluating package metadata (such as 'hello.name') for aarch64-darwin wrote 352 .drv files to the store, because the final no-op bootstrap stage asserted

  assert prevStage.libiconv == prevStage.darwin.libiconv;

Nix implements this comparison by computing both outPaths, which calls derivationStrict and writes the .drv closure of the bootstrap to the store. Since the stage assertions run on every evaluation of the Nixpkgs top level, this happened for any metadata-only evaluation.

This is the Darwin counterpart of the cc-wrapper fix in #539613. Unlike cc-wrapper, the comparison can't be deferred into a derivation attribute: the invariant is about the final package set, which doesn't exist yet at any point during the bootstrap. Move it to tests.top-level.darwinLibiconvAlias instead, which CI forces on every eval of the tests attrset.

Assisted-by: claude-code with claude-opus-4-8[1m]-high

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
