### PR TITLE
python3Packages.detect-secrets: separate optional dependencies

### DIFF
--- a/pkgs/development/python-modules/detect-secrets/default.nix
+++ b/pkgs/development/python-modules/detect-secrets/default.nix
@@ -62,11 +62,8 @@ buildPythonPackage rec {
     "test_basic"
     "test_handles_each_path_separately"
     "test_handles_multiple_directories"
-    "test_load_and_output"
     "test_make_decisions"
-    "test_restores_line_numbers"
     "test_saves_to_baseline"
-    "test_scan_all_files"
     "test_start_halfway"
   ];
 

--- a/pkgs/development/python-modules/detect-secrets/default.nix
+++ b/pkgs/development/python-modules/detect-secrets/default.nix
@@ -13,6 +13,8 @@
   setuptools,
   unidiff,
   writableTmpDirAsHomeHook,
+  withGibberish ? true,
+  withWordList ? true,
 }:
 
 buildPythonPackage rec {
@@ -31,11 +33,20 @@ buildPythonPackage rec {
   build-system = [ setuptools ];
 
   dependencies = [
-    gibberish-detector
     pyyaml
-    pyahocorasick
     requests
-  ];
+  ]
+  ++ lib.optionals withGibberish optional-dependencies.gibberish
+  ++ lib.optionals withWordList optional-dependencies.word_list;
+
+  optional-dependencies = {
+    gibberish = [
+      gibberish-detector
+    ];
+    word_list = [
+      pyahocorasick
+    ];
+  };
 
   nativeCheckInputs = [
     mock


### PR DESCRIPTION
This provides the means to install `detect-secrets` without the optional dependencies that have thus far been installed by default. These continue to be installed by default in order to not break any existing usage.

Also re-enables some tests which now pass.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
