### PR TITLE
beeper: 4.2.892 -> 4.2.985; support aarch64

### DIFF
--- a/pkgs/by-name/be/beeper/package.nix
+++ b/pkgs/by-name/be/beeper/package.nix
@@ -1,81 +1,49 @@
 {
   lib,
+  stdenv,
+  stdenvNoCC,
+  runCommand,
   fetchurl,
   appimageTools,
   makeWrapper,
   asar,
+  unzip,
   writeShellApplication,
   curl,
   common-updater-scripts,
 }:
 let
   pname = "beeper";
-  version = "4.2.892";
-  src = fetchurl {
-    url = "https://beeper-desktop.download.beeper.com/builds/Beeper-${version}-x86_64.AppImage";
-    hash = "sha256-kTX0VrfJb7UnQ6JVfRIgjLlIsDgzDVgTnx7twlYMf9k=";
+  version = "4.2.985";
+
+  inherit (stdenv.hostPlatform) system;
+
+  sources = {
+    x86_64-linux = fetchurl {
+      url = "https://beeper-desktop.download.beeper.com/builds/Beeper-${version}-x86_64.AppImage";
+      hash = "sha256-oWJdpZL+Q8/jaI/WJfgXUisPASuvHkxU6rOeJkedHSM=";
+    };
+    aarch64-linux = fetchurl {
+      url = "https://beeper-desktop.download.beeper.com/builds/Beeper-${version}-arm64.AppImage";
+      hash = "sha256-rY302fiRG2c6dwZ+a8e43DjDUklfR0j78XTixhPkvwY=";
+    };
+    aarch64-darwin = fetchurl {
+      # Zip unpacks cleanly with unzip; the download API redirects to a .dmg.
+      url = "https://beeper-desktop.download.beeper.com/builds/Beeper-${version}-arm64-mac.zip";
+      hash = "sha256-ptWKPPbpHql6Qe90fT65EYg4bIlU9fyPcEXgLUFIYxg=";
+    };
   };
-  appimageContents = appimageTools.extract {
-    inherit pname version src;
 
-    postExtract = ''
-      appRoot="$out/resources/app"
-      ${lib.getExe asar} extract "$out/resources/app.asar" "$appRoot"
-      rm "$out/resources/app.asar"
+  src = sources.${system} or (throw "beeper is not supported on ${system}");
 
-      # disable creating a desktop file and icon in the home folder during runtime
-      linuxConfigFilename=$appRoot/build/main/linux-*.mjs
-      echo "export function registerLinuxConfig() {}" > $linuxConfigFilename
-
-      # disable auto update
-      sed -i 's/c=d??{},p=c.hw_acceleration??!0/c={...(d??{}),auto_update_disabled:true},p=c.hw_acceleration??!0/g' $appRoot/build/main/index-*.mjs
-
-      # prevent updates
-      sed -i -E 's/executeDownload\([^)]+\)\{/executeDownload(){return;/g' $appRoot/build/main/main-entry-*.mjs
-
-      # hide version status element on about page otherwise an error message is shown
-      sed -i '$ a\.subview-prefs-about > div:nth-child(2) {display: none;}' $appRoot/build-browser/*.css
-
-    '';
-  };
-in
-appimageTools.wrapAppImage {
-  inherit pname version;
-
-  src = appimageContents;
-
-  extraPkgs = pkgs: [ pkgs.libsecret ];
-
-  extraInstallCommands = ''
-    install -Dm 644 ${appimageContents}/beepertexts.png $out/share/icons/hicolor/512x512/apps/beepertexts.png
-    install -Dm 644 ${appimageContents}/beepertexts.desktop -t $out/share/applications/
-    substituteInPlace $out/share/applications/beepertexts.desktop --replace-fail "AppRun" "beeper"
-
-    . ${makeWrapper}/nix-support/setup-hook
-    wrapProgram $out/bin/beeper \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}} --no-update" \
-      --set APPIMAGE beeper \
-      --run 'exec >/dev/null' # as recommended in #486164
+  # Beeper 4.2.985+ ships Linux AppImages without the type-2 magic bytes
+  # (ASCII "AI" + 0x02 at ELF offset 8) that appimageTools.extract requires.
+  # Restore them so extraction matches the existing x86_64-linux packaging path.
+  linuxSrc = runCommand "Beeper-${version}-appimage" { inherit src; } ''
+    cp $src $out
+    chmod +w $out
+    printf 'AI\x02' | dd of=$out bs=1 seek=8 conv=notrunc status=none
   '';
-
-  passthru = {
-    updateScript = lib.getExe (writeShellApplication {
-      name = "update-beeper";
-      runtimeInputs = [
-        curl
-        common-updater-scripts
-      ];
-      text = ''
-        set -o errexit
-        latestLinux="$(curl --silent --output /dev/null --write-out "%{redirect_url}\n" https://api.beeper.com/desktop/download/linux/x64/stable/com.automattic.beeper.desktop)"
-        version="$(echo "$latestLinux" | grep --only-matching --extended-regexp '[0-9]+\.[0-9]+\.[0-9]+')"
-        update-source-version beeper "$version"
-      '';
-    });
-
-    # needed for nix-update
-    inherit src;
-  };
 
   meta = {
     description = "Universal chat app";
@@ -89,7 +57,108 @@ appimageTools.wrapAppImage {
     maintainers = with lib.maintainers; [
       jshcmpbll
       zh4ngx
+      aspauldingcode
     ];
-    platforms = [ "x86_64-linux" ];
+    platforms = lib.attrNames sources;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "beeper";
   };
-}
+
+  passthru = {
+    inherit sources;
+    updateScript = lib.getExe (writeShellApplication {
+      name = "update-beeper";
+      runtimeInputs = [
+        curl
+        common-updater-scripts
+      ];
+      text = ''
+        set -o errexit
+        latestLinux="$(curl --silent --output /dev/null --write-out "%{redirect_url}\n" https://api.beeper.com/desktop/download/linux/x64/stable/com.automattic.beeper.desktop)"
+        version="$(echo "$latestLinux" | grep --only-matching --extended-regexp '[0-9]+\.[0-9]+\.[0-9]+')"
+        for platform in ${lib.escapeShellArgs (lib.attrNames sources)}; do
+          update-source-version beeper "$version" --ignore-same-version --source-key="passthru.sources.$platform"
+        done
+      '';
+    });
+  };
+
+  linux =
+    let
+      appimageContents = appimageTools.extract {
+        inherit pname version;
+        src = linuxSrc;
+
+        postExtract = ''
+          appRoot="$out/resources/app"
+          ${lib.getExe asar} extract "$out/resources/app.asar" "$appRoot"
+          rm "$out/resources/app.asar"
+
+          # disable creating a desktop file and icon in the home folder during runtime
+          linuxConfigFilename=$appRoot/build/main/linux-*.mjs
+          echo "export function registerLinuxConfig() {}" > $linuxConfigFilename
+
+          # disable auto update
+          sed -i 's/c=d??{},p=c.hw_acceleration??!0/c={...(d??{}),auto_update_disabled:true},p=c.hw_acceleration??!0/g' $appRoot/build/main/index-*.mjs
+
+          # prevent updates
+          sed -i -E 's/executeDownload\([^)]+\)\{/executeDownload(){return;/g' $appRoot/build/main/main-entry-*.mjs
+
+          # hide version status element on about page otherwise an error message is shown
+          sed -i '$ a\.subview-prefs-about > div:nth-child(2) {display: none;}' $appRoot/build-browser/*.css
+        '';
+      };
+    in
+    appimageTools.wrapAppImage {
+      inherit
+        pname
+        version
+        meta
+        passthru
+        ;
+
+      src = appimageContents;
+
+      extraPkgs = pkgs: [ pkgs.libsecret ];
+
+      extraInstallCommands = ''
+        install -Dm 644 ${appimageContents}/beepertexts.png $out/share/icons/hicolor/512x512/apps/beepertexts.png
+        install -Dm 644 ${appimageContents}/beepertexts.desktop -t $out/share/applications/
+        substituteInPlace $out/share/applications/beepertexts.desktop --replace-fail "AppRun" "beeper"
+
+        . ${makeWrapper}/nix-support/setup-hook
+        wrapProgram $out/bin/beeper \
+          --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}} --no-update" \
+          --set APPIMAGE beeper \
+          --run 'exec >/dev/null' # as recommended in #486164
+      '';
+    };
+
+  darwin = stdenvNoCC.mkDerivation {
+    inherit
+      pname
+      version
+      src
+      meta
+      passthru
+      ;
+
+    nativeBuildInputs = [
+      unzip
+      makeWrapper
+    ];
+
+    sourceRoot = ".";
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/{Applications,bin}
+      cp -r "Beeper Desktop.app" $out/Applications/
+      makeWrapper "$out/Applications/Beeper Desktop.app/Contents/MacOS/Beeper Desktop" $out/bin/beeper
+
+      runHook postInstall
+    '';
+  };
+in
+if stdenv.hostPlatform.isDarwin then darwin else linux


### PR DESCRIPTION
## Summary
- Bump Beeper to 4.2.985 and add **aarch64-linux** via the official arm64 AppImage, keeping the existing AppImage extract/wrap + auto-update disable path used on x86_64-linux
- Add **aarch64-darwin** Beeper Desktop from the arm64 mac zip (`unzip` + `Beeper Desktop.app` wrapper)
- Restore AppImage type-2 magic bytes for 4.2.985+ (upstream dropped them; required by `appimageTools.extract`)
- Add `aspauldingcode` as a package maintainer; update script covers all `passthru.sources`

## Test plan
- [x] `nix-build -A beeper` on aarch64-darwin (zip) — launches Beeper Desktop
- [x] `nix-build -A beeper --argstr system aarch64-linux` via linux builder — AppImage extract/wrap succeeds; headless launch reaches Electron (fails only on missing `$DISPLAY`)
- [x] Evaluates for `x86_64-linux` / `aarch64-linux` / `aarch64-darwin`
- [x] Confirmed x86_64 and aarch64 AppImages take the same postExtract patches (`linuxConfig`, `auto_update_disabled`, `executeDownload`)
- [ ] OfBorg / CI builds for `x86_64-linux` and `aarch64-linux`