### PR TITLE
web-researcher-mcp: init at 1.49.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -31393,6 +31393,12 @@
     email = "zoey.spessanha@outlook.com";
     keys = [ { fingerprint = "EAA1 51DB 472B 0122 109A  CB17 1E1E 889C DBD6 A315"; } ];
   };
+  zoharbabin = {
+    email = "z.babin@gmail.com";
+    github = "zoharbabin";
+    githubId = 150514;
+    name = "Zohar Babin";
+  };
   zohl = {
     email = "zohl@fmap.me";
     github = "zohl";

--- a/pkgs/by-name/we/web-researcher-mcp/package.nix
+++ b/pkgs/by-name/we/web-researcher-mcp/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "web-researcher-mcp";
+  version = "1.49.0";
+
+  src = fetchFromGitHub {
+    owner = "zoharbabin";
+    repo = "web-researcher-mcp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-F5WNvnvcWz1tSad69Hsc3KXVSC2OAkYk7LhfWZuj/Mo=";
+  };
+
+  # CGO_ENABLED=0 — pure Go, no C deps. No test network access needed.
+  env.CGO_ENABLED = 0;
+
+  # vendor hash: run `nix build` with lib.fakeHash first, then paste the real
+  # hash reported in the error. Or run: nix-prefetch-github --nix zoharbabin
+  # web-researcher-mcp --rev v<VERSION> then compute vendorHash separately.
+  vendorHash = "sha256-ipupXMIzvwHiW2v4wVAGbrMuZX78cd4GrjYWPD8W8TY=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  # go-rod launches a headless browser in tests; skip those — they require
+  # network access and a display, neither of which is available in the sandbox.
+  # The non-browser tests (unit + integration) all pass without network.
+  checkFlags = [
+    "-skip"
+    "TestBrowserScrape|TestHeadless|TestRod"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    # Lens JSON files enable site-restricted search across 20+ domain categories.
+    # The binary looks for them at $out/share/web-researcher-mcp/lenses/ when the
+    # WEB_RESEARCHER_MCP_LENSES_DIR env var is unset, so we install them there.
+    if [ -d lenses ]; then
+      install -dm755 "$out/share/web-researcher-mcp/lenses"
+      install -Dm644 lenses/*.json "$out/share/web-researcher-mcp/lenses/"
+    fi
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "MCP server that gives AI assistants web search, content extraction, and multi-source research with verifiable citations";
+    longDescription = ''
+      web-researcher-mcp is a Model Context Protocol (MCP) server that gives AI
+      assistants web search, content extraction, academic/patent/SEC filing/
+      case-law/economic data lookup, and multi-step research with real, verifiable
+      citations. Supports DuckDuckGo (zero-config), Google Custom Search, Brave,
+      Exa, Tavily, and more. Runs over STDIO or HTTP transport.
+    '';
+    homepage = "https://github.com/zoharbabin/web-researcher-mcp";
+    changelog = "https://github.com/zoharbabin/web-researcher-mcp/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ zoharbabin ];
+    mainProgram = "web-researcher-mcp";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
## Description

Adds `web-researcher-mcp` to nixpkgs. This is a Model Context Protocol (MCP)
server that gives AI assistants web search, content extraction, and multi-source
research with verifiable citations.

- Homepage: https://github.com/zoharbabin/web-researcher-mcp
- License: MIT
- Language: Go (pure Go, `CGO_ENABLED=0`, no C deps)
- Binary name: `web-researcher-mcp`

## Verification

- `nix build` succeeds on x86_64-linux and aarch64-darwin
- `web-researcher-mcp --help` exits 0
- Lens JSON files installed to `$out/share/web-researcher-mcp/lenses/`
- `passthru.updateScript = nix-update-script {}` wired for automated future bumps

## Checklist

- [x] `nix build` succeeds
- [x] Tests pass (browser/network tests skipped — require display + network)
- [x] `passthru.updateScript` set for automated future version bumps
- [x] `meta.mainProgram` set
- [x] `meta.changelog` set
- [x] Uses `buildGoModule` per nixpkgs packaging guidelines
- [x] Placed in `pkgs/by-name/we/web-researcher-mcp/package.nix` per by-name convention
- [x] `zoharbabin` added to `maintainers/maintainer-list.nix`
- [x] Follows the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy) — commit carries an `Assisted-by:` trailer, and a human maintainer (zoharbabin) reviews and responds to this PR personally.
