### PR TITLE
swift: strip -mtls-dialect=gnu2 from clang wrapper

### DIFF
--- a/pkgs/development/compilers/swift/compiler/default.nix
+++ b/pkgs/development/compilers/swift/compiler/default.nix
@@ -120,7 +120,17 @@ let
       + ''
         substituteInPlace $out/nix-support/cc-cflags \
           --replace-fail " -resource-dir=$out/resource-root" ""
-      '';
+      ''
+      +
+        lib.optionalString
+          (targetPlatform.isLinux && targetPlatform.isx86 && lib.versionAtLeast (lib.getVersion clang) "19.1")
+          ''
+            # Swift bundles Clang 16, which predates -mtls-dialect=gnu2
+            # support (added in Clang 19.1). The cc-wrapper adds it based
+            # on the system Clang version, so strip it here.
+            substituteInPlace $out/nix-support/add-local-cc-cflags-before.sh \
+              --replace-fail "'-mtls-dialect=gnu2'" ""
+          '';
   });
 
   # Build a tool used during the build to create a custom clang wrapper, with

--- a/pkgs/development/compilers/swift/wrapper/default.nix
+++ b/pkgs/development/compilers/swift/wrapper/default.nix
@@ -42,6 +42,20 @@ stdenv.mkDerivation (
               "-resource-dir=$out/resource-root" \
               "-resource-dir=${lib.getLib swift}/lib/swift/clang"
         ''
+        +
+          lib.optionalString
+            (
+              stdenv.targetPlatform.isLinux
+              && stdenv.targetPlatform.isx86
+              && lib.versionAtLeast (lib.getVersion clang) "19.1"
+            )
+            ''
+              # Swift bundles Clang 16, which predates -mtls-dialect=gnu2
+              # support (added in Clang 19.1). The cc-wrapper adds it based
+              # on the system Clang version, so strip it here.
+              substituteInPlace $out/nix-support/add-local-cc-cflags-before.sh \
+                --replace-fail "'-mtls-dialect=gnu2'" ""
+            ''
         # We need the libc++ headers corresponding to the LLVM version of
         # Swift’s Clang.
         + lib.optionalString (clang.libcxx != null) ''


### PR DESCRIPTION
Swift bundles its own Clang 16, which does not support the -mtls-dialect=gnu2 flag (added in Clang 19.1). The cc-wrapper adds this flag based on the *system* Clang version, not Swift's bundled Clang, causing build failures:

  clang-16-unwrapped: error: unknown argument: '-mtls-dialect=gnu2'

Strip the flag in the existing clangForWrappers extraBuildCommands block, following the same pattern as the existing -resource-dir strip.

Fixes: https://github.com/NixOS/nixpkgs/issues/540320

Assisted-by: OpenClaw (friendli/zai-org/GLM-5.2)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Note:

> Instead of stripping the flag in the swift module, cc-wrapper could expose a function argument to handle this — e.g. a disableTLSDialect flag or a cc-version override that controls which flags get injected. My initial approach was to handle it in the swift module since it's overriding the cc-wrapper, so the override seemed responsible for the flag mismatch. Open to feedback on which approach is preferred here.