### PR TITLE
nixos/atticd: add local PostgreSQL provisioning

### DIFF
--- a/nixos/modules/services/networking/atticd.nix
+++ b/nixos/modules/services/networking/atticd.nix
@@ -10,6 +10,9 @@ let
 
   cfg = config.services.atticd;
 
+  localPostgresql = cfg.database.createLocally;
+  localPostgresqlUrl = "postgresql://${cfg.user}@localhost/${cfg.user}?host=/run/postgresql";
+
   format = pkgs.formats.toml { };
 
   checkedConfigFile =
@@ -100,6 +103,16 @@ in
         default = "atticd";
       };
 
+      database.createLocally = lib.mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to automatically create a local PostgreSQL database and user
+          named after `services.atticd.user`. The database is accessed through
+          the local Unix socket using peer authentication.
+        '';
+      };
+
       settings = lib.mkOption {
         description = ''
           Structured configurations of atticd.
@@ -147,7 +160,25 @@ in
           Then, set `services.atticd.environmentFile` to the quoted absolute path of the file.
         '';
       }
+      {
+        assertion = localPostgresql -> cfg.settings.database.url == localPostgresqlUrl;
+        message = ''
+          services.atticd.settings.database.url must use the automatically
+          configured local PostgreSQL URL when database.createLocally is true.
+        '';
+      }
     ];
+
+    services.postgresql = lib.mkIf localPostgresql {
+      enable = true;
+      ensureDatabases = [ cfg.user ];
+      ensureUsers = [
+        {
+          name = cfg.user;
+          ensureDBOwnership = true;
+        }
+      ];
+    };
 
     services.atticd.settings = {
       chunking = lib.mkDefault {
@@ -157,7 +188,9 @@ in
         max-size = 262144; # 256 KiB
       };
 
-      database.url = lib.mkDefault "sqlite:///var/lib/atticd/server.db?mode=rwc";
+      database.url = lib.mkDefault (
+        if localPostgresql then localPostgresqlUrl else "sqlite:///var/lib/atticd/server.db?mode=rwc"
+      );
 
       # "storage" is internally tagged
       # if the user sets something the whole thing must be replaced

--- a/nixos/tests/atticd.nix
+++ b/nixos/tests/atticd.nix
@@ -26,6 +26,18 @@ in
       ];
     };
 
+    postgres = {
+      services.atticd = {
+        enable = true;
+        inherit environmentFile;
+        database.createLocally = true;
+      };
+
+      environment.systemPackages = [
+        pkgs.attic-client
+      ];
+    };
+
     s3 = {
       services.atticd = {
         enable = true;
@@ -79,6 +91,23 @@ in
           local.succeed(f"attic login local http://localhost:8080 {token}")
           local.succeed("attic cache create test-cache")
           local.succeed("attic push test-cache ${environmentFile}")
+
+      with subtest("PostgreSQL metadata survives a restart"):
+          postgres.wait_for_unit("postgresql.service")
+          postgres.wait_for_unit("atticd.service")
+          postgres.succeed(
+              "test \"$(sudo -u postgres psql -tAc \"select datdba::regrole::text from pg_database where datname = 'atticd'\")\" = atticd",
+              "test \"$(sudo -u postgres psql -tAc \"select count(*) from pg_tables where schemaname not in ('pg_catalog', 'information_schema')\" atticd)\" -gt 0",
+              "test ! -e /var/lib/atticd/server.db",
+          )
+
+          token = postgres.succeed("atticd-atticadm make-token --sub stop --validity 1y --create-cache '*' --pull '*' --push '*' --delete '*' --configure-cache '*' --configure-cache-retention '*'").strip()
+          postgres.succeed(f"attic login postgres http://localhost:8080 {token}")
+          postgres.succeed("attic cache create test-cache")
+          postgres.succeed("attic push test-cache ${environmentFile}")
+          postgres.succeed("systemctl restart atticd.service")
+          postgres.wait_for_unit("atticd.service")
+          postgres.succeed("attic cache info test-cache")
 
       with subtest("s3 storage push"):
           s3.wait_for_unit("garage.service")


### PR DESCRIPTION
Add an opt-in `services.atticd.database.createLocally` mode that provisions a local PostgreSQL database and role. Attic connects over the Unix socket with peer authentication, so no database password is placed in the Nix store.

SQLite remains the default. The existing NixOS test now also verifies the PostgreSQL owner and schema, absence of the SQLite metadata file, cache creation/upload, and persistence after an Attic restart.

This change was implemented with assistance from OpenAI Codex (GPT-5). The draft remains pending responsible human review under the nixpkgs automation/AI policy.

A [multi-platform `nixpkgs-review`](https://github.com/caniko/nixpkgs-review-gha/actions/runs/29492923501) passed on aarch64-linux, x86_64-linux, aarch64-darwin, and x86_64-darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

