### PR TITLE
python3Packages.swagger-spec-validator: replace importlib_resources with importlib.resources

### DIFF
--- a/pkgs/development/python-modules/swagger-spec-validator/default.nix
+++ b/pkgs/development/python-modules/swagger-spec-validator/default.nix
@@ -3,12 +3,10 @@
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
-  importlib-resources,
   jsonschema,
   pyyaml,
-  six,
   pytestCheckHook,
-  mock,
+  typing-extensions,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -23,18 +21,26 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-8T0973g8JZKLCTpYqyScr/JAiFdBexEReUJoMQh4vO4=";
   };
 
+  postPatch = ''
+    # https://github.com/Yelp/swagger_spec_validator/pull/176
+    substituteInPlace swagger_spec_validator/common.py tests/common_test.py \
+      --replace-fail "import importlib_resources" "import importlib.resources as importlib_resources"
+  '';
+
   build-system = [ setuptools ];
+
+  pythonRemoveDeps = [
+    "importlib-resources"
+  ];
 
   dependencies = [
     pyyaml
-    importlib-resources
     jsonschema
-    six
+    typing-extensions
   ];
 
   nativeCheckInputs = [
     pytestCheckHook
-    mock
   ];
 
   pythonImportsCheck = [ "swagger_spec_validator" ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
