### PR TITLE
glew: restore EGL+GLX compatibility patch

### DIFF
--- a/pkgs/by-name/gl/glew/package.nix
+++ b/pkgs/by-name/gl/glew/package.nix
@@ -21,6 +21,15 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-tkeQ+UuSas1+j4TF1gAKhstDlnvR5oiwMIkHl5nJ6Ik=";
   };
 
+  patches = [
+    # Allow a single GLEW build to support both EGL and GLX.
+    #
+    # Originally developed for the AUR glew-egl-glx package and later adopted by
+    # Arch Linux. Carry an updated copy in-tree after it was removed from Arch's
+    # packaging repository.
+    ./patches/egl+glx.patch
+  ];
+
   outputs = [
     "bin"
     "out"

--- a/pkgs/by-name/gl/glew/patches/egl+glx.patch
+++ b/pkgs/by-name/gl/glew/patches/egl+glx.patch
@@ -1,0 +1,172 @@
+--- a/src/glew.c
++++ b/src/glew.c
+@@ -36,6 +36,10 @@
+ #  include GLEW_INCLUDE
+ #endif
+ 
++#if defined(GLEW_EGL)
++#  include <GL/eglew.h>
++#endif
++
+ #if defined(GLEW_OSMESA)
+ #  define GLAPI extern
+ #  ifndef APIENTRY
+@@ -47,8 +51,6 @@
+ #    undef APIENTRY
+ #    undef GLEW_APIENTRY_DEFINED
+ #  endif
+-#elif defined(GLEW_EGL)
+-#  include <GL/eglew.h>
+ #elif defined(_WIN32)
+ /*
+  * If NOGDI is defined, wingdi.h won't be included by windows.h, and thus
+@@ -65,8 +67,7 @@
+ 
+ #include <stddef.h>  /* For size_t */
+ 
+-#if defined(GLEW_EGL)
+-#elif defined(GLEW_REGAL)
++#if defined(GLEW_REGAL)
+ 
+ /* In GLEW_REGAL mode we call directly into the linked
+    libRegal.so glGetProcAddressREGAL for looking up
+@@ -167,23 +168,37 @@ void* NSGLGetProcAddress (const GLubyte *name)
+  * Define glewGetProcAddress.
+  */
+ #if defined(GLEW_REGAL)
+-#  define glewGetProcAddress(name) regalGetProcAddress((const GLchar *)name)
++#  define _glewGetProcAddress(name) regalGetProcAddress((const GLchar *)name)
+ #elif defined(GLEW_OSMESA)
+-#  define glewGetProcAddress(name) OSMesaGetProcAddress((const char *)name)
+-#elif defined(GLEW_EGL)
+-#  define glewGetProcAddress(name) eglGetProcAddress((const char *)name)
++#  define _glewGetProcAddress(name) OSMesaGetProcAddress((const char *)name)
+ #elif defined(_WIN32)
+-#  define glewGetProcAddress(name) wglGetProcAddress((LPCSTR)name)
++#  define _glewGetProcAddress(name) wglGetProcAddress((LPCSTR)name)
+ #elif defined(__APPLE__) && !defined(GLEW_APPLE_GLX)
+-#  define glewGetProcAddress(name) NSGLGetProcAddress(name)
++#  define _glewGetProcAddress(name) NSGLGetProcAddress(name)
+ #elif defined(__sgi) || defined(__sun) || defined(__HAIKU__)
+-#  define glewGetProcAddress(name) dlGetProcAddress(name)
++#  define _glewGetProcAddress(name) dlGetProcAddress(name)
+ #elif defined(__ANDROID__)
+-#  define glewGetProcAddress(name) NULL /* TODO */
++#  define _glewGetProcAddress(name) NULL /* TODO */
+ #elif defined(__native_client__)
+-#  define glewGetProcAddress(name) NULL /* TODO */
++#  define _glewGetProcAddress(name) NULL /* TODO */
+ #else /* __linux */
+-#  define glewGetProcAddress(name) (*glXGetProcAddressARB)(name)
++#  define _glewGetProcAddress(name) (*glXGetProcAddressARB)(name)
++#endif
++
++#if defined(GLEW_EGL)
++static GLboolean _EGL_available = GL_FALSE;
++static void (*glewGetProcAddress (const GLubyte *name)) (void)
++{
++  void (*addr)(void);
++  if (_EGL_available)
++  {
++    addr = eglGetProcAddress((const char *)name);
++    if (addr) return addr;
++  }
++  return _glewGetProcAddress(name);
++}
++#else
++#  define glewGetProcAddress(name) _glewGetProcAddress(name)
+ #endif
+ 
+ /*
+@@ -19783,9 +19798,7 @@ GLenum GLEWAPIENTRY glewContextInit (void)
+ }
+ 
+ 
+-#if defined(GLEW_OSMESA)
+-
+-#elif defined(GLEW_EGL)
++#if defined(GLEW_EGL)
+ 
+ PFNEGLCHOOSECONFIGPROC __eglewChooseConfig = NULL;
+ PFNEGLCOPYBUFFERSPROC __eglewCopyBuffers = NULL;
+@@ -21074,8 +21087,8 @@ GLenum eglewInit (EGLDisplay display)
+   PFNEGLQUERYSTRINGPROC queryString = NULL;
+ 
+   /* Load necessary entry points */
+-  initialize = (PFNEGLINITIALIZEPROC)   glewGetProcAddress("eglInitialize");
+-  queryString = (PFNEGLQUERYSTRINGPROC) glewGetProcAddress("eglQueryString");
++  initialize = (PFNEGLINITIALIZEPROC)   eglGetProcAddress("eglInitialize");
++  queryString = (PFNEGLQUERYSTRINGPROC) eglGetProcAddress("eglQueryString");
+   if (!initialize || !queryString)
+     return 1;
+ 
+@@ -21669,7 +21682,9 @@ GLenum eglewInit (EGLDisplay display)
+   return GLEW_OK;
+ }
+ 
+-#elif defined(_WIN32)
++#endif
++
++#if defined(_WIN32)
+ 
+ PFNWGLSETSTEREOEMITTERSTATE3DLPROC __wglewSetStereoEmitterState3DL = NULL;
+ 
+@@ -23750,13 +23765,26 @@ GLenum GLEWAPIENTRY glewInit (void)
+   GLenum r;
+ #if defined(GLEW_EGL)
+   PFNEGLGETCURRENTDISPLAYPROC getCurrentDisplay = NULL;
++  EGLDisplay display;
+ #endif
+   r = glewContextInit();
+   if ( r != 0 ) return r;
+ #if defined(GLEW_EGL)
+-  getCurrentDisplay = (PFNEGLGETCURRENTDISPLAYPROC) glewGetProcAddress("eglGetCurrentDisplay");
+-  return eglewInit(getCurrentDisplay());
+-#elif defined(GLEW_OSMESA) || defined(__ANDROID__) || defined(__native_client__) || defined(__HAIKU__)
++  getCurrentDisplay = (PFNEGLGETCURRENTDISPLAYPROC) eglGetProcAddress("eglGetCurrentDisplay");
++  if (getCurrentDisplay)
++    display = getCurrentDisplay();
++  else
++    display = EGL_NO_DISPLAY;
++  if (display != EGL_NO_DISPLAY)
++  {
++    r = eglewInit(display);
++    if ( r == 0 ) {
++      _EGL_available = GL_TRUE;
++      return r;
++    }
++  }
++#endif
++#if defined(GLEW_OSMESA) || defined(__ANDROID__) || defined(__native_client__) || defined(__HAIKU__)
+   return r;
+ #elif defined(_WIN32)
+   return wglewInit();
+@@ -30675,7 +30703,7 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
+   return ret;
+ }
+ 
+-#if defined(_WIN32) && !defined(GLEW_EGL) && !defined(GLEW_OSMESA)
++#if defined(_WIN32) && !defined(GLEW_OSMESA)
+ 
+ GLboolean GLEWAPIENTRY wglewIsSupported (const char* name)
+ {
+@@ -31118,7 +31146,7 @@ GLboolean GLEWAPIENTRY wglewIsSupported (const char* name)
+   return ret;
+ }
+ 
+-#elif !defined(GLEW_OSMESA) && !defined(GLEW_EGL) && !defined(__ANDROID__) && !defined(__native_client__) && !defined(__HAIKU__) && !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
++#elif !defined(GLEW_OSMESA) && !defined(__ANDROID__) && !defined(__native_client__) && !defined(__HAIKU__) && !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
+ 
+ GLboolean glxewIsSupported (const char* name)
+ {
+@@ -31702,7 +31730,9 @@ GLboolean glxewIsSupported (const char* name)
+   return ret;
+ }
+ 
+-#elif defined(GLEW_EGL)
++#endif
++
++#if defined(GLEW_EGL)
+ 
+ GLboolean eglewIsSupported (const char* name)
+ {

--- a/pkgs/by-name/me/meshlab/package.nix
+++ b/pkgs/by-name/me/meshlab/package.nix
@@ -76,12 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
     bzip2
     muparser
     eigen
-    # MeshLab renders through Qt's xcb platform, which creates a GLX context,
-    # and calls glewInit() against it. The default EGL-enabled glew is built
-    # EGL-only (no GLX dispatch table), so glewInit can't read GL_VERSION and
-    # the app fails to launch with "GLEW initialization failed: Missing GL
-    # version". See https://github.com/NixOS/nixpkgs/issues/531470
-    (glew.override { enableEGL = false; })
+    glew
     gmp
     levmar
     qhull

--- a/pkgs/by-name/op/openscad/package.nix
+++ b/pkgs/by-name/op/openscad/package.nix
@@ -127,9 +127,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     eigen
     boost
-    # OpenSCAD's GLX offscreen renderer needs GLEW's GLXEW symbols (`__GLXEW_SGIX_pbuffer`, `__GLXEW_SGIX_fbconfig`)
-    # which are not found in the default EGL-enabled glew and causes the build failure in https://github.com/NixOS/nixpkgs/issues/530529
-    (glew.override { enableEGL = false; })
+    glew
     opencsg
     cgal_5
     mpfr

--- a/pkgs/by-name/rp/rpcs3/package.nix
+++ b/pkgs/by-name/rp/rpcs3/package.nix
@@ -117,9 +117,7 @@ stdenv.mkDerivation (finalAttrs: {
     qtbase
     qtmultimedia
     openal
-    # RPCS3's X11 swap-interval path uses GLEW's GLXEW symbols, which
-    # are not provided in the default EGL-enabled GLEW build.
-    (glew.override { enableEGL = false; })
+    glew
     vulkan-headers
     vulkan-loader
     libpng


### PR DESCRIPTION
Restore the downstream patch allowing a single `glew` build to support both EGL and GLX.

The patch [originated in the AUR](https://bugs.archlinux.org/task/64835.html#comment184595) `glew-egl-glx` package and was later [adopted by Arch Linux](https://gitlab.archlinux.org/archlinux/packaging/packages/glew/-/commit/ca08ff5d4cd3548a593eb1118d0a84b0c3670349). It was later [removed from Arch Linux](https://gitlab.archlinux.org/archlinux/packaging/packages/glew/-/commit/dfa7ffb3a91b17ff8498aeed0280077729961283)'s packaging repository, and was subsequently [removed from nixpkgs](https://github.com/NixOS/nixpkgs/pull/526521) when the Arch packaging repository stopped carrying it.

Without the patch, applications built with `GLEW_EGL` cannot initialize `GLX`. Several packages have worked around this by overriding `glew`[^2][^3][^4][^5] or through other package specific fixes[^6], while others remain broken[^7].

---

This PR:
- updates the patch for `glew` 2.3.1 and vendor it into nixpkgs
- removes the package specific `glew` overrides that became necessary after the patch was removed

---

The updated patch was verified with `endless-sky`, `meshlab`, `openscad` & `rpcs3`, which build and run correctly without overriding `glew`.

---

#### relevant issues/prs
- https://github.com/NixOS/nixpkgs/issues/513195#issuecomment-4661945312
- https://github.com/NixOS/nixpkgs/pull/539294
- https://github.com/NixOS/nixpkgs/pull/530580
- https://github.com/NixOS/nixpkgs/pull/530692
- https://github.com/NixOS/nixpkgs/pull/530605
- https://github.com/NixOS/nixpkgs/pull/542389#issuecomment-4985939760

[^2]: https://github.com/NixOS/nixpkgs/issues/513195#issuecomment-4661945312
[^3]: https://github.com/NixOS/nixpkgs/pull/539294
[^4]: https://github.com/NixOS/nixpkgs/pull/530580
[^5]: https://github.com/NixOS/nixpkgs/pull/530692
[^6]: https://github.com/NixOS/nixpkgs/pull/530605
[^7]: https://github.com/NixOS/nixpkgs/pull/542389#issuecomment-4985939760

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

[^2]: https://github.com/NixOS/nixpkgs/issues/513195#issuecomment-4661945312
[^3]: https://github.com/NixOS/nixpkgs/pull/539294
[^4]: https://github.com/NixOS/nixpkgs/pull/530580
[^5]: https://github.com/NixOS/nixpkgs/pull/530692
[^6]: https://github.com/NixOS/nixpkgs/pull/530605
[^7]: https://github.com/NixOS/nixpkgs/pull/542389#issuecomment-4985939760

cc @dotlambda

