### PR TITLE
ocamlPackages.lrgrep: init at 0.9

### DIFF
--- a/pkgs/development/ocaml-modules/cmon/default.nix
+++ b/pkgs/development/ocaml-modules/cmon/default.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  fetchurl,
+  buildDunePackage,
+  grenier,
+  pprint,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "cmon";
+  version = "0.2";
+
+  src = fetchurl {
+    url = "https://github.com/let-def/cmon/releases/download/v${finalAttrs.version}/cmon-${finalAttrs.version}.tbz";
+    hash = "sha256-lJi5NV27YqyDgUx1i4vBj/buzyzdWJSrSceGGs82grg=";
+  };
+
+  propagatedBuildInputs = [
+    grenier
+    pprint
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "A library for printing OCaml values with sharing";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/let-def/cmon";
+  };
+})

--- a/pkgs/development/ocaml-modules/grenier/default.nix
+++ b/pkgs/development/ocaml-modules/grenier/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchurl,
+  buildDunePackage,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "grenier";
+  version = "0.16";
+  src = fetchurl {
+    url = "https://github.com/let-def/grenier/releases/download/v${finalAttrs.version}/grenier-${finalAttrs.version}.tbz";
+    hash = "sha256-j9Iqv59FicIGAIZU+p7rsc9KWHN+uzQTjGcJUg82t18=";
+  };
+
+  doCheck = true;
+
+  meta = {
+    description = "A collection of various algorithms in OCaml";
+    license = lib.licenses.isc;
+    homepage = "https://github.com/let-def/grenier";
+  };
+})

--- a/pkgs/development/ocaml-modules/lrgrep/default.nix
+++ b/pkgs/development/ocaml-modules/lrgrep/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  fetchurl,
+  buildDunePackage,
+  menhir,
+  cmon,
+  menhirLib,
+  menhirSdk,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "lrgrep";
+  version = "0.9";
+
+  minimalOCamlVersion = "4.14";
+
+  src = fetchurl {
+    url = "https://github.com/let-def/lrgrep/releases/download/v${finalAttrs.version}/lrgrep-${finalAttrs.version}.tbz";
+    hash = "sha256-5T3hLkxcvmvKAGQ1kyZrT5+i4/ahOBle7/ekMp9cHHU=";
+  };
+
+  nativeBuildInputs = [ menhir ];
+
+  propagatedBuildInputs = [
+    cmon
+    menhirLib
+    menhirSdk
+  ];
+
+  doCheck = true;
+
+  meta = {
+    license = lib.licenses.isc;
+    description = "Detailed error messages for Menhir-generated parsers";
+    homepage = "https://github.com/let-def/lrgrep";
+  };
+})

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1161,6 +1161,8 @@ let
 
         lreplay = callPackage ../development/ocaml-modules/lreplay { };
 
+        lrgrep = callPackage ../development/ocaml-modules/lrgrep { };
+
         lru = callPackage ../development/ocaml-modules/lru { };
 
         lsp = callPackage ../development/ocaml-modules/ocaml-lsp/lsp.nix { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -796,6 +796,8 @@ let
 
         graphql_ppx = callPackage ../development/ocaml-modules/graphql_ppx { };
 
+        grenier = callPackage ../development/ocaml-modules/grenier { };
+
         gsl = callPackage ../development/ocaml-modules/gsl {
           inherit (pkgs) gsl;
         };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -271,6 +271,8 @@ let
 
         cmdliner_1 = cmdliner.override { version = "1.3.0"; };
 
+        cmon = callPackage ../development/ocaml-modules/cmon { };
+
         cohttp = callPackage ../development/ocaml-modules/cohttp { };
 
         cohttp_5_3 = cohttp.overrideAttrs (_: {


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
