### PR TITLE
endless-sky: add missing `libxext` & `libsm` deps

### DIFF
--- a/pkgs/by-name/en/endless-sky/package.nix
+++ b/pkgs/by-name/en/endless-sky/package.nix
@@ -7,7 +7,9 @@
   libpng,
   libjpeg,
   libogg,
+  libsm,
   libx11,
+  libxext,
   flac,
   glew,
   openal,
@@ -78,6 +80,8 @@ stdenv.mkDerivation (finalAttrs: {
     libpng
     libjpeg
     libogg
+    libsm
+    libxext
     flac
     openal
     libmad


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/538685#pullrequestreview-4689187036
<details>
<summary>Currently `endless-sky` has unresolved shared library dependencies</summary>

```
❯ ldd result/bin/endless-sky
        linux-vdso.so.1 (0x0000784cfaa05000)
        libSDL2-2.0.so.0 => /nix/store/paz38n6ydya6skfv7w1xfh55jq7rfdgy-sdl2-compat-2.32.70/lib/libSDL2-2.0.so.0 (0x0000784cfa98b000)
        libpng16.so.16 => /nix/store/p2qkymfwxislcs4dfsw1hl8pia59q8pz-libpng-apng-1.6.58/lib/libpng16.so.16 (0x0000784cfa94d000)
        libz.so.1 => /nix/store/b2swxfi8srrbsafvh9iyyhd26mz9giwf-zlib-1.3.2/lib/libz.so.1 (0x0000784cfa92c000)
        libjpeg.so.62 => /nix/store/2my7dfwg31bziws1ck2sqrwbj05nbdn1-libjpeg-turbo-3.1.4.1/lib/libjpeg.so.62 (0x0000784cfa85e000)
        libavif.so.16 => /nix/store/310a5dkk208avcssn660rwlbh37kxd8h-libavif-1.4.2/lib/libavif.so.16 (0x0000784cfa817000)
        libopenal.so.1 => /nix/store/vv4zp6i5l1sm8r5lq4zmg21lja7swl1a-openal-soft-1.24.3/lib/libopenal.so.1 (0x0000784cfa000000)
        libminizip.so.1 => /nix/store/4lnkrk560l7q1pavpi20wk61k03kklp3-minizip-1.3.2/lib/libminizip.so.1 (0x0000784cfa3f0000)
        libFLAC++.so.11 => /nix/store/yg7h23dlja3cjprl65z66aniw0xnn29r-flac-1.5.0/lib/libFLAC++.so.11 (0x0000784cfa3cf000)
        libFLAC.so.14 => /nix/store/yg7h23dlja3cjprl65z66aniw0xnn29r-flac-1.5.0/lib/libFLAC.so.14 (0x0000784cfa33f000)
        libogg.so.0 => /nix/store/l5khdjgjw9i04rzrq6sncznfq7xzpd51-libogg-1.3.6/lib/libogg.so.0 (0x0000784cfa334000)
        libmad.so.0 => /nix/store/6lvdhlzfbax7ch8ig8whjqq7gcjy0pc8-libmad-0.15.1b/lib/libmad.so.0 (0x0000784cfa312000)
        libpthread.so.0 => /nix/store/ias8xacs1h3jy7xgwi2awvim61k2ji6c-glibc-2.42-67/lib/libpthread.so.0 (0x0000784cfa30d000)
        libuuid.so.1 => /nix/store/bnz12q7krhpam19qyy7my8vyy2fq9vkx-util-linux-minimal-2.42.2-lib/lib/libuuid.so.1 (0x0000784cfa301000)
        libGLX.so.0 => /nix/store/adas3ix7v8zry5i1nqagc2j76y0ka7rx-libglvnd-1.7.0/lib/libGLX.so.0 (0x0000784cfa2cd000)
        libOpenGL.so.0 => /nix/store/adas3ix7v8zry5i1nqagc2j76y0ka7rx-libglvnd-1.7.0/lib/libOpenGL.so.0 (0x0000784cfa2a0000)
        libGLEW.so.2.3 => /nix/store/a1b2zazb0h13yxzqfq5j7ma8hq64fxxw-glew-2.3.1/lib/libGLEW.so.2.3 (0x0000784cf9f2c000)
        libSM.so.6 => not found
        libICE.so.6 => not found
        libX11.so.6 => /nix/store/arpk7prynk6iqwbh0204k878nv1ypyg2-libx11-1.8.13/lib/libX11.so.6 (0x0000784cf9ddc000)
        libXext.so.6 => not found
        libEGL.so.1 => /nix/store/adas3ix7v8zry5i1nqagc2j76y0ka7rx-libglvnd-1.7.0/lib/libEGL.so.1 (0x0000784cfa288000)
        libstdc++.so.6 => /nix/store/8lahnh9pn3lrrnhax5nk7ibvjcbjmnkm-gcc-15.2.0-lib/lib/libstdc++.so.6 (0x0000784cf9a00000)
        libm.so.6 => /nix/store/ias8xacs1h3jy7xgwi2awvim61k2ji6c-glibc-2.42-67/lib/libm.so.6 (0x0000784cf9ce4000)
        libgcc_s.so.1 => /nix/store/8lahnh9pn3lrrnhax5nk7ibvjcbjmnkm-gcc-15.2.0-lib/lib/libgcc_s.so.1 (0x0000784cf9cb7000)
        libc.so.6 => /nix/store/ias8xacs1h3jy7xgwi2awvim61k2ji6c-glibc-2.42-67/lib/libc.so.6 (0x0000784cf9600000)
        libdl.so.2 => /nix/store/ias8xacs1h3jy7xgwi2awvim61k2ji6c-glibc-2.42-67/lib/libdl.so.2 (0x0000784cfa281000)
        libyuv.so => /nix/store/n0j6h9wwy9ladp4r1jc07igmfyrp2i52-libyuv-1908/lib/libyuv.so (0x0000784cf9909000)
        libsharpyuv.so.0 => /nix/store/0n517hiwwwja7dmaz536f6rdanfs0gdc-libwebp-1.6.0/lib/libsharpyuv.so.0 (0x0000784cf9cab000)
        libdav1d.so.7 => /nix/store/qh05b1g2am30sqmwbmnyqzgffazbaw86-dav1d-1.5.3/lib/libdav1d.so.7 (0x0000784cf9416000)
        libaom.so.3 => /nix/store/rj1r78hwc3hc5pzf5yrp0rls8pnaxq2p-libaom-3.12.1/lib/libaom.so.3 (0x0000784cf8a00000)
        libasound.so.2 => /nix/store/6v3x79khipmf0zbn2yivvx7n15jccv47-alsa-lib-1.2.16/lib/libasound.so.2 (0x0000784cf92e7000)
        libpulse.so.0 => /nix/store/rydq1gn4xf5mw13xww5drbsssdzrwx3i-libpulseaudio-17.0/lib/libpulse.so.0 (0x0000784cf98b5000)
        libpipewire-0.3.so.0 => /nix/store/mnb6gpwx37k6vc66xhgha2d56llbshcv-pipewire-1.6.7/lib/libpipewire-0.3.so.0 (0x0000784cf88fe000)
        libatomic.so.1 => /nix/store/8lahnh9pn3lrrnhax5nk7ibvjcbjmnkm-gcc-15.2.0-lib/lib/libatomic.so.1 (0x0000784cf9c9d000)
        libdbus-1.so.3 => /nix/store/93vg59k99hwa17z57vphd5ik6fiwmsh8-dbus-1.16.2-lib/lib/libdbus-1.so.3 (0x0000784cf985b000)
        libXext.so.6 => /nix/store/3lhr3884dxnfks82vzbpsg60yfq64d5p-libxext-1.3.7/lib/libXext.so.6 (0x0000784cf9c86000)
        libGLdispatch.so.0 => /nix/store/adas3ix7v8zry5i1nqagc2j76y0ka7rx-libglvnd-1.7.0/lib/libGLdispatch.so.0 (0x0000784cf8845000)
        libSM.so.6 => /nix/store/z0a0jv900jhh66bp051zqcj10qqyyf8c-libsm-1.2.6/lib/libSM.so.6 (0x0000784cf9851000)
        libICE.so.6 => /nix/store/wms4868xa78il56lmd87shiyahdvv39m-libice-1.1.2/lib/libICE.so.6 (0x0000784cf9832000)
        libxcb.so.1 => /nix/store/zyvz6mkqf6iihqr5yfvmfr2inafxdlq4-libxcb-1.17.0/lib/libxcb.so.1 (0x0000784cf92bb000)
        /nix/store/ias8xacs1h3jy7xgwi2awvim61k2ji6c-glibc-2.42-67/lib/ld-linux-x86-64.so.2 => /nix/store/8kvxvr3pmsypxiypq4g8zy13glnfr7nx-glibc-2.42-67/lib64/ld-linux-x86-64.so.2 (0x0000784cfaa07000)
        libvmaf.so.3 => /nix/store/b2dlgdzn0wibj66nrg8wkczrr59yrvl5-libvmaf-3.0.0/lib/libvmaf.so.3 (0x0000784cf8735000)
        librt.so.1 => /nix/store/ias8xacs1h3jy7xgwi2awvim61k2ji6c-glibc-2.42-67/lib/librt.so.1 (0x0000784cf982d000)
        libpulsecommon-17.0.so => /nix/store/rydq1gn4xf5mw13xww5drbsssdzrwx3i-libpulseaudio-17.0/lib/pulseaudio/libpulsecommon-17.0.so (0x0000784cf86b0000)
        libsystemd.so.0 => /nix/store/c4bk50l40xii6bdgjx9ahj1h52diawjw-systemd-minimal-261/lib/libsystemd.so.0 (0x0000784cf8400000)
        libXau.so.6 => /nix/store/4shkpw9q0f12z737zjvh89246zszkiq8-libxau-1.0.12/lib/libXau.so.6 (0x0000784cf9827000)
        libXdmcp.so.6 => /nix/store/fgbrpz911jb9pxw0ys4cp5cv2rr7yh6p-libxdmcp-1.1.5/lib/libXdmcp.so.6 (0x0000784cf981f000)
        libsndfile.so.1 => /nix/store/qp6cf9ff5a4av4fh4bybz8153k19kkcd-libsndfile-1.2.2/lib/libsndfile.so.1 (0x0000784cf836a000)
        libvorbis.so.0 => /nix/store/10l732bi261wm8l855mzfimaw48vcqv2-libvorbis-1.3.7/lib/libvorbis.so.0 (0x0000784cf927e000)
        libvorbisenc.so.2 => /nix/store/10l732bi261wm8l855mzfimaw48vcqv2-libvorbis-1.3.7/lib/libvorbisenc.so.2 (0x0000784cf82be000)
        libopus.so.0 => /nix/store/wyf0la4vhx119zdhxzmh42flbl861cdl-libopus-1.6.1/lib/libopus.so.0 (0x0000784cf863a000)
        libmpg123.so.0 => /nix/store/4fi4rp35xmwr53lda3v6mzazp3zssxz2-libmpg123-1.33.5/lib/libmpg123.so.0 (0x0000784cf825c000)
        libmp3lame.so.0 => /nix/store/zivklm1zc7hy8d8nsmcnjcd888rhymqb-lame-3.100-lib/lib/libmp3lame.so.0 (0x0000784cf81df000)
        libmvec.so.1 => /nix/store/ias8xacs1h3jy7xgwi2awvim61k2ji6c-glibc-2.42-67/lib/libmvec.so.1 (0x0000784cf80e4000)
```
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
