### PR TITLE
programs/tmux: fix newSession option

### DIFF
--- a/nixos/modules/programs/tmux.nix
+++ b/nixos/modules/programs/tmux.nix
@@ -30,10 +30,11 @@ let
     set  -g history-limit   ${toString cfg.historyLimit}
 
     ${optionalString cfg.newSession ''
-      # Use -A to make new-session idempotent: attach if session "0" exists,
-      # otherwise create it. This prevents duplicate sessions when multiple
+      # Use -A to make new-session idempotent: attach if tmux
+      # is running and,there is an existing session, otherwise
+      # create one.  This prevents duplicate sessions when multiple
       # configs (e.g., system and user) both enable newSession.
-      new-session -A -s 0
+      new-session -A
     ''}
 
     ${optionalString cfg.reverseSplit ''


### PR DESCRIPTION
I removed `-s 0` from the programs.tmux.newSession option to restore the intended 'idempotent' behaviour.

As outlined in [issue 542321 here](https://github.com/NixOS/nixpkgs/issues/542321), enabling newSession would cause 'tmux' as entered on the cli to spawn two sessions, 0 and 1, attaching the user to session 1.

Commit [b3b1a85370516b5cdf386a2f90a85f852e0ce3bb](https://github.com/NixOS/nixpkgs/commit/b3b1a85370516b5cdf386a2f90a85f852e0ce3bb) changed newSession so that instead of inserting
`    ${optionalString cfg.newSession "new-session"}`

into tmux.conf, it inserted
```
    ${optionalString cfg.newSession ''
      # Use -A to make new-session idempotent: attach if session "0" exists,
      # otherwise create it. This prevents duplicate sessions when multiple
      # configs (e.g., system and user) both enable newSession.
      new-session -A -s 0
    ''}
```
Running `tmux new-session -A -s "0"` on the cli replicates the intended behaviour, but inserting that into tmux.conf causes `tmux new-session -A -s "0"` to be run twice, once from the initial command, and a second time as it reads the .conf.  Two sessions are started and the user is attached to the second one.

Removing the `-s "0"`causes `tmux` to attach to any running session or to create and attach to session 0.

I built and tested on nix, and confirmed on rhel and fedora vms by manually editing tmux.conf, this isn't a nix issue, this is expected behaviour for tmux.  I don't think they're necessary, but let me know if you'd like me to run through some of the tests.

RESOLVES #542321 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
