### PR TITLE
python3Packages.dspy: init at 3.2.1

### DIFF
--- a/pkgs/development/python-modules/dspy/default.nix
+++ b/pkgs/development/python-modules/dspy/default.nix
@@ -1,0 +1,128 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  anyio,
+  asyncer,
+  cachetools,
+  cloudpickle,
+  datamodel-code-generator,
+  diskcache,
+  gepa,
+  json-repair,
+  litellm,
+  mcp,
+  numpy,
+  openai,
+  orjson,
+  pillow,
+  pydantic,
+  pyprojectVersionPatchHook,
+  pytestCheckHook,
+  pytest-asyncio,
+  regex,
+  requests,
+  tenacity,
+  tqdm,
+  typeguard,
+  xxhash,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "dspy";
+  version = "3.2.1";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "stanfordnlp";
+    repo = "dspy";
+    tag = finalAttrs.version;
+    hash = "sha256-xquV+FyDfejm1SCWYfuiezIkyutmm/1zOvd5X+oElrM=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  nativeBuildInputs = [
+    pyprojectVersionPatchHook
+  ];
+
+  dependencies = [
+    anyio
+    asyncer
+    cachetools
+    cloudpickle
+    diskcache
+    gepa
+    json-repair
+    litellm
+    mcp
+    numpy
+    openai
+    orjson
+    pydantic
+    regex
+    requests
+    tenacity
+    tqdm
+    typeguard
+    xxhash
+  ];
+
+  pythonRelaxDeps = [
+    "asyncer"
+    "gepa"
+    "litellm"
+    "typeguard"
+  ];
+
+  # optuna is an optional dependency that dspy can use but doesn't require at import time
+  pythonRemoveDeps = [ "optuna" ];
+
+  # Prevent litellm from trying to fetch the remote model cost map at import
+  # time, which fails in environments without direct internet access.
+  postPatch = ''
+    sed -i '1i import os; os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "true")' dspy/__init__.py
+  '';
+
+  pythonImportsCheck = [ "dspy" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    datamodel-code-generator
+    pillow
+  ];
+
+  # skip tests that need network access
+  disabledTestPaths = [
+    "tests/signatures/test_adapter_image.py"
+  ];
+
+  # These tests start a litellm proxy server subprocess, which isn't available
+  # in the nix build sandbox (upstream skips them on Python 3.14 for the same reason).
+  disabledTests = [
+    "test_chat_lms_can_be_queried"
+    "test_dspy_cache"
+    "test_lm_calls_support_callables"
+    "test_lm_calls_support_pydantic_models"
+    "test_responses_api_tool_calls"
+    "test_streamify_yields_expected_response_chunks"
+    "test_streaming_response_yields_expected_response_chunks"
+    "test_text_lms_can_be_queried"
+  ];
+
+  meta = {
+    description = "Programming — not prompting — language models";
+    homepage = "https://github.com/stanfordnlp/dspy";
+    changelog = "https://github.com/stanfordnlp/dspy/releases/tag/${finalAttrs.version}";
+    maintainers = with lib.maintainers; [ jherland ];
+    license = lib.licenses.mit;
+    # The datamodel-code-generator dependency fails a test on Darwin, but we only need Linux support for now.
+    # This prevents rebuilding all of datamodel-code-generator's dependents.
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/development/python-modules/gepa/default.nix
+++ b/pkgs/development/python-modules/gepa/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  pyprojectVersionPatchHook,
   setuptools,
 }:
 
@@ -19,6 +20,10 @@ buildPythonPackage (finalAttrs: {
   };
 
   build-system = [ setuptools ];
+
+  nativeBuildInputs = [
+    pyprojectVersionPatchHook
+  ];
 
   pythonImportsCheck = [ "gepa" ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5166,6 +5166,8 @@ self: super: with self; {
 
   dsnap = callPackage ../development/python-modules/dsnap { };
 
+  dspy = callPackage ../development/python-modules/dspy { };
+
   dt8852 = callPackage ../development/python-modules/dt8852 { };
 
   dtfabric = callPackage ../development/python-modules/dtfabric { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
