### PR TITLE
[26.05] remark42: 1.15.0 -> 1.16.4, switch to pnpm_10

### DIFF
--- a/pkgs/by-name/re/remark42/package.nix
+++ b/pkgs/by-name/re/remark42/package.nix
@@ -3,14 +3,15 @@
   stdenv,
   fetchFromGitHub,
   buildGoModule,
-  nodejs_22,
-  pnpm_8,
+  nodejs-slim_22,
+  pnpm_9,
   fetchPnpmDeps,
   pnpmConfigHook,
   testers,
 }:
 
 let
+  pnpm = pnpm_9.override { nodejs-slim = nodejs-slim_22; };
   version = "1.15.0";
 
   src = fetchFromGitHub {
@@ -26,34 +27,49 @@ let
 
     strictDeps = true;
 
-    pnpmRoot = "frontend";
+    sourceRoot = "${src.name}/frontend";
 
     nativeBuildInputs = [
-      nodejs_22
-      pnpm_8
+      nodejs-slim_22
+      pnpm
       pnpmConfigHook
     ];
 
     pnpmDeps = fetchPnpmDeps {
-      inherit (finalAttrs) pname version src;
-      sourceRoot = "${finalAttrs.src.name}/frontend";
-      pnpm = pnpm_8;
-      fetcherVersion = 3;
-      hash = "sha256-E2tUZXhcufuztXS+Z//uZk9omvaPrevNbGqVd41Lwhw=";
+      inherit (finalAttrs)
+        pname
+        version
+        src
+        sourceRoot
+        postPatch
+        ;
+      inherit pnpm;
+      fetcherVersion = 4;
+      hash = "sha256-wFrMoSeD87H1yfMD0jBcw60DKDeh4yjka5aWyHuQssA=";
     };
+
+    postPatch = ''
+      substituteInPlace "package.json" "apps/remark42/package.json" \
+        --replace-fail "pnpm@8.15.9" "pnpm@${pnpm.version}"
+
+      substituteInPlace "apps/remark42/package.json" \
+        --replace-fail '"pnpm": "8.*"' '"pnpm": "9.*"'
+    '';
 
     buildPhase = ''
       runHook preBuild
-      pushd "$pnpmRoot"
+
       pnpm --filter ./apps/remark42 --fail-if-no-match run build
-      popd
+
       runHook postBuild
     '';
 
     installPhase = ''
       runHook preInstall
+
       mkdir -p $out/web
-      cp -r "$pnpmRoot/apps/remark42/public/." $out/web/
+      cp -r "apps/remark42/public/." $out/web/
+
       runHook postInstall
     '';
   });

--- a/pkgs/by-name/re/remark42/package.nix
+++ b/pkgs/by-name/re/remark42/package.nix
@@ -4,21 +4,21 @@
   fetchFromGitHub,
   buildGoModule,
   nodejs-slim_22,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   testers,
 }:
 
 let
-  pnpm = pnpm_9.override { nodejs-slim = nodejs-slim_22; };
-  version = "1.15.0";
+  pnpm = pnpm_10.override { nodejs-slim = nodejs-slim_22; };
+  version = "1.16.4";
 
   src = fetchFromGitHub {
     owner = "umputun";
     repo = "remark42";
     tag = "v${version}";
-    hash = "sha256-yd/qTRSZj0nZpgK77xP+XHyHcVXlNpyMzdfj6EbVcXQ=";
+    hash = "sha256-VCFpN/8GRziD7sKVw7jK33llo0AGqygW4ghHZxrluJc=";
   };
 
   remark42-web = stdenv.mkDerivation (finalAttrs: {
@@ -41,20 +41,11 @@ let
         version
         src
         sourceRoot
-        postPatch
         ;
       inherit pnpm;
       fetcherVersion = 4;
-      hash = "sha256-wFrMoSeD87H1yfMD0jBcw60DKDeh4yjka5aWyHuQssA=";
+      hash = "sha256-PInNiI8hcXzQoYWtHUy6BTQKgII7rHzlbSGFc+ixz7k=";
     };
-
-    postPatch = ''
-      substituteInPlace "package.json" "apps/remark42/package.json" \
-        --replace-fail "pnpm@8.15.9" "pnpm@${pnpm.version}"
-
-      substituteInPlace "apps/remark42/package.json" \
-        --replace-fail '"pnpm": "8.*"' '"pnpm": "9.*"'
-    '';
 
     buildPhase = ''
       runHook preBuild


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/539222/changes/5f7a35a9b36bfc2a6d41a568bb797e46bd237abd and https://github.com/NixOS/nixpkgs/pull/540515 to fix the insecure warning.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
