### PR TITLE
melos: fix melos failing outside a workspace

### DIFF
--- a/pkgs/by-name/me/melos/add-generic-main.patch
+++ b/pkgs/by-name/me/melos/add-generic-main.patch
@@ -1,8 +1,8 @@
 diff --git a/bin/melos.dart b/bin/melos.dart
-index 2476436..bd79fad 100644
+index 2476436..ee6adb0 100644
 --- a/packages/melos/bin/melos.dart
 +++ b/packages/melos/bin/melos.dart
-@@ -1,11 +1,72 @@
+@@ -1,11 +1,74 @@
  import 'package:cli_launcher/cli_launcher.dart';
  import 'package:melos/src/command_runner.dart';
 +import 'dart:io';
@@ -19,31 +19,29 @@ index 2476436..bd79fad 100644
 -);
 +final ExecutableName executableName = ExecutableName('melos');
 +
++// Substituted at build time to the package's install location in the
++// nix store (see preBuild in package.nix).
++const _globalPackageRoot = '__NIX_MELOS_PACKAGE_ROOT__';
++
 +Future<void> main(List<String> arguments) async {
-+  final workspaceRoot = _findLocalInstallation(Directory.current);
++  final localInstallation = _findLocalInstallation(Directory.current);
 +
-+  if (workspaceRoot == null) {
-+    print("Error: Could not find your work  ");
-+    return;
-+  }
-+
-+  melosEntryPoint(
++  await melosEntryPoint(
 +    arguments,
 +    LaunchContext(
 +      directory: Directory.current,
-+      localInstallation: ExecutableInstallation(
++      globalInstallation: ExecutableInstallation(
 +        name: executableName,
 +        isSelf: false,
-+        packageRoot: workspaceRoot,
++        packageRoot: Directory(_globalPackageRoot),
 +      ),
++      localInstallation: localInstallation,
 +    ),
 +  );
 +}
 +
 +// Stolen then simplified from https://github.com/blaugold/cli_launcher/blob/dcdf11c42b77ddc8e38e7e2445c8cff9b55658ec/lib/cli_launcher.dart#L249
-+Directory? _findLocalInstallation(
-+  Directory start,
-+) {
++ExecutableInstallation? _findLocalInstallation(Directory start) {
 +  if (path.equals(start.path, start.parent.path)) {
 +    return null;
 +  }
@@ -72,12 +70,16 @@ index 2476436..bd79fad 100644
 +
 +    final isSelf = name == executableName.package;
 +
-+    if ((isSelf) ||
++    if (isSelf ||
 +        (dependencies != null &&
 +            dependencies.containsKey(executableName.package)) ||
 +        (devDependencies != null &&
 +            devDependencies.containsKey(executableName.package))) {
-+      return start;
++      return ExecutableInstallation(
++        name: executableName,
++        isSelf: isSelf,
++        packageRoot: start,
++      );
 +    }
 +  }
 +

--- a/pkgs/by-name/me/melos/package.nix
+++ b/pkgs/by-name/me/melos/package.nix
@@ -27,6 +27,8 @@ buildDartApplication (finalAttrs: {
       --replace-fail "final melosPackageFileUri = await Isolate.resolvePackageUri(melosPackageUri);" "return \"$out\";"
     substituteInPlace packages/melos/lib/src/common/utils.dart \
       --replace-fail "return p.normalize('\''${melosPackageFileUri!.toFilePath()}/../..');" " "
+    substituteInPlace packages/melos/bin/melos.dart \
+      --replace-fail "__NIX_MELOS_PACKAGE_ROOT__" "$out"
     mkdir --parents $out
     cp --recursive packages/melos/templates $out/
   '';


### PR DESCRIPTION
Falls back to a synthetic global installation (pointing at $out) instead of erroring out when no local workspace is found, so melos --help/--version work from any directory.

Fixes: #542188

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
