### PR TITLE
scroll-reverser: Remove WBM indirection, add upgrade script

### DIFF
--- a/pkgs/by-name/sc/scroll-reverser/package.nix
+++ b/pkgs/by-name/sc/scroll-reverser/package.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   version = "1.9";
 
   src = fetchurl {
-    url = "https://web.archive.org/web/20250427052440/https://pilotmoon.com/downloads/ScrollReverser-${finalAttrs.version}.zip";
+    url = "https://pilotmoon.com/downloads/ScrollReverser-${finalAttrs.version}.zip";
     hash = "sha256-CWHbtvjvTl7dQyvw3W583UIZ2LrIs7qj9XavmkK79YU=";
   };
 

--- a/pkgs/by-name/sc/scroll-reverser/package.nix
+++ b/pkgs/by-name/sc/scroll-reverser/package.nix
@@ -3,6 +3,7 @@
   stdenvNoCC,
   fetchurl,
   unzip,
+  nix-update-script,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "scroll-reverser";
@@ -26,9 +27,19 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "v([0-9]*.*)"
+      "--url"
+      "https://github.com/pilotmoon/Scroll-Reverser"
+    ];
+  };
+
   meta = {
     description = "Tool to reverse the direction of scrolling";
     homepage = "https://pilotmoon.com/scrollreverser/";
+    changelog = "https://github.com/pilotmoon/Scroll-Reverser/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       stackptr


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- Removed the WBM indirection for the downloads, since the link is live.
- Added a upgrade script to get releases.
- Added metadata so we get the changelog information on upgrades.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
