### PR TITLE
rPackages.SingleR: fix build

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -2195,6 +2195,14 @@ let
       };
     });
 
+    SingleR = old.SingleR.overrideAttrs (attrs: {
+      postPatch = ''
+        substituteInPlace src/find_classic_markers.cpp --replace-fail \
+          "Rcpp::IntegerVector val(de_n);" \
+          "Rcpp::IntegerVector val(static_cast<int>(de_n));"
+      '';
+    });
+
     SpliceWiz = old.SpliceWiz.overrideAttrs (attrs: {
       postPatch = "patchShebangs configure";
     });


### PR DESCRIPTION
It looks like the new gcc is stricter, and doesn't allow overloading. Fix is not expected in the upstream until bioc builders hit the same version. I have no clue about c++, so please double check this patch, and decide if it's a good idea to fix it this way or better wait for upstream. I ran `example(getClassicMarkers)` using the patched function and the output looks ... like a legit example output.

https://github.com/NixOS/nixpkgs/pull/539315

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


