### PR TITLE
[26.05] rocketchat-desktop: 4.14.1 -> 4.15.6

### DIFF
--- a/pkgs/by-name/ro/rocketchat-desktop/package.nix
+++ b/pkgs/by-name/ro/rocketchat-desktop/package.nix
@@ -7,7 +7,7 @@
   pkg-config,
   node-gyp,
   python3Packages,
-  electron_40,
+  electron_42,
   vips,
   xvfb-run,
   copyDesktopItems,
@@ -17,17 +17,17 @@
 }:
 let
   yarn-berry = yarn-berry_4;
-  electron = electron_40;
+  electron = electron_42;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocketchat-desktop";
-  version = "4.14.1";
+  version = "4.15.0";
 
   src = fetchFromGitHub {
     owner = "RocketChat";
     repo = "Rocket.Chat.Electron";
     tag = finalAttrs.version;
-    hash = "sha256-O30MSLv2eQIFs6yjo6LU6aMwHVl5fn7KsVMpIiFL25I=";
+    hash = "sha256-2ko2medsG0C6uq8Lp7ej2RgEgA7OIDsVlMG2BD1ENcM=";
   };
 
   patches = [
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   offlineCache = yarn-berry.fetchYarnBerryDeps {
     inherit (finalAttrs) src missingHashes patches;
-    hash = "sha256-xb4HwmLjO1xCQ/KEav3EM2FwCu0vi/tXZVY+gSoonyQ=";
+    hash = "sha256-WfIY3kCVsL7rXbXiH7OTuiIZmGs7itdK2DG4onua3Bc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ro/rocketchat-desktop/package.nix
+++ b/pkgs/by-name/ro/rocketchat-desktop/package.nix
@@ -21,13 +21,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocketchat-desktop";
-  version = "4.15.0";
+  version = "4.15.2";
 
   src = fetchFromGitHub {
     owner = "RocketChat";
     repo = "Rocket.Chat.Electron";
     tag = finalAttrs.version;
-    hash = "sha256-2ko2medsG0C6uq8Lp7ej2RgEgA7OIDsVlMG2BD1ENcM=";
+    hash = "sha256-wme3RKGaHuoOf7yyXH3PZ/0xL73LqS9rPqL8IcxyAkA=";
   };
 
   patches = [
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   offlineCache = yarn-berry.fetchYarnBerryDeps {
     inherit (finalAttrs) src missingHashes patches;
-    hash = "sha256-WfIY3kCVsL7rXbXiH7OTuiIZmGs7itdK2DG4onua3Bc=";
+    hash = "sha256-XYfC5K7oXVjxP6Ndlc3qYb47Zh3GnwPx7c4+vBiA2AI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ro/rocketchat-desktop/package.nix
+++ b/pkgs/by-name/ro/rocketchat-desktop/package.nix
@@ -21,13 +21,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocketchat-desktop";
-  version = "4.15.2";
+  version = "4.15.6";
 
   src = fetchFromGitHub {
     owner = "RocketChat";
     repo = "Rocket.Chat.Electron";
     tag = finalAttrs.version;
-    hash = "sha256-wme3RKGaHuoOf7yyXH3PZ/0xL73LqS9rPqL8IcxyAkA=";
+    hash = "sha256-cCCE+d/YXUqTb5gMgcxsOjh2nDUZuuQ4L4QZYzIN4r0=";
   };
 
   patches = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Manual backports of: #537189 #539619 #542928
Related to: https://github.com/NixOS/nixpkgs/issues/537847 and #541856

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
