### PR TITLE
python3Packages.cucumber-expressions: 19.0.1 -> 20.0.0

### DIFF
--- a/pkgs/development/python-modules/cucumber-expressions/default.nix
+++ b/pkgs/development/python-modules/cucumber-expressions/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "cucumber-expressions";
-  version = "19.0.1";
+  version = "20.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "cucumber";
     repo = "cucumber-expressions";
     tag = "v${version}";
-    hash = "sha256-RosIA8LaXdpnqJYfowB4d1gWZTd8OfuetiBLNYX5dRc=";
+    hash = "sha256-aPxD6snSQCA0y5tagvMy95bVtsk0qGf4KglTsuCGolU=";
   };
 
   sourceRoot = "${src.name}/python";

--- a/pkgs/development/python-modules/cucumber-expressions/default.nix
+++ b/pkgs/development/python-modules/cucumber-expressions/default.nix
@@ -7,7 +7,7 @@
   pyyaml,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "cucumber-expressions";
   version = "20.0.0";
   pyproject = true;
@@ -15,11 +15,11 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "cucumber";
     repo = "cucumber-expressions";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-aPxD6snSQCA0y5tagvMy95bVtsk0qGf4KglTsuCGolU=";
   };
 
-  sourceRoot = "${src.name}/python";
+  sourceRoot = "${finalAttrs.src.name}/python";
 
   postPatch = ''
     substituteInPlace pyproject.toml \
@@ -36,10 +36,10 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    changelog = "https://github.com/cucumber/cucumber-expressions/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/cucumber/cucumber-expressions/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     description = "Human friendly alternative to Regular Expressions";
     homepage = "https://github.com/cucumber/cucumber-expressions/tree/main/python";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.dotlambda ];
   };
-}
+})

--- a/pkgs/development/python-modules/cucumber-tag-expressions/default.nix
+++ b/pkgs/development/python-modules/cucumber-tag-expressions/default.nix
@@ -10,21 +10,21 @@
 
 buildPythonPackage rec {
   pname = "cucumber-tag-expressions";
-  version = "9.1.0";
+  version = "10.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "cucumber";
     repo = "tag-expressions";
     tag = "v${version}";
-    hash = "sha256-jkuez7C3YDGmv484Lmc5PszVbnVXkcC12RryvTJkxxg=";
+    hash = "sha256-GXgFACoes5g8E+I24tYuI3KVzFhZaFB3Gr4TJXKBpQs=";
   };
 
   sourceRoot = "${src.name}/python";
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail "uv_build>=0.10.0,<0.11.0" uv_build
+      --replace-fail "uv_build>=0.11.0,<0.12.0" uv_build
   '';
 
   build-system = [

--- a/pkgs/development/python-modules/cucumber-tag-expressions/default.nix
+++ b/pkgs/development/python-modules/cucumber-tag-expressions/default.nix
@@ -8,7 +8,7 @@
   uv-build,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "cucumber-tag-expressions";
   version = "10.0.0";
   pyproject = true;
@@ -16,11 +16,11 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "cucumber";
     repo = "tag-expressions";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-GXgFACoes5g8E+I24tYuI3KVzFhZaFB3Gr4TJXKBpQs=";
   };
 
-  sourceRoot = "${src.name}/python";
+  sourceRoot = "${finalAttrs.src.name}/python";
 
   postPatch = ''
     substituteInPlace pyproject.toml \
@@ -38,10 +38,10 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    changelog = "https://github.com/cucumber/tag-expressions/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/cucumber/tag-expressions/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     homepage = "https://github.com/cucumber/tag-expressions";
     description = "Provides tag-expression parser for cucumber/behave";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ maxxk ];
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/cucumber/cucumber-expressions/compare/v19.0.1...v20.0.0

Changelog: https://github.com/cucumber/cucumber-expressions/blob/v20.0.0/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
