### PR TITLE
vesktop: migrate from electron_40 to electron_42

### DIFF
--- a/pkgs/by-name/ve/vesktop/package.nix
+++ b/pkgs/by-name/ve/vesktop/package.nix
@@ -8,7 +8,7 @@
   makeDesktopItem,
   copyDesktopItems,
   vencord,
-  electron_40,
+  electron_42,
   libicns,
   pipewire,
   libpulseaudio,
@@ -26,7 +26,7 @@
   withSystemVencord ? false,
 }:
 let
-  electron = electron_40;
+  electron = electron_42;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "vesktop";
@@ -89,9 +89,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   preBuild = ''
     # Validate electron version matches upstream package.json
-    if [ "`jq -r '.devDependencies.electron' < package.json | cut -d. -f1 | tr -d '^'`" != "${lib.versions.major electron.version}" ]
-    then
-      echo "ERROR: electron version mismatch between package.json and nixpkgs"
+    expectedMajor="$(jq -r '.devDependencies.electron | ltrimstr("^") | split(".") | .[0]' < package.json)"
+    actualMajor="${lib.versions.major electron.version}"
+    if [ "$actualMajor" -lt "$expectedMajor" ] 2>/dev/null; then
+      echo "ERROR: nixpkgs electron version (major $actualMajor) is older than upstream package.json requirement (major $expectedMajor)"
       exit 1
     fi
 


### PR DESCRIPTION
electron_40 is EOL and marked insecure. Use electron_42 instead.

Once #537831 (electron_43) is merged, vesktop should be migrated to electron_43.

Resolves: #542512

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests
  - [ ] Package tests
  - [ ] Tests in lib/tests or pkgs/test
- [ ] Ran `nixpkgs-review`
- [ ] Tested basic functionality of all binary files
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition
  - [ ] Module update
- [x] Fits CONTRIBUTING.md
- [x] Follows the automation/AI policy