### PR TITLE
hyprlandPlugins.*: fix builds and update scripts

### DIFF
--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hypr-darkwindow.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hypr-darkwindow.nix
@@ -13,7 +13,7 @@ mkHyprlandPlugin (finalAttrs: {
     owner = "micha4w";
     repo = "Hypr-DarkWindow";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-By/4CmpJvVvcBoyTtelH7MSLCKRaoXLCpiSfrbZIePc=";
+    hash = "sha256-91l5TD46OMfvmhd1WqWxm42cEnjR1yAj2Qk/73mr3ks=";
   };
 
   installPhase = ''

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprgrass.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprgrass.nix
@@ -12,13 +12,13 @@
 
 mkHyprlandPlugin {
   pluginName = "hyprgrass";
-  version = "0.8.2-unstable-2025-10-08";
+  version = "0.8.2-unstable-2026-06-10";
 
   src = fetchFromGitHub {
     owner = "horriblename";
     repo = "hyprgrass";
-    rev = "fdfa60d464a18ae20b7a7bc63c0d2336f37c164b";
-    hash = "sha256-2Y2D2wuNqSldprawq8BSca90gSYSR5ZKL5ZW2YAV2F8=";
+    rev = "d094a3e62f6ecaeb41515982d3e13edefaf8a4e7";
+    hash = "sha256-tCt7FNc1RBHou/ym7B0XzoOqqNq8Df+dizEDkAgJ4U0=";
   };
 
   nativeBuildInputs = [
@@ -34,7 +34,7 @@ mkHyprlandPlugin {
 
   doCheck = true;
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 
   meta = {
     description = "Hyprland plugin for touch gestures";

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprsplit.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprsplit.nix
@@ -8,13 +8,13 @@
 }:
 mkHyprlandPlugin (finalAttrs: {
   pluginName = "hyprsplit";
-  version = "0.54.2";
+  version = "0.54.3-unstable-2026-06-11";
 
   src = fetchFromGitHub {
     owner = "shezdy";
     repo = "hyprsplit";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-NFMLZmM6lM7v6WFcewOp7pKPlr6ampX/MB/kGxt/gPE=";
+    rev = "6b00b677d8905fb38779c91e12d6294e0e586a44";
+    hash = "sha256-PaoUtmk+qIP/ESdxkxnY7mUMpMHjix88qu22R5GLQqE=";
   };
 
   nativeBuildInputs = [
@@ -22,7 +22,7 @@ mkHyprlandPlugin (finalAttrs: {
     ninja
   ];
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 
   meta = {
     homepage = "https://github.com/shezdy/hyprsplit";

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/imgborders.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/imgborders.nix
@@ -5,31 +5,22 @@
   cmake,
   nix-update-script,
 }:
-mkHyprlandPlugin (finalAttrs: {
+mkHyprlandPlugin {
   pluginName = "imgborders";
-  version = "1.0.1";
+  version = "1.0.2-unstable-2026-05-17";
 
   src = fetchFromCodeberg {
     owner = "zacoons";
     repo = "imgborders";
-    tag = finalAttrs.version;
-    hash = "sha256-fCzz4gh8pd7J6KQJB/avYcS0Z7NYpxjznPMtOwypPSQ=";
+    rev = "a20b4d36d01f82823ba3749db95c91743d26f656";
+    hash = "sha256-e3PiaR7G6l/lMJ41xtSPcfMKhZcx8UHj13lr0u+8JAk=";
   };
 
   nativeBuildInputs = [
     cmake
   ];
 
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/lib
-    mv imgborders.so $out/lib/libimgborders.so
-
-    runHook postInstall
-  '';
-
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 
   meta = {
     homepage = "https://codeberg.org/zacoons/imgborders";
@@ -39,4 +30,4 @@ mkHyprlandPlugin (finalAttrs: {
       mrdev023
     ];
   };
-})
+}


### PR DESCRIPTION
Fix all failures noticed in #542362

Assisted-by: codex with gpt-5.6-sol-high

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
