### PR TITLE
dasel: 3.8.1 -> 3.11.2, fix version check

### DIFF
--- a/pkgs/by-name/da/dasel/package.nix
+++ b/pkgs/by-name/da/dasel/package.nix
@@ -7,13 +7,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "dasel";
-  version = "3.8.1";
+  version = "3.11.2";
 
   src = fetchFromGitHub {
     owner = "TomWright";
     repo = "dasel";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-/rQItj+nCr/IriT4Lgbxe+d9XfAyyZM+Q0nM0F3s//M=";
+    hash = "sha256-F7oNs65AsokIgYjaPqgSbtsZ5JwSFJ/A6Edm+LzQqgU=";
   };
 
   vendorHash = "sha256-oqGUHPnfCxgUTueB1zEJ8/h0L+2oxoVQHI+oJm3HcPo=";

--- a/pkgs/by-name/da/dasel/package.nix
+++ b/pkgs/by-name/da/dasel/package.nix
@@ -27,7 +27,7 @@ buildGoModule (finalAttrs: {
   doInstallCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
   installCheckPhase = ''
     runHook preInstallCheck
-    if [[ $($out/bin/dasel version) == "v${finalAttrs.version}" ]]; then
+    if [[ $($out/bin/dasel version) == "${finalAttrs.version}" ]]; then
       echo '{ "my": { "favourites": { "colour": "blue" } } }' \
         | $out/bin/dasel -i json 'my.favourites.colour = "red"' \
         | grep "red"


### PR DESCRIPTION
There are some useful additions since 3.8.1, specifically I'm interested in `kdl` support, i.e.

```
> nix-build -A dasel

> echo 'server host="localhost" port=8080' | ./result/bin/dasel -i kdl -o kdl --root 'server.port = 9090'
server host="localhost" port=9090
```

https://github.com/TomWright/dasel/releases#release-v3.11.2

https://github.com/TomWright/dasel/compare/v3.8.1...v3.11.2

Also, `version` doesn't have the `v` prefix anymore

```
> ./result/bin/dasel version
3.11.2
```

current unstable has it

```
> nix-shell -p dasel --run "dasel version"
v3.8.1
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
