### PR TITLE
gajim: 2.4.7.1 -> 2.5.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/gajim/default.nix
+++ b/pkgs/applications/networking/instant-messengers/gajim/default.nix
@@ -38,14 +38,14 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "gajim";
-  version = "2.4.7.1";
+  version = "2.5.0";
 
   src = fetchFromGitLab {
     domain = "dev.gajim.org";
     owner = "gajim";
     repo = "gajim";
-    tag = "${finalAttrs.version}+win";
-    hash = "sha256-/X2Xp1ZnPLTZc1Hf4Kp6R/+mezU6qoUhaT9OskYlnOY=";
+    tag = finalAttrs.version;
+    hash = "sha256-3/HQNizXLjeQpCdEK14LMflyNUKF1BI8eli3BGxiH40=";
   };
 
   pyproject = true;
@@ -55,11 +55,11 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     adwaita-icon-theme
     gtksourceview5
     glib-networking
+    gstreamer
+    gst-plugins-base
   ]
   ++ lib.optionals enableJingle [
     farstream
-    gstreamer
-    gst-plugins-base
     gst-libav
     gst-plugins-good
     libnice

--- a/pkgs/development/python-modules/nbxmpp/default.nix
+++ b/pkgs/development/python-modules/nbxmpp/default.nix
@@ -14,17 +14,17 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "nbxmpp";
-  version = "7.2.0";
+  version = "7.3.0";
   pyproject = true;
 
   src = fetchFromGitLab {
     domain = "dev.gajim.org";
     owner = "gajim";
     repo = "python-nbxmpp";
-    tag = version;
-    hash = "sha256-OtJzCcaqcy2a46iNRcpknORgdTbzMtILocs5c6Akzrc=";
+    tag = finalAttrs.version;
+    hash = "sha256-UsWCZ5g7LJImqc32kBfyLaGrT3DKsl8/muWUbPufmXs=";
   };
 
   nativeBuildInputs = [
@@ -50,8 +50,9 @@ buildPythonPackage rec {
 
   meta = {
     homepage = "https://dev.gajim.org/gajim/python-nbxmpp";
+    changelog = "https://dev.gajim.org/gajim/python-nbxmpp/-/blob/${finalAttrs.src.tag}/ChangeLog";
     description = "Non-blocking Jabber/XMPP module";
     license = lib.licenses.gpl3Plus;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ haansn08 ];
   };
-}
+})


### PR DESCRIPTION
Upstream changelog: https://dev.gajim.org/gajim/gajim/-/blob/2.5.0/ChangeLog
Notably, Gstreamer is now a mandatory dependency.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
