### PR TITLE
coqPackages.smtcoq: now depends on trakt

### DIFF
--- a/pkgs/development/coq-modules/smtcoq/default.nix
+++ b/pkgs/development/coq-modules/smtcoq/default.nix
@@ -43,36 +43,12 @@ mkCoqDerivation {
 
   inherit version;
   defaultVersion =
+    let
+      case = case: out: { inherit case out; };
+    in
     with lib.versions;
-    lib.switch coq.version [
-      {
-        case = isEq "8.19";
-        out = "SMTCoq-2.2+8.19";
-      }
-      {
-        case = isEq "8.18";
-        out = "SMTCoq-2.2+8.18";
-      }
-      {
-        case = isEq "8.17";
-        out = "SMTCoq-2.2+8.17";
-      }
-      {
-        case = isEq "8.16";
-        out = "SMTCoq-2.2+8.16";
-      }
-      {
-        case = isEq "8.15";
-        out = "SMTCoq-2.2+8.15";
-      }
-      {
-        case = isEq "8.14";
-        out = "SMTCoq-2.2+8.14";
-      }
-      {
-        case = isEq "8.13";
-        out = "SMTCoq-2.2+8.13";
-      }
+    lib.switch coq.coq-version [
+      (case (range "8.13" "8.19") "SMTCoq-2.2+${coq.coq-version}")
     ] null;
 
   propagatedBuildInputs = [

--- a/pkgs/development/coq-modules/smtcoq/default.nix
+++ b/pkgs/development/coq-modules/smtcoq/default.nix
@@ -25,6 +25,7 @@ mkCoqDerivation {
   pname = "smtcoq";
   owner = "smtcoq";
 
+  release."SMTCoq-2.3+8.20".hash = "sha256-ScWtdwSpFBf/PryPuvI/SkhgqWyYhcX3FCOqoXNho7Q=";
   release."SMTCoq-2.2+8.19".hash = "sha256-9Wv8AXRRyOHG/cjA/V9tSK55R/bofDMLTkDpuwYWkks=";
   release."SMTCoq-2.2+8.18".hash = "sha256-1iJAruI5Qn9nTZcUDjk8t/1Q+eFkYLOe9Ee0DmK03w8=";
   release."SMTCoq-2.2+8.17".hash = "sha256-kaodsyVUl1+QQagzoBTIjxbdD4X3IaaH0x2AsVUL+Z0=";
@@ -48,6 +49,7 @@ mkCoqDerivation {
     in
     with lib.versions;
     lib.switch coq.coq-version [
+      (case (isEq "8.20") "SMTCoq-2.3+${coq.coq-version}")
       (case (range "8.13" "8.19") "SMTCoq-2.2+${coq.coq-version}")
     ] null;
 

--- a/pkgs/development/coq-modules/smtcoq/default.nix
+++ b/pkgs/development/coq-modules/smtcoq/default.nix
@@ -6,6 +6,7 @@
   zchaff,
   cvc5,
   stdlib,
+  trakt,
   version ? null,
 }:
 
@@ -21,59 +22,72 @@
 #   };
 # in
 
-mkCoqDerivation {
-  pname = "smtcoq";
-  owner = "smtcoq";
+let
+  derivation = mkCoqDerivation {
+    pname = "smtcoq";
+    owner = "smtcoq";
+    opam-name = "rocq-smtcoq";
 
-  release."SMTCoq-2.3+8.20".hash = "sha256-ScWtdwSpFBf/PryPuvI/SkhgqWyYhcX3FCOqoXNho7Q=";
-  release."SMTCoq-2.2+8.19".hash = "sha256-9Wv8AXRRyOHG/cjA/V9tSK55R/bofDMLTkDpuwYWkks=";
-  release."SMTCoq-2.2+8.18".hash = "sha256-1iJAruI5Qn9nTZcUDjk8t/1Q+eFkYLOe9Ee0DmK03w8=";
-  release."SMTCoq-2.2+8.17".hash = "sha256-kaodsyVUl1+QQagzoBTIjxbdD4X3IaaH0x2AsVUL+Z0=";
-  release."SMTCoq-2.2+8.16".hash = "sha256-Hwm8IFlw97YiOY6H63HyJlwIXvQHr9lqc1+PgTnBtkw=";
-  release."SMTCoq-2.2+8.15".hash = "sha256-+GYOasJ32KJyOfqJlTtFmsJ2exd6gdueKwHdeMPErTo=";
-  release."SMTCoq-2.2+8.14".hash = "sha256-jqnF33E/4CqR1HSrLmUmLVCKslw9h3bbWi4YFmFYrhY=";
-  release."SMTCoq-2.2+8.13".hash = "sha256-AVpKU/SLaLYnCnx6GOEPGJjwbRrp28Fs5O50kJqdclI=";
-  release."SMTCoq-2.1+8.16".rev = "4996c00b455bfe98400e96c954839ceea93efdf7";
-  release."SMTCoq-2.1+8.16".hash = "sha256-k53e+frUjwq+ZZKbbOKd/EfVC40QeAzB2nCsGkCKnHA=";
-  release."SMTCoq-2.1+8.14".rev = "e11d9b424b0113f32265bcef0ddc962361da4dae";
-  release."SMTCoq-2.1+8.14".hash = "sha256-4a01/CRHUon2OfpagAnMaEVkBFipPX3MCVmSFS1Bnt4=";
-  release."SMTCoq-2.1+8.13".rev = "d02269c43739f4559d83873563ca00daad9faaf1";
-  release."SMTCoq-2.1+8.13".hash = "sha256-VZetGghdr5uJWDwZWSlhYScoNEoRHIbwqwJKSQyfKKg=";
+    release."SMTCoq-2.3+8.20".hash = "sha256-ScWtdwSpFBf/PryPuvI/SkhgqWyYhcX3FCOqoXNho7Q=";
+    release."SMTCoq-2.2+8.19".hash = "sha256-9Wv8AXRRyOHG/cjA/V9tSK55R/bofDMLTkDpuwYWkks=";
+    release."SMTCoq-2.2+8.18".hash = "sha256-1iJAruI5Qn9nTZcUDjk8t/1Q+eFkYLOe9Ee0DmK03w8=";
+    release."SMTCoq-2.2+8.17".hash = "sha256-kaodsyVUl1+QQagzoBTIjxbdD4X3IaaH0x2AsVUL+Z0=";
+    release."SMTCoq-2.2+8.16".hash = "sha256-Hwm8IFlw97YiOY6H63HyJlwIXvQHr9lqc1+PgTnBtkw=";
+    release."SMTCoq-2.2+8.15".hash = "sha256-+GYOasJ32KJyOfqJlTtFmsJ2exd6gdueKwHdeMPErTo=";
+    release."SMTCoq-2.2+8.14".hash = "sha256-jqnF33E/4CqR1HSrLmUmLVCKslw9h3bbWi4YFmFYrhY=";
+    release."SMTCoq-2.2+8.13".hash = "sha256-AVpKU/SLaLYnCnx6GOEPGJjwbRrp28Fs5O50kJqdclI=";
+    release."SMTCoq-2.1+8.16".rev = "4996c00b455bfe98400e96c954839ceea93efdf7";
+    release."SMTCoq-2.1+8.16".hash = "sha256-k53e+frUjwq+ZZKbbOKd/EfVC40QeAzB2nCsGkCKnHA=";
+    release."SMTCoq-2.1+8.14".rev = "e11d9b424b0113f32265bcef0ddc962361da4dae";
+    release."SMTCoq-2.1+8.14".hash = "sha256-4a01/CRHUon2OfpagAnMaEVkBFipPX3MCVmSFS1Bnt4=";
+    release."SMTCoq-2.1+8.13".rev = "d02269c43739f4559d83873563ca00daad9faaf1";
+    release."SMTCoq-2.1+8.13".hash = "sha256-VZetGghdr5uJWDwZWSlhYScoNEoRHIbwqwJKSQyfKKg=";
 
-  releaseRev = v: v;
+    releaseRev = v: v;
 
-  inherit version;
-  defaultVersion =
-    let
-      case = case: out: { inherit case out; };
-    in
-    with lib.versions;
-    lib.switch coq.coq-version [
-      (case (isEq "8.20") "SMTCoq-2.3+${coq.coq-version}")
-      (case (range "8.13" "8.19") "SMTCoq-2.2+${coq.coq-version}")
-    ] null;
+    inherit version;
+    defaultVersion =
+      let
+        case = case: out: { inherit case out; };
+      in
+      with lib.versions;
+      lib.switch coq.coq-version [
+        (case (isEq "8.20") "SMTCoq-2.3+${coq.coq-version}")
+        (case (range "8.13" "8.19") "SMTCoq-2.2+${coq.coq-version}")
+      ] null;
 
-  propagatedBuildInputs = [
-    cvc5
-    # veriT'  # c.f. comment above
-    zchaff
-    stdlib
-  ]
-  ++ (with coq.ocamlPackages; [
-    findlib
-    num
-    zarith
-  ]);
-  mlPlugin = true;
-  nativeBuildInputs = (with pkgs; [ gnumake42 ]) ++ (with coq.ocamlPackages; [ ocamlbuild ]);
+    propagatedBuildInputs = [
+      cvc5
+      # veriT'  # c.f. comment above
+      zchaff
+      stdlib
+    ]
+    ++ (with coq.ocamlPackages; [
+      findlib
+      num
+      zarith
+    ]);
+    useDuneifVersion = v: v != null && (v == "dev" || lib.versions.isGt "SMTCoq-2.3+8.20" v);
+    mlPlugin = true;
+    nativeBuildInputs = (with pkgs; [ gnumake42 ]) ++ (with coq.ocamlPackages; [ ocamlbuild ]);
 
-  # This is meant to ease future troubleshooting of cvc5 build failures
-  passthru = { inherit cvc5; };
+    # This is meant to ease future troubleshooting of cvc5 build failures
+    passthru = { inherit cvc5; };
 
-  meta = {
-    description = "Communication between Coq and SAT/SMT solvers";
-    maintainers = with lib.maintainers; [ siraben ];
-    license = lib.licenses.cecill-b;
-    platforms = lib.platforms.unix;
+    meta = {
+      description = "Communication between Coq and SAT/SMT solvers";
+      maintainers = with lib.maintainers; [ siraben ];
+      license = lib.licenses.cecill-b;
+      platforms = lib.platforms.unix;
+    };
   };
-}
+  patched-derivation1 = derivation.overrideAttrs (
+    o:
+    lib.optionalAttrs
+      (o.version != null && (o.version == "dev" || lib.versions.isGt "SMTCoq-2.3+8.20" o.version))
+      {
+        propagatedBuildInputs = o.propagatedBuildInputs ++ [ trakt ];
+      }
+  );
+in
+patched-derivation1


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
