### PR TITLE
ceph: Override arrow-cpp 24 -> 23 to fix build

### DIFF
--- a/pkgs/by-name/ce/ceph/arrow-cpp.nix
+++ b/pkgs/by-name/ce/ceph/arrow-cpp.nix
@@ -1,0 +1,21 @@
+{
+  arrow-cpp,
+  fetchFromGitHub,
+}:
+
+# Ceph's `s3select` code (`src/s3select`) includes `arrow/util/span.h`, which
+# `arrow-cpp` removed in version 24.0.0 in favour of `std::span`:
+#     https://github.com/apache/arrow/pull/49492
+# This broke the Ceph build once nixpkgs' `arrow-cpp` was bumped to 24.0.0:
+#     https://github.com/NixOS/nixpkgs/issues/542206
+# There is no upstream Ceph fix available yet, so we vendor the last `arrow-cpp`
+# version that still ships `arrow/util/span.h` (23.0.0) for use by Ceph only.
+arrow-cpp.overrideAttrs (finalAttrs: {
+  version = "23.0.0";
+  src = fetchFromGitHub {
+    owner = "apache";
+    repo = "arrow";
+    rev = "apache-arrow-${finalAttrs.version}";
+    hash = "sha256-BluUlbtGJwvlrpN/c/KziOfFh5dvzZyuCy4JZkkFea4=";
+  };
+})

--- a/pkgs/by-name/ce/ceph/ceph.nix
+++ b/pkgs/by-name/ce/ceph/ceph.nix
@@ -23,7 +23,7 @@
 
   # Runtime dependencies
 
-  arrow-cpp,
+  ceph-arrow-cpp,
   babeltrace,
   ceph-boost,
   bzip2,
@@ -173,7 +173,7 @@ stdenv.mkDerivation {
   buildInputs =
     cryptoLibsMap.${cryptoStr}
     ++ [
-      arrow-cpp
+      ceph-arrow-cpp
       babeltrace
       ceph-boost
       bzip2
@@ -389,7 +389,7 @@ stdenv.mkDerivation {
   passthru = {
     inherit (ceph-src) version;
     inherit overrideScope;
-    inherit arrow-cpp;
+    arrow-cpp = ceph-arrow-cpp; # remove once we remove version vendoring for this
     pythonEnv = ceph-python-env;
     tests = {
       inherit (nixosTests)

--- a/pkgs/by-name/ce/ceph/scope.nix
+++ b/pkgs/by-name/ce/ceph/scope.nix
@@ -4,6 +4,12 @@
 lib.makeScope pkgs.newScope (self: {
   ceph-rocksdb = self.callPackage ./rocksdb.nix { };
 
+  # Ceph's `s3select` code needs `arrow/util/span.h`, which `arrow-cpp` removed
+  # in 24.0.0. We vendor the last `arrow-cpp` version that still ships it.
+  # See: https://github.com/NixOS/nixpkgs/issues/542206
+  # Should be removed when Ceph supports arrow-cpp >= 24.
+  ceph-arrow-cpp = self.callPackage ./arrow-cpp.nix { };
+
   # to get an idea which Python versions are supported by Ceph, see upstream `do_cmake.sh` (see `PYBUILD=` variable)
   ceph-python = self.callPackage ({ python312 }: python312) { };
   ceph-python-common = self.callPackage ./python-common.nix { };


### PR DESCRIPTION
Fixes:

* #542206

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
