### PR TITLE
python3Packages.telethon: 1.42.0 -> 1.44.0

### DIFF
--- a/pkgs/development/python-modules/telethon/default.nix
+++ b/pkgs/development/python-modules/telethon/default.nix
@@ -2,11 +2,11 @@
   lib,
   buildPythonPackage,
   fetchFromCodeberg,
-  pythonAtLeast,
   openssl,
   rsa,
   pyaes,
   cryptg,
+  hatchling,
   setuptools,
   pytest-asyncio,
   pytestCheckHook,
@@ -14,24 +14,27 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "telethon";
-  version = "1.42.0";
+  version = "1.44.0";
   pyproject = true;
 
   src = fetchFromCodeberg {
     owner = "Lonami";
     repo = "Telethon";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-NMHJkSTGR3/tck0k97EfVN9f85PAWst+EZ6G7Tgrt5s=";
+    hash = "sha256-NzLlDwxzLWyySluUazQGPDukT71awCrJZEbjd5T9K/g=";
   };
-
-  disabled = pythonAtLeast "3.14";
 
   postPatch = ''
     substituteInPlace telethon/crypto/libssl.py --replace-fail \
       "ctypes.util.find_library('ssl')" "'${lib.getLib openssl}/lib/libssl.so'"
   '';
 
+  preCheck = ''
+    python setup.py gen
+  '';
+
   build-system = [
+    hatchling
     setuptools
   ];
 


### PR DESCRIPTION
Changelog: https://codeberg.org/Lonami/Telethon/blob/v1.44.0/readthedocs/misc/changelog.rst


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
