### PR TITLE
rPackages: prune packagesToSkipCheck, fix Rmpi

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -486,7 +486,10 @@ let
     Rigraphlib = [ pkgs.cmake ];
     Rlibeemd = [ pkgs.gsl ]; # for gsl-config
     RmecabKo = [ pkgs.mecab ]; # for mecab-config
-    Rmpi = [ pkgs.prrte ];
+    Rmpi = with pkgs; [
+      pkg-config
+      prrte
+    ];
     RoBMA = [ pkgs.pkg-config ];
     RoBSA = [ pkgs.pkg-config ];
     Rpoppler = [ pkgs.pkg-config ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -1778,6 +1778,7 @@ let
     "PKbioanalysis"
     "PSCBS"
     "Patterns"
+    "PhIPData"
     "Quartet"
     "RKorAPClient"
     "R_cache"
@@ -1842,15 +1843,9 @@ let
 
   packagesToSkipCheck = [
     # keep-sorted start
-    "CTdata" # tries to connect to ExperimentHub
-    "MsDataHub" # tries to connect to ExperimentHub
-    "PhIPData" # tries to download something from a DB
     "ReactomeContentService4R" # tries to connect to Reactome
-    "Rmpi" # tries to run MPI processes
     "coMethDMR" # tries to connect to ExperimentHub
-    "data_table" # fails to rename shared library before check
     "multiMiR" # tries to connect to DB
-    "pbdMPI" # tries to run MPI processes
     "rfaRm" # tries to connect to Ebi
     "snapcount" # tries to connect to snaptron.cs.jhu.edu
     # keep-sorted end


### PR DESCRIPTION
Targeting https://github.com/NixOS/nixpkgs/pull/539315

The most notable one is `Rmpi`. Because checks were disabled, the `Rmpi.so` file was not tested to actually be loadable.

The issue was that `-I{some_unset_var} -DMPI2` expanded to `-I -DMPI2` where `-I` thought that the next thing is a directory name instead of the next flag. Thus, the `#ifdef MPI2` stuff didn't get compiled.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
