### PR TITLE
stats: refactor build to data-driven Nix functions

### DIFF
--- a/pkgs/by-name/st/stats/package.nix
+++ b/pkgs/by-name/st/stats/package.nix
@@ -73,19 +73,7 @@ let
     { name = "Remote"; }
   ];
 
-  frameworks = [
-    "Kit"
-    "CPU"
-    "GPU"
-    "RAM"
-    "Disk"
-    "Net"
-    "Battery"
-    "Bluetooth"
-    "Sensors"
-    "Clock"
-    "Remote"
-  ];
+  frameworks = [ "Kit" ] ++ map (module: module.name) moduleConfigs;
   modules = lib.tail frameworks;
 
   toPlist = lib.generators.toPlist { escape = true; };

--- a/pkgs/by-name/st/stats/package.nix
+++ b/pkgs/by-name/st/stats/package.nix
@@ -6,6 +6,7 @@
   perl,
   actool,
   makeBinaryWrapper,
+  re-plistbuddy,
   rcodesign,
   nix-update-script,
 }:
@@ -41,32 +42,6 @@ let
       CFBundleVersion = "1";
     };
 
-  mainInfoPlist =
-    version:
-    toPlist {
-      CFBundleDevelopmentRegion = "en";
-      CFBundleExecutable = "Stats";
-      CFBundleIconFile = "AppIcon";
-      CFBundleIconName = "AppIcon";
-      CFBundleIdentifier = "eu.exelban.Stats";
-      CFBundleInfoDictionaryVersion = "6.0";
-      CFBundleName = "Stats";
-      CFBundlePackageType = "APPL";
-      CFBundleShortVersionString = version;
-      # CFBundleVersion is extracted from upstream's Info.plist at build time
-      Description = "Simple macOS system monitor in your menu bar";
-      LSApplicationCategoryType = "public.app-category.utilities";
-      LSMinimumSystemVersion = "12.0";
-      LSUIElement = true;
-      NSAppTransportSecurity = {
-        NSAllowsArbitraryLoads = true;
-      };
-      NSBluetoothAlwaysUsageDescription = "This permission allows obtaining battery level of Bluetooth devices";
-      NSHumanReadableCopyright = "Copyright © 2020 Serhiy Mytrovtsiy. All rights reserved.";
-      NSPrincipalClass = "NSApplication";
-      NSUserNotificationAlertStyle = "alert";
-      TeamId = "RP2S87B72W";
-    };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "stats";
@@ -292,6 +267,8 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     app="$out/Applications/Stats.app"
+    appInfo="$app/Contents/Info.plist"
+    assetInfo="$NIX_BUILD_TOP/asset-info.plist"
     mkdir -p "$app/Contents/"{MacOS,Frameworks,Resources}
 
     cp "$buildDir/Stats" "$app/Contents/MacOS/Stats"
@@ -304,14 +281,16 @@ stdenv.mkDerivation (finalAttrs: {
       printf '%s' ${lib.escapeShellArg (frameworkPlist fw)} > "$fwDir/Resources/Info.plist"
     '') frameworks}
 
-    printf '%s' ${lib.escapeShellArg (mainInfoPlist finalAttrs.version)} > "$app/Contents/Info.plist"
-    # Splice CFBundleVersion from upstream's checked-in Info.plist so it stays
-    # in sync automatically — nix-update-script bumps the tag & hash, and the
-    # new source tree carries the correct build number
-    bundleVersion=$(sed -n '/<key>CFBundleVersion<\/key>/{n;s/.*<string>\(.*\)<\/string>.*/\1/p;}' \
-      "Stats/Supporting Files/Info.plist")
-    sed -i "s|</dict>|<key>CFBundleVersion</key><string>$bundleVersion</string></dict>|" \
-      "$app/Contents/Info.plist"
+    # Keep upstream's plist as the source of truth so privacy and bundle
+    # metadata added by upstream are retained.
+    cp "Stats/Supporting Files/Info.plist" "$appInfo"
+    substituteInPlace "$appInfo" \
+      --replace-fail '$(DEVELOPMENT_LANGUAGE)' "en" \
+      --replace-fail '$(EXECUTABLE_NAME)' "Stats" \
+      --replace-fail '$(PRODUCT_BUNDLE_IDENTIFIER)' "eu.exelban.Stats" \
+      --replace-fail '$(PRODUCT_NAME)' "Stats" \
+      --replace-fail '$(MARKETING_VERSION)' "${finalAttrs.version}" \
+      --replace-fail '$(MACOSX_DEPLOYMENT_TARGET)' "12.0"
 
     # Compile asset catalogs
     actool \
@@ -319,8 +298,11 @@ stdenv.mkDerivation (finalAttrs: {
       --platform macosx \
       --minimum-deployment-target 14.0 \
       --app-icon AppIcon \
-      --output-partial-info-plist /dev/null \
+      --output-partial-info-plist "$assetInfo" \
       "Stats/Supporting Files/Assets.xcassets"
+
+    ${lib.getExe' re-plistbuddy "PlistBuddy"} -c "Merge $assetInfo" "$appInfo"
+    ${lib.getExe' re-plistbuddy "PlistBuddy"} -c "Delete :SMPrivilegedExecutables" "$appInfo"
 
     # Copy localization files
     find "Stats/Supporting Files" -name '*.lproj' -type d -exec cp -r {} "$app/Contents/Resources/" \;

--- a/pkgs/by-name/st/stats/package.nix
+++ b/pkgs/by-name/st/stats/package.nix
@@ -5,7 +5,7 @@
   leveldb,
   perl,
   actool,
-  makeWrapper,
+  makeBinaryWrapper,
   rcodesign,
   nix-update-script,
 }:
@@ -86,7 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
     swift
     perl
     actool
-    makeWrapper
+    makeBinaryWrapper
     rcodesign
   ];
 

--- a/pkgs/by-name/st/stats/package.nix
+++ b/pkgs/by-name/st/stats/package.nix
@@ -67,9 +67,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ leveldb ];
 
-  # Stats uses IOReport private API symbols declared in bridging headers
-  env.NIX_LDFLAGS = "-lIOReport";
-
   # Swift 5.10 doesn't support trailing commas in argument lists (Swift 6 feature)
   # Remove them from all Swift source files
   postPatch = ''
@@ -183,10 +180,10 @@ stdenv.mkDerivation (finalAttrs: {
       -o "$buildDir/libKit.dylib"
 
     buildFramework CPU "Modules/CPU/bridge.h" \
-      -lKit -framework IOKit
+      -lKit -lIOReport -framework IOKit
 
     buildFramework GPU "Modules/GPU/bridge.h" \
-      -lKit -framework IOKit -framework Metal
+      -lKit -lIOReport -framework IOKit -framework Metal
 
     buildFramework RAM "" \
       -lKit -framework IOKit
@@ -229,7 +226,7 @@ stdenv.mkDerivation (finalAttrs: {
       -import-objc-header "Modules/Sensors/bridge.h" \
       -I "$buildDir" \
       -L "$buildDir" \
-      -lKit \
+      -lKit -lIOReport \
       -framework IOKit \
       -Xlinker -install_name -Xlinker "@rpath/Sensors.framework/Sensors" \
       "$buildDir/sensors_reader.o" \

--- a/pkgs/by-name/st/stats/package.nix
+++ b/pkgs/by-name/st/stats/package.nix
@@ -14,6 +14,65 @@
 let
   inherit (swiftPackages) stdenv swift;
 
+  moduleConfigs = [
+    {
+      name = "CPU";
+      bridgingHeader = "Modules/CPU/bridge.h";
+      frameworks = [ "IOKit" ];
+      libraries = [ "IOReport" ];
+    }
+    {
+      name = "GPU";
+      bridgingHeader = "Modules/GPU/bridge.h";
+      frameworks = [
+        "IOKit"
+        "Metal"
+      ];
+      libraries = [ "IOReport" ];
+    }
+    {
+      name = "RAM";
+      frameworks = [ "IOKit" ];
+    }
+    {
+      name = "Disk";
+      bridgingHeader = "Modules/Disk/header.h";
+      frameworks = [
+        "IOKit"
+        "DiskArbitration"
+      ];
+    }
+    {
+      name = "Net";
+      frameworks = [
+        "IOKit"
+        "CoreWLAN"
+        "SystemConfiguration"
+      ];
+    }
+    {
+      name = "Battery";
+      frameworks = [ "IOKit" ];
+    }
+    {
+      name = "Bluetooth";
+      frameworks = [
+        "IOKit"
+        "IOBluetooth"
+        "CoreBluetooth"
+      ];
+    }
+    {
+      name = "Sensors";
+      bridgingHeader = "Modules/Sensors/bridge.h";
+      frameworks = [ "IOKit" ];
+      libraries = [ "IOReport" ];
+      objcSource = "Modules/Sensors/reader.m";
+    }
+    { name = "Clock"; }
+    { name = "Remote"; }
+  ];
+
   frameworks = [
     "Kit"
     "CPU"
@@ -41,6 +100,59 @@ let
       CFBundlePackageType = "FMWK";
       CFBundleVersion = "1";
     };
+
+  findSwiftFiles = varName: dirs: ''
+    ${varName}=()
+    while IFS= read -r -d "" f; do
+      ${varName}+=("$f")
+    done < <(find ${lib.escapeShellArgs dirs} -name '*.swift' -print0 2>/dev/null)
+  '';
+
+  buildModuleShell =
+    mod:
+    let
+      linkFlags = [
+        "-lKit"
+      ]
+      ++ map (library: "-l${library}") (mod.libraries or [ ])
+      ++ lib.concatMap (framework: [
+        "-framework"
+        framework
+      ]) (mod.frameworks or [ ]);
+    in
+    ''
+      echo "Building framework: ${mod.name}"
+
+      ${lib.optionalString (mod ? objcSource) ''
+        clang -x objective-c \
+          -I "Modules/${mod.name}" \
+          -fobjc-arc \
+          -O2 \
+          -c "${mod.objcSource}" \
+          -o "$buildDir/${lib.toLower mod.name}_objc.o"
+      ''}
+
+      ${findSwiftFiles "swiftFiles" [
+        mod.name
+        "Modules/${mod.name}"
+      ]}
+
+      swiftc \
+        "''${commonSwiftFlags[@]}" \
+        -emit-module \
+        -emit-library \
+        -module-name "${mod.name}" \
+        -module-link-name "${mod.name}" \
+        -emit-module-path "$buildDir/${mod.name}.swiftmodule" \
+        ${lib.optionalString (mod ? bridgingHeader) ''-import-objc-header "${mod.bridgingHeader}"''} \
+        -I "$buildDir" \
+        -L "$buildDir" \
+        -Xlinker -install_name -Xlinker "@rpath/${mod.name}.framework/${mod.name}" \
+        ${lib.escapeShellArgs linkFlags} \
+        ${lib.optionalString (mod ? objcSource) ''"$buildDir/${lib.toLower mod.name}_objc.o"''} \
+        "''${swiftFiles[@]}" \
+        -o "$buildDir/lib${mod.name}.dylib"
+    '';
 
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -100,48 +212,6 @@ stdenv.mkDerivation (finalAttrs: {
       -Xlinker -platform_version -Xlinker macos -Xlinker 14.0 -Xlinker 26.0
     )
 
-    buildFramework() {
-      local name="$1"
-      shift
-      local bridgingHeader="$1"
-      shift
-      local extraFlags=("$@")
-
-      echo "Building framework: $name"
-
-      local swiftFiles=()
-      while IFS= read -r -d "" f; do
-        swiftFiles+=("$f")
-      done < <(find "$name" -name '*.swift' -print0 2>/dev/null)
-
-      # For modules in Modules/ subdirectory
-      if [ ''${#swiftFiles[@]} -eq 0 ]; then
-        while IFS= read -r -d "" f; do
-          swiftFiles+=("$f")
-        done < <(find "Modules/$name" -name '*.swift' -print0 2>/dev/null)
-      fi
-
-      local bridgeFlags=()
-      if [ -n "$bridgingHeader" ]; then
-        bridgeFlags=(-import-objc-header "$bridgingHeader")
-      fi
-
-      swiftc \
-        "''${commonSwiftFlags[@]}" \
-        -emit-module \
-        -emit-library \
-        -module-name "$name" \
-        -module-link-name "$name" \
-        -emit-module-path "$buildDir/$name.swiftmodule" \
-        "''${bridgeFlags[@]}" \
-        -I "$buildDir" \
-        -L "$buildDir" \
-        -Xlinker -install_name -Xlinker "@rpath/$name.framework/$name" \
-        "''${extraFlags[@]}" \
-        "''${swiftFiles[@]}" \
-        -o "$buildDir/lib$name.dylib"
-    }
-
     echo "=== Building Kit ==="
 
     # Compile lldb.m (Objective-C++ with LevelDB)
@@ -179,65 +249,7 @@ stdenv.mkDerivation (finalAttrs: {
       "''${kitSwiftFiles[@]}" \
       -o "$buildDir/libKit.dylib"
 
-    buildFramework CPU "Modules/CPU/bridge.h" \
-      -lKit -lIOReport -framework IOKit
-
-    buildFramework GPU "Modules/GPU/bridge.h" \
-      -lKit -lIOReport -framework IOKit -framework Metal
-
-    buildFramework RAM "" \
-      -lKit -framework IOKit
-
-    buildFramework Disk "Modules/Disk/header.h" \
-      -lKit -framework IOKit -framework DiskArbitration
-
-    buildFramework Net "" \
-      -lKit -framework IOKit -framework CoreWLAN -framework SystemConfiguration
-
-    buildFramework Battery "" \
-      -lKit -framework IOKit
-
-    buildFramework Bluetooth "" \
-      -lKit -framework IOKit -framework IOBluetooth -framework CoreBluetooth
-
-    # Build Sensors - needs ObjC file too
-    echo "Building framework: Sensors"
-
-    # Compile reader.m (ObjC)
-    clang -x objective-c \
-      -I "Modules/Sensors" \
-      -fobjc-arc \
-      -O2 \
-      -c Modules/Sensors/reader.m \
-      -o "$buildDir/sensors_reader.o"
-
-    sensorsSwiftFiles=()
-    while IFS= read -r -d "" f; do
-      sensorsSwiftFiles+=("$f")
-    done < <(find Modules/Sensors -name '*.swift' -print0)
-
-    swiftc \
-      "''${commonSwiftFlags[@]}" \
-      -emit-module \
-      -emit-library \
-      -module-name Sensors \
-      -module-link-name Sensors \
-      -emit-module-path "$buildDir/Sensors.swiftmodule" \
-      -import-objc-header "Modules/Sensors/bridge.h" \
-      -I "$buildDir" \
-      -L "$buildDir" \
-      -lKit -lIOReport \
-      -framework IOKit \
-      -Xlinker -install_name -Xlinker "@rpath/Sensors.framework/Sensors" \
-      "$buildDir/sensors_reader.o" \
-      "''${sensorsSwiftFiles[@]}" \
-      -o "$buildDir/libSensors.dylib"
-
-    buildFramework Clock "" \
-      -lKit
-
-    buildFramework Remote "" \
-      -lKit
+    ${lib.concatMapStrings buildModuleShell moduleConfigs}
 
     echo "=== Building Stats app ==="
 

--- a/pkgs/by-name/st/stats/package.nix
+++ b/pkgs/by-name/st/stats/package.nix
@@ -309,9 +309,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Copy module config plists into each framework's Resources
     for mod in ${lib.concatStringsSep " " modules}; do
-      if [ -f "Modules/$mod/config.plist" ]; then
-        cp "Modules/$mod/config.plist" "$app/Contents/Frameworks/$mod.framework/Resources/config.plist"
-      fi
+      cp "Modules/$mod/config.plist" "$app/Contents/Frameworks/$mod.framework/Resources/config.plist"
     done
 
     makeWrapper "$app/Contents/MacOS/Stats" "$out/bin/stats"


### PR DESCRIPTION
Refactors the existing Stats 3.0.13 build around a shared, data-driven module configuration. The package attribute, app bundle, and `$out/bin/stats` interface are unchanged.

The rewrite addresses the maintainer review by:

- building every module, including Sensors' Objective-C source, through one shared builder;
- scoping IOReport linkage to CPU, GPU, and Sensors;
- preserving upstream's `Info.plist`, merging actool metadata, and removing the unused privileged-helper declaration;
- requiring all module `config.plist` files at build time; and
- using `makeBinaryWrapper` so Bash is not retained in the runtime closure.

Additional verification:

- Ran targeted `treefmt`, `git diff --check`, and `nix-build -A stats --no-out-link` before each of the six commits.
- `nixpkgs-review rev HEAD -p stats --systems aarch64-darwin --no-shell`: 1 package built (`stats`).
- Verified `CFBundleShortVersionString = 3.0.13`, upstream `CFBundleVersion = 835`, `NSAppleEventsUsageDescription` is present, and `SMPrivilegedExecutables` is absent.
- Verified all 11 frameworks and all 10 module configs are installed.
- Verified only CPU, GPU, and Sensors link IOReport.
- Verified `$out/bin/stats` is a Mach-O binary wrapper, the runtime closure contains no Bash, and closure size falls from 14.0 MiB to 11.2 MiB.
- Verified `codesign --verify --deep --strict`.
- Interactive launch testing could not be confirmed from the Codex sandbox: the rewritten build, the untouched master build, and the installed Home Manager app all fail through this session's LaunchServices boundary in the same way. `x86_64-darwin` was not tested locally.

Automation disclosure: This contribution, including the code changes and pull request summary, was prepared with assistance from Codex (GPT-5).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
