### PR TITLE
pint: init at 0.87.0

### DIFF
--- a/pkgs/by-name/pi/pint/package.nix
+++ b/pkgs/by-name/pi/pint/package.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+
+  versionCheckHook,
+  curl,
+  git,
+  perl,
+
+  nix-update-script,
+  testers,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "pint";
+  version = "0.87.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+  # required for tests
+  __darwinAllowLocalNetworking = true;
+
+  src = fetchFromGitHub {
+    owner = "cloudflare";
+    repo = "pint";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JPUEseo2J8JcsQ8BqYCh+jtw1p5gt5Av9z041M26rIs=";
+    # populate values that require us to use git. By doing this in postFetch we
+    # can delete .git afterwards and maintain better reproducibility of the src.
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      git rev-parse HEAD > $out/COMMIT
+      # 0000-00-00T00:00:00Z
+      date -u -d "@$(git log -1 --pretty=%ct)" "+%Y-%m-%dT%H:%M:%SZ" > $out/SOURCE_DATE_EPOCH
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
+  };
+
+  vendorHash = "sha256-BjFX0RWvNQq6BCR24FpIWT2CTJkRK5mkg3kCEInGE2E=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=main.version=${finalAttrs.version}"
+  ];
+
+  preBuild = ''
+    ldflags+=" -X main.commit=$(cat COMMIT)"
+  '';
+
+  nativeCheckInputs = [
+    curl # hits local server
+    git # creates local repo
+    perl # processes some output with perl
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  versionCheckProgramArg = "version";
+
+  passthru.updateScript = nix-update-script { };
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command = "pint version";
+    version = finalAttrs.version;
+  };
+
+  meta = {
+    description = "Prometheus rule linter/validator";
+    homepage = "https://cloudflare.github.io/pint/";
+    changelog = "https://cloudflare.github.io/pint/changelog.html#${
+      builtins.replaceStrings [ "." ] [ "" ] finalAttrs.src.tag
+    }";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      jk
+    ];
+    mainProgram = "pint";
+  };
+})


### PR DESCRIPTION
Package pint for nixpkgs

> pint is a Prometheus rule linter/validator.

https://cloudflare.github.io/pint/
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
