### PR TITLE
ocaml: fix cross-compile by adding bootstrapping ocaml

### DIFF
--- a/pkgs/development/compilers/ocaml/generic.nix
+++ b/pkgs/development/compilers/ocaml/generic.nix
@@ -21,6 +21,7 @@ in
   ncurses,
   binutils,
   buildEnv,
+  pkgsBuildBuild,
   libunwind,
   fetchpatch,
   libx11,
@@ -177,6 +178,7 @@ stdenv.mkDerivation (
         ]
       else
         [ "nixpkgs_world" ];
+    nativeBuildInputs = optional (stdenv.hostPlatform != stdenv.targetPlatform) pkgsBuildBuild.ocaml;
     buildInputs =
       optional (lib.versionOlder version "4.07") ncurses
       ++ optionals useX11 [


### PR DESCRIPTION
Error before

```
./configure: interpreter directive changed from "#! /bin/sh" to "/nix/store/v8llyqw71lygr2llhmcc8ya5bdlzq45v-bash-5.3p9/bin/sh"
configure flags: --disable-static -prefix /nix/store/j3mdxm53jdbahmh8bb5zs4k17hm119a8-ocaml-5.4.1 --enable-ocamltest --host=x86_64-unknown-linux-gnu --target=aarch64-unknown-linux-gnu
configure: Configuring OCaml version 5.4.1
checking build system type... x86_64-pc-linux-gnu
checking host system type... x86_64-unknown-linux-gnu
checking target system type... aarch64-unknown-linux-gnu
checking for csc... no
checking if the installed OCaml compiler can build the cross compiler... ./configure: line 4348: ocamlc: command not found
no (5.4.1 vs )
configure: error: exiting
```

Now:

```console
$ nix-build -E '(import ./. {}).pkgsCross.aarch64-multiplatform.ocamlPackages.cmdliner'
/nix/store/8zai2mchi8i1p4w50qzzmykvnqk1b6ai-cmdliner-aarch64-unknown-linux-gnu-2.1.1
```


Based on Rust using `pkgsBuildBuild.rustPackages` for bootstrapping.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.