### PR TITLE
python3Packages.wordfreq: 3.0.2 -> 3.2.0

### DIFF
--- a/pkgs/development/python-modules/locate/default.nix
+++ b/pkgs/development/python-modules/locate/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  setuptools,
+  setuptools-scm,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "locate";
+  version = "1.1.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "AutoActuary";
+    repo = "locate";
+    tag = finalAttrs.version;
+    hash = "sha256-cPBxSjcX0y0Ul7B6yOY+U2ylrQ1oBV6t3lN4qyutGlE=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "locate" ];
+
+  meta = {
+    description = "Locate files relative to the current Python script";
+    homepage = "https://github.com/AutoActuary/locate";
+    changelog = "https://github.com/AutoActuary/locate/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.geri1701 ];
+  };
+})

--- a/pkgs/development/python-modules/wordfreq/default.nix
+++ b/pkgs/development/python-modules/wordfreq/default.nix
@@ -4,6 +4,7 @@
   poetry-core,
   regex,
   langcodes,
+  locate,
   ftfy,
   msgpack,
   mecab-python3,
@@ -12,16 +13,17 @@
   fetchFromGitHub,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "wordfreq";
-  version = "3.0.2";
+  version = "3.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "rspeer";
     repo = "wordfreq";
-    tag = "v${version}";
-    hash = "sha256-ANOBbQWLB35Vz6oil6QZDpsNpKHeKUJnDKA5Q9JRVdE=";
+    # The v3.2 tag points to the preceding commit before the version bump.
+    rev = "912caf64b657478d1dff1138efdc078947d54bb1";
+    hash = "sha256-Ni93q6557jWTPYpqWCEriFmkJeYtMy9I5A8GLxJ7QfQ=";
   };
 
   nativeBuildInputs = [ poetry-core ];
@@ -29,6 +31,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     regex
     langcodes
+    locate
     ftfy
     msgpack
     mecab-python3
@@ -46,6 +49,7 @@ buildPythonPackage rec {
   meta = {
     description = "Library for looking up the frequencies of words in many languages, based on many sources of data";
     homepage = "https://github.com/rspeer/wordfreq/";
-    license = lib.licenses.mit;
+    changelog = "https://github.com/rspeer/wordfreq/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
   };
-}
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9841,6 +9841,8 @@ self: super: with self; {
 
   localzone = callPackage ../development/python-modules/localzone { };
 
+  locate = callPackage ../development/python-modules/locate { };
+
   locationsharinglib = callPackage ../development/python-modules/locationsharinglib { };
 
   locket = callPackage ../development/python-modules/locket { };


### PR DESCRIPTION
Update `python3Packages.wordfreq` to 3.2.0 and add its new `locate` runtime dependency.

The source is pinned to [the commit after the `v3.2` tag](https://github.com/rspeer/wordfreq/commit/912caf64b657478d1dff1138efdc078947d54bb1), because the tag points to the preceding commit before the version bump.

Closes #542466

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
