### PR TITLE
codechecker: 6.28.0 -> 6.28.2

### DIFF
--- a/pkgs/by-name/co/codechecker/package.nix
+++ b/pkgs/by-name/co/codechecker/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  fetchpatch,
   fetchPypi,
   makeWrapper,
   python3Packages,
@@ -16,19 +17,28 @@
 }:
 python3Packages.buildPythonApplication rec {
   pname = "codechecker";
-  version = "6.28.0";
+  version = "6.28.2";
   pyproject = true;
 
   strictDeps = true;
   __structuredAttrs = true;
 
+  patches = [
+    # Change lxml-stubs to types-lxml
+    (fetchpatch {
+      url = "https://github.com/Ericsson/codechecker/commit/4d3dbc7e8248c4b1ddaa3885c26521458712de55.patch";
+      hash = "sha256-wWXEzsYaBtP3N+63k6QAkZVHCMM1qhmrUv2QPyM4Xfo=";
+    })
+  ];
+
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-wxV+/hzsk7RrzWTXNz5HyweYdFFI1upNS508QRPCefo=";
+    hash = "sha256-7ZmrY/fEPW+hm4sPyXEHOu0T2x0ruRMKhOGwSSVFbfc=";
   };
 
   build-system = with python3Packages; [
     setuptools
+    types-setuptools
   ];
 
   dependencies = with python3Packages; [
@@ -49,6 +59,7 @@ python3Packages.buildPythonApplication rec {
     types-pyyaml
     sarif-tools
     types-psutil
+    types-lxml
   ];
 
   pythonRelaxDeps = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
