### PR TITLE
ctpv: add coreutils in wrapper, switch to ueberzugpp

### DIFF
--- a/pkgs/by-name/ct/ctpv/package.nix
+++ b/pkgs/by-name/ct/ctpv/package.nix
@@ -8,6 +8,7 @@
   atool,
   bat,
   chafa,
+  coreutils,
   delta,
   ffmpeg,
   ffmpegthumbnailer,
@@ -46,6 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
           atool # for archive files
           bat
           chafa # for image files on Wayland
+          coreutils
           delta # for diff files
           ffmpeg
           ffmpegthumbnailer

--- a/pkgs/by-name/ct/ctpv/package.nix
+++ b/pkgs/by-name/ct/ctpv/package.nix
@@ -17,7 +17,7 @@
   imagemagick,
   jq,
   poppler-utils,
-  ueberzug,
+  ueberzugpp,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -56,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
           imagemagick
           jq # for json files
           poppler-utils # for pdf files
-          ueberzug # for image files on X11
+          ueberzugpp # for image files on X11
         ]
       }";
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
In the ctpv source (at [this line](https://github.com/NikitaIvanovV/ctpv/blob/4efa0f976eaf8cb814e0aba4f4f1a1d12ee9262e/sh/helpers.sh#L44)) is the following bash expression:
```bash
dd oflag=nonblock conv=notrunc,nocreat count=0 of="$1" \
    >/dev/null 2>/dev/null
```
As it turns out, `oflag=nonblock` is a GNU-specific `dd` option.  I traced this to being the cause of ctpv image displays breaking on my machine.  I have toybox installed for some other programs, and the version of `dd` provided there doesn't honor the flag in question, which causes the script to exit with error.  Making sure coreutils has priority in `$PATH` fixes this and any other weird GNU/non-GNU differences that might pop up.  I'd like to backport this first commit.

The second commit is because Ueberzug was throwing an error (built on Nixpkgs commit `fd2fd1c14ce6fd3ec63a0167355fc4ab18e02a6d`) when trying to run and I think this has been a goal for a while (see #287962).  Ueberzugpp is a drop-in replacement and it works fine with ctpv on my machine.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
