### PR TITLE
home-assistant-custom-components.eero: init at 1.8.1

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/eero/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/eero/package.nix
@@ -1,0 +1,44 @@
+{
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  pypng,
+  pyqrcode,
+}:
+
+buildHomeAssistantComponent rec {
+  version = "1.8.1";
+  owner = "schmittx";
+  domain = "eero";
+
+  src = fetchFromGitHub {
+    owner = "schmittx";
+    repo = "home-assistant-eero";
+    tag = version;
+    hash = "sha256-iAY5ZlJaSZedykIOiRxULbrs+b8iK0pGed3fHbF3b8E=";
+  };
+
+  # no tests
+  doCheck = false;
+
+  ignoreVersionRequirement = [
+    "pypng"
+    "pyqrcode"
+  ];
+
+  dependencies = [
+    pypng
+    pyqrcode
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Custom component to allow control of Eero networks in Home Assistant";
+    homepage = "https://github.com/schmittx/home-assistant-eero";
+    changelog = "https://github.com/schmittx/home-assistant-eero/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ RoGreat ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Custom component to allow control of Eero networks in [Home Assistant](https://home-assistant.io/).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
