### PR TITLE
mcp-proxy-for-aws: init at v1.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16216,6 +16216,12 @@
     ];
     name = "Logan Barnett";
   };
+  loganphinney = {
+    name = "Logan Phinney";
+    email = "mail@loganphinney.com";
+    github = "loganphinney";
+    githubId = 154395727;
+  };
   logger = {
     name = "Ido Samuelson";
     email = "ido.samuelson@gmail.com";

--- a/pkgs/by-name/mc/mcp-proxy-for-aws/package.nix
+++ b/pkgs/by-name/mc/mcp-proxy-for-aws/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+}:
+
+let
+  pname = "mcp-proxy-for-aws";
+  version = "1.6.3";
+in
+
+python3Packages.buildPythonPackage {
+  inherit pname version;
+  pyproject = true;
+
+  disabled = python3Packages.pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "aws";
+    repo = "mcp-proxy-for-aws";
+    rev = "v${version}";
+    hash = "sha256-l8SUe6yjO3D0vchmzrzs6HxJQbO62YICU3BkEr4NUSk=";
+  };
+
+  build-system = [
+    python3Packages.hatchling
+  ];
+
+  dependencies = with python3Packages; [
+    fastmcp
+    boto3
+    botocore
+  ];
+
+  pythonImportsCheck = [
+    "mcp_proxy_for_aws"
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+    pytest-asyncio
+  ];
+
+  disabledTestPaths = [
+    "tests/integ"
+  ];
+
+  meta = {
+    description = "MCP Proxy for AWS";
+    homepage = "https://github.com/aws/mcp-proxy-for-aws";
+    license = lib.licenses.asl20;
+    mainProgram = "mcp-proxy-for-aws";
+    maintainers = with lib.maintainers; [ ];
+  };
+}

--- a/pkgs/by-name/mc/mcp-proxy-for-aws/package.nix
+++ b/pkgs/by-name/mc/mcp-proxy-for-aws/package.nix
@@ -50,6 +50,6 @@ python3Packages.buildPythonPackage {
     homepage = "https://github.com/aws/mcp-proxy-for-aws";
     license = lib.licenses.asl20;
     mainProgram = "mcp-proxy-for-aws";
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ loganphinney ];
   };
 }


### PR DESCRIPTION
Adding [mcp-proxy-for-aws](https://github.com/aws/mcp-proxy-for-aws) and myself as it's maintainer.

_"The MCP Proxy serves as a lightweight, client-side bridge between MCP clients (AI assistants and developer tools) and IAM-secured MCP servers on AWS. The proxy handles SigV4 authentication using local AWS credentials and provides dynamic tool discovery."_

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test