### PR TITLE
nixos/corosync-qnetd: init module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11053,6 +11053,12 @@
     githubId = 10136407;
     name = "Harsh Chokshi";
   };
+  hddq = {
+    name = "hddq";
+    email = "git@hddq.org";
+    github = "hddq";
+    githubId = 125512521;
+  };
   hdhog = {
     name = "Serg Larchenko";
     email = "hdhog@hdhog.ru";

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -32,6 +32,8 @@
 
 - [compsize](https://github.com/kilobyte/compsize), setcap wrapper for `compsize` package, a cli utility to to inspect compression type/ratio on BTRFS filesystems. Available as [programs.compsize](#opt-programs.compsize.enable)
 
+- [corosync-qnetd](https://github.com/corosync/corosync-qdevice), a Corosync Qdevice network daemon used to provide a tie-breaking vote to a Corosync cluster. Available as [services.corosync-qnetd](#opt-services.corosync-qnetd.enable).
+
 - [tranquil](https://tangled.org/tranquil.farm/tranquil-pds) is an ATProto PDS (personal data server) implementation in Rust. A featureful, spec conscious and community driven alternative to the Bluesky reference implementation PDS. Available as [services.tranquil-pds](#opt-services.tranquil-pds.enable).
 
 - [Moonlight Qt](https://moonlight-stream.org/), a client for playing your PC games on almost any device. Available as [programs.moonlight-qt](#opt-programs.moonlight-qt.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -496,6 +496,7 @@
   ./services/blockchain/ethereum/erigon.nix
   ./services/blockchain/ethereum/geth.nix
   ./services/blockchain/ethereum/lighthouse.nix
+  ./services/cluster/corosync-qnetd.nix
   ./services/cluster/corosync/default.nix
   ./services/cluster/druid/default.nix
   ./services/cluster/hadoop/default.nix

--- a/nixos/modules/services/cluster/corosync-qnetd.nix
+++ b/nixos/modules/services/cluster/corosync-qnetd.nix
@@ -1,0 +1,71 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.corosync-qnetd;
+in
+{
+  meta.maintainers = [ lib.maintainers.hddq ];
+
+  options.services.corosync-qnetd = {
+    enable = lib.mkEnableOption "Corosync Qdevice Network Daemon";
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to open the default port (5403) in the firewall
+        for the Corosync Qdevice Network Daemon.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      pkgs.corosync-qdevice
+      pkgs.nssTools
+    ];
+
+    users.groups.coroqnetd = { };
+    users.users.coroqnetd = {
+      isSystemUser = true;
+      group = "coroqnetd";
+      description = "Corosync QNetd daemon user";
+      home = "/var/lib/corosync-qnetd";
+    };
+
+    environment.etc."corosync/qnetd".source = "/var/lib/corosync-qnetd";
+
+    systemd.services.corosync-qnetd = {
+      description = "Corosync Qdevice Network Daemon";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      path = [
+        pkgs.nssTools
+        pkgs.corosync-qdevice
+      ];
+
+      serviceConfig = {
+        StateDirectory = "corosync-qnetd";
+        RuntimeDirectory = "corosync-qnetd";
+        ExecStartPre = [
+          "${pkgs.writeShellScript "corosync-qnetd-prestart" ''
+            if [ ! -f /var/lib/corosync-qnetd/nssdb/cert9.db ]; then
+              ${pkgs.corosync-qdevice}/bin/corosync-qnetd-certutil -i
+            fi
+          ''}"
+        ];
+        ExecStart = "${pkgs.corosync-qdevice}/bin/corosync-qnetd -f";
+        User = "coroqnetd";
+        Group = "coroqnetd";
+        Restart = "on-failure";
+      };
+    };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ 5403 ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -423,6 +423,7 @@ in
   convos = runTest ./convos.nix;
   coredns = runTest ./coredns.nix;
   corerad = runTest ./corerad.nix;
+  corosync-qnetd = runTest ./corosync-qnetd.nix;
   corteza = runTest ./corteza.nix;
   cosmic = runTest {
     imports = [ ./cosmic ];

--- a/nixos/tests/corosync-qnetd.nix
+++ b/nixos/tests/corosync-qnetd.nix
@@ -1,0 +1,18 @@
+{ pkgs, ... }:
+{
+  name = "corosync-qnetd";
+
+  meta.maintainers = with pkgs.lib.maintainers; [ hddq ];
+
+  nodes.machine = {
+    services.corosync-qnetd.enable = true;
+    services.corosync-qnetd.openFirewall = true;
+  };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("corosync-qnetd.service")
+    machine.wait_for_open_port(5403)
+    machine.succeed("corosync-qnetd-tool -s")
+  '';
+}

--- a/pkgs/by-name/co/corosync-qdevice/package.nix
+++ b/pkgs/by-name/co/corosync-qdevice/package.nix
@@ -10,6 +10,7 @@
   nspr,
   systemd,
   versionCheckHook,
+  nixosTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -61,5 +62,9 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [ x123 ];
     mainProgram = "corosync-qdevice";
     platforms = lib.platforms.linux;
+  };
+
+  passthru.tests = {
+    inherit (nixosTests) corosync-qnetd;
   };
 })


### PR DESCRIPTION
Corosync Qnetd (corosync-qnetd) is a daemon running outside of the cluster with the purpose of providing a vote to the corosync-qdevice model net. It's designed to support multiple clusters and be almost configuration and state free.

This adds a new NixOS module for `corosync-qnetd`.

Tested extensively by:
1. Running the NixOS VM test locally (`nixosTests.corosync-qnetd`).
2. Deploying to an `aarch64-linux` NixOS cloud VPS and configuring it as a Qdevice against a live Proxmox VE cluster.

*Assisted-by: Antigravity (Gemini 3.1 Pro)*

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].