### PR TITLE
fsnav: enable darwin support

### DIFF
--- a/pkgs/by-name/fs/fsnav/package.nix
+++ b/pkgs/by-name/fs/fsnav/package.nix
@@ -30,10 +30,12 @@ stdenv.mkDerivation rec {
     freetype
     libpng
     libjpeg
+  ]
+  ++ (lib.optionals stdenv.hostPlatform.isLinux [
     libGL
     libGLU
     freeglut
-  ];
+  ]);
 
   preBuild = ''
     makeFlagsArray+=(
@@ -54,7 +56,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ aaravrav ];
     mainProgram = "fsnav";
-    platforms = with lib.platforms; linux;
+    platforms = with lib.platforms; linux ++ darwin;
     broken = !stdenv.buildPlatform.canExecute stdenv.hostPlatform;
   };
 

--- a/pkgs/by-name/fs/fsnav/package.nix
+++ b/pkgs/by-name/fs/fsnav/package.nix
@@ -11,14 +11,14 @@
   freeglut,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "fsnav";
   version = "0.1";
 
   src = fetchFromGitHub {
     owner = "jtsiomb";
     repo = "fsnav";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Bt1QRqtJkVFR1uMzmB3OUyqyzUyJdQyQdbMOfMyWJOc=";
   };
 
@@ -37,13 +37,11 @@ stdenv.mkDerivation rec {
     freeglut
   ]);
 
-  preBuild = ''
-    makeFlagsArray+=(
-      "PREFIX=$out"
-      "CC=$CC"
-      "CXX=$CXX"
-    )
-  '';
+  makeFlags = [
+    "PREFIX=$(out)"
+    "CC=${stdenv.cc.targetPrefix}cc"
+    "CXX=${stdenv.cc.targetPrefix}c++"
+  ];
 
   preInstall = ''
     mkdir -p $out/bin
@@ -59,5 +57,4 @@ stdenv.mkDerivation rec {
     platforms = with lib.platforms; linux ++ darwin;
     broken = !stdenv.buildPlatform.canExecute stdenv.hostPlatform;
   };
-
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR has two commits for `fsnav`. The first adds Darwin to the list of supported platforms, and the second cleans up the derivation with what I understand are best practices. That said, the first commit is entirely independent of the second and so if it is deemed unnecessary / undesirable I can drop the commit and leave it with the darwin support.

Side note: I only tested the functionality on Darwin, whereas I just tested the builds on linux via `nix-rosetta-builder` for both x86_64 and aarch64 linux platforms.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
