### PR TITLE
cc-wrapper: Default-disable AltiVec with powerpc64-linux LLVM

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -370,7 +370,15 @@ let
     # Aarch64 uses TLSDESC by default and the option is completely ignored (at least on LLVM).
     # TODO: Enable by default in GCC via --with-tls since https://gcc.gnu.org/cgit/gcc/commit/?id=96a291c4bb0b8a00b0a125e6a60f60072ffe53a7 (GCC 16).
     # No equivalent build-time option for LLVM yet.
-    ++ optional (tlsDialect != null) "-mtls-dialect=${tlsDialect}";
+    ++ optional (tlsDialect != null) "-mtls-dialect=${tlsDialect}"
+    # LLVM default-enables AltiVec for powerpc64, and for many CPU targets that didn't actually have it.
+    # https://github.com/llvm/llvm-project/blob/40977001fcb190a509897aee592819cdd7e83740/llvm/lib/Target/PowerPC/PPC.td#L791-L796
+    # GCC is more conservative: Requires selecting POWER7 or higher for auto-enable, or opting into it on older ones.
+    # If no CPU is specified, disable AltiVec like GCC does.
+    # TODO: Specify CPU + AltiVec preference?
+    ++ optional (
+      (targetPlatform.isPower64 && targetPlatform.isBigEndian) && isClang && !(targetPlatform ? gcc.cpu)
+    ) "-mno-altivec";
 
   defaultHardeningFlags = bintools.defaultHardeningFlags or [ ];
 


### PR DESCRIPTION
Closes #517759 (which is one example of a project being unhappy with the current state of things)

On my Nixpkgs branch with various ppc64 PRs cherry-picked, this fixes `webkitgtk_6_0` when built on hardware (with a plethora of other PRs for software built along the way…). Cross fails in other places rn (at least `libgudev`, needs #528844).

Also built another minimal ISO with this (and other submitted PRs) applied, and everything builds and boots fine.

<img width="1020" height="564" alt="image" src="https://github.com/user-attachments/assets/695e427e-97ec-45ea-adbc-55f156313edf" />

<sub>(yes, this CPU happens to have AltiVec, but other CPUs don't)</sub>

Hope this is acceptable for a review…

---

GCC is very conservative about enabling AltiVec. The default target has it disabled, and it requires either:

- picking a CPU target that is generic POWER7 or higher, or is a specific CPU model that had AltiVec, or
- using -maltivec to opt into it

LLVM default-enables AltiVec, and has it marked as supported on CPUs that historically lacked it.

Inconsistency aside, this leads to issues when building things with Clang that do not expect just AltiVec to be enabled, like webkitgtk.

To make things more consistent, if no gcc.cpu is configured, pass -mno-altivec to Clang.

Alternatively, we'd have to patch all packaged LLVM versions…

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (no change)
  - [ ] aarch64-linux
  - [x] powerpc64-linux (native)
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
