### PR TITLE
clickup: 3.5.185 -> 3.5.230

### DIFF
--- a/pkgs/by-name/cl/clickup/package.nix
+++ b/pkgs/by-name/cl/clickup/package.nix
@@ -10,12 +10,12 @@
 }:
 let
   pname = "clickup";
-  version = "3.5.185";
+  version = "3.5.230";
 
   src = fetchurl {
     # Using archive.org because the website doesn't store older versions of the software.
-    url = "https://web.archive.org/web/20260323060753/https://desktop.clickup.com/linux";
-    hash = "sha256-szPbhY1vsEG0Zq4TD2I9qVTa4wAUYfoVA2O2xP4HGeE=";
+    url = "https://web.archive.org/web/20260715180901/https://desktop.clickup.com/linux";
+    hash = "sha256-9d4d/9FP158jHJE6xRCSaxL6kPxYLNad51UNl7RVlCs=";
   };
 
   appimage = appimageTools.wrapType2 {
@@ -47,7 +47,7 @@ stdenvNoCC.mkDerivation {
     install -m 444 -D ${appimageContents}/desktop.desktop $out/share/applications/clickup.desktop
 
     substituteInPlace $out/share/applications/clickup.desktop \
-      --replace-fail 'Exec=AppRun --no-sandbox %U' 'Exec=clickup' \
+      --replace-fail 'Exec=AppRun %U' 'Exec=clickup' \
       --replace-fail 'Icon=desktop' 'Icon=clickup'
 
     wrapProgram $out/bin/${pname} \


### PR DESCRIPTION
UPDATED PR COMMENT (original removed for policy violations):

Updates `clickup` from 3.5.185 to 3.5.230.

Change: Upstream 3.5.230 removed `--no-sandbox` from the `.desktop` `Exec` line.

Validation: ran `NIXPKGS_ALLOW_UNFREE=1 nix-build -A clickup --impure` and validated clickup works on 3.5.230 as intended.

## Disclosure

Claude Code (Claude Opus 4.8) assisted with this change. I reviewed it
and am accountable for it. The commit carries an `Assisted-by:` trailer
per CONTRIBUTING.md.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [x] Tested via `nix-build -A clickup` and launched the resulting binary
- [x] Ran the package's `passthru.updateScript`
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

cc @heisfer