### PR TITLE
python3Packages.envisage: 7.0.4 -> 7.0.4-unstable-2026-07-07

### DIFF
--- a/pkgs/development/python-modules/envisage/default.nix
+++ b/pkgs/development/python-modules/envisage/default.nix
@@ -2,7 +2,7 @@
   lib,
   apptools,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   pyface,
   pytestCheckHook,
   setuptools,
@@ -10,14 +10,16 @@
   traitsui,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "envisage";
-  version = "7.0.4";
+  version = "7.0.4-unstable-2026-07-07";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-1rspOLu0XE7xdmxV7W9sHHK2/OcEaKyfWw780e+MHZc=";
+  src = fetchFromGitHub {
+    owner = "enthought";
+    repo = "envisage";
+    rev = "8b1548a589ff1c317a3a1c709e2d186302e8df88";
+    hash = "sha256-EF0FEuKX0TPmb9eOyiF7M3DoLyvxpcq8ePQHxEfg30g=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
In particular, we need the fix at enthought/envisage#600.

All changes: https://github.com/enthought/envisage/compare/7.0.4...8b1548a589ff1c317a3a1c709e2d186302e8df88
Changelog: https://github.com/enthought/envisage/blob/8b1548a589ff1c317a3a1c709e2d186302e8df88/CHANGES.rst

Fixes #542236.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
