### PR TITLE
python314Packages.filelock: add another timeout sensitive test file

### DIFF
--- a/pkgs/development/python-modules/filelock/default.nix
+++ b/pkgs/development/python-modules/filelock/default.nix
@@ -41,6 +41,7 @@ buildPythonPackage rec {
     "tests/test_virtualenv.py"
     # Very prone to timeouts on busy machines
     "tests/test_filelock.py"
+    "tests/test_read_write.py"
   ];
 
   meta = {


### PR DESCRIPTION
```
python3.14-filelock> =================================== FAILURES ===================================
python3.14-filelock> __________________ test_write_lock_excludes_other_write_locks __________________
python3.14-filelock>
python3.14-filelock> lock_file = '/nix/var/nix/builds/nix-73577-2964134750/pytest-of-_nixbld16/pytest-0/test_write_lock_excludes_other0/test_lock.db'
python3.14-filelock>
python3.14-filelock>     @pytest.mark.timeout(20)
python3.14-filelock>     def test_write_lock_excludes_other_write_locks(lock_file: str) -> None:
python3.14-filelock>         """Test that a write lock prevents other processes from acquiring write locks."""
python3.14-filelock>         write1_acquired = Event()
python3.14-filelock>         release_write1 = Event()
python3.14-filelock>         write2_acquired = Event()
python3.14-filelock>
python3.14-filelock>         holder = Process(target=acquire_lock, args=(lock_file, "write", write1_acquired, release_write1))
python3.14-filelock>         contender = Process(target=acquire_lock, args=(lock_file, "write", write2_acquired, None, 0.5, True))
python3.14-filelock>
python3.14-filelock>         with cleanup_processes([holder]):
python3.14-filelock>             holder.start()
python3.14-filelock>             assert write1_acquired.wait(timeout=2), "First write lock not acquired"
python3.14-filelock>
python3.14-filelock>             with cleanup_processes([contender]):
python3.14-filelock>                 contender.start()
python3.14-filelock>                 assert not write2_acquired.wait(timeout=1), "Second write lock should not be acquired"
python3.14-filelock>
python3.14-filelock>                 release_write1.set()
python3.14-filelock>                 holder.join(timeout=2)
python3.14-filelock>                 assert not holder.is_alive(), "Holder did not exit cleanly"
python3.14-filelock>
python3.14-filelock>             write2_acquired.clear()
python3.14-filelock>             successor = Process(target=acquire_lock, args=(lock_file, "write", write2_acquired))
python3.14-filelock>
python3.14-filelock>             with cleanup_processes([successor]):
python3.14-filelock>                 successor.start()
python3.14-filelock> >               assert write2_acquired.wait(timeout=2), "Second write lock not acquired after first released"
python3.14-filelock> E               AssertionError: Second write lock not acquired after first released
python3.14-filelock> E               assert False
python3.14-filelock> E                +  where False = wait(timeout=2)
python3.14-filelock> E                +    where wait = <Event at 0x10b6d8710 unset>.wait
python3.14-filelock>
python3.14-filelock> tests/test_read_write.py:110: AssertionError
python3.14-filelock> _____________________ test_write_lock_excludes_read_locks ______________________
python3.14-filelock>
python3.14-filelock> lock_file = '/nix/var/nix/builds/nix-73577-2964134750/pytest-of-_nixbld16/pytest-0/test_write_lock_excludes_read_0/test_lock.db'
python3.14-filelock>
python3.14-filelock>     @pytest.mark.timeout(20)
python3.14-filelock>     def test_write_lock_excludes_read_locks(lock_file: str) -> None:
python3.14-filelock>         """Test that a write lock prevents other processes from acquiring read locks."""
python3.14-filelock>         write_acquired = Event()
python3.14-filelock>         release_write = Event()
python3.14-filelock>         read_acquired = Event()
python3.14-filelock>         read_started = Event()
python3.14-filelock>
python3.14-filelock>         writer = Process(target=acquire_lock, args=(lock_file, "write", write_acquired, release_write))
python3.14-filelock>         reader = Process(target=acquire_lock, args=(lock_file, "read", read_acquired, None, -1, True, read_started))
python3.14-filelock>
python3.14-filelock>         with cleanup_processes([writer, reader]):
python3.14-filelock>             writer.start()
python3.14-filelock> >           assert write_acquired.wait(timeout=2), "Write lock not acquired"
python3.14-filelock> E           AssertionError: Write lock not acquired
python3.14-filelock> E           assert False
python3.14-filelock> E            +  where False = wait(timeout=2)
python3.14-filelock> E            +    where wait = <Event at 0x10ad5bad0 unset>.wait
python3.14-filelock>
python3.14-filelock> tests/test_read_write.py:128: AssertionError
python3.14-filelock>
python3.14-filelock> During handling of the above exception, another exception occurred:
python3.14-filelock>
python3.14-filelock> lock_file = '/nix/var/nix/builds/nix-73577-2964134750/pytest-of-_nixbld16/pytest-0/test_write_lock_excludes_read_0/test_lock.db'
python3.14-filelock>
python3.14-filelock>     @pytest.mark.timeout(20)
python3.14-filelock>     def test_write_lock_excludes_read_locks(lock_file: str) -> None:
python3.14-filelock>         """Test that a write lock prevents other processes from acquiring read locks."""
python3.14-filelock>         write_acquired = Event()
python3.14-filelock>         release_write = Event()
python3.14-filelock>         read_acquired = Event()
python3.14-filelock>         read_started = Event()
python3.14-filelock>
python3.14-filelock>         writer = Process(target=acquire_lock, args=(lock_file, "write", write_acquired, release_write))
python3.14-filelock>         reader = Process(target=acquire_lock, args=(lock_file, "read", read_acquired, None, -1, True, read_started))
python3.14-filelock>
python3.14-filelock> >       with cleanup_processes([writer, reader]):
python3.14-filelock>              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
python3.14-filelock>
python3.14-filelock> tests/test_read_write.py:126:
python3.14-filelock> _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
python3.14-filelock> /nix/store/llk2h8rxqzv7zh53bi413ffibjrxskxw-python3-3.14.6/lib/python3.14/contextlib.py:162: in __exit__
python3.14-filelock>     self.gen.throw(value)
python3.14-filelock> tests/test_read_write.py:50: in cleanup_processes
python3.14-filelock>     proc.terminate()
python3.14-filelock> _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
python3.14-filelock>
python3.14-filelock> self = <Process name='Process-27' parent=1701 initial>
python3.14-filelock>
python3.14-filelock>     def terminate(self):
python3.14-filelock>         '''
python3.14-filelock>         Terminate process; sends SIGTERM signal or uses TerminateProcess()
python3.14-filelock>         '''
python3.14-filelock>         self._check_closed()
python3.14-filelock> >       self._popen.terminate()
python3.14-filelock>         ^^^^^^^^^^^^^^^^^^^^^
python3.14-filelock> E       AttributeError: 'NoneType' object has no attribute 'terminate'
python3.14-filelock>
python3.14-filelock> /nix/store/llk2h8rxqzv7zh53bi413ffibjrxskxw-python3-3.14.6/lib/python3.14/multiprocessing/process.py:140: AttributeError
python3.14-filelock> __________________________ test_write_non_starvation ___________________________
python3.14-filelock>
python3.14-filelock> lock_file = '/nix/var/nix/builds/nix-73577-2964134750/pytest-of-_nixbld16/pytest-0/test_write_non_starvation0/test_lock.db'
python3.14-filelock>
python3.14-filelock>     @pytest.mark.timeout(40)
python3.14-filelock>     def test_write_non_starvation(lock_file: str) -> None:
python3.14-filelock>         """Test that write locks can eventually be acquired even with continuous read locks.
python3.14-filelock>
python3.14-filelock>         Creates a chain of reader processes where the writer starts after the first reader acquires a lock. The writer
python3.14-filelock>         should be able to acquire its lock before the entire reader chain has finished, demonstrating non-starvation.
python3.14-filelock>
python3.14-filelock>         """
python3.14-filelock>         NUM_READERS = 7
python3.14-filelock>
python3.14-filelock>         chain_forward = [Event() for _ in range(NUM_READERS)]
python3.14-filelock>         chain_backward = [Event() for _ in range(NUM_READERS)]
python3.14-filelock>         writer_ready = Event()
python3.14-filelock>         writer_acquired = Event()
python3.14-filelock>
python3.14-filelock>         release_count = Value("i", 0)
python3.14-filelock>
python3.14-filelock>         readers = []
python3.14-filelock>         for idx in range(NUM_READERS):
python3.14-filelock>             next_reader = chain_forward[idx + 1] if idx < NUM_READERS - 1 else None
python3.14-filelock>             prev_or_writer = chain_backward[idx - 1] if idx > 0 else writer_ready
python3.14-filelock>             reader = Process(
python3.14-filelock>                 target=chain_reader,
python3.14-filelock>                 args=(idx, lock_file, release_count, chain_forward[idx], chain_backward[idx], next_reader, prev_or_writer),
python3.14-filelock>             )
python3.14-filelock>             readers.append(reader)
python3.14-filelock>
python3.14-filelock>         writer = Process(target=acquire_lock, args=(lock_file, "write", writer_acquired, None, 20, True, writer_ready))
python3.14-filelock>
python3.14-filelock>         with cleanup_processes([*readers, writer]):
python3.14-filelock>             for reader in readers:
python3.14-filelock>                 reader.start()
python3.14-filelock>
python3.14-filelock>             chain_forward[0].set()
python3.14-filelock>
python3.14-filelock>             assert writer_ready.wait(timeout=10), "First reader did not acquire lock"
python3.14-filelock>
python3.14-filelock>             writer.start()
python3.14-filelock>
python3.14-filelock>             assert writer_acquired.wait(timeout=22), "Writer couldn't acquire lock - possible starvation"
python3.14-filelock>
python3.14-filelock>             with release_count.get_lock():
python3.14-filelock>                 read_releases = release_count.value
python3.14-filelock>
python3.14-filelock> >           assert read_releases < 3, f"Writer acquired after {read_releases} readers released - this indicates starvation"
python3.14-filelock> E           AssertionError: Writer acquired after 3 readers released - this indicates starvation
python3.14-filelock> E           assert 3 < 3
python3.14-filelock>
python3.14-filelock> tests/test_read_write.py:251: AssertionError
python3.14-filelock> ____________________________ test_timeout_behavior _____________________________
python3.14-filelock>
python3.14-filelock> lock_file = '/nix/var/nix/builds/nix-73577-2964134750/pytest-of-_nixbld16/pytest-0/test_timeout_behavior0/test_lock.db'
python3.14-filelock>
python3.14-filelock>     @pytest.mark.timeout(10)
python3.14-filelock>     def test_timeout_behavior(lock_file: str) -> None:
python3.14-filelock>         """Test that timeout parameter works correctly in multi-process environment."""
python3.14-filelock>         write_acquired = Event()
python3.14-filelock>         release_write = Event()
python3.14-filelock>         read_acquired = Event()
python3.14-filelock>
python3.14-filelock>         writer = Process(target=acquire_lock, args=(lock_file, "write", write_acquired, release_write))
python3.14-filelock>         reader = Process(target=acquire_lock, args=(lock_file, "read", read_acquired, None, 0.5, True))
python3.14-filelock>
python3.14-filelock>         with cleanup_processes([writer, reader]):
python3.14-filelock>             writer.start()
python3.14-filelock> >           assert write_acquired.wait(timeout=2), "Write lock not acquired"
python3.14-filelock> E           AssertionError: Write lock not acquired
python3.14-filelock> E           assert False
python3.14-filelock> E            +  where False = wait(timeout=2)
python3.14-filelock> E            +    where wait = <Event at 0x10b70fe30 unset>.wait
python3.14-filelock>
python3.14-filelock> tests/test_read_write.py:324: AssertionError
python3.14-filelock>
python3.14-filelock> During handling of the above exception, another exception occurred:
python3.14-filelock>
python3.14-filelock> lock_file = '/nix/var/nix/builds/nix-73577-2964134750/pytest-of-_nixbld16/pytest-0/test_timeout_behavior0/test_lock.db'
python3.14-filelock>
python3.14-filelock>     @pytest.mark.timeout(10)
python3.14-filelock>     def test_timeout_behavior(lock_file: str) -> None:
python3.14-filelock>         """Test that timeout parameter works correctly in multi-process environment."""
python3.14-filelock>         write_acquired = Event()
python3.14-filelock>         release_write = Event()
python3.14-filelock>         read_acquired = Event()
python3.14-filelock>
python3.14-filelock>         writer = Process(target=acquire_lock, args=(lock_file, "write", write_acquired, release_write))
python3.14-filelock>         reader = Process(target=acquire_lock, args=(lock_file, "read", read_acquired, None, 0.5, True))
python3.14-filelock>
python3.14-filelock> >       with cleanup_processes([writer, reader]):
python3.14-filelock>              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
python3.14-filelock>
python3.14-filelock> tests/test_read_write.py:322:
python3.14-filelock> _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
python3.14-filelock> /nix/store/llk2h8rxqzv7zh53bi413ffibjrxskxw-python3-3.14.6/lib/python3.14/contextlib.py:162: in __exit__
python3.14-filelock>     self.gen.throw(value)
python3.14-filelock> tests/test_read_write.py:50: in cleanup_processes
python3.14-filelock>     proc.terminate()
python3.14-filelock> _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
python3.14-filelock>
python3.14-filelock> self = <Process name='Process-41' parent=1701 initial>
python3.14-filelock>
python3.14-filelock>     def terminate(self):
python3.14-filelock>         '''
python3.14-filelock>         Terminate process; sends SIGTERM signal or uses TerminateProcess()
python3.14-filelock>         '''
python3.14-filelock>         self._check_closed()
python3.14-filelock> >       self._popen.terminate()
python3.14-filelock>         ^^^^^^^^^^^^^^^^^^^^^
python3.14-filelock> E       AttributeError: 'NoneType' object has no attribute 'terminate'
python3.14-filelock>
python3.14-filelock> /nix/store/llk2h8rxqzv7zh53bi413ffibjrxskxw-python3-3.14.6/lib/python3.14/multiprocessing/process.py:140: AttributeError
python3.14-filelock> __________________________ test_non_blocking_behavior __________________________
python3.14-filelock>
python3.14-filelock> lock_file = '/nix/var/nix/builds/nix-73577-2964134750/pytest-of-_nixbld16/pytest-0/test_non_blocking_behavior0/test_lock.db'
python3.14-filelock>
python3.14-filelock>     @pytest.mark.timeout(10)
python3.14-filelock>     def test_non_blocking_behavior(lock_file: str) -> None:
python3.14-filelock>         """Test that non-blocking parameter works correctly.
python3.14-filelock>
python3.14-filelock>         This test directly attempts to acquire a read lock in non-blocking mode when a write lock is already held by another
python3.14-filelock>         process.
python3.14-filelock>
python3.14-filelock>         """
python3.14-filelock>         write_acquired = Event()
python3.14-filelock>         release_write = Event()
python3.14-filelock>
python3.14-filelock>         writer = Process(target=acquire_lock, args=(lock_file, "write", write_acquired, release_write))
python3.14-filelock>
python3.14-filelock>         with cleanup_processes([writer]):
python3.14-filelock>             writer.start()
python3.14-filelock> >           assert write_acquired.wait(timeout=2), "Write lock not acquired"
python3.14-filelock> E           AssertionError: Write lock not acquired
python3.14-filelock> E           assert False
python3.14-filelock> E            +  where False = wait(timeout=2)
python3.14-filelock> E            +    where wait = <Event at 0x10b70fb90 unset>.wait
python3.14-filelock>
python3.14-filelock> tests/test_read_write.py:354: AssertionError
python3.14-filelock> =============================== warnings summary ===============================
python3.14-filelock> tests/test_unix_fallback.py::test_fallback_swaps_to_soft
python3.14-filelock> tests/test_unix_fallback.py::test_fallback_writes_pid_and_hostname
python3.14-filelock> tests/test_unix_fallback.py::test_fallback_release_unlinks_file
python3.14-filelock> tests/test_unix_fallback.py::test_fallback_subsequent_acquire_skips_flock
python3.14-filelock> tests/test_unix_fallback.py::test_fallback_reentrant_locking
python3.14-filelock>   /nix/store/sh5q2v9hw926bchw6h8wa9n5n3m3221f-python3.14-filelock-3.29.0/lib/python3.14/site-packages/filelock/_unix.py:82: UserWarning: flock not supported on this filesystem, falling back to SoftFileLock
python3.14-filelock>     self._fallback_to_soft_lock()
python3.14-filelock>
python3.14-filelock> -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
python3.14-filelock> =========================== short test summary info ============================
python3.14-filelock> FAILED tests/test_read_write.py::test_write_lock_excludes_other_write_locks - AssertionError: Second write lock not acquired after first released
python3.14-filelock> FAILED tests/test_read_write.py::test_write_lock_excludes_read_locks - AttributeError: 'NoneType' object has no attribute 'terminate'
python3.14-filelock> FAILED tests/test_read_write.py::test_write_non_starvation - AssertionError: Writer acquired after 3 readers released - this indicates s...
python3.14-filelock> FAILED tests/test_read_write.py::test_timeout_behavior - AttributeError: 'NoneType' object has no attribute 'terminate'
python3.14-filelock> FAILED tests/test_read_write.py::test_non_blocking_behavior - AssertionError: Write lock not acquired
python3.14-filelock> ======= 5 failed, 317 passed, 5 skipped, 5 warnings in 126.11s (0:02:06) =======
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
