### PR TITLE
matrix-continuwuity: make rocksdb overridable

### DIFF
--- a/pkgs/by-name/ma/matrix-continuwuity/package.nix
+++ b/pkgs/by-name/ma/matrix-continuwuity/package.nix
@@ -6,7 +6,7 @@
   bzip2,
   zstd,
   stdenv,
-  rocksdb,
+  callPackage,
   nix-update-script,
   testers,
   matrix-continuwuity,
@@ -14,28 +14,7 @@
   liburing,
   nixosTests,
 }:
-let
-  rocksdb' =
-    (rocksdb.override {
-      # rocksdb does not support prefixed jemalloc, which is required on darwin
-      enableJemalloc = !stdenv.hostPlatform.isDarwin;
-      jemalloc = rust-jemalloc-sys-unprefixed;
-    }).overrideAttrs
-      (
-        final: old: {
-          version = "11.1.1";
-          src = fetchFromGitea {
-            domain = "forgejo.ellis.link";
-            owner = "continuwuation";
-            repo = "rocksdb";
-            rev = "3756b2b905e13216d8b56bcc783d814e7b073aff";
-            hash = "sha256-rSv4fr2bf9JJwdodgeuPCuceeh7k97KVxrAOC0wyPQY=";
-          };
 
-          patches = [ ];
-        }
-      );
-in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "matrix-continuwuity";
   version = "26.7.1";
@@ -64,12 +43,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   env = {
     ZSTD_SYS_USE_PKG_CONFIG = true;
-    ROCKSDB_INCLUDE_DIR = "${rocksdb'}/include";
-    ROCKSDB_LIB_DIR = "${rocksdb'}/lib";
+    ROCKSDB_INCLUDE_DIR = "${finalAttrs.rocksdb}/include";
+    ROCKSDB_LIB_DIR = "${finalAttrs.rocksdb}/lib";
   };
 
+  rocksdb = callPackage ./rocksdb.nix { }; # make used rocksdb version available (e.g., for backup scripts)
+
   passthru = {
-    rocksdb = rocksdb'; # make used rocksdb version available (e.g., for backup scripts)
     updateScript = nix-update-script { };
     tests = {
       version = testers.testVersion {

--- a/pkgs/by-name/ma/matrix-continuwuity/rocksdb.nix
+++ b/pkgs/by-name/ma/matrix-continuwuity/rocksdb.nix
@@ -1,0 +1,26 @@
+{
+  stdenv,
+  fetchFromGitea,
+  rocksdb,
+  rust-jemalloc-sys-unprefixed,
+}:
+
+(rocksdb.override {
+  # rocksdb does not support prefixed jemalloc, which is required on darwin
+  enableJemalloc = !stdenv.hostPlatform.isDarwin;
+  jemalloc = rust-jemalloc-sys-unprefixed;
+}).overrideAttrs
+  (
+    final: old: {
+      version = "11.1.1";
+      src = fetchFromGitea {
+        domain = "forgejo.ellis.link";
+        owner = "continuwuation";
+        repo = "rocksdb";
+        rev = "3756b2b905e13216d8b56bcc783d814e7b073aff";
+        hash = "sha256-rSv4fr2bf9JJwdodgeuPCuceeh7k97KVxrAOC0wyPQY=";
+      };
+
+      patches = [ ];
+    }
+  )


### PR DESCRIPTION
As I noticed multiple people I know (currently the grand total is at 3) had trouble downgrading/pinning Continuwuity, because RocksDB is not overridable. This PR fixes that.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
