### PR TITLE
beeper: support aarch64-darwin

### DIFF
--- a/pkgs/by-name/be/beeper/package.nix
+++ b/pkgs/by-name/be/beeper/package.nix
@@ -1,11 +1,13 @@
 {
   lib,
   stdenv,
+  stdenvNoCC,
   runCommand,
   fetchurl,
   appimageTools,
   makeWrapper,
   asar,
+  unzip,
   writeShellApplication,
   curl,
   common-updater-scripts,
@@ -25,6 +27,11 @@ let
       url = "https://beeper-desktop.download.beeper.com/builds/Beeper-${version}-arm64.AppImage";
       hash = "sha256-kWlKMZdicJ+DhGgYXCTqvSCYinI9QD0pJD4nb4yYdpI=";
     };
+    aarch64-darwin = fetchurl {
+      # Zip unpacks cleanly with unzip; the download API redirects to a .dmg.
+      url = "https://beeper-desktop.download.beeper.com/builds/Beeper-${version}-arm64-mac.zip";
+      hash = "sha256-79T3pPLEt+tQQ2xoC3XBAI/xpxMdnY11qSmVA2VFiVw=";
+    };
   };
 
   src = sources.${system} or (throw "beeper is not supported on ${system}");
@@ -37,50 +44,24 @@ let
     printf 'AI\x02' | dd of=$out bs=1 seek=8 conv=notrunc status=none
   '';
 
-  appimageContents = appimageTools.extract {
-    inherit pname version;
-    src = linuxSrc;
-
-    postExtract = ''
-      appRoot="$out/resources/app"
-      ${lib.getExe asar} extract "$out/resources/app.asar" "$appRoot"
-      rm "$out/resources/app.asar"
-
-      # disable creating a desktop file and icon in the home folder during runtime
-      linuxConfigFilename=$appRoot/build/main/linux-*.mjs
-      echo "export function registerLinuxConfig() {}" > $linuxConfigFilename
-
-      # Disable scheduled update checks.
-      autoUpdateConfigFilename=$(
-        grep -lF 'c=d??{},p=c.hw_acceleration??!0' $appRoot/build/main/index-*.mjs
-      )
-      substituteInPlace "$autoUpdateConfigFilename" \
-        --replace-fail 'c=d??{},p=c.hw_acceleration??!0' 'c={...(d??{}),auto_update_disabled:true},p=c.hw_acceleration??!0'
-
-      # Disable user-triggered update checks, which ignore auto_update_disabled.
-      substituteInPlace $appRoot/build/main/main-entry-*.mjs \
-        --replace-fail 'async checkForUpdates(r=!1){' 'async checkForUpdates(r=!1){return;'
+  meta = {
+    description = "Universal chat app";
+    longDescription = ''
+      Beeper is a universal chat app. With Beeper, you can send
+      and receive messages to friends, family and colleagues on
+      many different chat networks.
     '';
+    homepage = "https://beeper.com";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [
+      jshcmpbll
+      zh4ngx
+      aspauldingcode
+    ];
+    platforms = lib.attrNames sources;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "beeper";
   };
-in
-appimageTools.wrapAppImage {
-  inherit pname version;
-
-  src = appimageContents;
-
-  extraPkgs = pkgs: [ pkgs.libsecret ];
-
-  extraInstallCommands = ''
-    install -Dm 644 ${appimageContents}/beepertexts.png $out/share/icons/hicolor/512x512/apps/beepertexts.png
-    install -Dm 644 ${appimageContents}/beepertexts.desktop -t $out/share/applications/
-    substituteInPlace $out/share/applications/beepertexts.desktop --replace-fail "AppRun" "beeper"
-
-    . ${makeWrapper}/nix-support/setup-hook
-    wrapProgram $out/bin/beeper \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
-      --set APPIMAGE beeper \
-      --run 'exec >/dev/null' # as recommended in #486164
-  '';
 
   passthru = {
     inherit sources;
@@ -101,22 +82,84 @@ appimageTools.wrapAppImage {
     });
   };
 
-  meta = {
-    description = "Universal chat app";
-    longDescription = ''
-      Beeper is a universal chat app. With Beeper, you can send
-      and receive messages to friends, family and colleagues on
-      many different chat networks.
-    '';
-    homepage = "https://beeper.com";
-    license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [
-      jshcmpbll
-      zh4ngx
-      aspauldingcode
+  linux =
+    let
+      appimageContents = appimageTools.extract {
+        inherit pname version;
+        src = linuxSrc;
+
+        postExtract = ''
+          appRoot="$out/resources/app"
+          ${lib.getExe asar} extract "$out/resources/app.asar" "$appRoot"
+          rm "$out/resources/app.asar"
+
+          # disable creating a desktop file and icon in the home folder during runtime
+          linuxConfigFilename=$appRoot/build/main/linux-*.mjs
+          echo "export function registerLinuxConfig() {}" > $linuxConfigFilename
+
+          # Disable scheduled update checks.
+          autoUpdateConfigFilename=$(
+            grep -lF 'c=d??{},p=c.hw_acceleration??!0' $appRoot/build/main/index-*.mjs
+          )
+          substituteInPlace "$autoUpdateConfigFilename" \
+            --replace-fail 'c=d??{},p=c.hw_acceleration??!0' 'c={...(d??{}),auto_update_disabled:true},p=c.hw_acceleration??!0'
+
+          # Disable user-triggered update checks, which ignore auto_update_disabled.
+          substituteInPlace $appRoot/build/main/main-entry-*.mjs \
+            --replace-fail 'async checkForUpdates(r=!1){' 'async checkForUpdates(r=!1){return;'
+        '';
+      };
+    in
+    appimageTools.wrapAppImage {
+      inherit
+        pname
+        version
+        meta
+        passthru
+        ;
+
+      src = appimageContents;
+
+      extraPkgs = pkgs: [ pkgs.libsecret ];
+
+      extraInstallCommands = ''
+        install -Dm 644 ${appimageContents}/beepertexts.png $out/share/icons/hicolor/512x512/apps/beepertexts.png
+        install -Dm 644 ${appimageContents}/beepertexts.desktop -t $out/share/applications/
+        substituteInPlace $out/share/applications/beepertexts.desktop --replace-fail "AppRun" "beeper"
+
+        . ${makeWrapper}/nix-support/setup-hook
+        wrapProgram $out/bin/beeper \
+          --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+          --set APPIMAGE beeper \
+          --run 'exec >/dev/null' # as recommended in #486164
+      '';
+    };
+
+  darwin = stdenvNoCC.mkDerivation {
+    inherit
+      pname
+      version
+      src
+      meta
+      passthru
+      ;
+
+    nativeBuildInputs = [
+      unzip
+      makeWrapper
     ];
-    platforms = lib.attrNames sources;
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    mainProgram = "beeper";
+
+    sourceRoot = ".";
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/{Applications,bin}
+      cp -r "Beeper Desktop.app" $out/Applications/
+      makeWrapper "$out/Applications/Beeper Desktop.app/Contents/MacOS/Beeper Desktop" $out/bin/beeper
+
+      runHook postInstall
+    '';
   };
-}
+in
+if stdenv.hostPlatform.isDarwin then darwin else linux


### PR DESCRIPTION
## Summary
- Add **aarch64-darwin** Beeper Desktop from the arm64 mac zip (`unzip` + `Beeper Desktop.app` wrapper)
- Rebased onto current master (4.3.73) using the Darwin hash prepared by @zh4ngx

## Test plan
- [x] `NIXPKGS_ALLOW_UNFREE=1 nix-build -A beeper` on aarch64-darwin — builds and installs
- [x] Darwin zip hash verified: `sha256-79T3pPLEt+tQQ2xoC3XBAI/xpxMdnY11qSmVA2VFiVw=`
- [x] CI eval/lint green (darwin rebuild 1, linux 0)
