### PR TITLE
tinyauth: 5.0.7 -> 5.1.1

### DIFF
--- a/pkgs/by-name/ti/tinyauth/package.nix
+++ b/pkgs/by-name/ti/tinyauth/package.nix
@@ -3,23 +3,27 @@
   buildGoModule,
   fetchFromGitHub,
   stdenvNoCC,
-  bun,
+  nodejs-slim,
+  pnpmConfigHook,
+  pnpmBuildHook,
+  pnpm_11,
+  fetchPnpmDeps,
   nixosTests,
   nix-update-script,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "tinyauth";
-  version = "5.0.7";
+  version = "5.1.1";
 
   src = fetchFromGitHub {
-    owner = "steveiliop56";
+    owner = "tinyauthapp";
     repo = "tinyauth";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-VeII5jSNUJpGZgqons1o1fp6KXxDOBhSMciSqtQfaC4=";
+    hash = "sha256-leXqelsPCLixhxqJbL7aDgGIzj1KcZMnR/1UxRPa1bo=";
   };
 
-  vendorHash = "sha256-XP+kVfcDKWAvBdrvGjiTdWh7jNe6qiDsgVjPrFFPoDU=";
+  vendorHash = "sha256-rlMttXywppA39Vip6pIos4tY5434vvtN8dbhVn+S2Kg=";
 
   subPackages = [ "cmd/tinyauth" ];
 
@@ -27,8 +31,8 @@ buildGoModule (finalAttrs: {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/steveiliop56/tinyauth/internal/config.Version=v${finalAttrs.version}"
-    "-X github.com/steveiliop56/tinyauth/internal/config.CommitHash=${finalAttrs.src.rev}"
+    "-X github.com/tinyauthapp/tinyauth/internal/model.Version=v${finalAttrs.version}"
+    "-X github.com/tinyauthapp/tinyauth/internal/model.CommitHash=${finalAttrs.src.rev}"
   ];
 
   preBuild = ''
@@ -38,46 +42,32 @@ buildGoModule (finalAttrs: {
   frontend = stdenvNoCC.mkDerivation {
     pname = "tinyauth-frontend";
     inherit (finalAttrs) version src;
-    sourceRoot = "${finalAttrs.src.name}/frontend";
-
-    impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
-      "GIT_PROXY_COMMAND"
-      "SOCKS_SERVER"
-    ];
 
     nativeBuildInputs = [
-      bun
+      nodejs-slim
+      pnpmConfigHook
+      pnpmBuildHook
+      pnpm_11
     ];
 
-    configurePhase = ''
-      runHook preConfigure
+    pnpmDeps = fetchPnpmDeps {
+      inherit (finalAttrs) pname version src;
+      sourceRoot = "${finalAttrs.src.name}/frontend";
+      pnpm = pnpm_11;
+      fetcherVersion = 4;
+      hash = "sha256-WLPJ1ZH2mEoQKFa6F5TOmTfbcgN5lXKZZHHvgI4mMq4=";
+    };
 
-      bun install --no-progress --frozen-lockfile
-      substituteInPlace node_modules/.bin/{tsc,vite} \
-        --replace-fail "/usr/bin/env node" "${lib.getExe bun}"
-
-      runHook postConfigure
-    '';
-
-    buildPhase = ''
-      runHook preBuild
-
-      bun run build
-
-      runHook postBuild
-    '';
+    pnpmRoot = "frontend";
 
     installPhase = ''
       runHook preInstall
 
       mkdir -p $out/dist
-      cp -r dist $out
+      cp -r frontend/dist $out
 
       runHook postInstall
     '';
-
-    outputHashMode = "recursive";
-    outputHash = "sha256-FRACDa1akm+JnYIRwNXRcomzDIMCIAlJDbjMyS77sNA=";
   };
 
   passthru = {
@@ -95,8 +85,8 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Simple authentication middleware for web apps";
     homepage = "https://tinyauth.app";
-    changelog = "https://github.com/steveiliop56/tinyauth/releases/tag/v${finalAttrs.version}";
-    license = lib.licenses.gpl3Only;
+    changelog = "https://github.com/tinyauthapp/tinyauth/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.agpl3Only;
     mainProgram = "tinyauth";
     maintainers = with lib.maintainers; [
       shaunren


### PR DESCRIPTION
https://github.com/tinyauthapp/tinyauth/releases/tag/v5.1.1
https://github.com/tinyauthapp/tinyauth/releases/tag/v5.1.0

- In addition to the version bump:
  * Upstream URL is changed
  * License is changed from GPL3 to AGPL3
  * Frontend build now uses pnpm instead of bun

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
