### PR TITLE
python3Packages.datamodel-code-generator: 0.55.0 -> 0.68.1

### DIFF
--- a/pkgs/development/python-modules/datamodel-code-generator/default.nix
+++ b/pkgs/development/python-modules/datamodel-code-generator/default.nix
@@ -3,16 +3,21 @@
   argcomplete,
   black,
   buildPythonPackage,
+  email-validator,
   fetchFromGitHub,
   genson,
   graphql-core,
+  grpcio-tools,
   hatch-vcs,
   hatchling,
   httpx,
+  hypothesis,
+  hypothesis-jsonschema,
   inflect,
   inline-snapshot,
   isort,
   jinja2,
+  msgspec,
   openapi-spec-validator,
   packaging,
   prance,
@@ -20,6 +25,7 @@
   pydantic,
   pysnooper,
   pytest-mock,
+  pytest-timeout,
   pytestCheckHook,
   pyyaml,
   time-machine,
@@ -28,14 +34,14 @@
 
 buildPythonPackage rec {
   pname = "datamodel-code-generator";
-  version = "0.55.0";
+  version = "0.68.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "koxudaxi";
     repo = "datamodel-code-generator";
     tag = version;
-    hash = "sha256-zsLJv7gKhmnEIS/AUvnBzm+07QFQoMdiFo/PkfRyHek=";
+    hash = "sha256-fYnI7S4FJ927qZXyAsWQzxhLTrcpscYqJunmcSt/gkk=";
   };
 
   pythonRelaxDeps = [
@@ -52,6 +58,8 @@ buildPythonPackage rec {
     argcomplete
     black
     genson
+    hypothesis
+    hypothesis-jsonschema
     inflect
     isort
     jinja2
@@ -65,6 +73,7 @@ buildPythonPackage rec {
     debug = [ pysnooper ];
     graphql = [ graphql-core ];
     http = [ httpx ];
+    protobuf = [ grpcio-tools ];
     ruff = [ ruff ];
     validation = [
       openapi-spec-validator
@@ -76,8 +85,11 @@ buildPythonPackage rec {
   };
 
   nativeCheckInputs = [
+    email-validator
     inline-snapshot
+    msgspec
     pytest-mock
+    pytest-timeout
     pytestCheckHook
     time-machine
   ]
@@ -93,7 +105,7 @@ buildPythonPackage rec {
   meta = {
     description = "Pydantic model and dataclasses.dataclass generator for easy conversion of JSON, OpenAPI, JSON Schema, and YAML data sources";
     homepage = "https://github.com/koxudaxi/datamodel-code-generator";
-    changelog = "https://github.com/koxudaxi/datamodel-code-generator/releases/tag/${src.tag}";
+    changelog = "https://github.com/koxudaxi/datamodel-code-generator/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ tochiaha ];
     mainProgram = "datamodel-code-generator";

--- a/pkgs/development/python-modules/hypothesis-jsonschema/default.nix
+++ b/pkgs/development/python-modules/hypothesis-jsonschema/default.nix
@@ -1,0 +1,53 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  hypothesis,
+  jsonschema,
+  lib,
+  pytest-cov-stub,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "hypothesis-jsonschema";
+  version = "0.23.1";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  # no tags on GitHub
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-9KwDICQ0KkFJoQJTmE9aVza4Kz/ir7CIjzg0oxFT8hU=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    hypothesis
+    jsonschema
+  ];
+
+  pythonImportsCheck = [ "hypothesis_jsonschema" ];
+
+  nativeCheckInputs = [
+    pytest-cov-stub
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # imports gen_schemas.py, which is missing from sdist
+    "tests/test_canonicalise.py"
+    "tests/test_from_schema.py"
+    # reads CHANGELOD.md, which is missing from sdist
+    "tests/test_version.py"
+  ];
+
+  meta = {
+    changelog = "https://github.com/Zac-HD/hypothesis-jsonschema/blob/master/CHANGELOG.md";
+    description = "Generate test data from JSON schemata with Hypothesis";
+    homepage = "https://github.com/Zac-HD/hypothesis-jsonschema";
+    license = lib.licenses.mpl20;
+    maintainers = [ lib.maintainers.dotlambda ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7806,6 +7806,8 @@ self: super: with self; {
 
   hypothesis-auto = callPackage ../development/python-modules/hypothesis-auto { };
 
+  hypothesis-jsonschema = callPackage ../development/python-modules/hypothesis-jsonschema { };
+
   hypothesis_6_136 = callPackage ../development/python-modules/hypothesis/hypothesis_6_136.nix { };
 
   hypothesmith = callPackage ../development/python-modules/hypothesmith { };


### PR DESCRIPTION
Diff: https://github.com/koxudaxi/datamodel-code-generator/compare/0.55.0...0.68.1

Changelog: https://github.com/koxudaxi/datamodel-code-generator/releases/tag/0.68.1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
