### PR TITLE
ivpn*: 3.15.6 -> 3.15.13

### DIFF
--- a/pkgs/by-name/iv/ivpn-service/package.nix
+++ b/pkgs/by-name/iv/ivpn-service/package.nix
@@ -17,11 +17,11 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "ivpn-service";
-  version = "3.15.6";
+  version = "3.15.13";
 
   buildInputs = [
     wirelesstools
-    (finalAttrs.passthru.liboqs)
+    liboqs
   ];
   nativeBuildInputs = [ makeWrapper ];
 
@@ -29,7 +29,7 @@ buildGoModule (finalAttrs: {
     owner = "ivpn";
     repo = "desktop-app";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-C24klcr10i0lki74eNfJ4bappdIttp3S4FGg1wkAGcY=";
+    hash = "sha256-F5MhJ09ioqL4Xf4r2cdXUKmkK8ebj/qRFWfxKuodH3k=";
   };
 
   strictDeps = true;
@@ -37,7 +37,7 @@ buildGoModule (finalAttrs: {
 
   modRoot = "daemon";
   subPackages = [ "." ];
-  vendorHash = "sha256-YDvZVmResoieSBIp/yuZDvI9GSz3M6Bi5KksHOljuR0=";
+  vendorHash = "sha256-tygPc2hyKfiA3mTOlQMi97Zd/Ka1AtYbZqYOTmHZISA=";
 
   proxyVendor = true; # .c file
 
@@ -107,35 +107,6 @@ buildGoModule (finalAttrs: {
         ]
       }
   '';
-
-  # IVPN pins this to an older incompatible version, so we vendor it at that
-  # Lives in passthru so end-users can override it
-  passthru.liboqs = liboqs.overrideAttrs (
-    final: prev: {
-      version = "0.10.0";
-      src = fetchFromGitHub {
-        owner = "open-quantum-safe";
-        repo = "liboqs";
-        tag = "${final.version}";
-        hash = "sha256-BFDa5NUr02lFPcT4Hnb2rjGAi+2cXvh1SHLfqX/zLlI=";
-      };
-      # the main derivations patches don't apply onto the older version
-      patches = [ ];
-      # manually do what the main derivations pkg-config patch does (unbreak invalid path)
-      postPatch = ''
-        substituteInPlace src/liboqs.pc.in \
-          --replace-fail 'libdir=''${prefix}/@CMAKE_INSTALL_LIBDIR@' \
-          'libdir=@CMAKE_INSTALL_FULL_LIBDIR@' \
-          --replace-fail 'includedir=''${prefix}/@CMAKE_INSTALL_INCLUDEDIR@' \
-          'includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@'
-      '';
-      # This matches IVPNs build script at $src/daemon/References/common/kem-helper/build.sh
-      cmakeFlags = (prev.cmakeFlags or [ ]) ++ [
-        "-DOQS_USE_OPENSSL=OFF"
-        "-DOQS_MINIMAL_BUILD=KEM_kyber_1024;KEM_classic_mceliece_348864"
-      ];
-    }
-  );
 
   meta = {
     description = "Official IVPN Desktop app service daemon";

--- a/pkgs/by-name/iv/ivpn-ui/package.nix
+++ b/pkgs/by-name/iv/ivpn-ui/package.nix
@@ -2,7 +2,7 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
-  electron,
+  electron_42,
   copyDesktopItems,
   makeDesktopItem,
   nix-update-script,
@@ -11,37 +11,42 @@
 }:
 buildNpmPackage (finalAttrs: {
   pname = "ivpn-ui";
-  version = "3.15.6";
+  version = "3.15.13";
 
   src = fetchFromGitHub {
     owner = "ivpn";
     repo = "desktop-app";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-C24klcr10i0lki74eNfJ4bappdIttp3S4FGg1wkAGcY=";
+    hash = "sha256-F5MhJ09ioqL4Xf4r2cdXUKmkK8ebj/qRFWfxKuodH3k=";
   };
 
   sourceRoot = "source/ui";
 
-  npmDepsHash = "sha256-S/fB3MxEDLVEZ762EkBkyemYW2rgBGtCH5y/6p6nqgE=";
+  npmDepsHash = "sha256-Q8qrAo7+GrbUUx33t89/N4WHnJLbdpMSpBm5rLclJC0=";
 
   nativeBuildInputs = [
     copyDesktopItems
     makeWrapper
   ];
 
-  env = {
-    ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
-  };
+  # electron 42's install.js no longer honors ELECTRON_SKIP_BINARY_DOWNLOAD and
+  # unconditionally downloads the electron binary.
+  # install-app-deps is a no-op here, so drop the whole postinstall,
+  # that way the electron download is skipped properly.
+  postPatch = ''
+    substituteInPlace package.json \
+      --replace-fail '"postinstall": "node node_modules/electron/install.js && electron-builder install-app-deps",' ""
+  '';
 
   postBuild = ''
     electron_dist="$(mktemp -d)"
-    cp -r ${electron.dist}/. "$electron_dist"
+    cp -r ${electron_42.dist}/. "$electron_dist"
     chmod -R u+w "$electron_dist"
 
     npm exec electron-builder -- \
       --dir \
       -c.electronDist="$electron_dist" \
-      -c.electronVersion=${electron.version} \
+      -c.electronVersion=${electron_42.version} \
       --config electron-builder.config.js
   '';
 
@@ -53,7 +58,7 @@ buildNpmPackage (finalAttrs: {
 
     install -Dm644 $src/ui/References/Linux/ui/ivpnicon.svg $out/share/icons/hicolor/scalable/apps/ivpn-ui.svg
 
-    makeWrapper ${lib.getExe electron} $out/bin/ivpn-ui \
+    makeWrapper ${lib.getExe electron_42} $out/bin/ivpn-ui \
       --prefix PATH : ${lib.makeBinPath [ ivpn-service ]} \
       --add-flags $out/share/ivpn-ui/resources/app.asar \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \

--- a/pkgs/by-name/iv/ivpn/package.nix
+++ b/pkgs/by-name/iv/ivpn/package.nix
@@ -7,7 +7,7 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "ivpn";
-  version = "3.15.6";
+  version = "3.15.13";
 
   buildInputs = [ wirelesstools ];
 
@@ -15,13 +15,13 @@ buildGoModule (finalAttrs: {
     owner = "ivpn";
     repo = "desktop-app";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-C24klcr10i0lki74eNfJ4bappdIttp3S4FGg1wkAGcY=";
+    hash = "sha256-F5MhJ09ioqL4Xf4r2cdXUKmkK8ebj/qRFWfxKuodH3k=";
   };
 
   __structuredAttrs = true;
 
   modRoot = "cli";
-  vendorHash = "sha256-Qm3OZq3W8GyfkYP674Jzse7wDPWgXfc0bi8ZpYl4T1I=";
+  vendorHash = "sha256-Q3CbeKrenZr1kGFhSrXW7dcnn3iGKWhWO2qofqAFwgk=";
 
   proxyVendor = true; # .c file
 


### PR DESCRIPTION
Updates all ivpn packages to the latest. Changelog: https://github.com/ivpn/desktop-app/releases/tag/v3.15.13

On the packaging side, this removes a workaround from a previous version that required vendoring an older version of `liboqs` (https://github.com/NixOS/nixpkgs/pull/523464, https://github.com/NixOS/nixpkgs/pull/523461). Upstream now takes the newest version, so this can be fully dropped.
Also, the UI package requires some changes, as they updated their electron version.

Replaces https://github.com/NixOS/nixpkgs/pull/542287

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
