### PR TITLE
 python314Packages.flash-attn: remove psutil from setup_requires as we do not require it because we set MAX_JOBS

### DIFF
--- a/pkgs/development/python-modules/flash-attn/default.nix
+++ b/pkgs/development/python-modules/flash-attn/default.nix
@@ -19,133 +19,128 @@
   timm,
   transformers,
   writableTmpDirAsHomeHook,
-
-  # passthru
-  flash-attn,
 }:
 
 let
   inherit (torch) cudaCapabilities cudaPackages cudaSupport;
   inherit (cudaPackages.flags) dropDots;
-
-  self = buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
-    pname = "flash-attention";
-    version = "2.8.3.post1";
-    pyproject = true;
-    __structuredAttrs = true;
-
-    src = fetchFromGitHub {
-      owner = "Dao-AILab";
-      repo = "flash-attention";
-      tag = "v${finalAttrs.version}";
-      fetchSubmodules = true;
-      hash = "sha256-IgK517JorAf9ERcimusF20HgnuETBNKgnGaOxWBuV/M=";
-    };
-
-    preConfigure = ''
-      export MAX_JOBS="$NIX_BUILD_CORES"
-      export NVCC_THREADS=2
-    '';
-
-    env = lib.optionalAttrs cudaSupport {
-      FORCE_BUILD = "TRUE";
-      FLASH_ATTENTION_SKIP_CUDA_BUILD = "FALSE";
-
-      # 8.0;9.0;12.0
-      TORCH_CUDA_ARCH_LIST = lib.concatStringsSep ";" cudaCapabilities;
-      # 80;90;120
-      FLASH_ATTN_CUDA_ARCHS = lib.strings.concatMapStringsSep ";" dropDots cudaCapabilities;
-    };
-
-    build-system = [
-      ninja
-      setuptools
-      torch
-    ];
-
-    nativeBuildInputs = [
-      cudaPackages.cuda_nvcc
-    ];
-
-    buildInputs = [
-      cudaPackages.cccl # <thrust/*>
-      cudaPackages.libcublas # cublas_v2.h
-      cudaPackages.libcurand # curand.h
-      cudaPackages.libcusolver # cusolverDn.h
-      cudaPackages.libcusparse # cusparse.h
-      cudaPackages.cuda_cudart # cuda_runtime.h cuda_runtime_api.h
-    ];
-
-    dependencies = [
-      einops
-      torch
-    ];
-
-    # The CuTeDSL implementation (flash_attn/cute) is the FlashAttention-4 module,
-    # packaged separately as `flash-attn-4`. Drop the stale snapshot bundled in this
-    # FA2 release so the two packages don't collide on flash_attn/cute/ when a single
-    # environment installs both.
-    postInstall = ''
-      rm -rf "$out/${python.sitePackages}/flash_attn/cute"
-    '';
-
-    pythonImportsCheck = [ "flash_attn" ];
-
-    nativeCheckInputs = [
-      apex
-      pytestCheckHook
-      sentencepiece
-      timm
-      transformers
-      writableTmpDirAsHomeHook
-    ];
-
-    enabledTestPaths = [
-      "tests/"
-    ];
-
-    disabledTestPaths = [
-      # `fused_dense_lib` and `dropout_layer_norm` live under csrc/ as standalone Python packages
-      # with their own setup.py; the top-level setup.py does not build them, and they are not
-      # shipped on PyPI either.
-      "tests/ops/test_dropout_layer_norm.py"
-      "tests/ops/test_fused_dense.py"
-      "tests/ops/test_fused_dense_parallel.py"
-
-      # Imports `RotaryEmbedding` from `transformers.models.gpt_neox.modeling_gpt_neox`, which
-      # upstream transformers has since removed.
-      "tests/layers/test_rotary.py"
-
-      # Tests the ROCm composable_kernel backend; we only build the CUDA backend.
-      "tests/test_flash_attn_ck.py"
-
-      # Module-name collision with tests/test_flash_attn.py (both import as
-      # `test_flash_attn`). Disable the CUTE-DSL variant and keep the tests that
-      # exercise the C++ extension we actually build.
-      "tests/cute/test_flash_attn.py"
-    ];
-
-    preCheck = ''
-      rm -rf flash_attn
-    '';
-
-    # Tests require access to a physical GPU
-    doCheck = false;
-
-    passthru.gpuCheck = self.overridePythonAttrs {
-      requiredSystemFeatures = [ "cuda" ];
-      doCheck = true;
-    };
-
-    meta = {
-      # Upstream requires either CUDA or ROCm. Couldn't get it to work with ROCm for now.
-      broken = !cudaSupport;
-      description = "Official implementation of FlashAttention and FlashAttention-2";
-      homepage = "https://github.com/Dao-AILab/flash-attention/";
-      changelog = "https://github.com/Dao-AILab/flash-attention/releases/tag/${finalAttrs.src.tag}";
-      license = lib.licenses.bsd3;
-      maintainers = with lib.maintainers; [ jherland ];
-    };
-  });
 in
-self
+buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
+  pname = "flash-attention";
+  version = "2.8.3.post1";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Dao-AILab";
+    repo = "flash-attention";
+    tag = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-IgK517JorAf9ERcimusF20HgnuETBNKgnGaOxWBuV/M=";
+  };
+
+  preConfigure = ''
+    export MAX_JOBS="$NIX_BUILD_CORES"
+    export NVCC_THREADS=2
+  '';
+
+  env = lib.optionalAttrs cudaSupport {
+    FORCE_BUILD = "TRUE";
+    FLASH_ATTENTION_SKIP_CUDA_BUILD = "FALSE";
+
+    # 8.0;9.0;12.0
+    TORCH_CUDA_ARCH_LIST = lib.concatStringsSep ";" cudaCapabilities;
+    # 80;90;120
+    FLASH_ATTN_CUDA_ARCHS = lib.strings.concatMapStringsSep ";" dropDots cudaCapabilities;
+  };
+
+  build-system = [
+    ninja
+    setuptools
+    torch
+  ];
+
+  nativeBuildInputs = [
+    cudaPackages.cuda_nvcc
+  ];
+
+  buildInputs = [
+    cudaPackages.cccl # <thrust/*>
+    cudaPackages.libcublas # cublas_v2.h
+    cudaPackages.libcurand # curand.h
+    cudaPackages.libcusolver # cusolverDn.h
+    cudaPackages.libcusparse # cusparse.h
+    cudaPackages.cuda_cudart # cuda_runtime.h cuda_runtime_api.h
+  ];
+
+  dependencies = [
+    einops
+    torch
+  ];
+
+  # The CuTeDSL implementation (flash_attn/cute) is the FlashAttention-4 module,
+  # packaged separately as `flash-attn-4`. Drop the stale snapshot bundled in this
+  # FA2 release so the two packages don't collide on flash_attn/cute/ when a single
+  # environment installs both.
+  postInstall = ''
+    rm -rf "$out/${python.sitePackages}/flash_attn/cute"
+  '';
+
+  pythonImportsCheck = [ "flash_attn" ];
+
+  nativeCheckInputs = [
+    apex
+    pytestCheckHook
+    sentencepiece
+    timm
+    transformers
+    writableTmpDirAsHomeHook
+  ];
+
+  enabledTestPaths = [
+    "tests/"
+  ];
+
+  disabledTestPaths = [
+    # `fused_dense_lib` and `dropout_layer_norm` live under csrc/ as standalone Python packages
+    # with their own setup.py; the top-level setup.py does not build them, and they are not
+    # shipped on PyPI either.
+    "tests/ops/test_dropout_layer_norm.py"
+    "tests/ops/test_fused_dense.py"
+    "tests/ops/test_fused_dense_parallel.py"
+
+    # Imports `RotaryEmbedding` from `transformers.models.gpt_neox.modeling_gpt_neox`, which
+    # upstream transformers has since removed.
+    "tests/layers/test_rotary.py"
+
+    # Tests the ROCm composable_kernel backend; we only build the CUDA backend.
+    "tests/test_flash_attn_ck.py"
+
+    # Module-name collision with tests/test_flash_attn.py (both import as
+    # `test_flash_attn`). Disable the CUTE-DSL variant and keep the tests that
+    # exercise the C++ extension we actually build.
+    "tests/cute/test_flash_attn.py"
+  ];
+
+  preCheck = ''
+    rm -rf flash_attn
+  '';
+
+  # Tests require access to a physical GPU
+  doCheck = false;
+
+  passthru.gpuCheck = finalAttrs.finalPackage.overrideAttrs {
+    requiredSystemFeatures = [ "cuda" ];
+    doInstallCheck = true;
+  };
+
+  meta = {
+    # Upstream requires either CUDA or ROCm. Couldn't get it to work with ROCm for now.
+    broken = !cudaSupport;
+    description = "Official implementation of FlashAttention and FlashAttention-2";
+    homepage = "https://github.com/Dao-AILab/flash-attention/";
+    changelog = "https://github.com/Dao-AILab/flash-attention/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ jherland ];
+  };
+})

--- a/pkgs/development/python-modules/flash-attn/default.nix
+++ b/pkgs/development/python-modules/flash-attn/default.nix
@@ -39,6 +39,12 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
     hash = "sha256-IgK517JorAf9ERcimusF20HgnuETBNKgnGaOxWBuV/M=";
   };
 
+  # Avoid that MAX_JOBS could be ignored with future updates
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail '"psutil",' ""
+  '';
+
   preConfigure = ''
     export MAX_JOBS="$NIX_BUILD_CORES"
     export NVCC_THREADS=2


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
