### PR TITLE
nfs-ganesha: 9.16 -> 11.1

### DIFF
--- a/pkgs/by-name/nf/nfs-ganesha/package.nix
+++ b/pkgs/by-name/nf/nfs-ganesha/package.nix
@@ -22,11 +22,12 @@
   useDbus ? true,
   dbus,
   rdma-core,
+  openssl,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nfs-ganesha";
-  version = "9.16";
+  version = "11.1";
 
   outputs = [
     "out"
@@ -38,7 +39,8 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "nfs-ganesha";
     repo = "nfs-ganesha";
     tag = "V${finalAttrs.version}";
-    hash = "sha256-y5rsQjhmfhqZXQ7jXsItbNe/3Gq4lswIXUq7nnyQIcs=";
+    hash = "sha256-1l1l8wkGp0N0bYXzhF6IqGm8oGVh6523Jfpq8VucHQs=";
+    fetchSubmodules = true;
   };
 
   patches = lib.optional useDbus ./allow-bypassing-dbus-pkg-config-test.patch;
@@ -56,6 +58,8 @@ stdenv.mkDerivation (finalAttrs: {
     "-DUSE_MAN_PAGE=ON"
     "-DUSE_MONITORING=ON"
     "-DUSE_NFS_RDMA=ON"
+    "-DUSE_TLS=ON"
+    "-DUSE_QOS=ON"
   ]
   ++ lib.optionals useCeph [
     "-DUSE_RADOS_RECOV=ON"
@@ -93,6 +97,7 @@ stdenv.mkDerivation (finalAttrs: {
     nfs-utils
     prometheus-cpp-lite
     rdma-core
+    openssl
   ]
   ++ lib.optional useCeph ceph;
 

--- a/pkgs/by-name/nt/ntirpc/package.nix
+++ b/pkgs/by-name/nt/ntirpc/package.nix
@@ -9,17 +9,18 @@
   libnsl,
   prometheus-cpp-lite,
   rdma-core,
+  openssl,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ntirpc";
-  version = "9.16";
+  version = "10.0";
 
   src = fetchFromGitHub {
     owner = "nfs-ganesha";
     repo = "ntirpc";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-ZpjP1ugT9gN3TW7roBfJJBA6Y6FCkaOl31WRoRqPvTU=";
+    hash = "sha256-ZG1YuTBmfkyXn1w9aMZHFbWIAtIeqGiLOxFPPwqCgR4=";
   };
 
   outputs = [
@@ -43,11 +44,13 @@ stdenv.mkDerivation (finalAttrs: {
     libnsl
     prometheus-cpp-lite
     rdma-core
+    openssl
   ];
 
   cmakeFlags = [
     "-DUSE_MONITORING=ON"
     "-DUSE_RPC_RDMA=ON"
+    "-DUSE_TLS=ON"
   ];
 
   postInstall = ''


### PR DESCRIPTION
Changelogs: https://github.com/nfs-ganesha/nfs-ganesha/tags

Superseedes https://github.com/NixOS/nixpkgs/pull/538066
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->](https://github.com/nfs-ganesha/nfs-ganesha/tags)

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
