### PR TITLE
tests.nixos-functions: check that toplevel assertions are lazy

### DIFF
--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -60,7 +60,8 @@ let
       name = "nixos-system-${config.system.name}-${config.system.nixos.label}";
       preferLocalBuild = true;
       allowSubstitutes = false;
-      buildCommand = systemBuilder;
+      # We handle assertions here so that merely evaluating the name attribute (e.g. in `nix flake show`) doesn't trigger heavy instantiations.
+      buildCommand = lib.asserts.checkAssertWarn config.assertions config.warnings systemBuilder;
 
       systemd = config.systemd.package;
 
@@ -74,9 +75,6 @@ let
     }
   );
 
-  # Handle assertions and warnings
-  baseSystemAssertWarn = lib.asserts.checkAssertWarn config.assertions config.warnings baseSystem;
-
   # Replace runtime dependencies
   system =
     let
@@ -84,7 +82,7 @@ let
     in
     if replacements == [ ] then
       # Avoid IFD if possible, by sidestepping replaceDependencies if no replacements are specified.
-      baseSystemAssertWarn
+      baseSystem
     else
       (pkgs.replaceDependencies.override {
         replaceDirectDependencies = pkgs.replaceDirectDependencies.override {
@@ -92,7 +90,7 @@ let
         };
       })
         {
-          drv = baseSystemAssertWarn;
+          drv = baseSystem;
           inherit replacements cutoffPackages;
         };
 

--- a/pkgs/test/nixos-functions/default.nix
+++ b/pkgs/test/nixos-functions/default.nix
@@ -20,11 +20,11 @@ let
     versionSuffix = "test";
     label = "test";
   };
-in
-lib.optionalAttrs (stdenv.hostPlatform.isLinux) (
-  lib.recurseIntoAttrs {
-    nixos-test =
-      (pkgs.nixos {
+
+  minimalSystem =
+    module:
+    pkgs.nixos [
+      {
         system.nixos = dummyVersioning;
         boot.loader.grub.enable = false;
         fileSystems."/" = {
@@ -32,6 +32,34 @@ lib.optionalAttrs (stdenv.hostPlatform.isLinux) (
           fsType = "none";
         };
         system.stateVersion = lib.trivial.release;
-      }).toplevel;
+      }
+      module
+    ];
+in
+lib.optionalAttrs (stdenv.hostPlatform.isLinux) (
+  lib.recurseIntoAttrs {
+    nixos-test = (minimalSystem { }).toplevel;
+
+    # Cheap attributes of the toplevel derivation, such as its name (which
+    # `nix flake show` evaluates), must be accessible without checking
+    # assertions, since those force large parts of the configuration and can
+    # instantiate thousands of derivations. The assertions must still be
+    # checked when the derivation itself is instantiated.
+    nixos-toplevel-assertions-are-lazy =
+      let
+        toplevel =
+          (minimalSystem {
+            assertions = [
+              {
+                assertion = false;
+                message = "failed assertions must not block evaluation of the system name";
+              }
+            ];
+          }).toplevel;
+      in
+      assert (builtins.tryEval toplevel.name).success;
+      assert lib.hasPrefix "nixos-system-" toplevel.name;
+      assert !(builtins.tryEval toplevel.drvPath).success;
+      pkgs.emptyFile;
   }
 )


### PR DESCRIPTION
Regression test for #540403, depends on #540403

Assisted-by: claude-code with claude-opus-4-8[1m]-high

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
