### PR TITLE
bankjaneo-caprine: init at 2.61.24

### DIFF
--- a/pkgs/by-name/ba/bankjaneo-caprine/package.nix
+++ b/pkgs/by-name/ba/bankjaneo-caprine/package.nix
@@ -1,0 +1,63 @@
+{
+  caprine,
+  electron,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  lib,
+  nix-update-script,
+}:
+
+caprine.overrideAttrs (
+  finalAttrs: previousAttrs: {
+    pname = "bankjaneo-caprine";
+    version = "2.61.24";
+
+    __structuredAttrs = true;
+
+    src = fetchFromGitHub {
+      owner = "bankjaneo";
+      repo = "caprine";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-7iqB+gLphQzc53tS57ubH5c0gp/rZ6S2p7QTZ9oUx5c=";
+    };
+
+    npmDepsHash = "sha256-n+GNKx1m7e7B+NHG5RSlWNzIiz98spoIqByUCj349I4=";
+    npmDeps = fetchNpmDeps {
+      inherit (finalAttrs) src patches;
+      name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
+      hash = finalAttrs.npmDepsHash;
+    };
+
+    postBuild = ''
+      electron_dist="$(mktemp -d)"
+      cp -r ${electron.dist}/. "$electron_dist"
+      chmod -R u+w "$electron_dist"
+
+      npm exec electron-builder -- \
+        --dir \
+        -c.npmRebuild=true \
+        -c.asarUnpack="**/*.node" \
+        -c.electronDist="$electron_dist" \
+        -c.electronVersion=${electron.version} \
+        -c.mac.identity=null
+    '';
+
+    passthru = (previousAttrs.passthru or { }) // {
+      updateScript = nix-update-script {
+        extraArgs = [
+          "--use-github-releases"
+          "--version-regex"
+          "^v([0-9]+\\.[0-9]+\\.[0-9]+)$"
+        ];
+      };
+    };
+
+    meta = previousAttrs.meta // {
+      changelog = "https://github.com/bankjaneo/caprine/releases/tag/v${finalAttrs.version}";
+      description = "Fork of Caprine adapted to Facebook's current Messenger interface";
+      homepage = "https://github.com/bankjaneo/caprine";
+      maintainers = with lib.maintainers; [ tyceherrman ];
+      mainProgram = "caprine";
+    };
+  }
+)


### PR DESCRIPTION
Add the maintained [bankjaneo fork of Caprine](https://github.com/bankjaneo/caprine) as a separate `bankjaneo-caprine` package at version 2.61.24. The existing `caprine` and `caprine-bin` packages remain unchanged.

The fork adapts Caprine to Facebook's current Messenger interface. This package reuses the existing Caprine derivation while replacing the source and npm dependencies, disabling Electron Builder signing on Darwin, and using stable GitHub releases for updates. The installed app and executable remain `Caprine.app` and `caprine`, so this package is an alternative rather than a co-installable variant.

### Validation

- Built `bankjaneo-caprine` on aarch64-darwin.
- Launched `bin/caprine` with an isolated user-data directory and confirmed it remained running until terminated after the smoke test.
- Evaluated the package derivation on aarch64-linux and x86_64-linux.
- Ran the update script and confirmed 2.61.24 is the latest matching stable release.
- Ran the Nix formatter, `nix-instantiate --parse`, and the staged whitespace check.

### Automation disclosure

OpenAI Codex (GPT-5) assisted with the package expression, commit message, and pull request summary. The source and npm hashes, updater selection, formatting, evaluation, Darwin build, and launch behavior were verified as described above.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
