### PR TITLE
p4c: fix build

### DIFF
--- a/pkgs/development/compilers/p4c/default.nix
+++ b/pkgs/development/compilers/p4c/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   fetchpatch,
   cmake,
+  makeWrapper,
   boehmgc,
   bison,
   flex,
@@ -13,6 +14,8 @@
   python3,
   doxygen,
   graphviz,
+  makeFontsConf,
+  writableTmpDirAsHomeHook,
   libbpf,
   libllvm,
   enableDocumentation ? true,
@@ -47,12 +50,18 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/p4lang/p4c/commit/6756816100b7c51e3bf717ec55114a8e8575ba1d.patch";
       hash = "sha256-wWM1qjgQCNMPdrhQF38jzFgODUsAcaHTajdbV7L3y8o=";
     })
+    # Fix gcc-15 build by including cstdint directly.
+    ./gcc-15.patch
   ];
 
   postFetch = ''
     rm -rf backends/ebpf/runtime/contrib/libbpf
     rm -rf control-plane/p4runtime
   '';
+
+  env = lib.optionalAttrs enableDocumentation {
+    FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
+  };
 
   cmakeFlags = [
     "-DENABLE_BMV2=${toCMakeBoolean enableBMV2}"
@@ -77,12 +86,14 @@ stdenv.mkDerivation (finalAttrs: {
     bison
     flex
     cmake
+    makeWrapper
     protobuf
     python3
   ]
   ++ lib.optionals enableDocumentation [
     doxygen
     graphviz
+    writableTmpDirAsHomeHook
   ]
   ++ lib.optionals enableBPF [
     libllvm
@@ -96,6 +107,16 @@ stdenv.mkDerivation (finalAttrs: {
     gmp
     flex
   ];
+
+  postInstall = ''
+    wrapProgram $out/bin/p4c \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          python3
+          stdenv.cc
+        ]
+      }
+  '';
 
   meta = {
     changelog = "https://github.com/p4lang/p4c/releases";

--- a/pkgs/development/compilers/p4c/gcc-15.patch
+++ b/pkgs/development/compilers/p4c/gcc-15.patch
@@ -1,0 +1,12 @@
+diff --git a/lib/log.cpp b/lib/log.cpp
+index c85962822..7b1bc1ae7 100644
+--- a/lib/log.cpp
++++ b/lib/log.cpp
+@@ -22,6 +22,7 @@ limitations under the License.
+ #define NOGC_ARGS
+ #endif /* HAVE_LIBGC */
+ 
++#include <cstdint>
+ #include <cstring>
+ #include <fstream>  // IWYU pragma: keep
+ #include <iomanip>


### PR DESCRIPTION
Adds the missing `<cstdint>` include required by GCC 15 and wraps the `p4c` driver with its Python and C compiler runtime dependencies. Documentation builds also receive a declarative Fontconfig configuration and writable cache for Graphviz.

Closes #542520

Assisted-by: pi coding agent / Mika (OpenAI gpt-5.6-sol)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
