### PR TITLE
qt6.wrapQtAppsHook: preset LANG to avoid bash 5.3 fixup-loop segfault on Darwin

### DIFF
--- a/pkgs/development/libraries/qt-6/hooks/wrap-qt-apps-hook.sh
+++ b/pkgs/development/libraries/qt-6/hooks/wrap-qt-apps-hook.sh
@@ -74,6 +74,11 @@ if [[ -z "${__nix_wrapQtAppsHook-}" ]]; then
         [ -z "$wrapQtAppsHookHasRun" ] || return 0
         wrapQtAppsHookHasRun=1
 
+        # bash 5.3 segfaults on some macOS when the isELF/isMachO fixup helpers do a
+        # transient `LANG=C read` in a forked subshell with no locale set. Presetting
+        # LANG makes that switch a no-op.
+        export LANG="${LANG:-C}"
+
         local targetDirs=("$prefix/bin" "$prefix/sbin" "$prefix/libexec" "$prefix/Applications" "$prefix/"*.app)
         echo "wrapping Qt applications in ${targetDirs[@]}"
 


### PR DESCRIPTION
Presets `LANG="${LANG:-C}"` in `wrapQtAppsHook` before its fixup loop, to work
around a bash 5.3 segfault on macOS (see #431934).

`wrapQtAppsHook` (and its `wrapQtAppsNoGuiHook` variant) wraps output
executables via a `find … -executable -print0 | while read … isELF || isMachO`
loop. On some macOS versions (reproduced on macOS 14.5 / aarch64 with the bash
5.3 in current nixpkgs), bash segfaults when a **forked subshell** performs a
transient locale assignment with **no locale set** in the environment — exactly
what stdenv's `isELF`/`isMachO` do with `LANG=C read`, run inside that pipe's
subshell in the scrubbed nix builder env. The builder dies with exit 139:

```
> wrapping Qt applications in .../bin ...
>   Segmentation fault: 11     | while IFS= read -r -d '' file; do ...
error: builder failed with exit code 139
```

Any Qt derivation that installs an executable is affected. Minimal repro (any
bash 5.3, incl. 5.3p9):

```sh
<nix-bash-5.3>/bin/bash \
  -c 'echo x | while read l; do LANG=C true; echo ok; done'
# prints "ok" on a healthy setup; segfaults (exit 139) on the affected combo
```

Presetting `LANG` makes the transient `LANG=C` a no-op (no `setlocale`
transition from unset → C), which avoids the crash. The change is unconditional
and harmless elsewhere: `${LANG:-C}` leaves an already-set `LANG` untouched and
otherwise pins the POSIX default the fixup helpers already assume.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test