### PR TITLE
clickhouse-cpp: init at 2.6.2

### DIFF
--- a/pkgs/by-name/cl/clickhouse-cpp/clickhouse-cpp.pc.in
+++ b/pkgs/by-name/cl/clickhouse-cpp/clickhouse-cpp.pc.in
@@ -1,0 +1,11 @@
+prefix=@out@
+includedir=${prefix}/include
+libdir=${prefix}/lib
+
+Name: clickhouse-cpp
+Description: Library to interact with ClickHouse Database from C++ code
+URL: https://github.com/ClickHouse/clickhouse-cpp
+Version: @version@
+Cflags: -pthread -isystem${includedir}
+Libs: -pthread -L${libdir} -Wl,-rpath,${libdir} -lclickhouse-cpp-lib
+Requires: absl_int128

--- a/pkgs/by-name/cl/clickhouse-cpp/package.nix
+++ b/pkgs/by-name/cl/clickhouse-cpp/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  abseil-cpp,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "clickhouse-cpp";
+  version = "2.6.2";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "clickhouse";
+    repo = "clickhouse-cpp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-szvRPqj2xarzGTVyycPlSTJkWSxwLO4EKXADS1DpO7Q=";
+  };
+
+  flattenPackagesPrefix = "absl_";
+  flattenPcLookupDir = "${abseil-cpp}/lib/pkgconfig";
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  cmakeFlags = [
+    "-DWITH_SYSTEM_ABSEIL=1"
+    "-DBUILD_SHARED_LIBS=1"
+  ];
+
+  propagatedBuildInputs = [ abseil-cpp ];
+
+  postInstall = ''
+    mkdir -p $out/lib/pkgconfig
+    substituteAll ${./clickhouse-cpp.pc.in} $out/lib/pkgconfig/clickhouse-cpp.pc
+  '';
+
+  meta = {
+    description = "C++ client library for ClickHouse";
+    homepage = "https://github.com/clickhouse/clickhouse-cpp";
+    changelog = "https://github.com/clickhouse/clickhouse-cpp/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jlesquembre ];
+    mainProgram = "clickhouse-cpp";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
