### PR TITLE
battui: init at 0.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25998,6 +25998,12 @@
     github = "silicalet";
     githubId = 188071249;
   };
+  siliconwitch = {
+    name = "Raj Nakarja";
+    email = "raj@siliconwitchery.com";
+    github = "siliconwitch";
+    githubId = 7815190;
+  };
   silky = {
     name = "Noon van der Silk";
     email = "noonsilk+nixpkgs@gmail.com";

--- a/pkgs/by-name/ba/battui/package.nix
+++ b/pkgs/by-name/ba/battui/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "battui";
+  version = "0.3.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "siliconwitch";
+    repo = "battui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-4ckx9A8g/chCkFb3TCz8wAkxhnj/aU9DOjZyn8/eg2Q=";
+  };
+
+  vendorHash = "sha256-L/ASdcuE6eeuaKsL9CJioY7UP1F+KxGZ0MU/OzMx+NQ=";
+
+  env.CGO_ENABLED = 0;
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  postInstall = ''
+    install -Dm644 contrib/systemd/battui-log.service \
+      $out/lib/systemd/user/battui-log.service
+
+    substituteInPlace $out/lib/systemd/user/battui-log.service \
+      --replace-fail /usr/local/bin/battui $out/bin/battui
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "-version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Tiny battery monitor for the terminal";
+    homepage = "https://github.com/siliconwitch/battui";
+    changelog = "https://github.com/siliconwitch/battui/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "battui";
+    maintainers = with lib.maintainers; [ siliconwitch ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
battui is a tiny battery monitor for the terminal: a lightweight collector logs battery level and charging state to a small file, and the viewer draws it back as a bar graph over time, with battery health at a glance. It is a single static Go binary that reads `/sys/class/power_supply`, so the package is Linux-only. Upstream's systemd user unit for the collector is installed as well.

Homepage: https://github.com/siliconwitch/battui

I am the upstream author. The first commit adds me to the maintainer list as `siliconwitch`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Per that policy: the commits carry `Assisted-by:` trailers, and this PR description was drafted with Claude Code (claude-fable-5) and reviewed by me.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test