### PR TITLE
dart: support sqlite3 3.4.0

### DIFF
--- a/pkgs/development/compilers/dart/package-source-builders/sqlcipher_flutter_libs/default.nix
+++ b/pkgs/development/compilers/dart/package-source-builders/sqlcipher_flutter_libs/default.nix
@@ -37,6 +37,8 @@ stdenv.mkDerivation rec {
     runHook preInstall
 
     cp -r "$src" "$out"
+  ''
+  + lib.optionalString (lib.versionOlder version "0.7.0") ''
     _replace() {
       # --replace-fail messes with the file if it fails (is empty afterwards) so we do this instead
       if cat "$out/linux/CMakeLists.txt" | grep "$1" >/dev/null 2>/dev/null; then
@@ -49,6 +51,8 @@ stdenv.mkDerivation rec {
     ${lib.concatMapAttrsStringSep " || " (_: v: ''_replace "${v.url}" "${v.file}"'') artifacts} || \
     (echo "unknown version of sqlcipher, please add to pkgs/development/compilers/dart/package-source-builders/sqlcipher_flutter_libs" && cat linux/CMakeLists.txt | grep "https://storage.*" -o && exit 2)
 
+  ''
+  + ''
     runHook postInstall
   '';
 

--- a/pkgs/development/compilers/dart/package-source-builders/sqlite3/default.nix
+++ b/pkgs/development/compilers/dart/package-source-builders/sqlite3/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   postPatch =
-    if lib.versionAtLeast version "3.5.0" then
+    if lib.versionAtLeast version "3.4.0" then
       ''
         substituteInPlace lib/src/hook/compile/description.dart \
           --replace-fail "return fromGitHub(LibraryType.sqlite3);" "return LookupSystem('sqlite3');"

--- a/pkgs/development/compilers/dart/package-source-builders/sqlite3_flutter_libs/default.nix
+++ b/pkgs/development/compilers/dart/package-source-builders/sqlite3_flutter_libs/default.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   stdenv,
 }:
 
@@ -9,7 +10,7 @@ stdenv.mkDerivation {
   inherit version src;
   inherit (src) passthru;
 
-  postPatch = ''
+  postPatch = lib.optionalString (lib.versionOlder version "0.6.0") ''
     cp ${./CMakeLists.txt} linux/CMakeLists.txt
   '';
 

--- a/pkgs/test/dart/default.nix
+++ b/pkgs/test/dart/default.nix
@@ -1,0 +1,5 @@
+{ callPackage }:
+
+{
+  sqlite3 = callPackage ./sqlite3 { };
+}

--- a/pkgs/test/dart/sqlite3/bin/main.dart
+++ b/pkgs/test/dart/sqlite3/bin/main.dart
@@ -1,0 +1,11 @@
+import 'package:sqlite3/sqlite3.dart';
+
+void main() {
+  final database = sqlite3.openInMemory();
+  try {
+    final result = database.select('SELECT 40 + 2 AS answer');
+    print(result.single['answer']);
+  } finally {
+    database.dispose();
+  }
+}

--- a/pkgs/test/dart/sqlite3/default.nix
+++ b/pkgs/test/dart/sqlite3/default.nix
@@ -1,0 +1,37 @@
+{
+  buildDartApplication,
+  lib,
+  runCommand,
+}:
+
+let
+  application = buildDartApplication {
+    pname = "dart-sqlite3-test";
+    version = "0.0.1";
+
+    src = ./.;
+    pubspecLock = lib.importJSON ./pubspec.lock.json;
+
+    buildPhase = ''
+      runHook preBuild
+
+      dart build cli --output build/cli --target bin/main.dart
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p "$out"
+      cp -r build/cli/bundle/. "$out"
+
+      runHook postInstall
+    '';
+  };
+in
+runCommand "test-dart-sqlite3" { } ''
+  result=$(${application}/bin/main)
+  test "$result" = 42
+  touch "$out"
+''

--- a/pkgs/test/dart/sqlite3/pubspec.lock.json
+++ b/pkgs/test/dart/sqlite3/pubspec.lock.json
@@ -1,0 +1,237 @@
+{
+  "packages": {
+    "async": {
+      "dependency": "transitive",
+      "description": {
+        "name": "async",
+        "sha256": "e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.13.1"
+    },
+    "code_assets": {
+      "dependency": "transitive",
+      "description": {
+        "name": "code_assets",
+        "sha256": "bf394f466ba9205f1812a0433b392d6af280f155f56651eda7c18cc32ed493b8",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.2.1"
+    },
+    "collection": {
+      "dependency": "transitive",
+      "description": {
+        "name": "collection",
+        "sha256": "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.19.1"
+    },
+    "crypto": {
+      "dependency": "transitive",
+      "description": {
+        "name": "crypto",
+        "sha256": "c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.0.7"
+    },
+    "ffi": {
+      "dependency": "transitive",
+      "description": {
+        "name": "ffi",
+        "sha256": "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.2.0"
+    },
+    "file": {
+      "dependency": "transitive",
+      "description": {
+        "name": "file",
+        "sha256": "a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "7.0.1"
+    },
+    "glob": {
+      "dependency": "transitive",
+      "description": {
+        "name": "glob",
+        "sha256": "c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.3"
+    },
+    "hooks": {
+      "dependency": "transitive",
+      "description": {
+        "name": "hooks",
+        "sha256": "03a564c3704524ee0f7fc56fc621e8796cc2eb8c24d1f1a33b34979815b285c4",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.0"
+    },
+    "logging": {
+      "dependency": "transitive",
+      "description": {
+        "name": "logging",
+        "sha256": "c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.3.0"
+    },
+    "meta": {
+      "dependency": "transitive",
+      "description": {
+        "name": "meta",
+        "sha256": "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.19.0"
+    },
+    "native_toolchain_c": {
+      "dependency": "transitive",
+      "description": {
+        "name": "native_toolchain_c",
+        "sha256": "a1c26117c48cebe5677b0cf0e33a980a79a7c5577effc86f52e5a0d309cdcb60",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.19.3"
+    },
+    "path": {
+      "dependency": "transitive",
+      "description": {
+        "name": "path",
+        "sha256": "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.9.1"
+    },
+    "pub_semver": {
+      "dependency": "transitive",
+      "description": {
+        "name": "pub_semver",
+        "sha256": "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.2.0"
+    },
+    "record_use": {
+      "dependency": "transitive",
+      "description": {
+        "name": "record_use",
+        "sha256": "af37186ff9ede46fa32f152526c48f46c5b3ad7d3d5a566140cb5df3dc4ed737",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.0"
+    },
+    "source_span": {
+      "dependency": "transitive",
+      "description": {
+        "name": "source_span",
+        "sha256": "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.10.2"
+    },
+    "sqlcipher_flutter_libs": {
+      "dependency": "direct main",
+      "description": {
+        "name": "sqlcipher_flutter_libs",
+        "sha256": "38d62d659d2fb8739bf25a42c9a350d1fdd6c29a5a61f13a946778ec75d27929",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.7.0+eol"
+    },
+    "sqlite3": {
+      "dependency": "direct main",
+      "description": {
+        "name": "sqlite3",
+        "sha256": "61c7930bebf32c552ac5808c91bf33802e66711c9216090d3b5579c9f862e80c",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.4.0"
+    },
+    "sqlite3_flutter_libs": {
+      "dependency": "direct main",
+      "description": {
+        "name": "sqlite3_flutter_libs",
+        "sha256": "3ed7553eee7bb368f8950f58ba29f634e06e813c029aff6a0d60862b96de8454",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.6.0+eol"
+    },
+    "string_scanner": {
+      "dependency": "transitive",
+      "description": {
+        "name": "string_scanner",
+        "sha256": "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.4.1"
+    },
+    "term_glyph": {
+      "dependency": "transitive",
+      "description": {
+        "name": "term_glyph",
+        "sha256": "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.2.2"
+    },
+    "typed_data": {
+      "dependency": "transitive",
+      "description": {
+        "name": "typed_data",
+        "sha256": "f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.4.0"
+    },
+    "web": {
+      "dependency": "transitive",
+      "description": {
+        "name": "web",
+        "sha256": "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.1"
+    },
+    "yaml": {
+      "dependency": "transitive",
+      "description": {
+        "name": "yaml",
+        "sha256": "b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.1.3"
+    }
+  },
+  "sdks": {
+    "dart": ">=3.10.0 <4.0.0"
+  }
+}

--- a/pkgs/test/dart/sqlite3/pubspec.yaml
+++ b/pkgs/test/dart/sqlite3/pubspec.yaml
@@ -1,0 +1,15 @@
+name: dart_sqlite3_test
+description: Integration test for nixpkgs Dart SQLite source builders.
+version: 0.0.1
+publish_to: none
+
+environment:
+  sdk: '>=3.9.0 <4.0.0'
+
+dependencies:
+  sqlite3: 3.4.0
+  sqlite3_flutter_libs: 0.6.0+eol
+  sqlcipher_flutter_libs: 0.7.0+eol
+
+executables:
+  dart-sqlite3-test: main

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -111,6 +111,8 @@ in
 
   devShellTools = callPackage ../build-support/dev-shell-tools/tests { };
 
+  dart = recurseIntoAttrs (callPackage ./dart { });
+
   stdenv-inputs = callPackage ./stdenv-inputs { };
   stdenv = recurseIntoAttrs (callPackage ./stdenv { });
 


### PR DESCRIPTION
Support sqlite3 3.4.0's moved native-assets hook and the now-empty `sqlite3_flutter_libs` and `sqlcipher_flutter_libs` EOL releases in Dart dependency source builds.

Add a focused `tests.dart.sqlite3` regression test that builds these exact dependency versions and executes an in-memory SQLite query.

Closes #542550

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
