### PR TITLE
hyprland: use packaged udis86,  udis86: update

### DIFF
--- a/pkgs/by-name/hy/hyprland/package.nix
+++ b/pkgs/by-name/hy/hyprland/package.nix
@@ -14,6 +14,7 @@
   glslang,
   hyprcursor,
   hyprgraphics,
+  hyprland-protocols,
   hyprland-qtutils,
   hyprlang,
   hyprutils,
@@ -38,6 +39,7 @@
   readline,
   systemd,
   tomlplusplus,
+  udis86,
   uwsm,
   wayland,
   wayland-protocols,
@@ -90,9 +92,8 @@ customStdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = "hyprland";
-    fetchSubmodules = true;
     tag = "v${finalAttrs.version}";
-    hash = "sha256-jOcfiv+Zs2iz5oTIQcJXZ0+5MfqW0oLgGxD0cKdmXpE=";
+    hash = "sha256-IptZjFf/bE9lv8SQLef4Wmn3KOs3BwchYr6aFcCJ9NI=";
   };
 
   postPatch = ''
@@ -140,7 +141,6 @@ customStdenv.mkDerivation (finalAttrs: {
     cmake
     pkg-config
     wayland-scanner
-    # for udis86
     python3
   ];
 
@@ -158,6 +158,7 @@ customStdenv.mkDerivation (finalAttrs: {
       glslang
       hyprcursor.dev
       hyprgraphics
+      hyprland-protocols
       hyprlang
       hyprutils
       lcms2
@@ -176,6 +177,7 @@ customStdenv.mkDerivation (finalAttrs: {
       re2
       readline
       tomlplusplus
+      udis86
       wayland
       wayland-protocols
     ]

--- a/pkgs/by-name/ud/udis86/package.nix
+++ b/pkgs/by-name/ud/udis86/package.nix
@@ -2,29 +2,20 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   autoreconfHook,
   python3,
 }:
 
 stdenv.mkDerivation {
   pname = "udis86";
-  version = "unstable-2014-12-25";
+  version = "1.7.2-unstable-2022-10-13";
 
   src = fetchFromGitHub {
-    owner = "vmt";
+    owner = "canihavesomecoffee";
     repo = "udis86";
-    rev = "56ff6c87c11de0ffa725b14339004820556e343d";
-    hash = "sha256-bmm1rgzZeStQJXEmcT8vnplsnmgN3LJlYs7COmqsDU8=";
+    rev = "5336633af70f3917760a6d441ff02d93477b0c86";
+    hash = "sha256-HifdUQPGsKQKQprByeIznvRLONdOXeolOsU5nkwIv3g=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "support-python3-for-building";
-      url = "https://github.com/vmt/udis86/commit/3c05ce60372cb2eba39d6eb87ac05af8a664e1b1.patch";
-      hash = "sha256-uF4Cwt7UMkyd0RX6cCMQt9xvkkUNQvTDH/Z/6nHtVT8=";
-    })
-  ];
 
   nativeBuildInputs = [
     autoreconfHook
@@ -43,7 +34,7 @@ stdenv.mkDerivation {
   ];
 
   meta = {
-    homepage = "https://udis86.sourceforge.net";
+    homepage = "https://github.com/canihavesomecoffee/udis86";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ timor ];
     mainProgram = "udcli";


### PR DESCRIPTION
Switches udis86 to somewhat mantained fork instead of abandoned upstream
Uses it to build hyprland without submodules. python3 still needed for `meta/generateLuaStubs.py`

Assisted-by: codex with gpt-5.6-sol-high

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
