### PR TITLE
cloudflare-warp: 2026.3.846.0 -> 2026.6.836.0 (Darwin: 2026.6.822.0)

### DIFF
--- a/nixos/modules/services/networking/cloudflare-warp.nix
+++ b/nixos/modules/services/networking/cloudflare-warp.nix
@@ -39,6 +39,15 @@ in
   config = lib.mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
 
+    # Load D-Bus policies so the GUI client can communicate with the system daemon
+    services.dbus.packages = [ cfg.package ];
+    systemd.packages = [ cfg.package ];
+    systemd.user.services.warp-taskbar = {
+      description = "Cloudflare WARP Taskbar";
+      wantedBy = [ "graphical-session.target" ];
+      partOf = [ "graphical-session.target" ];
+    };
+
     networking.firewall = lib.mkIf cfg.openFirewall {
       allowedUDPPorts = [ cfg.udpPort ];
     };

--- a/pkgs/by-name/cl/cloudflare-warp/package.nix
+++ b/pkgs/by-name/cl/cloudflare-warp/package.nix
@@ -9,6 +9,9 @@
   dpkg,
   fetchurl,
   gtk3,
+  glib,
+  iproute2,
+  iptables,
   libpcap,
   makeDesktopItem,
   makeWrapper,
@@ -22,28 +25,84 @@
   common-updater-scripts,
   xar,
   cpio,
+  libayatana-appindicator,
+  libappindicator-gtk3,
+  libdbusmenu-gtk3,
+  hicolor-icon-theme,
+  webkitgtk_4_1,
+  tpm2-tss,
+  procps,
+  kmod,
+  openresolv,
+  systemd,
+  coreutils,
+  libGL,
+  libepoxy,
+  libxkbcommon,
+  wayland,
+  libnotify,
+  xdg-utils,
+  gsettings-desktop-schemas,
+  wireguard-tools,
   headless ? false,
 }:
 
 let
-  version = "2026.3.846.0";
+  linuxVersion = "2026.6.836.0";
+  darwinVersion = "2026.6.822.0";
+
   sources = {
     x86_64-linux = fetchurl {
-      url = "https://pkg.cloudflareclient.com/pool/noble/main/c/cloudflare-warp/cloudflare-warp_${version}_amd64.deb";
-      hash = "sha256-1SKTK0QW+3CcqBLqHbIsPny/6ekyjZe9qRcjYOMnR58=";
+      url = "https://pkg.cloudflareclient.com/pool/noble/main/c/cloudflare-warp/cloudflare-warp_${linuxVersion}_amd64.deb";
+      hash = "sha256-V4y9pZuXAV+Qz3hkj2v5LUAtW3tjADa7FH5PRTZZqb0=";
     };
     aarch64-linux = fetchurl {
-      url = "https://pkg.cloudflareclient.com/pool/noble/main/c/cloudflare-warp/cloudflare-warp_${version}_arm64.deb";
-      hash = "sha256-0zYsyZbX8qq/P+GHW4UHSTy2OsDa4fJAVjHcRbpHtSc=";
+      url = "https://pkg.cloudflareclient.com/pool/noble/main/c/cloudflare-warp/cloudflare-warp_${linuxVersion}_arm64.deb";
+      hash = "sha256-f5nH8Jy1veO49xMEcA+Jf4697axVgJikF2QxmhGLnHs=";
     };
     aarch64-darwin = fetchurl {
-      url = "https://downloads.cloudflareclient.com/v1/download/macos/version/${version}";
-      hash = "sha256-cDmoM0nIYYQyurJeeiVSX0IWJdIY0pVLmjIae5mEXI4=";
+      url = "https://downloads.cloudflareclient.com/v1/download/macos/version/${darwinVersion}";
+      hash = "sha256-YBgj5LPCpVt6n5FK3RvMG4oKScHHdi0TGYweyIAa78c=";
     };
   };
+
+  daemonPath = lib.makeBinPath [
+    iproute2
+    iptables
+    nftables
+    procps
+    kmod
+    openresolv
+    systemd
+    dbus
+    coreutils
+    wireguard-tools
+  ];
+
+  guiPath = lib.makeBinPath [
+    xdg-utils
+    dbus
+    coreutils
+    iproute2
+  ];
+  guiLibs = lib.makeLibraryPath [
+    libGL
+    libepoxy
+    libxkbcommon
+    wayland
+    libayatana-appindicator
+    libappindicator-gtk3
+    libdbusmenu-gtk3
+    libnotify
+    gtk3
+    glib
+    nss
+  ];
+  guiXdgDirs = "${gtk3}/share/gsettings-schemas/${gtk3.name}:${glib.out}/share/glib-2.0/schemas:${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${hicolor-icon-theme}/share";
+
 in
 stdenv.mkDerivation (finalAttrs: {
-  inherit version;
+  version = if stdenv.hostPlatform.isDarwin then darwinVersion else linuxVersion;
 
   pname = "cloudflare-warp" + lib.optionalString headless "-headless";
 
@@ -74,10 +133,21 @@ stdenv.mkDerivation (finalAttrs: {
       libpcap
       openssl
       nss
+      glib
       (lib.getLib stdenv.cc.cc)
     ]
     ++ lib.optionals (!headless) [
       gtk3
+      libayatana-appindicator
+      libappindicator-gtk3
+      libdbusmenu-gtk3
+      webkitgtk_4_1
+      tpm2-tss
+      libGL
+      libepoxy
+      libxkbcommon
+      wayland
+      libnotify
     ]
   );
 
@@ -100,13 +170,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   autoPatchelfIgnoreMissingDeps = [
     "libpcap.so.0.8"
+    "libjvm.so"
   ];
 
   unpackPhase = lib.optionalString stdenv.hostPlatform.isDarwin ''
     runHook preUnpack
 
     xar -xf $src
-    zcat < Cloudflare_WARP_${version}.pkg/Payload | cpio -i
+    zcat < Cloudflare_WARP_${darwinVersion}.pkg/Payload | cpio -i
 
     runHook postUnpack
   '';
@@ -135,36 +206,102 @@ stdenv.mkDerivation (finalAttrs: {
         mv etc $out
         patchelf --replace-needed libpcap.so.0.8 ${libpcap}/lib/libpcap.so $out/bin/warp-dex
         mv lib/systemd/system $out/lib/systemd/
+
         substituteInPlace $out/lib/systemd/system/warp-svc.service \
-          --replace-fail "ExecStart=" "ExecStart=$out"
+          --replace-fail "ExecStart=/bin/warp-svc" "ExecStart=$out/bin/warp-svc"
+
         ${lib.optionalString (!headless) ''
+          ln -sf $out/lib/warp/warp-taskbar $out/bin/warp-taskbar
+
           substituteInPlace $out/lib/systemd/user/warp-taskbar.service \
-            --replace-fail "ExecStart=" "ExecStart=$out" \
-            --replace-fail "BindsTo=" "PartOf="
+            --replace-fail "ExecStart=/bin/warp-taskbar" "ExecStart=$out/bin/warp-taskbar"
 
-          cat >>$out/lib/systemd/user/warp-taskbar.service <<EOF
-
-          [Service]
-          BindReadOnlyPaths=$out:/usr:
-          EOF
+          # Fix paths in D-Bus services and Desktop entries
+          for file in $out/share/applications/*.desktop $out/share/dbus-1/services/*.service; do
+            substituteInPlace "$file" \
+              --replace-quiet "/usr/lib/warp/warp-taskbar" "$out/bin/warp-taskbar" \
+              --replace-quiet "/bin/warp-taskbar" "$out/bin/warp-taskbar" \
+              --replace-quiet "Exec=warp-taskbar" "Exec=$out/bin/warp-taskbar"
+          done
         ''}
+
         ${lib.optionalString headless ''
-          # For headless version, remove GUI components
           rm $out/bin/warp-taskbar
           rm -r $out/lib/systemd/user
           rm -r $out/etc
           rm -r $out/share/applications
           rm -r $out/share/icons
-          rm -r $out/share/warp
+          rm -rf $out/lib/warp
         ''}
+
+        mkdir -p $out/libexec
+
+        # Patch hardcoded absolute paths in binaries
+        for bin in $out/bin/warp-svc $out/bin/warp-cli $out/bin/warp-dex; do
+          sed -i 's|/usr/sbin/ip6tables-restore|warp_ip6tables_restore_2___|g' $bin
+          ln -sf ${iptables}/bin/ip6tables-restore $out/libexec/warp_ip6tables_restore_2___ || true
+
+          sed -i 's|/usr/sbin/iptables-restore|warp_iptables_restore_2___|g' $bin
+          ln -sf ${iptables}/bin/iptables-restore $out/libexec/warp_iptables_restore_2___ || true
+
+          sed -i 's|/sbin/ip6tables-restore|warp_ip6tables_restore1|g' $bin
+          ln -sf ${iptables}/bin/ip6tables-restore $out/libexec/warp_ip6tables_restore1 || true
+
+          sed -i 's|/sbin/iptables-restore|warp_iptables_restore1|g' $bin
+          ln -sf ${iptables}/bin/iptables-restore $out/libexec/warp_iptables_restore1 || true
+
+          sed -i 's|/usr/sbin/ip6tables|warp_ip6tables_2___|g' $bin
+          ln -sf ${iptables}/bin/ip6tables $out/libexec/warp_ip6tables_2___ || true
+
+          sed -i 's|/usr/bin/resolvectl|warp_resolvectl____|g' $bin
+          ln -sf ${systemd}/bin/resolvectl $out/libexec/warp_resolvectl____ || true
+
+          sed -i 's|/usr/sbin/iptables|warp_iptables_2___|g' $bin
+          ln -sf ${iptables}/bin/iptables $out/libexec/warp_iptables_2___ || true
+
+          sed -i 's|/sbin/resolvconf|warp_resolvconf_|g' $bin
+          ln -sf ${openresolv}/bin/resolvconf $out/libexec/warp_resolvconf_ || true
+
+          sed -i 's|/sbin/ip6tables|warp_ip6tables1|g' $bin
+          ln -sf ${iptables}/bin/ip6tables $out/libexec/warp_ip6tables1 || true
+
+          sed -i 's|/sbin/iptables|warp_iptables1|g' $bin
+          ln -sf ${iptables}/bin/iptables $out/libexec/warp_iptables1 || true
+
+          sed -i 's|/sbin/modprobe|warp_modprobe1|g' $bin
+          ln -sf ${kmod}/bin/modprobe $out/libexec/warp_modprobe1 || true
+
+          sed -i 's|/usr/sbin/nft|warp_nft_1___|g' $bin
+          ln -sf ${nftables}/bin/nft $out/libexec/warp_nft_1___ || true
+
+          sed -i 's|/sbin/sysctl|warp_sysctl1|g' $bin
+          ln -sf ${procps}/bin/sysctl $out/libexec/warp_sysctl1 || true
+
+          sed -i 's|/sbin/nft|warp_nft_|g' $bin
+          ln -sf ${nftables}/bin/nft $out/libexec/warp_nft_ || true
+
+          sed -i 's|/sbin/ip|warp_ip_|g' $bin
+          ln -sf ${iproute2}/bin/ip $out/libexec/warp_ip_ || true
+
+          sed -i 's|/bin/ip|warp_ip|g' $bin
+          ln -sf ${iproute2}/bin/ip $out/libexec/warp_ip || true
+        done
 
         runHook postInstall
       '';
 
   postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
-    wrapProgram $out/bin/warp-svc --prefix PATH : ${lib.makeBinPath [ nftables ]}
+    wrapProgram $out/bin/warp-svc \
+      --prefix PATH : $out/libexec:${daemonPath}
+
     ${lib.optionalString (!headless) ''
-      wrapProgram $out/bin/warp-cli --prefix PATH : ${lib.makeBinPath [ desktop-file-utils ]}
+      wrapProgram $out/bin/warp-cli \
+        --prefix PATH : ${lib.makeBinPath [ desktop-file-utils ]}
+
+      wrapProgram $out/lib/warp/warp-taskbar \
+        --prefix PATH : $out/bin:${guiPath} \
+        --prefix LD_LIBRARY_PATH : $out/lib/warp/lib:${guiLibs} \
+        --prefix XDG_DATA_DIRS : $out/share:${guiXdgDirs}
     ''}
   '';
 
@@ -198,7 +335,9 @@ stdenv.mkDerivation (finalAttrs: {
             rg '([^/]+)\.yaml\b' --only-matching --replace '$1'
         )"
 
-        for platform in ${lib.escapeShellArgs finalAttrs.meta.platforms}; do
+        # Darwin is excluded because its upstream versions differ from Linux.
+        # This script is designed specifically to track and verify the linux/ga release directory.
+        for platform in x86_64-linux aarch64-linux; do
           update-source-version "${finalAttrs.pname}" "$new_version" --ignore-same-version --source-key="sources.$platform"
         done
       '';


### PR DESCRIPTION
Updates `cloudflare-warp` to the latest stable versions. Starting from version `2026.4.*`, the client GUI has been rewritten in Flutter, introducing new library dependencies and requiring changes to path patching and the NixOS module.

#### Summary of changes:
- **Package**: Bumped Linux to `2026.6.836.0` and macOS to `2026.6.822.0`. Added dependencies for the new Flutter GUI and patched absolute paths inside compiled binaries. Adjusted the `updateScript` to only target Linux automatically.
- **NixOS Module**: Registered D-Bus policies and added systemd user services to support the new GUI client.

- Changelog: https://developers.cloudflare.com/changelog/product/cloudflare-one-client/
---

#### Verification & Disclosures:
- **Testing**: Tested on `x86_64-linux` (Wayland and X11). Verification on macOS is welcome.
- **AI Policy**: AI was used to assist in the development of this PR.

---

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

#### Maintainers tagged:

@marcusramberg @anish

@treyfortmuller