### PR TITLE
clickup: 3.5.185 -> 3.5.230 (and fix upgrade script)

### DIFF
--- a/pkgs/by-name/cl/clickup/package.nix
+++ b/pkgs/by-name/cl/clickup/package.nix
@@ -10,12 +10,12 @@
 }:
 let
   pname = "clickup";
-  version = "3.5.185";
+  version = "3.5.230";
 
   src = fetchurl {
     # Using archive.org because the website doesn't store older versions of the software.
-    url = "https://web.archive.org/web/20260323060753/https://desktop.clickup.com/linux";
-    hash = "sha256-szPbhY1vsEG0Zq4TD2I9qVTa4wAUYfoVA2O2xP4HGeE=";
+    url = "https://web.archive.org/web/20260716144548/https://desktop.clickup.com/linux";
+    hash = "sha256-9d4d/9FP158jHJE6xRCSaxL6kPxYLNad51UNl7RVlCs=";
   };
 
   appimage = appimageTools.wrapType2 {
@@ -47,7 +47,7 @@ stdenvNoCC.mkDerivation {
     install -m 444 -D ${appimageContents}/desktop.desktop $out/share/applications/clickup.desktop
 
     substituteInPlace $out/share/applications/clickup.desktop \
-      --replace-fail 'Exec=AppRun --no-sandbox %U' 'Exec=clickup' \
+      --replace-fail 'Exec=AppRun %U' 'Exec=clickup' \
       --replace-fail 'Icon=desktop' 'Icon=clickup'
 
     wrapProgram $out/bin/${pname} \

--- a/pkgs/by-name/cl/clickup/package.nix
+++ b/pkgs/by-name/cl/clickup/package.nix
@@ -56,35 +56,38 @@ stdenvNoCC.mkDerivation {
     runHook postInstall
   '';
 
-  passthru.updateScript = lib.getExe (writeShellApplication {
-    name = "update-clickup";
-    runtimeInputs = [
-      curl
-      common-updater-scripts
-    ];
-    text = ''
-      upstream_version="$(curl --silent --location --range 0-0 --dump-header - --output /dev/null https://desktop.clickup.com/linux | grep --only-matching --extended-regexp '[0-9]+\.[0-9]+\.[0-9]+')"
+  passthru = {
+    packageSource = src;
+    updateScript = lib.getExe (writeShellApplication {
+      name = "update-clickup";
+      runtimeInputs = [
+        curl
+        common-updater-scripts
+      ];
+      text = ''
+        upstream_version="$(curl --silent --location --range 0-0 --dump-header - --output /dev/null https://desktop.clickup.com/linux | grep --only-matching --extended-regexp '[0-9]+\.[0-9]+\.[0-9]+')"
 
-      current_version="$(nix-instantiate --eval --strict -A clickup.version | tr -d '"')"
+        current_version="$(nix-instantiate --eval --strict -A clickup.version | tr -d '"')"
 
-      if [[ "$current_version" = "$upstream_version" ]]; then
-        echo "clickup is already up-to-date at $current_version"
-        exit 0
-      fi
+        if [[ "$current_version" = "$upstream_version" ]]; then
+          echo "clickup is already up-to-date at $current_version"
+          exit 0
+        fi
 
-      echo "Updating clickup from $current_version to $upstream_version"
+        echo "Updating clickup from $current_version to $upstream_version"
 
-      echo "Saving new version to archive.org..."
-      archived_url="$(curl --silent --max-time 600 --output /dev/null --dump-header - "https://web.archive.org/save/https://desktop.clickup.com/linux" | grep --ignore-case '^location:' | tr -d '\r' | cut -d' ' -f2)"
+        echo "Saving new version to archive.org..."
+        archived_url="$(curl --silent --max-time 600 --output /dev/null --dump-header - "https://web.archive.org/save/https://desktop.clickup.com/linux" | grep --ignore-case '^location:' | tr -d '\r' | cut -d' ' -f2)"
 
-      if [[ -z "$archived_url" || "$archived_url" != *"web.archive.org/web/"* ]]; then
-        echo "error: failed to archive URL on archive.org" >&2
-        exit 1
-      fi
+        if [[ -z "$archived_url" || "$archived_url" != *"web.archive.org/web/"* ]]; then
+          echo "error: failed to archive URL on archive.org" >&2
+          exit 1
+        fi
 
-      update-source-version clickup "$upstream_version" "" "$archived_url"
-    '';
-  });
+        update-source-version --source-key=passthru.packageSource clickup "$upstream_version" "" "$archived_url"
+      '';
+    });
+  };
 
   meta = {
     description = "All in one project management solution";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy]. <!-- meow -->

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
