### PR TITLE
rPackages: unify and fix packages using R CMD config --ldflags

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -476,12 +476,14 @@ let
       pkgs.hostname
     ];
     Rhpc = with pkgs; [
-      zlib
-      bzip2.dev
-      icu
-      xz.dev
       mpi
-      pcre.dev
+      # deps for `R CMD config --ldflags`
+      bzip2
+      icu
+      libdeflate
+      xz
+      zlib
+      zstd
     ];
     Rigraphlib = [ pkgs.cmake ];
     Rlibeemd = [ pkgs.gsl ]; # for gsl-config
@@ -492,13 +494,6 @@ let
     Rpoppler = [ pkgs.pkg-config ];
     Rsubbotools = [ pkgs.gsl ]; # for gsl-config
     Rsymphony = [ pkgs.pkg-config ];
-    SAVE = with pkgs; [
-      zlib
-      bzip2
-      icu
-      xz
-      pcre
-    ];
     SQLFormatteR = with pkgs; [
       cargo
       rustc
@@ -1156,12 +1151,13 @@ let
     archive = [ pkgs.libarchive ];
     arrangements = with pkgs; [ gmp.dev ];
     asciicast = with pkgs; [
-      bzip2.dev
-      icu.dev
+      # deps for `R CMD config --ldflags`
+      bzip2
+      icu
       libdeflate
-      xz.dev
-      zlib.dev
-      zstd.dev
+      xz
+      zlib
+      zstd
     ];
     audio = [ pkgs.portaudio ];
     bamsignals = with pkgs; [
@@ -1335,11 +1331,13 @@ let
     libstable4u = [ pkgs.gsl ];
     libstableR = [ pkgs.gsl ];
     littler = with pkgs; [
+      # deps for `R CMD config --ldflags`
+      bzip2
+      icu
+      libdeflate
       xz
       zlib
-      bzip2
       zstd
-      icu
     ];
     lpsymphony = with pkgs; [
       symphony
@@ -1431,11 +1429,13 @@ let
     ];
     rJPSGCS = [ pkgs.zlib.dev ];
     rJava = with pkgs; [
-      zlib
+      # deps for `R CMD config --ldflags`
       bzip2
+      icu
+      libdeflate
       xz
       zstd
-      icu
+      zlib
     ];
     raer = with pkgs; [
       zlib.dev
@@ -1464,14 +1464,6 @@ let
     rcdd = [ pkgs.gmp ];
     rcontroll = [ pkgs.gsl.dev ];
     redux = [ pkgs.hiredis ];
-    registr = with pkgs; [
-      icu.dev
-      zlib.dev
-      bzip2.dev
-      xz.dev
-      libdeflate
-      zstd.dev
-    ];
     resultant = with pkgs; [
       gmp
       mpfr
@@ -1646,12 +1638,13 @@ let
     units = [ pkgs.udunits ];
     unix = lib.optionals stdenv.hostPlatform.isLinux [ pkgs.libapparmor ];
     unrtf = with pkgs; [
-      bzip2.dev
-      icu.dev
+      # deps from $(LIBS) (same as `R CMD config --ldflags`)
+      bzip2
+      icu
       libdeflate
-      xz.dev
-      zlib.dev
-      zstd.dev
+      xz
+      zlib
+      zstd
     ];
     vapour = [ pkgs.proj ];
     vcfR = with pkgs; [ zlib.dev ];


### PR DESCRIPTION
Targeting: https://github.com/NixOS/nixpkgs/pull/539315

In my big dependency cleanup PR, I removed `littler`'s dependency on `libdeflate`, because it built fine without it.
After the `staging-next` merge, it became needed again. This is probably the culprit: https://github.com/NixOS/nixpkgs/pull/527320
`R CMD config --ldflags` didn't have `-ldeflate`, but now it does.

In any case, I tried to find the other places where `R CMD config --ldflags` was being used and added a comment to them.



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
