### PR TITLE
sage: work around ipython and scipy regressions

### DIFF
--- a/pkgs/by-name/sa/sage/patches/ipython-9_15-workaround.patch
+++ b/pkgs/by-name/sa/sage/patches/ipython-9_15-workaround.patch
@@ -1,0 +1,24 @@
+diff --git a/src/sage/doctest/test.py b/src/sage/doctest/test.py
+index 812f8167c12..38e553ad5bd 100644
+--- a/src/sage/doctest/test.py
++++ b/src/sage/doctest/test.py
+@@ -468,6 +468,7 @@ Test the ``--debug`` option::
+         s...: b = 5
+         s...: a + b
+         8
++    ...
+     sage:
+     <BLANKLINE>
+     Returning to doctests...
+diff --git a/src/sage/tests/cmdline.py b/src/sage/tests/cmdline.py
+index 56fc16a205c..be2ae2a1b3d 100644
+--- a/src/sage/tests/cmdline.py
++++ b/src/sage/tests/cmdline.py
+@@ -327,6 +327,7 @@ be ignored. In Pdb, we run the ``help`` command::
+     **********************************************************************
+     Previously executed commands:
+         s...: assert True is False
++    ...
+     sage:
+     <BLANKLINE>
+     Returning to doctests...

--- a/pkgs/by-name/sa/sage/patches/scipy-1_18-workaround.patch
+++ b/pkgs/by-name/sa/sage/patches/scipy-1_18-workaround.patch
@@ -1,0 +1,13 @@
+diff --git a/src/sage/plot/plot3d/plot3d.py b/src/sage/plot/plot3d/plot3d.py
+index bdf15a85e9d..36580eeab6b 100644
+--- a/src/sage/plot/plot3d/plot3d.py
++++ b/src/sage/plot/plot3d/plot3d.py
+@@ -316,7 +316,7 @@ class _Coordinates:
+             ....: [ 0.16763356,  0.19993708,  0.31403568,  0.47359696, 0.55282422],
+             ....: [ 0.16763356,  0.25683223,  0.16649297,  0.10594339, 0.55282422]])
+             sage: import scipy.interpolate
+-            sage: f=scipy.interpolate.RectBivariateSpline(v_phi,v_theta,m_r).ev
++            sage: f=lambda *x: scipy.interpolate.RectBivariateSpline(v_phi,v_theta,m_r).ev(*x).item()
+             sage: spherical_plot3d(f,(0,2*pi),(0,pi))
+             Graphics3d Object
+         """

--- a/pkgs/by-name/sa/sage/sage-src.nix
+++ b/pkgs/by-name/sa/sage/sage-src.nix
@@ -130,6 +130,14 @@ stdenv.mkDerivation rec {
       url = "https://github.com/sagemath/sage/commit/926f32aab22f81ddb9fda874a20fee84c7bfacc3.patch?full_index=1";
       hash = "sha256-EMn/fr5WlRQtFj5GHo02kczasmKaiqFfRSVZo2uvOPI=";
     })
+
+    # work around https://github.com/ipython/ipython/issues/15207, which
+    # will likely be properly fixed in IPython 9.16.
+    ./patches/ipython-9_15-workaround.patch
+
+    # work around https://github.com/scipy/scipy/issues/25471, which is
+    # fixed as part of SciPy 1.18.1.
+    ./patches/scipy-1_18-workaround.patch
   ];
 
   patches = nixPatches ++ bugfixPatches ++ packageUpgradePatches;


### PR DESCRIPTION
We recently upgraded IPython to 9.14 and SciPy to 1.18, which introduced some regressions, namely https://github.com/ipython/ipython/issues/15207 and https://github.com/scipy/scipy/issues/25471. The former had a fix attempt, and is still being properly fixed (https://github.com/ipython/ipython/pull/15314), and the latter will likely be fixed in SciPy 1.18.1 (https://github.com/scipy/scipy/pull/25542).

(The SciPy regression revealed a Sage bug, see https://github.com/sagemath/sage/issues/42539)

Fixes #541414.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
