### PR TITLE
glaze: disable SSL support by default, drop stale interop option

### DIFF
--- a/pkgs/by-name/gl/glaze/package.nix
+++ b/pkgs/by-name/gl/glaze/package.nix
@@ -5,7 +5,7 @@
   cmake,
   openssl,
   enableSIMD ? stdenv.hostPlatform.avx2Support,
-  enableSSL ? true,
+  enableSSL ? false,
   enableInterop ? true,
 }:
 

--- a/pkgs/by-name/gl/glaze/package.nix
+++ b/pkgs/by-name/gl/glaze/package.nix
@@ -6,8 +6,16 @@
   openssl,
   enableSIMD ? stdenv.hostPlatform.avx2Support,
   enableSSL ? false,
-  enableInterop ? true,
+  # Deprecated, remove after 26.05
+  enableInterop ? null,
 }:
+
+assert lib.warnIf (enableInterop != null) ''
+  glaze: `enableInterop` no longer has any effect and will be removed. Upstream
+  dropped the experimental FFI interop implementation and the
+  `glaze_BUILD_INTEROP` CMake option in 6.0.0, so please drop it from your
+  override.
+'' true;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "glaze";
@@ -27,7 +35,6 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "glaze_DISABLE_SIMD_WHEN_SUPPORTED" (!enableSIMD))
     (lib.cmakeBool "glaze_ENABLE_SSL" enableSSL)
-    (lib.cmakeBool "glaze_BUILD_INTEROP" enableInterop)
     (lib.cmakeBool "glaze_ENABLE_FUZZING" (!stdenv.hostPlatform.isMusl))
   ];
 

--- a/pkgs/by-name/hy/hyprshutdown/package.nix
+++ b/pkgs/by-name/hy/hyprshutdown/package.nix
@@ -40,7 +40,7 @@ gcc16Stdenv.mkDerivation (finalAttrs: {
     aquamarine
     hyprgraphics
     cairo
-    (glaze.override { enableSSL = false; })
+    glaze
   ];
 
   doInstallCheck = true;

--- a/pkgs/by-name/te/termbench-pro/package.nix
+++ b/pkgs/by-name/te/termbench-pro/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ cmake ];
   buildInputs = [
     fmt
-    (glaze.override { enableSSL = false; })
+    glaze
   ];
 
   installPhase = ''


### PR DESCRIPTION
Glaze is primarily a header-only serialization library, and upstream leaves glaze_ENABLE_SSL disabled by default. Enabling it changes the public CMake interface and propagates GLZ_ENABLE_SSL plus OpenSSL link dependencies to every consumer, including packages that only use serialization.

Make SSL support opt-in and remove the now-redundant overrides from hyprshutdown and termbench-pro.

Assisted-by: codex with gpt-5.6-sol-high

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
